### PR TITLE
Added the needed libssl-dev package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,8 @@ header files for python C extensions.
 Installing prerequisites on Ubuntu or Debian::
 
     $ sudo apt-get install build-essential python2.7-dev libffi-dev \
-                           python-pip python-setuptools sqlite3
+                           python-pip python-setuptools sqlite3 \
+                           libssl-dev
 
 Installing prerequisites on Mac OS X::
 


### PR DESCRIPTION
Installation on Ubuntu failed because of missing openssl/aes.h, installing libssl-dev fixes this.
