### PR TITLE
Database performance improvements.

### DIFF
--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -91,7 +91,7 @@ class FederationHandler(BaseHandler):
 
         yield run_on_reactor()
 
-        yield self.replication_layer.send_pdu(event, destinations)
+        self.replication_layer.send_pdu(event, destinations)
 
     @log_function
     @defer.inlineCallbacks
@@ -527,7 +527,7 @@ class FederationHandler(BaseHandler):
             event.signatures,
         )
 
-        yield self.replication_layer.send_pdu(new_pdu, destinations)
+        self.replication_layer.send_pdu(new_pdu, destinations)
 
         state_ids = [e.event_id for e in context.current_state.values()]
         auth_chain = yield self.store.get_auth_chain(set(

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -245,14 +245,12 @@ class RoomMemberHandler(BaseHandler):
         self.distributor.declare("user_left_room")
 
     @defer.inlineCallbacks
-    def get_room_members(self, room_id, membership=Membership.JOIN):
+    def get_room_members(self, room_id):
         hs = self.hs
 
-        memberships = yield self.store.get_room_members(
-            room_id=room_id, membership=membership
-        )
+        users = yield self.store.get_users_in_room(room_id)
 
-        defer.returnValue([hs.parse_userid(m.user_id) for m in memberships])
+        defer.returnValue([hs.parse_userid(u) for u in users])
 
     @defer.inlineCallbacks
     def fetch_room_distributions_into(self, room_id, localusers=None,
@@ -531,11 +529,10 @@ class RoomListHandler(BaseHandler):
     def get_public_room_list(self):
         chunk = yield self.store.get_rooms(is_public=True)
         for room in chunk:
-            joined_members = yield self.store.get_room_members(
+            joined_users = yield self.store.get_users_in_room(
                 room_id=room["room_id"],
-                membership=Membership.JOIN
             )
-            room["num_joined_members"] = len(joined_members)
+            room["num_joined_members"] = len(joined_users)
         # FIXME (erikj): START is no longer a valid value
         defer.returnValue({"start": "START", "end": "END", "chunk": chunk})
 

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -449,7 +449,8 @@ class SQLBaseStore(object):
         return [
             self._get_event_txn(
                 txn, event_id,
-                check_redacted=check_redacted, get_prev_content=get_prev_content
+                check_redacted=check_redacted,
+                get_prev_content=get_prev_content
             )
             for event_id in event_ids
         ]
@@ -473,7 +474,8 @@ class SQLBaseStore(object):
         internal_metadata, js, redacted = res
 
         return self._get_event_from_row_txn(
-            txn, internal_metadata, js, redacted, check_redacted=check_redacted,
+            txn, internal_metadata, js, redacted,
+            check_redacted=check_redacted,
             get_prev_content=get_prev_content,
         )
 

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -499,6 +499,8 @@ class SQLBaseStore(object):
 
         ev = FrozenEvent(d, internal_metadata_dict=internal_metadata)
 
+        return ev
+
         if check_redacted and redacted:
             ev = prune_event(ev)
 

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -440,15 +440,16 @@ class SQLBaseStore(object):
         )
 
     def _get_events_txn(self, txn, event_ids):
-	if not event_ids:
-		return []
+        if not event_ids:
+            return []
 
-	if len(event_ids) > 50:
-		events = []
-		n = 50
-		for e_ids in [event_ids[i:i + n] for i in range(0, len(event_ids), n)]:
-			events.extend(self._get_events_txn(txn, e_ids))
-		return events
+        if len(event_ids) > 50:
+            events = []
+            n = 50
+            split = [event_ids[i:i + n] for i in range(0, len(event_ids), n)]
+            for e_ids in split:
+                events.extend(self._get_events_txn(txn, e_ids))
+            return events
 
         where_clause = " OR ".join(["e.event_id = ?" for _ in event_ids])
 
@@ -482,13 +483,13 @@ class SQLBaseStore(object):
 
         internal_metadata, js, redacted = res
 
-	return self._get_event_from_row_txn(
-		txn, internal_metadata, js, redacted, check_redacted=check_redacted,
-		get_prev_content=get_prev_content,
-	)
+        return self._get_event_from_row_txn(
+            txn, internal_metadata, js, redacted, check_redacted=check_redacted,
+            get_prev_content=get_prev_content,
+        )
 
     def _get_event_from_row_txn(self, txn, internal_metadata, js, redacted,
-				check_redacted=True, get_prev_content=True):
+                                check_redacted=True, get_prev_content=True):
         d = json.loads(js)
         internal_metadata = json.loads(internal_metadata)
 

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -443,6 +443,8 @@ class SQLBaseStore(object):
         if not event_ids:
             return []
 
+        logger.debug("_get_events_txn called with %d events", len(event_ids))
+
         if len(event_ids) > 50:
             events = []
             n = 50
@@ -450,6 +452,8 @@ class SQLBaseStore(object):
             for e_ids in split:
                 events.extend(self._get_events_txn(txn, e_ids))
             return events
+
+        logger.debug("_get_events_txn Fetching %d events", len(event_ids))
 
         where_clause = " OR ".join(["e.event_id = ?" for _ in event_ids])
 

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -183,20 +183,14 @@ class RoomMemberStore(SQLBaseStore):
         )
 
     def _get_members_query_txn(self, txn, where_clause, where_values):
-        del_sql = (
-            "SELECT event_id FROM redactions WHERE redacts = e.event_id "
-            "LIMIT 1"
-        )
-
         sql = (
-            "SELECT e.*, (%(redacted)s) AS redacted FROM events as e "
+            "SELECT e.* FROM events as e "
             "INNER JOIN room_memberships as m "
             "ON e.event_id = m.event_id "
             "INNER JOIN current_state_events as c "
             "ON m.event_id = c.event_id "
             "WHERE %(where)s "
         ) % {
-            "redacted": del_sql,
             "where": where_clause,
         }
 

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -123,6 +123,19 @@ class RoomMemberStore(SQLBaseStore):
         else:
             return None
 
+    def get_users_in_room(self, room_id):
+        def f(txn):
+            sql = (
+                "SELECT m.user_id FROM room_memberships as m"
+                " INNER JOIN current_state_events as c"
+                " ON m.event_id = c.event_id"
+                " WHERE m.membership = ? AND m.room_id = ?"
+            )
+
+            txn.execute(sql, (Membership.JOIN, room_id))
+            return [r[0] for r in txn.fetchall()]
+        return self.runInteraction("get_users_in_room", f)
+
     def get_room_members(self, room_id, membership=None):
         """Retrieve the current room member list for a room.
 

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -15,6 +15,10 @@
 
 from ._base import SQLBaseStore
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class StateStore(SQLBaseStore):
     """ Keeps track of the state at a given event.
@@ -54,6 +58,8 @@ class StateStore(SQLBaseStore):
                 if group:
                     groups.add(group)
 
+            logger.debug("Got groups: %s", groups)
+
             res = {}
             for group in groups:
                 state_ids = self._simple_select_onecol_txn(
@@ -62,6 +68,12 @@ class StateStore(SQLBaseStore):
                     keyvalues={"state_group": group},
                     retcol="event_id",
                 )
+
+                logger.debug(
+                    "Got %d events for group %s",
+                    len(state_ids), group
+                )
+
                 state = self._get_events_txn(txn, state_ids)
 
                 res[group] = state

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -58,8 +58,6 @@ class StateStore(SQLBaseStore):
                 if group:
                     groups.add(group)
 
-            logger.debug("Got groups: %s", groups)
-
             res = {}
             for group in groups:
                 state_ids = self._simple_select_onecol_txn(
@@ -67,11 +65,6 @@ class StateStore(SQLBaseStore):
                     table="state_groups_state",
                     keyvalues={"state_group": group},
                     retcol="event_id",
-                )
-
-                logger.debug(
-                    "Got %d events for group %s",
-                    len(state_ids), group
                 )
 
                 state = self._get_events_txn(txn, state_ids)

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -62,14 +62,7 @@ class StateStore(SQLBaseStore):
                     keyvalues={"state_group": group},
                     retcol="event_id",
                 )
-                state = []
-                for state_id in state_ids:
-                    s = self._get_events_txn(
-                        txn,
-                        [state_id],
-                    )
-                    if s:
-                        state.extend(s)
+                state = self._get_events_txn(txn, state_ids)
 
                 res[group] = state
 

--- a/synapse/storage/stream.py
+++ b/synapse/storage/stream.py
@@ -142,7 +142,6 @@ class StreamStore(SQLBaseStore):
                                limit=0, with_feedback=False):
         # TODO (erikj): Handle compressed feedback
 
-
         current_room_membership_sql = (
             "SELECT m.room_id FROM room_memberships as m "
             "INNER JOIN current_state_events as c ON m.event_id = c.event_id "

--- a/synapse/storage/stream.py
+++ b/synapse/storage/stream.py
@@ -137,11 +137,11 @@ class StreamStore(SQLBaseStore):
                 with_feedback=with_feedback,
             )
 
-    @defer.inlineCallbacks
     @log_function
     def get_room_events_stream(self, user_id, from_key, to_key, room_id,
                                limit=0, with_feedback=False):
         # TODO (erikj): Handle compressed feedback
+
 
         current_room_membership_sql = (
             "SELECT m.room_id FROM room_memberships as m "
@@ -157,11 +157,6 @@ class StreamStore(SQLBaseStore):
             "WHERE m.user_id = ? "
         )
 
-        del_sql = (
-            "SELECT event_id FROM redactions WHERE redacts = e.event_id "
-            "LIMIT 1"
-        )
-
         if limit:
             limit = max(limit, MAX_STREAM_SIZE)
         else:
@@ -172,38 +167,42 @@ class StreamStore(SQLBaseStore):
         to_id = _parse_stream_token(to_key)
 
         if from_key == to_key:
-            defer.returnValue(([], to_key))
-            return
+            return defer.succeed(([], to_key))
 
         sql = (
-            "SELECT *, (%(redacted)s) AS redacted FROM events AS e WHERE "
+            "SELECT e.event_id, e.stream_ordering FROM events AS e WHERE "
             "(e.outlier = 0 AND (room_id IN (%(current)s)) OR "
             "(event_id IN (%(invites)s))) "
             "AND e.stream_ordering > ? AND e.stream_ordering <= ? "
             "ORDER BY stream_ordering ASC LIMIT %(limit)d "
         ) % {
-            "redacted": del_sql,
             "current": current_room_membership_sql,
             "invites": membership_sql,
             "limit": limit
         }
 
-        rows = yield self._execute_and_decode(
-            sql,
-            user_id, user_id, from_id, to_id
-        )
+        def f(txn):
+            txn.execute(sql, (user_id, user_id, from_id, to_id,))
 
-        ret = yield self._parse_events(rows)
+            rows = self.cursor_to_dict(txn)
 
-        if rows:
-            key = "s%d" % max([r["stream_ordering"] for r in rows])
-        else:
-            # Assume we didn't get anything because there was nothing to get.
-            key = to_key
+            ret = self._get_events_txn(
+                txn,
+                [r["event_id"] for r in rows],
+                get_prev_content=True
+            )
 
-        defer.returnValue((ret, key))
+            if rows:
+                key = "s%d" % max([r["stream_ordering"] for r in rows])
+            else:
+                # Assume we didn't get anything because there was nothing to
+                # get.
+                key = to_key
 
-    @defer.inlineCallbacks
+            return ret, key
+
+        return self.runInteraction("get_room_events_stream", f)
+
     @log_function
     def paginate_room_events(self, room_id, from_key, to_key=None,
                              direction='b', limit=-1,
@@ -221,7 +220,9 @@ class StreamStore(SQLBaseStore):
 
         bounds = _get_token_bound(from_key, from_comp)
         if to_key:
-            bounds = "%s AND %s" % (bounds, _get_token_bound(to_key, to_comp))
+            bounds = "%s AND %s" % (
+                bounds, _get_token_bound(to_key, to_comp)
+            )
 
         if int(limit) > 0:
             args.append(int(limit))
@@ -229,87 +230,78 @@ class StreamStore(SQLBaseStore):
         else:
             limit_str = ""
 
-        del_sql = (
-            "SELECT event_id FROM redactions WHERE redacts = events.event_id "
-            "LIMIT 1"
-        )
-
         sql = (
-            "SELECT *, (%(redacted)s) AS redacted FROM events"
+            "SELECT * FROM events"
             " WHERE outlier = 0 AND room_id = ? AND %(bounds)s"
             " ORDER BY topological_ordering %(order)s,"
             " stream_ordering %(order)s %(limit)s"
         ) % {
-            "redacted": del_sql,
             "bounds": bounds,
             "order": order,
             "limit": limit_str
         }
 
-        rows = yield self._execute_and_decode(
-            sql,
-            *args
-        )
+        def f(txn):
+            txn.execute(sql, args)
 
-        if rows:
-            topo = rows[-1]["topological_ordering"]
-            toke = rows[-1]["stream_ordering"]
-            if direction == 'b':
-                topo -= 1
-                toke -= 1
-            next_token = "t%s-%s" % (topo, toke)
-        else:
-            # TODO (erikj): We should work out what to do here instead.
-            next_token = to_key if to_key else from_key
+            rows = self.cursor_to_dict(txn)
 
-        events = yield self._parse_events(rows)
+            if rows:
+                topo = rows[-1]["topological_ordering"]
+                toke = rows[-1]["stream_ordering"]
+                if direction == 'b':
+                    topo -= 1
+                    toke -= 1
+                next_token = "t%s-%s" % (topo, toke)
+            else:
+                # TODO (erikj): We should work out what to do here instead.
+                next_token = to_key if to_key else from_key
 
-        defer.returnValue(
-            (
-                events,
-                next_token
+            events = self._get_events_txn(
+                txn,
+                [r["event_id"] for r in rows],
+                get_prev_content=True
             )
-        )
 
-    @defer.inlineCallbacks
+            return events, next_token,
+
+        return self.runInteraction("paginate_room_events", f)
+
     def get_recent_events_for_room(self, room_id, limit, end_token,
                                    with_feedback=False):
         # TODO (erikj): Handle compressed feedback
 
-        del_sql = (
-            "SELECT event_id FROM redactions WHERE redacts = events.event_id "
-            "LIMIT 1"
-        )
-
         sql = (
-            "SELECT *, (%(redacted)s) AS redacted FROM events "
+            "SELECT * FROM events "
             "WHERE room_id = ? AND stream_ordering <= ? AND outlier = 0 "
             "ORDER BY topological_ordering DESC, stream_ordering DESC LIMIT ? "
-        ) % {
-            "redacted": del_sql,
-        }
-
-        rows = yield self._execute_and_decode(
-            sql,
-            room_id, end_token, limit
         )
 
-        rows.reverse()  # As we selected with reverse ordering
+        def f(txn):
+            txn.execute(sql, (room_id, end_token, limit,))
 
-        if rows:
-            topo = rows[0]["topological_ordering"]
-            toke = rows[0]["stream_ordering"]
-            start_token = "t%s-%s" % (topo, toke)
+            rows = self.cursor_to_dict(txn)
 
-            token = (start_token, end_token)
-        else:
-            token = (end_token, end_token)
+            rows.reverse()  # As we selected with reverse ordering
 
-        events = yield self._parse_events(rows)
+            if rows:
+                topo = rows[0]["topological_ordering"]
+                toke = rows[0]["stream_ordering"]
+                start_token = "t%s-%s" % (topo, toke)
 
-        ret = (events, token)
+                token = (start_token, end_token)
+            else:
+                token = (end_token, end_token)
 
-        defer.returnValue(ret)
+            events = self._get_events_txn(
+                txn,
+                [r["event_id"] for r in rows],
+                get_prev_content=True
+            )
+
+            return events, token
+
+        return self.runInteraction("get_recent_events_for_room", f)
 
     def get_room_events_max_id(self):
         return self.runInteraction(


### PR DESCRIPTION
Summary of changes:
- Add new storage function to get the list of user ids in a given room. The current implementation will retrieve and parse the full member events from the database, which are often not needed. This considerably slowed sending typing and presence updates.
- When retrieving an event from the database only work out the prev_content if explicitly requested. Retrieving the prev_content key is relatively expensive (it involves another query to the database), and is only used in client facing scrolling and streaming APIs. This considerably slowed down the `get_state_groups` query.
- Use transactions in storage.streams module. Also tidy up the SQL queries.