### PR TITLE
create identicons for new users by default as default avatars

### DIFF
--- a/scripts/make_identicons.pl
+++ b/scripts/make_identicons.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use DBI;
+use DBD::SQLite;
+use JSON;
+
+my $dbh = DBI->connect("dbi:SQLite:dbname=homeserver.db","","") || die DBI->error;
+
+my $res = $dbh->selectall_arrayref("select token, name from access_tokens, users where access_tokens.user_id = users.id group by user_id") || die DBI->error;
+
+foreach (@$res) {
+    my ($token, $mxid) = ($_->[0], $_->[1]);
+    my ($user_id) = ($mxid =~ m/@(.*):/);
+    my ($url) = $dbh->selectrow_array("select avatar_url from profiles where user_id=?", undef, $user_id);
+    if (!$url || $url =~ /#auto$/) {
+        `curl -o tmp.png "http://localhost:8008/_matrix/media/v1/identicon?name=${mxid}&width=320&height=320"`;
+        my $json = `curl -X POST -H "Content-Type: image/png" -T "tmp.png" http://localhost:8008/_matrix/media/v1/upload?access_token=$token`;
+        my $content_uri = from_json($json)->{content_uri};
+        `curl -X PUT -H "Content-Type: application/json" --data '{ "avatar_url": "${content_uri}#auto"}' http://localhost:8008/_matrix/client/api/v1/profile/${mxid}/avatar_url?access_token=$token`;
+    }
+}

--- a/scripts/make_identicons.pl
+++ b/scripts/make_identicons.pl
@@ -6,19 +6,34 @@ use warnings;
 use DBI;
 use DBD::SQLite;
 use JSON;
+use Getopt::Long;
 
-my $dbh = DBI->connect("dbi:SQLite:dbname=homeserver.db","","") || die DBI->error;
+my $db; # = "homeserver.db";
+my $server = "http://localhost:8008";
+my $size = 320;
 
-my $res = $dbh->selectall_arrayref("select token, name from access_tokens, users where access_tokens.user_id = users.id group by user_id") || die DBI->error;
+GetOptions("db|d=s",     \$db,
+           "server|s=s", \$server,
+           "width|w=i",  \$size) or usage();
+
+usage() unless $db;
+
+my $dbh = DBI->connect("dbi:SQLite:dbname=$db","","") || die $DBI::errstr;
+
+my $res = $dbh->selectall_arrayref("select token, name from access_tokens, users where access_tokens.user_id = users.id group by user_id") || die $DBI::errstr;
 
 foreach (@$res) {
     my ($token, $mxid) = ($_->[0], $_->[1]);
     my ($user_id) = ($mxid =~ m/@(.*):/);
     my ($url) = $dbh->selectrow_array("select avatar_url from profiles where user_id=?", undef, $user_id);
     if (!$url || $url =~ /#auto$/) {
-        `curl -o tmp.png "http://localhost:8008/_matrix/media/v1/identicon?name=${mxid}&width=320&height=320"`;
-        my $json = `curl -X POST -H "Content-Type: image/png" -T "tmp.png" http://localhost:8008/_matrix/media/v1/upload?access_token=$token`;
+        `curl -s -o tmp.png "$server/_matrix/media/v1/identicon?name=${mxid}&width=$size&height=$size"`;
+        my $json = `curl -s -X POST -H "Content-Type: image/png" -T "tmp.png" $server/_matrix/media/v1/upload?access_token=$token`;
         my $content_uri = from_json($json)->{content_uri};
-        `curl -X PUT -H "Content-Type: application/json" --data '{ "avatar_url": "${content_uri}#auto"}' http://localhost:8008/_matrix/client/api/v1/profile/${mxid}/avatar_url?access_token=$token`;
+        `curl -X PUT -H "Content-Type: application/json" --data '{ "avatar_url": "${content_uri}#auto"}' $server/_matrix/client/api/v1/profile/${mxid}/avatar_url?access_token=$token`;
     }
+}
+
+sub usage {
+    die "usage: ./make-identicons.pl\n\t-d database [e.g. homeserver.db]\n\t-s homeserver (default: http://localhost:8008)\n\t-w identicon size in pixels (default 320)";
 }

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -99,6 +99,20 @@ class RegistrationHandler(BaseHandler):
                         raise RegistrationError(
                             500, "Cannot generate user ID.")
 
+        # create a default avatar for the user
+        # XXX: ideally clients would explicitly specify one, but given they don't
+        # and we want consistent and pretty identicons for random users, we'll
+        # do it here.
+        auth_user = UserID.from_string(user_id)
+        identicon_resource = self.hs.get_resource_for_media_repository().getChildWithDefault("identicon", None)
+        upload_resource = self.hs.get_resource_for_media_repository().getChildWithDefault("upload", None)
+        identicon_bytes = identicon_resource.generate_identicon(user_id, 320, 320)
+        content_uri = yield upload_resource.create_content(
+            "image/png", None, identicon_bytes, len(identicon_bytes), auth_user
+        )
+        profile_handler = self.hs.get_handlers().profile_handler
+        profile_handler.set_avatar_url(auth_user, auth_user, ("%s#auto" % content_uri))
+        
         defer.returnValue((user_id, token))
 
     @defer.inlineCallbacks

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -103,15 +103,18 @@ class RegistrationHandler(BaseHandler):
         # XXX: ideally clients would explicitly specify one, but given they don't
         # and we want consistent and pretty identicons for random users, we'll
         # do it here.
-        auth_user = UserID.from_string(user_id)
-        identicon_resource = self.hs.get_resource_for_media_repository().getChildWithDefault("identicon", None)
-        upload_resource = self.hs.get_resource_for_media_repository().getChildWithDefault("upload", None)
-        identicon_bytes = identicon_resource.generate_identicon(user_id, 320, 320)
-        content_uri = yield upload_resource.create_content(
-            "image/png", None, identicon_bytes, len(identicon_bytes), auth_user
-        )
-        profile_handler = self.hs.get_handlers().profile_handler
-        profile_handler.set_avatar_url(auth_user, auth_user, ("%s#auto" % content_uri))
+        try:
+            auth_user = UserID.from_string(user_id)
+            identicon_resource = self.hs.get_resource_for_media_repository().getChildWithDefault("identicon", None)
+            upload_resource = self.hs.get_resource_for_media_repository().getChildWithDefault("upload", None)
+            identicon_bytes = identicon_resource.generate_identicon(user_id, 320, 320)
+            content_uri = yield upload_resource.create_content(
+                "image/png", None, identicon_bytes, len(identicon_bytes), auth_user
+            )
+            profile_handler = self.hs.get_handlers().profile_handler
+            profile_handler.set_avatar_url(auth_user, auth_user, ("%s#auto" % content_uri))
+        except NotImplementedError:
+            pass # make tests pass without messing around creating default avatars
         
         defer.returnValue((user_id, token))
 


### PR DESCRIPTION
and provide a script to generate them for existing avatarless users.

this is preferable to identicons being a clientside hack (supported client's local HS) as:
 * everyone gets a consistent view of the user's avatar
 * they get cached by mxc:// properly

autogenerated avatars have form mxc://.../...#auto