### PR TITLE
Application services exclusive flag support

### DIFF
--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -12,10 +12,9 @@ Servers which use captchas will need to add their public key to::
 This is required in order to support registration fallback (typically used on
 mobile devices).
 
-Servers which have registered application services need to upgrade their
-database as the format of stored application services has changed in Synapse.
-Run ``python upgrade_appservice_db.py <database file path>`` to convert to the
-new format.
+The format of stored application services has changed in Synapse. You will need
+to run ``python upgrade_appservice_db.py <database file path>`` to convert to 
+the new format.
 
 Upgrading to v0.7.0
 ===================

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -12,6 +12,11 @@ Servers which use captchas will need to add their public key to::
 This is required in order to support registration fallback (typically used on
 mobile devices).
 
+Servers which have registered application services need to upgrade their
+database as the format of stored application services has changed in Synapse.
+Run ``python upgrade_appservice_db.py <database file path>`` to convert to the
+new format.
+
 Upgrading to v0.7.0
 ===================
 

--- a/scripts/upgrade_appservice_db.py
+++ b/scripts/upgrade_appservice_db.py
@@ -1,17 +1,28 @@
+from synapse.storage import read_schema
 import argparse
 import json
 import sqlite3
 
 
-def main(dbname):
-    con = sqlite3.connect(dbname)
-    cur = con.cursor()
+def do_other_deltas(cursor):
+    cursor.execute("PRAGMA user_version")
+    row = cursor.fetchone()
+
+    if row and row[0]:
+        user_version = row[0]
+        # Run every version since after the current version.
+        for v in range(user_version + 1, 10):
+            print "Running delta: %d" % (v,)
+            sql_script = read_schema("delta/v%d" % (v,))
+            cursor.executescript(sql_script)
+
+
+def update_app_service_table(cur):
     cur.execute("SELECT id, regex FROM application_services_regex")
     for row in cur.fetchall():
         try:
             print "checking %s..." % row[0]
             json.loads(row[1])
-            print "Already in new format"
         except ValueError:
             # row isn't in json, make it so.
             string_regex = row[1]
@@ -23,13 +34,20 @@ def main(dbname):
                 "UPDATE application_services_regex SET regex=? WHERE id=?",
                 (new_regex, row[0])
             )
+
+
+def main(dbname):
+    con = sqlite3.connect(dbname)
+    cur = con.cursor()
+    do_other_deltas(cur)
+    update_app_service_table(cur)
+    cur.execute("PRAGMA user_version = 14")
     cur.close()
     con.commit()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-
     parser.add_argument("database")
     args = parser.parse_args()
 

--- a/scripts/upgrade_appservice_db.py
+++ b/scripts/upgrade_appservice_db.py
@@ -1,0 +1,36 @@
+import argparse
+import json
+import sqlite3
+
+
+def main(dbname):
+    con = sqlite3.connect(dbname)
+    cur = con.cursor()
+    cur.execute("SELECT id, regex FROM application_services_regex")
+    for row in cur.fetchall():
+        try:
+            print "checking %s..." % row[0]
+            json.loads(row[1])
+            print "Already in new format"
+        except ValueError:
+            # row isn't in json, make it so.
+            string_regex = row[1]
+            new_regex = json.dumps({
+                "regex": string_regex,
+                "exclusive": True
+            })
+            cur.execute(
+                "UPDATE application_services_regex SET regex=? WHERE id=?",
+                (new_regex, row[0])
+            )
+    cur.close()
+    con.commit()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("database")
+    args = parser.parse_args()
+
+    main(args.database)

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -73,7 +73,7 @@ class ApplicationService(object):
                     )
         return namespaces
 
-    def _matches_regex(self, test_string, namespace_key):
+    def _matches_regex(self, test_string, namespace_key, return_obj=False):
         if not isinstance(test_string, basestring):
             logger.error(
                 "Expected a string to test regex against, but got %s",
@@ -81,9 +81,17 @@ class ApplicationService(object):
             )
             return False
 
-        for regex in self.namespaces[namespace_key]:
-            if re.match(regex, test_string):
+        for regex_obj in self.namespaces[namespace_key]:
+            if re.match(regex_obj["regex"], test_string):
+                if return_obj:
+                    return regex_obj
                 return True
+        return False
+
+    def _is_exclusive(self, ns_key, test_string):
+        regex_obj = self._matches_regex(test_string, ns_key, return_obj=True)
+        if regex_obj:
+            return regex_obj["exclusive"]
         return False
 
     def _matches_user(self, event, member_list):
@@ -154,6 +162,15 @@ class ApplicationService(object):
 
     def is_interested_in_room(self, room_id):
         return self._matches_regex(room_id, ApplicationService.NS_ROOMS)
+
+    def is_exclusive_user(self, user_id):
+        return self._is_exclusive(ApplicationService.NS_USERS, user_id)
+
+    def is_exclusive_alias(self, alias):
+        return self._is_exclusive(ApplicationService.NS_ALIASES, alias)
+
+    def is_exclusive_room(self, room_id):
+        return self._is_exclusive(ApplicationService.NS_ROOMS, room_id)
 
     def __str__(self):
         return "ApplicationService: %s" % (self.__dict__,)

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -46,19 +46,31 @@ class ApplicationService(object):
     def _check_namespaces(self, namespaces):
         # Sanity check that it is of the form:
         # {
-        #   users: ["regex",...],
-        #   aliases: ["regex",...],
-        #   rooms: ["regex",...],
+        #   users: [ {regex: "[A-z]+.*", exclusive: true}, ...],
+        #   aliases: [ {regex: "[A-z]+.*", exclusive: true}, ...],
+        #   rooms: [ {regex: "[A-z]+.*", exclusive: true}, ...],
         # }
         if not namespaces:
             return None
 
         for ns in ApplicationService.NS_LIST:
+            if ns not in namespaces:
+                namespaces[ns] = []
+                continue
+
             if type(namespaces[ns]) != list:
-                raise ValueError("Bad namespace value for '%s'", ns)
-            for regex in namespaces[ns]:
-                if not isinstance(regex, basestring):
-                    raise ValueError("Expected string regex for ns '%s'", ns)
+                raise ValueError("Bad namespace value for '%s'" % ns)
+            for regex_obj in namespaces[ns]:
+                if not isinstance(regex_obj, dict):
+                    raise ValueError("Expected dict regex for ns '%s'" % ns)
+                if not isinstance(regex_obj.get("exclusive"), bool):
+                    raise ValueError(
+                        "Expected bool for 'exclusive' in ns '%s'" % ns
+                    )
+                if not isinstance(regex_obj.get("regex"), basestring):
+                    raise ValueError(
+                        "Expected string for 'regex' in ns '%s'" % ns
+                    )
         return namespaces
 
     def _matches_regex(self, test_string, namespace_key):

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -232,13 +232,23 @@ class DirectoryHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def can_modify_alias(self, alias, user_id=None):
+        # Any application service "interested" in an alias they are regexing on
+        # can modify the alias.
+        # Users can only modify the alias if ALL the interested services have
+        # non-exclusive locks on the alias (or there are no interested services)
         services = yield self.store.get_app_services()
         interested_services = [
             s for s in services if s.is_interested_in_alias(alias.to_string())
         ]
+
         for service in interested_services:
             if user_id == service.sender:
-                # this user IS the app service
+                # this user IS the app service so they can do whatever they like
                 defer.returnValue(True)
                 return
-        defer.returnValue(len(interested_services) == 0)
+            elif service.is_exclusive_alias(alias.to_string()):
+                # another service has an exclusive lock on this alias.
+                defer.returnValue(False)
+                return
+        # either no interested services, or no service with an exclusive lock
+        defer.returnValue(True)

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -201,11 +201,12 @@ class RegistrationHandler(BaseHandler):
         interested_services = [
             s for s in services if s.is_interested_in_user(user_id)
         ]
-        if len(interested_services) > 0:
-            raise SynapseError(
-                400, "This user ID is reserved by an application service.",
-                errcode=Codes.EXCLUSIVE
-            )
+        for service in interested_services:
+            if service.is_exclusive_user(user_id):
+                raise SynapseError(
+                    400, "This user ID is reserved by an application service.",
+                    errcode=Codes.EXCLUSIVE
+                )
 
     def _generate_token(self, user_id):
         # urlsafe variant uses _ and - so use . as the separator and replace

--- a/synapse/storage/__init__.py
+++ b/synapse/storage/__init__.py
@@ -74,7 +74,7 @@ SCHEMAS = [
 
 # Remember to update this number every time an incompatible change is made to
 # database schema files, so the users will be informed on server restarts.
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 dir_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/synapse/storage/appservice.py
+++ b/synapse/storage/appservice.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import simplejson
+from simplejson import JSONDecodeError
 from twisted.internet import defer
 
 from synapse.api.errors import StoreError
@@ -23,12 +25,18 @@ from ._base import SQLBaseStore
 logger = logging.getLogger(__name__)
 
 
+def log_failure(failure):
+    logger.error("Failed to detect application services: %s", failure.value)
+    logger.error(failure.getTraceback())
+
+
 class ApplicationServiceStore(SQLBaseStore):
 
     def __init__(self, hs):
         super(ApplicationServiceStore, self).__init__(hs)
         self.services_cache = []
         self.cache_defer = self._populate_cache()
+        self.cache_defer.addErrback(log_failure)
 
     @defer.inlineCallbacks
     def unregister_app_service(self, token):
@@ -128,11 +136,11 @@ class ApplicationServiceStore(SQLBaseStore):
         )
         for (ns_int, ns_str) in enumerate(ApplicationService.NS_LIST):
             if ns_str in service.namespaces:
-                for regex in service.namespaces[ns_str]:
+                for regex_obj in service.namespaces[ns_str]:
                     txn.execute(
                         "INSERT INTO application_services_regex("
                         "as_id, namespace, regex) values(?,?,?)",
-                        (as_id, ns_int, regex)
+                        (as_id, ns_int, simplejson.dumps(regex_obj))
                     )
         return True
 
@@ -215,10 +223,12 @@ class ApplicationServiceStore(SQLBaseStore):
             try:
                 services[as_token]["namespaces"][
                     ApplicationService.NS_LIST[ns_int]].append(
-                    res["regex"]
+                    simplejson.loads(res["regex"])
                 )
             except IndexError:
                 logger.error("Bad namespace enum '%s'. %s", ns_int, res)
+            except JSONDecodeError:
+                logger.error("Bad regex object '%s'", res["regex"])
 
         # TODO get last successful txn id f.e. service
         for service in services.values():

--- a/tests/appservice/test_appservice.py
+++ b/tests/appservice/test_appservice.py
@@ -18,6 +18,13 @@ from mock import Mock, PropertyMock
 from tests import unittest
 
 
+def _regex(regex, exclusive=True):
+    return {
+        "regex": regex,
+        exclusive: exclusive
+    }
+
+
 class ApplicationServiceTestCase(unittest.TestCase):
 
     def setUp(self):
@@ -36,21 +43,21 @@ class ApplicationServiceTestCase(unittest.TestCase):
 
     def test_regex_user_id_prefix_match(self):
         self.service.namespaces[ApplicationService.NS_USERS].append(
-            "@irc_.*"
+            _regex("@irc_.*")
         )
         self.event.sender = "@irc_foobar:matrix.org"
         self.assertTrue(self.service.is_interested(self.event))
 
     def test_regex_user_id_prefix_no_match(self):
         self.service.namespaces[ApplicationService.NS_USERS].append(
-            "@irc_.*"
+            _regex("@irc_.*")
         )
         self.event.sender = "@someone_else:matrix.org"
         self.assertFalse(self.service.is_interested(self.event))
 
     def test_regex_room_member_is_checked(self):
         self.service.namespaces[ApplicationService.NS_USERS].append(
-            "@irc_.*"
+            _regex("@irc_.*")
         )
         self.event.sender = "@someone_else:matrix.org"
         self.event.type = "m.room.member"
@@ -59,21 +66,21 @@ class ApplicationServiceTestCase(unittest.TestCase):
 
     def test_regex_room_id_match(self):
         self.service.namespaces[ApplicationService.NS_ROOMS].append(
-            "!some_prefix.*some_suffix:matrix.org"
+            _regex("!some_prefix.*some_suffix:matrix.org")
         )
         self.event.room_id = "!some_prefixs0m3th1nGsome_suffix:matrix.org"
         self.assertTrue(self.service.is_interested(self.event))
 
     def test_regex_room_id_no_match(self):
         self.service.namespaces[ApplicationService.NS_ROOMS].append(
-            "!some_prefix.*some_suffix:matrix.org"
+            _regex("!some_prefix.*some_suffix:matrix.org")
         )
         self.event.room_id = "!XqBunHwQIXUiqCaoxq:matrix.org"
         self.assertFalse(self.service.is_interested(self.event))
 
     def test_regex_alias_match(self):
         self.service.namespaces[ApplicationService.NS_ALIASES].append(
-            "#irc_.*:matrix.org"
+            _regex("#irc_.*:matrix.org")
         )
         self.assertTrue(self.service.is_interested(
             self.event,
@@ -82,7 +89,7 @@ class ApplicationServiceTestCase(unittest.TestCase):
 
     def test_regex_alias_no_match(self):
         self.service.namespaces[ApplicationService.NS_ALIASES].append(
-            "#irc_.*:matrix.org"
+            _regex("#irc_.*:matrix.org")
         )
         self.assertFalse(self.service.is_interested(
             self.event,
@@ -91,10 +98,10 @@ class ApplicationServiceTestCase(unittest.TestCase):
 
     def test_regex_multiple_matches(self):
         self.service.namespaces[ApplicationService.NS_ALIASES].append(
-            "#irc_.*:matrix.org"
+            _regex("#irc_.*:matrix.org")
         )
         self.service.namespaces[ApplicationService.NS_USERS].append(
-            "@irc_.*"
+            _regex("@irc_.*")
         )
         self.event.sender = "@irc_foobar:matrix.org"
         self.assertTrue(self.service.is_interested(
@@ -104,10 +111,10 @@ class ApplicationServiceTestCase(unittest.TestCase):
 
     def test_restrict_to_rooms(self):
         self.service.namespaces[ApplicationService.NS_ROOMS].append(
-            "!flibble_.*:matrix.org"
+            _regex("!flibble_.*:matrix.org")
         )
         self.service.namespaces[ApplicationService.NS_USERS].append(
-            "@irc_.*"
+            _regex("@irc_.*")
         )
         self.event.sender = "@irc_foobar:matrix.org"
         self.event.room_id = "!wibblewoo:matrix.org"
@@ -118,10 +125,10 @@ class ApplicationServiceTestCase(unittest.TestCase):
 
     def test_restrict_to_aliases(self):
         self.service.namespaces[ApplicationService.NS_ALIASES].append(
-            "#xmpp_.*:matrix.org"
+            _regex("#xmpp_.*:matrix.org")
         )
         self.service.namespaces[ApplicationService.NS_USERS].append(
-            "@irc_.*"
+            _regex("@irc_.*")
         )
         self.event.sender = "@irc_foobar:matrix.org"
         self.assertFalse(self.service.is_interested(
@@ -132,10 +139,10 @@ class ApplicationServiceTestCase(unittest.TestCase):
 
     def test_restrict_to_senders(self):
         self.service.namespaces[ApplicationService.NS_ALIASES].append(
-            "#xmpp_.*:matrix.org"
+            _regex("#xmpp_.*:matrix.org")
         )
         self.service.namespaces[ApplicationService.NS_USERS].append(
-            "@irc_.*"
+            _regex("@irc_.*")
         )
         self.event.sender = "@xmpp_foobar:matrix.org"
         self.assertFalse(self.service.is_interested(
@@ -146,7 +153,7 @@ class ApplicationServiceTestCase(unittest.TestCase):
 
     def test_member_list_match(self):
         self.service.namespaces[ApplicationService.NS_USERS].append(
-            "@irc_.*"
+            _regex("@irc_.*")
         )
         join_list = [
             Mock(

--- a/tests/appservice/test_appservice.py
+++ b/tests/appservice/test_appservice.py
@@ -21,7 +21,7 @@ from tests import unittest
 def _regex(regex, exclusive=True):
     return {
         "regex": regex,
-        exclusive: exclusive
+        "exclusive": exclusive
     }
 
 
@@ -85,6 +85,54 @@ class ApplicationServiceTestCase(unittest.TestCase):
         self.assertTrue(self.service.is_interested(
             self.event,
             aliases_for_event=["#irc_foobar:matrix.org", "#athing:matrix.org"]
+        ))
+
+    def test_non_exclusive_alias(self):
+        self.service.namespaces[ApplicationService.NS_ALIASES].append(
+            _regex("#irc_.*:matrix.org", exclusive=False)
+        )
+        self.assertFalse(self.service.is_exclusive_alias(
+            "#irc_foobar:matrix.org"
+        ))
+
+    def test_non_exclusive_room(self):
+        self.service.namespaces[ApplicationService.NS_ROOMS].append(
+            _regex("!irc_.*:matrix.org", exclusive=False)
+        )
+        self.assertFalse(self.service.is_exclusive_room(
+            "!irc_foobar:matrix.org"
+        ))
+
+    def test_non_exclusive_user(self):
+        self.service.namespaces[ApplicationService.NS_USERS].append(
+            _regex("@irc_.*:matrix.org", exclusive=False)
+        )
+        self.assertFalse(self.service.is_exclusive_user(
+            "@irc_foobar:matrix.org"
+        ))
+
+    def test_exclusive_alias(self):
+        self.service.namespaces[ApplicationService.NS_ALIASES].append(
+            _regex("#irc_.*:matrix.org", exclusive=True)
+        )
+        self.assertTrue(self.service.is_exclusive_alias(
+            "#irc_foobar:matrix.org"
+        ))
+
+    def test_exclusive_user(self):
+        self.service.namespaces[ApplicationService.NS_USERS].append(
+            _regex("@irc_.*:matrix.org", exclusive=True)
+        )
+        self.assertTrue(self.service.is_exclusive_user(
+            "@irc_foobar:matrix.org"
+        ))
+
+    def test_exclusive_room(self):
+        self.service.namespaces[ApplicationService.NS_ROOMS].append(
+            _regex("!irc_.*:matrix.org", exclusive=True)
+        )
+        self.assertTrue(self.service.is_exclusive_room(
+            "!irc_foobar:matrix.org"
         ))
 
     def test_regex_alias_no_match(self):

--- a/tests/storage/test_appservice.py
+++ b/tests/storage/test_appservice.py
@@ -50,9 +50,15 @@ class ApplicationServiceStoreTestCase(unittest.TestCase):
     def test_update_and_retrieval_of_service(self):
         url = "https://matrix.org/appservices/foobar"
         hs_token = "hstok"
-        user_regex = ["@foobar_.*:matrix.org"]
-        alias_regex = ["#foobar_.*:matrix.org"]
-        room_regex = []
+        user_regex = [
+            {"regex": "@foobar_.*:matrix.org", "exclusive": True}
+        ]
+        alias_regex = [
+            {"regex": "#foobar_.*:matrix.org", "exclusive": True}
+        ]
+        room_regex = [
+
+        ]
         service = ApplicationService(
             url=url, hs_token=hs_token, token=self.as_token, namespaces={
                 ApplicationService.NS_USERS: user_regex,

--- a/tests/storage/test_appservice.py
+++ b/tests/storage/test_appservice.py
@@ -54,7 +54,7 @@ class ApplicationServiceStoreTestCase(unittest.TestCase):
             {"regex": "@foobar_.*:matrix.org", "exclusive": True}
         ]
         alias_regex = [
-            {"regex": "#foobar_.*:matrix.org", "exclusive": True}
+            {"regex": "#foobar_.*:matrix.org", "exclusive": False}
         ]
         room_regex = [
 


### PR DESCRIPTION
Up until now, all application services (AS) had "exclusive" control over the room aliases and user IDs they specified. This meant that no other user could create a room alias / user ID which matched the AS regex. This was troublesome for ASes that, for example, simply wanted to passively monitor content in certain room aliases. This PR fixes this by introducing a flag on the regex to indicate if it is ``exclusive`` or not.

In keeping with the [spec](http://matrix.org/docs/spec/#registration-api), the AS registration API has been changed. This change is a breaking change: ASes will need to use the new format in order to register successfully. Furthermore, Synapse will become unable to correctly parse the older format in the database for existing ``application_services_regex``, leading to any existing ASes not being sent events on upgrade.