### PR TITLE
Process transactions serially.

### DIFF
--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -117,16 +117,12 @@ class FederationServer(FederationBase):
             for pdu in pdu_list:
                 d = self._handle_new_pdu(transaction.origin, pdu)
 
-                def handle_failure(failure):
-                    failure.trap(FederationError)
-                    self.send_failure(failure.value, transaction.origin)
-                    return failure
-
-                d.addErrback(handle_failure)
-
                 try:
                     yield d
                     results.append({})
+                except FederationError as e:
+                    self.send_failure(e, transaction.origin)
+                    results.append({"error": str(e)})
                 except Exception as e:
                     results.append({"error": str(e)})
 


### PR DESCRIPTION
Since the events received in a transaction are ordered, later events
might depend on earlier events and so we shouldn't blindly process them
in parellel.