### PR TITLE
Neaten federation servlets

### DIFF
--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -161,7 +161,7 @@ class BaseFederationServlet(object):
         return new_code
 
     def register(self, server):
-        pattern = re.compile("^" + PREFIX + self.PATH)
+        pattern = re.compile("^" + PREFIX + self.PATH + "$")
 
         for method in ("GET", "PUT", "POST"):
             code = getattr(self, "on_%s" % (method), None)
@@ -172,7 +172,7 @@ class BaseFederationServlet(object):
 
 
 class FederationSendServlet(BaseFederationServlet):
-    PATH = "/send/([^/]*)/$"
+    PATH = "/send/([^/]*)/"
 
     def __init__(self, handler, server_name, **kwargs):
         super(FederationSendServlet, self).__init__(handler, **kwargs)
@@ -229,7 +229,7 @@ class FederationSendServlet(BaseFederationServlet):
 
 
 class FederationPullServlet(BaseFederationServlet):
-    PATH = "/pull/$"
+    PATH = "/pull/"
 
     # This is for when someone asks us for everything since version X
     def on_GET(self, origin, content, query):
@@ -237,7 +237,7 @@ class FederationPullServlet(BaseFederationServlet):
 
 
 class FederationEventServlet(BaseFederationServlet):
-    PATH = "/event/([^/]*)/$"
+    PATH = "/event/([^/]*)/"
 
     # This is when someone asks for a data item for a given server data_id pair.
     def on_GET(self, origin, content, query, event_id):
@@ -245,7 +245,7 @@ class FederationEventServlet(BaseFederationServlet):
 
 
 class FederationStateServlet(BaseFederationServlet):
-    PATH = "/state/([^/]*)/$"
+    PATH = "/state/([^/]*)/"
 
     # This is when someone asks for all data for a given context.
     def on_GET(self, origin, content, query, context):
@@ -255,7 +255,7 @@ class FederationStateServlet(BaseFederationServlet):
 
 
 class FederationBackfillServlet(BaseFederationServlet):
-    PATH = "/backfill/([^/]*)/$"
+    PATH = "/backfill/([^/]*)/"
 
     def on_GET(self, origin, content, query, context):
         versions = query["v"]
@@ -270,7 +270,7 @@ class FederationBackfillServlet(BaseFederationServlet):
 
 
 class FederationQueryServlet(BaseFederationServlet):
-    PATH = "/query/([^/]*)$"
+    PATH = "/query/([^/]*)"
 
     # This is when we receive a server-server Query
     def on_GET(self, origin, content, query, query_type):
@@ -280,7 +280,7 @@ class FederationQueryServlet(BaseFederationServlet):
 
 
 class FederationMakeJoinServlet(BaseFederationServlet):
-    PATH = "/make_join/([^/]*)/([^/]*)$"
+    PATH = "/make_join/([^/]*)/([^/]*)"
 
     @defer.inlineCallbacks
     def on_GET(self, origin, content, query, context, user_id):
@@ -289,14 +289,14 @@ class FederationMakeJoinServlet(BaseFederationServlet):
 
 
 class FederationEventAuthServlet(BaseFederationServlet):
-    PATH = "/event_auth/([^/]*)/([^/]*)$"
+    PATH = "/event_auth/([^/]*)/([^/]*)"
 
     def on_GET(self, origin, content, query, context, event_id):
         return self.handler.on_event_auth(origin, context, event_id)
 
 
 class FederationSendJoinServlet(BaseFederationServlet):
-    PATH = "/send_join/([^/]*)/([^/]*)$"
+    PATH = "/send_join/([^/]*)/([^/]*)"
 
     @defer.inlineCallbacks
     def on_PUT(self, origin, content, query, context, event_id):
@@ -307,7 +307,7 @@ class FederationSendJoinServlet(BaseFederationServlet):
 
 
 class FederationInviteServlet(BaseFederationServlet):
-    PATH = "/invite/([^/]*)/([^/]*)$"
+    PATH = "/invite/([^/]*)/([^/]*)"
 
     @defer.inlineCallbacks
     def on_PUT(self, origin, content, query, context, event_id):
@@ -318,7 +318,7 @@ class FederationInviteServlet(BaseFederationServlet):
 
 
 class FederationQueryAuthServlet(BaseFederationServlet):
-    PATH = "/query_auth/([^/]*)/([^/]*)$"
+    PATH = "/query_auth/([^/]*)/([^/]*)"
 
     @defer.inlineCallbacks
     def on_POST(self, origin, content, query, context, event_id):
@@ -330,7 +330,8 @@ class FederationQueryAuthServlet(BaseFederationServlet):
 
 
 class FederationGetMissingEventsServlet(BaseFederationServlet):
-    PATH = "/get_missing_events/([^/]*)/?$"
+    # TODO(paul): Why does this path alone end with "/?" optional?
+    PATH = "/get_missing_events/([^/]*)/?"
 
     @defer.inlineCallbacks
     def on_POST(self, origin, content, query, room_id):

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -102,7 +102,8 @@ class TransportLayerServer(object):
         Args:
             handler (TransportReceivedHandler)
         """
-        FederationSendServlet(handler,
+        FederationSendServlet(
+            handler,
             authenticator=self,
             ratelimiter=self.ratelimiter,
             server_name=self.server_name,
@@ -115,20 +116,9 @@ class TransportLayerServer(object):
         Args:
             handler (TransportRequestHandler)
         """
-        for servletclass in (
-                FederationPullServlet,
-                FederationEventServlet,
-                FederationStateServlet,
-                FederationBackfillServlet,
-                FederationQueryServlet,
-                FederationMakeJoinServlet,
-                FederationEventServlet,
-                FederationSendJoinServlet,
-                FederationInviteServlet,
-                FederationQueryAuthServlet,
-                FederationGetMissingEventsServlet,
-            ):
-            servletclass(handler,
+        for servletclass in SERVLET_CLASSES:
+            servletclass(
+                handler,
                 authenticator=self,
                 ratelimiter=self.ratelimiter,
             ).register(self.server)
@@ -138,11 +128,11 @@ class BaseFederationServlet(object):
     def __init__(self, handler, authenticator, ratelimiter):
         self.handler = handler
         self.authenticator = authenticator
-        self.ratelimiter   = ratelimiter
+        self.ratelimiter = ratelimiter
 
     def _wrap(self, code):
         authenticator = self.authenticator
-        ratelimiter   = self.ratelimiter
+        ratelimiter = self.ratelimiter
 
         @defer.inlineCallbacks
         @functools.wraps(code)
@@ -249,7 +239,9 @@ class FederationStateServlet(BaseFederationServlet):
 
     # This is when someone asks for all data for a given context.
     def on_GET(self, origin, content, query, context):
-        return self.handler.on_context_state_request(origin, context,
+        return self.handler.on_context_state_request(
+            origin,
+            context,
             query.get("event_id", [None])[0],
         )
 
@@ -274,7 +266,8 @@ class FederationQueryServlet(BaseFederationServlet):
 
     # This is when we receive a server-server Query
     def on_GET(self, origin, content, query, query_type):
-        return self.handler.on_query_request(query_type,
+        return self.handler.on_query_request(
+            query_type,
             {k: v[0].decode("utf-8") for k, v in query.items()}
         )
 
@@ -350,3 +343,18 @@ class FederationGetMissingEventsServlet(BaseFederationServlet):
         )
 
         defer.returnValue((200, content))
+
+
+SERVLET_CLASSES = (
+    FederationPullServlet,
+    FederationEventServlet,
+    FederationStateServlet,
+    FederationBackfillServlet,
+    FederationQueryServlet,
+    FederationMakeJoinServlet,
+    FederationEventServlet,
+    FederationSendJoinServlet,
+    FederationInviteServlet,
+    FederationQueryAuthServlet,
+    FederationGetMissingEventsServlet,
+)

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -109,12 +109,6 @@ class TransportLayerServer(object):
             defer.returnValue(response)
         return new_handler
 
-    def rate_limit_origin(self, handler):
-        def new_handler(origin, *args, **kwargs):
-            response = yield handler(origin, *args, **kwargs)
-            defer.returnValue(response)
-        return new_handler()
-
     @log_function
     def register_received_handler(self, handler):
         """ Register a handler that will be fired when we receive data.


### PR DESCRIPTION
This series of commits neatens up the way federation's TransportLayerServer registers its actual HTTP path handling code. It moves all the code from being bodies of anonymous lambdas, to being the bodies of methods of Servlet-named classes, similar to the way the client REST API works.

Primarily this makes the code a little shorter and neater to read, as it un-indents the body of the functions a few layers. But also it means that now every callback registered on the HTTP server is definitely a method of an instance of a sensibly-named class. This will have useful properties for adding automatic logging/metrics to the HTTP server to track requests/responses/times per responder class.