### PR TITLE
Improve get event cache

### DIFF
--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -46,9 +46,10 @@ def _event_dict_property(key):
 
 class EventBase(object):
     def __init__(self, event_dict, signatures={}, unsigned={},
-                 internal_metadata_dict={}):
+                 internal_metadata_dict={}, rejected_reason=None):
         self.signatures = signatures
         self.unsigned = unsigned
+        self.rejected_reason = rejected_reason
 
         self._event_dict = event_dict
 
@@ -109,7 +110,7 @@ class EventBase(object):
 
 
 class FrozenEvent(EventBase):
-    def __init__(self, event_dict, internal_metadata_dict={}):
+    def __init__(self, event_dict, internal_metadata_dict={}, rejected_reason=None):
         event_dict = dict(event_dict)
 
         # Signatures is a dict of dicts, and this is faster than doing a
@@ -128,6 +129,7 @@ class FrozenEvent(EventBase):
             signatures=signatures,
             unsigned=unsigned,
             internal_metadata_dict=internal_metadata_dict,
+            rejected_reason=rejected_reason,
         )
 
     @staticmethod

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -733,7 +733,8 @@ class SQLBaseStore(object):
     def _invalidate_get_event_cache(self, event_id):
         for check_redacted in (False, True):
             for get_prev_content in (False, True):
-                self._get_event_cache.invalidate(event_id, check_redacted, get_prev_content)
+                self._get_event_cache.invalidate(event_id, check_redacted,
+                                                 get_prev_content)
 
     def _get_event_txn(self, txn, event_id, check_redacted=True,
                        get_prev_content=False, allow_rejected=False):

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -732,6 +732,9 @@ class SQLBaseStore(object):
 
         return [e for e in events if e]
 
+    def _invalidate_get_event_cache(self, event_id):
+        self._get_event_cache.pop(event_id)
+
     def _get_event_txn(self, txn, event_id, check_redacted=True,
                        get_prev_content=False, allow_rejected=False):
 

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -784,6 +784,7 @@ class SQLBaseStore(object):
                 txn, internal_metadata, js, redacted,
                 check_redacted=check_redacted,
                 get_prev_content=get_prev_content,
+                rejected_reason=rejected_reason,
             )
             cache[(check_redacted, get_prev_content, allow_rejected)] = result
             return result
@@ -791,7 +792,8 @@ class SQLBaseStore(object):
             return None
 
     def _get_event_from_row_txn(self, txn, internal_metadata, js, redacted,
-                                check_redacted=True, get_prev_content=False):
+                                check_redacted=True, get_prev_content=False,
+                                rejected_reason=None):
 
         start_time = time.time() * 1000
 
@@ -806,7 +808,11 @@ class SQLBaseStore(object):
         internal_metadata = json.loads(internal_metadata)
         start_time = update_counter("decode_internal", start_time)
 
-        ev = FrozenEvent(d, internal_metadata_dict=internal_metadata)
+        ev = FrozenEvent(
+            d,
+            internal_metadata_dict=internal_metadata,
+            rejected_reason=rejected_reason,
+        )
         start_time = update_counter("build_frozen_event", start_time)
 
         if check_redacted and redacted:

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -94,7 +94,7 @@ class EventsStore(SQLBaseStore):
                            current_state=None):
 
         # Remove the any existing cache entries for the event_id
-        self._get_event_cache.pop(event.event_id)
+        self._invalidate_get_event_cache(event.event_id)
 
         # We purposefully do this first since if we include a `current_state`
         # key, we *want* to update the `current_state_events` table
@@ -356,7 +356,7 @@ class EventsStore(SQLBaseStore):
 
     def _store_redaction(self, txn, event):
         # invalidate the cache for the redacted event
-        self._get_event_cache.pop(event.redacts)
+        self._invalidate_get_event_cache(event.redacts)
         txn.execute(
             "INSERT INTO redactions (event_id, redacts) VALUES (?,?)",
             (event.event_id, event.redacts)


### PR DESCRIPTION
 * Implement the main getEvent cache using Cache() instead of a custom application of LruCache. This simplifies code logic.

 * Unify its two-level structure into just one, so that the size (of the outer) is actually a more meaningful measure, instead of letting each element contain up to 8 sub-elements "invisibly".

 * Don't use the "allow_redacted" condition as a cache key, instead implement the test after fetching the FrozenEvent. This halves the number of potential keys and improves cache usage.

After this change, the size limits might need to be increased as now the toplevel object count will be higher.