### PR TITLE
contrib/systemd: add a sample systemd unit file and a logger configuration

### DIFF
--- a/contrib/systemd/log_config.yaml
+++ b/contrib/systemd/log_config.yaml
@@ -1,0 +1,23 @@
+version: 1
+
+# In systemd's journal, loglevel is implicitly stored, so let's omit it
+# from the message text.
+formatters:
+    journal_fmt:
+        format: '%(name)s: [%(request)s] %(message)s'
+
+filters:
+    context:
+        (): synapse.util.logcontext.LoggingContextFilter
+        request: ""
+
+handlers:
+    journal:
+        class: systemd.journal.JournalHandler
+        formatter: journal_fmt
+        filters: [context]
+        SYSLOG_IDENTIFIER: synapse
+
+root:
+    level: INFO
+    handlers: [journal]

--- a/contrib/systemd/synapse.service
+++ b/contrib/systemd/synapse.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Synapse Matrix homeserver
+
+[Service]
+Type=simple
+User=synapse
+Group=synapse
+WorkingDirectory=/var/lib/synapse
+ExecStart=/usr/bin/python2.7 -m synapse.app.homeserver --config-path=/etc/synapse/homeserver.yaml --log-config=/etc/synapse/log_config.yaml
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds:
* a sample systemd unit file suitable for running a system-wide installation of Synapse;
* a python logging configuration file which redirects all messages into systemd's journal.