### PR TITLE
Config restructuring.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ traditionally used for convenience and simplicity.
 
 The advantages of Postgres include:
 
- * significant performannce improvements due to the superior threading and
+ * significant performance improvements due to the superior threading and
    caching model, smarter query optimiser
  * allowing the DB to be run on separate hardware
  * allowing basic active/backup high-availability with a "hot spare" synapse

--- a/README.rst
+++ b/README.rst
@@ -318,7 +318,7 @@ ArchLinux
 If running `$ synctl start` fails with 'returned non-zero exit status 1',
 you will need to explicitly call Python2.7 - either running as::
 
-    $ python2.7 -m synapse.app.homeserver --daemonize -c homeserver.yaml --pid-file homeserver.pid
+    $ python2.7 -m synapse.app.homeserver --daemonize -c homeserver.yaml
     
 ...or by editing synctl with the correct python executable.
 

--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ traditionally used for convenience and simplicity.
 
 The advantages of Postgres include:
 
- * significant performance improvements due to the superior threading and
+ * significant performannce improvements due to the superior threading and
    caching model, smarter query optimiser
  * allowing the DB to be run on separate hardware
  * allowing basic active/backup high-availability with a "hot spare" synapse
@@ -409,7 +409,6 @@ SRV record, as that is the name other machines will expect it to have::
 
     $ python -m synapse.app.homeserver \
         --server-name YOURDOMAIN \
-        --bind-port 8448 \
         --config-path homeserver.yaml \
         --generate-config
     $ python -m synapse.app.homeserver --config-path homeserver.yaml

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -26,9 +26,9 @@ for port in 8080 8081 8082; do
 
     https_port=$((port + 400))
     mkdir -p demo/$port
-    pushd demo/$port
+#    pushd demo/$port
 
-    rm $DIR/etc/$port.config
+    #rm $DIR/etc/$port.config
     python -m synapse.app.homeserver \
         --generate-config \
         -H "localhost:$https_port" \
@@ -39,7 +39,7 @@ for port in 8080 8081 8082; do
         -D \
         -vv \
 
-    popd
+ #   popd
 done
 
 cd "$CWD"

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -26,7 +26,7 @@ for port in 8080 8081 8082; do
 
     https_port=$((port + 400))
     mkdir -p demo/$port
-#    pushd demo/$port
+    pushd demo/$port
 
     #rm $DIR/etc/$port.config
     python -m synapse.app.homeserver \
@@ -39,7 +39,7 @@ for port in 8080 8081 8082; do
         -D \
         -vv \
 
- #   popd
+    popd
 done
 
 cd "$CWD"

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -30,7 +30,8 @@ for port in 8080 8081 8082; do
 
     rm $DIR/etc/$port.config
     python -m synapse.app.homeserver \
-        --generate-config "localhost:$https_port" \
+        --generate-config \
+        -H "localhost:$https_port" \
         --config-path "$DIR/etc/$port.config" \
 
     python -m synapse.app.homeserver \

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -16,30 +16,29 @@ if [ $# -eq 1 ]; then
     fi
 fi
 
+export PYTHONPATH=$(readlink -f $(pwd))
+
+
+echo $PYTHONPATH
+
 for port in 8080 8081 8082; do
     echo "Starting server on port $port... "
 
     https_port=$((port + 400))
+    mkdir -p demo/$port
+    pushd demo/$port
+
+    rm $DIR/etc/$port.config
+    python -m synapse.app.homeserver \
+        --generate-config "localhost:$https_port" \
+        --config-path "$DIR/etc/$port.config" \
 
     python -m synapse.app.homeserver \
-        --generate-config \
-        --config-path "demo/etc/$port.config" \
-        -p "$https_port" \
-        --unsecure-port "$port" \
-        -H "localhost:$https_port" \
-        -f "$DIR/$port.log" \
-        -d "$DIR/$port.db" \
-        -D --pid-file "$DIR/$port.pid" \
-        --manhole $((port + 1000)) \
-        --tls-dh-params-path "demo/demo.tls.dh" \
-        --media-store-path "demo/media_store.$port" \
-        $PARAMS $SYNAPSE_PARAMS \
-        --enable-registration
-
-    python -m synapse.app.homeserver \
-        --config-path "demo/etc/$port.config" \
+        --config-path "$DIR/etc/$port.config" \
+        -D \
         -vv \
 
+    popd
 done
 
 cd "$CWD"

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -406,7 +406,6 @@ def setup(config_options):
         redirect_root_to_web_client=True,
     )
 
-
     logger.info("Preparing database: %r...", config.database_config)
 
     try:

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -394,7 +394,6 @@ def setup(config_options):
         config.server_name,
         domain_with_port=domain_with_port,
         upload_dir=os.path.abspath("uploads"),
-        db_name=config.database_path,
         db_config=config.database_config,
         tls_context_factory=tls_context_factory,
         config=config,
@@ -407,9 +406,8 @@ def setup(config_options):
         redirect_root_to_web_client=True,
     )
 
-    db_name = hs.get_db_name()
 
-    logger.info("Preparing database: %s...", db_name)
+    logger.info("Preparing database: %r...", config.database_config)
 
     try:
         db_conn = database_engine.module.connect(
@@ -431,7 +429,7 @@ def setup(config_options):
         )
         sys.exit(1)
 
-    logger.info("Database prepared in %s.", db_name)
+    logger.info("Database prepared in %r.", config.database_config)
 
     if config.manhole:
         f = twisted.manhole.telnet.ShellFactory()

--- a/synapse/app/synctl.py
+++ b/synapse/app/synctl.py
@@ -18,6 +18,7 @@ import sys
 import os
 import subprocess
 import signal
+import yaml
 
 SYNAPSE = ["python", "-B", "-m", "synapse.app.homeserver"]
 
@@ -28,6 +29,7 @@ NORMAL = "\x1b[m"
 
 CONFIG = yaml.load(open(CONFIGFILE))
 PIDFILE = CONFIG["pid_file"]
+
 
 def start():
     if not os.path.exists(CONFIGFILE):

--- a/synapse/app/synctl.py
+++ b/synapse/app/synctl.py
@@ -22,11 +22,12 @@ import signal
 SYNAPSE = ["python", "-B", "-m", "synapse.app.homeserver"]
 
 CONFIGFILE = "homeserver.yaml"
-PIDFILE = "homeserver.pid"
 
 GREEN = "\x1b[1;32m"
 NORMAL = "\x1b[m"
 
+CONFIG = yaml.load(open(CONFIGFILE))
+PIDFILE = CONFIG["pid_file"]
 
 def start():
     if not os.path.exists(CONFIGFILE):
@@ -40,7 +41,7 @@ def start():
         sys.exit(1)
     print "Starting ...",
     args = SYNAPSE
-    args.extend(["--daemonize", "-c", CONFIGFILE, "--pid-file", PIDFILE])
+    args.extend(["--daemonize", "-c", CONFIGFILE])
     subprocess.check_call(args)
     print GREEN + "started" + NORMAL
 

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -27,30 +27,33 @@ class ConfigError(Exception):
 class Config(object):
 
     @staticmethod
-    def parse_size(string):
+    def parse_size(value):
+        if isinstance(value, int) or isinstance(value, long):
+            return value
         sizes = {"K": 1024, "M": 1024 * 1024}
         size = 1
-        suffix = string[-1]
+        suffix = value[-1]
         if suffix in sizes:
-            string = string[:-1]
+            value = value[:-1]
             size = sizes[suffix]
-        return int(string) * size
+        return int(value) * size
 
     @staticmethod
-    def parse_duration(string):
+    def parse_duration(value):
+        if isinstance(value, int) or isinstance(value, long):
+            return value
         second = 1000
         hour = 60 * 60 * second
         day = 24 * hour
         week = 7 * day
         year = 365 * day
-
         sizes = {"s": second, "h": hour, "d": day, "w": week, "y": year}
         size = 1
-        suffix = string[-1]
+        suffix = value[-1]
         if suffix in sizes:
-            string = string[:-1]
+            value = value[:-1]
             size = sizes[suffix]
-        return int(string) * size
+        return int(value) * size
 
     @staticmethod
     def abspath(file_path):

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -171,7 +171,7 @@ class Config(object):
                 config_bytes, config = obj.generate_config(
                     config_dir_path, server_name
                 )
-                obj.invoke_all("generate_keys", config)
+                obj.invoke_all("generate_files", config)
                 config_file.write(config_bytes)
             print (
                 "A config file has been generated in %s for server name"
@@ -192,6 +192,7 @@ class Config(object):
 
         server_name = specified_config["server_name"]
         _, config = obj.generate_config(config_dir_path, server_name)
+        config.pop("log_config")
         config.update(specified_config)
 
         obj.invoke_all("read_config", config)

--- a/synapse/config/appservice.py
+++ b/synapse/config/appservice.py
@@ -17,15 +17,11 @@ from ._base import Config
 
 class AppServiceConfig(Config):
 
-    def __init__(self, args):
-        super(AppServiceConfig, self).__init__(args)
-        self.app_service_config_files = args.app_service_config_files
+    def read_config(self, config):
+        self.app_service_config_files = config.get("app_service_config_files", [])
 
-    @classmethod
-    def add_arguments(cls, parser):
-        super(AppServiceConfig, cls).add_arguments(parser)
-        group = parser.add_argument_group("appservice")
-        group.add_argument(
-            "--app-service-config-files", type=str, nargs='+',
-            help="A list of application service config files to use."
-        )
+    def default_config(cls, config_dir_path, server_name):
+        return """\
+        # A list of application service config file to use
+        app_service_config_files: []
+        """

--- a/synapse/config/captcha.py
+++ b/synapse/config/captcha.py
@@ -47,5 +47,5 @@ class CaptchaConfig(Config):
         captcha_ip_origin_is_x_forwarded: False
 
         # A secret key used to bypass the captcha test entirely.
-        captcha_bypass_secret: ~
+        #captcha_bypass_secret: "YOUR_SECRET_HERE"
         """

--- a/synapse/config/captcha.py
+++ b/synapse/config/captcha.py
@@ -17,40 +17,34 @@ from ._base import Config
 
 class CaptchaConfig(Config):
 
-    def __init__(self, args):
-        super(CaptchaConfig, self).__init__(args)
-        self.recaptcha_private_key = args.recaptcha_private_key
-        self.recaptcha_public_key = args.recaptcha_public_key
-        self.enable_registration_captcha = args.enable_registration_captcha
+    def read_config(self, config):
+        self.recaptcha_private_key = config["recaptcha_private_key"]
+        self.recaptcha_public_key = config["recaptcha_public_key"]
+        self.enable_registration_captcha = config["enable_registration_captcha"]
         self.captcha_ip_origin_is_x_forwarded = (
-            args.captcha_ip_origin_is_x_forwarded
+            config["captcha_ip_origin_is_x_forwarded"]
         )
-        self.captcha_bypass_secret = args.captcha_bypass_secret
+        self.captcha_bypass_secret = config.get("captcha_bypass_secret")
 
-    @classmethod
-    def add_arguments(cls, parser):
-        super(CaptchaConfig, cls).add_arguments(parser)
-        group = parser.add_argument_group("recaptcha")
-        group.add_argument(
-            "--recaptcha-public-key", type=str, default="YOUR_PUBLIC_KEY",
-            help="This Home Server's ReCAPTCHA public key."
-        )
-        group.add_argument(
-            "--recaptcha-private-key", type=str, default="YOUR_PRIVATE_KEY",
-            help="This Home Server's ReCAPTCHA private key."
-        )
-        group.add_argument(
-            "--enable-registration-captcha", type=bool, default=False,
-            help="Enables ReCaptcha checks when registering, preventing signup"
-            + " unless a captcha is answered. Requires a valid ReCaptcha "
-            + "public/private key."
-        )
-        group.add_argument(
-            "--captcha_ip_origin_is_x_forwarded", type=bool, default=False,
-            help="When checking captchas, use the X-Forwarded-For (XFF) header"
-            + " as the client IP and not the actual client IP."
-        )
-        group.add_argument(
-            "--captcha_bypass_secret", type=str,
-            help="A secret key used to bypass the captcha test entirely."
-        )
+    def default_config(self, config_dir_path, server_name):
+        return """\
+        ## Captcha ##
+
+        # This Home Server's ReCAPTCHA public key.
+        recaptcha_private_key: "YOUR_PUBLIC_KEY"
+
+        # This Home Server's ReCAPTCHA private key.
+        recaptcha_public_key: "YOUR_PRIVATE_KEY"
+
+        # Enables ReCaptcha checks when registering, preventing signup
+        # unless a captcha is answered. Requires a valid ReCaptcha
+        # public/private key.
+        enable_registration_captcha: False
+
+        # When checking captchas, use the X-Forwarded-For (XFF) header
+        # as the client IP and not the actual client IP.
+        captcha_ip_origin_is_x_forwarded: False
+
+        # A secret key used to bypass the captcha test entirely.
+        captcha_bypass_secret: ~
+        """

--- a/synapse/config/database.py
+++ b/synapse/config/database.py
@@ -14,28 +14,21 @@
 # limitations under the License.
 
 from ._base import Config
-import os
-import yaml
 
 
 class DatabaseConfig(Config):
-    def __init__(self, args):
-        super(DatabaseConfig, self).__init__(args)
-        if args.database_path == ":memory:":
-            self.database_path = ":memory:"
-        else:
-            self.database_path = self.abspath(args.database_path)
-        self.event_cache_size = self.parse_size(args.event_cache_size)
 
-        if args.database_config:
-            with open(args.database_config) as f:
-                self.database_config = yaml.safe_load(f)
-        else:
+    def read_config(self, config):
+        self.event_cache_size = self.parse_size(
+            config.get("event_cache_size", "10K")
+        )
+
+        self.database_config = config.get("database")
+
+        if self.database_config is None:
             self.database_config = {
                 "name": "sqlite3",
-                "args": {
-                    "database": self.database_path,
-                },
+                "args": {},
             }
 
         name = self.database_config.get("name", None)
@@ -50,24 +43,36 @@ class DatabaseConfig(Config):
         else:
             raise RuntimeError("Unsupported database type '%s'" % (name,))
 
-    @classmethod
-    def add_arguments(cls, parser):
-        super(DatabaseConfig, cls).add_arguments(parser)
+        self.set_databasepath(config.get("database_path"))
+
+    def default_config(self, config, config_dir_path):
+        database_path = self.abspath("homeserver.db")
+        return """\
+        # Database configuration
+        database:
+          # The database engine name
+          name: "sqlite3"
+          # Arguments to pass to the engine
+          args:
+            # Path to the database
+            database: "%(database_path)s"
+        # Number of events to cache in memory.
+        event_cache_size: "10K"
+        """ % locals()
+
+    def read_arguments(self, args):
+        self.set_databasepath(args.database_path)
+
+    def set_databasepath(self, database_path):
+        if database_path != ":memory:":
+            database_path = self.abspath(database_path)
+        if self.database_config.get("name", None) == "sqlite3":
+            if database_path is not None:
+                self.database_config["database"] = database_path
+
+    def add_arguments(self, parser):
         db_group = parser.add_argument_group("database")
         db_group.add_argument(
-            "-d", "--database-path", default="homeserver.db",
-            metavar="SQLITE_DATABASE_PATH", help="The database name."
+            "-d", "--database-path", metavar="SQLITE_DATABASE_PATH",
+            help="The path to a sqlite database to use."
         )
-        db_group.add_argument(
-            "--event-cache-size", default="100K",
-            help="Number of events to cache in memory."
-        )
-        db_group.add_argument(
-            "--database-config", default=None,
-            help="Location of the database configuration file."
-        )
-
-    @classmethod
-    def generate_config(cls, args, config_dir_path):
-        super(DatabaseConfig, cls).generate_config(args, config_dir_path)
-        args.database_path = os.path.abspath(args.database_path)

--- a/synapse/config/database.py
+++ b/synapse/config/database.py
@@ -56,6 +56,7 @@ class DatabaseConfig(Config):
           args:
             # Path to the database
             database: "%(database_path)s"
+
         # Number of events to cache in memory.
         event_cache_size: "10K"
         """ % locals()
@@ -68,7 +69,7 @@ class DatabaseConfig(Config):
             database_path = self.abspath(database_path)
         if self.database_config.get("name", None) == "sqlite3":
             if database_path is not None:
-                self.database_config["database"] = database_path
+                self.database_config["args"]["database"] = database_path
 
     def add_arguments(self, parser):
         db_group = parser.add_argument_group("database")

--- a/synapse/config/homeserver.py
+++ b/synapse/config/homeserver.py
@@ -37,5 +37,5 @@ class HomeServerConfig(TlsConfig, ServerConfig, DatabaseConfig, LoggingConfig,
 if __name__ == '__main__':
     import sys
     sys.stdout.write(
-        HomeServerConfig().generate_config(sys.argv[1], sys.argv[2])
+        HomeServerConfig().generate_config(sys.argv[1], sys.argv[2])[0]
     )

--- a/synapse/config/homeserver.py
+++ b/synapse/config/homeserver.py
@@ -36,4 +36,6 @@ class HomeServerConfig(TlsConfig, ServerConfig, DatabaseConfig, LoggingConfig,
 
 if __name__ == '__main__':
     import sys
-    HomeServerConfig.load_config("Generate config", sys.argv[1:], "HomeServer")
+    sys.stdout.write(
+        HomeServerConfig().generate_config(sys.argv[1], sys.argv[2])
+    )

--- a/synapse/config/key.py
+++ b/synapse/config/key.py
@@ -120,9 +120,10 @@ class KeyConfig(Config):
             signing_keys = self.read_file(signing_key_path, "signing_key")
             if len(signing_keys.split("\n")[0].split()) == 1:
                 # handle keys in the old format.
+                key_id = "a_" + random_string(4)
                 key = syutil.crypto.signing_key.decode_signing_key_base64(
                     syutil.crypto.signing_key.NACL_ED25519,
-                    "auto",
+                    key_id,
                     signing_keys.split("\n")[0]
                 )
                 with open(signing_key_path, "w") as signing_key_file:

--- a/synapse/config/key.py
+++ b/synapse/config/key.py
@@ -20,6 +20,7 @@ from syutil.crypto.signing_key import (
     is_signing_algorithm_supported, decode_verify_key_bytes
 )
 from syutil.base64util import decode_base64
+from synapse.util.stringutils import random_string
 
 
 class KeyConfig(Config):
@@ -110,9 +111,10 @@ class KeyConfig(Config):
         signing_key_path = config["signing_key_path"]
         if not os.path.exists(signing_key_path):
             with open(signing_key_path, "w") as signing_key_file:
+                key_id = "a_" + random_string(4)
                 syutil.crypto.signing_key.write_signing_keys(
                     signing_key_file,
-                    (syutil.crypto.signing_key.generate_signing_key("auto"),),
+                    (syutil.crypto.signing_key.generate_signing_key(key_id),),
                 )
         else:
             signing_keys = self.read_file(signing_key_path, "signing_key")

--- a/synapse/config/key.py
+++ b/synapse/config/key.py
@@ -107,7 +107,7 @@ class KeyConfig(Config):
                 )
         return keys
 
-    def generate_keys(self, config):
+    def generate_files(self, config):
         signing_key_path = config["signing_key_path"]
         if not os.path.exists(signing_key_path):
             with open(signing_key_path, "w") as signing_key_file:

--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -22,22 +22,41 @@ import yaml
 
 
 class LoggingConfig(Config):
-    def __init__(self, args):
-        super(LoggingConfig, self).__init__(args)
-        self.verbosity = int(args.verbose) if args.verbose else None
-        self.log_config = self.abspath(args.log_config)
-        self.log_file = self.abspath(args.log_file)
 
-    @classmethod
+    def read_config(self, config):
+        self.verbosity = config.get("verbose", 0)
+        self.log_config = self.abspath(config.get("log_config"))
+        self.log_file = self.abspath(config.get("log_file"))
+
+    def default_config(self, config_dir_path, server_name):
+        log_file = self.abspath("homeserver.log")
+        return """
+        # Logging verbosity level.
+        verbose: 0
+
+        # File to write logging to
+        log_file: "%(log_file)s"
+
+        # A yaml python logging config file
+        #log_config: "your.log.config.yaml"
+        """ % locals()
+
+    def read_arguments(self, args):
+        if args.verbose is not None:
+            self.verbosity = args.verbose
+        if args.log_config is not None:
+            self.log_config = args.log_config
+        if args.log_file is not None:
+            self.log_file = args.log_file
+
     def add_arguments(cls, parser):
-        super(LoggingConfig, cls).add_arguments(parser)
         logging_group = parser.add_argument_group("logging")
         logging_group.add_argument(
             '-v', '--verbose', dest="verbose", action='count',
             help="The verbosity level."
         )
         logging_group.add_argument(
-            '-f', '--log-file', dest="log_file", default="homeserver.log",
+            '-f', '--log-file', dest="log_file",
             help="File to log to."
         )
         logging_group.add_argument(

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -17,20 +17,17 @@ from ._base import Config
 
 
 class MetricsConfig(Config):
-    def __init__(self, args):
-        super(MetricsConfig, self).__init__(args)
-        self.enable_metrics = args.enable_metrics
-        self.metrics_port = args.metrics_port
+    def read_config(self, config):
+        self.enable_metrics = config["enable_metrics"]
+        self.metrics_port = config["metrics_port"]
 
-    @classmethod
-    def add_arguments(cls, parser):
-        super(MetricsConfig, cls).add_arguments(parser)
-        metrics_group = parser.add_argument_group("metrics")
-        metrics_group.add_argument(
-            '--enable-metrics', dest="enable_metrics", action="store_true",
-            help="Enable collection and rendering of performance metrics"
-        )
-        metrics_group.add_argument(
-            '--metrics-port', metavar="PORT", type=int,
-            help="Separate port to accept metrics requests on (on localhost)"
-        )
+    def default_config(self, config_dir_path, server_name):
+        return """\
+        ## Metrics ###
+
+        # Enable collection and rendering of performance metrics
+        enable_metrics: False
+
+        # Separate port to accept metrics requests on (on localhost)
+        metrics_port: ~
+        """

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -19,7 +19,7 @@ from ._base import Config
 class MetricsConfig(Config):
     def read_config(self, config):
         self.enable_metrics = config["enable_metrics"]
-        self.metrics_port = config["metrics_port"]
+        self.metrics_port = config.get("metrics_port")
 
     def default_config(self, config_dir_path, server_name):
         return """\
@@ -29,5 +29,5 @@ class MetricsConfig(Config):
         enable_metrics: False
 
         # Separate port to accept metrics requests on (on localhost)
-        metrics_port: ~
+        # metrics_port: 8081
         """

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -17,56 +17,42 @@ from ._base import Config
 
 class RatelimitConfig(Config):
 
-    def __init__(self, args):
-        super(RatelimitConfig, self).__init__(args)
-        self.rc_messages_per_second = args.rc_messages_per_second
-        self.rc_message_burst_count = args.rc_message_burst_count
+    def read_config(self, config):
+        self.rc_messages_per_second = config["rc_messages_per_second"]
+        self.rc_message_burst_count = config["rc_message_burst_count"]
 
-        self.federation_rc_window_size = args.federation_rc_window_size
-        self.federation_rc_sleep_limit = args.federation_rc_sleep_limit
-        self.federation_rc_sleep_delay = args.federation_rc_sleep_delay
-        self.federation_rc_reject_limit = args.federation_rc_reject_limit
-        self.federation_rc_concurrent = args.federation_rc_concurrent
+        self.federation_rc_window_size = config["federation_rc_window_size"]
+        self.federation_rc_sleep_limit = config["federation_rc_sleep_limit"]
+        self.federation_rc_sleep_delay = config["federation_rc_sleep_delay"]
+        self.federation_rc_reject_limit = config["federation_rc_reject_limit"]
+        self.federation_rc_concurrent = config["federation_rc_concurrent"]
 
-    @classmethod
-    def add_arguments(cls, parser):
-        super(RatelimitConfig, cls).add_arguments(parser)
-        rc_group = parser.add_argument_group("ratelimiting")
-        rc_group.add_argument(
-            "--rc-messages-per-second", type=float, default=0.2,
-            help="number of messages a client can send per second"
-        )
-        rc_group.add_argument(
-            "--rc-message-burst-count", type=float, default=10,
-            help="number of message a client can send before being throttled"
-        )
+    def default_config(self, config_dir_path, server_name):
+        return """\
+        ## Ratelimiting ##
 
-        rc_group.add_argument(
-            "--federation-rc-window-size", type=int, default=10000,
-            help="The federation window size in milliseconds",
-        )
+        # Number of messages a client can send per second
+        rc_messages_per_second: 0.2
 
-        rc_group.add_argument(
-            "--federation-rc-sleep-limit", type=int, default=10,
-            help="The number of federation requests from a single server"
-                 " in a window before the server will delay processing the"
-                 " request.",
-        )
+        # Number of message a client can send before being throttled
+        rc_message_burst_count: 10.0
 
-        rc_group.add_argument(
-            "--federation-rc-sleep-delay", type=int, default=500,
-            help="The duration in milliseconds to delay processing events from"
-                 " remote servers by if they go over the sleep limit.",
-        )
+        # The federation window size in milliseconds
+        federation_rc_window_size: 1000
 
-        rc_group.add_argument(
-            "--federation-rc-reject-limit", type=int, default=50,
-            help="The maximum number of concurrent federation requests allowed"
-                 " from a single server",
-        )
+        # The number of federation requests from a single server in a window
+        # before the server will delay processing the request.
+        federation_rc_sleep_limit: 10
 
-        rc_group.add_argument(
-            "--federation-rc-concurrent", type=int, default=3,
-            help="The number of federation requests to concurrently process"
-                 " from a single server",
-        )
+        # The duration in milliseconds to delay processing events from
+        # remote servers by if they go over the sleep limit.
+        federation_rc_sleep_delay: 500
+
+        # The maximum number of concurrent federation requests allowed
+        # from a single server
+        federation_rc_reject_limit: 50
+
+        # The number of federation requests to concurrently process from a
+        # single server
+        federation_rc_concurrent: 3
+        """

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -26,6 +26,11 @@ class RegistrationConfig(Config):
         self.disable_registration = not bool(
             distutils.util.strtobool(str(config["enable_registration"]))
         )
+        if "disable_registration" in config:
+            self.disable_registration = bool(
+                distutils.util.strtobool(str(config["disable_registration"]))
+            )
+
         self.registration_shared_secret = config.get("registration_shared_secret")
 
     def default_config(self, config_dir, server_name):

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -17,18 +17,18 @@ from ._base import Config
 
 from synapse.util.stringutils import random_string_with_symbols
 
-import distutils.util
+from distutils.util import strtobool
 
 
 class RegistrationConfig(Config):
 
     def read_config(self, config):
         self.disable_registration = not bool(
-            distutils.util.strtobool(str(config["enable_registration"]))
+            strtobool(str(config["enable_registration"]))
         )
         if "disable_registration" in config:
             self.disable_registration = bool(
-                distutils.util.strtobool(str(config["disable_registration"]))
+                strtobool(str(config["disable_registration"]))
             )
 
         self.registration_shared_secret = config.get("registration_shared_secret")
@@ -45,3 +45,16 @@ class RegistrationConfig(Config):
         # secret, even if registration is otherwise disabled.
         registration_shared_secret: "%(registration_shared_secret)s"
         """ % locals()
+
+    def add_arguments(self, parser):
+        reg_group = parser.add_argument_group("registration")
+        reg_group.add_argument(
+            "--enable-registration", action="store_true",
+            help="Enable registration for new users."
+        )
+
+    def read_arguments(self, args):
+        if args.enable_registration is not None:
+            self.disable_registration = not bool(
+                strtobool(str(args.enable_registration))
+            )

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -22,40 +22,21 @@ import distutils.util
 
 class RegistrationConfig(Config):
 
-    def __init__(self, args):
-        super(RegistrationConfig, self).__init__(args)
-
-        # `args.enable_registration` may either be a bool or a string depending
-        # on if the option was given a value (e.g. --enable-registration=true
-        # would set `args.enable_registration` to "true" not True.)
+    def read_config(self, config):
         self.disable_registration = not bool(
-            distutils.util.strtobool(str(args.enable_registration))
+            distutils.util.strtobool(str(config["enable_registration"]))
         )
-        self.registration_shared_secret = args.registration_shared_secret
+        self.registration_shared_secret = config.get("registration_shared_secret")
 
-    @classmethod
-    def add_arguments(cls, parser):
-        super(RegistrationConfig, cls).add_arguments(parser)
-        reg_group = parser.add_argument_group("registration")
+    def default_config(self, config_dir, server_name):
+        registration_shared_secret = random_string_with_symbols(50)
+        return """\
+        ## Registration ##
 
-        reg_group.add_argument(
-            "--enable-registration",
-            const=True,
-            default=False,
-            nargs='?',
-            help="Enable registration for new users.",
-        )
-        reg_group.add_argument(
-            "--registration-shared-secret", type=str,
-            help="If set, allows registration by anyone who also has the shared"
-                 " secret, even if registration is otherwise disabled.",
-        )
+        # Enable registration for new users.
+        enable_registration: True
 
-    @classmethod
-    def generate_config(cls, args, config_dir_path):
-        super(RegistrationConfig, cls).generate_config(args, config_dir_path)
-        if args.enable_registration is None:
-            args.enable_registration = False
-
-        if args.registration_shared_secret is None:
-            args.registration_shared_secret = random_string_with_symbols(50)
+        # If set, allows registration by anyone who also has the shared
+        # secret, even if registration is otherwise disabled.
+        registration_shared_secret: "%(registration_shared_secret)s"
+        """ % locals()

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -49,7 +49,7 @@ class RegistrationConfig(Config):
     def add_arguments(self, parser):
         reg_group = parser.add_argument_group("registration")
         reg_group.add_argument(
-            "--enable-registration", action="store_true",
+            "--enable-registration", action="store_true", default=None,
             help="Enable registration for new users."
         )
 

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -17,11 +17,10 @@ from ._base import Config
 
 
 class ContentRepositoryConfig(Config):
-    def __init__(self, args):
-        super(ContentRepositoryConfig, self).__init__(args)
-        self.max_upload_size = self.parse_size(args.max_upload_size)
-        self.max_image_pixels = self.parse_size(args.max_image_pixels)
-        self.media_store_path = self.ensure_directory(args.media_store_path)
+    def read_config(self, config):
+        self.max_upload_size = self.parse_size(config["max_upload_size"])
+        self.max_image_pixels = self.parse_size(config["max_image_pixels"])
+        self.media_store_path = self.ensure_directory(config["media_store_path"])
 
     def parse_size(self, string):
         sizes = {"K": 1024, "M": 1024 * 1024}
@@ -32,17 +31,15 @@ class ContentRepositoryConfig(Config):
             size = sizes[suffix]
         return int(string) * size
 
-    @classmethod
-    def add_arguments(cls, parser):
-        super(ContentRepositoryConfig, cls).add_arguments(parser)
-        db_group = parser.add_argument_group("content_repository")
-        db_group.add_argument(
-            "--max-upload-size", default="10M"
-        )
-        db_group.add_argument(
-            "--media-store-path", default=cls.default_path("media_store")
-        )
-        db_group.add_argument(
-            "--max-image-pixels", default="32M",
-            help="Maximum number of pixels that will be thumbnailed"
-        )
+    def default_config(self, config_dir_path, server_name):
+        media_store = self.default_path("media_store")
+        return """
+        # Directory where uploaded images and attachments are stored.
+        media_store_path: "%(media_store)s"
+
+        # The largest allowed upload size in bytes
+        max_upload_size: "10M"
+
+        # Maximum number of pixels that will be thumbnailed
+        max_image_pixels: "32M"
+        """ % locals()

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -22,15 +22,6 @@ class ContentRepositoryConfig(Config):
         self.max_image_pixels = self.parse_size(config["max_image_pixels"])
         self.media_store_path = self.ensure_directory(config["media_store_path"])
 
-    def parse_size(self, string):
-        sizes = {"K": 1024, "M": 1024 * 1024}
-        size = 1
-        suffix = string[-1]
-        if suffix in sizes:
-            string = string[:-1]
-            size = sizes[suffix]
-        return int(string) * size
-
     def default_config(self, config_dir_path, server_name):
         media_store = self.default_path("media_store")
         return """

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -83,7 +83,7 @@ class ServerConfig(Config):
 
         # Turn on the twisted telnet manhole service on localhost on the given
         # port.
-        manhole: ~
+        #manhole: 9000
         """ % locals()
 
     def read_arguments(self, args):

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -17,64 +17,85 @@ from ._base import Config
 
 
 class ServerConfig(Config):
-    def __init__(self, args):
-        super(ServerConfig, self).__init__(args)
-        self.server_name = args.server_name
-        self.bind_port = args.bind_port
-        self.bind_host = args.bind_host
-        self.unsecure_port = args.unsecure_port
-        self.daemonize = args.daemonize
-        self.pid_file = self.abspath(args.pid_file)
-        self.web_client = args.web_client
-        self.manhole = args.manhole
-        self.soft_file_limit = args.soft_file_limit
 
-        if not args.content_addr:
-            host = args.server_name
+    def read_config(self, config):
+        self.server_name = config["server_name"]
+        self.bind_port = config["bind_port"]
+        self.bind_host = config["bind_host"]
+        self.unsecure_port = config["unsecure_port"]
+        self.manhole = config["manhole"]
+        self.pid_file = self.abspath(config.get("pid_file"))
+        self.web_client = config["web_client"]
+        self.soft_file_limit = config["soft_file_limit"]
+
+        # Attempt to guess the content_addr for the v0 content repostitory
+        content_addr = config.get("content_addr")
+        if not content_addr:
+            host = self.server_name
             if ':' not in host:
-                host = "%s:%d" % (host, args.unsecure_port)
+                host = "%s:%d" % (host, self.unsecure_port)
             else:
                 host = host.split(':')[0]
-                host = "%s:%d" % (host, args.unsecure_port)
-            args.content_addr = "http://%s" % (host,)
+                host = "%s:%d" % (host, self.unsecure_port)
+            content_addr = "http://%s" % (host,)
 
-        self.content_addr = args.content_addr
+        self.content_addr = content_addr
 
-    @classmethod
-    def add_arguments(cls, parser):
-        super(ServerConfig, cls).add_arguments(parser)
+    def default_config(self, config_dir_path, server_name):
+        if ":" in server_name:
+            bind_port = int(server_name.split(":")[1])
+            unsecure_port = bind_port - 400
+        else:
+            bind_port = 8448
+            unsecure_port = 8008
+
+        pid_file = self.abspath("homeserver.pid")
+        return """\
+        ## Server ##
+
+        # The domain name of the server, with optional explicit port.
+        # This is used by remote servers to connect to this server,
+        # e.g. matrix.org, localhost:8080, etc.
+        server_name: "%(server_name)s"
+
+        # The port to listen for HTTPS requests on.
+        # For when matrix traffic is sent directly to synapse.
+        bind_port: %(bind_port)s
+
+        # The port to listen for HTTP requests on.
+        # For when matrix traffic passes through loadbalancer that unwraps TLS.
+        unsecure_port: %(unsecure_port)s
+
+        # Local interface to listen on.
+        # The empty string will cause synapse to listen on all interfaces.
+        bind_host: ""
+
+        # When running as a daemon, the file to store the pid in
+        pid_file: %(pid_file)s
+
+        # Whether to serve a web client from the HTTP/HTTPS root resource.
+        web_client: True
+
+        # Set the soft limit on the number of file descriptors synapse can use
+        # Zero is used to indicate synapse should set the soft limit to the
+        # hard limit.
+        soft_file_limit: 0
+
+        # Turn on the twisted telnet manhole service on localhost on the given
+        # port.
+        manhole: ~
+        """ % locals()
+
+    def read_arguments(self, args):
+        if args.manhole is not None:
+            self.manhole = args.manhole
+        self.daemonize = args.daemonize
+
+    def add_arguments(self, parser):
         server_group = parser.add_argument_group("server")
-        server_group.add_argument(
-            "-H", "--server-name", default="localhost",
-            help="The domain name of the server, with optional explicit port. "
-                 "This is used by remote servers to connect to this server, "
-                 "e.g. matrix.org, localhost:8080, etc."
-        )
-        server_group.add_argument("-p", "--bind-port", metavar="PORT",
-                                  type=int, help="https port to listen on",
-                                  default=8448)
-        server_group.add_argument("--unsecure-port", metavar="PORT",
-                                  type=int, help="http port to listen on",
-                                  default=8008)
-        server_group.add_argument("--bind-host", default="",
-                                  help="Local interface to listen on")
         server_group.add_argument("-D", "--daemonize", action='store_true',
                                   help="Daemonize the home server")
-        server_group.add_argument('--pid-file', default="homeserver.pid",
-                                  help="When running as a daemon, the file to"
-                                  " store the pid in")
-        server_group.add_argument('--web_client', default=True, type=bool,
-                                  help="Whether or not to serve a web client")
         server_group.add_argument("--manhole", metavar="PORT", dest="manhole",
                                   type=int,
                                   help="Turn on the twisted telnet manhole"
                                   " service on the given port.")
-        server_group.add_argument("--content-addr", default=None,
-                                  help="The host and scheme to use for the "
-                                  "content repository")
-        server_group.add_argument("--soft-file-limit", type=int, default=0,
-                                  help="Set the soft limit on the number of "
-                                       "file descriptors synapse can use. "
-                                       "Zero is used to indicate synapse "
-                                       "should set the soft limit to the hard"
-                                       "limit.")

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -23,7 +23,7 @@ class ServerConfig(Config):
         self.bind_port = config["bind_port"]
         self.bind_host = config["bind_host"]
         self.unsecure_port = config["unsecure_port"]
-        self.manhole = config["manhole"]
+        self.manhole = config.get("manhole")
         self.pid_file = self.abspath(config.get("pid_file"))
         self.web_client = config["web_client"]
         self.soft_file_limit = config["soft_file_limit"]

--- a/synapse/config/tls.py
+++ b/synapse/config/tls.py
@@ -70,7 +70,7 @@ class TlsConfig(Config):
         private_key_pem = self.read_file(private_key_path, "tls_private_key")
         return crypto.load_privatekey(crypto.FILETYPE_PEM, private_key_pem)
 
-    def generate_keys(self, config):
+    def generate_files(self, config):
         tls_certificate_path = config["tls_certificate_path"]
         tls_private_key_path = config["tls_private_key_path"]
         tls_dh_params_path = config["tls_dh_params_path"]

--- a/synapse/config/voip.py
+++ b/synapse/config/voip.py
@@ -17,28 +17,21 @@ from ._base import Config
 
 class VoipConfig(Config):
 
-    def __init__(self, args):
-        super(VoipConfig, self).__init__(args)
-        self.turn_uris = args.turn_uris
-        self.turn_shared_secret = args.turn_shared_secret
-        self.turn_user_lifetime = args.turn_user_lifetime
+    def read_config(self, config):
+        self.turn_uris = config.get("turn_uris", [])
+        self.turn_shared_secret = config["turn_shared_secret"]
+        self.turn_user_lifetime = self.parse_duration(config["turn_user_lifetime"])
 
-    @classmethod
-    def add_arguments(cls, parser):
-        super(VoipConfig, cls).add_arguments(parser)
-        group = parser.add_argument_group("voip")
-        group.add_argument(
-            "--turn-uris", type=str, default=None, action='append',
-            help="The public URIs of the TURN server to give to clients"
-        )
-        group.add_argument(
-            "--turn-shared-secret", type=str, default=None,
-            help=(
-                "The shared secret used to compute passwords for the TURN"
-                " server"
-            )
-        )
-        group.add_argument(
-            "--turn-user-lifetime", type=int, default=(1000 * 60 * 60),
-            help="How long generated TURN credentials last, in ms"
-        )
+    def default_config(self, config_dir_path, server_name):
+        return """\
+        ## Turn ##
+
+        # The public URIs of the TURN server to give to clients
+        turn_uris: []
+
+        # The shared secret used to compute passwords for the TURN server
+        turn_shared_secret: "YOUR_SHARED_SECRET"
+
+        # How long generated TURN credentials last
+        turn_user_lifetime: "1h"
+        """

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -59,7 +59,6 @@ class BaseHomeServer(object):
         'config',
         'clock',
         'http_client',
-        'db_name',
         'db_pool',
         'persistence_service',
         'replication_layer',


### PR DESCRIPTION
This PR is intended to drastically reduce the number of options that are configured through both commandline arguments and through yaml. The yaml config is promoted to being the primary config file format and the automatic config generator will now include comments to document the yaml config options. The "--generate-config" option will no longer be able to incrementally add new defaults to an exiting config as there isn't an easy way to round trip a yaml file while preserving comments, therefore --generate-config will error if the file already exists.

This PR includes a number of other improvements:
* auto-generated key_ids have a random suffix
* A yaml logging config is automatically generated.
* Both enable_registration and disable_registration are supported.
* Durations can be specified in hours, days and weeks as well as in milliseconds.
* The default bind port will be automatically derived from the server_name.