### PR TITLE
Improvement to performance of presence event stream handling

### DIFF
--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -875,10 +875,15 @@ class PresenceEventSource(object):
 
         updates = []
         # TODO(paul): use a DeferredList ? How to limit concurrency.
-        for observed_user in cachemap.keys():
+        for observed_user in reversed(cachemap.keys()):
             cached = cachemap[observed_user]
 
-            if cached.serial <= from_key or cached.serial > max_serial:
+            # Since this is ordered in descending order of serial, we can just
+            # stop once we've seen enough
+            if cached.serial <= from_key:
+                break
+
+            if cached.serial > max_serial:
                 continue
 
             if not (yield self.is_visible(observer_user, observed_user)):


### PR DESCRIPTION
A fairly quick hackish improvement to the performance of presence event stream under large numbers of users, such as exhibited by large-scale `syload` load tests.

By using an OrderedDict, the actual event handler loop can skip out of the loop when it gets to the end of the updates, which makes it consume somewhat less CPU time.