### PR TITLE
Backfill support

### DIFF
--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -361,10 +361,13 @@ class FederationHandler(BaseHandler):
 
         tried_domains = set(likely_domains)
 
-        states = yield defer.gatherResults({
-            e: self.state_handler.resolve_state_groups([e])[1]
-            for e in extremities.keys()
-        })
+        event_ids = list(extremities.keys())
+
+        states = yield defer.gatherResults([
+            self.state_handler.resolve_state_groups([e])[1]
+            for e in event_ids
+        ])
+        states = dict(zip(event_ids, states))
 
         for e_id, _ in sorted_extremeties_tuple:
             likely_domains = get_domains_from_state(states[e_id])[0]

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -274,7 +274,7 @@ class FederationHandler(BaseHandler):
         if current_depth > max_depth:
             logger.debug(
                 "Not backfilling as we don't need to. %d < %d",
-                current_depth, max_depth,
+                max_depth, current_depth,
             )
             return
 
@@ -364,10 +364,10 @@ class FederationHandler(BaseHandler):
         event_ids = list(extremities.keys())
 
         states = yield defer.gatherResults([
-            self.state_handler.resolve_state_groups([e])[1]
+            self.state_handler.resolve_state_groups([e])
             for e in event_ids
         ])
-        states = dict(zip(event_ids, states))
+        states = dict(zip(event_ids, [s[1] for s in states]))
 
         for e_id, _ in sorted_extremeties_tuple:
             likely_domains = get_domains_from_state(states[e_id])[0]

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -325,7 +325,7 @@ class FederationHandler(BaseHandler):
                     )
                 except SynapseError:
                     logger.info(
-                        "Failed to backfil from %s because %s",
+                        "Failed to backfill from %s because %s",
                         dom, e,
                     )
                     continue
@@ -334,7 +334,7 @@ class FederationHandler(BaseHandler):
                         raise
 
                     logger.info(
-                        "Failed to backfil from %s because %s",
+                        "Failed to backfill from %s because %s",
                         dom, e,
                     )
                     continue
@@ -342,8 +342,8 @@ class FederationHandler(BaseHandler):
                     logger.info(e.message)
                     continue
                 except Exception as e:
-                    logger.info(
-                        "Failed to backfil from %s because %s",
+                    logger.warn(
+                        "Failed to backfill from %s because %s",
                         dom, e,
                     )
                     continue

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -370,7 +370,7 @@ class FederationHandler(BaseHandler):
         states = dict(zip(event_ids, [s[1] for s in states]))
 
         for e_id, _ in sorted_extremeties_tuple:
-            likely_domains = get_domains_from_state(states[e_id])[0]
+            likely_domains = get_domains_from_state(states[e_id])
 
             success = yield try_backfill([
                 dom for dom in likely_domains

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -89,7 +89,9 @@ class MessageHandler(BaseHandler):
 
         if not pagin_config.from_token:
             pagin_config.from_token = (
-                yield self.hs.get_event_sources().get_current_token()
+                yield self.hs.get_event_sources().get_current_token(
+                    direction='b'
+                )
             )
 
         room_token = RoomStreamToken.parse(pagin_config.from_token.room_key)

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -21,7 +21,7 @@ from synapse.streams.config import PaginationConfig
 from synapse.events.utils import serialize_event
 from synapse.events.validator import EventValidator
 from synapse.util.logcontext import PreserveLoggingContext
-from synapse.types import UserID
+from synapse.types import UserID, RoomStreamToken
 
 from ._base import BaseHandler
 
@@ -91,6 +91,14 @@ class MessageHandler(BaseHandler):
             pagin_config.from_token = (
                 yield self.hs.get_event_sources().get_current_token()
             )
+
+        room_token = RoomStreamToken.parse(pagin_config.from_token.room_key)
+        if room_token.topological is None:
+            raise SynapseError(400, "Invalid token")
+
+        yield self.hs.get_handlers().federation_handler.maybe_backfill(
+            room_id, room_token.topological
+        )
 
         user = UserID.from_string(user_id)
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -577,8 +577,8 @@ class RoomEventSource(object):
 
         defer.returnValue((events, end_key))
 
-    def get_current_key(self):
-        return self.store.get_room_events_max_id()
+    def get_current_key(self, direction='f'):
+        return self.store.get_room_events_max_id(direction)
 
     @defer.inlineCallbacks
     def get_pagination_rows(self, user, config, key):

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -343,7 +343,6 @@ class EventFederationStore(SQLBaseStore):
                 for e_id, _ in prev_events
             ])
 
-
             # Also delete from the backwards extremities table all ones that
             # reference events that we have already seen
             query = (
@@ -351,7 +350,6 @@ class EventFederationStore(SQLBaseStore):
                 " WHERE event_id = ? AND room_id = ?"
             )
             txn.executemany(query, [(e_id, room_id) for e_id, _ in prev_events])
-
 
             txn.call_after(
                 self.get_latest_event_ids_in_room.invalidate, room_id

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -336,15 +336,22 @@ class EventFederationStore(SQLBaseStore):
                 " SELECT 1 FROM event_backward_extremities"
                 " WHERE event_id = ? AND room_id = ?"
                 " )"
-                " AND NOT EXISTS ("
-                " SELECT 1 FROM events WHERE event_id = ? AND room_id = ?"
-                " )"
             )
 
             txn.executemany(query, [
-                (e_id, room_id, e_id, room_id, e_id, room_id,)
+                (e_id, room_id, e_id, room_id, )
                 for e_id, _ in prev_events
             ])
+
+
+            # Also delete from the backwards extremities table all ones that
+            # reference events that we have already seen
+            query = (
+                "DELETE FROM event_backward_extremities"
+                " WHERE event_id = ? AND room_id = ?"
+            )
+            txn.executemany(query, [(e_id, room_id) for e_id, _ in prev_events])
+
 
             txn.call_after(
                 self.get_latest_event_ids_in_room.invalidate, room_id

--- a/synapse/streams/events.py
+++ b/synapse/streams/events.py
@@ -31,7 +31,7 @@ class NullSource(object):
     def get_new_events_for_user(self, user, from_key, limit):
         return defer.succeed(([], from_key))
 
-    def get_current_key(self):
+    def get_current_key(self, direction='f'):
         return defer.succeed(0)
 
     def get_pagination_rows(self, user, pagination_config, key):
@@ -52,10 +52,10 @@ class EventSources(object):
         }
 
     @defer.inlineCallbacks
-    def get_current_token(self):
+    def get_current_token(self, direction='f'):
         token = StreamToken(
             room_key=(
-                yield self.sources["room"].get_current_key()
+                yield self.sources["room"].get_current_key(direction)
             ),
             presence_key=(
                 yield self.sources["presence"].get_current_key()

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -121,4 +121,56 @@ class StreamToken(
         return StreamToken(**d)
 
 
+class RoomStreamToken(namedtuple("_StreamToken", "topological stream")):
+    """Tokens are positions between events. The token "s1" comes after event 1.
+
+            s0    s1
+            |     |
+        [0] V [1] V [2]
+
+    Tokens can either be a point in the live event stream or a cursor going
+    through historic events.
+
+    When traversing the live event stream events are ordered by when they
+    arrived at the homeserver.
+
+    When traversing historic events the events are ordered by their depth in
+    the event graph "topological_ordering" and then by when they arrived at the
+    homeserver "stream_ordering".
+
+    Live tokens start with an "s" followed by the "stream_ordering" id of the
+    event it comes after. Historic tokens start with a "t" followed by the
+    "topological_ordering" id of the event it comes after, follewed by "-",
+    followed by the "stream_ordering" id of the event it comes after.
+    """
+    __slots__ = []
+
+    @classmethod
+    def parse(cls, string):
+        try:
+            if string[0] == 's':
+                return cls(topological=None, stream=int(string[1:]))
+            if string[0] == 't':
+                parts = string[1:].split('-', 1)
+                return cls(topological=int(parts[0]), stream=int(parts[1]))
+        except:
+            pass
+        raise SynapseError(400, "Invalid token %r" % (string,))
+
+    @classmethod
+    def parse_stream_token(cls, string):
+        try:
+            if string[0] == 's':
+                return cls(topological=None, stream=int(string[1:]))
+        except:
+            pass
+        raise SynapseError(400, "Invalid token %r" % (string,))
+
+    def __str__(self):
+        if self.topological is not None:
+            return "t%d-%d" % (self.topological, self.stream)
+        else:
+            return "s%d" % (self.stream,)
+
+
 ClientInfo = namedtuple("ClientInfo", ("device_id", "token_id"))


### PR DESCRIPTION
This is a fairly naive implementation of hooking backfill into pagination requests. The way this works is by triggering a backfill whenever a client paginates with a token that represents a depth less than one of "backward extremities" of the room. In this case we start picking remote servers and asking them for events, once a server returns at least one event (or all servers return nothing) we return to the normal pagination flow.

This means:
* We don't track which servers we failed to backfill from.
* We will paginate down all branches indiscriminately.
* We are at the mercy of whichever remote server we pick to return a sensible selection of events. We are liable to keep picking this server.