### PR TITLE
Make v1 and v2 client APIs interact with the notifier in the same way.

### DIFF
--- a/synapse/notifier.py
+++ b/synapse/notifier.py
@@ -311,7 +311,7 @@ class Notifier(object):
                     user, getattr(from_token, keyname), limit,
                 )
                 events.extend(stuff)
-                end_token = from_token.copy_and_replace(keyname, new_key)
+                end_token = end_token.copy_and_replace(keyname, new_key)
 
             if events:
                 defer.returnValue((events, (from_token, end_token)))


### PR DESCRIPTION
Reduce the amount of code duplication.