### PR TITLE
backfill fixes

### DIFF
--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -168,7 +168,11 @@ class FederationClient(FederationBase):
         for i, pdu in enumerate(pdus):
             pdus[i] = yield self._check_sigs_and_hash(pdu)
 
-            # FIXME: We should handle signature failures more gracefully.
+        # FIXME: We should handle signature failures more gracefully.
+        pdus[:] = yield defer.gatherResults(
+            [self._check_sigs_and_hash(pdu) for pdu in pdus],
+            consumeErrors=True,
+        ).addErrback(unwrapFirstError)
 
         defer.returnValue(pdus)
 

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -165,9 +165,6 @@ class FederationClient(FederationBase):
             for p in transaction_data["pdus"]
         ]
 
-        for i, pdu in enumerate(pdus):
-            pdus[i] = yield self._check_sigs_and_hash(pdu)
-
         # FIXME: We should handle signature failures more gracefully.
         pdus[:] = yield defer.gatherResults(
             [self._check_sigs_and_hash(pdu) for pdu in pdus],

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -411,7 +411,8 @@ class EventFederationStore(SQLBaseStore):
             )
 
             for row in txn.fetchall():
-                queue.put((-row[0], row[1]))
+                if row[1] not in event_results:
+                    queue.put((-row[0], row[1]))
 
         return event_results
 

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -378,7 +378,7 @@ class EventFederationStore(SQLBaseStore):
             room_id, repr(event_list), limit
         )
 
-        event_results = event_list
+        event_results = set(event_list)
 
         front = event_list
 

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -390,11 +390,6 @@ class EventFederationStore(SQLBaseStore):
         queue = PriorityQueue()
 
         for event_id in event_list:
-            txn.execute(
-                query,
-                (room_id, event_id, limit - len(event_results))
-            )
-
             depth = self._simple_select_one_onecol_txn(
                 txn,
                 table="events",

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -364,7 +364,11 @@ class EventFederationStore(SQLBaseStore):
         return self.runInteraction(
             "get_backfill_events",
             self._get_backfill_events, room_id, event_list, limit
-        ).addCallback(self._get_events)
+        ).addCallback(
+            self._get_events
+        ).addCallback(
+            lambda l: l.sort(key=lambda e: -e.depth)
+        )
 
     def _get_backfill_events(self, txn, room_id, event_list, limit):
         logger.debug(

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -411,6 +411,9 @@ class EventFederationStore(SQLBaseStore):
             except Empty:
                 break
 
+            if event_id in event_results:
+                continue
+
             event_results.add(event_id)
 
             txn.execute(

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -395,7 +395,7 @@ class EventFederationStore(SQLBaseStore):
             )
 
             for row in txn.fetchall():
-                queue.put(row)
+                queue.put((-row[0], row[1]))
 
         while not queue.empty() and len(event_results) < limit:
             try:
@@ -411,7 +411,7 @@ class EventFederationStore(SQLBaseStore):
             )
 
             for row in txn.fetchall():
-                queue.put(row)
+                queue.put((-row[0], row[1]))
 
         return event_results
 

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -383,6 +383,7 @@ class EventFederationStore(SQLBaseStore):
             " ON prev_event_id = events.event_id"
             " AND event_edges.room_id = events.room_id"
             " WHERE event_edges.room_id = ? AND event_edges.event_id = ?"
+            " AND event_edges.is_state = ?"
             " LIMIT ?"
         )
 
@@ -418,7 +419,7 @@ class EventFederationStore(SQLBaseStore):
 
             txn.execute(
                 query,
-                (room_id, event_id, limit - len(event_results))
+                (room_id, event_id, False, limit - len(event_results))
             )
 
             for row in txn.fetchall():

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -367,7 +367,7 @@ class EventFederationStore(SQLBaseStore):
         ).addCallback(
             self._get_events
         ).addCallback(
-            lambda l: l.sort(key=lambda e: -e.depth)
+            lambda l: sorted(l, key=lambda e: -e.depth)
         )
 
     def _get_backfill_events(self, txn, room_id, event_list, limit):

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -19,7 +19,7 @@ from ._base import SQLBaseStore, cached
 from syutil.base64util import encode_base64
 
 import logging
-from Queue import PriorityQueue
+from Queue import PriorityQueue, Empty
 
 
 logger = logging.getLogger(__name__)
@@ -398,7 +398,10 @@ class EventFederationStore(SQLBaseStore):
                 queue.put(row)
 
         while not queue.empty() and len(event_results) < limit:
-            _, event_id = queue.get_nowait()
+            try:
+                _, event_id = queue.get_nowait()
+            except Empty:
+                break
 
             event_results.add(event_id)
 

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -372,7 +372,7 @@ class EventFederationStore(SQLBaseStore):
             room_id, repr(event_list), limit
         )
 
-        event_results = set(event_list)
+        event_results = set()
 
         # We want to make sure that we do a breadth-first, "depth" ordered
         # search.

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -394,8 +394,16 @@ class EventFederationStore(SQLBaseStore):
                 (room_id, event_id, limit - len(event_results))
             )
 
-            for row in txn.fetchall():
-                queue.put((-row[0], row[1]))
+            depth = self._simple_select_one_onecol_txn(
+                txn,
+                table="events",
+                keyvalues={
+                    "event_id": event_id,
+                },
+                retcol="depth"
+            )
+
+            queue.put((-depth, event_id))
 
         while not queue.empty() and len(event_results) < limit:
             try:


### PR DESCRIPTION
Amongst other things, get the state for the new backward extremities so we can calculate the state for each newly acquired event.

It also fixes the response to backfill requests to actually return the correct events.