### PR TITLE
contrib/systemd: log_config.yaml: do not disable existing loggers

### DIFF
--- a/contrib/systemd/log_config.yaml
+++ b/contrib/systemd/log_config.yaml
@@ -21,3 +21,5 @@ handlers:
 root:
     level: INFO
     handlers: [journal]
+
+disable_existing_loggers: False


### PR DESCRIPTION
It turned out that merely configuring the root logger is not enough for "catch-all" semantics. The logging subsystem also needs to be told not to disable existing loggers (so that their messages will get propagated to handlers up the logging hierarchy, not silently discarded).