### PR TITLE
Improve backfill.

### DIFF
--- a/synapse/federation/federation_base.py
+++ b/synapse/federation/federation_base.py
@@ -118,7 +118,7 @@ class FederationBase(object):
             )
         except SynapseError:
             logger.warn(
-                "Signature check failed for %s, redacting",
+                "Signature check failed for %s",
                 pdu.event_id,
             )
             raise

--- a/synapse/federation/federation_base.py
+++ b/synapse/federation/federation_base.py
@@ -18,8 +18,6 @@ from twisted.internet import defer
 
 from synapse.events.utils import prune_event
 
-from syutil.jsonutil import encode_canonical_json
-
 from synapse.crypto.event_signing import check_event_content_hash
 
 from synapse.api.errors import SynapseError
@@ -120,16 +118,15 @@ class FederationBase(object):
             )
         except SynapseError:
             logger.warn(
-                "Signature check failed for %s redacted to %s",
-                encode_canonical_json(pdu.get_pdu_json()),
-                encode_canonical_json(redacted_pdu_json),
+                "Signature check failed for %s, redacting",
+                pdu.event_id,
             )
             raise
 
         if not check_event_content_hash(pdu):
             logger.warn(
-                "Event content has been tampered, redacting %s, %s",
-                pdu.event_id, encode_canonical_json(pdu.get_dict())
+                "Event content has been tampered, redacting.",
+                pdu.event_id,
             )
             defer.returnValue(redacted_event)
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -271,9 +271,10 @@ class FederationHandler(BaseHandler):
                 self._handle_new_event(
                     dest, a,
                     auth_events={
-                        (e.type, e.state_key): e for e in auth_events
-                        if e.event_id in [a_id for a_id, _ in a.auth_events]
-                    }
+                        (auth_events[a_id].type, auth_events[a_id].state_key):
+                        auth_events[a_id]
+                        for a_id, _ in a.auth_events
+                    },
                 )
                 for a in auth_events.values()
                 if a.event_id not in seen_events
@@ -286,9 +287,10 @@ class FederationHandler(BaseHandler):
                 self._handle_new_event(
                     dest, s,
                     auth_events={
-                        (e.type, e.state_key): e for e in auth_events
-                        if e.event_id in [a_id for a_id, _ in s.auth_events]
-                    }
+                        (auth_events[a_id].type, auth_events[a_id].state_key):
+                        auth_events[a_id]
+                        for a_id, _ in s.auth_events
+                    },
                 )
                 for s in state_events.values()
                 if s.event_id not in seen_events
@@ -303,9 +305,10 @@ class FederationHandler(BaseHandler):
                     state=events_to_state[e_id],
                     backfilled=True,
                     auth_events={
-                        (e.type, e.state_key): e for e in auth_events
-                        if e.event_id in [a_id for a_id, _ in a.auth_events]
-                    }
+                        (auth_events[a_id].type, auth_events[a_id].state_key):
+                        auth_events[a_id]
+                        for a_id, _ in event_map[e_id].auth_events
+                    },
                 )
                 for e_id in events_to_state
             ],

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -284,6 +284,7 @@ class FederationHandler(BaseHandler):
                     [dest],
                     event_id,
                     outlier=True,
+                    timeout=10000,
                 )
                 for event_id in missing_auth
             ],

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -262,7 +262,13 @@ class FederationHandler(BaseHandler):
 
         yield defer.gatherResults(
             [
-                self._handle_new_event(dest, a)
+                self._handle_new_event(
+                    dest, a,
+                    auth_events={
+                        (e.type, e.state_key): e for e in auth_events
+                        if e.event_id in [a_id for a_id, _ in a.auth_events]
+                    }
+                )
                 for a in auth_events.values()
             ],
             consumeErrors=True,
@@ -274,6 +280,10 @@ class FederationHandler(BaseHandler):
                     dest, event_map[e_id],
                     state=events_to_state[e_id],
                     backfilled=True,
+                    auth_events={
+                        (e.type, e.state_key): e for e in auth_events
+                        if e.event_id in [a_id for a_id, _ in a.auth_events]
+                    }
                 )
                 for e_id in events_to_state
             ],

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -247,6 +247,11 @@ class FederationHandler(BaseHandler):
             if set(e_id for e_id, _ in ev.prev_events) - event_ids
         ]
 
+        logger.info(
+            "backfill: Got %d events with %d edges",
+            len(events), len(edges),
+        )
+
         # For each edge get the current state.
 
         auth_events = {}


### PR DESCRIPTION
- Only persist state and auth events we haven't already seen.
- Fetch any missing auth events. 