### PR TITLE
Federation demo start.sh: Fixed --no-rate-limit param in the script

### DIFF
--- a/demo/clean.sh
+++ b/demo/clean.sh
@@ -12,8 +12,8 @@ if [ -f $PID_FILE ]; then
 fi
 
 for port in 8080 8081 8082; do
-    rm -rf demo/$port
-    rm -rf demo/media_store.$port
+    rm -rf $DIR/$port
+    rm -rf $DIR/media_store.$port
 done
 
 rm -rf $DIR/etc

--- a/demo/clean.sh
+++ b/demo/clean.sh
@@ -11,7 +11,9 @@ if [ -f $PID_FILE ]; then
     exit 1
 fi
 
-find "$DIR" -name "*.log" -delete
-find "$DIR" -name "*.db" -delete
+for port in 8080 8081 8082; do
+    rm -rf demo/$port
+    rm -rf demo/media_store.$port
+done
 
 rm -rf $DIR/etc

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -8,14 +8,6 @@ cd "$DIR/.."
 
 mkdir -p demo/etc
 
-# Check the --no-rate-limit param
-PARAMS=""
-if [ $# -eq 1 ]; then
-    if [ $1 = "--no-rate-limit" ]; then
-	    PARAMS="--rc-messages-per-second 1000 --rc-message-burst-count 1000"
-    fi
-fi
-
 export PYTHONPATH=$(readlink -f $(pwd))
 
 
@@ -34,6 +26,15 @@ for port in 8080 8081 8082; do
         --enable_registration \
         -H "localhost:$https_port" \
         --config-path "$DIR/etc/$port.config" \
+
+    # Check script parameters
+    if [ $# -eq 1 ]; then
+        if [ $1 = "--no-rate-limit" ]; then
+            # Set high limits in config file to disable rate limiting
+            perl -p -i -e 's/rc_messages_per_second.*/rc_messages_per_second: 1000/g' $DIR/etc/$port.config
+            perl -p -i -e 's/rc_message_burst_count.*/rc_message_burst_count: 1000/g' $DIR/etc/$port.config
+        fi
+    fi
 
     python -m synapse.app.homeserver \
         --config-path "$DIR/etc/$port.config" \


### PR DESCRIPTION
Implement back the --no-rate-limit param in federation start script by modifying rc_messages_per_second and rc_message_burst_count values in yaml config files.
clean.sh has been updated to follow folders organisation changes.