### PR TITLE
MANIFEST.in: include python schema delta scripts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include *.rst
 include demo/README
 
 recursive-include synapse/storage/schema *.sql
+recursive-include synapse/storage/schema *.py
 
 recursive-include demo *.dh
 recursive-include demo *.py


### PR DESCRIPTION
We now have one in `synapse/storage/schema/delta/20/pushers.py`. It didn't get installed, yielding on upgrade to 0.9.2 runtime errors like this:

```
Jun 13 09:45:12 server-9-20 synapse[15208]: synapse.storage: [] Could not open delta dir for version 20
                                            Traceback (most recent call last):
                                              File "/usr/lib/python2.7/site-packages/synapse/storage/__init__.py", line 322, in _upgrade_existing_database
                                                directory_entries = os.listdir(delta_dir)
                                            OSError: [Errno 2] No such file or directory: '/usr/lib/python2.7/site-packages/synapse/storage/schema/delta/20'
Jun 13 09:45:12 server-9-20 python2.7[15208]: Failed to upgrade database.
```

So, add `*.py` files in schema delta directories to the list of data files to install.