### PR TITLE
Change listener config.

### DIFF
--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -63,7 +63,6 @@ import synapse
 
 import logging
 import os
-import re
 import resource
 import subprocess
 
@@ -532,8 +531,9 @@ def create_resource_tree(desired_tree, redirect_root_to_web_client=True):
             # to be replaced with the desired resource.
             existing_dummy_resource = resource_mappings[res_id]
             for child_name in existing_dummy_resource.listNames():
-                child_res_id = _resource_id(existing_dummy_resource,
-                                                 child_name)
+                child_res_id = _resource_id(
+                    existing_dummy_resource, child_name
+                )
                 child_resource = resource_mappings[child_res_id]
                 # steal the children
                 res.putChild(child_name, child_resource)

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -408,13 +408,6 @@ def setup(config_options):
 
     logger.info("Database prepared in %r.", config.database_config)
 
-    if config.manhole:
-        f = twisted.manhole.telnet.ShellFactory()
-        f.username = "matrix"
-        f.password = "rabbithole"
-        f.namespace['hs'] = hs
-        reactor.listenTCP(config.manhole, f, interface='127.0.0.1')
-
     hs.start_listening()
 
     hs.get_pusherpool().start()

--- a/synapse/config/captcha.py
+++ b/synapse/config/captcha.py
@@ -21,10 +21,6 @@ class CaptchaConfig(Config):
         self.recaptcha_private_key = config["recaptcha_private_key"]
         self.recaptcha_public_key = config["recaptcha_public_key"]
         self.enable_registration_captcha = config["enable_registration_captcha"]
-        # XXX: This is used for more than just captcha
-        self.captcha_ip_origin_is_x_forwarded = (
-            config["captcha_ip_origin_is_x_forwarded"]
-        )
         self.captcha_bypass_secret = config.get("captcha_bypass_secret")
         self.recaptcha_siteverify_api = config["recaptcha_siteverify_api"]
 
@@ -42,10 +38,6 @@ class CaptchaConfig(Config):
         # unless a captcha is answered. Requires a valid ReCaptcha
         # public/private key.
         enable_registration_captcha: False
-
-        # When checking captchas, use the X-Forwarded-For (XFF) header
-        # as the client IP and not the actual client IP.
-        captcha_ip_origin_is_x_forwarded: False
 
         # A secret key used to bypass the captcha test entirely.
         #captcha_bypass_secret: "YOUR_SECRET_HERE"

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -28,10 +28,4 @@ class MetricsConfig(Config):
 
         # Enable collection and rendering of performance metrics
         enable_metrics: False
-
-        # Separate port to accept metrics requests on
-        # metrics_port: 8081
-
-        # Which host to bind the metric listener to
-        # metrics_bind_host: 127.0.0.1
         """

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -157,6 +157,8 @@ class ServerConfig(Config):
             bind_address: ''
             type: http
 
+            x_forwarded: False
+
             resources:
               - names: [client, webclient]
                 compress: true

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -183,8 +183,7 @@ class ServerConfig(Config):
 
           # Unsecure HTTP listener,
           # For when matrix traffic passes through loadbalancer that unwraps TLS.
-          -
-            port: %(unsecure_port)s
+          - port: %(unsecure_port)s
             tls: false
             bind_address: ''
             type: http

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -61,14 +61,6 @@ class ServerConfig(Config):
         # e.g. matrix.org, localhost:8080, etc.
         server_name: "%(server_name)s"
 
-        # The port to listen for HTTPS requests on.
-        # For when matrix traffic is sent directly to synapse.
-        bind_port: %(bind_port)s
-
-        # The port to listen for HTTP requests on.
-        # For when matrix traffic passes through loadbalancer that unwraps TLS.
-        unsecure_port: %(unsecure_port)s
-
         # Local interface to listen on.
         # The empty string will cause synapse to listen on all interfaces.
         bind_host: ""
@@ -92,6 +84,30 @@ class ServerConfig(Config):
         # This should be disabled if running synapse behind a load balancer
         # that can do automatic compression.
         gzip_responses: True
+
+        listeners:
+            # For when matrix traffic is sent directly to synapse.
+            secure:
+                # The type of
+                type: http_resource
+
+                # The port to listen for HTTPS requests on.
+                port: %(bind_port)s
+
+                # Is this a TLS socket?
+                tls: true
+
+                # Local interface to listen on.
+                # The empty string will cause synapse to listen on all interfaces.
+                bind_address: ""
+
+            # For when matrix traffic passes through loadbalancer that unwraps TLS.
+            unsecure:
+                port: %(unsecure_port)s
+                tls: false
+                bind_address: ""
+
+
         """ % locals()
 
     def read_arguments(self, args):

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -132,16 +132,8 @@ class BaseHomeServer(object):
         setattr(BaseHomeServer, "get_%s" % (depname), _get)
 
     def get_ip_from_request(self, request):
-        # May be an X-Forwarding-For header depending on config
-        ip_addr = request.getClientIP()
-        if self.config.captcha_ip_origin_is_x_forwarded:
-            # use the header
-            if request.requestHeaders.hasHeader("X-Forwarded-For"):
-                ip_addr = request.requestHeaders.getRawHeaders(
-                    "X-Forwarded-For"
-                )[0]
-
-        return ip_addr
+        # X-Forwarded-For is handled by our custom request type.
+        return request.getClientIP()
 
     def is_mine(self, domain_specific_string):
         return domain_specific_string.domain == self.hostname

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -114,6 +114,8 @@ class MockHttpResource(HttpServer):
         mock_request.method = http_method
         mock_request.uri = path
 
+        mock_request.getClientIP.return_value = "-"
+
         mock_request.requestHeaders.getRawHeaders.return_value=[
             "X-Matrix origin=test,key=,sig="
         ]


### PR DESCRIPTION
The format is as follows:

```yaml
        listeners:
          - port: 8448
            bind_address: ''
            type: http

            tls: false

            resources:
              - names: [client, webclient]
                compress: true
              - names: [federation]
                compress: false

          - port: 8008
            bind_address: ''
            type: http

            tls: true
            x_forwarded: False

            resources:
              - names: [client, webclient]
                compress: true
              - names: [federation]
                compress: false

          - port: 9000
            bind_address: ''
            type: manhole
```

The current recognized types are `http` and `manhole`.

The recognized resources for `http` are: 

- `static` - static resources, e.g. registration fallback
- `media` - media repository
- `keys` - key server
- `client` - client APIs, both v1 and v2 ⇒ ``static`` and ``media``
- `federation` - federation API  ⇒ ``keys`` and ``media``
- `webclient` - hosted webclient
- `metrics` - metrics API

TODO:

- [x] Initial Implementation.
- [x] Backwards compat with existing format.
- [x] Compression on a per listener basis
- [x] Support X-Forwarded-For on a per listener basis.
- [x] Annotate default config with documentation.
- ~~[ ] Fully document the listener options somewhere.~~
- ~~[ ] Deprecate existing config options. Warn on start up if they're used?~~