### PR TITLE
Add ability to restrict room history.

### DIFF
--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 AuthEventTypes = (
     EventTypes.Create, EventTypes.Member, EventTypes.PowerLevels,
-    EventTypes.JoinRules,
+    EventTypes.JoinRules, EventTypes.RoomHistoryVisibility,
 )
 
 

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -575,6 +575,7 @@ class Auth(object):
         levels_to_check = [
             ("users_default", []),
             ("events_default", []),
+            ("state_default", []),
             ("ban", []),
             ("redact", []),
             ("kick", []),

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -75,6 +75,8 @@ class EventTypes(object):
     Redaction = "m.room.redaction"
     Feedback = "m.room.message.feedback"
 
+    RoomHistoryVisibility = "m.room.history_visibility"
+
     # These are used for validation
     Message = "m.room.message"
     Topic = "m.room.topic"

--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -74,6 +74,8 @@ def prune_event(event):
         )
     elif event_type == EventTypes.Aliases:
         add_fields("aliases")
+    elif event_type == EventTypes.RoomHistoryVisibility:
+        add_fields("visibility")
 
     allowed_fields = {
         k: v

--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -75,7 +75,7 @@ def prune_event(event):
     elif event_type == EventTypes.Aliases:
         add_fields("aliases")
     elif event_type == EventTypes.RoomHistoryVisibility:
-        add_fields("visibility")
+        add_fields("history_visibility")
 
     allowed_fields = {
         k: v

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -31,6 +31,8 @@ from synapse.crypto.event_signing import (
 )
 from synapse.types import UserID
 
+from synapse.events.utils import prune_event
+
 from synapse.util.retryutils import NotRetryingDestination
 
 from twisted.internet import defer
@@ -221,6 +223,46 @@ class FederationHandler(BaseHandler):
                 yield self.distributor.fire(
                     "user_joined_room", user=user, room_id=event.room_id
                 )
+
+    @defer.inlineCallbacks
+    def _filter_events_for_server(self, server_name, room_id, events):
+        states = yield self.store.get_state_for_events(
+            room_id, [e.event_id for e in events],
+        )
+
+        events_and_states = zip(events, states)
+
+        def redact_disallowed(event_and_state):
+            event, state = event_and_state
+
+            if not state:
+                return event
+
+            history = state.get((EventTypes.RoomHistoryVisibility, ''), None)
+            if history and history.content.get("visibility", None) == "after_join":
+                for ev in state.values():
+                    if ev.type != EventTypes.Member:
+                        continue
+                    try:
+                        domain = UserID.from_string(ev.state_key).domain
+                    except:
+                        continue
+
+                    if domain != server_name:
+                        continue
+
+                    if ev.membership == Membership.JOIN:
+                        return event
+                else:
+                    return prune_event(event)
+
+            return event
+
+        res = map(redact_disallowed, events_and_states)
+
+        logger.info("_filter_events_for_server %r", res)
+
+        defer.returnValue(res)
 
     @log_function
     @defer.inlineCallbacks
@@ -881,6 +923,8 @@ class FederationHandler(BaseHandler):
             pdu_list,
             limit
         )
+
+        events = yield self._filter_events_for_server(origin, room_id, events)
 
         defer.returnValue(events)
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -242,6 +242,10 @@ class FederationHandler(BaseHandler):
             if history:
                 visibility = history.content.get("history_visibility", "shared")
                 if visibility in ["invited", "joined"]:
+                    # We now loop through all state events looking for
+                    # membership states for the requesting server to determine
+                    # if the server is either in the room or has been invited
+                    # into the room.
                     for ev in state.values():
                         if ev.type != EventTypes.Member:
                             continue

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -149,13 +149,29 @@ class MessageHandler(BaseHandler):
             if event.type == EventTypes.RoomHistoryVisibility:
                 return True
 
-            membership = state.get((EventTypes.Member, user_id), None)
-            if membership and membership.membership == Membership.JOIN:
+            membership_ev = state.get((EventTypes.Member, user_id), None)
+            if membership_ev:
+                membership = membership_ev.membership
+            else:
+                membership = Membership.LEAVE
+
+            if membership == Membership.JOIN:
                 return True
 
             history = state.get((EventTypes.RoomHistoryVisibility, ''), None)
-            if history and history.content.get("visibility", None) == "after_join":
-                return False
+            if history:
+                visibility = history.content.get("history_visibility", "shared")
+            else:
+                visibility = "shared"
+
+            if visibility == "public":
+                return True
+            elif visibility == "shared":
+                return True
+            elif visibility == "joined":
+                return membership == Membership.JOIN
+            elif visibility == "invited":
+                return membership == Membership.INVITE
 
             return True
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -213,6 +213,7 @@ class RoomCreationHandler(BaseHandler):
                 "events": {
                     EventTypes.Name: 100,
                     EventTypes.PowerLevels: 100,
+                    EventTypes.RoomHistoryVisibility: 100,
                 },
                 "events_default": 0,
                 "state_default": 50,


### PR DESCRIPTION
This adds the following restrictions to which events users/servers can see:

> If `m.room.history_visibility` event has `visibility` set to `after_join` then:
> - A user can only see that event if they were joined at that event.
> - A server can only see an unredacted version of that event if one of its users were joined at the time.

TODO:
- [x] Update names
- [x] Implement `invited` option
- [x] Set default power level for the event.