### PR TITLE
Implement read receipts.

### DIFF
--- a/synapse/handlers/__init__.py
+++ b/synapse/handlers/__init__.py
@@ -32,6 +32,7 @@ from .appservice import ApplicationServicesHandler
 from .sync import SyncHandler
 from .auth import AuthHandler
 from .identity import IdentityHandler
+from .receipts import ReceiptsHandler
 
 
 class Handlers(object):
@@ -57,6 +58,7 @@ class Handlers(object):
         self.directory_handler = DirectoryHandler(hs)
         self.typing_notification_handler = TypingNotificationHandler(hs)
         self.admin_handler = AdminHandler(hs)
+        self.receipts_handler = ReceiptsHandler(hs)
         asapi = ApplicationServiceApi(hs)
         self.appservice_handler = ApplicationServicesHandler(
             hs, asapi, AppServiceScheduler(

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -278,6 +278,11 @@ class MessageHandler(BaseHandler):
             user, pagination_config.get_source_config("presence"), None
         )
 
+        receipt_stream = self.hs.get_event_sources().sources["receipt"]
+        receipt, _ = yield receipt_stream.get_pagination_rows(
+            user, pagination_config.get_source_config("receipt"), None
+        )
+
         public_room_ids = yield self.store.get_public_room_ids()
 
         limit = pagin_config.limit
@@ -344,7 +349,8 @@ class MessageHandler(BaseHandler):
         ret = {
             "rooms": rooms_ret,
             "presence": presence,
-            "end": now_token.to_string()
+            "receipts": receipt,
+            "end": now_token.to_string(),
         }
 
         defer.returnValue(ret)
@@ -405,9 +411,12 @@ class MessageHandler(BaseHandler):
 
             defer.returnValue([p for success, p in presence_defs if success])
 
-        presence, (messages, token) = yield defer.gatherResults(
+        receipts_handler = self.hs.get_handlers().receipts_handler
+
+        presence, receipts, (messages, token) = yield defer.gatherResults(
             [
                 get_presence(),
+                receipts_handler.get_receipts_for_room(room_id, now_token.receipt_key),
                 self.store.get_recent_events_for_room(
                     room_id,
                     limit=limit,
@@ -431,5 +440,6 @@ class MessageHandler(BaseHandler):
                 "end": end_token.to_string(),
             },
             "state": state,
-            "presence": presence
+            "presence": presence,
+            "receipts": receipts,
         })

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -992,7 +992,7 @@ class PresenceHandler(BaseHandler):
             room_ids([str]): List of room_ids to notify.
         """
         with PreserveLoggingContext():
-            self.notifier.on_new_user_event(
+            self.notifier.on_new_event(
                 "presence_key",
                 self._user_cachemap_latest_serial,
                 users_to_push,

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 OpenMarket Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contains handlers for federation events."""
+
+from ._base import BaseHandler
+
+from twisted.internet import defer
+
+from synapse.util.logcontext import PreserveLoggingContext
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class ReceiptsHandler(BaseHandler):
+    def __init__(self, hs):
+        super(ReceiptsHandler, self).__init__(hs)
+
+        self.federation.register_edu_handler(
+            "m.receipt", self._received_remote_receipt
+        )
+
+        self._latest_serial = 0
+
+    @defer.inlineCallbacks
+    def received_client_receipt(self, room_id, receipt_type, user_id,
+                                event_id):
+        # 1. Persist.
+        # 2. Notify local clients
+        # 3. Notify remote servers
+
+        receipt = {
+            "room_id": room_id,
+            "receipt_type": receipt_type,
+            "user_id": user_id,
+            "event_ids": [event_id],
+        }
+
+        yield self._handle_new_receipts([receipt])
+        self._push_remotes([receipt])
+
+    @defer.inlineCallbacks
+    def _received_remote_receipt(self, origin, content):
+        receipts = [
+            {
+                "room_id": room_id,
+                "receipt_type": receipt_type,
+                "user_id": user_id,
+                "event_ids": [event_id],
+            }
+            for room_id, room_values in content.items()
+            for event_id, ev_values in room_values.items()
+            for receipt_type, users in ev_values.items()
+            for user_id in users
+        ]
+
+        yield self._handle_new_receipts(receipts)
+
+    @defer.inlineCallbacks
+    def _handle_new_receipts(self, receipts):
+        for receipt in receipts:
+            room_id = receipt["room_id"]
+            receipt_type = receipt["receipt_type"]
+            user_id = receipt["user_id"]
+            event_ids = receipt["event_ids"]
+
+            stream_id, max_persisted_id = yield self.store.insert_receipt(
+                room_id, receipt_type, user_id, event_ids,
+            )
+
+            # TODO: Use max_persisted_id
+
+            self._latest_serial = max(self._latest_serial, stream_id)
+
+            with PreserveLoggingContext():
+                self.notifier.on_new_user_event(
+                    "recei[t_key", self._latest_serial, rooms=[room_id]
+                )
+
+            localusers = set()
+            remotedomains = set()
+
+            rm_handler = self.homeserver.get_handlers().room_member_handler
+            yield rm_handler.fetch_room_distributions_into(
+                room_id, localusers=localusers, remotedomains=remotedomains
+            )
+
+            receipt["remotedomains"] = remotedomains
+
+            self.notifier.on_new_user_event(
+                "receipt_key", self._latest_room_serial, rooms=[room_id]
+            )
+
+    def _push_remotes(self, receipts):
+        # TODO: Some of this stuff should be coallesced.
+        for receipt in receipts:
+            room_id = receipt["room_id"]
+            receipt_type = receipt["receipt_type"]
+            user_id = receipt["user_id"]
+            event_ids = receipt["event_ids"]
+            remotedomains = receipt["remotedomains"]
+
+            for domain in remotedomains:
+                self.federation.send_edu(
+                    destination=domain,
+                    edu_type="m.receipt",
+                    content={
+                        room_id: {
+                            event_id: {
+                                receipt_type: [user_id]
+                            }
+                            for event_id in event_ids
+                        },
+                    },
+                )

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Contains handlers for federation events."""
-
 from ._base import BaseHandler
 
 from twisted.internet import defer

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -37,8 +37,7 @@ class ReceiptsHandler(BaseHandler):
             "m.receipt", self._received_remote_receipt
         )
 
-        # self._earliest_cached_serial = 0
-        # self._rooms_to_latest_serial = {}
+        self._receipt_cache = None
 
     @defer.inlineCallbacks
     def received_client_receipt(self, room_id, receipt_type, user_id,
@@ -162,17 +161,9 @@ class ReceiptEventSource(object):
 
         rooms = yield self.store.get_rooms_for_user(user.to_string())
         rooms = [room.room_id for room in rooms]
-        events = []
-        for room_id in rooms:
-            content = yield self.store.get_linearized_receipts_for_room(
-                room_id, from_key, to_key
-            )
-            if content:
-                events.append({
-                    "type": "m.receipt",
-                    "room_id": room_id,
-                    "content": content,
-                })
+        events = yield self.store.get_linearized_receipts_for_rooms(
+            rooms, from_key, to_key
+        )
 
         defer.returnValue((events, to_key))
 
@@ -190,16 +181,8 @@ class ReceiptEventSource(object):
 
         rooms = yield self.store.get_rooms_for_user(user.to_string())
         rooms = [room.room_id for room in rooms]
-        events = []
-        for room_id in rooms:
-            content = yield self.store.get_linearized_receipts_for_room(
-                room_id, from_key, to_key
-            )
-            if content:
-                events.append({
-                    "type": "m.receipt",
-                    "room_id": room_id,
-                    "content": content,
-                })
+        events = yield self.store.get_linearized_receipts_for_rooms(
+            rooms, from_key, to_key
+        )
 
         defer.returnValue((events, to_key))

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -149,7 +149,8 @@ class ReceiptsHandler(BaseHandler):
         """Gets all receipts for a room, upto the given key.
         """
         result = yield self.store.get_linearized_receipts_for_room(
-            room_id, None, to_key
+            room_id,
+            to_key=to_key,
         )
 
         if not result:
@@ -176,7 +177,9 @@ class ReceiptEventSource(object):
         rooms = yield self.store.get_rooms_for_user(user.to_string())
         rooms = [room.room_id for room in rooms]
         events = yield self.store.get_linearized_receipts_for_rooms(
-            rooms, from_key, to_key
+            rooms,
+            from_key=from_key,
+            to_key=to_key,
         )
 
         defer.returnValue((events, to_key))
@@ -196,7 +199,9 @@ class ReceiptEventSource(object):
         rooms = yield self.store.get_rooms_for_user(user.to_string())
         rooms = [room.room_id for room in rooms]
         events = yield self.store.get_linearized_receipts_for_rooms(
-            rooms, from_key, to_key
+            rooms,
+            from_key=from_key,
+            to_key=to_key,
         )
 
         defer.returnValue((events, to_key))

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -53,7 +53,7 @@ class ReceiptsHandler(BaseHandler):
             "user_id": user_id,
             "event_ids": [event_id],
             "data": {
-                "ts": self.clock.time_msec()
+                "ts": int(self.clock.time_msec()),
             }
         }
 

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -41,10 +41,9 @@ class ReceiptsHandler(BaseHandler):
     @defer.inlineCallbacks
     def received_client_receipt(self, room_id, receipt_type, user_id,
                                 event_id):
-        # 1. Persist.
-        # 2. Notify local clients
-        # 3. Notify remote servers
-
+        """Called when a client tells us a local user has read up to the given
+        event_id in the room.
+        """
         receipt = {
             "room_id": room_id,
             "receipt_type": receipt_type,
@@ -62,6 +61,8 @@ class ReceiptsHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def _received_remote_receipt(self, origin, content):
+        """Called when we receive an EDU of type m.receipt from a remote HS.
+        """
         receipts = [
             {
                 "room_id": room_id,
@@ -79,6 +80,8 @@ class ReceiptsHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def _handle_new_receipts(self, receipts):
+        """Takes a list of receipts, stores them and informs the notifier.
+        """
         for receipt in receipts:
             room_id = receipt["room_id"]
             receipt_type = receipt["receipt_type"]
@@ -105,6 +108,9 @@ class ReceiptsHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def _push_remotes(self, receipts):
+        """Given a list of receipts, works out which remote servers should be
+        poked and pokes them.
+        """
         # TODO: Some of this stuff should be coallesced.
         for receipt in receipts:
             room_id = receipt["room_id"]
@@ -140,6 +146,8 @@ class ReceiptsHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def get_receipts_for_room(self, room_id, to_key):
+        """Gets all receipts for a room, upto the given key.
+        """
         result = yield self.store.get_linearized_receipts_for_room(
             room_id, None, to_key
         )

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -144,9 +144,8 @@ class ReceiptsHandler(BaseHandler):
 
         event = {
             "type": "m.receipt",
-            "content": {
-                room_id: result,
-            },
+            "room_id": room_id,
+            "content": result,
         }
 
         defer.returnValue([event])
@@ -163,23 +162,19 @@ class ReceiptEventSource(object):
 
         rooms = yield self.store.get_rooms_for_user(user.to_string())
         rooms = [room.room_id for room in rooms]
-        content = {}
+        events = []
         for room_id in rooms:
-            result = yield self.store.get_linearized_receipts_for_room(
+            content = yield self.store.get_linearized_receipts_for_room(
                 room_id, from_key, to_key
             )
-            if result:
-                content[room_id] = result
+            if content:
+                events.append({
+                    "type": "m.receipt",
+                    "room_id": room_id,
+                    "content": content,
+                })
 
-        if not content:
-            defer.returnValue(([], to_key))
-
-        event = {
-            "type": "m.receipt",
-            "content": content,
-        }
-
-        defer.returnValue(([event], to_key))
+        defer.returnValue((events, to_key))
 
     def get_current_key(self, direction='f'):
         return self.store.get_max_receipt_stream_id()
@@ -195,20 +190,16 @@ class ReceiptEventSource(object):
 
         rooms = yield self.store.get_rooms_for_user(user.to_string())
         rooms = [room.room_id for room in rooms]
-        content = {}
+        events = []
         for room_id in rooms:
-            result = yield self.store.get_linearized_receipts_for_room(
+            content = yield self.store.get_linearized_receipts_for_room(
                 room_id, from_key, to_key
             )
-            if result:
-                content[room_id] = result
+            if content:
+                events.append({
+                    "type": "m.receipt",
+                    "room_id": room_id,
+                    "content": content,
+                })
 
-        if not content:
-            defer.returnValue(([], to_key))
-
-        event = {
-            "type": "m.receipt",
-            "content": content,
-        }
-
-        defer.returnValue(([event], to_key))
+        defer.returnValue((events, to_key))

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -88,7 +88,7 @@ class ReceiptsHandler(BaseHandler):
             self._latest_serial = max(self._latest_serial, stream_id)
 
             with PreserveLoggingContext():
-                self.notifier.on_new_user_event(
+                self.notifier.on_new_event(
                     "recei[t_key", self._latest_serial, rooms=[room_id]
                 )
 
@@ -102,7 +102,7 @@ class ReceiptsHandler(BaseHandler):
 
             receipt["remotedomains"] = remotedomains
 
-            self.notifier.on_new_user_event(
+            self.notifier.on_new_event(
                 "receipt_key", self._latest_room_serial, rooms=[room_id]
             )
 

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -31,6 +31,8 @@ class ReceiptsHandler(BaseHandler):
     def __init__(self, hs):
         super(ReceiptsHandler, self).__init__(hs)
 
+        self.hs = hs
+        self.federation = hs.get_replication_layer()
         self.federation.register_edu_handler(
             "m.receipt", self._received_remote_receipt
         )
@@ -89,13 +91,13 @@ class ReceiptsHandler(BaseHandler):
 
             with PreserveLoggingContext():
                 self.notifier.on_new_event(
-                    "recei[t_key", self._latest_serial, rooms=[room_id]
+                    "receipt_key", self._latest_serial, rooms=[room_id]
                 )
 
             localusers = set()
             remotedomains = set()
 
-            rm_handler = self.homeserver.get_handlers().room_member_handler
+            rm_handler = self.hs.get_handlers().room_member_handler
             yield rm_handler.fetch_room_distributions_into(
                 room_id, localusers=localusers, remotedomains=remotedomains
             )

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -218,7 +218,7 @@ class TypingNotificationHandler(BaseHandler):
         self._room_serials[room_id] = self._latest_room_serial
 
         with PreserveLoggingContext():
-            self.notifier.on_new_user_event(
+            self.notifier.on_new_event(
                 "typing_key", self._latest_room_serial, rooms=[room_id]
             )
 

--- a/synapse/notifier.py
+++ b/synapse/notifier.py
@@ -283,7 +283,7 @@ class Notifier(object):
 
     @defer.inlineCallbacks
     def wait_for_events(self, user, rooms, timeout, callback,
-                        from_token=StreamToken("s0", "0", "0")):
+                        from_token=StreamToken("s0", "0", "0", "0")):
         """Wait until the callback returns a non empty response or the
         timeout fires.
         """

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -31,6 +31,7 @@ REQUIREMENTS = {
     "pillow": ["PIL"],
     "pydenticon": ["pydenticon"],
     "ujson": ["ujson"],
+    "blist": ["blist"],
 }
 CONDITIONAL_REQUIREMENTS = {
     "web_client": {

--- a/synapse/rest/client/v2_alpha/__init__.py
+++ b/synapse/rest/client/v2_alpha/__init__.py
@@ -18,7 +18,8 @@ from . import (
     filter,
     account,
     register,
-    auth
+    auth,
+    receipts,
 )
 
 from synapse.http.server import JsonResource
@@ -38,3 +39,4 @@ class ClientV2AlphaRestResource(JsonResource):
         account.register_servlets(hs, client_resource)
         register.register_servlets(hs, client_resource)
         auth.register_servlets(hs, client_resource)
+        receipts.register_servlets(hs, client_resource)

--- a/synapse/rest/client/v2_alpha/receipts.py
+++ b/synapse/rest/client/v2_alpha/receipts.py
@@ -28,7 +28,7 @@ class ReceiptRestServlet(RestServlet):
     PATTERN = client_v2_pattern(
         "/rooms/(?P<room_id>[^/]*)"
         "/receipt/(?P<receipt_type>[^/]*)"
-        "/(?P<event_id>[^/])*"
+        "/(?P<event_id>[^/]*)$"
     )
 
     def __init__(self, hs):
@@ -41,7 +41,6 @@ class ReceiptRestServlet(RestServlet):
     def on_POST(self, request, room_id, receipt_type, event_id):
         user, client = yield self.auth.get_user_by_req(request)
 
-        # TODO: STUFF
         yield self.receipts_handler.received_client_receipt(
             room_id,
             receipt_type,

--- a/synapse/storage/__init__.py
+++ b/synapse/storage/__init__.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 # Remember to update this number every time a change is made to database
 # schema files, so the users will be informed on server restarts.
-SCHEMA_VERSION = 20
+SCHEMA_VERSION = 21
 
 dir_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/synapse/storage/__init__.py
+++ b/synapse/storage/__init__.py
@@ -38,6 +38,8 @@ from .state import StateStore
 from .signatures import SignatureStore
 from .filtering import FilteringStore
 
+from .receipts import ReceiptsStore
+
 
 import fnmatch
 import imp
@@ -74,6 +76,7 @@ class DataStore(RoomMemberStore, RoomStore,
                 PushRuleStore,
                 ApplicationServiceTransactionStore,
                 EventsStore,
+                ReceiptsStore,
                 ):
 
     def __init__(self, hs):

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -329,13 +329,14 @@ class SQLBaseStore(object):
 
         self.database_engine = hs.database_engine
 
-        self._stream_id_gen = StreamIdGenerator()
+        self._stream_id_gen = StreamIdGenerator("events", "stream_ordering")
         self._transaction_id_gen = IdGenerator("sent_transactions", "id", self)
         self._state_groups_id_gen = IdGenerator("state_groups", "id", self)
         self._access_tokens_id_gen = IdGenerator("access_tokens", "id", self)
         self._pushers_id_gen = IdGenerator("pushers", "id", self)
         self._push_rule_id_gen = IdGenerator("push_rules", "id", self)
         self._push_rules_enable_id_gen = IdGenerator("push_rules_enable", "id", self)
+        self._receipts_id_gen = StreamIdGenerator("receipts_linearized", "stream_id")
 
     def start_profiling(self):
         self._previous_loop_ts = self._clock.time_msec()

--- a/synapse/storage/receipts.py
+++ b/synapse/storage/receipts.py
@@ -188,6 +188,7 @@ class ReceiptsStore(SQLBaseStore):
             linearized_event_id = event_ids[0]
         else:
             # we need to points in graph -> linearized form.
+            # TODO: Make this better.
             def graph_to_linear(txn):
                 query = (
                     "SELECT event_id WHERE room_id = ? AND stream_ordering IN ("
@@ -200,8 +201,7 @@ class ReceiptsStore(SQLBaseStore):
                 if rows:
                     return rows[0][0]
                 else:
-                    # TODO: ARGH?!
-                    return None
+                    raise RuntimeError("Unrecognized event_ids: %r" % (event_ids,))
 
             linearized_event_id = yield self.runInteraction(
                 "insert_receipt_conv", graph_to_linear

--- a/synapse/storage/receipts.py
+++ b/synapse/storage/receipts.py
@@ -35,6 +35,8 @@ class ReceiptsStore(SQLBaseStore):
 
     @defer.inlineCallbacks
     def get_linearized_receipts_for_rooms(self, room_ids, from_key, to_key):
+        """Get receipts for multiple rooms for sending to clients.
+        """
         room_ids = set(room_ids)
 
         if from_key:
@@ -54,6 +56,8 @@ class ReceiptsStore(SQLBaseStore):
 
     @defer.inlineCallbacks
     def get_linearized_receipts_for_room(self, room_id, from_key, to_key):
+        """Get receipts for a single room for sending to clients.
+        """
         def f(txn):
             if from_key:
                 sql = (
@@ -107,6 +111,8 @@ class ReceiptsStore(SQLBaseStore):
     @cached
     @defer.inlineCallbacks
     def get_graph_receipts_for_room(self, room_id):
+        """Get receipts for sending to remote servers.
+        """
         rows = yield self._simple_select_list(
             table="receipts_graph",
             keyvalues={"room_id": room_id},
@@ -181,6 +187,11 @@ class ReceiptsStore(SQLBaseStore):
 
     @defer.inlineCallbacks
     def insert_receipt(self, room_id, receipt_type, user_id, event_ids, data):
+        """Insert a receipt, either from local client or remote server.
+
+        Automatically does conversion between linearized and graph
+        representations.
+        """
         if not event_ids:
             return
 

--- a/synapse/storage/receipts.py
+++ b/synapse/storage/receipts.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014, 2015 OpenMarket Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._base import SQLBaseStore, cached
+
+from twisted.internet import defer
+
+
+class ReceiptStore(SQLBaseStore):
+
+    @cached
+    @defer.inlineCallbacks
+    def get_linearized_receipts_for_room(self, room_id):
+        rows = yield self._simple_select_list(
+            table="receipts_linearized",
+            keyvalues={"room_id": room_id},
+            retcols=["receipt_type", "user_id", "event_id"],
+            desc="get_linearized_receipts_for_room",
+        )
+
+        result = {}
+        for row in rows:
+            result.setdefault(
+                row["event_id"], {}
+            ).setdefault(
+                row["receipt_type"], []
+            ).append(row["user_id"])
+
+        defer.returnValue(result)
+
+    @cached
+    @defer.inlineCallbacks
+    def get_graph_receipts_for_room(self, room_id):
+        rows = yield self._simple_select_list(
+            table="receipts_graph",
+            keyvalues={"room_id": room_id},
+            retcols=["receipt_type", "user_id", "event_id"],
+            desc="get_linearized_receipts_for_room",
+        )
+
+        result = {}
+        for row in rows:
+            result.setdefault(
+                row["user_id"], {}
+            ).setdefault(
+                row["receipt_type"], []
+            ).append(row["event_id"])
+
+        defer.returnValue(result)
+
+    def insert_linearized_receipt_txn(self, txn, room_id, receipt_type,
+                                      user_id, event_id, stream_id):
+        self._simple_delete_txn(
+            txn,
+            table="receipts_linearized",
+            keyvalues={
+                "stream_id": stream_id,
+                "room_id": room_id,
+                "receipt_type": receipt_type,
+                "user_id": user_id,
+            }
+        )
+
+        self._simple_insert_txn(
+            txn,
+            table="receipts_linearized",
+            values={
+                "room_id": room_id,
+                "receipt_type": receipt_type,
+                "user_id": user_id,
+                "event_id": event_id,
+            }
+        )
+
+    @defer.inlineCallbacks
+    def insert_receipt(self, room_id, receipt_type, user_id, event_ids):
+        if not event_ids:
+            return
+
+        if len(event_ids) == 1:
+            linearized_event_id = event_ids[0]
+        else:
+            # we need to points in graph -> linearized form.
+            def graph_to_linear(txn):
+                query = (
+                    "SELECT event_id WHERE room_id = ? AND stream_ordering IN ("
+                    " SELECT max(stream_ordering) WHERE event_id IN (%s)"
+                    ")"
+                ) % (",".join(["?"] * len(event_ids)))
+
+                txn.execute(query, [room_id] + event_ids)
+                rows = txn.fetchall()
+                if rows:
+                    return rows[0][0]
+                else:
+                    # TODO: ARGH?!
+                    return None
+
+            linearized_event_id = yield self.runInteraction(
+                graph_to_linear, desc="insert_receipt_conv"
+            )
+
+        stream_id_manager = yield self._stream_id_gen.get_next(self)
+        with stream_id_manager() as stream_id:
+            yield self.runInteraction(
+                self.insert_linearized_receipt_txn,
+                room_id, receipt_type, user_id, linearized_event_id,
+                stream_id=stream_id,
+                desc="insert_linearized_receipt"
+            )
+
+        yield self.insert_graph_receipt(
+            room_id, receipt_type, user_id, event_ids
+        )
+
+        max_persisted_id = yield self._stream_id_gen.get_max_token(self)
+        defer.returnValue((stream_id, max_persisted_id))
+
+    def insert_graph_receipt(self, room_id, receipt_type,
+                             user_id, event_ids):
+        return self.runInteraction(
+            self.insert_graph_receipt_txn,
+            room_id, receipt_type, user_id, event_ids,
+            desc="insert_graph_receipt"
+        )
+
+    def insert_graph_receipt_txn(self, txn, room_id, receipt_type,
+                                 user_id, event_ids):
+        self._simple_delete_txn(
+            txn,
+            table="receipts_graph",
+            keyvalues={
+                "room_id": room_id,
+                "receipt_type": receipt_type,
+                "user_id": user_id,
+            }
+        )
+        self._simple_insert_many_txn(
+            txn,
+            table="receipts_graph",
+            values=[
+                {
+                    "room_id": room_id,
+                    "receipt_type": receipt_type,
+                    "user_id": user_id,
+                    "event_id": event_id,
+                }
+                for event_id in event_ids
+            ],
+        )

--- a/synapse/storage/receipts.py
+++ b/synapse/storage/receipts.py
@@ -28,15 +28,26 @@ class ReceiptsStore(SQLBaseStore):
     @defer.inlineCallbacks
     def get_linearized_receipts_for_room(self, room_id, from_key, to_key):
         def f(txn):
-            sql = (
-                "SELECT * FROM receipts_linearized WHERE"
-                " room_id = ? AND stream_id > ? AND stream_id <= ?"
-            )
+            if from_key:
+                sql = (
+                    "SELECT * FROM receipts_linearized WHERE"
+                    " room_id = ? AND stream_id > ? AND stream_id <= ?"
+                )
 
-            txn.execute(
-                sql,
-                (room_id, from_key, to_key)
-            )
+                txn.execute(
+                    sql,
+                    (room_id, from_key, to_key)
+                )
+            else:
+                sql = (
+                    "SELECT * FROM receipts_linearized WHERE"
+                    " room_id = ? AND stream_id <= ?"
+                )
+
+                txn.execute(
+                    sql,
+                    (room_id, to_key)
+                )
 
             rows = self.cursor_to_dict(txn)
 

--- a/synapse/storage/schema/delta/21/receipts.sql
+++ b/synapse/storage/schema/delta/21/receipts.sql
@@ -18,11 +18,9 @@ CREATE TABLE IF NOT EXISTS receipts_graph(
     room_id TEXT NOT NULL,
     receipt_type TEXT NOT NULL,
     user_id TEXT NOT NULL,
-    event_id TEXT NOT NULL
-);
-
-CREATE INDEX receipts_graph_room_tuple ON receipts_graph(
-  room_id, receipt_type, user_id
+    event_ids TEXT NOT NULL,
+    data TEXT NOT NULL,
+    CONSTRAINT receipts_graph_uniqueness UNIQUE (room_id, receipt_type, user_id)
 );
 
 CREATE TABLE IF NOT EXISTS receipts_linearized (
@@ -30,11 +28,9 @@ CREATE TABLE IF NOT EXISTS receipts_linearized (
     room_id TEXT NOT NULL,
     receipt_type TEXT NOT NULL,
     user_id TEXT NOT NULL,
-    event_id TEXT NOT NULL
-);
-
-CREATE INDEX receipts_linearized_room_tuple ON receipts_linearized(
-  room_id, receipt_type, user_id
+    event_id TEXT NOT NULL,
+    data TEXT NOT NULL,
+    CONSTRAINT receipts_linearized_uniqueness UNIQUE (room_id, receipt_type, user_id)
 );
 
 CREATE INDEX receipts_linearized_id ON receipts_linearized(

--- a/synapse/storage/schema/delta/21/receipts.sql
+++ b/synapse/storage/schema/delta/21/receipts.sql
@@ -1,0 +1,35 @@
+# Copyright 2015 OpenMarket Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CREATE TABLE IF NOT EXISTS receipts_graph(
+    room_id TEXT NOT NULL,
+    receipt_type TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    event_id TEXT NOT NULL
+);
+
+CREATE INDEX receipts_graph_room_tuple ON receipts_graph(
+  room_id, receipt_type, user_id
+);
+
+CREATE TABLE IF NOT EXISTS receipts_linearized (
+    room_id TEXT NOT NULL,
+    receipt_type TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    event_id TEXT NOT NULL
+);
+
+CREATE INDEX receipts_graph_room_tuple ON receipts_graph(
+  room_id, receipt_type, user_id
+);

--- a/synapse/storage/schema/delta/21/receipts.sql
+++ b/synapse/storage/schema/delta/21/receipts.sql
@@ -33,6 +33,10 @@ CREATE TABLE IF NOT EXISTS receipts_linearized (
     event_id TEXT NOT NULL
 );
 
-CREATE INDEX receipts_linearized_room_tuple ON receipts_graph(
+CREATE INDEX receipts_linearized_room_tuple ON receipts_linearized(
   room_id, receipt_type, user_id
+);
+
+CREATE INDEX receipts_linearized_id ON receipts_linearized(
+  stream_id
 );

--- a/synapse/storage/schema/delta/21/receipts.sql
+++ b/synapse/storage/schema/delta/21/receipts.sql
@@ -1,16 +1,18 @@
-# Copyright 2015 OpenMarket Ltd
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+/* Copyright 2015 OpenMarket Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 CREATE TABLE IF NOT EXISTS receipts_graph(
     room_id TEXT NOT NULL,
@@ -24,12 +26,13 @@ CREATE INDEX receipts_graph_room_tuple ON receipts_graph(
 );
 
 CREATE TABLE IF NOT EXISTS receipts_linearized (
+    stream_id BIGINT NOT NULL,
     room_id TEXT NOT NULL,
     receipt_type TEXT NOT NULL,
     user_id TEXT NOT NULL,
     event_id TEXT NOT NULL
 );
 
-CREATE INDEX receipts_graph_room_tuple ON receipts_graph(
+CREATE INDEX receipts_linearized_room_tuple ON receipts_graph(
   room_id, receipt_type, user_id
 );

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -72,7 +72,10 @@ class StreamIdGenerator(object):
         with stream_id_gen.get_next_txn(txn) as stream_id:
             # ... persist event ...
     """
-    def __init__(self):
+    def __init__(self, table, column):
+        self.table = table
+        self.column = column
+
         self._lock = threading.Lock()
 
         self._current_max = None
@@ -126,7 +129,7 @@ class StreamIdGenerator(object):
 
     def _get_or_compute_current_max(self, txn):
         with self._lock:
-            txn.execute("SELECT MAX(stream_ordering) FROM events")
+            txn.execute("SELECT MAX(%s) FROM %s" % (self.column, self.table))
             rows = txn.fetchall()
             val, = rows[0]
 

--- a/synapse/streams/events.py
+++ b/synapse/streams/events.py
@@ -20,6 +20,7 @@ from synapse.types import StreamToken
 from synapse.handlers.presence import PresenceEventSource
 from synapse.handlers.room import RoomEventSource
 from synapse.handlers.typing import TypingNotificationEventSource
+from synapse.handlers.receipts import ReceiptEventSource
 
 
 class NullSource(object):
@@ -43,6 +44,7 @@ class EventSources(object):
         "room": RoomEventSource,
         "presence": PresenceEventSource,
         "typing": TypingNotificationEventSource,
+        "receipt": ReceiptEventSource,
     }
 
     def __init__(self, hs):
@@ -63,7 +65,9 @@ class EventSources(object):
             typing_key=(
                 yield self.sources["typing"].get_current_key()
             ),
-            receipt_key="0",
+            receipt_key=(
+                yield self.sources["receipt"].get_current_key()
+            ),
         )
         defer.returnValue(token)
 

--- a/synapse/streams/events.py
+++ b/synapse/streams/events.py
@@ -62,7 +62,8 @@ class EventSources(object):
             ),
             typing_key=(
                 yield self.sources["typing"].get_current_key()
-            )
+            ),
+            receipt_key="0",
         )
         defer.returnValue(token)
 

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -100,7 +100,7 @@ class EventID(DomainSpecificString):
 class StreamToken(
     namedtuple(
         "Token",
-        ("room_key", "presence_key", "typing_key")
+        ("room_key", "presence_key", "typing_key", "receipt_key")
     )
 ):
     _SEPARATOR = "_"
@@ -109,6 +109,9 @@ class StreamToken(
     def from_string(cls, string):
         try:
             keys = string.split(cls._SEPARATOR)
+            if len(keys) == len(cls._fields) - 1:
+                # i.e. old token from before receipt_key
+                keys.append("0")
             return cls(*keys)
         except:
             raise SynapseError(400, "Invalid Token")
@@ -131,6 +134,7 @@ class StreamToken(
             (other_token.room_stream_id < self.room_stream_id)
             or (int(other_token.presence_key) < int(self.presence_key))
             or (int(other_token.typing_key) < int(self.typing_key))
+            or (int(other_token.receipt_key) < int(self.receipt_key))
         )
 
     def copy_and_advance(self, key, new_value):

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -66,8 +66,8 @@ class TypingNotificationsTestCase(unittest.TestCase):
 
         self.mock_federation_resource = MockHttpResource()
 
-        mock_notifier = Mock(spec=["on_new_user_event"])
-        self.on_new_user_event = mock_notifier.on_new_user_event
+        mock_notifier = Mock(spec=["on_new_event"])
+        self.on_new_event = mock_notifier.on_new_event
 
         self.auth = Mock(spec=[])
 
@@ -182,7 +182,7 @@ class TypingNotificationsTestCase(unittest.TestCase):
             timeout=20000,
         )
 
-        self.on_new_user_event.assert_has_calls([
+        self.on_new_event.assert_has_calls([
             call('typing_key', 1, rooms=[self.room_id]),
         ])
 
@@ -245,7 +245,7 @@ class TypingNotificationsTestCase(unittest.TestCase):
             )
         )
 
-        self.on_new_user_event.assert_has_calls([
+        self.on_new_event.assert_has_calls([
             call('typing_key', 1, rooms=[self.room_id]),
         ])
 
@@ -299,7 +299,7 @@ class TypingNotificationsTestCase(unittest.TestCase):
             room_id=self.room_id,
         )
 
-        self.on_new_user_event.assert_has_calls([
+        self.on_new_event.assert_has_calls([
             call('typing_key', 1, rooms=[self.room_id]),
         ])
 
@@ -331,10 +331,10 @@ class TypingNotificationsTestCase(unittest.TestCase):
             timeout=10000,
         )
 
-        self.on_new_user_event.assert_has_calls([
+        self.on_new_event.assert_has_calls([
             call('typing_key', 1, rooms=[self.room_id]),
         ])
-        self.on_new_user_event.reset_mock()
+        self.on_new_event.reset_mock()
 
         self.assertEquals(self.event_source.get_current_key(), 1)
         events = yield self.event_source.get_new_events_for_user(self.u_apple, 0, None)
@@ -351,7 +351,7 @@ class TypingNotificationsTestCase(unittest.TestCase):
 
         self.clock.advance_time(11)
 
-        self.on_new_user_event.assert_has_calls([
+        self.on_new_event.assert_has_calls([
             call('typing_key', 2, rooms=[self.room_id]),
         ])
 
@@ -377,10 +377,10 @@ class TypingNotificationsTestCase(unittest.TestCase):
             timeout=10000,
         )
 
-        self.on_new_user_event.assert_has_calls([
+        self.on_new_event.assert_has_calls([
             call('typing_key', 3, rooms=[self.room_id]),
         ])
-        self.on_new_user_event.reset_mock()
+        self.on_new_event.reset_mock()
 
         self.assertEquals(self.event_source.get_current_key(), 3)
         events = yield self.event_source.get_new_events_for_user(self.u_apple, 0, None)

--- a/tests/rest/client/v1/test_events.py
+++ b/tests/rest/client/v1/test_events.py
@@ -183,7 +183,17 @@ class EventStreamPermissionsTestCase(RestTestCase):
         )
         self.assertEquals(200, code, msg=str(response))
 
-        self.assertEquals(0, len(response["chunk"]))
+        # We may get a presence event for ourselves down
+        self.assertEquals(
+            0,
+            len([
+                c for c in response["chunk"]
+                if not (
+                    c.get("type") == "m.presence"
+                    and c["content"].get("user_id") == self.user_id
+                )
+            ])
+        )
 
         # joined room (expect all content for room)
         yield self.join(room=room_id, user=self.user_id, tok=self.token)

--- a/tests/rest/client/v1/test_presence.py
+++ b/tests/rest/client/v1/test_presence.py
@@ -357,7 +357,7 @@ class PresenceEventStreamTestCase(unittest.TestCase):
         # all be ours
 
         # I'll already get my own presence state change
-        self.assertEquals({"start": "0_1_0", "end": "0_1_0", "chunk": []},
+        self.assertEquals({"start": "0_1_0_0", "end": "0_1_0_0", "chunk": []},
             response
         )
 
@@ -376,7 +376,7 @@ class PresenceEventStreamTestCase(unittest.TestCase):
                 "/events?from=s0_1_0&timeout=0", None)
 
         self.assertEquals(200, code)
-        self.assertEquals({"start": "s0_1_0", "end": "s0_2_0", "chunk": [
+        self.assertEquals({"start": "s0_1_0_0", "end": "s0_2_0_0", "chunk": [
             {"type": "m.presence",
              "content": {
                  "user_id": "@banana:test",


### PR DESCRIPTION
This adds a concept of 'receipts' to synapse.

TODO:

- ~~Batch sending of receipts to remote servers~~
- ~~Send current receipts to newly joined servers~~
- [x] Include receipts in initial sync (v1 only currently.)
- [x] Make sure the common flows are efficient.
- ~~Correctly map from position in client facing linearization of a room to position in server facing graph of room.~~
- [x] Add payload to receipts, used for e.g. time the event was read.