### PR TITLE
Integrate SAML2 basic authentication - uses pysaml2

### DIFF
--- a/synapse/config/homeserver.py
+++ b/synapse/config/homeserver.py
@@ -27,6 +27,7 @@ from .appservice import AppServiceConfig
 from .key import KeyConfig
 from .saml2 import SAML2Config
 
+
 class HomeServerConfig(TlsConfig, ServerConfig, DatabaseConfig, LoggingConfig,
                        RatelimitConfig, ContentRepositoryConfig, CaptchaConfig,
                        VoipConfig, RegistrationConfig, MetricsConfig,

--- a/synapse/config/homeserver.py
+++ b/synapse/config/homeserver.py
@@ -25,12 +25,12 @@ from .registration import RegistrationConfig
 from .metrics import MetricsConfig
 from .appservice import AppServiceConfig
 from .key import KeyConfig
-
+from .saml2 import SAML2Config
 
 class HomeServerConfig(TlsConfig, ServerConfig, DatabaseConfig, LoggingConfig,
                        RatelimitConfig, ContentRepositoryConfig, CaptchaConfig,
-                       VoipConfig, RegistrationConfig,
-                       MetricsConfig, AppServiceConfig, KeyConfig,):
+                       VoipConfig, RegistrationConfig, MetricsConfig,
+                       AppServiceConfig, KeyConfig, SAML2Config, ):
     pass
 
 

--- a/synapse/config/saml2.py
+++ b/synapse/config/saml2.py
@@ -15,6 +15,7 @@
 
 from ._base import Config
 
+
 class SAML2Config(Config):
     def read_config(self, config):
         self.saml2_config = config["saml2_config"]
@@ -24,4 +25,4 @@ class SAML2Config(Config):
         saml2_config:
             config_path: "%s/sp_conf.py"
             idp_redirect_url: "http://%s/idp"
-        """%(config_dir_path, server_name)
+        """ % (config_dir_path, server_name)

--- a/synapse/config/saml2.py
+++ b/synapse/config/saml2.py
@@ -16,6 +16,19 @@
 from ._base import Config
 
 
+#
+# SAML2 Configuration
+# Synapse uses pysaml2 libraries for providing SAML2 support
+#
+# config_path:      Path to the sp_conf.py configuration file
+# idp_redirect_url: Identity provider URL which will redirect
+#                   the user back to /login/saml2 with proper info.
+#
+# sp_conf.py file is something like:
+# https://github.com/rohe/pysaml2/blob/master/example/sp-repoze/sp_conf.py.example
+#
+# More information: https://pythonhosted.org/pysaml2/howto/config.html
+#
 class SAML2Config(Config):
     def read_config(self, config):
         self.saml2_config = config["saml2_config"]
@@ -23,6 +36,7 @@ class SAML2Config(Config):
     def default_config(self, config_dir_path, server_name):
         return """
         saml2_config:
+            enabled: false
             config_path: "%s/sp_conf.py"
             idp_redirect_url: "http://%s/idp"
         """ % (config_dir_path, server_name)

--- a/synapse/config/saml2.py
+++ b/synapse/config/saml2.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Ericsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._base import Config
+
+class SAML2Config(Config):
+    def read_config(self, config):
+        self.saml2_config = config["saml2_config"]
+
+    def default_config(self, config_dir_path, server_name):
+        return """
+        saml2_config:
+            config_path: "%s/sp_conf.py"
+            idp_redirect_url: "http://%s/idp"
+        """%(config_dir_path, server_name)

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -220,7 +220,6 @@ class RegistrationHandler(BaseHandler):
             # Ignore Registration errors
             logger.exception(e)
         defer.returnValue((user_id, token))
-        
 
     @defer.inlineCallbacks
     def register_email(self, threepidCreds):

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -193,6 +193,36 @@ class RegistrationHandler(BaseHandler):
             logger.info("Valid captcha entered from %s", ip)
 
     @defer.inlineCallbacks
+    def register_saml2(self, localpart):
+        """
+        Registers email_id as SAML2 Based Auth.
+        """
+        if urllib.quote(localpart) != localpart:
+            raise SynapseError(
+                400,
+                "User ID must only contain characters which do not"
+                " require URL encoding."
+                )
+        user = UserID(localpart, self.hs.hostname)
+        user_id = user.to_string()
+
+        yield self.check_user_id_is_valid(user_id)
+        token = self._generate_token(user_id)
+        try:
+            yield self.store.register(
+                user_id=user_id,
+                token=token,
+                password_hash=None
+            )
+            yield self.distributor.fire("registered_user", user)
+        except Exception, e:
+            yield self.store.add_access_token_to_user(user_id, token)
+            # Ignore Registration errors
+            logger.exception(e)
+        defer.returnValue((user_id, token))
+        
+
+    @defer.inlineCallbacks
     def register_email(self, threepidCreds):
         """
         Registers emails with an identity server.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -31,6 +31,7 @@ REQUIREMENTS = {
     "pillow": ["PIL"],
     "pydenticon": ["pydenticon"],
     "ujson": ["ujson"],
+    "pysaml2": ["saml2"],
 }
 CONDITIONAL_REQUIREMENTS = {
     "web_client": {

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -20,14 +20,32 @@ from synapse.types import UserID
 from base import ClientV1RestServlet, client_path_pattern
 
 import simplejson as json
+import cgi
+import urllib
+
+import logging
+from saml2 import BINDING_HTTP_REDIRECT
+from saml2 import BINDING_HTTP_POST
+from saml2.metadata import create_metadata_string
+from saml2 import config
+from saml2.client import Saml2Client
+from saml2.httputil import ServiceError
+from saml2.samlp import Extensions
+from saml2.extension.pefim import SPCertEnc
+from saml2.s_utils import rndstr
 
 
 class LoginRestServlet(ClientV1RestServlet):
     PATTERN = client_path_pattern("/login$")
     PASS_TYPE = "m.login.password"
+    SAML2_TYPE = "m.login.saml2"
+
+    def __init__(self, hs):
+        super(LoginRestServlet, self).__init__(hs)
+        self.idp_redirect_url = hs.config.saml2_config['idp_redirect_url']
 
     def on_GET(self, request):
-        return (200, {"flows": [{"type": LoginRestServlet.PASS_TYPE}]})
+        return (200, {"flows": [{"type": LoginRestServlet.PASS_TYPE}, {"type": LoginRestServlet.SAML2_TYPE}]})
 
     def on_OPTIONS(self, request):
         return (200, {})
@@ -39,6 +57,14 @@ class LoginRestServlet(ClientV1RestServlet):
             if login_submission["type"] == LoginRestServlet.PASS_TYPE:
                 result = yield self.do_password_login(login_submission)
                 defer.returnValue(result)
+            elif login_submission["type"] == LoginRestServlet.SAML2_TYPE:
+                relay_state = ""
+                if "relay_state" in login_submission:
+                    relay_state = "&RelayState="+urllib.quote(login_submission["relay_state"])
+                result = {
+                    "uri": "%s%s"%(self.idp_redirect_url, relay_state)
+                }
+                defer.returnValue((200, result))
             else:
                 raise SynapseError(400, "Bad login type.")
         except KeyError:
@@ -93,6 +119,39 @@ class PasswordResetRestServlet(ClientV1RestServlet):
                 "Missing keys. Requires 'email' and 'user_id'."
             )
 
+class SAML2RestServlet(ClientV1RestServlet):
+    PATTERN = client_path_pattern("/login/saml2")
+
+    def __init__(self, hs):
+        super(SAML2RestServlet, self).__init__(hs)
+        self.sp_config = hs.config.saml2_config['config_path']
+
+    @defer.inlineCallbacks
+    def on_POST(self, request):
+        saml2_auth = None
+        try:
+            conf = config.SPConfig()
+            conf.load_file(self.sp_config)
+            SP = Saml2Client(conf)
+            saml2_auth = SP.parse_authn_request_response(request.args['SAMLResponse'][0], BINDING_HTTP_POST)
+        except Exception, e: # Not authenticated
+            logger = logging.getLogger(__name__)
+            logger.exception(e)
+        if  saml2_auth and saml2_auth.status_ok() and not saml2_auth.not_signed:
+            username = saml2_auth.name_id.text
+            handler = self.handlers.registration_handler
+            (user_id, token) = yield handler.register_saml2(username)
+            # Forward to the RelayState callback along with ava
+            if 'RelayState' in request.args:
+                request.redirect(urllib.unquote(request.args['RelayState'][0])+'?status=authenticated&access_token='+token+'&user_id='+user_id+'&ava='+urllib.quote(json.dumps(saml2_auth.ava)))
+                request.finish()
+                defer.returnValue(None)
+            defer.returnValue((200, {"status":"authenticated", "user_id": user_id, "token": token, "ava":saml2_auth.ava}))
+        elif 'RelayState' in request.args:
+            request.redirect(urllib.unquote(request.args['RelayState'][0])+'?status=not_authenticated')
+            request.finish()
+            defer.returnValue(None)
+        defer.returnValue((200, {"status":"not_authenticated"}))
 
 def _parse_json(request):
     try:
@@ -106,4 +165,5 @@ def _parse_json(request):
 
 def register_servlets(hs, http_server):
     LoginRestServlet(hs).register(http_server)
+    SAML2RestServlet(hs).register(http_server)
     # TODO PasswordResetRestServlet(hs).register(http_server)

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -20,19 +20,15 @@ from synapse.types import UserID
 from base import ClientV1RestServlet, client_path_pattern
 
 import simplejson as json
-import cgi
 import urllib
 
 import logging
-from saml2 import BINDING_HTTP_REDIRECT
 from saml2 import BINDING_HTTP_POST
-from saml2.metadata import create_metadata_string
 from saml2 import config
 from saml2.client import Saml2Client
-from saml2.httputil import ServiceError
-from saml2.samlp import Extensions
-from saml2.extension.pefim import SPCertEnc
-from saml2.s_utils import rndstr
+
+
+logger = logging.getLogger(__name__)
 
 
 class LoginRestServlet(ClientV1RestServlet):
@@ -137,9 +133,8 @@ class SAML2RestServlet(ClientV1RestServlet):
             conf.load_file(self.sp_config)
             SP = Saml2Client(conf)
             saml2_auth = SP.parse_authn_request_response(
-                            request.args['SAMLResponse'][0], BINDING_HTTP_POST)
+                request.args['SAMLResponse'][0], BINDING_HTTP_POST)
         except Exception, e:        # Not authenticated
-            logger = logging.getLogger(__name__)
             logger.exception(e)
         if saml2_auth and saml2_auth.status_ok() and not saml2_auth.not_signed:
             username = saml2_auth.name_id.text


### PR DESCRIPTION
a) The actual call to the pysaml2 for auth/verification calls xmlsec binary (it seems). So, some optimizations around it might be good.
b) Tested only with Redirect based SAML2 auth
c) It requires the following (example) configuration in homeserver.yaml 
saml2_config:
    config_path: "/home/.../sp_conf.py"
    idp_redirect_url: "http://..../idp"
d) sp_conf.py is something like: https://github.com/rohe/pysaml2/blob/master/example/sp-repoze/sp_conf.py.example
    https://pythonhosted.org/pysaml2/howto/config.html