### PR TITLE
Implement presets at room creation

### DIFF
--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -90,5 +90,5 @@ class RejectedReason(object):
 
 
 class RoomCreationPreset(object):
-    PrivateChat = "private_chat"
-    PublicChat = "public_chat"
+    PRIVATE_CHAT = "private_chat"
+    PUBLIC_CHAT = "public_chat"

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -87,3 +87,8 @@ class RejectedReason(object):
     AUTH_ERROR = "auth_error"
     REPLACED = "replaced"
     NOT_ANCESTOR = "not_ancestor"
+
+
+class RoomCreationPreset(object):
+    PrivateChat = "private_chat"
+    PublicChat = "public_chat"

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -36,12 +36,12 @@ logger = logging.getLogger(__name__)
 class RoomCreationHandler(BaseHandler):
 
     PRESETS_DICT = {
-        RoomCreationPreset.PrivateChat: {
+        RoomCreationPreset.PRIVATE_CHAT: {
             "join_rules": JoinRules.INVITE,
             "history_visibility": "invited",
             "everyone_ops": False,
         },
-        RoomCreationPreset.PublicChat: {
+        RoomCreationPreset.PUBLIC_CHAT: {
             "join_rules": JoinRules.PUBLIC,
             "history_visibility": "shared",
             "everyone_ops": False,
@@ -138,9 +138,9 @@ class RoomCreationHandler(BaseHandler):
 
         preset_config = config.get(
             "preset",
-            RoomCreationPreset.PublicChat
+            RoomCreationPreset.PUBLIC_CHAT
             if is_public
-            else RoomCreationPreset.PrivateChat
+            else RoomCreationPreset.PRIVATE_CHAT
         )
 
         user = UserID.from_string(user_id)

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -39,12 +39,12 @@ class RoomCreationHandler(BaseHandler):
         RoomCreationPreset.PRIVATE_CHAT: {
             "join_rules": JoinRules.INVITE,
             "history_visibility": "invited",
-            "everyone_ops": False,
+            "original_invitees_have_ops": False,
         },
         RoomCreationPreset.PUBLIC_CHAT: {
             "join_rules": JoinRules.PUBLIC,
             "history_visibility": "shared",
-            "everyone_ops": False,
+            "original_invitees_have_ops": False,
         },
     }
 
@@ -248,7 +248,7 @@ class RoomCreationHandler(BaseHandler):
             "invite": 0,
         }
 
-        if config["everyone_ops"]:
+        if config["original_invitees_have_ops"]:
             for invitee in invite_list:
                 power_level_content["users"][invitee] = 100
 


### PR DESCRIPTION
Adds the ability to specify a `preset` when creating a room. Currently defined are:
* `public_chat` - for completely public rooms, where anyone can join and everyone can see history. 
* `private_chat` - for 1:1 and private group chats, invite only and people can only see history after they were invited.