### PR TITLE
Always return a thumbnail of the requested size.

### DIFF
--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -21,6 +21,17 @@ ThumbnailRequirement = namedtuple(
 )
 
 def parse_thumbnail_requirements(thumbnail_sizes):
+    """ Takes a list of dictionaries with "width", "height", and "method" keys
+    and creates a map from image media types to the thumbnail size, thumnailing
+    method, and thumbnail media type to precalculate
+
+    Args:
+        thumbnail_sizes(list): List of dicts with "width", "height", and
+            "method" keys
+    Returns:
+        Dictionary mapping from media type string to list of
+        ThumbnailRequirement tuples.
+    """
     requirements = {}
     for size in thumbnail_sizes:
         width = size["width"]

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -22,6 +22,7 @@ class ContentRepositoryConfig(Config):
         self.max_image_pixels = self.parse_size(config["max_image_pixels"])
         self.media_store_path = self.ensure_directory(config["media_store_path"])
         self.uploads_path = self.ensure_directory(config["uploads_path"])
+        self.dynamic_thumbnails = config["dynamic_thumbnails"]
 
     def default_config(self, config_dir_path, server_name):
         media_store = self.default_path("media_store")
@@ -38,4 +39,11 @@ class ContentRepositoryConfig(Config):
 
         # Maximum number of pixels that will be thumbnailed
         max_image_pixels: "32M"
+
+        # Whether to generate new thumbnails on the fly to precisely match
+        # the resolution requested by the client. If true then whenever
+        # a new resolution is requested by the client the server will
+        # generate a new thumbnail. If false the server will pick a thumbnail
+        # from a precalcualted list.
+        dynamic_thumbnails: false
         """ % locals()

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -20,6 +20,7 @@ ThumbnailRequirement = namedtuple(
     "ThumbnailRequirement", ["width", "height", "method", "media_type"]
 )
 
+
 def parse_thumbnail_requirements(thumbnail_sizes):
     """ Takes a list of dictionaries with "width", "height", and "method" keys
     and creates a map from image media types to the thumbnail size, thumnailing

--- a/synapse/rest/media/v1/base_resource.py
+++ b/synapse/rest/media/v1/base_resource.py
@@ -69,6 +69,7 @@ class BaseMediaResource(Resource):
         self.filepaths = filepaths
         self.version_string = hs.version_string
         self.downloads = {}
+        self.dynamic_thumbnails = hs.config.dynamic_thumbnails
 
     def _respond_404(self, request):
         respond_with_json(

--- a/synapse/rest/media/v1/base_resource.py
+++ b/synapse/rest/media/v1/base_resource.py
@@ -284,7 +284,7 @@ class BaseMediaResource(Resource):
                 return
 
             t_path = self.filepaths.remote_media_thumbnail(
-                media_id, t_width, t_height, t_type, t_method
+                server_name, file_id, t_width, t_height, t_type, t_method
             )
             self._makedirs(t_path)
 

--- a/synapse/rest/media/v1/base_resource.py
+++ b/synapse/rest/media/v1/base_resource.py
@@ -70,6 +70,7 @@ class BaseMediaResource(Resource):
         self.version_string = hs.version_string
         self.downloads = {}
         self.dynamic_thumbnails = hs.config.dynamic_thumbnails
+        self.thumbnail_requirements = hs.config.thumbnail_requirements
 
     def _respond_404(self, request):
         respond_with_json(
@@ -209,22 +210,7 @@ class BaseMediaResource(Resource):
             self._respond_404(request)
 
     def _get_thumbnail_requirements(self, media_type):
-        if media_type == "image/jpeg":
-            return (
-                (32, 32, "crop", "image/jpeg"),
-                (96, 96, "crop", "image/jpeg"),
-                (320, 240, "scale", "image/jpeg"),
-                (640, 480, "scale", "image/jpeg"),
-            )
-        elif (media_type == "image/png") or (media_type == "image/gif"):
-            return (
-                (32, 32, "crop", "image/png"),
-                (96, 96, "crop", "image/png"),
-                (320, 240, "scale", "image/png"),
-                (640, 480, "scale", "image/png"),
-            )
-        else:
-            return ()
+        return self.thumbnail_requirements.get(media_type, ())
 
     def _generate_thumbnail(self, input_path, t_path, t_width, t_height,
                             t_method, t_type):

--- a/synapse/rest/media/v1/base_resource.py
+++ b/synapse/rest/media/v1/base_resource.py
@@ -226,6 +226,89 @@ class BaseMediaResource(Resource):
             return ()
 
     @defer.inlineCallbacks
+    def _generate_local_exact_thumbnail(self, media_id, t_width, t_height,
+                                        t_method, t_type):
+        input_path = self.filepaths.local_media_filepath(media_id)
+
+        def thumbnail():
+            thumbnailer = Thumbnailer(input_path)
+            m_width = thumbnailer.width
+            m_height = thumbnailer.height
+
+            if m_width * m_height >= self.max_image_pixels:
+                logger.info(
+                    "Image too large to thumbnail %r x %r > %r",
+                    m_width, m_height, self.max_image_pixels
+                )
+                return
+
+            t_path = self.filepaths.local_media_thumbnail(
+                media_id, t_width, t_height, t_type, t_method
+            )
+            self._makedirs(t_path)
+
+            if t_method == "crop":
+                t_len = thumbnailer.crop(t_path, t_width, t_height, t_type)
+            elif t_method == "scale":
+                t_len = thumbnailer.scale(t_path, t_width, t_height, t_type)
+            else:
+                t_len = None
+
+            return t_len, t_path
+
+        res = yield threads.deferToThread(thumbnail)
+
+        if res:
+            t_len, t_path = res
+            yield self.store.store_local_thumbnail(
+                media_id, t_width, t_height, t_type, t_method, t_len
+            )
+
+            defer.returnValue(t_path)
+
+    @defer.inlineCallbacks
+    def _generate_remote_exact_thumbnail(self, server_name, file_id, media_id,
+                                         t_width, t_height, t_method, t_type):
+        input_path = self.filepaths.remote_media_filepath(server_name, file_id)
+
+        def thumbnail():
+            thumbnailer = Thumbnailer(input_path)
+            m_width = thumbnailer.width
+            m_height = thumbnailer.height
+
+            if m_width * m_height >= self.max_image_pixels:
+                logger.info(
+                    "Image too large to thumbnail %r x %r > %r",
+                    m_width, m_height, self.max_image_pixels
+                )
+                return
+
+            t_path = self.filepaths.remote_media_thumbnail(
+                media_id, t_width, t_height, t_type, t_method
+            )
+            self._makedirs(t_path)
+
+            if t_method == "crop":
+                t_len = thumbnailer.crop(t_path, t_width, t_height, t_type)
+            elif t_method == "scale":
+                t_len = thumbnailer.scale(t_path, t_width, t_height, t_type)
+            else:
+                t_len = None
+
+            return t_path, t_len
+
+        res = yield threads.deferToThread(thumbnail)
+
+        if res:
+            t_path, t_len = res
+            yield self.store.store_remote_media_thumbnail(
+                server_name, media_id, file_id,
+                t_width, t_height, t_type, t_method, t_len
+            )
+
+            defer.returnValue(t_path)
+
+    @defer.inlineCallbacks
     def _generate_local_thumbnails(self, media_id, media_info):
         media_type = media_info["media_type"]
         requirements = self._get_thumbnail_requirements(media_type)

--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -43,14 +43,25 @@ class ThumbnailResource(BaseMediaResource):
         m_type = parse_string(request, "type", "image/png")
 
         if server_name == self.server_name:
-            yield self._select_or_generate_local_thumbnail(
-                request, media_id, width, height, method, m_type
-            )
+            if self.dynamic_thumbnails:
+                yield self._select_or_generate_local_thumbnail(
+                    request, media_id, width, height, method, m_type
+                )
+            else:
+                yield self._respond_local_thumbnail(
+                    request, media_id, width, height, method, m_type
+                )
         else:
-            yield self._select_or_generate_remote_thumbnail(
-                request, server_name, media_id,
-                width, height, method, m_type
-            )
+            if self.dynamic_thumbnails:
+                yield self._select_or_generate_remote_thumbnail(
+                    request, server_name, media_id,
+                    width, height, method, m_type
+                )
+            else:
+                yield self._respond_remote_thumbnail(
+                    request, server_name, media_id,
+                    width, height, method, m_type
+                )
 
     @defer.inlineCallbacks
     def _respond_local_thumbnail(self, request, media_id, width, height,


### PR DESCRIPTION
Before, we returned a thumbnail that was at least as big (if possible)
as the requested size. Now, if we don't have a thumbnail of the given
size we generate (and persist) one of that size.