### PR TITLE
Ask syweb where the webclient is installed (SYN-443)

### DIFF
--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -98,7 +98,7 @@ class SynapseHomeServer(HomeServer):
 
     def build_resource_for_web_client(self):
         import syweb
-        syweb_path = os.path.dirname(syweb.__file__)
+        syweb_path = syweb.installed_location()
         webclient_path = os.path.join(syweb_path, "webclient")
         # GZip is disabled here due to
         # https://twistedmatrix.com/trac/ticket/7678


### PR DESCRIPTION
This makes debianising nicer.

Note that this PR is as-yet incomplete, as it doesn't declare a dependency on a sufficient version of `matrix-angular-sdk`. Once that is released (SYWEB-381) then that can be added here and merged.

TODO list:
- [x] Add config option
- [ ] Wait for syweb to be released and bump dep