### PR TITLE
Case insensitive registration/login

### DIFF
--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -295,6 +295,12 @@ class AuthHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def _find_user_id_and_pwd_hash(self, user_id):
+        """Checks to see if a user with the given id exists. Will check case
+        insensitively, but will throw if there are multiple inexact matches.
+
+        Returns:
+            tuple: A 2-tuple of `(canonical_user_id, password_hash)`
+        """
         user_infos = yield self.store.get_users_by_id_case_insensitive(user_id)
         if not user_infos:
             logger.warn("Attempted to login as %s but they do not exist", user_id)

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -57,8 +57,8 @@ class RegistrationHandler(BaseHandler):
 
         yield self.check_user_id_is_valid(user_id)
 
-        u = yield self.store.get_user_by_id(user_id)
-        if u:
+        users = yield self.store.get_users_by_id_case_insensitive(user_id)
+        if users:
             raise SynapseError(
                 400,
                 "User ID already taken.",

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -83,9 +83,10 @@ class LoginRestServlet(ClientV1RestServlet):
 
         if not user_id.startswith('@'):
             user_id = UserID.create(
-                user_id, self.hs.hostname).to_string()
+                user_id, self.hs.hostname
+            ).to_string()
 
-        token = yield self.handlers.auth_handler.login_with_password(
+        user_id, token = yield self.handlers.auth_handler.login_with_password(
             user_id=user_id,
             password=login_submission["password"])
 

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -98,6 +98,17 @@ class RegistrationStore(SQLBaseStore):
             allow_none=True,
         )
 
+    def get_users_by_id_case_insensitive(self, user_id):
+        def f(txn):
+            sql = (
+                "SELECT name, password_hash FROM users"
+                " WHERE name = lower(?)"
+            )
+            txn.execute(sql, (user_id,))
+            return self.cursor_to_dict(txn)
+
+        return self.runInteraction("get_users_by_id_case_insensitive", f)
+
     @defer.inlineCallbacks
     def user_set_password_hash(self, user_id, password_hash):
         """

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -99,13 +99,16 @@ class RegistrationStore(SQLBaseStore):
         )
 
     def get_users_by_id_case_insensitive(self, user_id):
+        """Gets users that match user_id case insensitively.
+        Returns a mapping of user_id -> password_hash.
+        """
         def f(txn):
             sql = (
                 "SELECT name, password_hash FROM users"
-                " WHERE name = lower(?)"
+                " WHERE lower(name) = lower(?)"
             )
             txn.execute(sql, (user_id,))
-            return self.cursor_to_dict(txn)
+            return dict(txn.fetchall())
 
         return self.runInteraction("get_users_by_id_case_insensitive", f)
 


### PR DESCRIPTION
- Disallow registration of user ids that match an existing id case insensitively.
- Allowing logging in with a user id that has an incorrect case *if and only if* there is a single case insensitive match.