### PR TITLE
Allow tests to be filter when using tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
 setenv =
     PYTHONDONTWRITEBYTECODE = no_byte_code
 commands =
-    coverage run --source=./synapse {envbindir}/trial tests
+    coverage run --source=./synapse {envbindir}/trial {posargs:tests}
     coverage report -m
 install_command =
     pip install --process-dependency-links --pre {opts} {packages}


### PR DESCRIPTION
`tox` will run all tests
`tox tests.api.test_auth.AuthTestCase` will run just the tests in AuthTestCase