### PR TITLE
Swap out bcrypt for md5 in tests

### DIFF
--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -25,7 +25,6 @@ import synapse.util.stringutils as stringutils
 from synapse.util.async import run_on_reactor
 from synapse.http.client import CaptchaServerHttpClient
 
-import bcrypt
 import logging
 import urllib
 

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -82,7 +82,7 @@ class RegistrationHandler(BaseHandler):
         yield run_on_reactor()
         password_hash = None
         if password:
-            password_hash = bcrypt.hashpw(password, bcrypt.gensalt())
+            password_hash = self.auth_handler().hash(password)
 
         if localpart:
             yield self.check_username(localpart)


### PR DESCRIPTION
This reduces our ~8 second sequential test time down to ~7 seconds