### PR TITLE
Fix the migration script so it doesn't crash on newish installs

### DIFF
--- a/scripts/port_from_sqlite_to_postgres.py
+++ b/scripts/port_from_sqlite_to_postgres.py
@@ -412,14 +412,17 @@ class Porter(object):
         self._convert_rows("sent_transactions", headers, rows)
 
         inserted_rows = len(rows)
-        max_inserted_rowid = max(r[0] for r in rows)
+        max_inserted_rowid = 0
 
-        def insert(txn):
-            self.postgres_store.insert_many_txn(
-                txn, "sent_transactions", headers[1:], rows
-            )
+        if inserted_rows > 0:
+            max_inserted_rowid = max(r[0] for r in rows)
 
-        yield self.postgres_store.execute(insert)
+            def insert(txn):
+                self.postgres_store.insert_many_txn(
+                    txn, "sent_transactions", headers[1:], rows
+                )
+
+            yield self.postgres_store.execute(insert)
 
         def get_start_id(txn):
             txn.execute(

--- a/scripts/port_from_sqlite_to_postgres.py
+++ b/scripts/port_from_sqlite_to_postgres.py
@@ -403,7 +403,7 @@ class Porter(object):
 
             ts_ind = headers.index('ts')
 
-            return headers, [r for r in rows if r[ts_ind] < yesterday]
+            return headers, [r for r in rows if r[ts_ind] >= yesterday]
 
         headers, rows = yield self.sqlite_store.runInteraction(
             "select", r,


### PR DESCRIPTION
If a DB has no sent_transactions, the script crashed with:

Traceback (most recent call last):
  File "bin/port_from_sqlite_to_postgres.py", line 347, in run
    consumeErrors=True,
FirstError: FirstError[#35, [Failure instance: Traceback: <type 'exceptions.ValueError'>: max() arg is an empty sequence

Meanwhile, I think our metric for having no sent_transactions is wrong, as we were looking for max transaction IDs per host which are *older* than yesterday rather than *newer*...