### PR TITLE
Bundle in some room state in invites.

### DIFF
--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -103,7 +103,10 @@ def format_event_raw(d):
 def format_event_for_client_v1(d):
     d["user_id"] = d.pop("sender", None)
 
-    move_keys = ("age", "redacted_because", "replaces_state", "prev_content")
+    move_keys = (
+        "age", "redacted_because", "replaces_state", "prev_content",
+        "invite_room_state",
+    )
     for key in move_keys:
         if key in d["unsigned"]:
             d[key] = d["unsigned"][key]

--- a/synapse/handlers/_base.py
+++ b/synapse/handlers/_base.py
@@ -132,6 +132,7 @@ class BaseHandler(object):
                         "type": e.type,
                         "state_key": e.state_key,
                         "content": e.content,
+                        "sender": e.sender,
                     }
                     for k, e in context.current_state.items()
                     if e.type in (

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -354,7 +354,11 @@ class MessageHandler(BaseHandler):
             }
 
             if event.membership == Membership.INVITE:
+                time_now = self.clock.time_msec()
                 d["inviter"] = event.sender
+
+                invite_event = yield self.store.get_event(event.event_id)
+                d["invite"] = serialize_event(invite_event, time_now, as_client_event)
 
             rooms_ret.append(d)
 

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 RoomsForUser = namedtuple(
     "RoomsForUser",
-    ("room_id", "sender", "membership")
+    ("room_id", "sender", "membership", "event_id")
 )
 
 
@@ -141,7 +141,7 @@ class RoomMemberStore(SQLBaseStore):
         args.extend(membership_list)
 
         sql = (
-            "SELECT m.room_id, m.sender, m.membership"
+            "SELECT m.event_id, m.room_id, m.sender, m.membership"
             " FROM room_memberships as m"
             " INNER JOIN current_state_events as c"
             " ON m.event_id = c.event_id "


### PR DESCRIPTION
Changes:
- When an invite is sent to someone, bundle in the state of the room at the time under `unsigned.invite_room_state`. In v1 C-S API this is copied to a top level key of `invite_room_state`.
- Include the invite event in `initialSync`.

The state events that are included are:

- Room name
- Room avatar
- Canonical Alias
- Join rules

The fields of the events that are included:

- `type`
- `state_key`
- `content`

This is not a particularly nice way of getting this done, but to do it any nicer would probably involve changing the federation API in a non backwards compatible way.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/matrix-org/synapse/275)
<!-- Reviewable:end -->
