### PR TITLE
Add trivial yaml config editor to synctl

### DIFF
--- a/synapse/app/synctl.py
+++ b/synapse/app/synctl.py
@@ -55,6 +55,7 @@ def stop():
         os.kill(pid, signal.SIGTERM)
         print GREEN + "stopped" + NORMAL
 
+
 """
 Very basic tool for editing the synapse config from the cli
 Supports setting the value of root level keys and appending to arrays
@@ -62,6 +63,8 @@ Does not support nested keys, removing items from arrays or removing keys.
 Uses ruamel.yaml feature that preserves comments and formatting (although
 does quoting slightly differently)
 """
+
+
 def cfgedit(args):
     if len(args) < 3:
         raise Exception(
@@ -74,7 +77,7 @@ def cfgedit(args):
     if op == '+=':
         if CONFIG[key] and not isinstance(CONFIG[key], list):
             raise Exception("%s is not a list" % key)
-        if not key in CONFIG:
+        if key not in CONFIG:
             CONFIG[key] = []
         CONFIG[key].append(val)
     elif op == '=':

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -25,6 +25,7 @@ REQUIREMENTS = {
     "service_identity>=1.0.0": ["service_identity>=1.0.0"],
     "pyopenssl>=0.14": ["OpenSSL>=0.14"],
     "pyyaml": ["yaml"],
+    "ruamel.yaml": ["ruamel.yaml"],
     "pyasn1": ["pyasn1"],
     "pynacl>=0.3.0": ["nacl>=0.3.0"],
     "daemonize": ["daemonize"],


### PR DESCRIPTION
This would make automated synapse installs like docker and unit tests a lot less painful. It keeps comments and formatting, although does change some minor things like the quoting style. Thoughts?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/matrix-org/synapse/278)
<!-- Reviewable:end -->
