### PR TITLE
When updating a stored event from outlier to non-outlier, remember to update the extremeties

### DIFF
--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -306,6 +306,12 @@ class EventFederationStore(SQLBaseStore):
         self._update_extremeties(txn, events)
 
     def _update_extremeties(self, txn, events):
+        """Updates the event_*_extremities tables based on the new/updated
+        events being persisted.
+
+        This is called for new events *and* for events that were outliers, but
+        are are now being persisted as non-outliers.
+        """
         events_by_room = {}
         for ev in events:
             events_by_room.setdefault(ev.room_id, []).append(ev)

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -303,6 +303,9 @@ class EventFederationStore(SQLBaseStore):
             ],
         )
 
+        self._update_extremeties(txn, events)
+
+    def _update_extremeties(self, txn, events):
         events_by_room = {}
         for ev in events:
             events_by_room.setdefault(ev.room_id, []).append(ev)

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -275,6 +275,8 @@ class EventsStore(SQLBaseStore):
                     (False, event.event_id,)
                 )
 
+                self._update_extremeties(txn, [event])
+
         events_and_contexts = filter(
             lambda ec: ec[0] not in to_remove,
             events_and_contexts


### PR DESCRIPTION
This fixes: https://matrix.org/jira/browse/SYN-392 

Summary: Three users A¹, A² and B¹ are on servers A and B. If A¹ and B¹ are in a room and B¹ invites A², then A² is unable to join.