### PR TITLE
Fix order of ON constraints in _get_rooms_for_user_where_membership

### DIFF
--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -142,12 +142,12 @@ class RoomMemberStore(SQLBaseStore):
 
         sql = (
             "SELECT m.room_id, m.sender, m.membership, m.event_id, e.stream_ordering"
-            " FROM room_memberships as m"
-            " INNER JOIN current_state_events as c"
-            " ON e.event_id = c.event_id "
-            " INNER JOIN events as e "
-            " ON m.event_id = c.event_id "
-            " AND m.room_id = c.room_id "
+            " FROM current_state_events as c"
+            " INNER JOIN room_memberships as m"
+            " ON m.event_id = c.event_id"
+            " INNER JOIN events as e"
+            " ON e.event_id = c.event_id"
+            " AND m.room_id = c.room_id"
             " AND m.user_id = c.state_key"
             " WHERE %s"
         ) % (where_clause,)


### PR DESCRIPTION
We were referencing a table 'e' in a ON constraint before the INNER JOIN that defined the table 'e'.