### PR TITLE
Validate the receipt type before passing it on to the receipt handler

### DIFF
--- a/synapse/rest/client/v2_alpha/receipts.py
+++ b/synapse/rest/client/v2_alpha/receipts.py
@@ -15,6 +15,7 @@
 
 from twisted.internet import defer
 
+from synapse.api.errors import SynapseError
 from synapse.http.servlet import RestServlet
 from ._base import client_v2_pattern
 
@@ -40,6 +41,9 @@ class ReceiptRestServlet(RestServlet):
     @defer.inlineCallbacks
     def on_POST(self, request, room_id, receipt_type, event_id):
         user, _ = yield self.auth.get_user_by_req(request)
+
+        if receipt_type != "m.read":
+            raise SynapseError(400, "Receipt type must be 'm.read'")
 
         yield self.receipts_handler.received_client_receipt(
             room_id,


### PR DESCRIPTION
Check that the receipt type is `m.read` to avoid clients sending incompatible forms of "read" e.g. read/Read/READ/m.read/ :red_circle:  / :book: