### PR TITLE
Allow synapse's useragent to be customized

### DIFF
--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -26,6 +26,7 @@ class ServerConfig(Config):
         self.soft_file_limit = config["soft_file_limit"]
         self.daemonize = config.get("daemonize")
         self.print_pidfile = config.get("print_pidfile")
+        self.user_agent_override = config.get("user_agent_override")
         self.use_frozen_dicts = config.get("use_frozen_dicts", True)
 
         self.listeners = config.get("listeners", [])

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -26,7 +26,7 @@ class ServerConfig(Config):
         self.soft_file_limit = config["soft_file_limit"]
         self.daemonize = config.get("daemonize")
         self.print_pidfile = config.get("print_pidfile")
-        self.user_agent_override = config.get("user_agent_override")
+        self.user_agent_suffix = config.get("user_agent_suffix")
         self.use_frozen_dicts = config.get("use_frozen_dicts", True)
 
         self.listeners = config.get("listeners", [])

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -69,7 +69,7 @@ class SimpleHttpClient(object):
         )
         self.user_agent = hs.version_string
         if hs.config.user_agent_suffix:
-            self.user_agent += " " + hs.config.user_agent_suffix
+            self.user_agent = "%s %s" % (self.user_agent, hs.config.user_agent_suffix,)
 
     def request(self, method, uri, *args, **kwargs):
         # A small wrapper around self.agent.request() so we can easily attach

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -69,7 +69,7 @@ class SimpleHttpClient(object):
         )
         self.user_agent = hs.version_string
         if hs.config.user_agent_suffix:
-            self.user_agent += " - " + hs.config.user_agent_suffix
+            self.user_agent += " " + hs.config.user_agent_suffix
 
     def request(self, method, uri, *args, **kwargs):
         # A small wrapper around self.agent.request() so we can easily attach

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -67,9 +67,9 @@ class SimpleHttpClient(object):
             connectTimeout=15,
             contextFactory=hs.get_http_client_context_factory()
         )
-        self.user_agent = hs.config.user_agent_override
-        if self.user_agent is None:
-            self.user_agent = hs.version_string
+        self.user_agent = hs.version_string
+        if hs.config.user_agent_suffix:
+            self.user_agent += " - " + hs.config.user_agent_suffix
 
     def request(self, method, uri, *args, **kwargs):
         # A small wrapper around self.agent.request() so we can easily attach

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -67,7 +67,9 @@ class SimpleHttpClient(object):
             connectTimeout=15,
             contextFactory=hs.get_http_client_context_factory()
         )
-        self.version_string = hs.version_string
+        self.user_agent = hs.config.user_agent_override
+        if self.user_agent is None:
+            self.user_agent = hs.version_string
 
     def request(self, method, uri, *args, **kwargs):
         # A small wrapper around self.agent.request() so we can easily attach
@@ -112,7 +114,7 @@ class SimpleHttpClient(object):
             uri.encode("ascii"),
             headers=Headers({
                 b"Content-Type": [b"application/x-www-form-urlencoded"],
-                b"User-Agent": [self.version_string],
+                b"User-Agent": [self.user_agent],
             }),
             bodyProducer=FileBodyProducer(StringIO(query_bytes))
         )
@@ -131,7 +133,8 @@ class SimpleHttpClient(object):
             "POST",
             uri.encode("ascii"),
             headers=Headers({
-                "Content-Type": ["application/json"]
+                b"Content-Type": [b"application/json"],
+                b"User-Agent": [self.user_agent],
             }),
             bodyProducer=FileBodyProducer(StringIO(json_str))
         )
@@ -165,7 +168,7 @@ class SimpleHttpClient(object):
             "GET",
             uri.encode("ascii"),
             headers=Headers({
-                b"User-Agent": [self.version_string],
+                b"User-Agent": [self.user_agent],
             })
         )
 
@@ -206,7 +209,7 @@ class SimpleHttpClient(object):
             "PUT",
             uri.encode("ascii"),
             headers=Headers({
-                b"User-Agent": [self.version_string],
+                b"User-Agent": [self.user_agent],
                 "Content-Type": ["application/json"]
             }),
             bodyProducer=FileBodyProducer(StringIO(json_str))
@@ -241,7 +244,7 @@ class CaptchaServerHttpClient(SimpleHttpClient):
             bodyProducer=FileBodyProducer(StringIO(query_bytes)),
             headers=Headers({
                 b"Content-Type": [b"application/x-www-form-urlencoded"],
-                b"User-Agent": [self.version_string],
+                b"User-Agent": [self.user_agent],
             })
         )
 


### PR DESCRIPTION
This will allow me to write tests which verify which server made HTTP
requests in a federation context.