### PR TITLE
Remove log line that was generated whenever an error was created.

### DIFF
--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -47,7 +47,6 @@ class CodeMessageException(RuntimeError):
     """An exception with integer code and message string attributes."""
 
     def __init__(self, code, msg):
-        logger.info("%s: %s, %s", type(self).__name__, code, msg)
         super(CodeMessageException, self).__init__("%d: %s" % (code, msg))
         self.code = code
         self.msg = msg


### PR DESCRIPTION
We are now creating error objects that aren't raised so it's probably a bit too confusing to keep