### PR TITLE
Provide ability to login using CAS

### DIFF
--- a/synapse/config/cas.py
+++ b/synapse/config/cas.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 OpenMarket Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._base import Config
+
+
+class CasConfig(Config):
+    """Cas Configuration
+
+    cas_server_url: URL of CAS server
+    """
+
+    def read_config(self, config):
+        cas_config = config.get("cas_config", None)
+        if cas_config:
+            self.cas_enabled = True
+            self.cas_server_url = cas_config["server_url"]
+        else:
+            self.cas_enabled = False
+            self.cas_server_url = None
+
+    def default_config(self, config_dir_path, server_name, **kwargs):
+        return """
+        # Enable CAS for registration and login.
+        #cas_config:
+        #   server_url: "https://cas-server.com"
+        """

--- a/synapse/config/homeserver.py
+++ b/synapse/config/homeserver.py
@@ -26,12 +26,13 @@ from .metrics import MetricsConfig
 from .appservice import AppServiceConfig
 from .key import KeyConfig
 from .saml2 import SAML2Config
+from .cas import CasConfig
 
 
 class HomeServerConfig(TlsConfig, ServerConfig, DatabaseConfig, LoggingConfig,
                        RatelimitConfig, ContentRepositoryConfig, CaptchaConfig,
                        VoipConfig, RegistrationConfig, MetricsConfig,
-                       AppServiceConfig, KeyConfig, SAML2Config, ):
+                       AppServiceConfig, KeyConfig, SAML2Config, CasConfig):
     pass
 
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -296,6 +296,37 @@ class AuthHandler(BaseHandler):
         defer.returnValue((user_id, access_token, refresh_token))
 
     @defer.inlineCallbacks
+    def login_with_cas_user_id(self, user_id):
+        """
+        Authenticates the user with the given user ID, intended to have been captured from a CAS response
+
+        Args:
+            user_id (str): User ID
+        Returns:
+            A tuple of:
+              The user's ID.
+              The access token for the user's session.
+              The refresh token for the user's session.
+        Raises:
+            StoreError if there was a problem storing the token.
+            LoginError if there was an authentication problem.
+        """
+        user_id, ignored = yield self._find_user_id_and_pwd_hash(user_id)
+
+        logger.info("Logging in user %s", user_id)
+        access_token = yield self.issue_access_token(user_id)
+        refresh_token = yield self.issue_refresh_token(user_id)
+        defer.returnValue((user_id, access_token, refresh_token))
+
+    @defer.inlineCallbacks
+    def does_user_exist(self, user_id):
+        try:
+            yield self._find_user_id_and_pwd_hash(user_id)
+            defer.returnValue(True)
+        except LoginError:
+            defer.returnValue(False)
+
+    @defer.inlineCallbacks
     def _find_user_id_and_pwd_hash(self, user_id):
         """Checks to see if a user with the given id exists. Will check case
         insensitively, but will throw if there are multiple inexact matches.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -298,7 +298,8 @@ class AuthHandler(BaseHandler):
     @defer.inlineCallbacks
     def login_with_cas_user_id(self, user_id):
         """
-        Authenticates the user with the given user ID, intended to have been captured from a CAS response
+        Authenticates the user with the given user ID,
+        intended to have been captured from a CAS response
 
         Args:
             user_id (str): User ID

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -157,7 +157,7 @@ class LoginRestServlet(ClientV1RestServlet):
                         "home_server": self.hs.hostname,
                     }
 
-            defer.returnValue((200, result))
+                defer.returnValue((200, result))
 
         raise LoginError(401, "Invalid CAS response", errcode=Codes.UNAUTHORIZED)
 

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -77,9 +77,13 @@ class LoginRestServlet(ClientV1RestServlet):
                     "uri": "%s%s" % (self.idp_redirect_url, relay_state)
                 }
                 defer.returnValue((200, result))
-            elif self.cas_enabled and (login_submission["type"] == LoginRestServlet.CAS_TYPE):
+            elif self.cas_enabled and (login_submission["type"] ==
+                                       LoginRestServlet.CAS_TYPE):
                 url = "%s/proxyValidate" % (self.cas_server_url)
-                parameters = {"ticket": login_submission["ticket"], "service": login_submission["service"]}
+                parameters = {
+                    "ticket": login_submission["ticket"],
+                    "service": login_submission["service"]
+                }
                 response = requests.get(url, verify=False, params=parameters)
                 result = yield self.do_cas_login(response.text)
                 defer.returnValue(result)
@@ -130,7 +134,8 @@ class LoginRestServlet(ClientV1RestServlet):
                 auth_handler = self.handlers.auth_handler
                 user_exists = yield auth_handler.does_user_exist(user_id)
                 if user_exists:
-                    user_id, access_token, refresh_token = yield auth_handler.login_with_cas_user_id(user_id)
+                    user_id, access_token, refresh_token = yield
+                    auth_handler.login_with_cas_user_id(user_id)
                     result = {
                         "user_id": user_id,  # may have changed
                         "access_token": access_token,
@@ -139,7 +144,8 @@ class LoginRestServlet(ClientV1RestServlet):
                     }
 
                 else:
-                    user_id, access_token = yield self.handlers.registration_handler.register(localpart=user)
+                    user_id, access_token = yield
+                    self.handlers.registration_handler.register(localpart=user)
                     result = {
                         "user_id": user_id,  # may have changed
                         "access_token": access_token,
@@ -147,7 +153,6 @@ class LoginRestServlet(ClientV1RestServlet):
                     }
 
             defer.returnValue((200, result))
-
 
         raise LoginError(401, "Invalid CAS response", errcode=Codes.UNAUTHORIZED)
 
@@ -224,6 +229,7 @@ class SAML2RestServlet(ClientV1RestServlet):
             defer.returnValue(None)
         defer.returnValue((200, {"status": "not_authenticated"}))
 
+
 class CasRestServlet(ClientV1RestServlet):
     PATTERN = client_path_pattern("/login/cas")
 
@@ -233,6 +239,7 @@ class CasRestServlet(ClientV1RestServlet):
 
     def on_GET(self, request):
         return (200, {"serverUrl": self.cas_server_url})
+
 
 def _parse_json(request):
     try:

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -133,7 +133,7 @@ class LoginRestServlet(ClientV1RestServlet):
         for child in root[0]:
             if child.tag.endswith("user"):
                 user = child.text
-                user_id = "@%s:%s" % (user, self.servername)
+                user_id = UserID.create(user, self.hs.hostname).to_string()
                 auth_handler = self.handlers.auth_handler
                 user_exists = yield auth_handler.does_user_exist(user_id)
                 if user_exists:

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -137,8 +137,9 @@ class LoginRestServlet(ClientV1RestServlet):
                 auth_handler = self.handlers.auth_handler
                 user_exists = yield auth_handler.does_user_exist(user_id)
                 if user_exists:
-                    user_id, access_token, refresh_token = yield
-                    auth_handler.login_with_cas_user_id(user_id)
+                    user_id, access_token, refresh_token = (
+                        yield auth_handler.login_with_cas_user_id(user_id)
+                    )
                     result = {
                         "user_id": user_id,  # may have changed
                         "access_token": access_token,
@@ -147,8 +148,9 @@ class LoginRestServlet(ClientV1RestServlet):
                     }
 
                 else:
-                    user_id, access_token = yield
-                    self.handlers.registration_handler.register(localpart=user)
+                    user_id, access_token = (
+                        yield self.handlers.registration_handler.register(localpart=user)
+                    )
                     result = {
                         "user_id": user_id,  # may have changed
                         "access_token": access_token,


### PR DESCRIPTION
Initial support for CAS login.

Important! - Will login as the user returned from CAS. So if that user already exists, CAS login will login with that account. If no user yet exists with the user returned from CAS, we register and then login.

Doesn't handle CAS logout or anything like that yet, just simple login.

There will be further pull requests for matrix-js-sdk and matrix-react-sdk to show support there.

I've tested this locally using OpenMarket CAS and manually hitting APIs and it appears to work.

Any questions, let me know.


Signed-off-by: Steven Hammerton <steven.hammerton@openmarket.com>