### PR TITLE
Stuff signed data in a standalone object

### DIFF
--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 
 """This module contains classes for authenticating the user."""
-from nacl.exceptions import BadSignatureError
+from signedjson.key import decode_verify_key_bytes
+from signedjson.sign import verify_signed_json, SignatureVerifyException
 
 from twisted.internet import defer
 
@@ -26,7 +27,6 @@ from synapse.util import third_party_invites
 from unpaddedbase64 import decode_base64
 
 import logging
-import nacl.signing
 import pymacaroons
 
 logger = logging.getLogger(__name__)
@@ -416,16 +416,23 @@ class Auth(object):
                     key_validity_url
                 )
                 return False
-            for _, signature_block in join_third_party_invite["signatures"].items():
+            signed = join_third_party_invite["signed"]
+            if signed["mxid"] != event.user_id:
+                return False
+            if signed["token"] != token:
+                return False
+            for server, signature_block in signed["signatures"].items():
                 for key_name, encoded_signature in signature_block.items():
                     if not key_name.startswith("ed25519:"):
                         return False
-                    verify_key = nacl.signing.VerifyKey(decode_base64(public_key))
-                    signature = decode_base64(encoded_signature)
-                    verify_key.verify(token, signature)
+                    verify_key = decode_verify_key_bytes(
+                        key_name,
+                        decode_base64(public_key)
+                    )
+                    verify_signed_json(signed, server, verify_key)
                     return True
             return False
-        except (KeyError, BadSignatureError,):
+        except (KeyError, SignatureVerifyException,):
             return False
 
     def _get_power_level_event(self, auth_events):

--- a/synapse/util/third_party_invites.py
+++ b/synapse/util/third_party_invites.py
@@ -23,8 +23,8 @@ JOIN_KEYS = {
     "token",
     "public_key",
     "key_validity_url",
-    "signatures",
     "sender",
+    "signed",
 }
 
 


### PR DESCRIPTION
Makes both generating it in sydent, and verifying it here, simpler at
the cost of some repetition