### PR TITLE
Don't 500 on /login when the email doesn't map to a valid user ID.

### DIFF
--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -102,9 +102,7 @@ class LoginRestServlet(ClientV1RestServlet):
                 login_submission['medium'], login_submission['address']
             )
             if not user_id:
-                raise LoginError(
-                    401, "Unrecognised address", errcode=Codes.UNAUTHORIZED
-                )
+                raise LoginError(403, "", errcode=Codes.FORBIDDEN)
         else:
             user_id = login_submission['user']
 

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -101,6 +101,10 @@ class LoginRestServlet(ClientV1RestServlet):
             user_id = yield self.hs.get_datastore().get_user_id_by_threepid(
                 login_submission['medium'], login_submission['address']
             )
+            if not user_id:
+                raise LoginError(
+                    401, "Unrecognised address", errcode=Codes.UNAUTHORIZED
+                )
         else:
             user_id = login_submission['user']
 


### PR DESCRIPTION
If you tried to login with an email address which was not recognised, Synapse would 500. This is now fixed to instead 401 with an "Unrecognised address" message.

This is related to:
https://github.com/vector-im/vector-web/issues/220

I'm not sure how we should best handle the codes/messages here. By exposing anything other than a 403 we are exposing that the email address is or is not registered on the target HS, but UX demands that people who try to login with an invalid email address should be told.

Further, should we be using a separate `M_UNKNOWN_ADDRESS` error code? At the moment, clients would need to either display the `error` directly or assume that a 401 when giving a `medium`/`address` means "unknown address".