### PR TITLE
Fix missing profile data in federation joins

### DIFF
--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -357,7 +357,8 @@ class FederationClient(FederationBase):
         defer.returnValue(signed_auth)
 
     @defer.inlineCallbacks
-    def make_membership_event(self, destinations, room_id, user_id, membership):
+    def make_membership_event(self, destinations, room_id, user_id, membership,
+                              content={},):
         """
         Creates an m.room.member event, with context, without participating in the room.
 
@@ -397,6 +398,8 @@ class FederationClient(FederationBase):
                 pdu_dict = ret["event"]
 
                 logger.debug("Got response to make_%s: %s", membership, pdu_dict)
+
+                pdu_dict["content"].update(content)
 
                 defer.returnValue(
                     (destination, self.event_from_pdu_json(pdu_dict))

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -564,7 +564,7 @@ class FederationHandler(BaseHandler):
 
     @log_function
     @defer.inlineCallbacks
-    def do_invite_join(self, target_hosts, room_id, joinee):
+    def do_invite_join(self, target_hosts, room_id, joinee, content):
         """ Attempts to join the `joinee` to the room `room_id` via the
         server `target_host`.
 
@@ -584,7 +584,8 @@ class FederationHandler(BaseHandler):
             target_hosts,
             room_id,
             joinee,
-            "join"
+            "join",
+            content,
         )
 
         self.room_queues[room_id] = []
@@ -840,12 +841,14 @@ class FederationHandler(BaseHandler):
         defer.returnValue(None)
 
     @defer.inlineCallbacks
-    def _make_and_verify_event(self, target_hosts, room_id, user_id, membership):
+    def _make_and_verify_event(self, target_hosts, room_id, user_id, membership,
+                               content={},):
         origin, pdu = yield self.replication_layer.make_membership_event(
             target_hosts,
             room_id,
             user_id,
-            membership
+            membership,
+            content,
         )
 
         logger.debug("Got response to make_%s: %s", membership, pdu)

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -504,7 +504,8 @@ class RoomMemberHandler(BaseHandler):
             yield handler.do_invite_join(
                 room_hosts,
                 room_id,
-                event.user_id
+                event.user_id,
+                event.content,
             )
         else:
             logger.debug("Doing normal join")


### PR DESCRIPTION
There was a regression where we stopped including profile data in
initial joins for rooms joined over federation.