### PR TITLE
Allow user to redact with an equal power

### DIFF
--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -860,7 +860,7 @@ class Auth(object):
 
         redact_level = self._get_named_level(auth_events, "redact", 50)
 
-        if user_level > redact_level:
+        if user_level >= redact_level:
             return False
 
         redacter_domain = EventID.from_string(event.event_id).domain


### PR DESCRIPTION
Users only need their power level to be equal to the redact level for
them to be allowed to redact events.