### PR TITLE
Copy rather than move the fields to shuffle between a v1 and a v2 event.

### DIFF
--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -102,7 +102,9 @@ def format_event_raw(d):
 def format_event_for_client_v1(d):
     d = format_event_for_client_v2(d)
 
-    d["user_id"] = d.get("sender", None)
+    sender = d.get("sender")
+    if sender is not None:
+        d["user_id"] = sender
 
     copy_keys = (
         "age", "redacted_because", "replaces_state", "prev_content",

--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -100,22 +100,18 @@ def format_event_raw(d):
 
 
 def format_event_for_client_v1(d):
-    d["user_id"] = d.pop("sender", None)
+    d = format_event_for_client_v2(d)
 
-    move_keys = (
+    d["user_id"] = d.get("sender", None)
+
+    copy_keys = (
         "age", "redacted_because", "replaces_state", "prev_content",
         "invite_room_state",
     )
-    for key in move_keys:
+    for key in copy_keys:
         if key in d["unsigned"]:
             d[key] = d["unsigned"][key]
 
-    drop_keys = (
-        "auth_events", "prev_events", "hashes", "signatures", "depth",
-        "unsigned", "origin", "prev_state"
-    )
-    for key in drop_keys:
-        d.pop(key, None)
     return d
 
 


### PR DESCRIPTION
This should make all v1 APIs compatible with v2 clients. While still
allowing v1 clients to access the fields.

This makes the documentation easier since we can just document the v2
format and explain that some of the fields, in some of the APIs are
duplicated for backwards compatibility, rather than having to document
two separate event formats.