### PR TITLE
Only fire user_joined_room if the user has actually joined.

### DIFF
--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -239,6 +239,9 @@ class FederationHandler(BaseHandler):
                 )
                 prev_state = context.current_state.get((event.type, event.state_key))
                 if not prev_state or prev_state.membership != Membership.JOIN:
+                    # Only fire user_joined_room if the user has acutally
+                    # joined the room. Don't bother if the user is just
+                    # changing their profile info.
                     user = UserID.from_string(event.state_key)
                     yield user_joined_room(self.distributor, user, event.room_id)
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -177,7 +177,7 @@ class FederationHandler(BaseHandler):
                 )
 
             try:
-                _, event_stream_id, max_stream_id = yield self._handle_new_event(
+                context, event_stream_id, max_stream_id = yield self._handle_new_event(
                     origin,
                     event,
                     state=state,
@@ -234,9 +234,6 @@ class FederationHandler(BaseHandler):
 
         if event.type == EventTypes.Member:
             if event.membership == Membership.JOIN:
-                context = yield self.state_handler.compute_event_context(
-                    event, old_state=state, outlier=event.internal_metadata.is_outlier()
-                )
                 prev_state = context.current_state.get((event.type, event.state_key))
                 if not prev_state or prev_state.membership != Membership.JOIN:
                     # Only fire user_joined_room if the user has acutally

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -517,10 +517,12 @@ class RoomMemberHandler(BaseHandler):
                 do_auth=do_auth,
             )
 
-        user = UserID.from_string(event.user_id)
-        yield self.distributor.fire(
-            "user_joined_room", user=user, room_id=room_id
-        )
+        prev_state = context.current_state.get((event.type, event.state_key))
+        if not prev_state or prev_state.membership != Membership.JOIN:
+            user = UserID.from_string(event.user_id)
+            yield self.distributor.fire(
+                "user_joined_room", user=user, room_id=room_id
+            )
 
     @defer.inlineCallbacks
     def get_inviter(self, event):

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -527,6 +527,9 @@ class RoomMemberHandler(BaseHandler):
 
         prev_state = context.current_state.get((event.type, event.state_key))
         if not prev_state or prev_state.membership != Membership.JOIN:
+            # Only fire user_joined_room if the user has acutally joined the
+            # room. Don't bother if the user is just changing their profile
+            # info.
             user = UserID.from_string(event.user_id)
             yield user_joined_room(self.distributor, user, room_id)
 


### PR DESCRIPTION
Synapse sends presence EDUs whenever a user joins the room. However it currently sends them whenever it sees a m.room.member event with membership join, even if the user was already joined to the room. This causes problems because setting the displayname results in a new join event for each room the user is a member of, which in turn will cause synapse to send an EDU for each remote server joined to each of those rooms.

This PR should fix this by only notifying if the user wasn't already joined to the room.