### PR TITLE
Change the m.room.message rule to be disabled by default

### DIFF
--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -247,6 +247,7 @@ def make_base_append_underride_rules(user):
         },
         {
             'rule_id': 'global/underride/.m.rule.message',
+            'enabled': False,
             'conditions': [
                 {
                     'kind': 'event_match',


### PR DESCRIPTION
so we only notify for 1:1 rooms / highlights out-of-the-box.