### PR TITLE
Fix mock import in tests.

### DIFF
--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import uuid
-from mock.mock import Mock
+from mock import Mock
 from synapse.types import RoomID, UserID
 
 from tests import unittest


### PR DESCRIPTION
For some reason, one test imports `Mock` class from `mock.mock` rather than from `mock`.
This change fixes this error.
