### PR TITLE
Actually look up required remote server key IDs

### DIFF
--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -230,7 +230,9 @@ class Keyring(object):
 
             missing_keys = {}
             for group in group_id_to_group.values():
-                missing_keys.setdefault(group.server_name, set()).union(group.key_ids)
+                missing_keys.setdefault(group.server_name, set()).update(
+                    group.key_ids
+                )
 
             for fn in key_fetch_fns:
                 results = yield fn(missing_keys.items())


### PR DESCRIPTION
This fixes SYN-558

set.union() is a side-effect-free function that returns the union of two
sets. This clearly wanted .update(), which is the side-effecting mutator
version.

---

This also makes sytest run somewhat faster too; without:
    real    1m9.419s

with:
    real    1m5.685s

I expect a realworld test would show a much larger improvement here; because synapses under sytest spend a huge amount of their time just provisioning new testing users who hardly ever send federated traffic, whereas realworld cases would send a lot more federation about the place.

----- 

Also some quick stats of client logs in sytest:

$ grep "/key/v2/server/" log-broken.log | grep GET | wc -l
31

$ grep "/key/v2/server/" log-fixed.log | grep GET | wc -l
8
