### PR TITLE
Expose /login under r0

### DIFF
--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 
 class LoginRestServlet(ClientV1RestServlet):
-    PATTERNS = client_path_patterns("/login$", releases=(), include_in_unstable=False)
+    PATTERNS = client_path_patterns("/login$")
     PASS_TYPE = "m.login.password"
     SAML2_TYPE = "m.login.saml2"
     CAS_TYPE = "m.login.cas"


### PR DESCRIPTION
The spec says /login should be available at r0 and 'unstable', so make it so.