### PR TITLE
Dont fire user_joined_room when guest hits /events

### DIFF
--- a/synapse/handlers/events.py
+++ b/synapse/handlers/events.py
@@ -36,10 +36,6 @@ def stopped_user_eventstream(distributor, user):
     return distributor.fire("stopped_user_eventstream", user)
 
 
-def user_joined_room(distributor, user, room_id):
-    return distributor.fire("user_joined_room", user, room_id)
-
-
 class EventStreamHandler(BaseHandler):
 
     def __init__(self, hs):
@@ -135,9 +131,6 @@ class EventStreamHandler(BaseHandler):
                 # Add some randomness to this value to try and mitigate against
                 # thundering herds on restart.
                 timeout = random.randint(int(timeout*0.9), int(timeout*1.1))
-
-            if is_guest:
-                yield user_joined_room(self.distributor, auth_user, room_id)
 
             events, tokens = yield self.notifier.get_events_for(
                 auth_user, pagin_config, timeout,


### PR DESCRIPTION
Firing the 'user_joined_room' signal everytime a guest hits /events
causes all presence for that room to be returned in the stream. This may
sound helpful, but causes clients to tightloop calling /events.

In general, guest users should get the initial presence from (room)
intial sync and so we don't require presence to sbsequently come down
the event stream.