### PR TITLE
Finish removing the .*Table objects from the storage layer.

### DIFF
--- a/synapse/storage/event_push_actions.py
+++ b/synapse/storage/event_push_actions.py
@@ -42,7 +42,7 @@ class EventPushActionsStore(SQLBaseStore):
         yield self.runInteraction(
             "set_actions_for_event_and_users",
             self._simple_insert_many_txn,
-            EventPushActionsTable.table_name,
+            "event_push_actions",
             values
         )
 
@@ -104,7 +104,3 @@ class EventPushActionsStore(SQLBaseStore):
             "remove_push_actions_for_event_id",
             f
         )
-
-
-class EventPushActionsTable(object):
-    table_name = "event_push_actions"

--- a/synapse/storage/pusher.py
+++ b/synapse/storage/pusher.py
@@ -86,7 +86,7 @@ class PusherStore(SQLBaseStore):
         try:
             next_id = yield self._pushers_id_gen.get_next()
             yield self._simple_upsert(
-                PushersTable.table_name,
+                "pushers",
                 dict(
                     app_id=app_id,
                     pushkey=pushkey,
@@ -114,7 +114,7 @@ class PusherStore(SQLBaseStore):
     @defer.inlineCallbacks
     def delete_pusher_by_app_id_pushkey_user_name(self, app_id, pushkey, user_name):
         yield self._simple_delete_one(
-            PushersTable.table_name,
+            "pushers",
             {"app_id": app_id, "pushkey": pushkey, 'user_name': user_name},
             desc="delete_pusher_by_app_id_pushkey_user_name",
         )
@@ -122,7 +122,7 @@ class PusherStore(SQLBaseStore):
     @defer.inlineCallbacks
     def update_pusher_last_token(self, app_id, pushkey, user_name, last_token):
         yield self._simple_update_one(
-            PushersTable.table_name,
+            "pushers",
             {'app_id': app_id, 'pushkey': pushkey, 'user_name': user_name},
             {'last_token': last_token},
             desc="update_pusher_last_token",
@@ -132,7 +132,7 @@ class PusherStore(SQLBaseStore):
     def update_pusher_last_token_and_success(self, app_id, pushkey, user_name,
                                              last_token, last_success):
         yield self._simple_update_one(
-            PushersTable.table_name,
+            "pushers",
             {'app_id': app_id, 'pushkey': pushkey, 'user_name': user_name},
             {'last_token': last_token, 'last_success': last_success},
             desc="update_pusher_last_token_and_success",
@@ -142,12 +142,8 @@ class PusherStore(SQLBaseStore):
     def update_pusher_failing_since(self, app_id, pushkey, user_name,
                                     failing_since):
         yield self._simple_update_one(
-            PushersTable.table_name,
+            "pushers",
             {'app_id': app_id, 'pushkey': pushkey, 'user_name': user_name},
             {'failing_since': failing_since},
             desc="update_pusher_failing_since",
         )
-
-
-class PushersTable(object):
-    table_name = "pushers"

--- a/synapse/storage/room.py
+++ b/synapse/storage/room.py
@@ -49,7 +49,7 @@ class RoomStore(SQLBaseStore):
         """
         try:
             yield self._simple_insert(
-                RoomsTable.table_name,
+                "rooms",
                 {
                     "room_id": room_id,
                     "creator": room_creator_user_id,
@@ -70,9 +70,9 @@ class RoomStore(SQLBaseStore):
             A namedtuple containing the room information, or an empty list.
         """
         return self._simple_select_one(
-            table=RoomsTable.table_name,
+            table="rooms",
             keyvalues={"room_id": room_id},
-            retcols=RoomsTable.fields,
+            retcols=("room_id", "is_public", "creator"),
             desc="get_room",
             allow_none=True,
         )
@@ -275,13 +275,3 @@ class RoomStore(SQLBaseStore):
                     aliases.extend(e.content['aliases'])
 
         defer.returnValue((name, aliases))
-
-
-class RoomsTable(object):
-    table_name = "rooms"
-
-    fields = [
-        "room_id",
-        "is_public",
-        "creator"
-    ]

--- a/synapse/storage/transactions.py
+++ b/synapse/storage/transactions.py
@@ -16,8 +16,6 @@
 from ._base import SQLBaseStore
 from synapse.util.caches.descriptors import cached
 
-from collections import namedtuple
-
 from canonicaljson import encode_canonical_json
 import logging
 
@@ -50,12 +48,15 @@ class TransactionStore(SQLBaseStore):
     def _get_received_txn_response(self, txn, transaction_id, origin):
         result = self._simple_select_one_txn(
             txn,
-            table=ReceivedTransactionsTable.table_name,
+            table="received_transactions",
             keyvalues={
                 "transaction_id": transaction_id,
                 "origin": origin,
             },
-            retcols=ReceivedTransactionsTable.fields,
+            retcols=(
+                "transaction_id", "origin", "ts", "response_code", "response_json",
+                "has_been_referenced",
+            ),
             allow_none=True,
         )
 
@@ -79,7 +80,7 @@ class TransactionStore(SQLBaseStore):
         """
 
         return self._simple_insert(
-            table=ReceivedTransactionsTable.table_name,
+            table="received_transactions",
             values={
                 "transaction_id": transaction_id,
                 "origin": origin,
@@ -136,7 +137,7 @@ class TransactionStore(SQLBaseStore):
 
         self._simple_insert_txn(
             txn,
-            table=SentTransactions.table_name,
+            table="sent_transactions",
             values={
                 "id": next_id,
                 "transaction_id": transaction_id,
@@ -171,7 +172,7 @@ class TransactionStore(SQLBaseStore):
                        code, response_json):
         self._simple_update_one_txn(
             txn,
-            table=SentTransactions.table_name,
+            table="sent_transactions",
             keyvalues={
                 "transaction_id": transaction_id,
                 "destination": destination,
@@ -229,11 +230,11 @@ class TransactionStore(SQLBaseStore):
     def _get_destination_retry_timings(self, txn, destination):
         result = self._simple_select_one_txn(
             txn,
-            table=DestinationsTable.table_name,
+            table="destinations",
             keyvalues={
                 "destination": destination,
             },
-            retcols=DestinationsTable.fields,
+            retcols=("destination", "retry_last_ts", "retry_interval"),
             allow_none=True,
         )
 
@@ -304,52 +305,3 @@ class TransactionStore(SQLBaseStore):
 
         txn.execute(query, (self._clock.time_msec(),))
         return self.cursor_to_dict(txn)
-
-
-class ReceivedTransactionsTable(object):
-    table_name = "received_transactions"
-
-    fields = [
-        "transaction_id",
-        "origin",
-        "ts",
-        "response_code",
-        "response_json",
-        "has_been_referenced",
-    ]
-
-
-class SentTransactions(object):
-    table_name = "sent_transactions"
-
-    fields = [
-        "id",
-        "transaction_id",
-        "destination",
-        "ts",
-        "response_code",
-        "response_json",
-    ]
-
-    EntryType = namedtuple("SentTransactionsEntry", fields)
-
-
-class TransactionsToPduTable(object):
-    table_name = "transaction_id_to_pdu"
-
-    fields = [
-        "transaction_id",
-        "destination",
-        "pdu_id",
-        "pdu_origin",
-    ]
-
-
-class DestinationsTable(object):
-    table_name = "destinations"
-
-    fields = [
-        "destination",
-        "retry_last_ts",
-        "retry_interval",
-    ]

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -28,7 +28,6 @@ from synapse.api.constants import PresenceState
 from synapse.api.errors import SynapseError
 from synapse.handlers.presence import PresenceHandler, UserPresenceCache
 from synapse.streams.config import SourcePaginationConfig
-from synapse.storage.transactions import DestinationsTable
 from synapse.types import UserID
 
 OFFLINE = PresenceState.OFFLINE

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -27,7 +27,6 @@ from ..utils import (
 from synapse.api.errors import AuthError
 from synapse.handlers.typing import TypingNotificationHandler
 
-from synapse.storage.transactions import DestinationsTable
 from synapse.types import UserID
 
 


### PR DESCRIPTION
Most of the storage layer stopped using the .*Table objects ages ago.
However there are still a few stragglers. This PR removes them from the last couple of places they were used.

Replacing embedded string constants is usually a noble goal, but has less value in a dynamically interpreted language. If you have to execute the code in order to check that it works then there isn't much difference between a SQL error with "table not found" and a python name lookup error.

Adding the layer of indirection makes it harder to see what SQL is actually happening at the call site.