### PR TITLE
Require ID and as_token be unique for ASs

### DIFF
--- a/tests/appservice/test_appservice.py
+++ b/tests/appservice/test_appservice.py
@@ -29,6 +29,7 @@ class ApplicationServiceTestCase(unittest.TestCase):
 
     def setUp(self):
         self.service = ApplicationService(
+            id="unique_identifier",
             url="some_url",
             token="some_token",
             namespaces={


### PR DESCRIPTION
Defaults ID to as_token if not specified. This will change
when IDs are fully supported.