### PR TITLE
SYN-606: Peeking does not wake up /events

### DIFF
--- a/synapse/notifier.py
+++ b/synapse/notifier.py
@@ -403,7 +403,9 @@ class Notifier(object):
             # over /events.
             #
             # I am sorry for what I have done.
-            user_id_for_stream = "_PEEKING_" + user_id_for_stream
+            user_id_for_stream = "_PEEKING_%s_%s" % (
+                explicit_room_id, user_id_for_stream
+            )
 
         result = yield self.wait_for_events(
             user_id_for_stream,


### PR DESCRIPTION
If a real user attempted to first peek into one room, and then another,
their room event stream would not be woken up for events in the later
room.