### PR TITLE
Sanitize filters

### DIFF
--- a/synapse/rest/client/v2_alpha/filter.py
+++ b/synapse/rest/client/v2_alpha/filter.py
@@ -59,7 +59,7 @@ class GetFilterRestServlet(RestServlet):
                 filter_id=filter_id,
             )
 
-            defer.returnValue((200, filter.filter_json))
+            defer.returnValue((200, filter.get_filter_json()))
         except KeyError:
             raise SynapseError(400, "No such filter")
 

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -504,4 +504,4 @@ class FilteringTestCase(unittest.TestCase):
             filter_id=filter_id,
         )
 
-        self.assertEquals(filter.filter_json, user_filter_json)
+        self.assertEquals(filter.get_filter_json(), user_filter_json)


### PR DESCRIPTION
In particular, an passing an unrecognised `filter_id` to `/sync` will error, rather than falling back to the default filter.