### PR TITLE
Better fix for actions with both dont_notify and tweaks

### DIFF
--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -135,16 +135,8 @@ class BulkPushRuleEvaluator:
                     evaluator, rule['conditions'], uid, display_name, condition_cache
                 )
                 if matches:
-                    notify = False
-                    actions = []
-                    for a in rule['actions']:
-                        if a != 'dont_notify':
-                            actions.append(a)
-                        elif a == 'notify':
-                            notify = True
-
                     actions = [x for x in rule['actions'] if x != 'dont_notify']
-                    if actions and notify:
+                    if actions:
                         actions_by_user[uid] = actions
                     break
         defer.returnValue(actions_by_user)

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -136,7 +136,7 @@ class BulkPushRuleEvaluator:
                 )
                 if matches:
                     actions = [x for x in rule['actions'] if x != 'dont_notify']
-                    if actions:
+                    if actions and 'notify' in actions:
                         actions_by_user[uid] = actions
                     break
         defer.returnValue(actions_by_user)


### PR DESCRIPTION
Previous fix was broken since we never set notify to true due to spurious else if, and did the filtering twice for no reason. Much easier to just test if 'notify' actually appears in the list.