### PR TITLE
Only notify for messages in one to one rooms, not every event

### DIFF
--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -173,6 +173,12 @@ BASE_APPEND_UNDERRIDE_RULES = [
                 'kind': 'room_member_count',
                 'is': '2',
                 '_id': 'member_count',
+            },
+            {
+                'kind': 'event_match',
+                'key': 'type',
+                'pattern': 'm.room.message',
+                '_id': '_message',
             }
         ],
         'actions': [


### PR DESCRIPTION
Fixes the fact that candidate events and hangups generated notifications.