### PR TITLE
Pull guest access token out of the auth session params

### DIFF
--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -152,6 +152,7 @@ class RegisterRestServlet(RestServlet):
 
         desired_username = params.get("username", None)
         new_password = params.get("password", None)
+        guest_access_token = params.get("guest_access_token", None)
 
         (user_id, token) = yield self.registration_handler.register(
             localpart=desired_username,


### PR DESCRIPTION
Otherwise it will break if you open the email on a different device.

Helps fix https://github.com/vector-im/vector-web/issues/827 (but vector has bugs that cause that break that too)