### PR TITLE
Merge another room join codepath

### DIFF
--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -237,8 +237,12 @@ class JoinRoomAliasServlet(ClientV1RestServlet):
 
         # TODO: Support for specifying the home server to join with?
 
-        yield handler.do_join(
-            requester, room_id, hosts=hosts
+        yield handler.update_membership(
+            requester,
+            requester.user,
+            room_id,
+            "join",
+            room_hosts=hosts
         )
         defer.returnValue((200, {"room_id": room_id}))
 


### PR DESCRIPTION
There's *still* at least one more.

Side effects:
 * More membership events have a top-level "membership" key set for
   backwards compatibility.
 * Set access_token_id for /join/<room_id_or_alias> requests.