### PR TITLE
Merge all of the room membership codepaths into one

### DIFF
--- a/synapse/handlers/_base.py
+++ b/synapse/handlers/_base.py
@@ -188,8 +188,11 @@ class BaseHandler(object):
         )
 
     @defer.inlineCallbacks
-    def handle_new_client_event(self, event, context, extra_users=[]):
+    def handle_new_client_event(self, event, context, ratelimit=True, extra_users=[]):
         # We now need to go and hit out to wherever we need to hit out to.
+
+        if ratelimit:
+            self.ratelimit(event.sender)
 
         self.auth.check(event, auth_events=context.current_state)
 

--- a/synapse/handlers/_base.py
+++ b/synapse/handlers/_base.py
@@ -222,7 +222,8 @@ class BaseHandler(object):
             if event_type == EventTypes.Member
         ]
         if len(room_members) == 0:
-            # has the room been created so we can join it?
+            # Have we just created the room, and is this about to be the very
+            # first member event?
             create_event = current_state.get(("m.room.create", ""))
             if create_event:
                 return True

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -216,7 +216,7 @@ class DirectoryHandler(BaseHandler):
         aliases = yield self.store.get_aliases_for_room(room_id)
 
         msg_handler = self.hs.get_handlers().message_handler
-        yield msg_handler.create_and_send_event({
+        yield msg_handler.create_and_send_nonmember_event({
             "type": EventTypes.Aliases,
             "state_key": self.hs.hostname,
             "room_id": room_id,

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1658,7 +1658,7 @@ class FederationHandler(BaseHandler):
             self.auth.check(event, context.current_state)
             yield self._validate_keyserver(event, auth_events=context.current_state)
             member_handler = self.hs.get_handlers().room_member_handler
-            yield member_handler.send_membership_event(event, context)
+            yield member_handler.send_membership_event(event, context, from_client=False)
         else:
             destinations = set([x.split(":", 1)[-1] for x in (sender, room_id)])
             yield self.replication_layer.forward_third_party_invite(
@@ -1687,7 +1687,7 @@ class FederationHandler(BaseHandler):
         # TODO: Make sure the signatures actually are correct.
         event.signatures.update(returned_invite.signatures)
         member_handler = self.hs.get_handlers().room_member_handler
-        yield member_handler.send_membership_event(event, context)
+        yield member_handler.send_membership_event(event, context, from_client=False)
 
     @defer.inlineCallbacks
     def add_display_name_to_third_party_invite(self, event_dict, event, context):

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -229,7 +229,7 @@ class MessageHandler(BaseHandler):
         if event.type == EventTypes.Member:
             raise SynapseError(
                 500,
-                "Tried to send member even through non-member codepath"
+                "Tried to send member event through non-member codepath"
             )
 
         user = UserID.from_string(event.sender)

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -253,12 +253,18 @@ class MessageHandler(BaseHandler):
                 presence.bump_presence_active_time(user)
 
     def deduplicate_state_event(self, event, context):
-        prev_state = context.current_state.get((event.type, event.state_key))
-        if prev_state and event.user_id == prev_state.user_id:
-            prev_content = encode_canonical_json(prev_state.content)
+        """
+        Checks whether event is in the latest resolved state in context.
+
+        If so, returns the version of the event in context.
+        Otherwise, returns None.
+        """
+        prev_event = context.current_state.get((event.type, event.state_key))
+        if prev_event and event.user_id == prev_event.user_id:
+            prev_content = encode_canonical_json(prev_event.content)
             next_content = encode_canonical_json(event.content)
             if prev_content == next_content:
-                return prev_state
+                return prev_event
         return None
 
     @defer.inlineCallbacks

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -16,7 +16,7 @@
 from twisted.internet import defer
 
 from synapse.api.constants import EventTypes, Membership
-from synapse.api.errors import AuthError, Codes
+from synapse.api.errors import AuthError, Codes, SynapseError
 from synapse.streams.config import PaginationConfig
 from synapse.events.utils import serialize_event
 from synapse.events.validator import EventValidator
@@ -216,7 +216,7 @@ class MessageHandler(BaseHandler):
         defer.returnValue((event, context))
 
     @defer.inlineCallbacks
-    def send_event(self, event, context, ratelimit=True, is_guest=False, room_hosts=None):
+    def send_nonmember_event(self, event, context, ratelimit=True):
         """
         Persists and notifies local clients and federation of an event.
 
@@ -226,61 +226,63 @@ class MessageHandler(BaseHandler):
             ratelimit (bool): Whether to rate limit this send.
             is_guest (bool): Whether the sender is a guest.
         """
+        if event.type == EventTypes.Member:
+            raise SynapseError(
+                500,
+                "Tried to send member even through non-member codepath"
+            )
+
         user = UserID.from_string(event.sender)
 
         assert self.hs.is_mine(user), "User must be our own: %s" % (user,)
 
         if event.is_state():
-            prev_state = context.current_state.get((event.type, event.state_key))
-            if prev_state and event.user_id == prev_state.user_id:
-                prev_content = encode_canonical_json(prev_state.content)
-                next_content = encode_canonical_json(event.content)
-                if prev_content == next_content:
-                    # Duplicate suppression for state updates with same sender
-                    # and content.
-                    defer.returnValue(prev_state)
+            prev_state = self.deduplicate_state_event(event, context)
+            if prev_state is not None:
+                defer.returnValue(prev_state)
 
-        if event.type == EventTypes.Member:
-            member_handler = self.hs.get_handlers().room_member_handler
-            yield member_handler.send_membership_event(
-                event,
-                context,
-                is_guest=is_guest,
-                ratelimit=ratelimit,
-                room_hosts=room_hosts
-            )
-        else:
-            yield self.handle_new_client_event(
-                event=event,
-                context=context,
-                ratelimit=ratelimit,
-            )
+        yield self.handle_new_client_event(
+            event=event,
+            context=context,
+            ratelimit=ratelimit,
+        )
 
         if event.type == EventTypes.Message:
             presence = self.hs.get_handlers().presence_handler
             with PreserveLoggingContext():
                 presence.bump_presence_active_time(user)
 
+    def deduplicate_state_event(self, event, context):
+        prev_state = context.current_state.get((event.type, event.state_key))
+        if prev_state and event.user_id == prev_state.user_id:
+            prev_content = encode_canonical_json(prev_state.content)
+            next_content = encode_canonical_json(event.content)
+            if prev_content == next_content:
+                return prev_state
+        return None
+
     @defer.inlineCallbacks
-    def create_and_send_event(self, event_dict, ratelimit=True,
-                              token_id=None, txn_id=None, is_guest=False,
-                              room_hosts=None):
+    def create_and_send_nonmember_event(
+        self,
+        event_dict,
+        ratelimit=True,
+        token_id=None,
+        txn_id=None
+    ):
         """
         Creates an event, then sends it.
 
-        See self.create_event and self.send_event.
+        See self.create_event and self.send_nonmember_event.
         """
         event, context = yield self.create_event(
             event_dict,
             token_id=token_id,
             txn_id=txn_id
         )
-        yield self.send_event(
+        yield self.send_nonmember_event(
             event,
             context,
             ratelimit=ratelimit,
-            is_guest=is_guest,
-            room_hosts=room_hosts,
         )
         defer.returnValue(event)
 

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -217,7 +217,7 @@ class ProfileHandler(BaseHandler):
                     user,
                     j.room_id,
                     "join",  # We treat a profile update like a join.
-                    ratelimit=False,
+                    ratelimit=False,  # Try to hide that these events aren't atomic.
                 )
             except Exception as e:
                 logger.warn(

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -404,7 +404,14 @@ class RoomMemberHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def update_membership(
-            self, requester, target, room_id, action, txn_id=None, room_hosts=None
+            self,
+            requester,
+            target,
+            room_id,
+            action,
+            txn_id=None,
+            room_hosts=None,
+            ratelimit=True,
     ):
         effective_membership_state = action
         if action in ["kick", "unban"]:
@@ -451,7 +458,7 @@ class RoomMemberHandler(BaseHandler):
         yield msg_handler.send_event(
             event,
             context,
-            ratelimit=True,
+            ratelimit=ratelimit,
             is_guest=requester.is_guest,
             room_hosts=room_hosts,
         )

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -41,10 +41,6 @@ logger = logging.getLogger(__name__)
 id_server_scheme = "https://"
 
 
-def collect_presencelike_data(distributor, user, content):
-    return distributor.fire("collect_presencelike_data", user, content)
-
-
 def user_left_room(distributor, user, room_id):
     return preserve_context_over_fn(
         distributor.fire,

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -490,11 +490,10 @@ class RoomMemberHandler(BaseHandler):
             sender = UserID.from_string(event.sender)
             assert self.hs.is_mine(sender), "Sender must be our own: %s" % (sender,)
 
-        if event.is_state():
-            message_handler = self.hs.get_handlers().message_handler
-            prev_event = message_handler.deduplicate_state_event(event, context)
-            if prev_event is not None:
-                return
+        message_handler = self.hs.get_handlers().message_handler
+        prev_event = message_handler.deduplicate_state_event(event, context)
+        if prev_event is not None:
+            return
 
         action = "send"
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -76,13 +76,11 @@ class RoomCreationHandler(BaseHandler):
     }
 
     @defer.inlineCallbacks
-    def create_room(self, user_id, room_id, config):
+    def create_room(self, requester, config):
         """ Creates a new room.
 
         Args:
             user_id (str): The ID of the user creating the new room.
-            room_id (str): The proposed ID for the new room. Can be None, in
-            which case one will be created for you.
             config (dict) : A dict of configuration options.
         Returns:
             The new room ID.
@@ -90,6 +88,8 @@ class RoomCreationHandler(BaseHandler):
             SynapseError if the room ID was taken, couldn't be stored, or
             something went horribly wrong.
         """
+        user_id = requester.user.to_string()
+
         self.ratelimit(user_id)
 
         if "room_alias_name" in config:
@@ -121,40 +121,28 @@ class RoomCreationHandler(BaseHandler):
 
         is_public = config.get("visibility", None) == "public"
 
-        if room_id:
-            # Ensure room_id is the correct type
-            room_id_obj = RoomID.from_string(room_id)
-            if not self.hs.is_mine(room_id_obj):
-                raise SynapseError(400, "Room id must be local")
-
-            yield self.store.store_room(
-                room_id=room_id,
-                room_creator_user_id=user_id,
-                is_public=is_public
-            )
-        else:
-            # autogen room IDs and try to create it. We may clash, so just
-            # try a few times till one goes through, giving up eventually.
-            attempts = 0
-            room_id = None
-            while attempts < 5:
-                try:
-                    random_string = stringutils.random_string(18)
-                    gen_room_id = RoomID.create(
-                        random_string,
-                        self.hs.hostname,
-                    )
-                    yield self.store.store_room(
-                        room_id=gen_room_id.to_string(),
-                        room_creator_user_id=user_id,
-                        is_public=is_public
-                    )
-                    room_id = gen_room_id.to_string()
-                    break
-                except StoreError:
-                    attempts += 1
-            if not room_id:
-                raise StoreError(500, "Couldn't generate a room ID.")
+        # autogen room IDs and try to create it. We may clash, so just
+        # try a few times till one goes through, giving up eventually.
+        attempts = 0
+        room_id = None
+        while attempts < 5:
+            try:
+                random_string = stringutils.random_string(18)
+                gen_room_id = RoomID.create(
+                    random_string,
+                    self.hs.hostname,
+                )
+                yield self.store.store_room(
+                    room_id=gen_room_id.to_string(),
+                    room_creator_user_id=user_id,
+                    is_public=is_public
+                )
+                room_id = gen_room_id.to_string()
+                break
+            except StoreError:
+                attempts += 1
+        if not room_id:
+            raise StoreError(500, "Couldn't generate a room ID.")
 
         if room_alias:
             directory_handler = self.hs.get_handlers().directory_handler

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -63,24 +63,12 @@ class RoomCreateRestServlet(ClientV1RestServlet):
     def on_POST(self, request):
         requester = yield self.auth.get_user_by_req(request)
 
-        room_config = self.get_room_config(request)
-        info = yield self.make_room(
-            room_config,
-            requester.user,
-            None,
-        )
-        room_config.update(info)
-        defer.returnValue((200, info))
-
-    @defer.inlineCallbacks
-    def make_room(self, room_config, auth_user, room_id):
         handler = self.handlers.room_creation_handler
         info = yield handler.create_room(
-            user_id=auth_user.to_string(),
-            room_id=room_id,
-            config=room_config
+            requester, self.get_room_config(request)
         )
-        defer.returnValue(info)
+
+        defer.returnValue((200, info))
 
     def get_room_config(self, request):
         try:

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -242,23 +242,12 @@ class JoinRoomAliasServlet(ClientV1RestServlet):
                 room_identifier,
             ))
 
-        msg_handler = self.handlers.message_handler
-        content = {"membership": Membership.JOIN}
-        if requester.is_guest:
-            content["kind"] = "guest"
-        yield msg_handler.create_and_send_event(
-            {
-                "type": EventTypes.Member,
-                "content": content,
-                "room_id": room_id,
-                "sender": requester.user.to_string(),
-                "state_key": requester.user.to_string(),
-
-                "membership": Membership.JOIN,  # For backwards compatibility
-            },
-            token_id=requester.access_token_id,
+        yield self.handlers.room_member_handler.update_membership(
+            requester=requester,
+            target=requester.user,
+            room_id=room_id,
+            action="join",
             txn_id=txn_id,
-            is_guest=requester.is_guest,
             room_hosts=room_hosts,
         )
 

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -246,7 +246,7 @@ class JoinRoomAliasServlet(ClientV1RestServlet):
         if is_room_alias:
             handler = self.handlers.room_member_handler
             ret_dict = yield handler.join_room_alias(
-                requester.user,
+                requester,
                 identifier,
             )
             defer.returnValue((200, ret_dict))

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -230,11 +230,11 @@ class JoinRoomAliasServlet(ClientV1RestServlet):
 
         if RoomID.is_valid(room_identifier):
             room_id = room_identifier
-            room_hosts = None
+            remote_room_hosts = None
         elif RoomAlias.is_valid(room_identifier):
             handler = self.handlers.room_member_handler
             room_alias = RoomAlias.from_string(room_identifier)
-            room_id, room_hosts = yield handler.lookup_room_alias(room_alias)
+            room_id, remote_room_hosts = yield handler.lookup_room_alias(room_alias)
             room_id = room_id.to_string()
         else:
             raise SynapseError(400, "%s was not legal room ID or room alias" % (
@@ -247,7 +247,7 @@ class JoinRoomAliasServlet(ClientV1RestServlet):
             room_id=room_id,
             action="join",
             txn_id=txn_id,
-            room_hosts=room_hosts,
+            remote_room_hosts=remote_room_hosts,
         )
 
         defer.returnValue((200, {"room_id": room_id}))

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -114,10 +114,10 @@ class EventFederationStore(SQLBaseStore):
             retcol="event_id",
         )
 
-    def get_latest_events_in_room(self, room_id):
+    def get_latest_event_ids_and_hashes_in_room(self, room_id):
         return self.runInteraction(
-            "get_latest_events_in_room",
-            self._get_latest_events_in_room,
+            "get_latest_event_ids_and_hashes_in_room",
+            self._get_latest_event_ids_and_hashes_in_room,
             room_id,
         )
 
@@ -132,7 +132,7 @@ class EventFederationStore(SQLBaseStore):
             desc="get_latest_event_ids_in_room",
         )
 
-    def _get_latest_events_in_room(self, txn, room_id):
+    def _get_latest_event_ids_and_hashes_in_room(self, txn, room_id):
         sql = (
             "SELECT e.event_id, e.depth FROM events as e "
             "INNER JOIN event_forward_extremities as f "

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -73,6 +73,14 @@ class DomainSpecificString(
         """Return a string encoding the fields of the structure object."""
         return "%s%s:%s" % (self.SIGIL, self.localpart, self.domain)
 
+    @classmethod
+    def is_valid(cls, s):
+        try:
+            cls.from_string(s)
+            return True
+        except:
+            return False
+
     __str__ = to_string
 
     @classmethod


### PR DESCRIPTION
Previously, there were several codepaths all of which performed inconsistent auth checks, and had different ways of looking up remote room IDs, inviters, and such. Now there is one.

It also fixes several minor bugs along the way.