### PR TITLE
handlers/_base: allow peeking users to see events in rooms they are members of

### DIFF
--- a/synapse/handlers/_base.py
+++ b/synapse/handlers/_base.py
@@ -81,9 +81,6 @@ class BaseHandler(object):
             if visibility == "world_readable":
                 return True
 
-            if is_peeking:
-                return False
-
             membership_event = state.get((EventTypes.Member, user_id), None)
             if membership_event:
                 if membership_event.event_id in event_id_forgotten:
@@ -96,11 +93,8 @@ class BaseHandler(object):
             if membership == Membership.JOIN:
                 return True
 
-            if event.type == EventTypes.RoomHistoryVisibility:
-                return not is_peeking
-
             if visibility == "shared":
-                return True
+                return not is_peeking
             elif visibility == "joined":
                 return membership == Membership.JOIN
             elif visibility == "invited":


### PR DESCRIPTION
According to spec guests should be able to use the normal /sync API to participate in rooms that they have joined. (Last sentence of [11.13.2.1   GET /_matrix/client/r0/events](https://matrix.org/docs/spec/r0.0.1/client_server.html#id49))

I'm not sure about the logic here though, so gonna need some review. I'm a bit confused about filtering out the room history visibility event for peeking users, and also defaulting to `return True` if the room visibility is set to an invalid value.