### PR TITLE
Add a test for TreeCache.__contains__

### DIFF
--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -61,6 +61,9 @@ class CounterMetricTestCase(unittest.TestCase):
             'vector{method="PUT"} 1',
         ])
 
+        # Check that passing too few values errors
+        self.assertRaises(ValueError, counter.inc)
+
 
 class CallbackMetricTestCase(unittest.TestCase):
 

--- a/tests/util/test_treecache.py
+++ b/tests/util/test_treecache.py
@@ -77,3 +77,9 @@ class TreeCacheTestCase(unittest.TestCase):
         cache[("b",)] = "B"
         cache.clear()
         self.assertEquals(len(cache), 0)
+
+    def test_contains(self):
+        cache = TreeCache()
+        cache[("a",)] = "A"
+        self.assertTrue(("a",) in cache)
+        self.assertFalse(("b",) in cache)


### PR DESCRIPTION
Check that the metrics error if too few values are passed.