### PR TITLE
handlers/_base: don't allow room create event to be changed

### DIFF
--- a/synapse/handlers/_base.py
+++ b/synapse/handlers/_base.py
@@ -342,6 +342,12 @@ class BaseHandler(object):
                         "You don't have permission to redact events"
                     )
 
+        if event.type == EventTypes.Create and context.current_state:
+            raise AuthError(
+                403,
+                "Changing the room create event is forbidden",
+            )
+
         action_generator = ActionGenerator(self.hs)
         yield action_generator.handle_push_actions_for_event(
             event, context, self


### PR DESCRIPTION
Beginning of the [m.room.create spec](https://matrix.org/docs/spec/r0.0.1/client_server.html#m-room-create) says

> This is the first event in a room and cannot be changed.

This could arguably be interpreted as that specific event not being changed, or the m.room.create state as a whole. I chose to interpret it as the latter, which I also think makes sense, as it is currently possible to e.g. change the creator key of the create state.

In either case this is a spec bug as well.