### PR TITLE
handlers/sync: fix SyncResult not counting account_data change when converting to bool

### DIFF
--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -121,7 +121,7 @@ class SyncResult(collections.namedtuple("SyncResult", [
         events.
         """
         return bool(
-            self.presence or self.joined or self.invited or self.archived
+            self.presence or self.joined or self.invited or self.archived or self.account_data
         )
 
 


### PR DESCRIPTION
This fixes account_data events not triggering an immediate /sync response