### PR TITLE
handlers/register: make sure another user id is generated when a collision occurs

### DIFF
--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -157,6 +157,7 @@ class RegistrationHandler(BaseHandler):
                     )
                 except SynapseError:
                     # if user id is taken, just generate another
+                    user = None
                     user_id = None
                     token = None
                     attempts += 1


### PR DESCRIPTION
Fixes a race condition that would cause user registration to fail with
```
twisted.python.failure.Failure sqlite3.IntegrityError: UNIQUE constraint failed: profiles.user_id
```

without returning an error to the client, but just setting the user id and access token to null.