### PR TITLE
Handle rejections of invites from local users locally

### DIFF
--- a/synapse/handlers/_base.py
+++ b/synapse/handlers/_base.py
@@ -221,7 +221,8 @@ class BaseHandler(object):
                 e.event_id for e in context.current_state.values()
             )
 
-            if (prev_member_event and
+            if (
+                prev_member_event and
                 prev_member_event.event_id not in context_event_ids
             ):
                 # The prev_member_event is missing from context, so it must

--- a/synapse/handlers/_base.py
+++ b/synapse/handlers/_base.py
@@ -215,7 +215,7 @@ class BaseHandler(object):
             #
             context_events = (e.event_id for e in context.current_state.values())
 
-            if prev_member_event and not prev_member_event.event_id in context_events:
+            if prev_member_event and prev_member_event.event_id not in context_events:
                 # The prev_member_event is missing from context, so it must
                 # have arrived over federation and is an outlier. We forcibly
                 # set our context to the invite we received over federation

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -493,6 +493,8 @@ class RoomMemberHandler(BaseHandler):
         Raises:
             SynapseError if there was a problem changing the membership.
         """
+        remote_room_hosts = remote_room_hosts or []
+
         target_user = UserID.from_string(event.state_key)
         room_id = event.room_id
 
@@ -537,8 +539,7 @@ class RoomMemberHandler(BaseHandler):
                     pass
                 else:
                     # send the rejection to the inviter's HS.
-                    remote_room_hosts = remote_room_hosts or []
-                    remote_room_hosts.append(inviter.domain)
+                    remote_room_hosts = remote_room_hosts + [inviter.doman]
                     action = "remote_reject"
 
         federation_handler = self.hs.get_handlers().federation_handler

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -521,8 +521,24 @@ class RoomMemberHandler(BaseHandler):
                 action = "remote_join"
         elif event.membership == Membership.LEAVE:
             is_host_in_room = self.is_host_in_room(context.current_state)
+
             if not is_host_in_room:
-                action = "remote_reject"
+                # perhaps we've been invited
+                inviter = self.get_inviter(target_user.to_string(), context.current_state)
+                if not inviter:
+                    raise SynapseError(404, "Not a known room")
+
+                if inviter.domain == self.server_name:
+                    # the inviter was on our server, but has now left. Carry on
+                    # with the normal rejection codepath.
+                    #
+                    # This is a bit of a hack, because the room might still be
+                    # active on other servers.
+                    pass
+                else:
+                    # send the rejection to the inviter's HS.
+                    remote_room_hosts = [inviter.domain]
+                    action = "remote_reject"
 
         federation_handler = self.hs.get_handlers().federation_handler
 
@@ -541,11 +557,8 @@ class RoomMemberHandler(BaseHandler):
                 event.content,
             )
         elif action == "remote_reject":
-            inviter = self.get_inviter(target_user.to_string(), context.current_state)
-            if not inviter:
-                raise SynapseError(404, "No known servers")
             yield federation_handler.do_remotely_reject_invite(
-                [inviter.domain],
+                remote_room_hosts,
                 room_id,
                 event.user_id
             )

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -539,7 +539,7 @@ class RoomMemberHandler(BaseHandler):
                     pass
                 else:
                     # send the rejection to the inviter's HS.
-                    remote_room_hosts = remote_room_hosts + [inviter.doman]
+                    remote_room_hosts = remote_room_hosts + [inviter.domain]
                     action = "remote_reject"
 
         federation_handler = self.hs.get_handlers().federation_handler

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -528,7 +528,7 @@ class RoomMemberHandler(BaseHandler):
                 if not inviter:
                     raise SynapseError(404, "Not a known room")
 
-                if inviter.domain == self.server_name:
+                if self.hs.is_mine(inviter):
                     # the inviter was on our server, but has now left. Carry on
                     # with the normal rejection codepath.
                     #
@@ -537,7 +537,8 @@ class RoomMemberHandler(BaseHandler):
                     pass
                 else:
                     # send the rejection to the inviter's HS.
-                    remote_room_hosts = [inviter.domain]
+                    remote_room_hosts = remote_room_hosts or []
+                    remote_room_hosts.append(inviter.domain)
                     action = "remote_reject"
 
         federation_handler = self.hs.get_handlers().federation_handler


### PR DESCRIPTION
Slightly hacky fix to SYN-642, which avoids the federation codepath when trying
to reject invites from local users.