### PR TITLE
Stop using checkpw as it seems to have vanished from bcrypt.

### DIFF
--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -477,4 +477,4 @@ class AuthHandler(BaseHandler):
         Returns:
             Whether self.hash(password) == stored_hash (bool).
         """
-        return bcrypt.checkpw(password, stored_hash)
+        return bcrypt.hashpw(password, stored_hash) == stored_hash


### PR DESCRIPTION
Use `bcrypt.hashpw(password, hashed) == hashed` as per the bcrypt README.