### PR TITLE
Make sure we add all invited members before returning from createRoom

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -210,7 +210,7 @@ class RoomCreationHandler(BaseHandler):
                 ratelimit=False)
 
         for invitee in invite_list:
-            room_member_handler.update_membership(
+            yield room_member_handler.update_membership(
                 requester,
                 UserID.from_string(invitee),
                 room_id,


### PR DESCRIPTION
add a missing yield.

This fixes a flaky test ("190 - Can re-join room if re-invited - history_visibility = shared")

!blame @illicitonion for introducing it in 4bfb32f6