### PR TITLE
Create add-room-admin.sh

### DIFF
--- a/scripts-dev/add-room-admin.sh
+++ b/scripts-dev/add-room-admin.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# This script manipulates a matrix room by adding another administrator to it
+# A room created by the @appservice_irc user of the IRC-bridge has only that user as admin
+# This script manipulates a matrix room, created by the @appservice_irc user by adding another administrator to it
 
 ### config settings ####################
 SERVER="matrix.yourserver.org"

--- a/scripts-dev/add-room-admin.sh
+++ b/scripts-dev/add-room-admin.sh
@@ -2,6 +2,7 @@
 # This script manipulates a matrix room by adding another administrator to it
 
 ### config settings ####################
+SERVER="matrix.yourserver.org"
 ROOM='!vOCcdPDdvueotEgTms:matrix.org'
 ADMIN="new_admin_username"
 TOKEN="8KnWIxCa17exampletokenD"
@@ -17,7 +18,7 @@ echo
 echo copy and paste this into bash:
 echo
 echo "curl -X PUT --header 'Content-Type: application/json' --header 'Accept: application/json' -d '"
-sed '/@appservice_irc:matrix.eclabs.de/a ,"@'$ADMIN':matrix.eclabs.de": 100' /tmp/matrix_room
+sed '/@appservice_irc:'$SERVER'/a ,"@'$ADMIN':matrix.eclabs.de": 100' /tmp/matrix_room
 echo "' '"localhost:8008/_matrix/client/r0/rooms/$ROOM/state/m.room.power_levels?access_token=$TOKEN"'"
 
 exit

--- a/scripts-dev/add-room-admin.sh
+++ b/scripts-dev/add-room-admin.sh
@@ -5,6 +5,8 @@
 ROOM='!vOCcdPDdvueotEgTms:matrix.org'
 ADMIN="new_admin_username"
 TOKEN="8KnWIxCa17exampletokenD"
+# find your as_token with
+# grep as_token matrix-appservice-irc/appservice-registration-irc.yaml
 #########################################
 
 # get original settings

--- a/scripts-dev/add-room-admin.sh
+++ b/scripts-dev/add-room-admin.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# This script manipulates a matrix room by adding another administrator to it
+
+### config settings ####################
+ROOM='!vOCcdPDdvueotEgTms:matrix.org'
+ADMIN="new_admin_username"
+TOKEN="8KnWIxCa17exampletokenD"
+#########################################
+
+# get original settings
+curl 'localhost:8008/_matrix/client/r0/rooms/'$ROOM'/state/m.room.power_levels?access_token='$TOKEN -o /tmp/matrix_room
+
+# genarate output
+echo
+echo copy and paste this into bash:
+echo
+echo "curl -X PUT --header 'Content-Type: application/json' --header 'Accept: application/json' -d '"
+sed '/@appservice_irc:matrix.eclabs.de/a ,"@'$ADMIN':matrix.eclabs.de": 100' /tmp/matrix_room
+echo "' '"localhost:8008/_matrix/client/r0/rooms/$ROOM/state/m.room.power_levels?access_token=$TOKEN"'"
+
+exit


### PR DESCRIPTION
Signed-off-by: Ruben Barkow <github@r.z11.de>

A room created by the @appservice_irc user of the IRC-bridge has only that user as admin.

This script manipulates a matrix room, created by the @appservice_irc user by adding another administrator to it
