### PR TITLE
Encode unicode objects given to post_urlencode*

### DIFF
--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -268,16 +268,19 @@ class CaptchaServerHttpClient(SimpleHttpClient):
             # twisted dislikes google's response, no content length.
             defer.returnValue(e.response)
 
+
 def encode_urlencode_args(args):
-    return { k: encode_urlencode_arg(v) for k, v in args.items() }
+    return {k: encode_urlencode_arg(v) for k, v in args.items()}
+
 
 def encode_urlencode_arg(arg):
     if isinstance(arg, unicode):
         return arg.encode('utf-8')
     elif isinstance(arg, list):
-        return [ encode_urlencode_arg(i) for i in arg ]
+        return [encode_urlencode_arg(i) for i in arg]
     else:
         return arg
+
 
 def _print_ex(e):
     if hasattr(e, "reasons") and e.reasons:

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -103,7 +103,7 @@ class SimpleHttpClient(object):
         # TODO: Do we ever want to log message contents?
         logger.debug("post_urlencoded_get_json args: %s", args)
 
-        query_bytes = urllib.urlencode(args, True)
+        query_bytes = urllib.urlencode(encode_urlencode_args(args), True)
 
         response = yield self.request(
             "POST",
@@ -249,7 +249,7 @@ class CaptchaServerHttpClient(SimpleHttpClient):
 
     @defer.inlineCallbacks
     def post_urlencoded_get_raw(self, url, args={}):
-        query_bytes = urllib.urlencode(args, True)
+        query_bytes = urllib.urlencode(encode_urlencode_args(args), True)
 
         response = yield self.request(
             "POST",
@@ -268,6 +268,16 @@ class CaptchaServerHttpClient(SimpleHttpClient):
             # twisted dislikes google's response, no content length.
             defer.returnValue(e.response)
 
+def encode_urlencode_args(args):
+    return { k: encode_urlencode_arg(v) for k, v in args.items() }
+
+def encode_urlencode_arg(arg):
+    if isinstance(arg, unicode):
+        return arg.encode('utf-8')
+    elif isinstance(arg, list):
+        return [ encode_urlencode_arg(i) for i in arg ]
+    else:
+        return arg
 
 def _print_ex(e):
     if hasattr(e, "reasons") and e.reasons:


### PR DESCRIPTION
otherwise urllib.urlencode chokes (sydent was getting '?' characters instead of valid urlencoded utf-8.