### PR TITLE
Idempotent-ise schema update script

### DIFF
--- a/synapse/storage/schema/delta/30/as_users.py
+++ b/synapse/storage/schema/delta/30/as_users.py
@@ -20,7 +20,11 @@ logger = logging.getLogger(__name__)
 
 def run_upgrade(cur, database_engine, config, *args, **kwargs):
     # NULL indicates user was not registered by an appservice.
-    cur.execute("ALTER TABLE users ADD COLUMN appservice_id TEXT")
+    try:
+        cur.execute("ALTER TABLE users ADD COLUMN appservice_id TEXT")
+    except:
+        # Maybe we already added the column? Hope so...
+        pass
 
     cur.execute("SELECT name FROM users")
     rows = cur.fetchall()


### PR DESCRIPTION
If any ASes don't have an ID, the schema will fail, and then it will
error when trying to add the column again.