### PR TITLE
SYN-646 - Register endpoint returns refresh_token

### DIFF
--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -62,12 +62,15 @@ class RegisterRestServletTestCase(unittest.TestCase):
         self.registration_handler.appservice_register = Mock(
             return_value=(user_id, token)
         )
-        result = yield self.servlet.on_POST(self.request)
-        self.assertEquals(result, (200, {
-            "user_id": user_id,
-            "access_token": token,
-            "home_server": self.hs.hostname
-        }))
+        (code, result) = yield self.servlet.on_POST(self.request)
+        self.assertEquals(code, 200)
+        det_data = {
+             "user_id": user_id,
+             "access_token": token,
+             "home_server": self.hs.hostname
+        }
+        self.assertDictContainsSubset(det_data, result)
+        self.assertIn("refresh_token", result)
 
     @defer.inlineCallbacks
     def test_POST_appservice_registration_invalid(self):
@@ -112,12 +115,15 @@ class RegisterRestServletTestCase(unittest.TestCase):
         })
         self.registration_handler.register = Mock(return_value=(user_id, token))
 
-        result = yield self.servlet.on_POST(self.request)
-        self.assertEquals(result, (200, {
-            "user_id": user_id,
-            "access_token": token,
-            "home_server": self.hs.hostname
-        }))
+        (code, result) = yield self.servlet.on_POST(self.request)
+        self.assertEquals(code, 200)
+        det_data = {
+             "user_id": user_id,
+             "access_token": token,
+             "home_server": self.hs.hostname
+        }
+        self.assertDictContainsSubset(det_data, result)
+        self.assertIn("refresh_token", result)
 
     def test_POST_disabled_registration(self):
         self.hs.config.enable_registration = False

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -65,9 +65,9 @@ class RegisterRestServletTestCase(unittest.TestCase):
         (code, result) = yield self.servlet.on_POST(self.request)
         self.assertEquals(code, 200)
         det_data = {
-             "user_id": user_id,
-             "access_token": token,
-             "home_server": self.hs.hostname
+            "user_id": user_id,
+            "access_token": token,
+            "home_server": self.hs.hostname
         }
         self.assertDictContainsSubset(det_data, result)
         self.assertIn("refresh_token", result)
@@ -118,9 +118,9 @@ class RegisterRestServletTestCase(unittest.TestCase):
         (code, result) = yield self.servlet.on_POST(self.request)
         self.assertEquals(code, 200)
         det_data = {
-             "user_id": user_id,
-             "access_token": token,
-             "home_server": self.hs.hostname
+            "user_id": user_id,
+            "access_token": token,
+            "home_server": self.hs.hostname
         }
         self.assertDictContainsSubset(det_data, result)
         self.assertIn("refresh_token", result)


### PR DESCRIPTION
Guest registration still doesn't return refresh_token