### PR TITLE
Fix logout on password change

### DIFF
--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -439,10 +439,10 @@ class AuthHandler(BaseHandler):
 
         yield self.store.user_set_password_hash(user_id, password_hash)
         yield self.store.user_delete_access_tokens_except(
-                user_id, except_access_token_ids
+            user_id, except_access_token_ids
         )
         yield self.hs.get_pusherpool().remove_pushers_by_user_except_access_tokens(
-                user_id, except_access_token_ids
+            user_id, except_access_token_ids
         )
 
     @defer.inlineCallbacks

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -441,7 +441,7 @@ class AuthHandler(BaseHandler):
         yield self.store.user_delete_access_tokens(
             user_id, except_access_token_ids
         )
-        yield self.hs.get_pusherpool().remove_pushers_by_user_except_access_tokens(
+        yield self.hs.get_pusherpool().remove_pushers_by_user(
             user_id, except_access_token_ids
         )
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -432,13 +432,18 @@ class AuthHandler(BaseHandler):
         )
 
     @defer.inlineCallbacks
-    def set_password(self, user_id, newpassword):
+    def set_password(self, user_id, newpassword, requester=None):
         password_hash = self.hash(newpassword)
 
+        except_access_token_ids = [requester.access_token_id] if requester else []
+
         yield self.store.user_set_password_hash(user_id, password_hash)
-        yield self.store.user_delete_access_tokens(user_id)
-        yield self.hs.get_pusherpool().remove_pushers_by_user(user_id)
-        yield self.store.flush_user(user_id)
+        yield self.store.user_delete_access_tokens_except(
+                user_id, except_access_token_ids
+        )
+        yield self.hs.get_pusherpool().remove_pushers_by_user_except_access_tokens(
+                user_id, except_access_token_ids
+        )
 
     @defer.inlineCallbacks
     def add_threepid(self, user_id, medium, address, validated_at):

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -438,7 +438,7 @@ class AuthHandler(BaseHandler):
         except_access_token_ids = [requester.access_token_id] if requester else []
 
         yield self.store.user_set_password_hash(user_id, password_hash)
-        yield self.store.user_delete_access_tokens_except(
+        yield self.store.user_delete_access_tokens(
             user_id, except_access_token_ids
         )
         yield self.hs.get_pusherpool().remove_pushers_by_user_except_access_tokens(

--- a/synapse/push/pusherpool.py
+++ b/synapse/push/pusherpool.py
@@ -92,7 +92,7 @@ class PusherPool:
                 yield self.remove_pusher(p['app_id'], p['pushkey'], p['user_name'])
 
     @defer.inlineCallbacks
-    def remove_pushers_by_user_except_access_tokens(self, user_id, except_token_ids):
+    def remove_pushers_by_user(self, user_id, except_token_ids=[]):
         all = yield self.store.get_all_pushers()
         logger.info(
             "Removing all pushers for user %s except access tokens ids %r",

--- a/synapse/push/pusherpool.py
+++ b/synapse/push/pusherpool.py
@@ -92,14 +92,14 @@ class PusherPool:
                 yield self.remove_pusher(p['app_id'], p['pushkey'], p['user_name'])
 
     @defer.inlineCallbacks
-    def remove_pushers_by_user(self, user_id):
+    def remove_pushers_by_user_except_access_tokens(self, user_id, except_token_ids):
         all = yield self.store.get_all_pushers()
         logger.info(
-            "Removing all pushers for user %s",
-            user_id,
+            "Removing all pushers for user %s except access tokens ids %r",
+            user_id, except_token_ids
         )
         for p in all:
-            if p['user_name'] == user_id:
+            if p['user_name'] == user_id and p['access_token'] not in except_token_ids:
                 logger.info(
                     "Removing pusher for app id %s, pushkey %s, user %s",
                     p['app_id'], p['pushkey'], p['user_name']

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -79,7 +79,7 @@ class PasswordRestServlet(RestServlet):
         new_password = params['new_password']
 
         yield self.auth_handler.set_password(
-            user_id, new_password
+            user_id, new_password, requester
         )
 
         defer.returnValue((200, {}))

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -198,14 +198,12 @@ class RegistrationStore(SQLBaseStore):
     def user_delete_access_tokens(self, user_id, except_token_ids):
         def f(txn):
             txn.execute(
-                "SELECT id, token FROM access_tokens WHERE user_id = ? LIMIT 50",
-                (user_id,)
+                "SELECT id, token FROM access_tokens "
+                "WHERE user_id = ? AND id not in LIMIT 50",
+                (user_id,except_token_ids)
             )
             rows = txn.fetchall()
             for r in rows:
-                if r[0] in except_token_ids:
-                    continue
-
                 txn.call_after(self.get_user_by_access_token.invalidate, (r[1],))
             txn.execute(
                 "DELETE FROM access_tokens WHERE id in (%s)" % ",".join(

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -195,20 +195,7 @@ class RegistrationStore(SQLBaseStore):
         })
 
     @defer.inlineCallbacks
-    def user_delete_access_tokens(self, user_id):
-        yield self.runInteraction(
-            "user_delete_access_tokens",
-            self._user_delete_access_tokens, user_id
-        )
-
-    def _user_delete_access_tokens(self, txn, user_id):
-        txn.execute(
-            "DELETE FROM access_tokens WHERE user_id = ?",
-            (user_id, )
-        )
-
-    @defer.inlineCallbacks
-    def user_delete_access_tokens_except(self, user_id, except_token_ids):
+    def user_delete_access_tokens(self, user_id, except_token_ids):
         def f(txn):
             txn.execute(
                 "SELECT id, token FROM access_tokens WHERE user_id = ? LIMIT 50",
@@ -226,7 +213,7 @@ class RegistrationStore(SQLBaseStore):
                 ), [r[0] for r in rows]
             )
             return len(rows) == 50
-        while (yield self.runInteraction("user_delete_access_tokens_except", f)):
+        while (yield self.runInteraction("user_delete_access_tokens", f)):
             pass
 
     @cached()

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -200,7 +200,7 @@ class RegistrationStore(SQLBaseStore):
             txn.execute(
                 "SELECT id, token FROM access_tokens "
                 "WHERE user_id = ? AND id not in LIMIT 50",
-                (user_id,except_token_ids)
+                (user_id, except_token_ids)
             )
             rows = txn.fetchall()
             for r in rows:

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -212,7 +212,7 @@ class RegistrationStore(SQLBaseStore):
         def f(txn):
             txn.execute(
                 "SELECT id, token FROM access_tokens WHERE user_id = ? LIMIT 50",
-                    (user_id,)
+                (user_id,)
             )
             rows = txn.fetchall()
             for r in rows:


### PR DESCRIPTION
Fix cache invalidation so deleting access tokens (which we did when changing password) actually takes effect without HS restart. Reinstate the code to avoid logging out the session that changed the password, removed in 415c2f05491ce65a4fc34326519754cd1edd9c54

Tests to come in sytest