### PR TITLE
Fix regression where synapse checked whether push rules were valid

### DIFF
--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -119,13 +119,13 @@ def parse_string(request, name, default=None, required=False,
             return default
 
 
-def parse_json_object_from_request(request):
-    """Parse a JSON object from the body of a twisted HTTP request.
+def parse_json_value_from_request(request):
+    """Parse a JSON value from the body of a twisted HTTP request.
 
     :param request: the twisted HTTP request.
+    :returns: The JSON value.
     :raises
-        SynapseError if the request body couldn't be decoded as JSON or
-            if it wasn't a JSON object.
+        SynapseError if the request body couldn't be decoded as JSON.
     """
     try:
         content_bytes = request.content.read()
@@ -136,6 +136,19 @@ def parse_json_object_from_request(request):
         content = simplejson.loads(content_bytes)
     except simplejson.JSONDecodeError:
         raise SynapseError(400, "Content not JSON.", errcode=Codes.NOT_JSON)
+
+    return content
+
+
+def parse_json_object_from_request(request):
+    """Parse a JSON object from the body of a twisted HTTP request.
+
+    :param request: the twisted HTTP request.
+    :raises
+        SynapseError if the request body couldn't be decoded as JSON or
+            if it wasn't a JSON object.
+    """
+    content = parse_json_value_from_request(request)
 
     if type(content) != dict:
         message = "Content must be a JSON object."

--- a/synapse/rest/client/v1/push_rule.py
+++ b/synapse/rest/client/v1/push_rule.py
@@ -25,7 +25,7 @@ from synapse.storage.push_rule import (
 from synapse.push.clientformat import format_push_rules_for_user
 from synapse.push.baserules import BASE_RULE_IDS
 from synapse.push.rulekinds import PRIORITY_CLASS_MAP
-from synapse.http.servlet import parse_json_object_from_request
+from synapse.http.servlet import parse_json_value_from_request
 
 
 class PushRuleRestServlet(ClientV1RestServlet):
@@ -51,7 +51,7 @@ class PushRuleRestServlet(ClientV1RestServlet):
         if '/' in spec['rule_id'] or '\\' in spec['rule_id']:
             raise SynapseError(400, "rule_id may not contain slashes")
 
-        content = parse_json_object_from_request(request)
+        content = parse_json_value_from_request(request)
 
         user_id = requester.user.to_string()
 


### PR DESCRIPTION
Fix regression where synapse checked whether push rules were valid JSON before the compatibility hack that handled clients sending invalid JSON