### PR TITLE
Add config to create guest account on 3pid invite

### DIFF
--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -37,6 +37,10 @@ class RegistrationConfig(Config):
         self.trusted_third_party_id_servers = config["trusted_third_party_id_servers"]
         self.allow_guest_access = config.get("allow_guest_access", False)
 
+        self.invite_3pid_guest = (
+            self.allow_guest_access and config.get("invite_3pid_guest", False)
+        )
+
     def default_config(self, **kwargs):
         registration_shared_secret = random_string_with_symbols(50)
 


### PR DESCRIPTION
Currently, when a 3pid invite request is sent to an identity server, it
includes a provisioned guest access token. This allows the link in the,
say, invite email to include the guest access token ensuring that the
same account is used each time the link is clicked.

This flow has a number of flaws, including when using different servers
or servers that have guest access disabled.

For now, we keep this implementation but hide it behind a config option
until a better flow is implemented.