### PR TITLE
Remove some unused parameters from persist_event

### DIFF
--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -531,7 +531,6 @@ class FederationServer(FederationBase):
         yield self.handler.on_receive_pdu(
             origin,
             pdu,
-            backfilled=False,
             state=state,
             auth_chain=auth_chain,
         )

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -123,7 +123,6 @@ class FederationHandler(BaseHandler):
 
         # FIXME (erikj): Awful hack to make the case where we are not currently
         # in the room work
-        current_state = None
         is_in_room = yield self.auth.check_host_in_room(
             event.room_id,
             self.server_name
@@ -187,7 +186,6 @@ class FederationHandler(BaseHandler):
                     event,
                     state=state,
                     backfilled=backfilled,
-                    current_state=current_state,
                 )
             except AuthError as e:
                 raise FederationError(


### PR DESCRIPTION
Since the backfill code uses ``persist_events`` rather than ``persist_event`` there isn't any code that actually passes a backfill parameter to ``persist_event``.

Additionally ``_handle_new_event`` took a ``current_state`` parameter, however that parameter was always ``None``, so can be removed.