### PR TITLE
Don't require alias in public room list.

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -953,6 +953,13 @@ class RoomListHandler(BaseHandler):
             def get_state(etype, state_key):
                 return self.state_handler.get_current_state(room_id, etype, state_key)
 
+            # Double check that this is actually a public room.
+            join_rules_event = yield get_state(EventTypes.JoinRules, "")
+            if join_rules_event:
+                join_rule = join_rules_event.content.get("join_rule", None)
+                if join_rule and join_rule != JoinRules.PUBLIC:
+                    defer.returnValue(None)
+
             result = {"room_id": room_id}
             if aliases:
                 result["aliases"] = aliases

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -119,7 +119,8 @@ class RoomCreationHandler(BaseHandler):
 
         invite_3pid_list = config.get("invite_3pid", [])
 
-        is_public = config.get("visibility", None) == "public"
+        visibility = config.get("visibility", None)
+        is_public = visibility == "public"
 
         # autogen room IDs and try to create it. We may clash, so just
         # try a few times till one goes through, giving up eventually.
@@ -155,9 +156,9 @@ class RoomCreationHandler(BaseHandler):
 
         preset_config = config.get(
             "preset",
-            RoomCreationPreset.PUBLIC_CHAT
-            if is_public
-            else RoomCreationPreset.PRIVATE_CHAT
+            RoomCreationPreset.PRIVATE_CHAT
+            if visibility == "private"
+            else RoomCreationPreset.PUBLIC_CHAT
         )
 
         raw_initial_state = config.get("initial_state", [])

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -947,6 +947,9 @@ class RoomListHandler(BaseHandler):
         def handle_room(room_id):
             aliases = yield self.store.get_aliases_for_room(room_id)
 
+            # We pull each bit of state out indvidually to avoid pulling the
+            # full state into memory. Due to how the caching works this should
+            # be fairly quick, even if not originally in the cache.
             def get_state(etype, state_key):
                 return self.state_handler.get_current_state(room_id, etype, state_key)
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -946,53 +946,52 @@ class RoomListHandler(BaseHandler):
         @defer.inlineCallbacks
         def handle_room(room_id):
             aliases = yield self.store.get_aliases_for_room(room_id)
-            if not aliases:
-                defer.returnValue(None)
 
-            state = yield self.state_handler.get_current_state(room_id)
+            def get_state(etype, state_key):
+                return self.state_handler.get_current_state(room_id, etype, state_key)
 
-            result = {"aliases": aliases, "room_id": room_id}
+            result = {"room_id": room_id}
+            if aliases:
+                result["aliases"] = aliases
 
-            name_event = state.get((EventTypes.Name, ""), None)
+            name_event = yield get_state(EventTypes.Name, "")
             if name_event:
                 name = name_event.content.get("name", None)
                 if name:
                     result["name"] = name
 
-            topic_event = state.get((EventTypes.Topic, ""), None)
+            topic_event = yield get_state(EventTypes.Topic, "")
             if topic_event:
                 topic = topic_event.content.get("topic", None)
                 if topic:
                     result["topic"] = topic
 
-            canonical_event = state.get((EventTypes.CanonicalAlias, ""), None)
+            canonical_event = yield get_state(EventTypes.CanonicalAlias, "")
             if canonical_event:
                 canonical_alias = canonical_event.content.get("alias", None)
                 if canonical_alias:
                     result["canonical_alias"] = canonical_alias
 
-            visibility_event = state.get((EventTypes.RoomHistoryVisibility, ""), None)
+            visibility_event = yield get_state(EventTypes.RoomHistoryVisibility, "")
             visibility = None
             if visibility_event:
                 visibility = visibility_event.content.get("history_visibility", None)
             result["world_readable"] = visibility == "world_readable"
 
-            guest_event = state.get((EventTypes.GuestAccess, ""), None)
+            guest_event = yield get_state(EventTypes.GuestAccess, "")
             guest = None
             if guest_event:
                 guest = guest_event.content.get("guest_access", None)
             result["guest_can_join"] = guest == "can_join"
 
-            avatar_event = state.get(("m.room.avatar", ""), None)
+            avatar_event = yield get_state("m.room.avatar", "")
             if avatar_event:
                 avatar_url = avatar_event.content.get("url", None)
                 if avatar_url:
                     result["avatar_url"] = avatar_url
 
-            result["num_joined_members"] = sum(
-                1 for (event_type, _), ev in state.items()
-                if event_type == EventTypes.Member and ev.membership == Membership.JOIN
-            )
+            joined_users = yield self.store.get_users_in_room(room_id)
+            result["num_joined_members"] = len(joined_users)
 
             defer.returnValue(result)
 

--- a/synapse/storage/schema/delta/30/public_rooms.sql
+++ b/synapse/storage/schema/delta/30/public_rooms.sql
@@ -15,7 +15,9 @@
 
 
 /* This release removes the restriction that published rooms must have an alias,
- * so we go back and ensure the only 'public' rooms are ones with an alias.*/
+ * so we go back and ensure the only 'public' rooms are ones with an alias.
+ * We use (1 = 0) and (1 = 1) so that it works in both postgres and sqlite
+ */
 UPDATE rooms SET is_public = (1 = 0) WHERE is_public = (1 = 1) AND room_id not in (
     SELECT room_id FROM room_aliases
 );

--- a/synapse/storage/schema/delta/30/public_rooms.sql
+++ b/synapse/storage/schema/delta/30/public_rooms.sql
@@ -16,6 +16,6 @@
 
 /* This release removes the restriction that published rooms must have an alias,
  * so we go back and ensure the only 'public' rooms are ones with an alias.*/
-UPDATE rooms SET is_public = 0 WHERE is_public = 1 AND room_id not in (
+UPDATE rooms SET is_public = (1 = 0) WHERE is_public = (1 = 1) AND room_id not in (
     SELECT room_id FROM room_aliases
 );

--- a/synapse/storage/schema/delta/30/public_rooms.sql
+++ b/synapse/storage/schema/delta/30/public_rooms.sql
@@ -1,0 +1,21 @@
+/* Copyright 2016 OpenMarket Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/* This release removes the restriction that published rooms must have an alias,
+ * so we go back and ensure the only 'public' rooms are ones with an alias.*/
+UPDATE rooms SET is_public = 0 WHERE is_public = 1 AND room_id not in (
+    SELECT room_id FROM room_aliases
+);


### PR DESCRIPTION
Rooms now no longer require an alias to be published.

Also, changes the way we pull out state of each room to not require fetching all state events.