### PR TITLE
Remove the is_new_state argument to persist event.

### DIFF
--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -33,6 +33,9 @@ class _EventInternalMetadata(object):
     def is_outlier(self):
         return getattr(self, "outlier", False)
 
+    def is_invite_from_remote(self):
+        return getattr(self, "invite_from_remote", False)
+
 
 def _event_dict_property(key):
     def getter(self):

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -485,12 +485,12 @@ class EventsStore(SQLBaseStore):
             ],
         )
 
-        for event, _ in state_events_and_contexts:
-            if backfilled:
-                # Backfilled events come before the current state so shouldn't
-                # clobber it.
-                continue
+        if backfilled:
+            # Backfilled events come before the current state so we don't need
+            # to update the current state table
+            return
 
+        for event, _ in state_events_and_contexts:
             if (not event.internal_metadata.is_invite_from_remote()
                     and event.internal_metadata.is_outlier()):
                 # Outlier events generally shouldn't clobber the current state.


### PR DESCRIPTION
Move the checks for whether an event is new state inside persist
event itself.

This was harder than expected because there wasn't enough information
passed to persist event to correctly handle invites from remote servers
for new rooms.