### PR TITLE
Fix stuck invites

### DIFF
--- a/synapse/storage/__init__.py
+++ b/synapse/storage/__init__.py
@@ -94,7 +94,8 @@ class DataStore(RoomMemberStore, RoomStore,
         )
 
         self._stream_id_gen = StreamIdGenerator(
-            db_conn, "events", "stream_ordering"
+            db_conn, "events", "stream_ordering",
+            extra_tables=[("local_invites", "stream_id")]
         )
         self._backfill_id_gen = StreamIdGenerator(
             db_conn, "events", "stream_ordering", step=-1


### PR DESCRIPTION
If rejecting a remote invite fails with an error response don't fail the entire request; instead mark the invite as locally rejected.

This fixes the bug where users can get stuck invites which they can neither accept nor reject.