### PR TITLE
Add environment file to systemd unit configuration.

### DIFF
--- a/contrib/systemd/synapse.service
+++ b/contrib/systemd/synapse.service
@@ -9,6 +9,7 @@ Description=Synapse Matrix homeserver
 Type=simple
 User=synapse
 Group=synapse
+EnvironmentFile=-/etc/sysconfig/synapse
 WorkingDirectory=/var/lib/synapse
 ExecStart=/usr/bin/python2.7 -m synapse.app.homeserver --config-path=/etc/synapse/homeserver.yaml --log-config=/etc/synapse/log_config.yaml
 


### PR DESCRIPTION
Now there is at least one environment variable that controls synapse server's behaviour: `SYNAPSE_CACHE_FACTOR`.
So, it makes sense to make systemd unit file to use environment configuration file that can set this variable's value.