### PR TITLE
Fix login to error for nonexistent users

### DIFF
--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -441,7 +441,7 @@ class AuthHandler(BaseHandler):
             user_id, password_hash = yield self._find_user_id_and_pwd_hash(user_id)
             defer.returnValue(not self.validate_hash(password, password_hash))
         except LoginError:
-            defer.returnValue(False)
+            defer.returnValue(True)
 
     @defer.inlineCallbacks
     def _check_ldap_password(self, user_id, password):


### PR DESCRIPTION
Fixes SYN-680

This needs to go out as soon as possible as it could be exploitable, but the meanings of the returns values in the various levels of functions down the stack called to check credentials are very unintuitive and undocumented. This really needs to be fixed to be clearer. Also a sytest for logging in a nonexistent user wouldn't hurt.