### PR TITLE
Lower timeout for make_membership_event

### DIFF
--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -179,7 +179,8 @@ class TransportLayerClient(object):
         content = yield self.client.get_json(
             destination=destination,
             path=path,
-            retry_on_dns_fail=True,
+            retry_on_dns_fail=False,
+            timeout=20000,
         )
 
         defer.returnValue(content)


### PR DESCRIPTION
Calls to make_membership_event are done in response to client requests,
and so should not be retried over long timeframes.