### PR TITLE
Fix password reset

### DIFF
--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -52,6 +52,7 @@ class PasswordRestServlet(RestServlet):
             defer.returnValue((401, result))
 
         user_id = None
+        requester = None
 
         if LoginType.PASSWORD in result:
             # if using password, they should also be logged in


### PR DESCRIPTION
Default requester to None, otherwise it isn't defined when resetting using email auth