### PR TITLE
Shuffle when we get the signing_key attribute.

### DIFF
--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -48,7 +48,6 @@ class MessageHandler(BaseHandler):
         self.clock = hs.get_clock()
         self.validator = EventValidator()
         self.snapshot_cache = SnapshotCache()
-        self.signing_key = hs.config.signing_key[0]
 
     @defer.inlineCallbacks
     def get_messages(self, requester, room_id=None, pagin_config=None,
@@ -766,8 +765,9 @@ class MessageHandler(BaseHandler):
 
         yield self.auth.add_auth_events(builder, context)
 
+        signing_key = self.hs.config.signing_key[0]
         add_hashes_and_signatures(
-            builder, self.server_name, self.signing_key
+            builder, self.server_name, signing_key
         )
 
         event = builder.build()


### PR DESCRIPTION
Wait until we sign a message to get the signing key from the homeserver
config. This means that the message handler can be created without
having a signing key in the config which means that separate processes
like the pusher that don't send messages and don't need to sign them can
still access the handlers.