### PR TITLE
Split out the room list handler

### DIFF
--- a/synapse/handlers/__init__.py
+++ b/synapse/handlers/__init__.py
@@ -17,7 +17,7 @@ from synapse.appservice.scheduler import AppServiceScheduler
 from synapse.appservice.api import ApplicationServiceApi
 from .register import RegistrationHandler
 from .room import (
-    RoomCreationHandler, RoomListHandler, RoomContextHandler,
+    RoomCreationHandler, RoomContextHandler,
 )
 from .room_member import RoomMemberHandler
 from .message import MessageHandler
@@ -50,7 +50,6 @@ class Handlers(object):
         self.event_handler = EventHandler(hs)
         self.federation_handler = FederationHandler(hs)
         self.profile_handler = ProfileHandler(hs)
-        self.room_list_handler = RoomListHandler(hs)
         self.directory_handler = DirectoryHandler(hs)
         self.admin_handler = AdminHandler(hs)
         self.receipts_handler = ReceiptsHandler(hs)

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -279,7 +279,7 @@ class PublicRoomListRestServlet(ClientV1RestServlet):
 
     @defer.inlineCallbacks
     def on_GET(self, request):
-        handler = self.handlers.room_list_handler
+        handler = self.hs.get_room_list_handler()
         data = yield handler.get_public_room_list()
         defer.returnValue((200, data))
 

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -30,6 +30,7 @@ from synapse.handlers import Handlers
 from synapse.handlers.presence import PresenceHandler
 from synapse.handlers.sync import SyncHandler
 from synapse.handlers.typing import TypingHandler
+from synapse.handlers.room import RoomListHandler
 from synapse.state import StateHandler
 from synapse.storage import DataStore
 from synapse.util import Clock
@@ -84,6 +85,7 @@ class HomeServer(object):
         'presence_handler',
         'sync_handler',
         'typing_handler',
+        'room_list_handler',
         'notifier',
         'distributor',
         'client_resource',
@@ -178,6 +180,9 @@ class HomeServer(object):
 
     def build_sync_handler(self):
         return SyncHandler(self)
+
+    def build_room_list_handler(self):
+        return RoomListHandler(self)
 
     def build_event_sources(self):
         return EventSources(self)


### PR DESCRIPTION
So I can use it from federation bits without pulling in all the handlers.

@NegativeMjark suggested refactoring this out of the handlers, so this PR does this.