### PR TITLE
Add secondary_directory_servers option to fetch room list from other servers

### DIFF
--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -159,8 +159,12 @@ class ServerConfig(Config):
 
         # A list of other Home Servers to fetch the public room directory from
         # and include in the public room directory of this home server
+        # This is a temporary stopgap solution to populate new server with a
+        # list of rooms until there exists a good solution of a decentralized
+        # room directory.
         # secondary_directory_servers:
         #     - matrix.org
+        #     - vector.im
 
         # List of ports that Synapse should listen on, their purpose and their
         # configuration.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -29,6 +29,7 @@ class ServerConfig(Config):
         self.user_agent_suffix = config.get("user_agent_suffix")
         self.use_frozen_dicts = config.get("use_frozen_dicts", True)
         self.public_baseurl = config.get("public_baseurl")
+        self.secondary_directory_servers = config.get("secondary_directory_servers", [])
 
         if self.public_baseurl is not None:
             if self.public_baseurl[-1] != '/':
@@ -155,6 +156,11 @@ class ServerConfig(Config):
         # Zero is used to indicate synapse should set the soft limit to the
         # hard limit.
         soft_file_limit: 0
+
+        # A list of other Home Servers to fetch the public room directory from
+        # and include in the public room directory of this home server
+        # secondary_directory_servers:
+        #     - matrix.org
 
         # List of ports that Synapse should listen on, their purpose and their
         # configuration.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -24,6 +24,7 @@ from synapse.api.errors import (
     CodeMessageException, HttpResponseException, SynapseError,
 )
 from synapse.util import unwrapFirstError
+from synapse.util.async import concurrently_execute
 from synapse.util.caches.expiringcache import ExpiringCache
 from synapse.util.logutils import log_function
 from synapse.events import FrozenEvent
@@ -549,6 +550,26 @@ class FederationClient(FederationBase):
                 )
 
         raise RuntimeError("Failed to send to any server.")
+
+    @defer.inlineCallbacks
+    def get_public_rooms(self, destinations):
+        results_by_server = {}
+
+        @defer.inlineCallbacks
+        def _get_result(s):
+            if s == self.server_name:
+                defer.returnValue()
+
+            try:
+                result = yield self.transport_layer.get_public_rooms(s)
+                results_by_server[s] = result
+            except:
+                logger.exception("Error getting room list from server %r", s)
+
+
+        yield concurrently_execute(_get_result, destinations, 3)
+
+        defer.returnValue(results_by_server)
 
     @defer.inlineCallbacks
     def query_auth(self, destination, room_id, event_id, local_auth):

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -566,7 +566,6 @@ class FederationClient(FederationBase):
             except:
                 logger.exception("Error getting room list from server %r", s)
 
-
         yield concurrently_execute(_get_result, destinations, 3)
 
         defer.returnValue(results_by_server)

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -226,6 +226,18 @@ class TransportLayerClient(object):
 
     @defer.inlineCallbacks
     @log_function
+    def get_public_rooms(self, remote_server):
+        path = PREFIX + "/publicRooms"
+
+        response = yield self.client.get_json(
+            destination=remote_server,
+            path=path,
+        )
+
+        defer.returnValue(response)
+
+    @defer.inlineCallbacks
+    @log_function
     def exchange_third_party_invite(self, destination, room_id, event_dict):
         path = PREFIX + "/exchange_third_party_invite/%s" % (room_id,)
 

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -530,23 +530,6 @@ class PublicRoomList(BaseFederationServlet):
         data = yield self.room_list_handler.get_public_room_list()
         defer.returnValue((200, data))
 
-        token = parse_string(request, "access_token")
-        if token is None:
-            defer.returnValue((401, {
-                "errcode": "M_MISSING_TOKEN", "error": "Access Token required"
-            }))
-            return
-
-        user_id = yield self.handler.on_openid_userinfo(token)
-
-        if user_id is None:
-            defer.returnValue((401, {
-                "errcode": "M_UNKNOWN_TOKEN",
-                "error": "Access Token unknown or expired"
-            }))
-
-        defer.returnValue((200, {"sub": user_id}))
-
     # Avoid doing remote HS authorization checks which are done by default by
     # BaseFederationServlet.
     def _wrap(self, code):

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -134,10 +134,11 @@ class Authenticator(object):
 
 
 class BaseFederationServlet(object):
-    def __init__(self, handler, authenticator, ratelimiter, server_name):
+    def __init__(self, handler, authenticator, ratelimiter, server_name, room_list_handler):
         self.handler = handler
         self.authenticator = authenticator
         self.ratelimiter = ratelimiter
+        self.room_list_handler = room_list_handler
 
     def _wrap(self, code):
         authenticator = self.authenticator
@@ -491,6 +492,66 @@ class OpenIdUserInfo(BaseFederationServlet):
     def _wrap(self, code):
         return code
 
+class PublicRoomList(BaseFederationServlet):
+    """
+    Fetch the public room list for this server.
+
+    This API returns information in the same format as /publicRooms on the
+    client API, but will only ever include local public rooms and hence is
+    intended for consumption by other home servers.
+
+    GET /publicRooms HTTP/1.1
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+        "chunk": [
+            {
+                "aliases": [
+                    "#test:localhost"
+                ],
+                "guest_can_join": false,
+                "name": "test room",
+                "num_joined_members": 3,
+                "room_id": "!whkydVegtvatLfXmPN:localhost",
+                "world_readable": false
+            }
+        ],
+        "end": "END",
+        "start": "START"
+    }
+    """
+
+    PATH = "/publicRooms"
+
+    @defer.inlineCallbacks
+    def on_GET(self, request):
+        data = yield self.room_list_handler.get_public_room_list()
+        defer.returnValue((200, data))
+
+        token = parse_string(request, "access_token")
+        if token is None:
+            defer.returnValue((401, {
+                "errcode": "M_MISSING_TOKEN", "error": "Access Token required"
+            }))
+            return
+
+        user_id = yield self.handler.on_openid_userinfo(token)
+
+        if user_id is None:
+            defer.returnValue((401, {
+                "errcode": "M_UNKNOWN_TOKEN",
+                "error": "Access Token unknown or expired"
+            }))
+
+        defer.returnValue((200, {"sub": user_id}))
+
+    # Avoid doing remote HS authorization checks which are done by default by
+    # BaseFederationServlet.
+    def _wrap(self, code):
+        return code
+
 
 SERVLET_CLASSES = (
     FederationSendServlet,
@@ -513,6 +574,7 @@ SERVLET_CLASSES = (
     FederationThirdPartyInviteExchangeServlet,
     On3pidBindServlet,
     OpenIdUserInfo,
+    PublicRoomList,
 )
 
 
@@ -523,4 +585,5 @@ def register_servlets(hs, resource, authenticator, ratelimiter):
             authenticator=authenticator,
             ratelimiter=ratelimiter,
             server_name=hs.hostname,
+            room_list_handler=hs.get_room_list_handler(),
         ).register(resource)

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -134,7 +134,8 @@ class Authenticator(object):
 
 
 class BaseFederationServlet(object):
-    def __init__(self, handler, authenticator, ratelimiter, server_name, room_list_handler):
+    def __init__(self, handler, authenticator, ratelimiter, server_name,
+                 room_list_handler):
         self.handler = handler
         self.authenticator = authenticator
         self.ratelimiter = ratelimiter
@@ -491,6 +492,7 @@ class OpenIdUserInfo(BaseFederationServlet):
     # BaseFederationServlet.
     def _wrap(self, code):
         return code
+
 
 class PublicRoomList(BaseFederationServlet):
     """

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -527,7 +527,7 @@ class PublicRoomList(BaseFederationServlet):
 
     @defer.inlineCallbacks
     def on_GET(self, request):
-        data = yield self.room_list_handler.get_public_room_list()
+        data = yield self.room_list_handler.get_local_public_room_list()
         defer.returnValue((200, data))
 
     # Avoid doing remote HS authorization checks which are done by default by

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -280,7 +280,8 @@ class PublicRoomListRestServlet(ClientV1RestServlet):
     @defer.inlineCallbacks
     def on_GET(self, request):
         handler = self.hs.get_room_list_handler()
-        data = yield handler.get_public_room_list()
+        data = yield handler.get_aggregated_public_room_list()
+
         defer.returnValue((200, data))
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -67,6 +67,7 @@ def setup_test_homeserver(name="test", datastore=None, config=None, **kargs):
             version_string="Synapse/tests",
             database_engine=create_engine(config.database_config),
             get_db_conn=db_pool.get_db_conn,
+            room_list_handler=object(),
             **kargs
         )
         hs.setup()
@@ -75,6 +76,7 @@ def setup_test_homeserver(name="test", datastore=None, config=None, **kargs):
             name, db_pool=None, datastore=datastore, config=config,
             version_string="Synapse/tests",
             database_engine=create_engine(config.database_config),
+            room_list_handler=object(),
             **kargs
         )
 


### PR DESCRIPTION
This polls the list of remote servers for their lists every minute, returning the cached results from the last successful fetch (since server restart). If there is no cached result, it will wait for any currently running poll to complete before returning the result.

We probably want an additional cache somewhere to reduce the load from producing the local room list, which I suspect will be a cache of the whole aggregated room list. If so, this probably belongs in a separate PR.