### PR TITLE
Use user_id in email greeting if display name is null

### DIFF
--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -122,6 +122,8 @@ class Mailer(object):
             user_display_name = yield self.store.get_profile_displayname(
                 UserID.from_string(user_id).localpart
             )
+            if user_display_name is None:
+                user_display_name = user_id
         except StoreError:
             user_display_name = user_id
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/vector-web/issues/1577