### PR TITLE
Remove redundant handling of ldap tls activation

### DIFF
--- a/synapse/config/ldap.py
+++ b/synapse/config/ldap.py
@@ -23,7 +23,6 @@ class LDAPConfig(Config):
             self.ldap_enabled = ldap_config.get("enabled", False)
             self.ldap_server = ldap_config["server"]
             self.ldap_port = ldap_config["port"]
-            self.ldap_tls = ldap_config.get("tls", False)
             self.ldap_search_base = ldap_config["search_base"]
             self.ldap_search_property = ldap_config["search_property"]
             self.ldap_email_property = ldap_config["email_property"]
@@ -32,7 +31,6 @@ class LDAPConfig(Config):
             self.ldap_enabled = False
             self.ldap_server = None
             self.ldap_port = None
-            self.ldap_tls = False
             self.ldap_search_base = None
             self.ldap_search_property = None
             self.ldap_email_property = None
@@ -42,9 +40,8 @@ class LDAPConfig(Config):
         return """\
         # ldap_config:
         #   enabled: true
-        #   server: "ldap://localhost"
-        #   port: 389
-        #   tls: false
+        #   server: "ldaps://ldap.example.com"
+        #   port: 636
         #   search_base: "ou=Users,dc=example,dc=com"
         #   search_property: "cn"
         #   email_property: "email"

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -52,7 +52,6 @@ class AuthHandler(BaseHandler):
         self.ldap_enabled = hs.config.ldap_enabled
         self.ldap_server = hs.config.ldap_server
         self.ldap_port = hs.config.ldap_port
-        self.ldap_tls = hs.config.ldap_tls
         self.ldap_search_base = hs.config.ldap_search_base
         self.ldap_search_property = hs.config.ldap_search_property
         self.ldap_email_property = hs.config.ldap_email_property
@@ -463,12 +462,8 @@ class AuthHandler(BaseHandler):
             ldap_url = "%s:%s" % (self.ldap_server, self.ldap_port)
             logger.debug("Connecting LDAP server at %s" % ldap_url)
             l = ldap.initialize(ldap_url)
-            if self.ldap_tls:
-                logger.debug("Initiating TLS")
-                self._connection.start_tls_s()
 
             local_name = UserID.from_string(user_id).localpart
-
             dn = "%s=%s, %s" % (
                 self.ldap_search_property,
                 local_name,
@@ -484,7 +479,7 @@ class AuthHandler(BaseHandler):
                 )
 
             defer.returnValue(True)
-        except ldap.LDAPError, e:
+        except ldap.LDAPError as e:
             logger.warn("LDAP error: %s", e)
             defer.returnValue(False)
 


### PR DESCRIPTION
Whether or not to use LDAP via SSL/TLS or plain can be specified
within the URI Scheme in the `server` variable.
```yaml
ldap_config:
   server: "ldap://ldap.example.com"
```
```yaml
ldap_config:
   server: "ldaps://ldaps.example.com"
```

Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>