### PR TITLE
Rewrite LDAP Authentication against ldap3

### DIFF
--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -48,6 +48,9 @@ CONDITIONAL_REQUIREMENTS = {
         "Jinja2>=2.8": ["Jinja2>=2.8"],
         "bleach>=1.4.2": ["bleach>=1.4.2"],
     },
+    "ldap": {
+        "ldap3>=1.0": ["ldap3>=1.0"],
+    },
 }
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -56,6 +56,7 @@ def setup_test_homeserver(name="test", datastore=None, config=None, **kargs):
 
     config.use_frozen_dicts = True
     config.database_config = {"name": "sqlite3"}
+    config.ldap_enabled = False
 
     if "clock" not in kargs:
         kargs["clock"] = MockClock()


### PR DESCRIPTION
This makes synapse ldap capable without requiring a system dependency.

Offer a `search` mode in addition to the pre-existing `simple_bind` mode.
Searching requires a valid `bind_dn` and `bind_password` within the configuration
but allows subtree searches for valid `user_dn`

Signed-of-by: Martin Weinelt <hexa@darmstadt.ccc.de>