### PR TITLE
Fix TypeError in call to bcrypt.hashpw

### DIFF
--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -626,6 +626,6 @@ class AuthHandler(BaseHandler):
             Whether self.hash(password) == stored_hash (bool).
         """
         if stored_hash:
-            return bcrypt.hashpw(password, stored_hash) == stored_hash
+            return bcrypt.hashpw(password, stored_hash.encode('utf-8')) == stored_hash
         else:
             return False


### PR DESCRIPTION
- At the very least, this TypeError caused logins to fail on my own
  running instance of Synapse, and the simple (explicit) UTF-8
  conversion resolved login errors for me.

Signed-off-by: Salvatore LaMendola <salvatore.lamendola@gmail.com>

Relevant stack trace bits from when the error was encountered:
```
  File "/usr/lib/python2.7/dist-packages/synapse/handlers/auth.py", line 629, in validate_hash
    return bcrypt.hashpw(password, stored_hash) == stored_hash
  File "/usr/lib/python2.7/dist-packages/bcrypt/__init__.py", line 57, in hashpw
    raise TypeError("Unicode-objects must be encoded before hashing")
```