### PR TITLE
Remove registered_users from the distributor.

### DIFF
--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -36,13 +36,6 @@ class ProfileHandler(BaseHandler):
             "profile", self.on_profile_query
         )
 
-        distributor = hs.get_distributor()
-
-        distributor.observe("registered_user", self.registered_user)
-
-    def registered_user(self, user):
-        return self.store.create_profile(user.localpart)
-
     @defer.inlineCallbacks
     def get_displayname(self, target_user):
         if self.hs.is_mine(target_user):

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -138,6 +138,7 @@ class RegistrationHandler(BaseHandler):
                 was_guest=was_guest,
                 make_guest=make_guest,
                 create_profile_with_localpart=(
+                    # If the user was a guest then they already have a profile
                     None if was_guest else user.localpart
                 ),
             )

--- a/synapse/storage/profile.py
+++ b/synapse/storage/profile.py
@@ -17,6 +17,12 @@ from ._base import SQLBaseStore
 
 
 class ProfileStore(SQLBaseStore):
+    def create_profile(self, user_localpart):
+        return self._simple_insert(
+            table="profiles",
+            values={"user_id": user_localpart},
+            desc="create_profile",
+        )
 
     def get_profile_displayname(self, user_localpart):
         return self._simple_select_one_onecol(

--- a/synapse/storage/profile.py
+++ b/synapse/storage/profile.py
@@ -17,12 +17,6 @@ from ._base import SQLBaseStore
 
 
 class ProfileStore(SQLBaseStore):
-    def create_profile(self, user_localpart):
-        return self._simple_insert(
-            table="profiles",
-            values={"user_id": user_localpart},
-            desc="create_profile",
-        )
 
     def get_profile_displayname(self, user_localpart):
         return self._simple_select_one_onecol(

--- a/synapse/util/distributor.py
+++ b/synapse/util/distributor.py
@@ -27,10 +27,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def registered_user(distributor, user):
-    return distributor.fire("registered_user", user)
-
-
 def user_left_room(distributor, user, room_id):
     return preserve_context_over_fn(
         distributor.fire,


### PR DESCRIPTION
The only place that was observed was to set the profile. I've made it
so that the profile is set within store.register in the same transaction
that creates the user.

This required some slight changes to the registration code for upgrading
guest users, since it previously relied on the distributor swallowing errors
if the profile already existed.