### PR TITLE
Rick cogley coturn readme 2

### DIFF
--- a/docs/turn-howto.rst
+++ b/docs/turn-howto.rst
@@ -19,18 +19,21 @@ coturn Setup
 You may be able to setup coturn via your package manager,  or set it up manually using the usual ``configure, make, make install`` process.  
 
  1. Check out coturn::
+ 
       git clone https://github.com/coturn/coturn.git coturn
       cd coturn
 
  2. Configure it::
+ 
       ./configure
 
-    You may need to install libevent2: if so, you should do so
+    You may need to install ``libevent2``: if so, you should do so
     in the way recommended by your operating system.
     You can ignore warnings about lack of database support: a
     database is unnecessary for this purpose.
 
  3. Build and install it::
+ 
       make
       make install
 
@@ -55,6 +58,7 @@ You may be able to setup coturn via your package manager,  or set it up manually
     import your private key and certificate.
 
  7. Start the turn server::
+ 
        bin/turnserver -o
 
 

--- a/docs/turn-howto.rst
+++ b/docs/turn-howto.rst
@@ -19,7 +19,7 @@ coturn Setup
 You may be able to setup coturn via your package manager,  or set it up manually using the usual ``configure, make, make install`` process.  
 
  1. Check out coturn::
-      svn checkout https://github.com/coturn/coturn.git coturn
+      git clone https://github.com/coturn/coturn.git coturn
       cd coturn
 
  2. Configure it::

--- a/docs/turn-howto.rst
+++ b/docs/turn-howto.rst
@@ -19,11 +19,11 @@ coturn Setup
 You may be able to setup coturn via your package manager,  or set it up manually using the usual ``configure, make, make install`` process.  
 
  1. Check out coturn::
-      svn checkout https://github.com/coturn/coturn.git coturn  
-      cd coturn  
+      svn checkout https://github.com/coturn/coturn.git coturn
+      cd coturn
 
  2. Configure it::
-      ./configure  
+      ./configure
 
     You may need to install libevent2: if so, you should do so
     in the way recommended by your operating system.
@@ -31,21 +31,21 @@ You may be able to setup coturn via your package manager,  or set it up manually
     database is unnecessary for this purpose.
 
  3. Build and install it::
-      make  
-      make install  
+      make
+      make install
 
  4. Create or edit the config file in ``/etc/turnserver.conf``. The relevant
     lines, with example values, are::
 
-      lt-cred-mech  
-      use-auth-secret  
-      static-auth-secret=[your secret key here]  
-      realm=turn.myserver.org  
+      lt-cred-mech
+      use-auth-secret
+      static-auth-secret=[your secret key here]
+      realm=turn.myserver.org
 
     See turnserver.conf for explanations of the options.
     One way to generate the static-auth-secret is with pwgen::
 
-       pwgen -s 64 1  
+       pwgen -s 64 1
 
  5. Ensure youe firewall allows traffic into the TURN server on
     the ports you've configured it to listen on (remember to allow
@@ -55,7 +55,7 @@ You may be able to setup coturn via your package manager,  or set it up manually
     import your private key and certificate.
 
  7. Start the turn server::
-       bin/turnserver -o  
+       bin/turnserver -o
 
 
 synapse Setup
@@ -92,4 +92,3 @@ Now, restart synapse::
     ./synctl restart
 
 ...and your Home Server now supports VoIP relaying!
-

--- a/docs/turn-howto.rst
+++ b/docs/turn-howto.rst
@@ -9,19 +9,21 @@ the Home Server to generate credentials that are valid for use on the TURN
 server through the use of a secret shared between the Home Server and the
 TURN server.
 
-This document described how to install coturn
-(https://code.google.com/p/coturn/) which also supports the TURN REST API,
+This document describes how to install coturn
+(https://github.com/coturn/coturn) which also supports the TURN REST API,
 and integrate it with synapse.
 
 coturn Setup
 ============
 
+You may be able to setup coturn via your package manager,  or set it up manually using the usual ``configure, make, make install`` process.  
+
  1. Check out coturn::
-      svn checkout http://coturn.googlecode.com/svn/trunk/ coturn
-      cd coturn
+      svn checkout https://github.com/coturn/coturn.git coturn  
+      cd coturn  
 
  2. Configure it::
-      ./configure
+      ./configure  
 
     You may need to install libevent2: if so, you should do so
     in the way recommended by your operating system.
@@ -29,22 +31,21 @@ coturn Setup
     database is unnecessary for this purpose.
 
  3. Build and install it::
-      make
-      make install
+      make  
+      make install  
 
- 4. Make a config file in /etc/turnserver.conf. You can customise
-    a config file from turnserver.conf.default. The relevant
+ 4. Create or edit the config file in ``/etc/turnserver.conf``. The relevant
     lines, with example values, are::
 
-      lt-cred-mech
-      use-auth-secret
-      static-auth-secret=[your secret key here]
-      realm=turn.myserver.org
+      lt-cred-mech  
+      use-auth-secret  
+      static-auth-secret=[your secret key here]  
+      realm=turn.myserver.org  
 
-    See turnserver.conf.default for explanations of the options.
+    See turnserver.conf for explanations of the options.
     One way to generate the static-auth-secret is with pwgen::
 
-       pwgen -s 64 1
+       pwgen -s 64 1  
 
  5. Ensure youe firewall allows traffic into the TURN server on
     the ports you've configured it to listen on (remember to allow
@@ -54,7 +55,7 @@ coturn Setup
     import your private key and certificate.
 
  7. Start the turn server::
-       bin/turnserver -o
+       bin/turnserver -o  
 
 
 synapse Setup
@@ -91,3 +92,4 @@ Now, restart synapse::
     ./synctl restart
 
 ...and your Home Server now supports VoIP relaying!
+


### PR DESCRIPTION
Updated various to reflect actual, changing to the correct repo at github and using git clone instead of svn checkout. Added a carriage return before code blocks after the ``::`` bits, to get the code blocks to format correctly. 

Signed-off-by: Rick Cogley <rick.cogley@esolia.co.jp>
