### PR TITLE
Optionally include password hash in createUser endpoint

### DIFF
--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -358,7 +358,7 @@ class RegistrationHandler(BaseHandler):
         defer.returnValue(data)
 
     @defer.inlineCallbacks
-    def get_or_create_user(self, localpart, displayname, duration_seconds):
+    def get_or_create_user(self, localpart, displayname, duration_seconds, password_hash=None):
         """Creates a new user if the user does not exist,
         else revokes all previous access tokens and generates a new one.
 
@@ -394,7 +394,7 @@ class RegistrationHandler(BaseHandler):
             yield self.store.register(
                 user_id=user_id,
                 token=token,
-                password_hash=None,
+                password_hash=password_hash,
                 create_profile_with_localpart=user.localpart,
             )
         else:

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -358,7 +358,8 @@ class RegistrationHandler(BaseHandler):
         defer.returnValue(data)
 
     @defer.inlineCallbacks
-    def get_or_create_user(self, localpart, displayname, duration_seconds, password_hash=None):
+    def get_or_create_user(self, localpart, displayname, duration_seconds,
+                           password_hash=None):
         """Creates a new user if the user does not exist,
         else revokes all previous access tokens and generates a new one.
 

--- a/synapse/rest/client/v1/register.py
+++ b/synapse/rest/client/v1/register.py
@@ -410,7 +410,8 @@ class CreateUserRestServlet(ClientV1RestServlet):
             raise SynapseError(400, "Failed to parse 'duration_seconds'")
         if duration_seconds > self.direct_user_creation_max_duration:
             duration_seconds = self.direct_user_creation_max_duration
-        password_hash = user_json["password_hash"].encode("utf-8") if user_json.get("password_hash") else None
+        password_hash = user_json["password_hash"].encode("utf-8") \
+            if user_json.get("password_hash") else None
 
         handler = self.handlers.registration_handler
         user_id, token = yield handler.get_or_create_user(

--- a/synapse/rest/client/v1/register.py
+++ b/synapse/rest/client/v1/register.py
@@ -410,12 +410,14 @@ class CreateUserRestServlet(ClientV1RestServlet):
             raise SynapseError(400, "Failed to parse 'duration_seconds'")
         if duration_seconds > self.direct_user_creation_max_duration:
             duration_seconds = self.direct_user_creation_max_duration
+        password_hash = user_json["password_hash"].encode("utf-8") if user_json["password_hash"] else None
 
         handler = self.handlers.registration_handler
         user_id, token = yield handler.get_or_create_user(
             localpart=localpart,
             displayname=displayname,
-            duration_seconds=duration_seconds
+            duration_seconds=duration_seconds,
+            password_hash=password_hash
         )
 
         defer.returnValue({

--- a/synapse/rest/client/v1/register.py
+++ b/synapse/rest/client/v1/register.py
@@ -410,7 +410,7 @@ class CreateUserRestServlet(ClientV1RestServlet):
             raise SynapseError(400, "Failed to parse 'duration_seconds'")
         if duration_seconds > self.direct_user_creation_max_duration:
             duration_seconds = self.direct_user_creation_max_duration
-        password_hash = user_json["password_hash"].encode("utf-8") if user_json["password_hash"] else None
+        password_hash = user_json["password_hash"].encode("utf-8") if user_json.get("password_hash") else None
 
         handler = self.handlers.registration_handler
         user_id, token = yield handler.get_or_create_user(


### PR DESCRIPTION
I'm working on a potential application service called [Diaspora](https://github.com/diaspora/diaspora), a decentralized social networking site, which I would like to register Matrix users from. The idea is that Vector would be embedded in Diaspora as attached below. However I would also like any Diaspora user to login to their Matrix accounts through Vector or any other clients that are made in the future using their Diaspora credentials.

Matthew brought up the concern in matrix-dev that this would couple bcrypt to Synapse. My response is that if bcrypt became insecure for some reason, then it would mean that Diaspora would also have to change hashing algorithms too, and thus there wouldn't be much concern about making breaking changes. I would also not mind simply having this optional argument marked as unstable - as in Synapse will be free to make breaking changes whenever they want in terms of hashing algorithms - as it would be much easier than maintaining my own fork.

![vector](https://cloud.githubusercontent.com/assets/6329898/16543928/5848c572-412b-11e6-8c29-160666efacc5.png)
