### PR TITLE
Follow up to adding password pepper

### DIFF
--- a/scripts/hash_password
+++ b/scripts/hash_password
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 
 import argparse
+
+import sys
+
 import bcrypt
 import getpass
 
+import yaml
+
 bcrypt_rounds=12
+password_pepper = ""
 
 def prompt_for_pass():
     password = getpass.getpass("Password: ")
@@ -28,12 +34,22 @@ if __name__ == "__main__":
         default=None,
         help="New password for user. Will prompt if omitted.",
     )
+    parser.add_argument(
+        "-c", "--config",
+        type=argparse.FileType('r'),
+        help="Path to server config file. Used to read in bcrypt_rounds and password_pepper.",
+    )
 
     args = parser.parse_args()
+    if "config" in args and args.config:
+        config = yaml.safe_load(args.config)
+        bcrypt_rounds = config.get("bcrypt_rounds", bcrypt_rounds)
+        password_config = config.get("password_config", {})
+        password_pepper = password_config.get("pepper", password_pepper)
     password = args.password
 
     if not password:
         password = prompt_for_pass()
 
-    print bcrypt.hashpw(password, bcrypt.gensalt(bcrypt_rounds))
+    print bcrypt.hashpw(password + password_pepper, bcrypt.gensalt(bcrypt_rounds))
 

--- a/synapse/config/password.py
+++ b/synapse/config/password.py
@@ -30,7 +30,7 @@ class PasswordConfig(Config):
         # Enable password for login.
         password_config:
            enabled: true
-           # Change to a secret random string.
+           # Uncomment and change to a secret random string for extra security.
            # DO NOT CHANGE THIS AFTER INITIAL SETUP!
            #pepper: ""
         """


### PR DESCRIPTION
Ran using config with bcrypt rounds 10 and pepper "hello" with password "random"
```
(env)kents-air:synapse kent$ python scripts/hash_password -c demo/etc/8080.config
Password: 
Confirm password: 
$2a$10$f3O5aysDic74GSqKjljtsO1dTzVaLmsAXwVW1DjG7N6EHFtT.qzxa
```
Tested with
```
import bcrypt

stored_hash = "$2a$10$f3O5aysDic74GSqKjljtsO1dTzVaLmsAXwVW1DjG7N6EHFtT.qzxa"
print(bcrypt.hashpw("randomhello".encode('utf-8'), stored_hash.encode('utf-8')) == stored_hash.encode('utf-8')) # prints True
```

Ran without passing in config with password "random"
```
(env)kents-air:synapse kent$ python scripts/hash_password 
Password: 
Confirm password: 
$2a$12$6WzQnYQoglWXtewHCGhEqOxYry7vRgPkUeO7NrHMc9iW.lj39xwGi
```

Tested with
```
import bcrypt

stored_hash = "$2a$12$6WzQnYQoglWXtewHCGhEqOxYry7vRgPkUeO7NrHMc9iW.lj39xwGi"
print(bcrypt.hashpw("random".encode('utf-8'), stored_hash.encode('utf-8')) == stored_hash.encode('utf-8')) # prints True
```

Ran with non-existing config
```
(env)kents-air:synapse kent$ python scripts/hash_password -c diaspora.config
usage: hash_password [-h] [-p PASSWORD] [-c CONFIG]
hash_password: error: argument -c/--config: can't open 'diaspora.config': [Errno 2] No such file or directory: 'diaspora.config'
```

Ran with config that didn't contain pepper again with password "random" with bcrypt rounds 10
```
(env)kents-air:synapse kent$ python scripts/hash_password -c demo/etc/8080.config
Password: 
Confirm password: 
$2a$10$UZFvoKbz2n7LGHag6dC.Su81fGP9SphUTZO4ptde6a8TavBgVhipC
```

Tested with
```
import bcrypt

stored_hash = "$2a$10$UZFvoKbz2n7LGHag6dC.Su81fGP9SphUTZO4ptde6a8TavBgVhipC"
print(bcrypt.hashpw("random".encode('utf-8'), stored_hash.encode('utf-8')) == stored_hash.encode('utf-8')) # prints True
```