### PR TITLE
Fall back to 'username' if 'user' is not given for appservice registration.

### DIFF
--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -134,9 +134,11 @@ class RegisterRestServlet(RestServlet):
             # fallback to 'username' if they gave one.
             if isinstance(body.get("user"), basestring):
                 desired_username = body["user"]
-            result = yield self._do_appservice_registration(
-                desired_username, request.args["access_token"][0]
-            )
+
+            if isinstance(desired_username, basestring):
+                result = yield self._do_appservice_registration(
+                    desired_username, request.args["access_token"][0]
+                )
             defer.returnValue((200, result))  # we throw for non 200 responses
             return
 

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -132,8 +132,7 @@ class RegisterRestServlet(RestServlet):
             # Set the desired user according to the AS API (which uses the
             # 'user' key not 'username'). Since this is a new addition, we'll
             # fallback to 'username' if they gave one.
-            if isinstance(body.get("user"), basestring):
-                desired_username = body["user"]
+            desired_username = body.get("user", desired_username)
 
             if isinstance(desired_username, basestring):
                 result = yield self._do_appservice_registration(


### PR DESCRIPTION
It's stated in the comments that (quite sensibly) we should fallback to 'username' if user isn't given, yet this didn't appear to be implemented. This allows for either key with a preference for 'user'.