### PR TITLE
rest/client/v2_alpha/register.py: Refactor flow somewhat.

### DIFF
--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -114,7 +114,8 @@ class RegisterRestServletTestCase(unittest.TestCase):
             "username": "kermit",
             "password": "monkey"
         }, None)
-        self.registration_handler.register = Mock(return_value=(user_id, token))
+        self.registration_handler.register = Mock(return_value=(user_id, None))
+        self.auth_handler.issue_access_token = Mock(return_value=token)
 
         (code, result) = yield self.servlet.on_POST(self.request)
         self.assertEquals(code, 200)


### PR DESCRIPTION
This is meant to be an *almost* non-functional change, with the exception that it fixes what looks a lot like a bug in that it only calls `auth_handler.add_threepid` and `add_pusher` once instead of three times.

The idea is to move the generation of the `access_token` out of `registration_handler.register`, because `access_token`s now require a device_id, and we only want to generate a device_id once registration has been successful.

Please could you pay particular attention to my comments - I've inferred what the code is trying to do as best I can, but my inferences are hand-wavey and may be wrong. Better comments and answers to the "XXX" would be very welcome!