### PR TITLE
Make the device id on e2e key upload optional

### DIFF
--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -143,6 +143,10 @@ class DeviceHandler(BaseHandler):
             delete_refresh_tokens=True,
         )
 
+        yield self.store.delete_e2e_keys_by_device(
+            user_id=user_id, device_id=device_id
+        )
+
     @defer.inlineCallbacks
     def update_device(self, user_id, device_id, content):
         """ Update the given device

--- a/synapse/rest/client/v2_alpha/keys.py
+++ b/synapse/rest/client/v2_alpha/keys.py
@@ -19,6 +19,9 @@ import simplejson as json
 from canonicaljson import encode_canonical_json
 from twisted.internet import defer
 
+import synapse.api.errors
+import synapse.server
+import synapse.types
 from synapse.http.servlet import RestServlet, parse_json_object_from_request
 from synapse.types import UserID
 from ._base import client_v2_patterns
@@ -28,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 class KeyUploadServlet(RestServlet):
     """
-    POST /keys/upload/<device_id> HTTP/1.1
+    POST /keys/upload HTTP/1.1
     Content-Type: application/json
 
     {
@@ -51,22 +54,50 @@ class KeyUploadServlet(RestServlet):
       },
     }
     """
-    PATTERNS = client_v2_patterns("/keys/upload/(?P<device_id>[^/]*)", releases=())
+    PATTERNS = client_v2_patterns("/keys/upload(/(?P<device_id>[^/]+))?$",
+                                  releases=(), v2_alpha=False)
 
     def __init__(self, hs):
+        """
+        Args:
+            hs (synapse.server.HomeServer): server
+        """
         super(KeyUploadServlet, self).__init__()
         self.store = hs.get_datastore()
         self.clock = hs.get_clock()
         self.auth = hs.get_auth()
+        self.device_handler = hs.get_device_handler()
 
     @defer.inlineCallbacks
     def on_POST(self, request, device_id):
         requester = yield self.auth.get_user_by_req(request)
+
         user_id = requester.user.to_string()
-        # TODO: Check that the device_id matches that in the authentication
-        # or derive the device_id from the authentication instead.
 
         body = parse_json_object_from_request(request)
+
+        if device_id is not None:
+            # passing the device_id here is deprecated; however, we allow it
+            # for now for compatibility with older clients. But if a device_id
+            # was given here and in the auth, they must match.
+
+            if (requester.device_id is not None and
+                    device_id != requester.device_id):
+                raise synapse.api.errors.SynapseError(
+                    400, "Can only upload keys for current device"
+                )
+
+            self.device_handler.check_device_registered(
+                user_id, device_id, "unknown device"
+            )
+        else:
+            device_id = requester.device_id
+
+        if device_id is None:
+            raise synapse.api.errors.SynapseError(
+                400,
+                "To upload keys, you must pass device_id when authenticating"
+            )
 
         time_now = self.clock.time_msec()
 
@@ -99,14 +130,6 @@ class KeyUploadServlet(RestServlet):
             yield self.store.add_e2e_one_time_keys(
                 user_id, device_id, time_now, key_list
             )
-
-        result = yield self.store.count_e2e_one_time_keys(user_id, device_id)
-        defer.returnValue((200, {"one_time_key_counts": result}))
-
-    @defer.inlineCallbacks
-    def on_GET(self, request, device_id):
-        requester = yield self.auth.get_user_by_req(request)
-        user_id = requester.user.to_string()
 
         result = yield self.store.count_e2e_one_time_keys(user_id, device_id)
         defer.returnValue((200, {"one_time_key_counts": result}))

--- a/synapse/rest/client/v2_alpha/keys.py
+++ b/synapse/rest/client/v2_alpha/keys.py
@@ -55,7 +55,7 @@ class KeyUploadServlet(RestServlet):
     }
     """
     PATTERNS = client_v2_patterns("/keys/upload(/(?P<device_id>[^/]+))?$",
-                                  releases=(), v2_alpha=False)
+                                  releases=())
 
     def __init__(self, hs):
         """
@@ -78,14 +78,12 @@ class KeyUploadServlet(RestServlet):
 
         if device_id is not None:
             # passing the device_id here is deprecated; however, we allow it
-            # for now for compatibility with older clients. But if a device_id
-            # was given here and in the auth, they must match.
-
+            # for now for compatibility with older clients.
             if (requester.device_id is not None and
                     device_id != requester.device_id):
-                raise synapse.api.errors.SynapseError(
-                    400, "Can only upload keys for current device"
-                )
+                logger.warning("Client uploading keys for a different device "
+                               "(logged in as %s, uploading for %s)",
+                               requester.device_id, device_id)
         else:
             device_id = requester.device_id
 

--- a/synapse/storage/end_to_end_keys.py
+++ b/synapse/storage/end_to_end_keys.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import twisted.internet.defer
+
 from ._base import SQLBaseStore
 
 
@@ -122,4 +124,17 @@ class EndToEndKeyStore(SQLBaseStore):
             return result
         return self.runInteraction(
             "claim_e2e_one_time_keys", _claim_e2e_one_time_keys
+        )
+
+    @twisted.internet.defer.inlineCallbacks
+    def delete_e2e_keys_by_device(self, user_id, device_id):
+        yield self._simple_delete(
+            table="e2e_device_keys_json",
+            keyvalues={"user_id": user_id, "device_id": device_id},
+            desc="delete_e2e_device_keys_by_device"
+        )
+        yield self._simple_delete(
+            table="e2e_one_time_keys_json",
+            keyvalues={"user_id": user_id, "device_id": device_id},
+            desc="delete_e2e_one_time_keys_by_device"
         )

--- a/synapse/storage/schema/delta/33/devices_for_e2e_keys.sql
+++ b/synapse/storage/schema/delta/33/devices_for_e2e_keys.sql
@@ -16,4 +16,4 @@
 -- make sure that we have a device record for each set of E2E keys, so that the
 -- user can delete them if they like.
 INSERT INTO devices
-    SELECT user_id, device_id, "unknown device" FROM e2e_device_keys_json;
+    SELECT user_id, device_id, 'unknown device' FROM e2e_device_keys_json;

--- a/synapse/storage/schema/delta/33/devices_for_e2e_keys.sql
+++ b/synapse/storage/schema/delta/33/devices_for_e2e_keys.sql
@@ -1,0 +1,19 @@
+/* Copyright 2016 OpenMarket Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- make sure that we have a device record for each set of E2E keys, so that the
+-- user can delete them if they like.
+INSERT INTO devices
+    SELECT user_id, device_id, "unknown device" FROM e2e_device_keys_json;


### PR DESCRIPTION
We should now be able to get our device_id from the access_token, so the device_id on the upload request is optional. Where it is supplied, we should check that it matches.

Also make sure that the device_id is registered in the devices table, for both new e2e keys and those already in the database.

Finally, delete e2e keys from the database when we delete a device.