### PR TITLE
Forbid non-ASes from registering users whose names begin with '_'

### DIFF
--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -53,6 +53,13 @@ class RegistrationHandler(BaseHandler):
                 Codes.INVALID_USERNAME
             )
 
+        if localpart[0] == '_':
+            raise SynapseError(
+                400,
+                "User ID may not begin with _",
+                Codes.INVALID_USERNAME
+            )
+
         user = UserID(localpart, self.hs.hostname)
         user_id = user.to_string()
 


### PR DESCRIPTION
This code path is not involved when ASes register users, so ASes will still be able to make use of this prefix.

Tested by https://github.com/matrix-org/sytest/pull/272