### PR TITLE
Add /state_ids federation API

### DIFF
--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -364,6 +364,20 @@ class FederationClient(FederationBase):
 
     @defer.inlineCallbacks
     def get_events(self, destinations, room_id, event_ids, return_local=True):
+        """Fetch events from some remote destinations, checking if we already
+        have them.
+
+        Args:
+            destinations (list)
+            room_id (str)
+            event_ids (list)
+            return_local (bool): Whether to include events we already have in
+                the DB in the returned list of events
+
+        Returns:
+            Deferred: A deferred resolving to a 2-tuple where the first is a list of
+            events and the second is a list of event ids that we failed to fetch.
+        """
         if return_local:
             seen_events = yield self.store.get_events(event_ids)
             signed_events = seen_events.values()

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -396,7 +396,7 @@ class FederationClient(FederationBase):
             seen_events = yield self.store.have_events(event_ids)
             signed_events = []
 
-        failed_to_fetch = []
+        failed_to_fetch = set()
 
         missing_events = set(event_ids)
         for k in seen_events:
@@ -411,8 +411,8 @@ class FederationClient(FederationBase):
             return srvs
 
         batch_size = 20
-        missing_events = len(missing_events)
-        for i in xrange(0, batch_size, batch_size):
+        missing_events = list(missing_events)
+        for i in xrange(0, len(missing_events), batch_size):
             batch = set(missing_events[i:i + batch_size])
 
             deferreds = [

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -348,6 +348,10 @@ class FederationClient(FederationBase):
             else:
                 raise e
 
+        result = yield self.transport_layer.get_room_state(
+            destination, room_id, event_id=event_id,
+        )
+
         pdus = [
             self.event_from_pdu_json(p, outlier=True) for p in result["pdus"]
         ]

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -325,9 +325,16 @@ class FederationClient(FederationBase):
             state_event_ids = result["pdus"]
             auth_event_ids = result.get("auth_chain", [])
 
-            event_map, _failed_to_fetch = yield self.get_events(
+            fetched_events, failed_to_fetch = yield self.get_events(
                 [destination], room_id, set(state_event_ids + auth_event_ids)
             )
+
+            if failed_to_fetch:
+                logger.warn("Failed to get %r", failed_to_fetch)
+
+            event_map = {
+                ev.event_id: ev for ev in fetched_events
+            }
 
             pdus = [event_map[e_id] for e_id in state_event_ids]
             auth_chain = [event_map[e_id] for e_id in auth_event_ids]

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -322,8 +322,8 @@ class FederationClient(FederationBase):
                 destination, room_id, event_id=event_id,
             )
 
-            state_event_ids = result["pdus"]
-            auth_event_ids = result.get("auth_chain", [])
+            state_event_ids = result["pdu_ids"]
+            auth_event_ids = result.get("auth_chain_ids", [])
 
             fetched_events, failed_to_fetch = yield self.get_events(
                 [destination], room_id, set(state_event_ids + auth_event_ids)

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -623,7 +623,7 @@ class FederationServer(FederationBase):
                     origin, pdu.room_id, pdu.event_id,
                 )
             except:
-                logger.warn("Failed to get state for event: %s", pdu.event_id)
+                logger.exception("Failed to get state for event: %s", pdu.event_id)
 
         yield self.handler.on_receive_pdu(
             origin,

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -231,8 +231,8 @@ class FederationServer(FederationBase):
         )
 
         defer.returnValue((200, {
-            "pdus": [pdu.event_id for pdu in pdus],
-            "auth_chain": [pdu.event_id for pdu in auth_chain],
+            "pdu_ids": [pdu.event_id for pdu in pdus],
+            "auth_chain_ids": [pdu.event_id for pdu in auth_chain],
         }))
 
     @defer.inlineCallbacks

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -55,6 +55,28 @@ class TransportLayerClient(object):
         )
 
     @log_function
+    def get_room_state_ids(self, destination, room_id, event_id):
+        """ Requests all state for a given room from the given server at the
+        given event. Returns the state's event_id's
+
+        Args:
+            destination (str): The host name of the remote home server we want
+                to get the state from.
+            context (str): The name of the context we want the state of
+            event_id (str): The event we want the context at.
+
+        Returns:
+            Deferred: Results in a dict received from the remote homeserver.
+        """
+        logger.debug("get_room_state_ids dest=%s, room=%s",
+                     destination, room_id)
+
+        path = PREFIX + "/state_ids/%s/" % room_id
+        return self.client.get_json(
+            destination, path=path, args={"event_id": event_id},
+        )
+
+    @log_function
     def get_event(self, destination, event_id, timeout=None):
         """ Requests the pdu with give id and origin from the given server.
 

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -271,6 +271,17 @@ class FederationStateServlet(BaseFederationServlet):
         )
 
 
+class FederationStateIdsServlet(BaseFederationServlet):
+    PATH = "/state_ids/(?P<room_id>[^/]*)/"
+
+    def on_GET(self, origin, content, query, room_id):
+        return self.handler.on_state_ids_request(
+            origin,
+            room_id,
+            query.get("event_id", [None])[0],
+        )
+
+
 class FederationBackfillServlet(BaseFederationServlet):
     PATH = "/backfill/(?P<context>[^/]*)/"
 
@@ -538,6 +549,7 @@ SERVLET_CLASSES = (
     FederationPullServlet,
     FederationEventServlet,
     FederationStateServlet,
+    FederationStateIdsServlet,
     FederationBackfillServlet,
     FederationQueryServlet,
     FederationMakeJoinServlet,


### PR DESCRIPTION
The new API only returns the event_ids for the state, as most requesters will already have the vast majority of the events already.