### PR TITLE
Fix token login

### DIFF
--- a/synapse/server.pyi
+++ b/synapse/server.pyi
@@ -1,3 +1,4 @@
+import synapse.api.auth
 import synapse.handlers
 import synapse.handlers.auth
 import synapse.handlers.device
@@ -6,6 +7,9 @@ import synapse.storage
 import synapse.state
 
 class HomeServer(object):
+    def get_auth(self) -> synapse.api.auth.Auth:
+        pass
+
     def get_auth_handler(self) -> synapse.handlers.auth.AuthHandler:
         pass
 

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -22,6 +22,7 @@ from synapse.handlers.auth import AuthHandler
 from tests import unittest
 from tests.utils import setup_test_homeserver
 
+
 class AuthHandlers(object):
     def __init__(self, hs):
         self.auth_handler = AuthHandler(hs)


### PR DESCRIPTION
login with token (as used by CAS auth) was broken by 067596d, such that it
always returned a 401.