### PR TITLE
Set `Content-Security-Policy` on media repo

### DIFF
--- a/synapse/rest/media/v1/download_resource.py
+++ b/synapse/rest/media/v1/download_resource.py
@@ -45,6 +45,7 @@ class DownloadResource(Resource):
     @request_handler()
     @defer.inlineCallbacks
     def _async_render_GET(self, request):
+        request.setHeader("Content-Security-Policy", "sandbox")
         server_name, media_id, name = parse_media_id(request)
         if server_name == self.server_name:
             yield self._respond_local_file(request, media_id, name)


### PR DESCRIPTION
This is to inform browsers that they should sandbox the returned
media. This is particularly crucial for javascript/HTML files.