### PR TITLE
3rd party entity lookup

### DIFF
--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -81,13 +81,17 @@ class ApplicationService(object):
     NS_LIST = [NS_USERS, NS_ALIASES, NS_ROOMS]
 
     def __init__(self, token, url=None, namespaces=None, hs_token=None,
-                 sender=None, id=None):
+                 sender=None, id=None, protocols=None):
         self.token = token
         self.url = url
         self.hs_token = hs_token
         self.sender = sender
         self.namespaces = self._check_namespaces(namespaces)
         self.id = id
+        if protocols:
+            self.protocols = set(protocols)
+        else:
+            self.protocols = set()
 
     def _check_namespaces(self, namespaces):
         # Sanity check that it is of the form:
@@ -218,6 +222,9 @@ class ApplicationService(object):
             self._is_exclusive(ApplicationService.NS_USERS, user_id)
             or user_id == self.sender
         )
+
+    def is_interested_in_protocol(self, protocol):
+        return protocol in self.protocols
 
     def is_exclusive_alias(self, alias):
         return self._is_exclusive(ApplicationService.NS_ALIASES, alias)

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -78,7 +78,7 @@ class ApplicationServiceApi(SimpleHttpClient):
         try:
             response = yield self.get_json(uri, fields)
             defer.returnValue(response)
-        except:
+        except Exception:
             # TODO: would be noisy to log lookup failures, but we want to log
             # other things. Hrm.
             defer.returnValue([])

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -17,6 +17,7 @@ from twisted.internet import defer
 from synapse.api.errors import CodeMessageException
 from synapse.http.client import SimpleHttpClient
 from synapse.events.utils import serialize_event
+from synapse.types import ThirdPartyEntityKind
 
 import logging
 import urllib
@@ -72,25 +73,21 @@ class ApplicationServiceApi(SimpleHttpClient):
         defer.returnValue(False)
 
     @defer.inlineCallbacks
-    def query_3pu(self, service, protocol, fields):
-        uri = "%s/3pu/%s" % (service.url, urllib.quote(protocol))
-        response = None
-        try:
-            response = yield self.get_json(uri, fields)
-            defer.returnValue(response)
-        except Exception as ex:
-            logger.warning("query_3pu to %s threw exception %s", uri, ex)
-            defer.returnValue([])
+    def query_3pe(self, service, kind, protocol, fields):
+        if kind == ThirdPartyEntityKind.USER:
+            uri = "%s/3pu/%s" % (service.url, urllib.quote(protocol))
+        elif kind == ThirdPartyEntityKind.LOCATION:
+            uri = "%s/3pl/%s" % (service.url, urllib.quote(protocol))
+        else:
+            raise ValueError(
+                "Unrecognised 'kind' argument %r to query_3pe()", kind
+            )
 
-    @defer.inlineCallbacks
-    def query_3pl(self, service, protocol, fields):
-        uri = "%s/3pl/%s" % (service.url, urllib.quote(protocol))
-        response = None
         try:
             response = yield self.get_json(uri, fields)
             defer.returnValue(response)
         except Exception as ex:
-            logger.warning("query_3pl to %s threw exception %s", uri, ex)
+            logger.warning("query_3pe to %s threw exception %s", uri, ex)
             defer.returnValue([])
 
     @defer.inlineCallbacks

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -71,8 +71,17 @@ class ApplicationServiceApi(SimpleHttpClient):
             logger.warning("query_alias to %s threw exception %s", uri, ex)
         defer.returnValue(False)
 
+    @defer.inlineCallbacks
     def query_3pu(self, service, protocol, fields):
-        return False
+        uri = service.url + ("/3pu/%s" % urllib.quote(protocol))
+        response = None
+        try:
+            response = yield self.get_json(uri, fields)
+            defer.returnValue(response)
+        except:
+            # TODO: would be noisy to log lookup failures, but we want to log
+            # other things. Hrm.
+            defer.returnValue([])
 
     @defer.inlineCallbacks
     def push_bulk(self, service, events, txn_id=None):

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -83,6 +83,17 @@ class ApplicationServiceApi(SimpleHttpClient):
             defer.returnValue([])
 
     @defer.inlineCallbacks
+    def query_3pl(self, service, protocol, fields):
+        uri = service.url + ("/3pl/%s" % urllib.quote(protocol))
+        response = None
+        try:
+            response = yield self.get_json(uri, fields)
+            defer.returnValue(response)
+        except Exception as ex:
+            logger.warning("query_3pl to %s threw exception %s", uri, ex)
+            defer.returnValue([])
+
+    @defer.inlineCallbacks
     def push_bulk(self, service, events, txn_id=None):
         events = self._serialize(events)
 

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -73,7 +73,7 @@ class ApplicationServiceApi(SimpleHttpClient):
 
     @defer.inlineCallbacks
     def query_3pu(self, service, protocol, fields):
-        uri = service.url + ("/3pu/%s" % urllib.quote(protocol))
+        uri = "%s/3pu/%s" % (service.url, urllib.quote(protocol))
         response = None
         try:
             response = yield self.get_json(uri, fields)
@@ -84,7 +84,7 @@ class ApplicationServiceApi(SimpleHttpClient):
 
     @defer.inlineCallbacks
     def query_3pl(self, service, protocol, fields):
-        uri = service.url + ("/3pl/%s" % urllib.quote(protocol))
+        uri = "%s/3pl/%s" % (service.url, urllib.quote(protocol))
         response = None
         try:
             response = yield self.get_json(uri, fields)

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -78,9 +78,8 @@ class ApplicationServiceApi(SimpleHttpClient):
         try:
             response = yield self.get_json(uri, fields)
             defer.returnValue(response)
-        except Exception:
-            # TODO: would be noisy to log lookup failures, but we want to log
-            # other things. Hrm.
+        except Exception as ex:
+            logger.warning("query_3pu to %s threw exception %s", uri, ex)
             defer.returnValue([])
 
     @defer.inlineCallbacks

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -71,6 +71,9 @@ class ApplicationServiceApi(SimpleHttpClient):
             logger.warning("query_alias to %s threw exception %s", uri, ex)
         defer.returnValue(False)
 
+    def query_3pu(self, service, protocol, fields):
+        return False
+
     @defer.inlineCallbacks
     def push_bulk(self, service, events, txn_id=None):
         events = self._serialize(events)

--- a/synapse/config/appservice.py
+++ b/synapse/config/appservice.py
@@ -122,6 +122,15 @@ def _load_appservice(hostname, as_info, config_filename):
                     raise ValueError(
                         "Missing/bad type 'exclusive' key in %s", regex_obj
                     )
+    # protocols check
+    protocols = as_info.get("protocols")
+    if protocols:
+        # Because strings are lists in python
+        if isinstance(protocols, str) or not isinstance(protocols, list):
+            raise KeyError("Optional 'protocols' must be a list if present.")
+        for p in protocols:
+            if not isinstance(p, str):
+                raise KeyError("Bad value for 'protocols' item")
     return ApplicationService(
         token=as_info["as_token"],
         url=as_info["url"],
@@ -129,4 +138,5 @@ def _load_appservice(hostname, as_info, config_filename):
         hs_token=as_info["hs_token"],
         sender=user_id,
         id=as_info["id"],
+        protocols=protocols,
     )

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -121,6 +121,21 @@ class ApplicationServicesHandler(object):
                 defer.returnValue(result)
 
     @defer.inlineCallbacks
+    def query_3pu(self, protocol, fields):
+        services = yield self._get_services_for_3pn(protocol)
+
+        # TODO(paul): scattergather
+        results = []
+        for service in services:
+            result = yield self.appservice_api.query_3pu(
+                service, protocol, fields
+            )
+            if result:
+                results.append(result)
+
+        defer.returnValue(results)
+
+    @defer.inlineCallbacks
     def _get_services_for_event(self, event, restrict_to="", alias_list=None):
         """Retrieve a list of application services interested in this event.
 
@@ -162,6 +177,12 @@ class ApplicationServicesHandler(object):
             )
         ]
         defer.returnValue(interested_list)
+
+    @defer.inlineCallbacks
+    def _get_services_for_3pn(self, protocol):
+        # TODO(paul): Filter by protocol
+        services = yield self.store.get_app_services()
+        defer.returnValue(services)
 
     @defer.inlineCallbacks
     def _is_unknown_user(self, user_id):

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -184,7 +184,12 @@ class ApplicationServicesHandler(object):
                 continue
             if not isinstance(result, list):
                 continue
-            ret.extend(r for r in result if _is_valid_3pu_result(r))
+            for r in result:
+                if _is_valid_3pu_result(r):
+                    ret.append(r)
+                else:
+                    logger.warn("Application service returned an " +
+                                "invalid result %r", r)
 
         defer.returnValue(ret)
 

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -172,13 +172,10 @@ class ApplicationServicesHandler(object):
     def query_3pu(self, protocol, fields):
         services = yield self._get_services_for_3pn(protocol)
 
-        deferreds = []
-        for service in services:
-            deferreds.append(self.appservice_api.query_3pu(
-                service, protocol, fields
-            ))
-
-        results = yield defer.DeferredList(deferreds, consumeErrors=True)
+        results = yield defer.DeferredList([
+            self.appservice_api.query_3pu(service, protocol, fields)
+            for service in services
+        ], consumeErrors=True)
 
         ret = []
         for (success, result) in results:
@@ -199,13 +196,10 @@ class ApplicationServicesHandler(object):
     def query_3pl(self, protocol, fields):
         services = yield self._get_services_for_3pn(protocol)
 
-        deferreds = []
-        for service in services:
-            deferreds.append(self.appservice_api.query_3pl(
-                service, protocol, fields
-            ))
-
-        results = yield defer.DeferredList(deferreds, consumeErrors=True)
+        results = yield defer.DeferredList([
+            self.appservice_api.query_3pl(service, protocol, fields)
+            for service in services
+        ], consumeErrors=True)
 
         ret = []
         for (success, result) in results:

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -131,7 +131,7 @@ class ApplicationServicesHandler(object):
                 service, protocol, fields
             )
             if result:
-                results.append(result)
+                results.extend(result)
 
         defer.returnValue(results)
 

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -187,15 +187,20 @@ class ApplicationServicesHandler(object):
         ret = []
         for (success, result) in results:
             if not success:
+                logger.warn("Application service failed %r", result)
                 continue
             if not isinstance(result, list):
+                logger.warn(
+                    "Application service returned an invalid response %r", result
+                )
                 continue
             for r in result:
                 if _is_valid_3pentity_result(r, field=required_field):
                     ret.append(r)
                 else:
-                    logger.warn("Application service returned an " +
-                                "invalid result %r", r)
+                    logger.warn(
+                        "Application service returned an invalid result %r", r
+                    )
 
         defer.returnValue(ret)
 

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -191,9 +191,11 @@ class ApplicationServicesHandler(object):
 
     @defer.inlineCallbacks
     def _get_services_for_3pn(self, protocol):
-        # TODO(paul): Filter by protocol
         services = yield self.store.get_app_services()
-        defer.returnValue(services)
+        interested_list = [
+            s for s in services if s.is_interested_in_protocol(protocol)
+        ]
+        defer.returnValue(interested_list)
 
     @defer.inlineCallbacks
     def _is_unknown_user(self, user_id):

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -34,6 +34,7 @@ def log_failure(failure):
         )
     )
 
+
 def _is_valid_3pentity_result(r, field):
     if not isinstance(r, dict):
         return False
@@ -54,6 +55,7 @@ def _is_valid_3pentity_result(r, field):
             return False
 
     return True
+
 
 class ApplicationServicesHandler(object):
 

--- a/synapse/rest/__init__.py
+++ b/synapse/rest/__init__.py
@@ -47,6 +47,7 @@ from synapse.rest.client.v2_alpha import (
     report_event,
     openid,
     devices,
+    thirdparty,
 )
 
 from synapse.http.server import JsonResource
@@ -92,3 +93,4 @@ class ClientRestResource(JsonResource):
         report_event.register_servlets(hs, client_resource)
         openid.register_servlets(hs, client_resource)
         devices.register_servlets(hs, client_resource)
+        thirdparty.register_servlets(hs, client_resource)

--- a/synapse/rest/client/v2_alpha/thirdparty.py
+++ b/synapse/rest/client/v2_alpha/thirdparty.py
@@ -35,7 +35,11 @@ class ThirdPartyUserServlet(RestServlet):
 
     @defer.inlineCallbacks
     def on_GET(self, request, protocol):
-        fields = {} # TODO
+        fields = request.args
+        del fields["access_token"]
+
+        # TODO(paul): Some type checking on the request args might be nice
+        #   They should probably all be strings
         results = yield self.appservice_handler.query_3pu(protocol, fields)
 
         defer.returnValue((200, results))

--- a/synapse/rest/client/v2_alpha/thirdparty.py
+++ b/synapse/rest/client/v2_alpha/thirdparty.py
@@ -19,6 +19,7 @@ import logging
 from twisted.internet import defer
 
 from synapse.http.servlet import RestServlet
+from synapse.types import ThirdPartyEntityKind
 from ._base import client_v2_patterns
 
 logger = logging.getLogger(__name__)
@@ -41,7 +42,9 @@ class ThirdPartyUserServlet(RestServlet):
         fields = request.args
         del fields["access_token"]
 
-        results = yield self.appservice_handler.query_3pu(protocol, fields)
+        results = yield self.appservice_handler.query_3pe(
+            ThirdPartyEntityKind.USER, protocol, fields
+        )
 
         defer.returnValue((200, results))
 
@@ -63,7 +66,9 @@ class ThirdPartyLocationServlet(RestServlet):
         fields = request.args
         del fields["access_token"]
 
-        results = yield self.appservice_handler.query_3pl(protocol, fields)
+        results = yield self.appservice_handler.query_3pe(
+            ThirdPartyEntityKind.LOCATION, protocol, fields
+        )
 
         defer.returnValue((200, results))
 

--- a/synapse/rest/client/v2_alpha/thirdparty.py
+++ b/synapse/rest/client/v2_alpha/thirdparty.py
@@ -31,10 +31,13 @@ class ThirdPartyUserServlet(RestServlet):
     def __init__(self, hs):
         super(ThirdPartyUserServlet, self).__init__()
 
+        self.auth = hs.get_auth()
         self.appservice_handler = hs.get_application_service_handler()
 
     @defer.inlineCallbacks
     def on_GET(self, request, protocol):
+        yield self.auth.get_user_by_req(request)
+
         fields = request.args
         del fields["access_token"]
 
@@ -50,10 +53,13 @@ class ThirdPartyLocationServlet(RestServlet):
     def __init__(self, hs):
         super(ThirdPartyLocationServlet, self).__init__()
 
+        self.auth = hs.get_auth()
         self.appservice_handler = hs.get_application_service_handler()
 
     @defer.inlineCallbacks
     def on_GET(self, request, protocol):
+        yield self.auth.get_user_by_req(request)
+
         fields = request.args
         del fields["access_token"]
 

--- a/synapse/rest/client/v2_alpha/thirdparty.py
+++ b/synapse/rest/client/v2_alpha/thirdparty.py
@@ -16,6 +16,8 @@
 
 import logging
 
+from twisted.internet import defer
+
 from synapse.http.servlet import RestServlet
 from ._base import client_v2_patterns
 
@@ -28,10 +30,15 @@ class ThirdPartyUserServlet(RestServlet):
 
     def __init__(self, hs):
         super(ThirdPartyUserServlet, self).__init__()
-        pass
 
+        self.appservice_handler = hs.get_application_service_handler()
+
+    @defer.inlineCallbacks
     def on_GET(self, request, protocol):
-        return (200, {"TODO":"TODO"})
+        fields = {} # TODO
+        results = yield self.appservice_handler.query_3pu(protocol, fields)
+
+        defer.returnValue((200, results))
 
 
 def register_servlets(hs, http_server):

--- a/synapse/rest/client/v2_alpha/thirdparty.py
+++ b/synapse/rest/client/v2_alpha/thirdparty.py
@@ -43,5 +43,25 @@ class ThirdPartyUserServlet(RestServlet):
         defer.returnValue((200, results))
 
 
+class ThirdPartyLocationServlet(RestServlet):
+    PATTERNS = client_v2_patterns("/3pl(/(?P<protocol>[^/]+))?$",
+                                  releases=())
+
+    def __init__(self, hs):
+        super(ThirdPartyLocationServlet, self).__init__()
+
+        self.appservice_handler = hs.get_application_service_handler()
+
+    @defer.inlineCallbacks
+    def on_GET(self, request, protocol):
+        fields = request.args
+        del fields["access_token"]
+
+        results = yield self.appservice_handler.query_3pl(protocol, fields)
+
+        defer.returnValue((200, results))
+
+
 def register_servlets(hs, http_server):
     ThirdPartyUserServlet(hs).register(http_server)
+    ThirdPartyLocationServlet(hs).register(http_server)

--- a/synapse/rest/client/v2_alpha/thirdparty.py
+++ b/synapse/rest/client/v2_alpha/thirdparty.py
@@ -38,8 +38,6 @@ class ThirdPartyUserServlet(RestServlet):
         fields = request.args
         del fields["access_token"]
 
-        # TODO(paul): Some type checking on the request args might be nice
-        #   They should probably all be strings
         results = yield self.appservice_handler.query_3pu(protocol, fields)
 
         defer.returnValue((200, results))

--- a/synapse/rest/client/v2_alpha/thirdparty.py
+++ b/synapse/rest/client/v2_alpha/thirdparty.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015, 2016 OpenMarket Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+
+from synapse.http.servlet import RestServlet
+from ._base import client_v2_patterns
+
+logger = logging.getLogger(__name__)
+
+
+class ThirdPartyUserServlet(RestServlet):
+    PATTERNS = client_v2_patterns("/3pu(/(?P<protocol>[^/]+))?$",
+                                  releases=())
+
+    def __init__(self, hs):
+        super(ThirdPartyUserServlet, self).__init__()
+        pass
+
+    def on_GET(self, request, protocol):
+        return (200, {"TODO":"TODO"})
+
+
+def register_servlets(hs, http_server):
+    ThirdPartyUserServlet(hs).register(http_server)

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -269,3 +269,10 @@ class RoomStreamToken(namedtuple("_StreamToken", "topological stream")):
             return "t%d-%d" % (self.topological, self.stream)
         else:
             return "s%d" % (self.stream,)
+
+
+# Some arbitrary constants used for internal API enumerations. Don't rely on
+# exact values; always pass or compare symbolically
+class ThirdPartyEntityKind(object):
+    USER = 'user'
+    LOCATION = 'location'


### PR DESCRIPTION
Adds ability for clients to make requests about 3rd party users and locations (rooms). The HS acts as a proxy to any configured ASes that claim to know about the requested protocol domain.

 * Adds an optional `protocol` field to AS config files
 * Adds two client API endpoints `/_matrix/client/unstable/3pu` and `.../3pl`

Tested by:
  https://github.com/matrix-org/sytest/pull/290

API documented (in progress) by:
  https://docs.google.com/document/d/13NGa46a_WWno-XYfe8mQrglQdtOYMFVZtxkPKXDC3ac/edit#