### PR TITLE
Extend 3PE lookup APIs for metadata query

### DIFF
--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -88,6 +88,8 @@ class ApplicationService(object):
         self.sender = sender
         self.namespaces = self._check_namespaces(namespaces)
         self.id = id
+
+        # .protocols is a publicly visible field
         if protocols:
             self.protocols = set(protocols)
         else:

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -52,6 +52,13 @@ class ApplicationServiceApi(SimpleHttpClient):
     pushing.
     """
 
+    PROTOCOL_META = {
+        # TODO(paul): Declare kinds of metadata in here
+        "gitter": {
+            "user_fields": ["username"],
+        }
+    }
+
     def __init__(self, hs):
         super(ApplicationServiceApi, self).__init__(hs)
         self.clock = hs.get_clock()
@@ -130,6 +137,19 @@ class ApplicationServiceApi(SimpleHttpClient):
         except Exception as ex:
             logger.warning("query_3pe to %s threw exception %s", uri, ex)
             defer.returnValue([])
+
+    @defer.inlineCallbacks
+    def get_3pe_protocol(self, service, protocol):
+        # TODO: cache
+        uri = "%s/thirdparty/protocol/%s" % (service.url, urllib.quote(protocol))
+        try:
+            response = yield self.get_json(uri, {})
+            defer.returnValue(response)
+        except Exception as ex:
+            logger.warning("query_3pe_protocol to %s threw exception %s",
+                uri, ex
+            )
+            defer.returnValue({})
 
     @defer.inlineCallbacks
     def push_bulk(self, service, events, txn_id=None):

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -52,13 +52,6 @@ class ApplicationServiceApi(SimpleHttpClient):
     pushing.
     """
 
-    PROTOCOL_META = {
-        # TODO(paul): Declare kinds of metadata in here
-        "gitter": {
-            "user_fields": ["username"],
-        }
-    }
-
     def __init__(self, hs):
         super(ApplicationServiceApi, self).__init__(hs)
         self.clock = hs.get_clock()

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -97,10 +97,10 @@ class ApplicationServiceApi(SimpleHttpClient):
     @defer.inlineCallbacks
     def query_3pe(self, service, kind, protocol, fields):
         if kind == ThirdPartyEntityKind.USER:
-            uri = "%s/3pu/%s" % (service.url, urllib.quote(protocol))
+            uri = "%s/thirdparty/user/%s" % (service.url, urllib.quote(protocol))
             required_field = "userid"
         elif kind == ThirdPartyEntityKind.LOCATION:
-            uri = "%s/3pl/%s" % (service.url, urllib.quote(protocol))
+            uri = "%s/thirdparty/location/%s" % (service.url, urllib.quote(protocol))
             required_field = "alias"
         else:
             raise ValueError(

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -60,7 +60,7 @@ class ApplicationServiceApi(SimpleHttpClient):
         super(ApplicationServiceApi, self).__init__(hs)
         self.clock = hs.get_clock()
 
-        self.protocol_meta_cache = ResponseCache(hs, timeout_ms=1*HOUR_IN_MS)
+        self.protocol_meta_cache = ResponseCache(hs, timeout_ms=HOUR_IN_MS)
 
     @defer.inlineCallbacks
     def query_user(self, service, user_id):
@@ -145,8 +145,7 @@ class ApplicationServiceApi(SimpleHttpClient):
                 defer.returnValue((yield self.get_json(uri, {})))
             except Exception as ex:
                 logger.warning("query_3pe_protocol to %s threw exception %s",
-                    uri, ex
-                )
+                               uri, ex)
                 defer.returnValue({})
 
         key = (service.id, protocol)

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -176,6 +176,14 @@ class ApplicationServicesHandler(object):
         defer.returnValue(ret)
 
     @defer.inlineCallbacks
+    def get_3pe_protocols(self):
+        services = yield self.store.get_app_services()
+        protocols = set()
+        for s in services:
+            protocols.update(s.protocols)
+        defer.returnValue(protocols)
+
+    @defer.inlineCallbacks
     def _get_services_for_event(self, event):
         """Retrieve a list of application services interested in this event.
 

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -37,13 +37,6 @@ def log_failure(failure):
 
 class ApplicationServicesHandler(object):
 
-    PROTOCOL_META = {
-        # TODO(paul): Declare kinds of metadata in here
-        "gitter": {
-            "user_fields": ["username"],
-        }
-    }
-
     def __init__(self, hs):
         self.store = hs.get_datastore()
         self.is_mine_id = hs.is_mine_id
@@ -195,12 +188,7 @@ class ApplicationServicesHandler(object):
         protocols = {}
         for s in services:
             for p in s.protocols:
-                if p in self.PROTOCOL_META:
-                    protocols[p] = self.PROTOCOL_META[p]
-                else:
-                    # We don't know any metadata for it, but we'd best at least
-                    # still declare that we know it exists
-                    protocols[p] = {}
+                protocols[p] = yield self.appservice_api.get_3pe_protocol(s, p)
 
         self.supported_protocols = protocols
         defer.returnValue(protocols)

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -48,7 +48,6 @@ class ApplicationServicesHandler(object):
 
         self.current_max = 0
         self.is_processing = False
-        self.supported_protocols = None
 
     @defer.inlineCallbacks
     def notify_interested_services(self, current_id):
@@ -178,19 +177,12 @@ class ApplicationServicesHandler(object):
 
     @defer.inlineCallbacks
     def get_3pe_protocols(self):
-        # The set of supported AS protocols and the metadata about them is
-        # effectively static during the lifetime of a homeserver process. We
-        # can look this up once and just cache it.
-        if self.supported_protocols:
-            defer.returnValue(self.supported_protocols)
-
         services = yield self.store.get_app_services()
         protocols = {}
         for s in services:
             for p in s.protocols:
                 protocols[p] = yield self.appservice_api.get_3pe_protocol(s, p)
 
-        self.supported_protocols = protocols
         defer.returnValue(protocols)
 
     @defer.inlineCallbacks

--- a/synapse/rest/client/v2_alpha/thirdparty.py
+++ b/synapse/rest/client/v2_alpha/thirdparty.py
@@ -28,13 +28,6 @@ logger = logging.getLogger(__name__)
 class ThirdPartyProtocolsServlet(RestServlet):
     PATTERNS = client_v2_patterns("/thirdparty/protocols", releases=())
 
-    META = {
-        # TODO(paul): Declare kinds of metadata in here
-        "gitter": {
-            "user_fields": ["username"],
-        }
-    }
-
     def __init__(self, hs):
         super(ThirdPartyProtocolsServlet, self).__init__()
 
@@ -46,19 +39,7 @@ class ThirdPartyProtocolsServlet(RestServlet):
         yield self.auth.get_user_by_req(request)
 
         protocols = yield self.appservice_handler.get_3pe_protocols()
-
-        result = {}
-        # TODO(paul): Eventually this kind of metadata wants to come from the
-        #   ASes themselves
-        for protocol in protocols:
-            if protocol in self.META:
-                result[protocol] = self.META[protocol]
-            else:
-                # We don't know any metadata for it, but we'd best at least
-                # still declare that we know it exists
-                result[protocol] = {}
-
-        defer.returnValue((200, result))
+        defer.returnValue((200, protocols))
 
 
 class ThirdPartyUserServlet(RestServlet):

--- a/synapse/rest/client/v2_alpha/thirdparty.py
+++ b/synapse/rest/client/v2_alpha/thirdparty.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 class ThirdPartyUserServlet(RestServlet):
-    PATTERNS = client_v2_patterns("/3pu(/(?P<protocol>[^/]+))?$",
+    PATTERNS = client_v2_patterns("/thirdparty/user(/(?P<protocol>[^/]+))?$",
                                   releases=())
 
     def __init__(self, hs):
@@ -50,7 +50,7 @@ class ThirdPartyUserServlet(RestServlet):
 
 
 class ThirdPartyLocationServlet(RestServlet):
-    PATTERNS = client_v2_patterns("/3pl(/(?P<protocol>[^/]+))?$",
+    PATTERNS = client_v2_patterns("/thirdparty/location(/(?P<protocol>[^/]+))?$",
                                   releases=())
 
     def __init__(self, hs):

--- a/synapse/rest/client/v2_alpha/thirdparty.py
+++ b/synapse/rest/client/v2_alpha/thirdparty.py
@@ -30,6 +30,9 @@ class ThirdPartyProtocolsServlet(RestServlet):
 
     META = {
         # TODO(paul): Declare kinds of metadata in here
+        "gitter": {
+            "user_fields": ["username"],
+        }
     }
 
     def __init__(self, hs):


### PR DESCRIPTION
* Renames path components to `thirdparty/...` for better future expansion
* Adds `thirdparty/protocols` to get metadata about what kinds of protocols and queries upon them are supported

Tested in https://github.com/matrix-org/sytest/pull/293