### PR TITLE
Allow application services to have an optional 'url'

### DIFF
--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -67,6 +67,8 @@ class ApplicationServiceApi(SimpleHttpClient):
 
     @defer.inlineCallbacks
     def query_user(self, service, user_id):
+        if service.url == "":
+            defer.returnValue(False)
         uri = service.url + ("/users/%s" % urllib.quote(user_id))
         response = None
         try:
@@ -86,6 +88,8 @@ class ApplicationServiceApi(SimpleHttpClient):
 
     @defer.inlineCallbacks
     def query_alias(self, service, alias):
+        if service.url == "":
+            defer.returnValue(False)
         uri = service.url + ("/rooms/%s" % urllib.quote(alias))
         response = None
         try:
@@ -113,6 +117,8 @@ class ApplicationServiceApi(SimpleHttpClient):
             raise ValueError(
                 "Unrecognised 'kind' argument %r to query_3pe()", kind
             )
+        if service.url == "":
+            defer.returnValue([])
 
         uri = "%s%s/thirdparty/%s/%s" % (
             service.url,
@@ -145,6 +151,8 @@ class ApplicationServiceApi(SimpleHttpClient):
             defer.returnValue([])
 
     def get_3pe_protocol(self, service, protocol):
+        if service.url == "":
+            defer.returnValue({})
         @defer.inlineCallbacks
         def _get():
             uri = "%s%s/thirdparty/protocol/%s" % (
@@ -166,6 +174,9 @@ class ApplicationServiceApi(SimpleHttpClient):
 
     @defer.inlineCallbacks
     def push_bulk(self, service, events, txn_id=None):
+        if service.url == "":
+            defer.returnValue(True)
+
         events = self._serialize(events)
 
         if txn_id is None:

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -153,6 +153,7 @@ class ApplicationServiceApi(SimpleHttpClient):
     def get_3pe_protocol(self, service, protocol):
         if service.url == "":
             defer.returnValue({})
+
         @defer.inlineCallbacks
         def _get():
             uri = "%s%s/thirdparty/protocol/%s" % (

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -67,7 +67,7 @@ class ApplicationServiceApi(SimpleHttpClient):
 
     @defer.inlineCallbacks
     def query_user(self, service, user_id):
-        if service.url == "":
+        if service.url is None:
             defer.returnValue(False)
         uri = service.url + ("/users/%s" % urllib.quote(user_id))
         response = None
@@ -88,7 +88,7 @@ class ApplicationServiceApi(SimpleHttpClient):
 
     @defer.inlineCallbacks
     def query_alias(self, service, alias):
-        if service.url == "":
+        if service.url is None:
             defer.returnValue(False)
         uri = service.url + ("/rooms/%s" % urllib.quote(alias))
         response = None
@@ -117,7 +117,7 @@ class ApplicationServiceApi(SimpleHttpClient):
             raise ValueError(
                 "Unrecognised 'kind' argument %r to query_3pe()", kind
             )
-        if service.url == "":
+        if service.url is None:
             defer.returnValue([])
 
         uri = "%s%s/thirdparty/%s/%s" % (
@@ -151,7 +151,7 @@ class ApplicationServiceApi(SimpleHttpClient):
             defer.returnValue([])
 
     def get_3pe_protocol(self, service, protocol):
-        if service.url == "":
+        if service.url is None:
             defer.returnValue({})
 
         @defer.inlineCallbacks
@@ -175,7 +175,7 @@ class ApplicationServiceApi(SimpleHttpClient):
 
     @defer.inlineCallbacks
     def push_bulk(self, service, events, txn_id=None):
-        if service.url == "":
+        if service.url is None:
             defer.returnValue(True)
 
         events = self._serialize(events)

--- a/synapse/config/appservice.py
+++ b/synapse/config/appservice.py
@@ -96,7 +96,8 @@ def _load_appservice(hostname, as_info, config_filename):
 
     # 'url' must either be a string or explicitly null, not missing
     # to avoid accidentally turning off push for ASes.
-    if not isinstance(as_info.get("url"), basestring) and as_info.get("url", "") is not None:
+    if (not isinstance(as_info.get("url"), basestring) and
+            as_info.get("url", "") is not None):
         raise KeyError(
             "Required string field or explicit null: 'url' (%s)" % (config_filename,)
         )
@@ -140,7 +141,7 @@ def _load_appservice(hostname, as_info, config_filename):
             if not isinstance(p, str):
                 raise KeyError("Bad value for 'protocols' item")
 
-    if as_info["url"] == None:
+    if as_info["url"] is None:
         logger.info(
             "(%s) Explicitly empty 'url' provided. This application service"
             " will not receive events or queries.",

--- a/synapse/config/appservice.py
+++ b/synapse/config/appservice.py
@@ -86,13 +86,20 @@ def load_appservices(hostname, config_files):
 
 def _load_appservice(hostname, as_info, config_filename):
     required_string_fields = [
-        "id", "url", "as_token", "hs_token", "sender_localpart"
+        "id", "as_token", "hs_token", "sender_localpart"
     ]
     for field in required_string_fields:
         if not isinstance(as_info.get(field), basestring):
             raise KeyError("Required string field: '%s' (%s)" % (
                 field, config_filename,
             ))
+
+    # 'url' must either be a string or explicitly null, not missing
+    # to avoid accidentally turning off push for ASes.
+    if not isinstance(as_info.get("url"), basestring) and as_info.get("url", "") is not None:
+        raise KeyError(
+            "Required string field or explicit null: 'url' (%s)" % (config_filename,)
+        )
 
     localpart = as_info["sender_localpart"]
     if urllib.quote(localpart) != localpart:
@@ -133,10 +140,10 @@ def _load_appservice(hostname, as_info, config_filename):
             if not isinstance(p, str):
                 raise KeyError("Bad value for 'protocols' item")
 
-    if as_info["url"] == "":
+    if as_info["url"] == None:
         logger.info(
-            "(%s) Explicitly empty 'url' provided. This application service " +
-            "will not receive events or queries.",
+            "(%s) Explicitly empty 'url' provided. This application service"
+            " will not receive events or queries.",
             config_filename,
         )
     return ApplicationService(

--- a/synapse/config/appservice.py
+++ b/synapse/config/appservice.py
@@ -132,6 +132,12 @@ def _load_appservice(hostname, as_info, config_filename):
         for p in protocols:
             if not isinstance(p, str):
                 raise KeyError("Bad value for 'protocols' item")
+
+    if as_info["url"] == "":
+        logger.info(
+            "(%s) Explicitly empty 'url' provided. This application service will not receive events or queries.",
+            config_filename,
+        )
     return ApplicationService(
         token=as_info["as_token"],
         url=as_info["url"],

--- a/synapse/config/appservice.py
+++ b/synapse/config/appservice.py
@@ -135,7 +135,8 @@ def _load_appservice(hostname, as_info, config_filename):
 
     if as_info["url"] == "":
         logger.info(
-            "(%s) Explicitly empty 'url' provided. This application service will not receive events or queries.",
+            "(%s) Explicitly empty 'url' provided. This application service " +
+            "will not receive events or queries.",
             config_filename,
         )
     return ApplicationService(


### PR DESCRIPTION
If 'url' is not specified, they will not be pushed for events or queries. This is useful for bots who simply wish to reserve large chunks of user/alias namespace, and don't care about being pushed for events.

This is done by **explicitly** setting the `url` field in the registration file to the empty string. This is done to ensure that this is a conscious decision, and not just a forgotten field. We also log when we encounter ASes which will not be pushed.