### PR TITLE
make device IDs more useful for human disambiguation

### DIFF
--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -58,7 +58,7 @@ class DeviceHandler(BaseHandler):
         attempts = 0
         while attempts < 5:
             try:
-                device_id = stringutils.random_string_with_symbols(16)
+                device_id = stringutils.random_string(10).upper()
                 yield self.store.store_device(
                     user_id=user_id,
                     device_id=device_id,


### PR DESCRIPTION
Currently synapse generates unique IDs for devices which are horrible for human disambiguation of devices as they are long and contain a variety of homoglyphs and generally look ugly to the eye - e.g. `Hu3d_G:;jj3*D:rF`.

This makes them simpler - 10 upper case characters.  It does reduce the available device IDs from (26+26+10+15)^16 (1E30) to 26^10 (1E14), but I think the tradeoff is probably acceptable in terms of making the IDs more usable as a means of distinguishing one Vector running on Chrome from another Vector running on Chrome.