### PR TITLE
Optional Lock version for displayname and avatar_url

### DIFF
--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -65,7 +65,7 @@ class ProfileHandler(BaseHandler):
                 defer.returnValue(result["displayname"])
 
     @defer.inlineCallbacks
-    def set_displayname(self, target_user, requester, new_displayname):
+    def set_displayname(self, target_user, requester, new_displayname, lock_version=None):
         """target_user is the user whose displayname is to be changed;
         auth_user is the user attempting to make this change."""
         if not self.hs.is_mine(target_user):
@@ -78,7 +78,7 @@ class ProfileHandler(BaseHandler):
             new_displayname = None
 
         yield self.store.set_profile_displayname(
-            target_user.localpart, new_displayname
+            target_user.localpart, new_displayname, lock_version
         )
 
         yield self._update_join_states(requester)
@@ -111,7 +111,7 @@ class ProfileHandler(BaseHandler):
             defer.returnValue(result["avatar_url"])
 
     @defer.inlineCallbacks
-    def set_avatar_url(self, target_user, requester, new_avatar_url):
+    def set_avatar_url(self, target_user, requester, new_avatar_url, lock_version=None):
         """target_user is the user whose avatar_url is to be changed;
         auth_user is the user attempting to make this change."""
         if not self.hs.is_mine(target_user):
@@ -121,7 +121,7 @@ class ProfileHandler(BaseHandler):
             raise AuthError(400, "Cannot set another user's avatar_url")
 
         yield self.store.set_profile_avatar_url(
-            target_user.localpart, new_avatar_url
+            target_user.localpart, new_avatar_url, lock_version
         )
 
         yield self._update_join_states(requester)

--- a/synapse/rest/client/v1/profile.py
+++ b/synapse/rest/client/v1/profile.py
@@ -32,13 +32,9 @@ class ProfileDisplaynameRestServlet(ClientV1RestServlet):
     def on_GET(self, request, user_id):
         user = UserID.from_string(user_id)
 
-        displayname = yield self.handlers.profile_handler.get_displayname(
+        ret = yield self.handlers.profile_handler.get_displayname(
             user,
         )
-
-        ret = {}
-        if displayname is not None:
-            ret["displayname"] = displayname
 
         defer.returnValue((200, ret))
 
@@ -55,7 +51,7 @@ class ProfileDisplaynameRestServlet(ClientV1RestServlet):
             defer.returnValue((400, "Unable to parse name"))
 
         yield self.handlers.profile_handler.set_displayname(
-            user, requester, new_name)
+            user, requester, new_name, content.get("lock_version"))
 
         defer.returnValue((200, {}))
 

--- a/synapse/storage/profile.py
+++ b/synapse/storage/profile.py
@@ -25,33 +25,43 @@ class ProfileStore(SQLBaseStore):
         )
 
     def get_profile_displayname(self, user_localpart):
-        return self._simple_select_one_onecol(
+        return self._simple_select_one_row(
             table="profiles",
             keyvalues={"user_id": user_localpart},
-            retcol="displayname",
+            retcol=["displayname", "lock_version"],
             desc="get_profile_displayname",
         )
 
-    def set_profile_displayname(self, user_localpart, new_displayname):
+    def set_profile_displayname(self, user_localpart, new_displayname, lock_version=None):
+        keyvalues = {"user_id": user_localpart}
+        updatevalues = {"displayname": new_displayname}
+        if lock_version is not None:
+            keyvalues["lock_version"] = lock_version
+            updatevalues["lock_version"] = lock_version + 1
         return self._simple_update_one(
             table="profiles",
-            keyvalues={"user_id": user_localpart},
-            updatevalues={"displayname": new_displayname},
+            keyvalues=keyvalues,
+            updatevalues=updatevalues,
             desc="set_profile_displayname",
         )
 
     def get_profile_avatar_url(self, user_localpart):
-        return self._simple_select_one_onecol(
+        return self._simple_select_one_row(
             table="profiles",
             keyvalues={"user_id": user_localpart},
-            retcol="avatar_url",
+            retcol=["avatar_url", "lock_version"],
             desc="get_profile_avatar_url",
         )
 
-    def set_profile_avatar_url(self, user_localpart, new_avatar_url):
+    def set_profile_avatar_url(self, user_localpart, new_avatar_url, lock_version=None):
+        keyvalues = {"user_id": user_localpart}
+        updatevalues = {"avatar_url": new_avatar_url}
+        if lock_version is not None:
+            keyvalues["lock_version"] = lock_version
+            updatevalues["lock_version"] = lock_version + 1
         return self._simple_update_one(
             table="profiles",
-            keyvalues={"user_id": user_localpart},
-            updatevalues={"avatar_url": new_avatar_url},
+            keyvalues=keyvalues,
+            updatevalues=updatevalues,
             desc="set_profile_avatar_url",
         )

--- a/synapse/storage/schema/full_schemas/16/profiles.sql
+++ b/synapse/storage/schema/full_schemas/16/profiles.sql
@@ -16,5 +16,6 @@ CREATE TABLE IF NOT EXISTS profiles(
     user_id TEXT NOT NULL,
     displayname TEXT,
     avatar_url TEXT,
+    lock_version INTEGER DEFAULT 0,
     UNIQUE(user_id)
 );


### PR DESCRIPTION
This is a cursory first part of an attempt to address the very slow settings opening on vector-web (currently all of the settings are re-fetched from the HS on each load, since they currently is not guaranteed way to sync these with mobile or other connected devices). 

Adding `lock_version` column to the database for `profile` and in the future other `settings` related toggles can provide a backwards compatible way to move towards a more responsive UI for these features. The only relevant API change is that rather than returning the current single key/value dict: 

```
{"displayname": u"foo"}
```

A dict with `lock_version` will be returned instead for HS running this patch e.g. 

```
{"displayname": u"foo", "lock_version": 324344}
```

The client may than still ignore the `lock_version` field and `PUT` to the `/displayname` endpoint forgoing it entirely, but if they do choose to specify it the HS will fail to update the related profile fields if  the `lock_version` does not match, instead returning a `404, Invalid Lock Version`. 
