### PR TITLE
Fix _delete_old_forward_extrem_cache query

### DIFF
--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -398,12 +398,11 @@ class EventFederationStore(SQLBaseStore):
             sql = ("""
                 DELETE FROM stream_ordering_to_exterm
                 WHERE
-                (
-                    SELECT max(stream_ordering) AS stream_ordering
+                room_id IN (
+                    SELECT room_id AS stream_ordering
                     FROM stream_ordering_to_exterm
-                    WHERE room_id = stream_ordering_to_exterm.room_id
-                ) > ?
-                AND stream_ordering < ?
+                    WHERE stream_ordering > ?
+                ) AND stream_ordering < ?
             """)
             txn.execute(
                 sql,

--- a/synapse/storage/event_federation.py
+++ b/synapse/storage/event_federation.py
@@ -399,7 +399,7 @@ class EventFederationStore(SQLBaseStore):
                 DELETE FROM stream_ordering_to_exterm
                 WHERE
                 room_id IN (
-                    SELECT room_id AS stream_ordering
+                    SELECT room_id
                     FROM stream_ordering_to_exterm
                     WHERE stream_ordering > ?
                 ) AND stream_ordering < ?

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 # Remember to update this number every time a change is made to database
 # schema files, so the users will be informed on server restarts.
-SCHEMA_VERSION = 35
+SCHEMA_VERSION = 36
 
 dir_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/synapse/storage/schema/delta/36/readd_public_rooms.sql
+++ b/synapse/storage/schema/delta/36/readd_public_rooms.sql
@@ -1,0 +1,22 @@
+/* Copyright 2016 OpenMarket Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+INSERT INTO public_room_list_stream (stream_id, room_id, visibility)
+    SELECT 1, room_id, is_public FROM rooms AS r
+    WHERE is_public = CAST(1 AS BOOLEAN)
+    AND NOT EXISTS (
+        SELECT room_id FROM stream_ordering_to_exterm WHERE room_id = r.room_id
+    );

--- a/synapse/storage/schema/delta/36/readd_public_rooms.sql
+++ b/synapse/storage/schema/delta/36/readd_public_rooms.sql
@@ -16,7 +16,7 @@
 -- Re-add some entries to stream_ordering_to_exterm that were incorrectly deleted
 INSERT INTO stream_ordering_to_exterm (stream_ordering, room_id, event_id)
     SELECT
-        (SELECT max(stream_ordering) FROM events where room_id = e.room_id) AS stream_ordering,
+        (SELECT stream_ordering FROM events where event_id = e.event_id) AS stream_ordering,
         room_id,
         event_id
     FROM event_forward_extremities AS e

--- a/synapse/storage/schema/delta/36/readd_public_rooms.sql
+++ b/synapse/storage/schema/delta/36/readd_public_rooms.sql
@@ -13,10 +13,14 @@
  * limitations under the License.
  */
 
-
-INSERT INTO public_room_list_stream (stream_id, room_id, visibility)
-    SELECT 1, room_id, is_public FROM rooms AS r
-    WHERE is_public = CAST(1 AS BOOLEAN)
-    AND NOT EXISTS (
-        SELECT room_id FROM stream_ordering_to_exterm WHERE room_id = r.room_id
+-- Re-add some entries to stream_ordering_to_exterm that were incorrectly deleted
+INSERT INTO stream_ordering_to_exterm (stream_ordering, room_id, event_id)
+    SELECT
+        (SELECT max(stream_ordering) FROM events where room_id = e.room_id) AS stream_ordering,
+        room_id,
+        event_id
+    FROM event_forward_extremities AS e
+    WHERE NOT EXISTS (
+        SELECT room_id FROM stream_ordering_to_exterm AS s
+        WHERE s.room_id = e.room_id
     );


### PR DESCRIPTION
The query for deleting old entries in `stream_ordering_to_exterm` had a bug in the logic that tried ensure there was always at least one entry per room.