### PR TITLE
Allow invites via 3pid to bypass sender sig check

### DIFF
--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -103,9 +103,10 @@ class Auth(object):
 
                 # Check the sender's domain has signed the event
                 if not event.signatures.get(sender_domain):
-                    # We allow invites via 3pid to have a sender from a differnt
+                    # We allow invites via 3pid to have a sender from a different
                     # HS, as the sender must match the sender of the original
-                    # 3pid invite. This is checked further down.
+                    # 3pid invite. This is checked further down with the
+                    # other dedicated membership checks.
                     if not is_invite_via_3pid:
                         raise AuthError(403, "Event not signed by sender's server")
 

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -103,6 +103,9 @@ class Auth(object):
 
                 # Check the sender's domain has signed the event
                 if not event.signatures.get(sender_domain):
+                    # We allow invites via 3pid to have a sender from a differnt
+                    # HS, as the sender must match the sender of the original
+                    # 3pid invite. This is checked further down.
                     if not is_invite_via_3pid:
                         raise AuthError(403, "Event not signed by sender's server")
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1930,6 +1930,9 @@ class FederationHandler(BaseHandler):
                 "Could not find invite event for third_party_invite: %r",
                 event_dict
             )
+            # We don't discard here as this is not the appropriate place to do
+            # auth checks. If we need the invite and don't have it then the
+            # auth check code will explode appropriately.
 
         builder = self.event_builder_factory.new(event_dict)
         EventValidator().validate_new(builder)

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1922,15 +1922,15 @@ class FederationHandler(BaseHandler):
             original_invite = yield self.store.get_event(
                 original_invite_id, allow_none=True
             )
-        if not original_invite:
+        if original_invite:
+            display_name = original_invite.content["display_name"]
+            event_dict["content"]["third_party_invite"]["display_name"] = display_name
+        else:
             logger.info(
-                "Could not find invite event for third_party_invite - "
-                "discarding: %s" % (event_dict,)
+                "Could not find invite event for third_party_invite: %r",
+                event_dict
             )
-            return
 
-        display_name = original_invite.content["display_name"]
-        event_dict["content"]["third_party_invite"]["display_name"] = display_name
         builder = self.event_builder_factory.new(event_dict)
         EventValidator().validate_new(builder)
         message_handler = self.hs.get_handlers().message_handler

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -56,7 +56,7 @@ def get_domain_from_id(string):
     try:
         return string.split(":", 1)[1]
     except IndexError:
-        raise SynapseError(400, "Invalid ID: %r", string)
+        raise SynapseError(400, "Invalid ID: %r" % (string,))
 
 
 class DomainSpecificString(


### PR DESCRIPTION
When a server sends a third party invite another server may be the one
that the inviting user registers with. In this case it is that remote
server that will issue an actual invitation, and wants to do it "in the
name of" the original invitee. However, the new proper invite will not
be signed by the original server, and thus other servers would reject
the invite if it was seen as coming from the original user.

To fix this, a special case has been added to the auth rules whereby
another server can send an invite "in the name of" another server's
user, so long as that user had previously issued a third party invite
that is now being accepted.