### PR TITLE
api/auth: fix for not being allowed to set your own state_key

### DIFF
--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -1002,16 +1002,6 @@ class Auth(object):
                         403,
                         "You are not allowed to set others state"
                     )
-                else:
-                    sender_domain = UserID.from_string(
-                        event.user_id
-                    ).domain
-
-                    if sender_domain != event.state_key:
-                        raise AuthError(
-                            403,
-                            "You are not allowed to set others state"
-                        )
 
         return True
 


### PR DESCRIPTION
I believe this is how it's supposed to work, as at the moment it doesn't seem to be possible to use state_keys that start with '@' at all.

Haven't run tests or found the description in the spec, but /discuss :>