### PR TITLE
Clarify Error codes for GET /filter/

### DIFF
--- a/synapse/rest/client/v2_alpha/filter.py
+++ b/synapse/rest/client/v2_alpha/filter.py
@@ -15,7 +15,7 @@
 
 from twisted.internet import defer
 
-from synapse.api.errors import AuthError, SynapseError
+from synapse.api.errors import AuthError, SynapseError, StoreError, Codes
 from synapse.http.servlet import RestServlet, parse_json_object_from_request
 from synapse.types import UserID
 
@@ -45,7 +45,7 @@ class GetFilterRestServlet(RestServlet):
             raise AuthError(403, "Cannot get filters for other users")
 
         if not self.hs.is_mine(target_user):
-            raise SynapseError(400, "Can only get filters for local users")
+            raise AuthError(403, "Can only get filters for local users")
 
         try:
             filter_id = int(filter_id)
@@ -59,8 +59,8 @@ class GetFilterRestServlet(RestServlet):
             )
 
             defer.returnValue((200, filter.get_filter_json()))
-        except KeyError:
-            raise SynapseError(400, "No such filter")
+        except (KeyError, StoreError):
+            raise SynapseError(400, "No such filter", errcode=Codes.NOT_FOUND)
 
 
 class CreateFilterRestServlet(RestServlet):

--- a/synapse/rest/client/v2_alpha/filter.py
+++ b/synapse/rest/client/v2_alpha/filter.py
@@ -74,6 +74,7 @@ class CreateFilterRestServlet(RestServlet):
 
     @defer.inlineCallbacks
     def on_POST(self, request, user_id):
+
         target_user = UserID.from_string(user_id)
         requester = yield self.auth.get_user_by_req(request)
 
@@ -81,10 +82,9 @@ class CreateFilterRestServlet(RestServlet):
             raise AuthError(403, "Cannot create filters for other users")
 
         if not self.hs.is_mine(target_user):
-            raise SynapseError(400, "Can only create filters for local users")
+            raise AuthError(403, "Can only create filters for local users")
 
         content = parse_json_object_from_request(request)
-
         filter_id = yield self.filtering.add_user_filter(
             user_localpart=target_user.localpart,
             user_filter=content,

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -85,7 +85,6 @@ class LoggingTransaction(object):
         sql_logger.debug("[SQL] {%s} %s", self.name, sql)
 
         sql = self.database_engine.convert_param_style(sql)
-
         if args:
             try:
                 sql_logger.debug(

--- a/tests/rest/client/v2_alpha/test_filter.py
+++ b/tests/rest/client/v2_alpha/test_filter.py
@@ -19,7 +19,7 @@ from . import V2AlphaRestTestCase
 
 from synapse.rest.client.v2_alpha import filter
 
-from synapse.api.errors import StoreError
+from synapse.api.errors import StoreError, Codes
 
 
 class FilterTestCase(V2AlphaRestTestCase):
@@ -82,11 +82,20 @@ class FilterTestCase(V2AlphaRestTestCase):
         (code, response) = yield self.mock_resource.trigger_get(
             "/user/%s/filter/2" % (self.USER_ID)
         )
-        self.assertEquals(404, code)
+        self.assertEquals(400, code)
 
     @defer.inlineCallbacks
     def test_get_filter_no_user(self):
         (code, response) = yield self.mock_resource.trigger_get(
             "/user/%s/filter/0" % (self.USER_ID)
         )
-        self.assertEquals(404, code)
+        self.assertEquals(400, code)
+        self.assertEquals(response['errcode'], Codes.FORBIDDEN)
+
+    @defer.inlineCallbacks
+    def test_get_filter_missing_id(self):
+        (code, response) = yield self.mock_resource.trigger_get(
+            "/user/%s/filter/0" % (self.USER_ID)
+        )
+        self.assertEquals(400, code)
+        self.assertEquals(response['errcode'], Codes.NOT_FOUND)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -188,7 +188,7 @@ class MockHttpResource(HttpServer):
                     )
                     defer.returnValue((code, response))
                 except CodeMessageException as e:
-                    defer.returnValue((e.code, cs_error(e.msg)))
+                    defer.returnValue((e.code, cs_error(e.msg, code=e.errcode)))
 
         raise KeyError("No event can handle %s" % path)
 


### PR DESCRIPTION
SynapseError creates errors with https://github.com/matrix-org/synapse/blob/master/synapse/api/errors.py#L66 `errcode` set to `M_UNKNOWN` by default. This just updates the errors raised at the endpoint to send the correct errors, also `get_user_filter` should catch `StoreError` which is raised (https://github.com/matrix-org/synapse/blob/master/synapse/storage/_base.py#L561) when no row is found. I also added an `M_INVALID_PARAM` for the "Invalid FilterId" error since I couldn't find an appropriately matching `errcode` (should this be a separate commit?).

https://github.com/matrix-org/matrix-js-sdk/pull/228