### PR TITLE
Standardise prometheus metrics

### DIFF
--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -52,6 +52,7 @@ from synapse.config.homeserver import HomeServerConfig
 from synapse.crypto import context_factory
 from synapse.util.logcontext import LoggingContext
 from synapse.metrics import register_memory_metrics, get_metrics_for
+from synapse.metrics.process_collector import register_process_collector
 from synapse.metrics.resource import MetricsResource, METRICS_PREFIX
 from synapse.replication.resource import ReplicationResource, REPLICATION_PREFIX
 from synapse.federation.transport.server import TransportLayerServer
@@ -337,6 +338,7 @@ def setup(config_options):
         hs.get_replication_layer().start_get_pdu_cache()
 
         register_memory_metrics(hs)
+        register_process_collector()
 
     reactor.callWhenRunning(start)
 

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -143,6 +143,7 @@ TYPES = {
     stat.S_IFIFO: "FIFO",
 }
 
+
 def update_resource_metrics():
     global rusage
     rusage = getrusage(RUSAGE_SELF)
@@ -183,7 +184,7 @@ def _process_fds():
     return counts
 
 
-## Legacy synapse-invented metric names
+# Legacy synapse-invented metric names
 
 resource_metrics = get_metrics_for("process.resource")
 
@@ -196,8 +197,9 @@ resource_metrics.register_callback("maxrss", lambda: rusage.ru_maxrss * 1024)
 
 get_metrics_for("process").register_callback("fds", _process_fds, labels=["type"])
 
-## New prometheus-standard metric names
-process_metrics = get_metrics_for("process");
+# New prometheus-standard metric names
+
+process_metrics = get_metrics_for("process")
 
 if HAVE_PROC_SELF_STAT:
     process_metrics.register_callback(

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -119,6 +119,8 @@ def update_resource_metrics():
     global rusage
     rusage = getrusage(RUSAGE_SELF)
 
+## Legacy synapse-invented metric names
+
 resource_metrics = get_metrics_for("process.resource")
 
 # msecs
@@ -164,6 +166,19 @@ def _process_fds():
     return counts
 
 get_metrics_for("process").register_callback("fds", _process_fds, labels=["type"])
+
+## New prometheus-standard metric names
+process_metrics = get_metrics_for("process");
+
+process_metrics.register_callback(
+    "cpu_user_seconds_total", lambda: rusage.ru_utime
+)
+process_metrics.register_callback(
+    "cpu_system_seconds_total", lambda: rusage.ru_stime
+)
+process_metrics.register_callback(
+    "cpu_seconds_total", lambda: rusage.ru_utime + rusage.ru_stime
+)
 
 reactor_metrics = get_metrics_for("reactor")
 tick_time = reactor_metrics.register_distribution("tick_time")

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 all_metrics = []
+all_collectors = []
 
 
 class Metrics(object):
@@ -45,6 +46,9 @@ class Metrics(object):
 
     def __init__(self, name):
         self.name_prefix = name
+
+    def register_collector(self, func):
+        all_collectors.append(func)
 
     def _register(self, metric_class, name, *args, **kwargs):
         full_name = "%s_%s" % (self.name_prefix, name)
@@ -94,8 +98,8 @@ def get_metrics_for(pkg_name):
 def render_all():
     strs = []
 
-    # TODO(paul): Internal hack
-    update_resource_metrics()
+    for collector in all_collectors:
+        collector()
 
     for metric in all_metrics:
         try:
@@ -187,6 +191,8 @@ def _process_fds():
 # Legacy synapse-invented metric names
 
 resource_metrics = get_metrics_for("process.resource")
+
+resource_metrics.register_collector(update_resource_metrics)
 
 # msecs
 resource_metrics.register_callback("utime", lambda: rusage.ru_utime * 1000)

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -113,6 +113,7 @@ def render_all():
 # process resource usage
 
 TICKS_PER_SEC = 100
+BYTES_PER_PAGE = 4096
 
 rusage = None
 stats = None
@@ -186,6 +187,13 @@ process_metrics.register_callback(
 )
 process_metrics.register_callback(
     "cpu_seconds_total", lambda: (float(stats[11]) + float(stats[12])) / TICKS_PER_SEC
+)
+
+process_metrics.register_callback(
+    "virtual_memory_bytes", lambda: int(stats[20])
+)
+process_metrics.register_callback(
+    "resident_memory_bytes", lambda: int(stats[21]) * BYTES_PER_PAGE
 )
 
 reactor_metrics = get_metrics_for("reactor")

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -118,6 +118,7 @@ BYTES_PER_PAGE = 4096
 HAVE_PROC_STAT = os.path.exists("/proc/stat")
 HAVE_PROC_SELF_STAT = os.path.exists("/proc/self/stat")
 HAVE_PROC_SELF_LIMITS = os.path.exists("/proc/self/limits")
+HAVE_PROC_SELF_FDS = os.path.exists("/proc/self/fds")
 
 rusage = None
 stats = None
@@ -162,7 +163,7 @@ def _process_fds():
     counts[("other",)] = 0
 
     # Not every OS will have a /proc/self/fd directory
-    if not os.path.exists("/proc/self/fd"):
+    if not HAVE_PROC_SELF_FDS:
         return counts
 
     for fd in os.listdir("/proc/self/fd"):
@@ -217,11 +218,12 @@ if HAVE_PROC_SELF_STAT:
     )
 
     process_metrics.register_callback(
-        "open_fds", lambda: sum(fd_counts.values())
+        "start_time_seconds", lambda: boot_time + int(stats[19]) / TICKS_PER_SEC
     )
 
+if HAVE_PROC_SELF_FDS:
     process_metrics.register_callback(
-        "start_time_seconds", lambda: boot_time + int(stats[19]) / TICKS_PER_SEC
+        "open_fds", lambda: sum(fd_counts.values())
     )
 
 if HAVE_PROC_SELF_LIMITS:

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -205,6 +205,19 @@ process_metrics.register_callback(
     "open_fds", lambda: sum(fd_counts.values())
 )
 
+def _get_max_fds():
+    with open("/proc/self/limits") as limits:
+        for line in limits:
+            if not line.startswith("Max open files "):
+                continue
+            # Line is  Max open files  $SOFT  $HARD
+            return int(line.split()[3])
+    return None
+
+process_metrics.register_callback(
+    "max_fds", lambda: _get_max_fds()
+)
+
 reactor_metrics = get_metrics_for("reactor")
 tick_time = reactor_metrics.register_distribution("tick_time")
 pending_calls_metric = reactor_metrics.register_distribution("pending_calls")

--- a/synapse/metrics/metric.py
+++ b/synapse/metrics/metric.py
@@ -98,9 +98,9 @@ class CallbackMetric(BaseMetric):
         value = self.callback()
 
         if self.is_scalar():
-            return ["%s %d" % (self.name, value)]
+            return ["%s %.12g" % (self.name, value)]
 
-        return ["%s%s %d" % (self.name, self._render_key(k), value[k])
+        return ["%s%s %.12g" % (self.name, self._render_key(k), value[k])
                 for k in sorted(value.keys())]
 
 

--- a/synapse/metrics/process_collector.py
+++ b/synapse/metrics/process_collector.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015, 2016 OpenMarket Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Because otherwise 'resource' collides with synapse.metrics.resource
+from __future__ import absolute_import
+
+import os
+import stat
+from resource import getrusage, RUSAGE_SELF
+
+from synapse.metrics import get_metrics_for
+
+
+TICKS_PER_SEC = 100
+BYTES_PER_PAGE = 4096
+
+HAVE_PROC_STAT = os.path.exists("/proc/stat")
+HAVE_PROC_SELF_STAT = os.path.exists("/proc/self/stat")
+HAVE_PROC_SELF_LIMITS = os.path.exists("/proc/self/limits")
+HAVE_PROC_SELF_FD = os.path.exists("/proc/self/fd")
+
+TYPES = {
+    stat.S_IFSOCK: "SOCK",
+    stat.S_IFLNK: "LNK",
+    stat.S_IFREG: "REG",
+    stat.S_IFBLK: "BLK",
+    stat.S_IFDIR: "DIR",
+    stat.S_IFCHR: "CHR",
+    stat.S_IFIFO: "FIFO",
+}
+
+
+rusage = None
+stats = None
+fd_counts = None
+
+# In order to report process_start_time_seconds we need to know the
+# machine's boot time, because the value in /proc/self/stat is relative to
+# this
+boot_time = None
+if HAVE_PROC_STAT:
+    with open("/proc/stat") as _procstat:
+        for line in _procstat:
+            if line.startswith("btime "):
+                boot_time = int(line.split()[1])
+
+
+def update_resource_metrics():
+    global rusage
+    rusage = getrusage(RUSAGE_SELF)
+
+    if HAVE_PROC_SELF_STAT:
+        global stats
+        with open("/proc/self/stat") as s:
+            line = s.read()
+            # line is PID (command) more stats go here ...
+            stats = line.split(") ", 1)[1].split(" ")
+
+    global fd_counts
+    fd_counts = _process_fds()
+
+
+def _process_fds():
+    counts = {(k,): 0 for k in TYPES.values()}
+    counts[("other",)] = 0
+
+    # Not every OS will have a /proc/self/fd directory
+    if not HAVE_PROC_SELF_FD:
+        return counts
+
+    for fd in os.listdir("/proc/self/fd"):
+        try:
+            s = os.stat("/proc/self/fd/%s" % (fd))
+            fmt = stat.S_IFMT(s.st_mode)
+            if fmt in TYPES:
+                t = TYPES[fmt]
+            else:
+                t = "other"
+
+            counts[(t,)] += 1
+        except OSError:
+            # the dirh itself used by listdir() is usually missing by now
+            pass
+
+    return counts
+
+
+def register_process_collector():
+    # Legacy synapse-invented metric names
+
+    resource_metrics = get_metrics_for("process.resource")
+
+    resource_metrics.register_collector(update_resource_metrics)
+
+    # msecs
+    resource_metrics.register_callback("utime", lambda: rusage.ru_utime * 1000)
+    resource_metrics.register_callback("stime", lambda: rusage.ru_stime * 1000)
+
+    # kilobytes
+    resource_metrics.register_callback("maxrss", lambda: rusage.ru_maxrss * 1024)
+
+    get_metrics_for("process").register_callback("fds", _process_fds, labels=["type"])
+
+    # New prometheus-standard metric names
+
+    process_metrics = get_metrics_for("process")
+
+    if HAVE_PROC_SELF_STAT:
+        process_metrics.register_callback(
+            "cpu_user_seconds_total", lambda: float(stats[11]) / TICKS_PER_SEC
+        )
+        process_metrics.register_callback(
+            "cpu_system_seconds_total", lambda: float(stats[12]) / TICKS_PER_SEC
+        )
+        process_metrics.register_callback(
+            "cpu_seconds_total", lambda: (float(stats[11]) + float(stats[12])) / TICKS_PER_SEC
+        )
+
+        process_metrics.register_callback(
+            "virtual_memory_bytes", lambda: int(stats[20])
+        )
+        process_metrics.register_callback(
+            "resident_memory_bytes", lambda: int(stats[21]) * BYTES_PER_PAGE
+        )
+
+        process_metrics.register_callback(
+            "start_time_seconds", lambda: boot_time + int(stats[19]) / TICKS_PER_SEC
+        )
+
+    if HAVE_PROC_SELF_FD:
+        process_metrics.register_callback(
+            "open_fds", lambda: sum(fd_counts.values())
+        )
+
+    if HAVE_PROC_SELF_LIMITS:
+        def _get_max_fds():
+            with open("/proc/self/limits") as limits:
+                for line in limits:
+                    if not line.startswith("Max open files "):
+                        continue
+                    # Line is  Max open files  $SOFT  $HARD
+                    return int(line.split()[3])
+            return None
+
+        process_metrics.register_callback(
+            "max_fds", lambda: _get_max_fds()
+        )

--- a/synapse/metrics/process_collector.py
+++ b/synapse/metrics/process_collector.py
@@ -139,7 +139,7 @@ def register_process_collector():
             "cpu_system_seconds_total", lambda: float(stats["stime"]) / TICKS_PER_SEC
         )
         process_metrics.register_callback(
-            "cpu_seconds_total", lambda: (float(stats["utime"]) + float(stats["stime"])) / TICKS_PER_SEC
+            "cpu_seconds_total", lambda: (float(stats["utime"] + stats["stime"])) / TICKS_PER_SEC
         )
 
         process_metrics.register_callback(

--- a/synapse/metrics/process_collector.py
+++ b/synapse/metrics/process_collector.py
@@ -133,29 +133,36 @@ def register_process_collector():
 
     if HAVE_PROC_SELF_STAT:
         process_metrics.register_callback(
-            "cpu_user_seconds_total", lambda: float(stats["utime"]) / TICKS_PER_SEC
+            "cpu_user_seconds_total",
+            lambda: float(stats["utime"]) / TICKS_PER_SEC
         )
         process_metrics.register_callback(
-            "cpu_system_seconds_total", lambda: float(stats["stime"]) / TICKS_PER_SEC
+            "cpu_system_seconds_total",
+            lambda: float(stats["stime"]) / TICKS_PER_SEC
         )
         process_metrics.register_callback(
-            "cpu_seconds_total", lambda: (float(stats["utime"] + stats["stime"])) / TICKS_PER_SEC
-        )
-
-        process_metrics.register_callback(
-            "virtual_memory_bytes", lambda: int(stats["vsize"])
-        )
-        process_metrics.register_callback(
-            "resident_memory_bytes", lambda: int(stats["rss"]) * BYTES_PER_PAGE
+            "cpu_seconds_total",
+            lambda: (float(stats["utime"] + stats["stime"])) / TICKS_PER_SEC
         )
 
         process_metrics.register_callback(
-            "start_time_seconds", lambda: boot_time + int(stats["starttime"]) / TICKS_PER_SEC
+            "virtual_memory_bytes",
+            lambda: int(stats["vsize"])
+        )
+        process_metrics.register_callback(
+            "resident_memory_bytes",
+            lambda: int(stats["rss"]) * BYTES_PER_PAGE
+        )
+
+        process_metrics.register_callback(
+            "start_time_seconds",
+            lambda: boot_time + int(stats["starttime"]) / TICKS_PER_SEC
         )
 
     if HAVE_PROC_SELF_FD:
         process_metrics.register_callback(
-            "open_fds", lambda: sum(fd_counts.values())
+            "open_fds",
+            lambda: sum(fd_counts.values())
         )
 
     if HAVE_PROC_SELF_LIMITS:
@@ -169,5 +176,6 @@ def register_process_collector():
             return None
 
         process_metrics.register_callback(
-            "max_fds", lambda: _get_max_fds()
+            "max_fds",
+            lambda: _get_max_fds()
         )


### PR DESCRIPTION
When I originally wrote the process-wide metric collection, I wasn't aware that there are standard names and semantics for the set of metrics you're supposed to export. Namely:
  https://prometheus.io/docs/instrumenting/writing_clientlibs/#standard-and-runtime-collectors

This PR attempts to address this by:
 * Providing currently-duplicate exporting of process-wide stats that already existed, now to standard names and units (`process_cpu_*_seconds_total`, `process_open_fds`)
 * Adding new standard process-wide metrics that didn't used to exist (`process_*_memory_bytes`, `process_start_time_seconds`, `process_max_fds`)

The intention is that once there's about a week of data in the new format logged by prometheus, I'll update grafana graphs to use those standard metric names instead, then make another commit to remove the "old" variable names.