### PR TITLE
Bugfix for process-wide metric export on split processes

### DIFF
--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -338,7 +338,7 @@ def setup(config_options):
         hs.get_replication_layer().start_get_pdu_cache()
 
         register_memory_metrics(hs)
-        register_process_collector()
+        register_process_collector(get_metrics_for("process"))
 
     reactor.callWhenRunning(start)
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -52,7 +52,6 @@ from synapse.config.homeserver import HomeServerConfig
 from synapse.crypto import context_factory
 from synapse.util.logcontext import LoggingContext
 from synapse.metrics import register_memory_metrics, get_metrics_for
-from synapse.metrics.process_collector import register_process_collector
 from synapse.metrics.resource import MetricsResource, METRICS_PREFIX
 from synapse.replication.resource import ReplicationResource, REPLICATION_PREFIX
 from synapse.federation.transport.server import TransportLayerServer
@@ -338,7 +337,6 @@ def setup(config_options):
         hs.get_replication_layer().start_get_pdu_cache()
 
         register_memory_metrics(hs)
-        register_process_collector(get_metrics_for("process"))
 
     reactor.callWhenRunning(start)
 

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -41,6 +41,9 @@ class Metrics(object):
     def __init__(self, name):
         self.name_prefix = name
 
+    def make_subspace(self, name):
+        return Metrics("%s_%s" % (self.name_prefix, name))
+
     def register_collector(self, func):
         all_collectors.append(func)
 

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -24,6 +24,7 @@ from .metric import (
     CounterMetric, CallbackMetric, DistributionMetric, CacheMetric,
     MemoryUsageMetric,
 )
+from .process_collector import register_process_collector
 
 
 logger = logging.getLogger(__name__)
@@ -120,6 +121,8 @@ gc_unreachable = reactor_metrics.register_counter("gc_unreachable", labels=["gen
 reactor_metrics.register_callback(
     "gc_counts", lambda: {(i,): v for i, v in enumerate(gc.get_count())}, labels=["gen"]
 )
+
+register_process_collector(get_metrics_for("process"))
 
 
 def runUntilCurrentTimer(func):

--- a/synapse/metrics/process_collector.py
+++ b/synapse/metrics/process_collector.py
@@ -20,8 +20,6 @@ import os
 import stat
 from resource import getrusage, RUSAGE_SELF
 
-from synapse.metrics import get_metrics_for
-
 
 TICKS_PER_SEC = 100
 BYTES_PER_PAGE = 4096
@@ -111,10 +109,10 @@ def _process_fds():
     return counts
 
 
-def register_process_collector():
+def register_process_collector(process_metrics):
     # Legacy synapse-invented metric names
 
-    resource_metrics = get_metrics_for("process.resource")
+    resource_metrics = process_metrics.make_subspace("resource")
 
     resource_metrics.register_collector(update_resource_metrics)
 
@@ -125,11 +123,9 @@ def register_process_collector():
     # kilobytes
     resource_metrics.register_callback("maxrss", lambda: rusage.ru_maxrss * 1024)
 
-    get_metrics_for("process").register_callback("fds", _process_fds, labels=["type"])
+    process_metrics.register_callback("fds", _process_fds, labels=["type"])
 
     # New prometheus-standard metric names
-
-    process_metrics = get_metrics_for("process")
 
     if HAVE_PROC_SELF_STAT:
         process_metrics.register_callback(


### PR DESCRIPTION
The previous PR on the subject of metrics moved the code responsible for registering process-wide metrics out of `synapse/metrics/__init__.py` into `synapse/app/homeserver.py`, in order to avoid an awkward cyclic dependency on its split-up implementation. This had the unintended consequence that now, only the toplevel "synapse" split-worker process exports these metrics; the other workers currently do not.

This PR restores the previous behaviour (that all such split-process workers export metrics), by returning the registration code back to `__init__.py` by passing an object in, to avoid the cyclic dependency which would otherwise result.