### PR TITLE
More updates to Promethese metrics exposition

### DIFF
--- a/docs/metrics-howto.rst
+++ b/docs/metrics-howto.rst
@@ -51,9 +51,9 @@ python_gc_counts            reactor_gc_counts
 
 The twisted-specific reactor metrics have been renamed.
 
-==================================== =================
+==================================== =====================
 New name                             Old name
------------------------------------- -----------------
-python_twisted_reactor_pending_calls reactor_tick_time
+------------------------------------ ---------------------
+python_twisted_reactor_pending_calls reactor_pending_calls
 python_twisted_reactor_tick_time     reactor_tick_time
-==================================== =================
+==================================== =====================

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -111,18 +111,20 @@ def render_all():
     return "\n".join(strs)
 
 
-reactor_metrics = get_metrics_for("reactor")
-tick_time = reactor_metrics.register_distribution("tick_time")
-pending_calls_metric = reactor_metrics.register_distribution("pending_calls")
+register_process_collector(get_metrics_for("process"))
 
-gc_time = reactor_metrics.register_distribution("gc_time", labels=["gen"])
-gc_unreachable = reactor_metrics.register_counter("gc_unreachable", labels=["gen"])
 
-reactor_metrics.register_callback(
+python_metrics = get_metrics_for("python")
+
+gc_time = python_metrics.register_distribution("gc_time", labels=["gen"])
+gc_unreachable = python_metrics.register_counter("gc_unreachable_total", labels=["gen"])
+python_metrics.register_callback(
     "gc_counts", lambda: {(i,): v for i, v in enumerate(gc.get_count())}, labels=["gen"]
 )
 
-register_process_collector(get_metrics_for("process"))
+reactor_metrics = get_metrics_for("python.twisted.reactor")
+tick_time = reactor_metrics.register_distribution("tick_time")
+pending_calls_metric = reactor_metrics.register_distribution("pending_calls")
 
 
 def runUntilCurrentTimer(func):

--- a/synapse/metrics/process_collector.py
+++ b/synapse/metrics/process_collector.py
@@ -110,22 +110,7 @@ def _process_fds():
 
 
 def register_process_collector(process_metrics):
-    # Legacy synapse-invented metric names
-
-    resource_metrics = process_metrics.make_subspace("resource")
-
-    resource_metrics.register_collector(update_resource_metrics)
-
-    # msecs
-    resource_metrics.register_callback("utime", lambda: rusage.ru_utime * 1000)
-    resource_metrics.register_callback("stime", lambda: rusage.ru_stime * 1000)
-
-    # kilobytes
-    resource_metrics.register_callback("maxrss", lambda: rusage.ru_maxrss * 1024)
-
-    process_metrics.register_callback("fds", _process_fds, labels=["type"])
-
-    # New prometheus-standard metric names
+    process_metrics.register_collector(update_resource_metrics)
 
     if HAVE_PROC_SELF_STAT:
         process_metrics.register_callback(

--- a/synapse/metrics/process_collector.py
+++ b/synapse/metrics/process_collector.py
@@ -13,12 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Because otherwise 'resource' collides with synapse.metrics.resource
-from __future__ import absolute_import
-
 import os
 import stat
-from resource import getrusage, RUSAGE_SELF
 
 
 TICKS_PER_SEC = 100
@@ -49,7 +45,6 @@ STAT_FIELDS = {
 }
 
 
-rusage = None
 stats = {}
 fd_counts = None
 
@@ -65,9 +60,6 @@ if HAVE_PROC_STAT:
 
 
 def update_resource_metrics():
-    global rusage
-    rusage = getrusage(RUSAGE_SELF)
-
     if HAVE_PROC_SELF_STAT:
         global stats
         with open("/proc/self/stat") as s:


### PR DESCRIPTION
 * Delete old process-wide metrics and code supporting them
 * Rename the python and twisted-specific ones
 * Fix copypaste error in the docs