### PR TITLE
Fix LDAP search bind behavior

### DIFF
--- a/synapse/util/ldap_auth_provider.py
+++ b/synapse/util/ldap_auth_provider.py
@@ -219,9 +219,8 @@ class LdapAuthProvider(object):
 
         return ldap_config
 
-    def _ldap_simple_bind(self, server, localpart, password):
-        """ Attempt a simple bind with the credentials
-            given by the user against the LDAP server.
+    def _ldap_internal_bind(self, server, bind_dn, password):
+        """ Attempt a simple bind with the given dn against the LDAP server.
 
             Returns True, LDAP3Connection
                 if the bind was successful
@@ -230,18 +229,11 @@ class LdapAuthProvider(object):
         """
 
         try:
-            # bind with the the local users ldap credentials
-            bind_dn = "{prop}={value},{base}".format(
-                prop=self.ldap_attributes['uid'],
-                value=localpart,
-                base=self.ldap_base
-            )
             conn = ldap3.Connection(server, bind_dn, password)
             logger.debug(
                 "Established LDAP connection in simple bind mode: %s",
                 conn
             )
-
             if self.ldap_start_tls:
                 conn.start_tls()
                 logger.debug(
@@ -265,6 +257,25 @@ class LdapAuthProvider(object):
         except ldap3.core.exceptions.LDAPException as e:
             logger.warn("Error during LDAP authentication: %s", e)
             return False, None
+
+    def _ldap_simple_bind(self, server, localpart, password):
+        """ Attempt a simple bind with the credentials
+            given by the user against the LDAP server.
+
+            Returns True, LDAP3Connection
+                if the bind was successful
+            Returns False, None
+                if an error occured
+        """
+
+        # bind with the the local users ldap credentials
+        bind_dn = "{prop}={value},{base}".format(
+            prop=self.ldap_attributes['uid'],
+            value=localpart,
+            base=self.ldap_base
+        )
+
+        return self._ldap_internal_bind(server, bind_dn, password)
 
     def _ldap_authenticated_search(self, server, localpart, password):
         """ Attempt to login with the preconfigured bind_dn
@@ -337,7 +348,7 @@ class LdapAuthProvider(object):
                 # Note: do not use rebind(), for some reason it did not verify
                 #       the password for me!
                 conn.unbind()
-                return self._ldap_simple_bind(server, localpart, password)
+                return self._ldap_internal_bind(server, user_dn, password)
             else:
                 # BAD: found 0 or > 1 results, abort!
                 if len(conn.response) == 0:

--- a/synapse/util/ldap_auth_provider.py
+++ b/synapse/util/ldap_auth_provider.py
@@ -219,7 +219,7 @@ class LdapAuthProvider(object):
 
         return ldap_config
 
-    def _ldap_internal_bind(self, server, bind_dn, password):
+    def _ldap_bind(self, server, bind_dn, password):
         """ Attempt a simple bind with the given dn against the LDAP server.
 
             Returns True, LDAP3Connection
@@ -274,7 +274,7 @@ class LdapAuthProvider(object):
             base=self.ldap_base
         )
 
-        return self._ldap_internal_bind(server, bind_dn, password)
+        return self._ldap_bind(server, bind_dn, password)
 
     def _ldap_authenticated_search(self, server, localpart, password):
         """ Attempt to login with the preconfigured bind_dn
@@ -295,7 +295,7 @@ class LdapAuthProvider(object):
         try:
             logger.info("Search bind against LDAP for '%s'.", localpart)
 
-            success, conn = self._ldap_internal_bind(
+            success, conn = self._ldap_bind(
                 server,
                 self.ldap_bind_dn,
                 self.ldap_bind_password
@@ -336,7 +336,7 @@ class LdapAuthProvider(object):
                 # Note: do not use rebind(), for some reason it did not verify
                 #       the password for me!
                 conn.unbind()
-                return self._ldap_internal_bind(server, user_dn, password)
+                return self._ldap_bind(server, user_dn, password)
             else:
                 # BAD: found 0 or > 1 results, abort!
                 if len(conn.response) == 0:

--- a/synapse/util/ldap_auth_provider.py
+++ b/synapse/util/ldap_auth_provider.py
@@ -245,7 +245,7 @@ class LdapAuthProvider(object):
 
             # BAD: bind failed
             logger.info(
-                "Binding against LDAP failed for '%s' failed: %s",
+                "Binding against LDAP for '%s' failed: %s",
                 bind_dn, conn.result['description']
             )
             conn.unbind()


### PR DESCRIPTION
My directory has an uid entry for users, that should be used for finding a proper DN for doing the actual bind in search mode, ie. the search returns something like 'cn=John Doe,ou=users,dc=example' for uid 'jdoe'. The old code did a simple bind with 'uid=jdoe,ou=users,dc=example' which didn't work. Now the returned DN is used for the simple bind.