### PR TITLE
default config: blacklist more internal ips

### DIFF
--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -167,6 +167,8 @@ class ContentRepositoryConfig(Config):
         # - '10.0.0.0/8'
         # - '172.16.0.0/12'
         # - '192.168.0.0/16'
+        # - '100.64.0.0/10'
+        # - '169.254.0.0/16'
         #
         # List of IP address CIDR ranges that the URL preview spider is allowed
         # to access even if they are specified in url_preview_ip_range_blacklist.


### PR DESCRIPTION
The server making requests to 169.254.169.254 is particularly scary because quite sensitive information can be stored there (e.g. the ec2 metadata service)

That being said, since none of those pages have a title, are html, or are media, the chance of it leading to any active information leak is pretty low, so I don't feel this is an actual vulnerability, just a more complete default setting.
For completeness I included another private ip range too that was missing