### PR TITLE
matrixfederationclient: Fix Content-Type parsing

### DIFF
--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -294,7 +294,7 @@ class MatrixFederationHttpClient(object):
             # We need to update the transactions table to say it was sent?
             c_type = response.headers.getRawHeaders("Content-Type")
 
-            if "application/json" not in c_type:
+            if c_type and "application/json" not in c_type.pop():
                 raise RuntimeError(
                     "Content-Type not application/json"
                 )
@@ -344,7 +344,7 @@ class MatrixFederationHttpClient(object):
             # We need to update the transactions table to say it was sent?
             c_type = response.headers.getRawHeaders("Content-Type")
 
-            if "application/json" not in c_type:
+            if c_type and "application/json" not in c_type.pop():
                 raise RuntimeError(
                     "Content-Type not application/json"
                 )
@@ -402,7 +402,7 @@ class MatrixFederationHttpClient(object):
             # We need to update the transactions table to say it was sent?
             c_type = response.headers.getRawHeaders("Content-Type")
 
-            if "application/json" not in c_type:
+            if c_type and "application/json" not in c_type.pop():
                 raise RuntimeError(
                     "Content-Type not application/json"
                 )


### PR DESCRIPTION
Content-Types do not have to consist of the literal string, they can
also specify the charset.