### PR TITLE
Logging: Fix console filter breaking when level is DEBUG

### DIFF
--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -50,6 +50,7 @@ handlers:
   console:
     class: logging.StreamHandler
     formatter: precise
+    filters: [context]
 
 loggers:
     synapse:


### PR DESCRIPTION
Specifically the default Template does not add a `filters: [context]` to the console handler which causes the `_fmt % record.__dict__` to produce a KeyError. On a side-note, why is the alternate path PythonCode (it produces no-logging as far as I can see) vs. simply `logging.config.dictConfig(yaml.load(DEFAULT_LOG_CONFIG.template))` wouldn't that be preferable anyways? 