### PR TITLE
Fix unittests under tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,15 @@ deps =
     mock
     python-subunit
     junitxml
+
+    # needed by some of the tests
+    lxml
+
 setenv =
     PYTHONDONTWRITEBYTECODE = no_byte_code
+    # As of twisted 16.4, trial tries to import the tests as a package, which
+    # means it needs to be on the pythonpath.
+    PYTHONPATH = {toxinidir}
 commands =
     /bin/sh -c "find {toxinidir} -name '*.pyc' -delete ; coverage run {env:COVERAGE_OPTS:} --source={toxinidir}/synapse \
         {envbindir}/trial {env:TRIAL_FLAGS:} {posargs:tests} {env:TOXSUFFIX:}"


### PR DESCRIPTION
We now need to set PYTHONPATH when running the unit tests; update tox config to
do so.