### PR TITLE
Prevent user tokens being used as guest tokens

### DIFF
--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -690,7 +690,7 @@ class Auth(object):
         """
         try:
             macaroon = pymacaroons.Macaroon.deserialize(token)
-        except Exception: # deserialize can throw more-or-less anything
+        except Exception:  # deserialize can throw more-or-less anything
             # doesn't look like a macaroon: treat it as an opaque token which
             # must be in the database.
             # TODO: it would be nice to get rid of this, but apparently some

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -81,7 +81,7 @@ class RegistrationHandler(BaseHandler):
                     "User ID already taken.",
                     errcode=Codes.USER_IN_USE,
                 )
-            user_data = yield self.auth.get_user_from_macaroon(guest_access_token)
+            user_data = yield self.auth.get_user_by_access_token(guest_access_token)
             if not user_data["is_guest"] or user_data["user"].localpart != localpart:
                 raise AuthError(
                     403,


### PR DESCRIPTION
Make sure that a user cannot pretend to be a guest by adding 'guest = True'
caveats.