### PR TITLE
Fix crash in url preview

### DIFF
--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -381,7 +381,10 @@ def _calc_og(tree, media_uri):
     if 'og:title' not in og:
         # do some basic spidering of the HTML
         title = tree.xpath("(//title)[1] | (//h1)[1] | (//h2)[1] | (//h3)[1]")
-        og['og:title'] = title[0].text.strip() if title else None
+        if title and title[0].text is not None:
+            og['og:title'] = title[0].text.strip()
+        else:
+            og['og:title'] = None
 
     if 'og:image' not in og:
         # TODO: extract a favicon failing all else

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -215,3 +215,53 @@ class PreviewUrlTestCase(unittest.TestCase):
             u"og:title": u"Foo",
             u"og:description": u"Some text."
         })
+
+    def test_missing_title(self):
+        html = u"""
+        <html>
+        <body>
+        Some text.
+        </body>
+        </html>
+        """
+
+        og = decode_and_calc_og(html, "http://example.com/test.html")
+
+        self.assertEquals(og, {
+            u"og:title": None,
+            u"og:description": u"Some text."
+        })
+
+    def test_h1_as_title(self):
+        html = u"""
+        <html>
+        <meta property="og:description" content="Some text."/>
+        <body>
+        <h1>Title</h1>
+        </body>
+        </html>
+        """
+
+        og = decode_and_calc_og(html, "http://example.com/test.html")
+
+        self.assertEquals(og, {
+            u"og:title": u"Title",
+            u"og:description": u"Some text."
+        })
+
+    def test_missing_title_and_broken_h1(self):
+        html = u"""
+        <html>
+        <body>
+        <h1><a href="foo"/></h1>
+        Some text.
+        </body>
+        </html>
+        """
+
+        og = decode_and_calc_og(html, "http://example.com/test.html")
+
+        self.assertEquals(og, {
+            u"og:title": None,
+            u"og:description": u"Some text."
+        })


### PR DESCRIPTION
Hi, it's an attempt to fix traceback I found in synapse logs:

    python[10786]: Traceback (most recent call last):
    python[10786]:   File "/opt/synapse/lib/python2.7/site-packages/synapse/http/server.py", line 118, in wrapped_request_handler
    python[10786]:     yield request_handler(self, request)
    python[10786]:   File "/opt/synapse/lib/python2.7/site-packages/twisted/internet/defer.py", line 1299, in _inlineCallbacks
    python[10786]:     result = g.send(result)
    python[10786]:   File "/opt/synapse/lib/python2.7/site-packages/synapse/rest/media/v1/preview_url_resource.py", line 199, in _async_render_GET
    python[10786]:     og = decode_and_calc_og(body, media_info['uri'], encoding)
    python[10786]:   File "/opt/synapse/lib/python2.7/site-packages/synapse/rest/media/v1/preview_url_resource.py", line 337, in decode_and_calc_og
    python[10786]:     og = _calc_og(tree, media_uri)
    python[10786]:   File "/opt/synapse/lib/python2.7/site-packages/synapse/rest/media/v1/preview_url_resource.py", line 384, in _calc_og
    python[10786]:     og['og:title'] = title[0].text.strip() if (title and title[0]) else None
    python[10786]: AttributeError: 'NoneType' object has no attribute 'strip'

I added `test_missing_title_and_broken_h1` to `test_preview.py` which reproduces this problem.

(Thanks for fantastic piece of software. Besides this minor issue above, Synapse has been very reliable and fast for me)