### PR TITLE
Fix check for bind_address

### DIFF
--- a/synapse/app/appservice.py
+++ b/synapse/app/appservice.py
@@ -87,7 +87,7 @@ class AppserviceServer(HomeServer):
 
         root_resource = create_resource_tree(resources, Resource())
 
-        if bind_address:
+        if bind_address is not None:
             bind_addresses.append(bind_address)
 
         for address in bind_addresses:
@@ -112,7 +112,7 @@ class AppserviceServer(HomeServer):
                 bind_address = listener.get("bind_address", None)
                 bind_addresses = listener.get("bind_addresses", [])
 
-                if bind_address:
+                if bind_address is not None:
                     bind_addresses.append(bind_address)
 
                 for address in bind_addresses:

--- a/synapse/app/client_reader.py
+++ b/synapse/app/client_reader.py
@@ -110,7 +110,7 @@ class ClientReaderServer(HomeServer):
 
         root_resource = create_resource_tree(resources, Resource())
 
-        if bind_address:
+        if bind_address is not None:
             bind_addresses.append(bind_address)
 
         for address in bind_addresses:
@@ -135,7 +135,7 @@ class ClientReaderServer(HomeServer):
                 bind_address = listener.get("bind_address", None)
                 bind_addresses = listener.get("bind_addresses", [])
 
-                if bind_address:
+                if bind_address is not None:
                     bind_addresses.append(bind_address)
 
                 for address in bind_addresses:

--- a/synapse/app/federation_reader.py
+++ b/synapse/app/federation_reader.py
@@ -101,7 +101,7 @@ class FederationReaderServer(HomeServer):
 
         root_resource = create_resource_tree(resources, Resource())
 
-        if bind_address:
+        if bind_address is not None:
             bind_addresses.append(bind_address)
 
         for address in bind_addresses:
@@ -126,7 +126,7 @@ class FederationReaderServer(HomeServer):
                 bind_address = listener.get("bind_address", None)
                 bind_addresses = listener.get("bind_addresses", [])
 
-                if bind_address:
+                if bind_address is not None:
                     bind_addresses.append(bind_address)
 
                 for address in bind_addresses:

--- a/synapse/app/federation_sender.py
+++ b/synapse/app/federation_sender.py
@@ -93,7 +93,7 @@ class FederationSenderServer(HomeServer):
 
         root_resource = create_resource_tree(resources, Resource())
 
-        if bind_address:
+        if bind_address is not None:
             bind_addresses.append(bind_address)
 
         for address in bind_addresses:
@@ -118,7 +118,7 @@ class FederationSenderServer(HomeServer):
                 bind_address = listener.get("bind_address", None)
                 bind_addresses = listener.get("bind_addresses", [])
 
-                if bind_address:
+                if bind_address is not None:
                     bind_addresses.append(bind_address)
 
                 for address in bind_addresses:

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -175,7 +175,7 @@ class SynapseHomeServer(HomeServer):
 
         root_resource = create_resource_tree(resources, root_resource)
 
-        if bind_address:
+        if bind_address is not None:
             bind_addresses.append(bind_address)
 
         if tls:
@@ -215,7 +215,7 @@ class SynapseHomeServer(HomeServer):
                 bind_address = listener.get("bind_address", None)
                 bind_addresses = listener.get("bind_addresses", [])
 
-                if bind_address:
+                if bind_address is not None:
                     bind_addresses.append(bind_address)
 
                 for address in bind_addresses:

--- a/synapse/app/media_repository.py
+++ b/synapse/app/media_repository.py
@@ -107,7 +107,7 @@ class MediaRepositoryServer(HomeServer):
 
         root_resource = create_resource_tree(resources, Resource())
 
-        if bind_address:
+        if bind_address is not None:
             bind_addresses.append(bind_address)
 
         for address in bind_addresses:
@@ -132,7 +132,7 @@ class MediaRepositoryServer(HomeServer):
                 bind_address = listener.get("bind_address", None)
                 bind_addresses = listener.get("bind_addresses", [])
 
-                if bind_address:
+                if bind_address is not None:
                     bind_addresses.append(bind_address)
 
                 for address in bind_addresses:

--- a/synapse/app/pusher.py
+++ b/synapse/app/pusher.py
@@ -132,7 +132,7 @@ class PusherServer(HomeServer):
 
         root_resource = create_resource_tree(resources, Resource())
 
-        if bind_address:
+        if bind_address is not None:
             bind_addresses.append(bind_address)
 
         for address in bind_addresses:
@@ -168,7 +168,7 @@ class PusherServer(HomeServer):
                 bind_address = listener.get("bind_address", None)
                 bind_addresses = listener.get("bind_addresses", [])
 
-                if bind_address:
+                if bind_address is not None:
                     bind_addresses.append(bind_address)
 
                 for address in bind_addresses:

--- a/synapse/app/synchrotron.py
+++ b/synapse/app/synchrotron.py
@@ -312,7 +312,7 @@ class SynchrotronServer(HomeServer):
 
         root_resource = create_resource_tree(resources, Resource())
 
-        if bind_address:
+        if bind_address is not None:
             bind_addresses.append(bind_address)
 
         for address in bind_addresses:
@@ -337,7 +337,7 @@ class SynchrotronServer(HomeServer):
                 bind_address = listener.get("bind_address", None)
                 bind_addresses = listener.get("bind_addresses", [])
 
-                if bind_address:
+                if bind_address is not None:
                     bind_addresses.append(bind_address)
 
                 for address in bind_addresses:


### PR DESCRIPTION
The empty string is a valid setting for the bind_address option, so
explicitly check for None here instead.

This fixes a regression in 7dfd70fc834a14b7003beb220eebae6fead5dbf3