### PR TITLE
Use TLSv1.x rather than SSLv2/3

### DIFF
--- a/scripts/register_new_matrix_user
+++ b/scripts/register_new_matrix_user
@@ -60,7 +60,7 @@ def request_registration(user, password, server_location, shared_secret, admin=F
         if sys.version_info[:3] >= (2, 7, 9):
             # As of version 2.7.9, urllib2 now checks SSL certs
             import ssl
-            f = urllib2.urlopen(req, context=ssl.SSLContext(ssl.PROTOCOL_SSLv23))
+            f = urllib2.urlopen(req, context=ssl.SSLContext(ssl.PROTOCOL_TLSv1))
         else:
             f = urllib2.urlopen(req)
         f.read()


### PR DESCRIPTION
Signed-off-by: Bob Mottram <bob@freedombone.net>