### PR TITLE
JSONSchema Validation For Filters

### DIFF
--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -78,7 +78,7 @@ ROOM_FILTER_SCHEMA = {
         "timeline": {
             "$ref": "#/definitions/room_event_filter"
         },
-        "accpount_data": {
+        "account_data": {
             "$ref": "#/definitions/room_event_filter"
         },
     }
@@ -131,7 +131,7 @@ USER_ID_ARRAY_SCHEMA = {
     "type": "array",
     "items": {
         "type": "string",
-        "pattern": "^[A-Za-z0-9_]+:[A-Za-z0-9_-\.]+$"
+        "pattern": "^@[A-Za-z0-9_]+:[A-Za-z0-9_\-\.]+$"
     }
 }
 
@@ -155,9 +155,10 @@ USER_FILTER_SCHEMA = {
         "room": {
             "$ref": "#/definitions/room_filter"
         },
-        # "event_format": {
-        #     "type": { "enum": [ "client", "federation" ] }
-        # },
+        "event_format": {
+            "type": "string",
+            "enum": ["client", "federation"]
+        },
         "event_fields": {
             "type": "array",
             "items": {

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -19,6 +19,7 @@ from distutils.version import LooseVersion
 logger = logging.getLogger(__name__)
 
 REQUIREMENTS = {
+    "jsonschema>=2.5.1": ["jsonschema>=2.5.1"],
     "frozendict>=0.4": ["frozendict"],
     "unpaddedbase64>=1.1.0": ["unpaddedbase64>=1.1.0"],
     "canonicaljson>=1.0.0": ["canonicaljson>=1.0.0"],

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -35,6 +35,7 @@ def MockEvent(**kwargs):
         kwargs["type"] = "fake_type"
     return FrozenEvent(kwargs)
 
+
 class FilteringTestCase(unittest.TestCase):
 
     @defer.inlineCallbacks
@@ -56,18 +57,61 @@ class FilteringTestCase(unittest.TestCase):
 
     def test_errors_on_invalid_filters(self):
         invalid_filters = [
-            { "boom": {} },
-            { "account_data": "Hello World" },
-            { "event_fields": ["\\foo"] },
-            { "room": { "timeline" : { "limit" : 0 }, "state": { "not_bars": ["*"]} } },
+            {"boom": {}},
+            {"account_data": "Hello World"},
+            {"event_fields": ["\\foo"]},
+            {"room": {"timeline": {"limit": 0}, "state": {"not_bars": ["*"]}}},
+            {"event_format": "other"}
         ]
         for filter in invalid_filters:
             with self.assertRaises(SynapseError) as check_filter_error:
                 self.filtering.check_valid_filter(filter)
                 self.assertIsInstance(check_filter_error.exception, SynapseError)
 
+    def test_valid_filters(self):
+        valid_filters = [
+            {
+                "room": {
+                    "timeline": {"limit": 20},
+                    "state": {"not_types": ["m.room.member"]},
+                    "ephemeral": {"limit": 0, "not_types": ["*"]},
+                    "include_leave": False,
+                    "rooms": ["#dee:pik-test"],
+                    "not_rooms": ["#gee:pik-test"],
+                    "account_data": {"limit": 0, "types": ["*"]}
+                }
+            },
+            {
+                "room": {
+                    "state": {
+                        "types": ["m.room.*"],
+                        "not_rooms": ["!726s6s6q:example.com"]
+                    },
+                    "timeline": {
+                        "limit": 10,
+                        "types": ["m.room.message"],
+                        "not_rooms": ["!726s6s6q:example.com"],
+                        "not_senders": ["@spam:example.com"]
+                    },
+                    "ephemeral": {
+                        "types": ["m.receipt", "m.typing"],
+                        "not_rooms": ["!726s6s6q:example.com"],
+                        "not_senders": ["@spam:example.com"]
+                    }
+                },
+                "presence": {
+                    "types": ["m.presence"],
+                    "not_senders": ["@alice:example.com"]
+                },
+                "event_format": "client",
+                "event_fields": ["type", "content", "sender"]
+            }
+        ]
+        for filter in valid_filters:
+            self.filtering.check_valid_filter(filter)
+
     def test_limits_are_applied(self):
-        #TODO
+        # TODO
         pass
 
     def test_definition_types_works_with_literals(self):

--- a/tests/rest/client/v2_alpha/test_filter.py
+++ b/tests/rest/client/v2_alpha/test_filter.py
@@ -33,8 +33,8 @@ PATH_PREFIX = "/_matrix/client/v2_alpha"
 class FilterTestCase(unittest.TestCase):
 
     USER_ID = "@apple:test"
-    EXAMPLE_FILTER = {"type": ["m.*"]}
-    EXAMPLE_FILTER_JSON = '{"type": ["m.*"]}'
+    EXAMPLE_FILTER = {"room": {"timeline": {"types": ["m.room.message"]}}}
+    EXAMPLE_FILTER_JSON = '{"room": {"timeline": {"types": ["m.room.message"]}}}'
     TO_REGISTER = [filter]
 
     @defer.inlineCallbacks


### PR DESCRIPTION
- Errors are now raised for invalid filter properties
- Easier to test / human-readable (compared to the for-loops from before)
- Adds invalid filter tests 

Also the that the `room_event_filter` schema supplied by the spec does not actually function in all cases e.g. #https://github.com/matrix-org/synapse/issues/1782 - should probably be addressed, adding test cases and either by adding the missing functionality or limiting the schema.