### PR TITLE
Added user level db schema support

### DIFF
--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -244,6 +244,11 @@ class SynapseHomeServer(HomeServer):
 
         if run_new_connection:
             self.database_engine.on_new_connection(db_conn)
+
+        db_schema = self.db_config.get("db_schema", None)
+        db_user = db_params.get("user", None)
+        if db_schema and db_user:
+            self.database_engine.set_user_schema(db_conn, db_schema, db_user)
         return db_conn
 
 

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -68,6 +68,3 @@ class PostgresEngine(object):
         cursor.execute("CREATE SCHEMA IF NOT EXISTS " + db_schema_name)
         cursor.execute("ALTER USER " + db_user + " SET SEARCH_PATH TO " + db_schema_name)
         cursor.close()
-
-
-

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -62,3 +62,12 @@ class PostgresEngine(object):
 
     def lock_table(self, txn, table):
         txn.execute("LOCK TABLE %s in EXCLUSIVE MODE" % (table,))
+
+    def set_user_schema(self, db_conn, db_schema_name, db_user):
+        cursor = db_conn.cursor()
+        cursor.execute("CREATE SCHEMA IF NOT EXISTS " + db_schema_name)
+        cursor.execute("ALTER USER " + db_user + " SET SEARCH_PATH TO " + db_schema_name)
+        cursor.close()
+
+
+

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -65,6 +65,5 @@ class PostgresEngine(object):
 
     def set_user_schema(self, db_conn, db_schema_name, db_user):
         cursor = db_conn.cursor()
-        cursor.execute("CREATE SCHEMA IF NOT EXISTS " + db_schema_name)
         cursor.execute("ALTER USER " + db_user + " SET SEARCH_PATH TO " + db_schema_name)
         cursor.close()

--- a/synapse/storage/engines/sqlite3.py
+++ b/synapse/storage/engines/sqlite3.py
@@ -43,6 +43,9 @@ class Sqlite3Engine(object):
     def lock_table(self, txn, table):
         return
 
+    def set_user_schema(self, db_conn, db_schema_name, db_user):
+        pass
+
 
 # Following functions taken from: https://github.com/coleifer/peewee
 


### PR DESCRIPTION
Production postgres databases often requires more than one working db schema. I've added quick solution for setting user level default schema (i.e. for synapse we have to have separate db user)