### PR TITLE
Don't clobber a displayname or avatar_url if provided by an m.room.member event

### DIFF
--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -208,8 +208,10 @@ class MessageHandler(BaseHandler):
                     content = builder.content
 
                     try:
-                        content["displayname"] = yield profile.get_displayname(target)
-                        content["avatar_url"] = yield profile.get_avatar_url(target)
+                        if "displayname" not in content:
+                            content["displayname"] = yield profile.get_displayname(target)
+                        if "avatar_url" not in content:
+                            content["avatar_url"] = yield profile.get_avatar_url(target)
                     except Exception as e:
                         logger.info(
                             "Failed to get profile information for %r: %s",


### PR DESCRIPTION
This fixes #1382 

This functionallity is required by the `matrix-appservice-tg` Telegram portal, to provide displaynames on a per-room basis in a way that doesn't leak them as public information.

This is tested by https://github.com/matrix-org/sytest/pull/337