### PR TITLE
Use signedjson.sign instead of syutil.crypto.jsonsign

### DIFF
--- a/contrib/cmdclient/console.py
+++ b/contrib/cmdclient/console.py
@@ -32,7 +32,7 @@ import urlparse
 import nacl.signing
 import nacl.encoding
 
-from syutil.crypto.jsonsign import verify_signed_json, SignatureVerifyException
+from signedjson.sign import verify_signed_json, SignatureVerifyException
 
 CONFIG_JSON = "cmdclient_config.json"
 


### PR DESCRIPTION
Functions from syutil.crypto.jsonsign are now available in
signedjson, so use that instead of depending on syutil.