### PR TITLE
http txns: Do not cache error responses

### DIFF
--- a/synapse/rest/client/transactions.py
+++ b/synapse/rest/client/transactions.py
@@ -97,7 +97,7 @@ class HttpTransactionCache(object):
         # from the transaction map. This is done to ensure that we don't
         # cache transient errors like rate-limiting errors, etc.
         def remove_from_map(err):
-            del self.transactions[txn_key]
+            self.transactions.pop(txn_key, None)
             return err
         observable.addErrback(remove_from_map)
         return observable.observe()

--- a/synapse/rest/client/transactions.py
+++ b/synapse/rest/client/transactions.py
@@ -87,19 +87,19 @@ class HttpTransactionCache(object):
 
         deferred = fn(*args, **kwargs)
 
-        # We don't add an errback to the raw deferred, so we ask ObservableDeferred
-        # to swallow the error. This is fine as the error will still be reported
-        # to the observers.
-        observable = ObservableDeferred(deferred, consumeErrors=True)
-        self.transactions[txn_key] = (observable, self.clock.time_msec())
-
         # if the request fails with a Twisted failure, remove it
         # from the transaction map. This is done to ensure that we don't
         # cache transient errors like rate-limiting errors, etc.
         def remove_from_map(err):
             self.transactions.pop(txn_key, None)
             return err
-        observable.addErrback(remove_from_map)
+        deferred.addErrback(remove_from_map)
+
+        # We don't add any other errbacks to the raw deferred, so we ask
+        # ObservableDeferred to swallow the error. This is fine as the error will
+        # still be reported to the observers.
+        observable = ObservableDeferred(deferred, consumeErrors=True)
+        self.transactions[txn_key] = (observable, self.clock.time_msec())
         return observable.observe()
 
     def _cleanup(self):


### PR DESCRIPTION
Previously we did. This meant that, amongst other errors, rate-limiting errors
would be cached and prevent messages with that txn ID being sent.