### PR TITLE
Remove some DNS lookups to support IPv6

### DIFF
--- a/synapse/http/endpoint.py
+++ b/synapse/http/endpoint.py
@@ -280,26 +280,14 @@ def resolve_service(service_name, dns_client=client, cache=SERVER_CACHE, clock=t
                 continue
 
             payload = answer.payload
-            host = str(payload.target)
-            srv_ttl = answer.ttl
 
-            try:
-                answers, _, _ = yield dns_client.lookupAddress(host)
-            except DNSNameError:
-                continue
-
-            for answer in answers:
-                if answer.type == dns.A and answer.payload:
-                    ip = answer.payload.dottedQuad()
-                    host_ttl = min(srv_ttl, answer.ttl)
-
-                    servers.append(_Server(
-                        host=ip,
-                        port=int(payload.port),
-                        priority=int(payload.priority),
-                        weight=int(payload.weight),
-                        expires=int(clock.time()) + host_ttl,
-                    ))
+            servers.append(_Server(
+                host=str(payload.target),
+                port=int(payload.port),
+                priority=int(payload.priority),
+                weight=int(payload.weight),
+                expires=int(clock.time()) + answer.ttl,
+            ))
 
         servers.sort()
         cache[service_name] = list(servers)

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -32,7 +32,6 @@ class DnsTestCase(unittest.TestCase):
 
         service_name = "test_service.examle.com"
         host_name = "example.com"
-        ip_address = "127.0.0.1"
 
         answer_srv = dns.RRHeader(
             type=dns.SRV,
@@ -41,15 +40,7 @@ class DnsTestCase(unittest.TestCase):
             )
         )
 
-        answer_a = dns.RRHeader(
-            type=dns.A,
-            payload=dns.Record_A(
-                address=ip_address,
-            )
-        )
-
         dns_client_mock.lookupService.return_value = ([answer_srv], None, None)
-        dns_client_mock.lookupAddress.return_value = ([answer_a], None, None)
 
         cache = {}
 
@@ -58,11 +49,10 @@ class DnsTestCase(unittest.TestCase):
         )
 
         dns_client_mock.lookupService.assert_called_once_with(service_name)
-        dns_client_mock.lookupAddress.assert_called_once_with(host_name)
 
         self.assertEquals(len(servers), 1)
         self.assertEquals(servers, cache[service_name])
-        self.assertEquals(servers[0].host, ip_address)
+        self.assertEquals(servers[0].host, host_name)
 
     @defer.inlineCallbacks
     def test_from_cache_expired_and_dns_fail(self):


### PR DESCRIPTION
The current implementation only does a lookup for an A record. This is troublesome for IPv6-enabled or IPv6-only servers. Removing the lookup lets Twisted do the resolving.

Note that the alternative (doing both A and AAAA lookups) is troublesome as this will break servers having only IPv4 or IPv6 connectivity unless the server's connectivity is also checked.