### PR TITLE
hide state redaction events from clients as an emergency temporary measure

### DIFF
--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -94,7 +94,7 @@ class BulkPushRuleEvaluator:
                 if event.type == EventTypes.Member and event.state_key == uid:
                     display_name = event.content.get("displayname", None)
 
-            filtered = filtered_by_user[uid]
+            filtered = filtered_by_user.get(uid, [])
             if len(filtered) == 0:
                 continue
 

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -90,13 +90,6 @@ def filter_events_for_clients(store, user_tuples, events, event_id_to_state):
         if not event.is_state() and event.sender in ignore_list:
             return False
 
-        # As a very temporary measure, don't relay redaction messages to clients
-        # as it causes a thundering herd.  FIXME: this should be removed once
-        # room initialSync is optimised enough to make the herd not a problem.
-        # https://github.com/vector-im/riot-android/issues/928
-        if event.is_state() and event.type == EventTypes.Redaction:
-            return False
-
         state = event_id_to_state[event.event_id]
 
         # get the room_visibility at the time of the event.
@@ -177,14 +170,37 @@ def filter_events_for_clients(store, user_tuples, events, event_id_to_state):
             # we don't know when they left.
             return not is_peeking
 
-    defer.returnValue({
-        user_id: [
-            event
-            for event in events
-            if allowed(event, user_id, is_peeking, ignore_dict.get(user_id, []))
-        ]
-        for user_id, is_peeking in user_tuples
-    })
+    @defer.inlineCallbacks
+    def is_state_redaction(event):
+        # As a very temporary measure, don't relay state redaction events to clients
+        # as it causes a thundering herd.  FIXME: this should be removed once
+        # room initialSync is optimised enough to make the herd not a problem.
+        # https://github.com/vector-im/riot-android/issues/928
+        if event.type == EventTypes.Redaction:
+            original_event = yield store.get_event(
+                event.redacts,
+                check_redacted=False,
+                get_prev_content=False,
+                allow_rejected=False,
+                allow_none=False
+            )
+            if original_event and original_event.is_state():
+                defer.returnValue(True)
+            else:
+                defer.returnValue(False)
+        else:
+            defer.returnValue(False)
+
+    res = {}
+    for user_id, is_peeking in user_tuples:
+        for event in events:
+            if (
+                allowed(event, user_id, is_peeking, ignore_dict.get(user_id, []))
+                and not (yield is_state_redaction(event))
+            ):
+                res.setdefault(user_id, []).append(event)
+
+    defer.returnValue(res)
 
 
 @defer.inlineCallbacks

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -90,6 +90,13 @@ def filter_events_for_clients(store, user_tuples, events, event_id_to_state):
         if not event.is_state() and event.sender in ignore_list:
             return False
 
+        # As a very temporary measure, don't relay redaction messages to clients
+        # as it causes a thundering herd.  FIXME: this should be removed once
+        # room initialSync is optimised enough to make the herd not a problem.
+        # https://github.com/vector-im/riot-android/issues/928
+        if event.is_state() and event.type == EventTypes.Redaction:
+            return False
+
         state = event_id_to_state[event.event_id]
 
         # get the room_visibility at the time of the event.


### PR DESCRIPTION
...to stop a recurrence of the thundering herd problems described at
https://matrix.org/blog/2017/02/17/load-problems-on-the-matrix-org-homeserver/
until we've optimised room initialSync etc.
I know that we've punted room initialSync to the synchrotrons for now, but
hopefully this is a better mitigation for the next few days until we get
to the proper soln.