### PR TITLE
A BOOL value was missing in the BOOL definitions.

### DIFF
--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -40,6 +40,7 @@ BOOLEAN_COLUMNS = {
     "presence_list": ["accepted"],
     "presence_stream": ["currently_active"],
     "public_room_list_stream": ["visibility"],
+    "device_lists_outbound_pokes": ["sent"],
 }
 
 


### PR DESCRIPTION
The values coming from SQLite3's `sent` field in `device_lists_outbound_pokes` are of BOOL type but with values `1`, and that won't get accepted by PostgreSQL.

So updated the `BOOL` table definitions.