### PR TITLE
Guest access of turn server login info

### DIFF
--- a/docs/turn-howto.rst
+++ b/docs/turn-howto.rst
@@ -83,12 +83,16 @@ Your home server configuration file needs the following extra keys:
     to refresh credentials. The TURN REST API specification recommends
     one day (86400000).
 
+ 4. "turn_allow_guest": If this is set to True, guest users are allowed 
+    to fetch the TURN server information. By default it is set to False. 
+
 As an example, here is the relevant section of the config file for
 matrix.org::
 
     turn_uris: [ "turn:turn.matrix.org:3478?transport=udp", "turn:turn.matrix.org:3478?transport=tcp" ]
     turn_shared_secret: n0t4ctuAllymatr1Xd0TorgSshar3d5ecret4obvIousreAsons
     turn_user_lifetime: 86400000
+    turn_allow_guest: False
 
 Now, restart synapse::
 

--- a/synapse/config/voip.py
+++ b/synapse/config/voip.py
@@ -23,6 +23,7 @@ class VoipConfig(Config):
         self.turn_username = config.get("turn_username")
         self.turn_password = config.get("turn_password")
         self.turn_user_lifetime = self.parse_duration(config["turn_user_lifetime"])
+        self.turn_allow_guest = self.parse_duration(config["turn_allow_guest"])
 
     def default_config(self, **kwargs):
         return """\

--- a/synapse/rest/client/v1/voip.py
+++ b/synapse/rest/client/v1/voip.py
@@ -28,7 +28,8 @@ class VoipRestServlet(ClientV1RestServlet):
 
     @defer.inlineCallbacks
     def on_GET(self, request):
-        requester = yield self.auth.get_user_by_req(request)
+        allowGuest = self.hs.config.turn_allow_guest
+        requester = yield self.auth.get_user_by_req(request, allowGuest)
 
         turnUris = self.hs.config.turn_uris
         turnSecret = self.hs.config.turn_shared_secret


### PR DESCRIPTION
As discussed in the Riot forum, under certain situation, to allow the guest access TURN server login info might be easier to manage the end user's behaviour and experience. please check the minor changes.


Signed-off-by: Ken Dai <ken.dai@ericsson.com>