### PR TITLE
Support registration & login with phone number

### DIFF
--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014-2016 OpenMarket Ltd
+# Copyright 2017 Vector Creations Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,6 +45,7 @@ class JoinRules(object):
 class LoginType(object):
     PASSWORD = u"m.login.password"
     EMAIL_IDENTITY = u"m.login.email.identity"
+    MSISDN = u"m.login.msisdn"
     RECAPTCHA = u"m.login.recaptcha"
     DUMMY = u"m.login.dummy"
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -309,13 +309,11 @@ class AuthHandler(BaseHandler):
                 defer.returnValue(True)
         raise LoginError(401, "", errcode=Codes.UNAUTHORIZED)
 
-    @defer.inlineCallbacks
     def _check_email_identity(self, authdict, _):
-        defer.returnValue(self._check_threepid('email', authdict))
+        return self._check_threepid('email', authdict)
 
-    @defer.inlineCallbacks
     def _check_msisdn(self, authdict, _):
-        defer.returnValue(self._check_threepid('msisdn', authdict))
+        return self._check_threepid('msisdn', authdict)
 
     @defer.inlineCallbacks
     def _check_dummy_auth(self, authdict, _):

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -344,7 +344,7 @@ class AuthHandler(BaseHandler):
                     medium, threepid['medium'],
                 ),
                 errcode=Codes.UNAUTHORIZED
-             )
+            )
 
         threepid['threepid_creds'] = authdict['threepid_creds']
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -331,7 +331,7 @@ class AuthHandler(BaseHandler):
 
         identity_handler = self.hs.get_handlers().identity_handler
 
-        logger.info("Getting validated threepid. threepidcreds: %r" % (threepid_creds,))
+        logger.info("Getting validated threepid. threepidcreds: %r", (threepid_creds,))
         threepid = yield identity_handler.threepid_from_creds(threepid_creds)
 
         if not threepid:

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -321,7 +321,7 @@ class AuthHandler(BaseHandler):
         defer.returnValue(True)
 
     @defer.inlineCallbacks
-    def _check_threepid(self, medium, authdict, ):
+    def _check_threepid(self, medium, authdict):
         yield run_on_reactor()
 
         if 'threepid_creds' not in authdict:

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015, 2016 OpenMarket Ltd
+# Copyright 2017 Vector Creations Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -150,10 +151,44 @@ class IdentityHandler(BaseHandler):
         params.update(kwargs)
 
         try:
-            data = yield self.http_client.post_urlencoded_get_json(
+            data = yield self.http_client.post_json_get_json(
                 "https://%s%s" % (
                     id_server,
                     "/_matrix/identity/api/v1/validate/email/requestToken"
+                ),
+                params
+            )
+            defer.returnValue(data)
+        except CodeMessageException as e:
+            logger.info("Proxied requestToken failed: %r", e)
+            raise e
+
+    @defer.inlineCallbacks
+    def requestMsisdnToken(
+            self, id_server, country, phone_number,
+            client_secret, send_attempt, **kwargs
+    ):
+        yield run_on_reactor()
+
+        if not self._should_trust_id_server(id_server):
+            raise SynapseError(
+                400, "Untrusted ID server '%s'" % id_server,
+                Codes.SERVER_NOT_TRUSTED
+            )
+
+        params = {
+            'country': country,
+            'phone_number': phone_number,
+            'client_secret': client_secret,
+            'send_attempt': send_attempt,
+        }
+        params.update(kwargs)
+
+        try:
+            data = yield self.http_client.post_json_get_json(
+                "https://%s%s" % (
+                    id_server,
+                    "/_matrix/identity/api/v1/validate/msisdn/requestToken"
                 ),
                 params
             )

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -192,6 +192,16 @@ def parse_json_object_from_request(request):
     return content
 
 
+def assert_params_in_request(body, required):
+    absent = []
+    for k in required:
+        if k not in body:
+            absent.append(k)
+
+    if len(absent) > 0:
+        raise SynapseError(400, "Missing params: %r" % absent, Codes.MISSING_PARAM)
+
+
 class RestServlet(object):
 
     """ A Synapse REST Servlet.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -1,4 +1,5 @@
 # Copyright 2015, 2016 OpenMarket Ltd
+# Copyright 2017 Vector Creations Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,6 +38,7 @@ REQUIREMENTS = {
     "pysaml2>=3.0.0,<4.0.0": ["saml2>=3.0.0,<4.0.0"],
     "pymacaroons-pynacl": ["pymacaroons"],
     "msgpack-python>=0.3.0": ["msgpack"],
+    "phonenumbers>=8.2.0": ["phonenumbers"],
 }
 CONDITIONAL_REQUIREMENTS = {
     "web_client": {

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -43,7 +43,6 @@ def login_submission_legacy_convert(submission):
     If the input login submission is an old style object
     (ie. with top-level user / medium / address) convert it
     to a typed object.
-    Returns: Typed-object style login identifier
     """
     if "user" in submission:
         submission["identifier"] = {

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -80,7 +80,7 @@ def login_id_thirdparty_from_phone(identifier):
     except phonenumbers.NumberParseException:
         raise SynapseError(400, "Unable to parse phone number")
     msisdn = phonenumbers.format_number(
-            phoneNumber, phonenumbers.PhoneNumberFormat.E164
+        phoneNumber, phonenumbers.PhoneNumberFormat.E164
     )[1:]
 
     return {
@@ -188,7 +188,7 @@ class LoginRestServlet(ClientV1RestServlet):
 
         # convert threepid identifiers to user IDs
         if identifier["type"] == "m.id.thirdparty":
-            if not 'medium' in identifier or not 'address' in identifier:
+            if 'medium' not in identifier or 'address' not in identifier:
                 raise SynapseError(400, "Invalid thirdparty identifier")
 
             address = identifier['address']
@@ -198,7 +198,7 @@ class LoginRestServlet(ClientV1RestServlet):
                 # (See add_threepid in synapse/handlers/auth.py)
                 address = address.lower()
             user_id = yield self.hs.get_datastore().get_user_id_by_threepid(
-                    identifier['medium'], address
+                identifier['medium'], address
             )
             if not user_id:
                 raise LoginError(403, "", errcode=Codes.FORBIDDEN)

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -66,7 +66,7 @@ def login_id_thirdparty_from_phone(identifier):
     """
     Convert a phone login identifier type to a generic threepid identifier
     Args:
-        identifier: Login identifier dict of type 'm.id.phone'
+        identifier(dict): Login identifier dict of type 'm.id.phone'
 
     Returns: Login identifier dict of type 'm.id.threepid'
     """

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -18,7 +18,9 @@ from twisted.internet import defer
 
 from synapse.api.constants import LoginType
 from synapse.api.errors import LoginError, SynapseError, Codes
-from synapse.http.servlet import RestServlet, parse_json_object_from_request
+from synapse.http.servlet import (
+    RestServlet, parse_json_object_from_request, assert_params_in_request
+)
 from synapse.util.async import run_on_reactor
 from synapse.util.msisdn import phone_number_to_msisdn
 
@@ -42,14 +44,9 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
     def on_POST(self, request):
         body = parse_json_object_from_request(request)
 
-        required = ['id_server', 'client_secret', 'email', 'send_attempt']
-        absent = []
-        for k in required:
-            if k not in body:
-                absent.append(k)
-
-        if absent:
-            raise SynapseError(400, "Missing params: %r" % absent, Codes.MISSING_PARAM)
+        assert_params_in_request(body, [
+            'id_server', 'client_secret', 'email', 'send_attempt'
+        ])
 
         existingUid = yield self.hs.get_datastore().get_user_id_by_threepid(
             'email', body['email']
@@ -74,17 +71,10 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
     def on_POST(self, request):
         body = parse_json_object_from_request(request)
 
-        required = [
+        assert_params_in_request(body,[
             'id_server', 'client_secret',
             'country', 'phone_number', 'send_attempt',
-        ]
-        absent = []
-        for k in required:
-            if k not in body:
-                absent.append(k)
-
-        if absent:
-            raise SynapseError(400, "Missing params: %r" % absent, Codes.MISSING_PARAM)
+        ])
 
         msisdn = phone_number_to_msisdn(body['country'], body['phone_number'])
 
@@ -95,7 +85,7 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
         if existingUid is None:
             raise SynapseError(400, "MSISDN not found", Codes.THREEPID_NOT_FOUND)
 
-        ret = yield self.identity_handler.requestEmailToken(**body)
+        ret = yield self.identity_handler.requestMsisdnToken(**body)
         defer.returnValue((200, ret))
 
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -93,7 +93,7 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
         except phonenumbers.NumberParseException:
             raise SynapseError(400, "Unable to parse phone number")
         msisdn = phonenumbers.format_number(
-                phoneNumber, phonenumbers.PhoneNumberFormat.E164
+            phoneNumber, phonenumbers.PhoneNumberFormat.E164
         )[1:]
 
         existingUid = yield self.hs.get_datastore().get_user_id_by_threepid(
@@ -279,7 +279,7 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
         except phonenumbers.NumberParseException:
             raise SynapseError(400, "Unable to parse phone number")
         msisdn = phonenumbers.format_number(
-                phoneNumber, phonenumbers.PhoneNumberFormat.E164
+            phoneNumber, phonenumbers.PhoneNumberFormat.E164
         )[1:]
 
         existingUid = yield self.hs.get_datastore().get_user_id_by_threepid(

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -72,7 +72,7 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
     def on_POST(self, request):
         body = parse_json_object_from_request(request)
 
-        assert_params_in_request(body,[
+        assert_params_in_request(body, [
             'id_server', 'client_secret',
             'country', 'phone_number', 'send_attempt',
         ])

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -20,12 +20,11 @@ from synapse.api.constants import LoginType
 from synapse.api.errors import LoginError, SynapseError, Codes
 from synapse.http.servlet import RestServlet, parse_json_object_from_request
 from synapse.util.async import run_on_reactor
+from synapse.util.msisdn import phone_number_to_msisdn
 
 from ._base import client_v2_patterns
 
 import logging
-
-import phonenumbers
 
 
 logger = logging.getLogger(__name__)
@@ -87,14 +86,7 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
         if absent:
             raise SynapseError(400, "Missing params: %r" % absent, Codes.MISSING_PARAM)
 
-        phoneNumber = None
-        try:
-            phoneNumber = phonenumbers.parse(body['phone_number'], body['country'])
-        except phonenumbers.NumberParseException:
-            raise SynapseError(400, "Unable to parse phone number")
-        msisdn = phonenumbers.format_number(
-            phoneNumber, phonenumbers.PhoneNumberFormat.E164
-        )[1:]
+        msisdn = phone_number_to_msisdn(body['country'], body['phone_number'])
 
         existingUid = yield self.hs.get_datastore().get_user_id_by_threepid(
             'msisdn', msisdn
@@ -273,14 +265,7 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
         if absent:
             raise SynapseError(400, "Missing params: %r" % absent, Codes.MISSING_PARAM)
 
-        phoneNumber = None
-        try:
-            phoneNumber = phonenumbers.parse(body['phone_number'], body['country'])
-        except phonenumbers.NumberParseException:
-            raise SynapseError(400, "Unable to parse phone number")
-        msisdn = phonenumbers.format_number(
-            phoneNumber, phonenumbers.PhoneNumberFormat.E164
-        )[1:]
+        msisdn = phone_number_to_msisdn(body['country'], body['phone_number'])
 
         existingUid = yield self.hs.get_datastore().get_user_id_by_threepid(
             'msisdn', msisdn

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -65,6 +65,7 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
     def __init__(self, hs):
         super(MsisdnPasswordRequestTokenRestServlet, self).__init__()
         self.hs = hs
+        self.datastore = self.hs.get_datastore()
         self.identity_handler = hs.get_handlers().identity_handler
 
     @defer.inlineCallbacks
@@ -78,7 +79,7 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
 
         msisdn = phone_number_to_msisdn(body['country'], body['phone_number'])
 
-        existingUid = yield self.hs.get_datastore().get_user_id_by_threepid(
+        existingUid = yield self.datastore.get_user_id_by_threepid(
             'msisdn', msisdn
         )
 
@@ -97,6 +98,7 @@ class PasswordRestServlet(RestServlet):
         self.hs = hs
         self.auth = hs.get_auth()
         self.auth_handler = hs.get_auth_handler()
+        self.datastore = self.hs.get_datastore()
 
     @defer.inlineCallbacks
     def on_POST(self, request):
@@ -132,7 +134,7 @@ class PasswordRestServlet(RestServlet):
                 # (See add_threepid in synapse/handlers/auth.py)
                 threepid['address'] = threepid['address'].lower()
             # if using email, we must know about the email they're authing with!
-            threepid_user_id = yield self.hs.get_datastore().get_user_id_by_threepid(
+            threepid_user_id = yield self.datastore.get_user_id_by_threepid(
                 threepid['medium'], threepid['address']
             )
             if not threepid_user_id:
@@ -206,6 +208,7 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
         self.hs = hs
         super(EmailThreepidRequestTokenRestServlet, self).__init__()
         self.identity_handler = hs.get_handlers().identity_handler
+        self.datastore = self.hs.get_datastore()
 
     @defer.inlineCallbacks
     def on_POST(self, request):
@@ -220,7 +223,7 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
         if absent:
             raise SynapseError(400, "Missing params: %r" % absent, Codes.MISSING_PARAM)
 
-        existingUid = yield self.hs.get_datastore().get_user_id_by_threepid(
+        existingUid = yield self.datastore.get_user_id_by_threepid(
             'email', body['email']
         )
 
@@ -238,6 +241,7 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
         self.hs = hs
         super(MsisdnThreepidRequestTokenRestServlet, self).__init__()
         self.identity_handler = hs.get_handlers().identity_handler
+        self.datastore = self.hs.get_datastore()
 
     @defer.inlineCallbacks
     def on_POST(self, request):
@@ -257,7 +261,7 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
 
         msisdn = phone_number_to_msisdn(body['country'], body['phone_number'])
 
-        existingUid = yield self.hs.get_datastore().get_user_id_by_threepid(
+        existingUid = yield self.datastore.get_user_id_by_threepid(
             'msisdn', msisdn
         )
 
@@ -277,6 +281,7 @@ class ThreepidRestServlet(RestServlet):
         self.identity_handler = hs.get_handlers().identity_handler
         self.auth = hs.get_auth()
         self.auth_handler = hs.get_auth_handler()
+        self.datastore = self.hs.get_datastore()
 
     @defer.inlineCallbacks
     def on_GET(self, request):
@@ -284,7 +289,7 @@ class ThreepidRestServlet(RestServlet):
 
         requester = yield self.auth.get_user_by_req(request)
 
-        threepids = yield self.hs.get_datastore().user_get_threepids(
+        threepids = yield self.datastore.user_get_threepids(
             requester.user.to_string()
         )
 

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -372,6 +372,7 @@ class RegisterRestServlet(RestServlet):
         """
         reqd = ('medium', 'address', 'validated_at')
         if any(x not in threepid for x in reqd):
+            # This will only happen if the ID server returns a malformed response
             logger.info("Can't add incomplete 3pid")
             return
 
@@ -437,6 +438,7 @@ class RegisterRestServlet(RestServlet):
         """
         reqd = ('medium', 'address', 'validated_at')
         if any(x not in threepid for x in reqd):
+            # This will only happen if the ID server returns a malformed response
             logger.info("Can't add incomplete 3pid")
             defer.returnValue()
 

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -107,7 +107,9 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
         )
 
         if existingUid is not None:
-            raise SynapseError(400, "MSISDN is already in use", Codes.THREEPID_IN_USE)
+            raise SynapseError(
+                400, "Phone number is already in use", Codes.THREEPID_IN_USE
+            )
 
         ret = yield self.identity_handler.requestMsisdnToken(**body)
         defer.returnValue((200, ret))

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -262,7 +262,7 @@ class RegisterRestServlet(RestServlet):
                 "Already registered user ID %r for this session",
                 registered_user_id
             )
-            # don't re-register the email address
+            # don't re-register the threepids
             add_email = False
             add_msisdn = False
         else:
@@ -420,7 +420,7 @@ class RegisterRestServlet(RestServlet):
 
     @defer.inlineCallbacks
     def _register_msisdn_threepid(self, user_id, threepid, token, bind_msisdn):
-        """Add aphone number as a 3pid identifier
+        """Add a phone number as a 3pid identifier
 
         Also optionally binds msisdn to the given user_id on the identity server
 

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -371,7 +371,7 @@ class RegisterRestServlet(RestServlet):
         reqd = ('medium', 'address', 'validated_at')
         if any(x not in threepid for x in reqd):
             logger.info("Can't add incomplete 3pid")
-            defer.returnValue()
+            return
 
         yield self.auth_handler.add_threepid(
             user_id,
@@ -447,9 +447,7 @@ class RegisterRestServlet(RestServlet):
 
         if bind_msisdn:
             logger.info("bind_msisdn specified: binding")
-            logger.debug("Binding msisdn %s to %s" % (
-                threepid, user_id
-            ))
+            logger.debug("Binding msisdn %s to %s", threepid, user_id)
             yield self.identity_handler.bind_threepid(
                 threepid['threepid_creds'], user_id
             )

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -116,7 +116,7 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
         except phonenumbers.NumberParseException:
             raise SynapseError(400, "Unable to parse phone number")
         msisdn = phonenumbers.format_number(
-                phoneNumber, phonenumbers.PhoneNumberFormat.E164
+            phoneNumber, phonenumbers.PhoneNumberFormat.E164
         )[1:]
 
         existingUid = yield self.hs.get_datastore().get_user_id_by_threepid(

--- a/synapse/util/msisdn.py
+++ b/synapse/util/msisdn.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015, 2016 OpenMarket Ltd
 # Copyright 2017 Vector Creations Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/util/msisdn.py
+++ b/synapse/util/msisdn.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015, 2016 OpenMarket Ltd
+# Copyright 2017 Vector Creations Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import phonenumbers
+from synapse.api.errors import SynapseError
+
+def phone_number_to_msisdn(country, number):
+    try:
+        phoneNumber = phonenumbers.parse(number, country)
+    except phonenumbers.NumberParseException:
+        raise SynapseError(400, "Unable to parse phone number")
+    return phonenumbers.format_number(
+        phoneNumber, phonenumbers.PhoneNumberFormat.E164
+    )[1:]

--- a/synapse/util/msisdn.py
+++ b/synapse/util/msisdn.py
@@ -17,6 +17,7 @@
 import phonenumbers
 from synapse.api.errors import SynapseError
 
+
 def phone_number_to_msisdn(country, number):
     try:
         phoneNumber = phonenumbers.parse(number, country)

--- a/synapse/util/msisdn.py
+++ b/synapse/util/msisdn.py
@@ -18,6 +18,19 @@ from synapse.api.errors import SynapseError
 
 
 def phone_number_to_msisdn(country, number):
+    """
+    Takes an ISO-3166-1 2 letter country code and phone number and
+    returns an msisdn representing the canonical version of that
+    phone number.
+    Args:
+        country (str): ISO-3166-1 2 letter country code
+        number (str): Phone number in a national or international format
+
+    Returns:
+        (str) The canonical form of the phone number, as an msisdn
+    Raises:
+            SynapseError if the number could not be parsed.
+    """
     try:
         phoneNumber = phonenumbers.parse(number, country)
     except phonenumbers.NumberParseException:


### PR DESCRIPTION
 * Adds the msisdn form of the proxy requestToken APIs
 * Changes the call to the ID servers to use JSON rather than x-www-form-urlencoded
 * Adds support for binding msisdns at registration time
 * Adds support for m.login.msisdn UI auth type and offers flows that use it in the registration API