### PR TITLE
Throw exceptions, not classes

### DIFF
--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -130,7 +130,7 @@ class DeviceHandler(BaseHandler):
         try:
             device = yield self.store.get_device(user_id, device_id)
         except errors.StoreError:
-            raise errors.NotFoundError
+            raise errors.NotFoundError()
         ips = yield self.store.get_last_client_ip_by_device(
             devices=((user_id, device_id),)
         )

--- a/synapse/rest/client/v1/push_rule.py
+++ b/synapse/rest/client/v1/push_rule.py
@@ -303,7 +303,7 @@ def _filter_ruleset_with_path(ruleset, path):
         if r['rule_id'] == rule_id:
             the_rule = r
     if the_rule is None:
-        raise NotFoundError
+        raise NotFoundError()
 
     path = path[1:]
     if len(path) == 0:


### PR DESCRIPTION
Fix a couple of `raise`s which appear to be throwing a class rather than an
exception.