### PR TITLE
When updating member states after a profile change, skip custom profiles in rooms.

### DIFF
--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -165,9 +165,6 @@ class ProfileHandler(BaseHandler):
             try:
                 # Assume the user isn't a guest because we don't let guests set
                 # profile or avatar data.
-                # XXX why are we recreating `requester` here for each room?
-                # what was wrong with the `requester` we were passed?
-                requester = synapse.types.create_requester(user)
                 yield handler.update_membership(
                     requester,
                     user,

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -177,18 +177,6 @@ class RoomMemberHandler(BaseHandler):
         defer.returnValue(result)
 
     @defer.inlineCallbacks
-    def get_member_event(self, target, room_id):
-        latest_event_ids = yield self.store.get_latest_event_ids_in_room(room_id)
-        current_state_ids = yield self.state_handler.get_current_state_ids(
-            room_id, latest_event_ids=latest_event_ids,
-        )
-        state_id = current_state_ids.get((EventTypes.Member, target.to_string()))
-        result = None
-        if state_id:
-            result = yield self.store.get_event(state_id, allow_none=True)
-        defer.returnValue(result)
-
-    @defer.inlineCallbacks
     def _update_membership(
             self,
             requester,

--- a/synapse/storage/profile.py
+++ b/synapse/storage/profile.py
@@ -24,6 +24,14 @@ class ProfileStore(SQLBaseStore):
             desc="create_profile",
         )
 
+    def get_profile(self, user_localpart):
+        return self._simple_select_one(
+            table="profiles",
+            keyvalues={"user_id": user_localpart},
+            retcols=["displayname", "avatar_url"],
+            desc="get_profile",
+        )
+
     def get_profile_displayname(self, user_localpart):
         return self._simple_select_one_onecol(
             table="profiles",


### PR DESCRIPTION
This change is so that member events with custom profile info will stick between updates of a users profile. Currently this checks the old member profile against the old profile and uses that to determine whether it should be updated. This might turn out to be too flimsy so any hole poking is appreciated.

Signed-off-by: Will Hunt <half-shot@molrams.com>