### PR TITLE
Don't user upsert to persist new one time keys

### DIFF
--- a/synapse/storage/end_to_end_keys.py
+++ b/synapse/storage/end_to_end_keys.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 from twisted.internet import defer
 
+from synapse.api.errors import SynapseError
+
 from canonicaljson import encode_canonical_json
 import ujson as json
 
@@ -150,8 +152,8 @@ class EndToEndKeyStore(SQLBaseStore):
             if key_id in existing_key_map:
                 ex_algo, ex_bytes = existing_key_map[key_id]
                 if algorithm != ex_algo or json_bytes != ex_bytes:
-                    raise Exception(
-                        "One time key with key_id %r already exists" % (key_id,)
+                    raise SynapseError(
+                        400, "One time key with key_id %r already exists" % (key_id,)
                     )
             else:
                 new_keys.append((algorithm, key_id, json_bytes))

--- a/synapse/storage/end_to_end_keys.py
+++ b/synapse/storage/end_to_end_keys.py
@@ -144,14 +144,14 @@ class EndToEndKeyStore(SQLBaseStore):
         )
 
         existing_key_map = {
-            row["key_id"]: (row["algorithm"], row["key_json"]) for row in rows
+            (row["algorithm"], row["key_id"]): row["key_json"] for row in rows
         }
 
         new_keys = []  # Keys that we need to insert
         for algorithm, key_id, json_bytes in key_list:
-            if key_id in existing_key_map:
-                ex_algo, ex_bytes = existing_key_map[key_id]
-                if algorithm != ex_algo or json_bytes != ex_bytes:
+            if (algorithm, key_id) in existing_key_map:
+                ex_bytes = existing_key_map[key_id]
+                if json_bytes != ex_bytes:
                     raise SynapseError(
                         400, "One time key with key_id %r already exists" % (key_id,)
                     )

--- a/synapse/storage/end_to_end_keys.py
+++ b/synapse/storage/end_to_end_keys.py
@@ -149,12 +149,11 @@ class EndToEndKeyStore(SQLBaseStore):
 
         new_keys = []  # Keys that we need to insert
         for algorithm, key_id, json_bytes in key_list:
-            if (algorithm, key_id) in existing_key_map:
-                ex_bytes = existing_key_map[key_id]
-                if json_bytes != ex_bytes:
-                    raise SynapseError(
-                        400, "One time key with key_id %r already exists" % (key_id,)
-                    )
+            ex_bytes = existing_key_map.get((algorithm, key_id), None)
+            if ex_bytes and json_bytes != ex_bytes:
+                raise SynapseError(
+                    400, "One time key with key_id %r already exists" % (key_id,)
+                )
             else:
                 new_keys.append((algorithm, key_id, json_bytes))
 

--- a/synapse/storage/end_to_end_keys.py
+++ b/synapse/storage/end_to_end_keys.py
@@ -150,10 +150,11 @@ class EndToEndKeyStore(SQLBaseStore):
         new_keys = []  # Keys that we need to insert
         for algorithm, key_id, json_bytes in key_list:
             ex_bytes = existing_key_map.get((algorithm, key_id), None)
-            if ex_bytes and json_bytes != ex_bytes:
-                raise SynapseError(
-                    400, "One time key with key_id %r already exists" % (key_id,)
-                )
+            if ex_bytes:
+                if json_bytes != ex_bytes:
+                    raise SynapseError(
+                        400, "One time key with key_id %r already exists" % (key_id,)
+                    )
             else:
                 new_keys.append((algorithm, key_id, json_bytes))
 


### PR DESCRIPTION
Instead we no-op duplicate one time key uploads, an error if the key_id
already exists but encodes a different key.