### PR TITLE
Use presence replication stream to invalidate cache

### DIFF
--- a/synapse/replication/slave/storage/presence.py
+++ b/synapse/replication/slave/storage/presence.py
@@ -57,5 +57,6 @@ class SlavedPresenceStore(BaseSlavedStore):
                 self.presence_stream_cache.entity_has_changed(
                     user_id, position
                 )
+                self._get_presence_for_user.invalidate((user_id,))
 
         return super(SlavedPresenceStore, self).process_replication(result)

--- a/synapse/storage/presence.py
+++ b/synapse/storage/presence.py
@@ -85,8 +85,8 @@ class PresenceStore(SQLBaseStore):
                 self.presence_stream_cache.entity_has_changed,
                 state.user_id, stream_id,
             )
-            self._invalidate_cache_and_stream(
-                txn, self._get_presence_for_user, (state.user_id,)
+            txn.call_after(
+                self._get_presence_for_user, (state.user_id,)
             )
 
         # Actually insert new rows

--- a/synapse/storage/presence.py
+++ b/synapse/storage/presence.py
@@ -86,7 +86,7 @@ class PresenceStore(SQLBaseStore):
                 state.user_id, stream_id,
             )
             txn.call_after(
-                self._get_presence_for_user, (state.user_id,)
+                self._get_presence_for_user.invalidate, (state.user_id,)
             )
 
         # Actually insert new rows


### PR DESCRIPTION
Instead of using the cache invalidation replication stream to invalidate
the _get_presence_cache, we can instead rely on the presence replication
stream. This reduces the amount of replication traffic considerably.