### PR TITLE
Use twisted logger for top level exception handlers

### DIFF
--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -28,6 +28,7 @@ from canonicaljson import (
 )
 
 from twisted.internet import defer
+from twisted.logger import Logger
 from twisted.web import server, resource
 from twisted.web.server import NOT_DONE_YET
 from twisted.web.util import redirectTo
@@ -38,6 +39,7 @@ import urllib
 import ujson
 
 logger = logging.getLogger(__name__)
+log = Logger()
 
 metrics = synapse.metrics.get_metrics_for(__name__)
 
@@ -131,12 +133,12 @@ def wrap_request_handler(request_handler, include_metrics=False):
                             version_string=self.version_string,
                         )
                     except:
-                        logger.exception(
-                            "Failed handle request %s.%s on %r: %r",
-                            request_handler.__module__,
-                            request_handler.__name__,
-                            self,
-                            request
+                        log.failure(
+                            "Failed handle request {m}.{n} on {s!r}: {req!r}",
+                            m=request_handler.__module__,
+                            n=request_handler.__name__,
+                            s=self,
+                            req=request,
                         )
                         respond_with_json(
                             request,

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -17,6 +17,7 @@ from synapse.push import PusherConfigException
 
 from twisted.internet import defer, reactor
 from twisted.internet.error import AlreadyCalled, AlreadyCancelled
+from twisted.logger import Logger
 
 import logging
 import push_rule_evaluator
@@ -26,6 +27,7 @@ from synapse.util.logcontext import LoggingContext
 from synapse.util.metrics import Measure
 
 logger = logging.getLogger(__name__)
+log = Logger()
 
 
 class HttpPusher(object):
@@ -132,7 +134,7 @@ class HttpPusher(object):
                         try:
                             yield self._unsafe_process()
                         except:
-                            logger.exception("Exception processing notifs")
+                            log.failure("Exception processing notifs")
                         if self.max_stream_ordering == starting_max_ordering:
                             break
                 finally:


### PR DESCRIPTION
As the twisted logger is more likely to report the actual stack trace