### PR TITLE
add user friendly report of assertion error in synctl.py

### DIFF
--- a/synapse/app/synctl.py
+++ b/synapse/app/synctl.py
@@ -175,7 +175,8 @@ def main():
         worker_app = worker_config["worker_app"]
         worker_pidfile = worker_config["worker_pid_file"]
         worker_daemonize = worker_config["worker_daemonize"]
-        assert worker_daemonize  # TODO print something more user friendly
+        assert worker_daemonize, "In config %r: expected '%s' to be True" % (
+            worker_configfile, "worker_daemonize")
         worker_cache_factor = worker_config.get("synctl_cache_factor")
         workers.append(Worker(
             worker_app, worker_configfile, worker_pidfile, worker_cache_factor,


### PR DESCRIPTION
This should work,
however I haven't tested this as I am not acquainted with synapse workers. 