### PR TITLE
Speed up copy_and_replace

### DIFF
--- a/synapse/types.py
+++ b/synapse/types.py
@@ -216,9 +216,7 @@ class StreamToken(
             return self
 
     def copy_and_replace(self, key, new_value):
-        d = self._asdict()
-        d[key] = new_value
-        return StreamToken(**d)
+        return self._replace(**{key: new_value})
 
 
 StreamToken.START = StreamToken(


### PR DESCRIPTION
This appeared as a major component of startup churn for the synchrotrons for some reason.