### PR TITLE
presence.py: de-dup hosts_to_states

### DIFF
--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -588,8 +588,10 @@ class PresenceHandler(object):
             host = get_domain_from_id(user_id)
             hosts_to_states.setdefault(host, []).extend(local_states)
 
-        # TODO: de-dup hosts_to_states, as a single host might have multiple
+        # de-dup hosts_to_states, as a single host might have multiple
         # of same presence
+        for h in hosts_to_states:
+            hosts_to_states[h] = list(set(hosts_to_states[h]))
 
         defer.returnValue((room_ids_to_states, users_to_states, hosts_to_states))
 


### PR DESCRIPTION
presence.py: de-dup `hosts_to_states` in `_get_interested_parties`

The comment seems weird, should I correct it to something ? 