### PR TITLE
Extend _AccountHandler proxy object

### DIFF
--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -724,3 +724,27 @@ class _AccountHandler(object):
         """
         reg = self.hs.get_handlers().registration_handler
         return reg.register(localpart=localpart)
+
+    def set_displayname(self, localpart, displayname):
+        """ Setup Display Name from external auth source
+        """
+        # TODO (slipeer) : It may be necessary to check that
+        # the new name differs from the old one.
+        # And call self.get_handlers().profile_handler._update_join_states()
+        # for notifying in the rooms about changing the name.
+        yield self.get_handlers().profile_handler.storeset_profile_displayname(
+            localpart,
+            displayname
+        )
+
+    def set_3pid(self, user_id, type, threepid):
+        """ Setup 3pid from external auth source
+        """
+        validated_at = self.hs.get_clock().time_msec()
+        yield self.get_handlers().profile_handler.store.user_add_threepid(
+            user_id,
+            type,
+            threepid,
+            validated_at,
+            validated_at
+        )


### PR DESCRIPTION
Extend _AccountHandler proxy (in synapse/handlers/auth.py) object to allow setup additional user data from password auth providers.
For example to setup DisplayName or 3pid from LDAP.
There [TODO mark in matrix-synapse-ldap](https://github.com/matrix-org/matrix-synapse-ldap3/blob/master/ldap_auth_provider.py#L189) which can not be properly implemented without these changes.

PR created for this issue: https://github.com/matrix-org/synapse/issues/2085