### PR TITLE
Implement Read Marker API

### DIFF
--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015, 2016 OpenMarket Ltd
+# Copyright 2017 Vector Creations Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015, 2016 OpenMarket Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._base import BaseHandler
+
+from twisted.internet import defer
+
+from synapse.util.logcontext import PreserveLoggingContext
+from synapse.types import get_domain_from_id
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class ReadMarkerHandler(BaseHandler):
+    def __init__(self, hs):
+        super(ReadMarkerHandler, self).__init__(hs)
+
+        self.server_name = hs.config.server_name
+        self.store = hs.get_datastore()
+
+    @defer.inlineCallbacks
+    def received_client_read_marker(self, room_id, user_id, event_id):
+        """NEEDS DOC
+        """
+
+        room_id = read_marker["room_id"]
+        user_id = read_marker["user_id"]
+        event_id = read_marker["event_id"]
+
+        # Get ordering for existing read marker
+        account_data = yield self.store.get_account_data_for_room(user_id, room_id)
+        existing_read_marker = account_data["m.read_marker"]
+
+        if existing_read_marker:
+            # Get ordering for new read marker
+            res = self.store._simple_select_one_txn(
+                txn,
+                table="events",
+                retcols=["topological_ordering", "stream_ordering"],
+                keyvalues={"event_id": event_id},
+                allow_none=True
+            )
+            new_to = int(res["topological_ordering"]) if res else None
+            new_so = int(res["stream_ordering"]) if res else None
+
+            res = self.store._simple_select_one_txn(
+                txn,
+                table="events",
+                retcols=["topological_ordering", "stream_ordering"],
+                keyvalues={"event_id": existing_read_marker.content.marker},
+                allow_none=True
+            )
+            existing_to = int(res["topological_ordering"]) if res else None
+            existing_so = int(res["stream_ordering"]) if res else None
+
+            if new_to > existing_to:
+                return False
+            elif new_to == existing_to and new_so >= existing_so:
+                return False
+
+        # Update account data
+        content = {
+            "marker": event_id
+        }
+        yield self.store.add_account_data_to_room(
+            user_id, room_id, "m.read_marker", content
+        )

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -40,13 +40,10 @@ class ReadMarkerHandler(BaseHandler):
         the read marker has changed.
         """
 
-        # Get ordering for existing read marker
         with (yield self.read_marker_linearizer.queue((room_id, user_id))):
             account_data = yield self.store.get_account_data_for_room(user_id, room_id)
 
-            existing_read_marker = None
-            if "m.read_marker" in account_data:
-                existing_read_marker = account_data["m.read_marker"]
+            existing_read_marker = account_data.get("m.read_marker", None)
 
             should_update = True
 

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -48,9 +48,10 @@ class ReadMarkerHandler(BaseHandler):
             should_update = True
 
             if existing_read_marker:
+                # Only update if the new marker is ahead in the stream
                 should_update = yield self.store.is_event_after(
-                    existing_read_marker['marker'],
-                    event_id
+                    event_id,
+                    existing_read_marker['marker']
                 )
 
             if should_update:

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -18,7 +18,6 @@ from ._base import BaseHandler
 from twisted.internet import defer
 
 from synapse.util.async import Linearizer
-from synapse.api.errors import SynapseError
 
 import logging
 logger = logging.getLogger(__name__)

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -60,6 +60,4 @@ class ReadMarkerHandler(BaseHandler):
                 max_id = yield self.store.add_account_data_to_room(
                     user_id, room_id, "m.read_marker", content
                 )
-                self.notifier.on_new_event(
-                    "account_data_key", max_id, users=[user_id], rooms=[room_id]
-                )
+                self.notifier.on_new_event("account_data_key", max_id, users=[user_id])

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -18,65 +18,74 @@ from ._base import BaseHandler
 from twisted.internet import defer
 
 from synapse.util.logcontext import PreserveLoggingContext
+from synapse.util.async import Linearizer
 from synapse.types import get_domain_from_id
+from synapse.api.errors import SynapseError
 
 import logging
-
-
 logger = logging.getLogger(__name__)
-
 
 class ReadMarkerHandler(BaseHandler):
     def __init__(self, hs):
         super(ReadMarkerHandler, self).__init__(hs)
-
         self.server_name = hs.config.server_name
         self.store = hs.get_datastore()
+        self.read_marker_linearizer = Linearizer(name="read_marker")
+        self.notifier = hs.get_notifier()
 
     @defer.inlineCallbacks
     def received_client_read_marker(self, room_id, user_id, event_id):
-        """NEEDS DOC
+        """Updates the read marker for a given user in a given room if the event ID given
+        is ahead in the stream relative to the current read marker.
+
+        This uses a notifier to indicate that account data should be sent down /sync if
+        the read marker has changed.
         """
 
-        room_id = read_marker["room_id"]
-        user_id = read_marker["user_id"]
-        event_id = read_marker["event_id"]
-
         # Get ordering for existing read marker
-        account_data = yield self.store.get_account_data_for_room(user_id, room_id)
-        existing_read_marker = account_data["m.read_marker"]
+        with (yield self.read_marker_linearizer.queue(room_id + "_" + user_id)):
+            account_data = yield self.store.get_account_data_for_room(user_id, room_id)
+            existing_read_marker = account_data["m.read_marker"]
 
-        if existing_read_marker:
-            # Get ordering for new read marker
-            res = self.store._simple_select_one_txn(
-                txn,
+            should_update = True
+
+            res = yield self.store._simple_select_one(
                 table="events",
                 retcols=["topological_ordering", "stream_ordering"],
                 keyvalues={"event_id": event_id},
                 allow_none=True
             )
-            new_to = int(res["topological_ordering"]) if res else None
-            new_so = int(res["stream_ordering"]) if res else None
 
-            res = self.store._simple_select_one_txn(
-                txn,
-                table="events",
-                retcols=["topological_ordering", "stream_ordering"],
-                keyvalues={"event_id": existing_read_marker.content.marker},
-                allow_none=True
-            )
-            existing_to = int(res["topological_ordering"]) if res else None
-            existing_so = int(res["stream_ordering"]) if res else None
+            if not res:
+                raise SynapseError(404, 'Event does not exist')
 
-            if new_to > existing_to:
-                return False
-            elif new_to == existing_to and new_so >= existing_so:
-                return False
+            if existing_read_marker:
+                new_to = int(res["topological_ordering"])
+                new_so = int(res["stream_ordering"])
 
-        # Update account data
-        content = {
-            "marker": event_id
-        }
-        yield self.store.add_account_data_to_room(
-            user_id, room_id, "m.read_marker", content
-        )
+                # Get ordering for existing read marker
+                res = yield self.store._simple_select_one(
+                    table="events",
+                    retcols=["topological_ordering", "stream_ordering"],
+                    keyvalues={"event_id": existing_read_marker['marker']},
+                    allow_none=True
+                )
+                existing_to = int(res["topological_ordering"]) if res else None
+                existing_so = int(res["stream_ordering"]) if res else None
+
+                # Prevent updating if the existing marker is ahead in the stream
+                if existing_to > new_to:
+                    should_update = False
+                elif existing_to == new_to and existing_so >= new_so:
+                    should_update = False
+
+            if should_update:
+                content = {
+                    "marker": event_id
+                }
+                max_id = yield self.store.add_account_data_to_room(
+                    user_id, room_id, "m.read_marker", content
+                )
+                self.notifier.on_new_event(
+                    "account_data_key", max_id, users=[user_id], rooms=[room_id]
+                )

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -43,7 +43,10 @@ class ReadMarkerHandler(BaseHandler):
         # Get ordering for existing read marker
         with (yield self.read_marker_linearizer.queue((room_id, user_id))):
             account_data = yield self.store.get_account_data_for_room(user_id, room_id)
-            existing_read_marker = account_data["m.read_marker"]
+
+            existing_read_marker = None
+            if "m.read_marker" in account_data:
+                existing_read_marker = account_data["m.read_marker"]
 
             should_update = True
 

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -17,13 +17,12 @@ from ._base import BaseHandler
 
 from twisted.internet import defer
 
-from synapse.util.logcontext import PreserveLoggingContext
 from synapse.util.async import Linearizer
-from synapse.types import get_domain_from_id
 from synapse.api.errors import SynapseError
 
 import logging
 logger = logging.getLogger(__name__)
+
 
 class ReadMarkerHandler(BaseHandler):
     def __init__(self, hs):

--- a/synapse/rest/__init__.py
+++ b/synapse/rest/__init__.py
@@ -40,6 +40,7 @@ from synapse.rest.client.v2_alpha import (
     register,
     auth,
     receipts,
+    read_marker,
     keys,
     tokenrefresh,
     tags,
@@ -88,6 +89,7 @@ class ClientRestResource(JsonResource):
         register.register_servlets(hs, client_resource)
         auth.register_servlets(hs, client_resource)
         receipts.register_servlets(hs, client_resource)
+        read_marker.register_servlets(hs, client_resource)
         keys.register_servlets(hs, client_resource)
         tokenrefresh.register_servlets(hs, client_resource)
         tags.register_servlets(hs, client_resource)

--- a/synapse/rest/client/v2_alpha/account_data.py
+++ b/synapse/rest/client/v2_alpha/account_data.py
@@ -85,8 +85,8 @@ class RoomAccountDataServlet(RestServlet):
         if account_data_type == "m.read_marker":
             raise SynapseError(
                 405,
-                "Cannot set m.read_marker through this API. "
-                "Use /rooms/!roomId:server.name/read_marker"
+                "Cannot set m.read_marker through this API."
+                " Use /rooms/!roomId:server.name/read_marker"
             )
 
         max_id = yield self.store.add_account_data_to_room(

--- a/synapse/rest/client/v2_alpha/account_data.py
+++ b/synapse/rest/client/v2_alpha/account_data.py
@@ -16,7 +16,7 @@
 from ._base import client_v2_patterns
 
 from synapse.http.servlet import RestServlet, parse_json_object_from_request
-from synapse.api.errors import AuthError
+from synapse.api.errors import AuthError, SynapseError
 
 from twisted.internet import defer
 
@@ -81,6 +81,12 @@ class RoomAccountDataServlet(RestServlet):
             raise AuthError(403, "Cannot add account data for other users.")
 
         body = parse_json_object_from_request(request)
+
+        if account_data_type == "m.read_marker":
+            raise SynapseError(405,
+                "Cannot set m.read_marker through this API. "
+                "Use /rooms/!roomId:server.name/read_marker"
+            )
 
         max_id = yield self.store.add_account_data_to_room(
             user_id, room_id, account_data_type, body

--- a/synapse/rest/client/v2_alpha/account_data.py
+++ b/synapse/rest/client/v2_alpha/account_data.py
@@ -83,7 +83,8 @@ class RoomAccountDataServlet(RestServlet):
         body = parse_json_object_from_request(request)
 
         if account_data_type == "m.read_marker":
-            raise SynapseError(405,
+            raise SynapseError(
+                405,
                 "Cannot set m.read_marker through this API. "
                 "Use /rooms/!roomId:server.name/read_marker"
             )

--- a/synapse/rest/client/v2_alpha/read_marker.py
+++ b/synapse/rest/client/v2_alpha/read_marker.py
@@ -15,7 +15,6 @@
 
 from twisted.internet import defer
 
-from synapse.api.errors import SynapseError
 from synapse.http.servlet import RestServlet, parse_json_object_from_request
 from ._base import client_v2_patterns
 
@@ -45,7 +44,7 @@ class ReadMarkerRestServlet(RestServlet):
         body = parse_json_object_from_request(request)
 
         if "m.read" in body:
-            read_event_id = body["m.read"];
+            read_event_id = body["m.read"]
             yield self.receipts_handler.received_client_receipt(
                 room_id,
                 "m.read",

--- a/synapse/rest/client/v2_alpha/read_marker.py
+++ b/synapse/rest/client/v2_alpha/read_marker.py
@@ -25,14 +25,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class ReceiptRestServlet(RestServlet):
-    PATTERNS = client_v2_patterns(
-        "/rooms/(?P<room_id>[^/]*)"
-        "/read_marker$"
-    )
+class ReadMarkerRestServlet(RestServlet):
+    PATTERNS = client_v2_patterns("/rooms/(?P<room_id>[^/]*)/read_marker$")
 
     def __init__(self, hs):
-        super(ReceiptRestServlet, self).__init__()
+        super(ReadMarkerRestServlet, self).__init__()
         self.hs = hs
         self.auth = hs.get_auth()
         self.receipts_handler = hs.get_receipts_handler()
@@ -40,7 +37,7 @@ class ReceiptRestServlet(RestServlet):
         self.presence_handler = hs.get_presence_handler()
 
     @defer.inlineCallbacks
-    def on_POST(self, request, room_id, receipt_type, event_id):
+    def on_POST(self, request, room_id):
         requester = yield self.auth.get_user_by_req(request)
 
         yield self.presence_handler.bump_presence_active_time(requester.user)
@@ -68,4 +65,4 @@ class ReceiptRestServlet(RestServlet):
 
 
 def register_servlets(hs, http_server):
-    ReceiptRestServlet(hs).register(http_server)
+    ReadMarkerRestServlet(hs).register(http_server)

--- a/synapse/rest/client/v2_alpha/read_marker.py
+++ b/synapse/rest/client/v2_alpha/read_marker.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Vector Creations Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from twisted.internet import defer
+
+from synapse.api.errors import SynapseError
+from synapse.http.servlet import RestServlet, parse_json_object_from_request
+from ._base import client_v2_patterns
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class ReceiptRestServlet(RestServlet):
+    PATTERNS = client_v2_patterns(
+        "/rooms/(?P<room_id>[^/]*)"
+        "/read_marker$"
+    )
+
+    def __init__(self, hs):
+        super(ReceiptRestServlet, self).__init__()
+        self.hs = hs
+        self.auth = hs.get_auth()
+        self.receipts_handler = hs.get_receipts_handler()
+        self.read_marker_handler = hs.get_read_marker_handler()
+        self.presence_handler = hs.get_presence_handler()
+
+    @defer.inlineCallbacks
+    def on_POST(self, request, room_id, receipt_type, event_id):
+        requester = yield self.auth.get_user_by_req(request)
+
+        yield self.presence_handler.bump_presence_active_time(requester.user)
+
+        body = parse_json_object_from_request(request)
+
+        if "m.read" in body:
+            read_event_id = body["m.read"];
+            yield self.receipts_handler.received_client_receipt(
+                room_id,
+                "m.read",
+                user_id=requester.user.to_string(),
+                event_id=read_event_id
+            )
+
+        if "m.read_marker" in body:
+            read_marker_event_id = body["m.read_marker"]
+            yield self.read_marker_handler.received_client_read_marker(
+                room_id,
+                user_id=requester.user.to_string(),
+                event_id=read_marker_event_id
+            )
+
+        defer.returnValue((200, {}))
+
+
+def register_servlets(hs, http_server):
+    ReceiptRestServlet(hs).register(http_server)

--- a/synapse/rest/client/v2_alpha/read_marker.py
+++ b/synapse/rest/client/v2_alpha/read_marker.py
@@ -29,7 +29,6 @@ class ReadMarkerRestServlet(RestServlet):
 
     def __init__(self, hs):
         super(ReadMarkerRestServlet, self).__init__()
-        self.hs = hs
         self.auth = hs.get_auth()
         self.receipts_handler = hs.get_receipts_handler()
         self.read_marker_handler = hs.get_read_marker_handler()

--- a/synapse/rest/client/v2_alpha/read_marker.py
+++ b/synapse/rest/client/v2_alpha/read_marker.py
@@ -42,8 +42,8 @@ class ReadMarkerRestServlet(RestServlet):
 
         body = parse_json_object_from_request(request)
 
-        if "m.read" in body:
-            read_event_id = body["m.read"]
+        read_event_id = body.get("m.read", None)
+        if read_event_id:
             yield self.receipts_handler.received_client_receipt(
                 room_id,
                 "m.read",
@@ -51,8 +51,8 @@ class ReadMarkerRestServlet(RestServlet):
                 event_id=read_event_id
             )
 
-        if "m.read_marker" in body:
-            read_marker_event_id = body["m.read_marker"]
+        read_marker_event_id = body.get("m.read_marker", None)
+        if read_marker_event_id:
             yield self.read_marker_handler.received_client_read_marker(
                 room_id,
                 user_id=requester.user.to_string(),

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -48,6 +48,7 @@ from synapse.handlers.typing import TypingHandler
 from synapse.handlers.events import EventHandler, EventStreamHandler
 from synapse.handlers.initial_sync import InitialSyncHandler
 from synapse.handlers.receipts import ReceiptsHandler
+from synapse.handlers.read_marker import ReadMarkerHandler
 from synapse.http.client import SimpleHttpClient, InsecureInterceptableContextFactory
 from synapse.http.matrixfederationclient import MatrixFederationHttpClient
 from synapse.notifier import Notifier
@@ -133,6 +134,7 @@ class HomeServer(object):
         'receipts_handler',
         'macaroon_generator',
         'tcp_replication',
+        'read_marker_handler',
     ]
 
     def __init__(self, hostname, **kwargs):
@@ -290,6 +292,9 @@ class HomeServer(object):
 
     def build_receipts_handler(self):
         return ReceiptsHandler(self)
+
+    def build_read_marker_handler(self):
+        return ReadMarkerHandler(self)
 
     def build_tcp_replication(self):
         raise NotImplementedError()

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -2161,18 +2161,11 @@ class EventsStore(SQLBaseStore):
 
     @defer.inlineCallbacks
     def is_event_after(self, event_id1, event_id2):
-        is_after = True
-
+        """Returns True if event_id1 is after event_id2 in the stream
+        """
         to_1, so_1 = yield self._get_event_ordering(event_id1)
         to_2, so_2 = yield self._get_event_ordering(event_id2)
-
-        # Prevent updating if the existing marker is ahead in the stream
-        if to_1 > to_2:
-            is_after = False
-        elif to_1 == to_2 and so_1 >= so_2:
-            is_after = False
-
-        defer.returnValue(is_after)
+        defer.returnValue(to_1 > to_2 and so_1 > so_2)
 
     @defer.inlineCallbacks
     def _get_event_ordering(self, event_id):

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -2165,7 +2165,7 @@ class EventsStore(SQLBaseStore):
         """
         to_1, so_1 = yield self._get_event_ordering(event_id1)
         to_2, so_2 = yield self._get_event_ordering(event_id2)
-        defer.returnValue(to_1 > to_2 and so_1 > so_2)
+        defer.returnValue((to_1, so_1) > (to_2, so_2))
 
     @defer.inlineCallbacks
     def _get_event_ordering(self, event_id):

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -2188,6 +2188,7 @@ class EventsStore(SQLBaseStore):
 
         defer.returnValue((int(res["topological_ordering"]), int(res["stream_ordering"])))
 
+
 AllNewEventsResult = namedtuple("AllNewEventsResult", [
     "new_forward_events", "new_backfill_events",
     "forward_ex_outliers", "backward_ex_outliers",

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -2159,6 +2159,34 @@ class EventsStore(SQLBaseStore):
             ]
         )
 
+    @defer.inlineCallbacks
+    def is_event_after(self, event_id1, event_id2):
+        is_after = True
+
+        to_1, so_1 = yield self._get_event_ordering(event_id1)
+        to_2, so_2 = yield self._get_event_ordering(event_id2)
+
+        # Prevent updating if the existing marker is ahead in the stream
+        if to_1 > to_2:
+            is_after = False
+        elif to_1 == to_2 and so_1 >= so_2:
+            is_after = False
+
+        defer.returnValue(is_after)
+
+    @defer.inlineCallbacks
+    def _get_event_ordering(self, event_id):
+        res = yield self._simple_select_one(
+            table="events",
+            retcols=["topological_ordering", "stream_ordering"],
+            keyvalues={"event_id": event_id},
+            allow_none=True
+        )
+
+        if not res:
+            raise SynapseError(404, "Could not find event %s" % (event_id,))
+
+        defer.returnValue((int(res["topological_ordering"]), int(res["stream_ordering"])))
 
 AllNewEventsResult = namedtuple("AllNewEventsResult", [
     "new_forward_events", "new_backfill_events",


### PR DESCRIPTION
This implements the design at https://docs.google.com/document/d/1UWqdS-e1sdwkLDUY0wA4gZyIkRp-ekjsLZ8k6g_Zvso/edit#heading=h.8jqdhkapw60, summarised below.

### m.read_marker event
```json
{
    "content": {
        "marker”: “$123456789098765hhjGslf:matrix.org"
    },
    "room_id": "!someroomid:matrix.org",
    "type": "m.read_marker"
}
```
To update it, the client sends a PUT.

### RESTful HTTP endpoint
```http
PUT /_matrix/client/r0/rooms/%21someroomid%3Amatrix.org/read_marker HTTP/1.1
Content-Type: application/json

{
	"m.read": "$347926718ewsc:example.com",
	"m.read_marker": "$4536432343kljf:example.com"
}
```

The REST API hits:
 -  the RR handler if “m.read” has been set. This is optional and means that we don’t end up doing one call for RM and one separate call for RR, which is the common case when the user has caught up on their scrollback;
 - the RM handler if “m.read_marker” has been set. This handler asserts that the RM event ID is ahead in the stream in comparison to the current one and then uses the room account data API to store the `m.read_marker` event. 
