### PR TITLE
print something legible if synapse already running

### DIFF
--- a/synapse/app/synctl.py
+++ b/synapse/app/synctl.py
@@ -234,6 +234,9 @@ def main():
 
     if action == "start" or action == "restart":
         if start_stop_synapse:
+            # Check if synapse is already running
+            if os.path.exists(pidfile) and pid_running(int(open(pidfile).read())):
+                abort("synapse.app.homeserver already running")
             start(configfile)
 
         for worker in workers:


### PR DESCRIPTION
Check if synapse is already running before calling start.
Otherwise `start synapse` fails and dumps the log.
The error is not clear from log easily.
So print something legible instead.

Signed-off-by: Anant Prakash <anantprakashjsr@gmail.com>