### PR TITLE
m.read_marker -> m.fully_read

### DIFF
--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -43,7 +43,7 @@ class ReadMarkerHandler(BaseHandler):
         with (yield self.read_marker_linearizer.queue((room_id, user_id))):
             account_data = yield self.store.get_account_data_for_room(user_id, room_id)
 
-            existing_read_marker = account_data.get("m.read_up_to", None)
+            existing_read_marker = account_data.get("m.fully_read", None)
 
             should_update = True
 
@@ -59,6 +59,6 @@ class ReadMarkerHandler(BaseHandler):
                     "event_id": event_id
                 }
                 max_id = yield self.store.add_account_data_to_room(
-                    user_id, room_id, "m.read_up_to", content
+                    user_id, room_id, "m.fully_read", content
                 )
                 self.notifier.on_new_event("account_data_key", max_id, users=[user_id])

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -43,7 +43,7 @@ class ReadMarkerHandler(BaseHandler):
         with (yield self.read_marker_linearizer.queue((room_id, user_id))):
             account_data = yield self.store.get_account_data_for_room(user_id, room_id)
 
-            existing_read_marker = account_data.get("m.read_marker", None)
+            existing_read_marker = account_data.get("m.read_up_to", None)
 
             should_update = True
 
@@ -51,14 +51,14 @@ class ReadMarkerHandler(BaseHandler):
                 # Only update if the new marker is ahead in the stream
                 should_update = yield self.store.is_event_after(
                     event_id,
-                    existing_read_marker['marker']
+                    existing_read_marker['event_id']
                 )
 
             if should_update:
                 content = {
-                    "marker": event_id
+                    "event_id": event_id
                 }
                 max_id = yield self.store.add_account_data_to_room(
-                    user_id, room_id, "m.read_marker", content
+                    user_id, room_id, "m.read_up_to", content
                 )
                 self.notifier.on_new_event("account_data_key", max_id, users=[user_id])

--- a/synapse/rest/client/v2_alpha/account_data.py
+++ b/synapse/rest/client/v2_alpha/account_data.py
@@ -82,11 +82,11 @@ class RoomAccountDataServlet(RestServlet):
 
         body = parse_json_object_from_request(request)
 
-        if account_data_type == "m.read_marker":
+        if account_data_type == "m.fully_read":
             raise SynapseError(
                 405,
-                "Cannot set m.read_marker through this API."
-                " Use /rooms/!roomId:server.name/read_marker"
+                "Cannot set m.fully_read through this API."
+                " Use /rooms/!roomId:server.name/read_markers"
             )
 
         max_id = yield self.store.add_account_data_to_room(

--- a/synapse/rest/client/v2_alpha/read_marker.py
+++ b/synapse/rest/client/v2_alpha/read_marker.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 class ReadMarkerRestServlet(RestServlet):
-    PATTERNS = client_v2_patterns("/rooms/(?P<room_id>[^/]*)/read_marker$")
+    PATTERNS = client_v2_patterns("/rooms/(?P<room_id>[^/]*)/read_markers$")
 
     def __init__(self, hs):
         super(ReadMarkerRestServlet, self).__init__()
@@ -51,7 +51,7 @@ class ReadMarkerRestServlet(RestServlet):
                 event_id=read_event_id
             )
 
-        read_marker_event_id = body.get("m.read_marker", None)
+        read_marker_event_id = body.get("m.read_up_to", None)
         if read_marker_event_id:
             yield self.read_marker_handler.received_client_read_marker(
                 room_id,

--- a/synapse/rest/client/v2_alpha/read_marker.py
+++ b/synapse/rest/client/v2_alpha/read_marker.py
@@ -51,7 +51,7 @@ class ReadMarkerRestServlet(RestServlet):
                 event_id=read_event_id
             )
 
-        read_marker_event_id = body.get("m.read_up_to", None)
+        read_marker_event_id = body.get("m.fully_read", None)
         if read_marker_event_id:
             yield self.read_marker_handler.received_client_read_marker(
                 room_id,


### PR DESCRIPTION
Also:
 - change the REST endpoint to have a "S" on the end (so it's now /read_markers)
 - change the content of the m.read_up_to event to have the key "event_id" instead of "marker".

This is reflected in recent changes to https://docs.google.com/document/d/1UWqdS-e1sdwkLDUY0wA4gZyIkRp-ekjsLZ8k6g_Zvso/edit#