### PR TITLE
web_client_location documentation fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -335,8 +335,11 @@ ArchLinux
 ---------
 
 The quickest way to get up and running with ArchLinux is probably with the community package
-https://www.archlinux.org/packages/community/any/matrix-synapse/, which should pull in all
-the necessary dependencies.
+https://www.archlinux.org/packages/community/any/matrix-synapse/, which should pull in most of
+the necessary dependencies. If the default web client is to be served (enabled by default in
+the generated config),
+https://www.archlinux.org/packages/community/any/python2-matrix-angular-sdk/ will also need to
+be installed. 
 
 Alternatively, to install using pip a few changes may be needed as ArchLinux
 defaults to python 3, but synapse currently assumes python 2.7 by default:

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -88,11 +88,10 @@ def build_resource_for_web_client(hs):
                 "the location of the source to serve via the configuration\n"
                 "option `web_client_location`\n\n"
                 "To install the `matrix-angular-sdk` via pip, run:\n\n"
-                "    pip install '%(dep)s'\n"
+                "    pip install matrix-angular-sdk\n"
                 "\n"
                 "You can also disable hosting of the webclient via the\n"
                 "configuration option `web_client`\n"
-                % {"dep": DEPENDENCY_LINKS["matrix-angular-sdk"]}
             )
         syweb_path = os.path.dirname(syweb.__file__)
         webclient_path = os.path.join(syweb_path, "webclient")

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -24,7 +24,9 @@ import sys
 import synapse.config.logger
 from synapse.config._base import ConfigError
 
-from synapse.python_dependencies import check_requirements
+from synapse.python_dependencies import (
+    check_requirements, CONDITIONAL_REQUIREMENTS
+)
 
 from synapse.rest import ClientRestResource
 from synapse.storage.engines import create_engine, IncorrectDatabaseSetup
@@ -86,10 +88,11 @@ def build_resource_for_web_client(hs):
                 "the location of the source to serve via the configuration\n"
                 "option `web_client_location`\n\n"
                 "To install the `matrix-angular-sdk` via pip, run:\n\n"
-                "    pip install matrix-angular-sdk\n"
+                "    pip install '%(dep)s'\n"
                 "\n"
                 "You can also disable hosting of the webclient via the\n"
                 "configuration option `web_client`\n"
+                % {"dep": CONDITIONAL_REQUIREMENTS["web_client"].keys()[0]}
             )
         syweb_path = os.path.dirname(syweb.__file__)
         webclient_path = os.path.join(syweb_path, "webclient")

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -24,9 +24,7 @@ import sys
 import synapse.config.logger
 from synapse.config._base import ConfigError
 
-from synapse.python_dependencies import (
-    check_requirements, DEPENDENCY_LINKS
-)
+from synapse.python_dependencies import check_requirements
 
 from synapse.rest import ClientRestResource
 from synapse.storage.engines import create_engine, IncorrectDatabaseSetup

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -144,6 +144,12 @@ class ServerConfig(Config):
         # Whether to serve a web client from the HTTP/HTTPS root resource.
         web_client: True
 
+        # The root directory to server for the above web client.
+        # If left undefined, synapse will serve the matrix-angular-sdk web client.
+        # Make sure matrix-angular-sdk is installed with pip if web_client is True
+        # and web_client_location is undefined
+        # web_client_location: "/path/to/web/root"
+
         # The public-facing base URL for the client API (not including _matrix/...)
         # public_baseurl: https://example.com:8448/
 


### PR DESCRIPTION
The config option web_client_location is very sparsely documented. In my case, I wanted to see if I could get the matrix homeserver to host the riot.im electron app sources. To remedy the lack in documentation, I

1. Made the generated ``homeserver.yaml`` include information about this field. (``synapse/config/server.py``)

2. Changed the Readme portion for Arch Linux users. The AngularJS sdk is not distributed with the synapse package, so running synapse with the default ``homeserver.yaml`` will fail on Arch if matrix-synpase is installed from the repo. This is documented on the Arch wiki but not here.

3. Removed the string substitution from the error message in ``synapse/app/homeserver.py``. The error message implies that it will only be printed if matrix-angular-sdk is not installed. But if matrix-angular-sdk is not installed, the program will crash when trying to perform the string substitution and not print the error message, defeating its purpose. If there's a better way to prevent this error, please enlighten me. 

I saw that yall welcome additions to ``AUTHORS.rst``. I feel like this fix isn't big enough for it to be appropriate to put my name next to the real developers. But hey if yall are fine with it I'd be happy to put my name there.

Signed-off-by: Matthew Wolff <matthewjwolff@gmail.com>