### PR TITLE
Propagate errors sensibly from proxied IS requests

### DIFF
--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -66,6 +66,17 @@ class CodeMessageException(RuntimeError):
         return cs_error(self.msg)
 
 
+class MatrixCodeMessageException(CodeMessageException):
+    """An error from a general matrix endpoint, eg. from a proxied Matrix API call.
+
+    Attributes:
+        errcode (str): Matrix error code e.g 'M_FORBIDDEN'
+    """
+    def __init__(self, code, msg, errcode=Codes.UNKNOWN):
+        super(MatrixCodeMessageException, self).__init__(code, msg)
+        self.errcode = errcode
+
+
 class SynapseError(CodeMessageException):
     """A base exception type for matrix errors which have an errcode and error
     message (as well as an HTTP status code).

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -84,7 +84,7 @@ class IdentityHandler(BaseHandler):
         data = {}
         try:
             data = yield self.http_client.get_json(
-                "http://%s%s" % (
+                "https://%s%s" % (
                     id_server,
                     "/_matrix/identity/api/v1/3pid/getValidated3pid"
                 ),
@@ -122,7 +122,7 @@ class IdentityHandler(BaseHandler):
 
         try:
             data = yield self.http_client.post_urlencoded_get_json(
-                "http://%s%s" % (
+                "https://%s%s" % (
                     id_server, "/_matrix/identity/api/v1/3pid/bind"
                 ),
                 {
@@ -155,7 +155,7 @@ class IdentityHandler(BaseHandler):
 
         try:
             data = yield self.http_client.post_json_get_json(
-                "http://%s%s" % (
+                "https://%s%s" % (
                     id_server,
                     "/_matrix/identity/api/v1/validate/email/requestToken"
                 ),
@@ -192,7 +192,7 @@ class IdentityHandler(BaseHandler):
 
         try:
             data = yield self.http_client.post_json_get_json(
-                "http://%s%s" % (
+                "https://%s%s" % (
                     id_server,
                     "/_matrix/identity/api/v1/validate/msisdn/requestToken"
                 ),

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -35,7 +35,7 @@ class IdentityHandler(BaseHandler):
     def __init__(self, hs):
         super(IdentityHandler, self).__init__(hs)
 
-        self.http_client = hs.get_simple_http_client()
+        self.proxy_client = hs.get_matrix_proxy_client()
 
         self.trusted_id_servers = set(hs.config.trusted_third_party_id_servers)
         self.trust_any_id_server_just_for_testing_do_not_use = (
@@ -83,7 +83,7 @@ class IdentityHandler(BaseHandler):
 
         data = {}
         try:
-            data = yield self.http_client.get_json(
+            data = yield self.proxy_client.get_json(
                 "https://%s%s" % (
                     id_server,
                     "/_matrix/identity/api/v1/3pid/getValidated3pid"
@@ -118,7 +118,7 @@ class IdentityHandler(BaseHandler):
             raise SynapseError(400, "No client_secret in creds")
 
         try:
-            data = yield self.http_client.post_urlencoded_get_json(
+            data = yield self.proxy_client.post_urlencoded_get_json(
                 "https://%s%s" % (
                     id_server, "/_matrix/identity/api/v1/3pid/bind"
                 ),
@@ -151,7 +151,7 @@ class IdentityHandler(BaseHandler):
         params.update(kwargs)
 
         try:
-            data = yield self.http_client.post_json_get_json(
+            data = yield self.proxy_client.post_json_get_json(
                 "https://%s%s" % (
                     id_server,
                     "/_matrix/identity/api/v1/validate/email/requestToken"
@@ -185,7 +185,7 @@ class IdentityHandler(BaseHandler):
         params.update(kwargs)
 
         try:
-            data = yield self.http_client.post_json_get_json(
+            data = yield self.proxy_client.post_json_get_json(
                 "https://%s%s" % (
                     id_server,
                     "/_matrix/identity/api/v1/validate/msisdn/requestToken"

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -260,7 +260,7 @@ class SimpleHttpClient(object):
             errcode = jsonBody['errcode']
             error = jsonBody['error']
             return MatrixCodeMessageException(response.code, error, errcode)
-        except (ValueError, KeyError) as e:
+        except (ValueError, KeyError):
             return CodeMessageException(response.code, body)
 
     # XXX: FIXME: This is horribly copy-pasted from matrixfederationclient.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -260,8 +260,7 @@ class SimpleHttpClient(object):
             errcode = jsonBody['errcode']
             error = jsonBody['error']
             return MatrixCodeMessageException(response.code, error, errcode)
-        except e:
-            print e
+        except:
             return CodeMessageException(response.code, body)
 
     # XXX: FIXME: This is horribly copy-pasted from matrixfederationclient.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -260,7 +260,7 @@ class SimpleHttpClient(object):
             errcode = jsonBody['errcode']
             error = jsonBody['error']
             return MatrixCodeMessageException(response.code, error, errcode)
-        except:
+        except (ValueError, KeyError) as e:
             return CodeMessageException(response.code, body)
 
     # XXX: FIXME: This is horribly copy-pasted from matrixfederationclient.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -169,12 +169,11 @@ class SimpleHttpClient(object):
             On a non-2xx HTTP response. The response body will be used as the
             error message.
         """
-        body = yield self.get_raw(uri, args)
-
-        if 200 <= response.code < 300:
+        try:
+            body = yield self.get_raw(uri, args)
             defer.returnValue(json.loads(body))
-        else:
-            raise self._exceptionFromFailedRequest(response, body)
+        except CodeMessageException as e:
+            raise self._exceptionFromFailedRequest(e.code, e.msg)
 
     @defer.inlineCallbacks
     def put_json(self, uri, json_body, args={}):

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -145,7 +145,7 @@ class SimpleHttpClient(object):
 
         body = yield preserve_context_over_fn(readBody, response)
 
-        if response.code / 100 != 2:
+        if response.code / 100 >= 4:
             raise CodeMessageException(response.code, body)
 
         defer.returnValue(json.loads(body))

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -323,7 +323,7 @@ class MatrixProxyClient(object):
             result = yield self.simpleHttpClient.post_json_get_json(uri, post_json)
             defer.returnValue(result)
         except CodeMessageException as cme:
-            ex = self._tryGetMatrixError(cme.msg)
+            ex = self._tryGetMatrixError(cme)
             if ex is not None:
                 raise ex
             raise cme
@@ -334,17 +334,17 @@ class MatrixProxyClient(object):
             result = yield self.simpleHttpClient.get_json(uri, args)
             defer.returnValue(result)
         except CodeMessageException as cme:
-            ex = self._tryGetMatrixError(cme.msg)
+            ex = self._tryGetMatrixError(cme)
             if ex is not None:
                 raise ex
             raise cme
 
-    def _tryGetMatrixError(self, body):
+    def _tryGetMatrixError(self, codeMessageException):
         try:
-            errbody = json.loads(body)
+            errbody = json.loads(codeMessageException.msg)
             errcode = errbody['errcode']
             errtext = errbody['error']
-            return SynapseError(cme.code, errtext, errcode)
+            return SynapseError(codeMessageException.code, errtext, errcode)
         except:
             return None
 

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -49,9 +49,7 @@ from synapse.handlers.events import EventHandler, EventStreamHandler
 from synapse.handlers.initial_sync import InitialSyncHandler
 from synapse.handlers.receipts import ReceiptsHandler
 from synapse.handlers.read_marker import ReadMarkerHandler
-from synapse.http.client import (
-    SimpleHttpClient, InsecureInterceptableContextFactory, MatrixProxyClient
-)
+from synapse.http.client import SimpleHttpClient, InsecureInterceptableContextFactory
 from synapse.http.matrixfederationclient import MatrixFederationHttpClient
 from synapse.notifier import Notifier
 from synapse.push.pusherpool import PusherPool
@@ -130,7 +128,6 @@ class HomeServer(object):
         'filtering',
         'http_client_context_factory',
         'simple_http_client',
-        'matrix_proxy_client',
         'media_repository',
         'federation_transport_client',
         'federation_sender',
@@ -192,9 +189,6 @@ class HomeServer(object):
 
     def build_simple_http_client(self):
         return SimpleHttpClient(self)
-
-    def build_matrix_proxy_client(self):
-        return MatrixProxyClient(self)
 
     def build_v1auth(self):
         orf = Auth(self)

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -48,7 +48,9 @@ from synapse.handlers.typing import TypingHandler
 from synapse.handlers.events import EventHandler, EventStreamHandler
 from synapse.handlers.initial_sync import InitialSyncHandler
 from synapse.handlers.receipts import ReceiptsHandler
-from synapse.http.client import SimpleHttpClient, InsecureInterceptableContextFactory
+from synapse.http.client import (
+    SimpleHttpClient, InsecureInterceptableContextFactory, MatrixProxyClient
+)
 from synapse.http.matrixfederationclient import MatrixFederationHttpClient
 from synapse.notifier import Notifier
 from synapse.push.pusherpool import PusherPool
@@ -127,6 +129,7 @@ class HomeServer(object):
         'filtering',
         'http_client_context_factory',
         'simple_http_client',
+        'matrix_proxy_client',
         'media_repository',
         'federation_transport_client',
         'federation_sender',
@@ -187,6 +190,9 @@ class HomeServer(object):
 
     def build_simple_http_client(self):
         return SimpleHttpClient(self)
+
+    def build_matrix_proxy_client(self):
+        return MatrixProxyClient(self)
 
     def build_v1auth(self):
         orf = Auth(self)


### PR DESCRIPTION
When we're proxying Matrix endpoints, parse out Matrix error
responses and turn them into SynapseErrors so they can be
propagated sensibly upstream.

This will allow clients to give sensible error messages if the ID server rejects their request, for example https://github.com/vector-im/riot-web/issues/3542