### PR TITLE
Fix code for reporting old verify keys in synapse

### DIFF
--- a/synapse/rest/key/v2/local_key_resource.py
+++ b/synapse/rest/key/v2/local_key_resource.py
@@ -84,12 +84,11 @@ class LocalKey(Resource):
             }
 
         old_verify_keys = {}
-        for key in self.config.old_signing_keys:
-            key_id = "%s:%s" % (key.alg, key.version)
+        for key_id, key in self.config.old_signing_keys.items():
             verify_key_bytes = key.encode()
             old_verify_keys[key_id] = {
                 u"key": encode_base64(verify_key_bytes),
-                u"expired_ts": key.expired,
+                u"expired_ts": key.expired_ts,
             }
 
         tls_fingerprints = self.config.tls_fingerprints


### PR DESCRIPTION
The code for generating the `"old_verify_keys"` section in local_key_resource was buggy.
It was assuming that the `old_signing_keys` was a list when in fact it was a dict.
The net result was that any server that tried to fill out the `"old_signing_keys"` config entry would crash on startup as it tried to pre-generate the local key response.
