### PR TITLE
Reduce size of joined_user cache

### DIFF
--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -88,7 +88,7 @@ class BulkPushRuleEvaluator:
 
         for uid, rules in self.rules_by_user.items():
             display_name = None
-            profile_info = room_members.get(uid, {})
+            profile_info = room_members.get(uid)
             if profile_info:
                 display_name = profile_info.display_name
             else:

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -91,7 +91,8 @@ class BulkPushRuleEvaluator:
             profile_info = room_members.get(uid)
             if profile_info:
                 display_name = profile_info.display_name
-            else:
+
+            if not display_name:
                 # Handle the case where we are pushing a membership event to
                 # that user, as they might not be already joined.
                 if event.type == EventTypes.Member and event.state_key == uid:

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -87,8 +87,11 @@ class BulkPushRuleEvaluator:
         condition_cache = {}
 
         for uid, rules in self.rules_by_user.items():
-            display_name = room_members.get(uid, {}).get("display_name", None)
-            if not display_name:
+            display_name = None
+            profile_info = room_members.get(uid, {})
+            if profile_info:
+                display_name = profile_info.display_name
+            else:
                 # Handle the case where we are pushing a membership event to
                 # that user, as they might not be already joined.
                 if event.type == EventTypes.Member and event.state_key == uid:

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -406,7 +406,13 @@ class JoinedRoomMemberListRestServlet(ClientV1RestServlet):
         users_with_profile = yield self.state.get_current_user_in_room(room_id)
 
         defer.returnValue((200, {
-            "joined": users_with_profile
+            "joined": {
+                user_id: {
+                    "avatar_url": profile.avatar_url,
+                    "display_name": profile.display_name,
+                }
+                for user_id, profile in users_with_profile.iteritems()
+            }
         }))
 
 

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -36,6 +36,8 @@ RoomsForUser = namedtuple(
 )
 
 
+# We store this using a namedtuple so that we save about 3x space over using a
+# dict.
 ProfileInfo = namedtuple(
     "ProfileInfo", ("avatar_url", "display_name")
 )

--- a/synapse/util/stringutils.py
+++ b/synapse/util/stringutils.py
@@ -40,3 +40,17 @@ def is_ascii(s):
         return False
     else:
         return True
+
+
+def to_ascii(s):
+    """Converts a string to ascii if it is ascii, otherwise leave it alone.
+
+    If given None then will return None.
+    """
+    if s is None:
+        return None
+
+    try:
+        return s.encode("ascii")
+    except UnicodeEncodeError:
+        return s


### PR DESCRIPTION
The _get_joined_users_from_context cache stores a mapping from `user_id` to `avatar_url` and `display_name`. Instead of storing those in a dict, store them in a `namedtuple` as that uses much less memory.

We also try converting the string to ascii to further reduce the size.