### PR TITLE
Instantiate DeferredTimedOutError correctly

### DIFF
--- a/synapse/util/__init__.py
+++ b/synapse/util/__init__.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 class DeferredTimedOutError(SynapseError):
     def __init__(self):
-        super(SynapseError, self).__init__(504, "Timed out")
+        super(DeferredTimedOutError, self).__init__(504, "Timed out")
 
 
 def unwrapFirstError(failure):


### PR DESCRIPTION
Call `super` correctly, so that we correctly initialise the `errcode` field.

Fixes https://github.com/matrix-org/synapse/issues/2179.

(This was introduced in 0.20 at https://github.com/matrix-org/synapse/pull/2052/files#diff-1715c3aac07d6c81ab37084dff6e0f6fR29).