### PR TITLE
Modify register/available to be GET with query param

### DIFF
--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -54,6 +54,13 @@ class RegistrationHandler(BaseHandler):
                 Codes.INVALID_USERNAME
             )
 
+        if len(localpart) == 0:
+            raise SynapseError(
+                400,
+                "User ID cannot be empty",
+                Codes.INVALID_USERNAME
+            )
+
         if localpart[0] == '_':
             raise SynapseError(
                 400,

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -54,7 +54,7 @@ class RegistrationHandler(BaseHandler):
                 Codes.INVALID_USERNAME
             )
 
-        if len(localpart) == 0:
+        if not localpart:
             raise SynapseError(
                 400,
                 "User ID cannot be empty",

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -21,7 +21,7 @@ from synapse.api.auth import get_access_token_from_request, has_access_token
 from synapse.api.constants import LoginType
 from synapse.api.errors import SynapseError, Codes, UnrecognizedRequestError
 from synapse.http.servlet import (
-    RestServlet, parse_json_object_from_request, assert_params_in_request
+    RestServlet, parse_json_object_from_request, assert_params_in_request, parse_string
 )
 from synapse.util.msisdn import phone_number_to_msisdn
 
@@ -142,15 +142,14 @@ class UsernameAvailabilityRestServlet(RestServlet):
         )
 
     @defer.inlineCallbacks
-    def on_POST(self, request):
+    def on_GET(self, request):
         ip = self.hs.get_ip_from_request(request)
         with self.ratelimiter.ratelimit(ip) as wait_deferred:
             yield wait_deferred
 
-            body = parse_json_object_from_request(request)
-            assert_params_in_request(body, ['username'])
+            username = parse_string(request, "username", required=True)
 
-            yield self.registration_handler.check_username(body['username'])
+            yield self.registration_handler.check_username(username)
 
             defer.returnValue((200, {"available": True}))
 


### PR DESCRIPTION
- GET is now the method for register/available
- a query parameter "username" is now used

Also, empty usernames are now handled with an error message on registration or via register/available: `User ID cannot be empty`