### PR TITLE
Remote room list error instead of Internal Server Error

### DIFF
--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -20,6 +20,8 @@ from ._base import BaseHandler
 from synapse.api.constants import (
     EventTypes, JoinRules,
 )
+from synapse.api.errors import HttpResponseException, SynapseError
+
 from synapse.util.async import concurrently_execute
 from synapse.util.caches.descriptors import cachedInlineCallbacks
 from synapse.util.caches.response_cache import ResponseCache
@@ -372,12 +374,14 @@ class RoomListHandler(BaseHandler):
             # to do it manually without pagination
             limit = None
             since_token = None
-
-        res = yield self._get_remote_list_cached(
-            server_name, limit=limit, since_token=since_token,
-            include_all_networks=include_all_networks,
-            third_party_instance_id=third_party_instance_id,
-        )
+        try:
+            res = yield self._get_remote_list_cached(
+                server_name, limit=limit, since_token=since_token,
+                include_all_networks=include_all_networks,
+                third_party_instance_id=third_party_instance_id,
+            )
+        except HttpResponseException as e:
+            raise SynapseError(e.code, "Failed to fetch Remote Room List")
 
         if search_filter:
             res = {"chunk": [


### PR DESCRIPTION
Not sure if the error code on the `HttpResponseException` should be forwarded directly or replaced by a 4xx one? 

