### PR TITLE
Make get_joined_users faster when we have delta state

### DIFF
--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -420,7 +420,12 @@ class RoomMemberStore(SQLBaseStore):
             for key, e_id in current_state_ids.iteritems()
             if key[0] == EventTypes.Member
         ]
+
         if context is not None:
+            # If we have a context with a delta from a previous state group,
+            # check if we also have the result from the previous group in cache.
+            # If we do then we can reuse that result and simply update it with
+            # any membership changes in `delta_ids`
             if context.prev_group and context.delta_ids:
                 prev_res = self._get_joined_users_from_context.cache.get(
                     (room_id, context.prev_group), None


### PR DESCRIPTION
If we have a context with delta state IDs, we can use the cached result from the previous group and simply update with the changes