### PR TITLE
Adapt the default config to bind on IPv6.

### DIFF
--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -177,13 +177,14 @@ class ServerConfig(Config):
             port: %(bind_port)s
 
             # Local addresses to listen on.
-            # This will listen on all IPv4 addresses by default.
+            # On Linux and Mac OS, this will listen on all IPv4 and IPv6
+            # addresses by default. For most other OSes, this will only listen
+            # on IPv6.
             bind_addresses:
-              - '0.0.0.0'
-              # Uncomment to listen on all IPv6 interfaces
-              # N.B: On at least Linux this will also listen on all IPv4
-              # addresses, so you will need to comment out the line above.
-              # - '::'
+              - '::'
+              # For systems other than Linux or Mac OS, uncomment the next line
+              # to also listen on IPv4.
+              #- '0.0.0.0'
 
             # This is a 'http' listener, allows us to specify 'resources'.
             type: http
@@ -214,7 +215,7 @@ class ServerConfig(Config):
           # For when matrix traffic passes through loadbalancer that unwraps TLS.
           - port: %(unsecure_port)s
             tls: false
-            bind_addresses: ['0.0.0.0']
+            bind_addresses: ['::']
             type: http
 
             x_forwarded: false
@@ -228,7 +229,7 @@ class ServerConfig(Config):
           # Turn on the twisted ssh manhole service on localhost on the given
           # port.
           # - port: 9000
-          #   bind_address: 127.0.0.1
+          #   bind_addresses: ['::1', '127.0.0.1']
           #   type: manhole
         """ % locals()
 


### PR DESCRIPTION
Most deployments are on Linux, so this would actually bind on both IPv4 and IPv6. Resolves #1886.

This change would additionally prevent timeouts for domain names with both A and AAAA records, and allows IPv6-only homeservers to connect to servers with an AAAA record.