### PR TITLE
Change is_host_joined to use current_state table

### DIFF
--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -144,17 +144,8 @@ class Auth(object):
     @defer.inlineCallbacks
     def check_host_in_room(self, room_id, host):
         with Measure(self.clock, "check_host_in_room"):
-            latest_event_ids = yield self.store.get_latest_event_ids_in_room(room_id)
-
-            logger.debug("calling resolve_state_groups from check_host_in_room")
-            entry = yield self.state.resolve_state_groups(
-                room_id, latest_event_ids
-            )
-
-            ret = yield self.store.is_host_joined(
-                room_id, host, entry.state_group, entry.state
-            )
-            defer.returnValue(ret)
+            latest_event_ids = yield self.store.is_host_joined(room_id, host)
+            defer.returnValue(latest_event_ids)
 
     def _check_joined_room(self, member, user_id, room_id):
         if not member or member.membership != Membership.JOIN:

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -151,7 +151,7 @@ class UserDirectoyHandler(object):
     def _handle_intial_room(self, room_id):
         """Called when we initially fill out user_directory one room at a time
         """
-        is_in_room = yield self.state.get_is_host_in_room(room_id, self.server_name)
+        is_in_room = yield self.store.is_host_joined(room_id, self.server_name)
         if not is_in_room:
             return
 
@@ -209,7 +209,7 @@ class UserDirectoyHandler(object):
                 if not change:
                     # Need to check if the server left the room entirely, if so
                     # we might need to remove all the users in that room
-                    is_in_room = yield self.state.get_is_host_in_room(
+                    is_in_room = yield self.store.is_host_joined(
                         room_id, self.server_name,
                     )
                     if not is_in_room:
@@ -346,7 +346,7 @@ class UserDirectoyHandler(object):
             if not update_user_in_public and not update_user_dir:
                 break
 
-            is_in_room = yield self.state.get_is_host_in_room(
+            is_in_room = yield self.store.is_host_joined(
                 j_room_id, self.server_name,
             )
 

--- a/synapse/replication/slave/storage/events.py
+++ b/synapse/replication/slave/storage/events.py
@@ -154,7 +154,6 @@ class SlavedEventStore(BaseSlavedStore):
         DataStore.get_room_events_stream_for_rooms.__func__
     )
     is_host_joined = DataStore.is_host_joined.__func__
-    _is_host_joined = RoomMemberStore.__dict__["_is_host_joined"]
     get_stream_token_for_event = DataStore.get_stream_token_for_event.__func__
 
     _set_before_and_after = staticmethod(DataStore._set_before_and_after)

--- a/synapse/state.py
+++ b/synapse/state.py
@@ -183,17 +183,6 @@ class StateHandler(object):
         defer.returnValue(joined_hosts)
 
     @defer.inlineCallbacks
-    def get_is_host_in_room(self, room_id, host, latest_event_ids=None):
-        if not latest_event_ids:
-            latest_event_ids = yield self.store.get_latest_event_ids_in_room(room_id)
-        logger.debug("calling resolve_state_groups from get_is_host_in_room")
-        entry = yield self.resolve_state_groups(room_id, latest_event_ids)
-        is_host_joined = yield self.store.is_host_joined(
-            room_id, host, entry.state_id, entry.state
-        )
-        defer.returnValue(is_host_joined)
-
-    @defer.inlineCallbacks
     def compute_event_context(self, event, old_state=None):
         """Build an EventContext structure for the event.
 

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -507,9 +507,12 @@ class RoomMemberStore(SQLBaseStore):
             raise Exception("Invalid host name")
 
         sql = """
-            SELECT state_key FROM current_state_events
-            INNER JOIN room_memberships USING (room_id, event_id)
-            WHERE membership = 'join' AND room_id = ? AND state_key LIKE ?
+            SELECT state_key FROM current_state_events AS c
+            INNER JOIN room_memberships USING (event_id)
+            WHERE membership = 'join'
+                AND type = 'm.room.member'
+                AND c.room_id = ?
+                AND state_key LIKE ?
             LIMIT 1
         """
 

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -501,40 +501,34 @@ class RoomMemberStore(SQLBaseStore):
 
         defer.returnValue(users_in_room)
 
-    def is_host_joined(self, room_id, host, state_group, state_ids):
-        if not state_group:
-            # If state_group is None it means it has yet to be assigned a
-            # state group, i.e. we need to make sure that calls with a state_group
-            # of None don't hit previous cached calls with a None state_group.
-            # To do this we set the state_group to a new object as object() != object()
-            state_group = object()
+    @defer.inlineCallbacks
+    def is_host_joined(self, room_id, host):
+        if '%' in host or '_' in host:
+            raise Exception("Invalid host name")
 
-        return self._is_host_joined(
-            room_id, host, state_group, state_ids
-        )
+        sql = """
+            SELECT state_key FROM current_state_events
+            INNER JOIN room_memberships USING (room_id, event_id)
+            WHERE membership = 'join' AND room_id = ? AND state_key LIKE ?
+            LIMIT 1
+        """
 
-    @cachedInlineCallbacks(num_args=3)
-    def _is_host_joined(self, room_id, host, state_group, current_state_ids):
-        # We don't use `state_group`, its there so that we can cache based
-        # on it. However, its important that its never None, since two current_state's
-        # with a state_group of None are likely to be different.
-        # See bulk_get_push_rules_for_room for how we work around this.
-        assert state_group is not None
+        # We do need to be careful to ensure that host doesn't have any wild cards
+        # in it, but we checked above for known ones and we'll check below that
+        # the returned user actually has the correct domain.
+        like_clause = "%:" + host
 
-        for (etype, state_key), event_id in current_state_ids.items():
-            if etype == EventTypes.Member:
-                try:
-                    if get_domain_from_id(state_key) != host:
-                        continue
-                except:
-                    logger.warn("state_key not user_id: %s", state_key)
-                    continue
+        rows = yield self._execute("is_host_joined", None, sql, room_id, like_clause)
 
-                event = yield self.get_event(event_id, allow_none=True)
-                if event and event.content["membership"] == Membership.JOIN:
-                    defer.returnValue(True)
+        if not rows:
+            defer.returnValue(False)
 
-        defer.returnValue(False)
+        user_id = rows[0][0]
+        if get_domain_from_id(user_id) != host:
+            # This can only happen if the host name has something funky in it
+            raise Exception("Invalid host name")
+
+        defer.returnValue(True)
 
     def get_joined_hosts(self, room_id, state_entry):
         state_group = state_entry.state_group


### PR DESCRIPTION
This bypasses a bug where using the state groups to figure out if a host
is in a room sometimes errors if the servers isn't in the room. (For
example when the server rejected an invite to a remote room)