### PR TITLE
Fix has_any_entity_changed

### DIFF
--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -99,7 +99,7 @@ class StreamChangeCache(object):
             keys = self._cache.keys()
             i = keys.bisect_right(stream_pos)
 
-            return len(keys[i:]) > 0
+            return i < len(keys)
         else:
             self.metrics.inc_misses()
             return True

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -96,10 +96,10 @@ class StreamChangeCache(object):
 
         if stream_pos >= self._earliest_known_stream_pos:
             self.metrics.inc_hits()
-            if stream_pos >= max(self._cache):
-                return False
-            else:
-                return True
+            keys = self._cache.keys()
+            i = keys.bisect_right(stream_pos)
+
+            return len(keys[i:]) > 0
         else:
             self.metrics.inc_misses()
             return True


### PR DESCRIPTION
Occasionally has_any_entity_changed would throw the error: "Set changed size during iteration" when taking the max of the `sorteddict`. While its uncertain how that happens, its quite inefficient to iterate over the entire dict anyway so we change to using the more traditional `bisect_*` functions.