### PR TITLE
allow Authorization header

### DIFF
--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -412,7 +412,7 @@ def set_cors_headers(request):
     )
     request.setHeader(
         "Access-Control-Allow-Headers",
-        "Origin, X-Requested-With, Content-Type, Accept"
+        "Origin, X-Requested-With, Content-Type, Accept, Authorization"
     )
 
 


### PR DESCRIPTION
The implementation of the Authorization header got implemented in #1098 but the header was not allowed (CORS)