### PR TITLE
python_dependencies: Use bcrypt module instead of py-bcrypt

### DIFF
--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -31,7 +31,7 @@ REQUIREMENTS = {
     "pyyaml": ["yaml"],
     "pyasn1": ["pyasn1"],
     "daemonize": ["daemonize"],
-    "py-bcrypt": ["bcrypt"],
+    "bcrypt": ["bcrypt"],
     "pillow": ["PIL"],
     "pydenticon": ["pydenticon"],
     "ujson": ["ujson"],


### PR DESCRIPTION
py-bcrypt has been unmaintained for a long while, while bcrypt is
actively maintained. And since ff8b87118dcfb153d972e29c2b77b195244d5ddc
we're compatible with the bcrypt anyway.

This allows distro maintainer to drop the unmaintained module which also
happens to conflict with the bcrypt module.