### PR TITLE
Use an ExpiringCache for storing registration sessions

### DIFF
--- a/synapse/util/caches/expiringcache.py
+++ b/synapse/util/caches/expiringcache.py
@@ -94,6 +94,9 @@ class ExpiringCache(object):
 
         return entry.value
 
+    def __contains__(self, key):
+        return key in self._cache
+
     def get(self, key, default=None):
         try:
             return self[key]


### PR DESCRIPTION
This is because pruning them was a significant performance drain on matrix.org