### PR TITLE
encode sync-response statically

### DIFF
--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -164,7 +164,9 @@ class SyncRestServlet(RestServlet):
             )
 
         time_now = self.clock.time_msec()
-        response_content = self.encode_response(time_now, sync_result, requester.access_token_id, filter)
+        response_content = self.encode_response(
+            time_now, sync_result, requester.access_token_id, filter
+        )
 
         defer.returnValue((200, response_content))
 


### PR DESCRIPTION
Motivation:
1. I would like to use the `encode_*`-methods statically to avoid duplication of code e.g. for WebSocket-Usage.
2. I wanted to reduce the used data by omiting objects that are empty. As matrix-js-sdk (e.g.) checks if the objects are empty or not I think it should be secure to omit them from a response.

Signed-off-by: Matthias Kesler <krombel@krombel.de>