### PR TITLE
reduce sync response (omit empty objects)

### DIFF
--- a/changelog.d/2358.feature
+++ b/changelog.d/2358.feature
@@ -1,0 +1,1 @@
+reduce sync response (omit empty objects)

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -394,24 +394,26 @@ class SyncRestServlet(RestServlet):
                     event.event_id, room.room_id, event.room_id,
                 )
 
-        serialized_state = [serialize(e) for e in state_events]
-        serialized_timeline = [serialize(e) for e in timeline_events]
-
         account_data = room.account_data
 
-        result = {
-            "timeline": {
+        result = {}
+        if timeline_events:
+            serialized_timeline = [serialize(e) for e in timeline_events]
+            result["timeline"] = {
                 "events": serialized_timeline,
                 "prev_batch": room.timeline.prev_batch.to_string(),
                 "limited": room.timeline.limited,
-            },
-            "state": {"events": serialized_state},
-            "account_data": {"events": account_data},
-        }
+            }
+        if state_events:
+            serialized_state = [serialize(e) for e in state_events]
+            result["state"] = {"events": serialized_state}
+        if account_data:
+            result["account_data"] = {"events": account_data}
 
         if joined:
             ephemeral_events = room.ephemeral
-            result["ephemeral"] = {"events": ephemeral_events}
+            if ephemeral_events:
+                result["ephemeral"] = {"events": ephemeral_events}
             result["unread_notifications"] = room.unread_notifications
             result["summary"] = room.summary
 

--- a/tests/rest/client/v2_alpha/test_sync.py
+++ b/tests/rest/client/v2_alpha/test_sync.py
@@ -41,11 +41,7 @@ class FilterTestCase(unittest.HomeserverTestCase):
             set(
                 [
                     "next_batch",
-                    "rooms",
-                    "presence",
-                    "account_data",
-                    "to_device",
-                    "device_lists",
+                    "device_one_time_keys_count",
                 ]
             ).issubset(set(channel.json_body.keys()))
         )
@@ -62,6 +58,9 @@ class FilterTestCase(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, 200)
         self.assertTrue(
             set(
-                ["next_batch", "rooms", "account_data", "to_device", "device_lists"]
+                [
+                    "next_batch",
+                    "device_one_time_keys_count",
+                ]
             ).issubset(set(channel.json_body.keys()))
         )


### PR DESCRIPTION
Instead of returning all objects (even if they are empty) this PR introduces the behavior to just respond objects that contain data. The aim is to reduce data consumption.

Open TODO's before merging:
* [ ] Change doc to outline that not all objects have to be in the response
* [x] Check if it is working in current (popular clients)
  * [x] riot-android
  * [x] riot-ios
  * [x] riot-web
  * [x] nheko [mujx/nheko#67]
  * [ ] others?
* [x] fix tests to allow not-existence of objects