### PR TITLE
Fix iteration of requests_missing_keys; list doesn't have .values()

### DIFF
--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -305,7 +305,7 @@ class Keyring(object):
                     if not missing_keys:
                         break
 
-                for verify_request in requests_missing_keys.values():
+                for verify_request in requests_missing_keys:
                     verify_request.deferred.errback(SynapseError(
                         401,
                         "No key for %s with id %s" % (


### PR DESCRIPTION
This was causing multiple exceptions in my recently installed server.

Signed-off-by: Kenny Keslar <r3dey3@r3dey3.com>