### PR TITLE
Fix for createRoom API when all invitees get the same display name

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -197,12 +197,12 @@ class RoomCreationHandler(BaseHandler):
                 },
                 ratelimit=False)
 
-        content = {}
         is_direct = config.get("is_direct", None)
-        if is_direct:
-            content["is_direct"] = is_direct
 
         for invitee in invite_list:
+            content = {}
+            if is_direct:
+                content["is_direct"] = is_direct
             yield room_member_handler.update_membership(
                 requester,
                 UserID.from_string(invitee),


### PR DESCRIPTION
Fix for issue in createRoom API where all invitees set in the API get the same display name. The fix is to reset the "content" field for each invitee.
Signed-off-by: Florence Jacquet <flo@ljf.ch>