### PR TITLE
Add require_auth_for_room_directory option

### DIFF
--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -43,6 +43,9 @@ class ServerConfig(Config):
 
         self.filter_timeline_limit = config.get("filter_timeline_limit", -1)
 
+        self.require_auth_for_room_directory = \
+            config.get("require_auth_for_room_directory", False)
+
         if self.public_baseurl is not None:
             if self.public_baseurl[-1] != '/':
                 self.public_baseurl += '/'
@@ -193,6 +196,11 @@ class ServerConfig(Config):
         # Set the limit on the returned events in the timeline in the get
         # and sync operations. The default value is -1, means no upper limit.
         # filter_timeline_limit: 5000
+
+        # Set whether this server's public room directory is restricted to
+        # local authenticated users, or visible to the wider world.
+        # Default is to be visible to the wider world.
+        require_auth_for_room_directory: False
 
         # List of ports that Synapse should listen on, their purpose and their
         # configuration.

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -294,7 +294,7 @@ class PublicRoomListRestServlet(ClientV1RestServlet):
             # In both cases we call the auth function, as that has the side
             # effect of logging who issued this request if an access token was
             # provided.
-            if server:
+            if server or self.hs.config.require_auth_for_room_directory:
                 raise e
             else:
                 pass


### PR DESCRIPTION
This specifies whether a server's /publicRooms API is available to the general public or not, or whether it requires the user to have an account on the server in question.

This lets people opt out of /publicRooms spiders.