### PR TITLE
Fix missprint (or CopyPaste) that brake push: redact_content setting.

### DIFF
--- a/synapse/config/push.py
+++ b/synapse/config/push.py
@@ -20,7 +20,7 @@ class PushConfig(Config):
     def read_config(self, config):
         self.push_redact_content = False
 
-        push_config = config.get("email", {})
+        push_config = config.get("push", {})
         self.push_redact_content = push_config.get("redact_content", False)
 
     def default_config(self, config_dir_path, server_name, **kwargs):


### PR DESCRIPTION
Fix missprint (or CopyPaste) that brake push: redact_content setting.
There was mistake in config section name.