### PR TITLE
Add support for event_id_only push format

### DIFF
--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -244,7 +244,7 @@ class HttpPusher(object):
 
     @defer.inlineCallbacks
     def _build_notification_dict(self, event, tweaks, badge):
-        if 'format' in self.data and self.data['format'] == 'event_id_only':
+        if self.data.get('format') == 'event_id_only':
             d = {
                 'notification': {
                     'event_id': event.event_id,

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -244,6 +244,25 @@ class HttpPusher(object):
 
     @defer.inlineCallbacks
     def _build_notification_dict(self, event, tweaks, badge):
+        if 'format' in self.data and self.data['format'] == 'event_id_only':
+            d = {
+                'notification': {
+                    'event_id': event.event_id,
+                    'counts': {
+                        'unread': badge,
+                    },
+                    'devices': [
+                        {
+                            'app_id': self.app_id,
+                            'pushkey': self.pushkey,
+                            'pushkey_ts': long(self.pushkey_ts / 1000),
+                            'data': self.data_minus_url,
+                        }
+                    ]
+                }
+            }
+            defer.returnValue(d)
+
         ctx = yield push_tools.get_context_for_event(
             self.store, self.state_handler, event, self.user_id
         )

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -248,6 +248,7 @@ class HttpPusher(object):
             d = {
                 'notification': {
                     'event_id': event.event_id,
+                    'room_id': event.room_id,
                     'counts': {
                         'unread': badge,
                     },


### PR DESCRIPTION
Param in the data dict of a pusher that tells an HTTP pusher to
send just the event_id of the event it's notifying about and the
notification counts. For clients that want to go & fetch the body
of the event themselves anyway.