### PR TITLE
Add a config option to block all room invites

### DIFF
--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -519,6 +519,14 @@ class Auth(object):
             )
 
     def is_server_admin(self, user):
+        """ Check if the given user is a local server admin.
+
+        Args:
+            user (str): mxid of user to check
+
+        Returns:
+            bool: True if the user is an admin
+        """
         return self.store.is_server_admin(user)
 
     @defer.inlineCallbacks

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -43,6 +43,12 @@ class ServerConfig(Config):
 
         self.filter_timeline_limit = config.get("filter_timeline_limit", -1)
 
+        # Whether we should block invites sent to users on this server
+        # (other than those sent by local server admins)
+        self.block_non_admin_invites = config.get(
+            "block_non_admin_invites", False,
+        )
+
         if self.public_baseurl is not None:
             if self.public_baseurl[-1] != '/':
                 self.public_baseurl += '/'
@@ -193,6 +199,10 @@ class ServerConfig(Config):
         # Set the limit on the returned events in the timeline in the get
         # and sync operations. The default value is -1, means no upper limit.
         # filter_timeline_limit: 5000
+
+        # Whether room invites to users on this server should be blocked
+        # (except those sent by local server admins). The default is False.
+        # block_non_admin_invites: True
 
         # List of ports that Synapse should listen on, their purpose and their
         # configuration.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1074,6 +1074,9 @@ class FederationHandler(BaseHandler):
         if is_blocked:
             raise SynapseError(403, "This room has been blocked on this server")
 
+        if self.hs.config.block_non_admin_invites:
+            raise SynapseError(403, "This server does not accept room invites")
+
         membership = event.content.get("membership")
         if event.type != EventTypes.Member or membership != Membership.INVITE:
             raise SynapseError(400, "The event was not an m.room.member invite event")

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -212,8 +212,9 @@ class RoomMemberHandler(BaseHandler):
 
         if (effective_membership_state == "invite" and
                 self.hs.config.block_non_admin_invites):
-            is_requester_admin = \
-                yield self.auth.is_server_admin(requester.user)
+            is_requester_admin = yield self.auth.is_server_admin(
+                requester.user,
+            )
             if not is_requester_admin:
                 raise SynapseError(
                     403, "Invites have been disabled on this server",
@@ -483,8 +484,9 @@ class RoomMemberHandler(BaseHandler):
             txn_id
     ):
         if self.hs.config.block_non_admin_invites:
-            is_requester_admin = \
-                yield self.auth.is_server_admin(requester.user)
+            is_requester_admin = yield self.auth.is_server_admin(
+                requester.user,
+            )
             if not is_requester_admin:
                 raise SynapseError(
                     403, "Invites have been disabled on this server",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -56,6 +56,7 @@ def setup_test_homeserver(name="test", datastore=None, config=None, **kargs):
         config.worker_replication_url = ""
         config.worker_app = None
         config.email_enable_notifs = False
+        config.block_non_admin_invites = False
 
     config.use_frozen_dicts = True
     config.database_config = {"name": "sqlite3"}


### PR DESCRIPTION
- allows sysadmins the ability to lock down their servers so that people can't
send their users room invites.