### PR TITLE
Remove non-existing files, add stop, use synctl

### DIFF
--- a/contrib/systemd/synapse.service
+++ b/contrib/systemd/synapse.service
@@ -9,9 +9,9 @@ Description=Synapse Matrix homeserver
 Type=simple
 User=synapse
 Group=synapse
-EnvironmentFile=-/etc/sysconfig/synapse
 WorkingDirectory=/var/lib/synapse
-ExecStart=/usr/bin/python2.7 -m synapse.app.homeserver --config-path=/etc/synapse/homeserver.yaml --log-config=/etc/synapse/log_config.yaml
+ExecStart=/usr/bin/synctl start /etc/synapse/homeserver.yaml
+ExecStop=/usr/bin/synctl stop /etc/synapse/homeserver.yaml
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/synapse.service
+++ b/contrib/systemd/synapse.service
@@ -10,8 +10,9 @@ Type=simple
 User=synapse
 Group=synapse
 WorkingDirectory=/var/lib/synapse
-ExecStart=/usr/bin/synctl start /etc/synapse/homeserver.yaml
+ExecStart=/usr/bin/python2.7 -m synapse.app.homeserver --config-path=/etc/synapse/homeserver.yaml
 ExecStop=/usr/bin/synctl stop /etc/synapse/homeserver.yaml
 
 [Install]
 WantedBy=multi-user.target
+


### PR DESCRIPTION
Non-existing files, when running the suggested from https://github.com/matrix-org/synapse#configuring-synapse
/etc/synapse/log_config.yaml so the --log-config leads to an error
/etc/sysconfig/synapse The environment-file or even the /etc/sysconfig does not exist in arch linux

Also instead of calling python2 we use synctl, as this seems to be the proper way to start it, and it gives us a more useful error in the systemctl status. And we now allow stop (and therefore restart).