### PR TITLE
Ignore incoming events for rooms that we have left

### DIFF
--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -125,6 +125,29 @@ class FederationHandler(BaseHandler):
             self.room_queues[pdu.room_id].append((pdu, origin))
             return
 
+        # If we're no longer in the room just ditch the event entirely. This
+        # is probably an old server that has come back and thinks we're still
+        # in the room.
+        #
+        # If we were never in the room then maybe our database got vaped and
+        # we should check if we *are* in fact in the room. If we are then we
+        # can magically rejoin the room.
+        is_in_room = yield self.auth.check_host_in_room(
+            pdu.room_id,
+            self.server_name
+        )
+        if not is_in_room:
+            was_in_room = yield self.store.was_host_joined(
+                pdu.room_id, self.server_name,
+
+            )
+            if was_in_room:
+                logger.info(
+                    "Ignoring PDU %s for room %s from %s as we've left the room!",
+                    pdu.event_id, pdu.room_id, origin,
+                )
+                return
+
         state = None
 
         auth_chain = []

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -139,7 +139,6 @@ class FederationHandler(BaseHandler):
         if not is_in_room:
             was_in_room = yield self.store.was_host_joined(
                 pdu.room_id, self.server_name,
-
             )
             if was_in_room:
                 logger.info(

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -127,7 +127,7 @@ class FederationHandler(BaseHandler):
 
         # If we're no longer in the room just ditch the event entirely. This
         # is probably an old server that has come back and thinks we're still
-        # in the room.
+        # in the room (or we've been rejoined to the room by a state reset).
         #
         # If we were never in the room then maybe our database got vaped and
         # we should check if we *are* in fact in the room. If we are then we

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -784,6 +784,9 @@ class EventsStore(SQLBaseStore):
                     self._invalidate_cache_and_stream(
                         txn, self.is_host_joined, (room_id, host)
                     )
+                    self._invalidate_cache_and_stream(
+                        txn, self.was_host_joined, (room_id, host)
+                    )
 
                 self._invalidate_cache_and_stream(
                     txn, self.get_users_in_room, (room_id,)

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -536,6 +536,13 @@ class RoomMemberStore(SQLBaseStore):
     @cachedInlineCallbacks()
     def was_host_joined(self, room_id, host):
         """Check whether the server is or ever was in the room.
+
+        Args:
+            room_id (str)
+            host (str)
+
+        Returns:
+            bool: whether the host is/was in the room or not
         """
         if '%' in host or '_' in host:
             raise Exception("Invalid host name")

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -533,6 +533,38 @@ class RoomMemberStore(SQLBaseStore):
 
         defer.returnValue(True)
 
+    @cachedInlineCallbacks()
+    def was_host_joined(self, room_id, host):
+        """Check whether the server is or ever was in the room.
+        """
+        if '%' in host or '_' in host:
+            raise Exception("Invalid host name")
+
+        sql = """
+            SELECT user_id FROM room_memberships
+            WHERE room_id = ?
+                AND user_id LIKE ?
+                AND membership = 'join'
+            LIMIT 1
+        """
+
+        # We do need to be careful to ensure that host doesn't have any wild cards
+        # in it, but we checked above for known ones and we'll check below that
+        # the returned user actually has the correct domain.
+        like_clause = "%:" + host
+
+        rows = yield self._execute("was_host_joined", None, sql, room_id, like_clause)
+
+        if not rows:
+            defer.returnValue(False)
+
+        user_id = rows[0][0]
+        if get_domain_from_id(user_id) != host:
+            # This can only happen if the host name has something funky in it
+            raise Exception("Invalid host name")
+
+        defer.returnValue(True)
+
     def get_joined_hosts(self, room_id, state_entry):
         state_group = state_entry.state_group
         if not state_group:

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -542,7 +542,8 @@ class RoomMemberStore(SQLBaseStore):
             host (str)
 
         Returns:
-            bool: whether the host is/was in the room or not
+            Deferred: Resolves to True if the host is/was in the room, otherwise
+            False.
         """
         if '%' in host or '_' in host:
             raise Exception("Invalid host name")


### PR DESCRIPTION
When synapse receives an event for a room its not in over federation, it
double checks with the remote server to see if it is in fact in the
room. This is done so that if the server has forgotten about the room
(usually as a result of the database being dropped) it can recover from
it.

However, in the presence of state resets in large rooms, this can cause
a lot of work for servers that have legitimately left. As a hacky
solution that supports both cases we drop incoming events for rooms that
we have explicitly left.

This means that we no longer support the case of servers having
forgotten that they've rejoined a room, but that is sufficiently rare
that we're not going to support it for now.