### PR TITLE
Drop search values with nul characters

### DIFF
--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -376,10 +376,13 @@ class Porter(object):
                         " VALUES (?,?,?,?,to_tsvector('english', ?),?,?)"
                     )
 
-                    rows_dict = [
-                        dict(zip(headers, row))
-                        for row in rows
-                    ]
+                    rows_dict = []
+                    for row in rows:
+                        d = dict(zip(headers, row))
+                        if "\0" in d['value']:
+                            logger.warn('dropping search row %s', d)
+                        else:
+                            rows_dict.append(d)
 
                     txn.executemany(sql, [
                         (


### PR DESCRIPTION
https://github.com/matrix-org/synapse/issues/2187 contains a report of a port
failing due to nul characters somewhere in the search table. Let's try dropping
the offending rows.