### PR TITLE
Add room creation checks to spam checker

### DIFF
--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -85,6 +85,7 @@ class SpamChecker(object):
 
         Args:
             userid (string): The sender's user ID
+            room_alias (string): The alias to be created
 
         Returns:
             bool: True if the user may create a room alias, otherwise False
@@ -93,3 +94,20 @@ class SpamChecker(object):
             return True
 
         return self.spam_checker.user_may_create_room_alias(userid, room_alias)
+
+    def user_may_publish_room(self, userid, room_id):
+        """Checks if a given user may publish a room to the directory
+
+        If this method returns false, the publish request will be rejected.
+
+        Args:
+            userid (string): The sender's user ID
+            room_id (string): The ID of the room that would be published
+
+        Returns:
+            bool: True if the user may publish the room, otherwise False
+        """
+        if self.spam_checker is None:
+            return True
+
+        return self.spam_checker.user_may_publish_room(userid, room_id)

--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -61,3 +61,35 @@ class SpamChecker(object):
             return True
 
         return self.spam_checker.user_may_invite(userid, room_id)
+
+    def user_may_create_room(self, userid):
+        """Checks if a given user may create a room
+
+        If this method returns false, the creation request will be rejected.
+
+        Args:
+            userid (string): The sender's user ID
+
+        Returns:
+            bool: True if the user may create a room, otherwise False
+        """
+        if self.spam_checker is None:
+            return True
+
+        return self.spam_checker.user_may_create_room(userid)
+
+    def user_may_create_room_alias(self, userid, room_alias):
+        """Checks if a given user may create a room alias
+
+        If this method returns false, the association request will be rejected.
+
+        Args:
+            userid (string): The sender's user ID
+
+        Returns:
+            bool: True if the user may create a room alias, otherwise False
+        """
+        if self.spam_checker is None:
+            return True
+
+        return self.spam_checker.user_may_create_room_alias(userid, room_alias)

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -40,6 +40,8 @@ class DirectoryHandler(BaseHandler):
             "directory", self.on_directory_query
         )
 
+        self.spam_checker = hs.get_spam_checker()
+
     @defer.inlineCallbacks
     def _create_association(self, room_alias, room_id, servers=None, creator=None):
         # general association creation for both human users and app services
@@ -72,6 +74,11 @@ class DirectoryHandler(BaseHandler):
     def create_association(self, user_id, room_alias, room_id, servers=None):
         # association creation for human users
         # TODO(erikj): Do user auth.
+
+        if not self.spam_checker.user_may_create_room_alias(user_id, room_alias):
+            raise SynapseError(
+                403, "This user is not permitted to create this alias",
+            )
 
         can_create = yield self.can_modify_alias(
             room_alias,

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -334,6 +334,14 @@ class DirectoryHandler(BaseHandler):
         room_id (str)
         visibility (str): "public" or "private"
         """
+        if not self.spam_checker.user_may_publish_room(
+            requester.user.to_string(), room_id
+        ):
+            raise AuthError(
+                403,
+                "This user is not permitted to publish rooms to the room list"
+            )
+
         if requester.is_guest:
             raise AuthError(403, "Guests cannot edit the published room list")
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -60,6 +60,11 @@ class RoomCreationHandler(BaseHandler):
         },
     }
 
+    def __init__(self, hs):
+        super(RoomCreationHandler, self).__init__(hs)
+
+        self.spam_checker = hs.get_spam_checker()
+
     @defer.inlineCallbacks
     def create_room(self, requester, config, ratelimit=True):
         """ Creates a new room.
@@ -74,6 +79,9 @@ class RoomCreationHandler(BaseHandler):
             horribly wrong.
         """
         user_id = requester.user.to_string()
+
+        if not self.spam_checker.user_may_create_room(user_id):
+                raise SynapseError(403, "You are not permitted to create rooms")
 
         if ratelimit:
             yield self.ratelimit(requester)

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -81,7 +81,7 @@ class RoomCreationHandler(BaseHandler):
         user_id = requester.user.to_string()
 
         if not self.spam_checker.user_may_create_room(user_id):
-                raise SynapseError(403, "You are not permitted to create rooms")
+            raise SynapseError(403, "You are not permitted to create rooms")
 
         if ratelimit:
             yield self.ratelimit(requester)


### PR DESCRIPTION
Lets the spam checker deny attempts to create rooms and add aliases
to them.