### PR TITLE
log pdu_failures from incoming transactions

### DIFF
--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -168,8 +168,9 @@ class FederationServer(FederationBase):
                     edu.content
                 )
 
-            for failure in getattr(transaction, "pdu_failures", []):
-                logger.info("Got failure %r", failure)
+        pdu_failures = getattr(transaction, "pdu_failures", [])
+        for failure in pdu_failures:
+            logger.info("Got failure %r", failure)
 
         response = {
             "pdus": pdu_results,


### PR DESCRIPTION
... even if we have no EDUs.

This appears to have been introduced in
476899295f5fd6cff64799bcbc84cd4bf9005e33.