### PR TITLE
Fix 500 error when we get an error handling a PDU

### DIFF
--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -192,7 +192,6 @@ class FederationServer(FederationBase):
                     pdu_results[event_id] = {}
                 except FederationError as e:
                     logger.warn("Error handling PDU %s: %s", event_id, e)
-                    self.send_failure(e, transaction.origin)
                     pdu_results[event_id] = {"error": str(e)}
                 except Exception as e:
                     pdu_results[event_id] = {"error": str(e)}


### PR DESCRIPTION
FederationServer doesn't have a send_failure (and nor does its subclass,
ReplicationLayer), so this was failing.

I'm not really sure what the idea behind send_failure is, given (a) we don't do
anything at the other end with it except log it, and (b) we also send back the
failure via the transaction response. I suspect there's a whole lot of dead
code around it, but for now I'm just removing the broken bit.