### PR TITLE
Updates to ID checking

### DIFF
--- a/synapse/groups/groups_server.py
+++ b/synapse/groups/groups_server.py
@@ -794,5 +794,5 @@ def _validate_group_id(group_id):
     if types.contains_invalid_mxid_characters(localpart):
         raise SynapseError(
             400,
-            "Group ID can only contain characters a-z, 0-9, or '_-./'",
+            "Group ID can only contain characters a-z, 0-9, or '=_-./'",
         )

--- a/synapse/groups/groups_server.py
+++ b/synapse/groups/groups_server.py
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.internet import defer
-
-from synapse.api.errors import SynapseError
-from synapse.types import UserID, get_domain_from_id, RoomID, GroupID
-
-
 import logging
-import urllib
+
+from synapse import types
+from synapse.api.errors import SynapseError
+from synapse.types import GroupID, RoomID, UserID, get_domain_from_id
+from twisted.internet import defer
 
 logger = logging.getLogger(__name__)
 
@@ -793,10 +791,7 @@ def _validate_group_id(group_id):
     """
     localpart = GroupID.from_string(group_id).localpart
 
-    if localpart.lower() != localpart:
-        raise SynapseError(400, "Group ID must be lower case")
-
-    if urllib.quote(localpart.encode('utf-8')) != localpart:
+    if types.contains_invalid_mxid_characters(localpart):
         raise SynapseError(
             400,
             "Group ID can only contain characters a-z, 0-9, or '_-./'",

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -49,7 +49,7 @@ class RegistrationHandler(BaseHandler):
         if types.contains_invalid_mxid_characters(localpart):
             raise SynapseError(
                 400,
-                "User ID can only contain characters a-z, 0-9, or '_-./'",
+                "User ID can only contain characters a-z, 0-9, or '=_-./'",
                 Codes.INVALID_USERNAME
             )
 
@@ -255,8 +255,7 @@ class RegistrationHandler(BaseHandler):
         if types.contains_invalid_mxid_characters(localpart):
             raise SynapseError(
                 400,
-                "User ID must only contain characters which do not"
-                " require URL encoding."
+                "User ID can only contain characters a-z, 0-9, or '=_-./'",
             )
         user = UserID(localpart, self.hs.hostname)
         user_id = user.to_string()

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -15,7 +15,6 @@
 
 """Contains functions for registering clients."""
 import logging
-import urllib
 
 from twisted.internet import defer
 
@@ -23,6 +22,7 @@ from synapse.api.errors import (
     AuthError, Codes, SynapseError, RegistrationError, InvalidCaptchaError
 )
 from synapse.http.client import CaptchaServerHttpClient
+from synapse import types
 from synapse.types import UserID
 from synapse.util.async import run_on_reactor
 from ._base import BaseHandler
@@ -46,9 +46,7 @@ class RegistrationHandler(BaseHandler):
     @defer.inlineCallbacks
     def check_username(self, localpart, guest_access_token=None,
                        assigned_user_id=None):
-        yield run_on_reactor()
-
-        if urllib.quote(localpart.encode('utf-8')) != localpart:
+        if types.contains_invalid_mxid_characters(localpart):
             raise SynapseError(
                 400,
                 "User ID can only contain characters a-z, 0-9, or '_-./'",
@@ -81,7 +79,7 @@ class RegistrationHandler(BaseHandler):
                     "A different user ID has already been registered for this session",
                 )
 
-        yield self.check_user_id_not_appservice_exclusive(user_id)
+        self.check_user_id_not_appservice_exclusive(user_id)
 
         users = yield self.store.get_users_by_id_case_insensitive(user_id)
         if users:
@@ -254,7 +252,7 @@ class RegistrationHandler(BaseHandler):
         """
         Registers email_id as SAML2 Based Auth.
         """
-        if urllib.quote(localpart) != localpart:
+        if types.contains_invalid_mxid_characters(localpart):
             raise SynapseError(
                 400,
                 "User ID must only contain characters which do not"

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -162,7 +162,7 @@ class GroupID(DomainSpecificString):
     SIGIL = "+"
 
 
-mxid_localpart_allowed_characters = set("_-./" + string.ascii_lowercase + string.digits)
+mxid_localpart_allowed_characters = set("_-./=" + string.ascii_lowercase + string.digits)
 
 
 def contains_invalid_mxid_characters(localpart):

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import string
 
 from synapse.api.errors import SynapseError
 
@@ -159,6 +160,21 @@ class EventID(DomainSpecificString):
 class GroupID(DomainSpecificString):
     """Structure representing a group ID."""
     SIGIL = "+"
+
+
+mxid_localpart_allowed_characters = set("_-./" + string.ascii_lowercase + string.digits)
+
+
+def contains_invalid_mxid_characters(localpart):
+    """Check for characters not allowed in an mxid or groupid localpart
+
+    Args:
+        localpart (basestring): the localpart to be checked
+
+    Returns:
+        bool: True if there are any naughty characters
+    """
+    return any(c not in mxid_localpart_allowed_characters for c in localpart)
 
 
 class StreamToken(

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -161,6 +161,23 @@ class GroupID(DomainSpecificString):
     """Structure representing a group ID."""
     SIGIL = "+"
 
+    @classmethod
+    def from_string(cls, s):
+        group_id = super(GroupID, cls).from_string(s)
+        if not group_id.localpart:
+            raise SynapseError(
+                400,
+                "Group ID cannot be empty",
+            )
+
+        if contains_invalid_mxid_characters(group_id.localpart):
+            raise SynapseError(
+                400,
+                "Group ID can only contain characters a-z, 0-9, or '=_-./'",
+            )
+
+        return group_id
+
 
 mxid_localpart_allowed_characters = set("_-./=" + string.ascii_lowercase + string.digits)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -17,7 +17,7 @@ from tests import unittest
 
 from synapse.api.errors import SynapseError
 from synapse.server import HomeServer
-from synapse.types import UserID, RoomAlias
+from synapse.types import UserID, RoomAlias, GroupID
 
 mock_homeserver = HomeServer(hostname="my.domain")
 
@@ -60,3 +60,25 @@ class RoomAliasTestCase(unittest.TestCase):
         room = RoomAlias("channel", "my.domain")
 
         self.assertEquals(room.to_string(), "#channel:my.domain")
+
+
+class GroupIDTestCase(unittest.TestCase):
+    def test_parse(self):
+        group_id = GroupID.from_string("+group/=_-.123:my.domain")
+        self.assertEqual("group/=_-.123", group_id.localpart)
+        self.assertEqual("my.domain", group_id.domain)
+
+    def test_validate(self):
+        bad_ids = [
+            "$badsigil:domain",
+            "+:empty",
+        ] + [
+            "+group" + c + ":domain" for c in "A%?æ£"
+        ]
+        for id_string in bad_ids:
+            try:
+                GroupID.from_string(id_string)
+                self.fail("Parsing '%s' should raise exception" % id_string)
+            except SynapseError as exc:
+                self.assertEqual(400, exc.code)
+                self.assertEqual("M_UNKNOWN", exc.errcode)


### PR DESCRIPTION
* Disallow capital letters in userids, and allow = in mxids and groupids, cos
  that's what the spec says.

* Validate group ids when parsing, so we check it at the same time as the sigil
  and the basic structure.