### PR TITLE
Add option for groups to hide their membership list from the world

### DIFF
--- a/synapse/groups/groups_server.py
+++ b/synapse/groups/groups_server.py
@@ -385,7 +385,7 @@ class GroupsServerHandler(object):
         is_user_in_group = yield self.store.is_user_in_group(requester_user_id, group_id)
         group = yield self.store.get_group(group_id)
         is_membership_public = not group["membership_is_private"] \
-                               or group["membership_is_private"] is None
+            or group["membership_is_private"] is None
 
         user_results = []
         if is_membership_public or is_user_in_group:

--- a/synapse/groups/groups_server.py
+++ b/synapse/groups/groups_server.py
@@ -386,7 +386,7 @@ class GroupsServerHandler(object):
         group = yield self.store.get_group(group_id)
 
         user_results = []
-        if not group.membership_is_private:
+        if not group["membership_is_private"] or group["membership_is_private"] is None:
             user_results = yield self.store.get_users_in_group(
                 group_id, include_private=is_user_in_group,
             )

--- a/synapse/groups/groups_server.py
+++ b/synapse/groups/groups_server.py
@@ -383,10 +383,13 @@ class GroupsServerHandler(object):
         yield self.check_group_is_ours(group_id, and_exists=True)
 
         is_user_in_group = yield self.store.is_user_in_group(requester_user_id, group_id)
+        group = yield self.store.get_group(group_id)
 
-        user_results = yield self.store.get_users_in_group(
-            group_id, include_private=is_user_in_group,
-        )
+        user_results = []
+        if not group.membership_is_private:
+            user_results = yield self.store.get_users_in_group(
+                group_id, include_private=is_user_in_group,
+            )
 
         chunk = []
         for user_result in user_results:
@@ -725,6 +728,7 @@ class GroupsServerHandler(object):
         short_description = profile.get("short_description")
         long_description = profile.get("long_description")
         user_profile = content.get("user_profile", {})
+        membership_is_private = content.get("membership_is_private", False)
 
         yield self.store.create_group(
             group_id,
@@ -733,6 +737,7 @@ class GroupsServerHandler(object):
             avatar_url=avatar_url,
             short_description=short_description,
             long_description=long_description,
+            membership_is_private=membership_is_private,
         )
 
         if not self.hs.is_mine_id(user_id):

--- a/synapse/groups/groups_server.py
+++ b/synapse/groups/groups_server.py
@@ -384,7 +384,8 @@ class GroupsServerHandler(object):
 
         is_user_in_group = yield self.store.is_user_in_group(requester_user_id, group_id)
         group = yield self.store.get_group(group_id)
-        is_membership_public = not group["membership_is_private"] or group["membership_is_private"] is None
+        is_membership_public = not group["membership_is_private"] \
+                               or group["membership_is_private"] is None
 
         user_results = []
         if is_membership_public or is_user_in_group:

--- a/synapse/groups/groups_server.py
+++ b/synapse/groups/groups_server.py
@@ -370,6 +370,8 @@ class GroupsServerHandler(object):
                 if not isinstance(value, basestring):
                     raise SynapseError(400, "%r value is not a string" % (keyname,))
                 profile[keyname] = value
+        if not isinstance(content["membership_is_private"], bool):
+            profile["membership_is_private"] = content["membership_is_private"]
 
         yield self.store.update_group_profile(group_id, profile)
 

--- a/synapse/groups/groups_server.py
+++ b/synapse/groups/groups_server.py
@@ -384,9 +384,10 @@ class GroupsServerHandler(object):
 
         is_user_in_group = yield self.store.is_user_in_group(requester_user_id, group_id)
         group = yield self.store.get_group(group_id)
+        is_membership_public = not group["membership_is_private"] or group["membership_is_private"] is None
 
         user_results = []
-        if not group["membership_is_private"] or group["membership_is_private"] is None:
+        if is_membership_public or is_user_in_group:
             user_results = yield self.store.get_users_in_group(
                 group_id, include_private=is_user_in_group,
             )

--- a/synapse/storage/group_server.py
+++ b/synapse/storage/group_server.py
@@ -35,7 +35,7 @@ class GroupServerStore(SQLBaseStore):
             keyvalues={
                 "group_id": group_id,
             },
-            retcols=("name", "short_description", "long_description", "avatar_url",),
+            retcols=("name", "short_description", "long_description", "avatar_url", "membership_is_private"),
             allow_none=True,
             desc="is_user_in_group",
         )
@@ -1017,7 +1017,7 @@ class GroupServerStore(SQLBaseStore):
 
     @defer.inlineCallbacks
     def create_group(self, group_id, user_id, name, avatar_url, short_description,
-                     long_description,):
+                     long_description, membership_is_private):
         yield self._simple_insert(
             table="groups",
             values={
@@ -1026,6 +1026,7 @@ class GroupServerStore(SQLBaseStore):
                 "avatar_url": avatar_url,
                 "short_description": short_description,
                 "long_description": long_description,
+                "membership_is_private": membership_is_private,
             },
             desc="create_group",
         )

--- a/synapse/storage/group_server.py
+++ b/synapse/storage/group_server.py
@@ -35,7 +35,8 @@ class GroupServerStore(SQLBaseStore):
             keyvalues={
                 "group_id": group_id,
             },
-            retcols=("name", "short_description", "long_description", "avatar_url", "membership_is_private"),
+            retcols=("name", "short_description", "long_description", "avatar_url",
+                     "membership_is_private"),
             allow_none=True,
             desc="is_user_in_group",
         )

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 # Remember to update this number every time a change is made to database
 # schema files, so the users will be informed on server restarts.
-SCHEMA_VERSION = 45
+SCHEMA_VERSION = 46
 
 dir_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/synapse/storage/schema/delta/46/track_group_membership_publicity.sql
+++ b/synapse/storage/schema/delta/46/track_group_membership_publicity.sql
@@ -1,0 +1,17 @@
+/* Copyright 2017 Travis Ralston
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+ALTER TABLE groups ADD COLUMN membership_is_private BOOLEAN;


### PR DESCRIPTION
This is intended to be used by bridges, but may have usefulness for other communities. The idea behind this is that members can have flair in designated rooms, but not be visible as a group member otherwise. Bridges may be interested in this for their portal rooms where the bridged users have flair, but the group they are part of doesn't supply an easily acquirable list of users to spam.

Solves https://github.com/vector-im/riot-web/issues/5365 (which probably shouldn't have been a Riot ticket in the first place).