### PR TITLE
Ignore <noscript> tags when generating URL preview descriptions

### DIFF
--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -520,7 +520,14 @@ def _calc_og(tree, media_uri):
             from lxml import etree
 
             TAGS_TO_REMOVE = (
-                "header", "nav", "aside", "footer", "script", "style", etree.Comment
+                "header",
+                "nav",
+                "aside",
+                "footer",
+                "script",
+                "noscript",
+                "style",
+                etree.Comment
             )
 
             # Split all the text nodes into paragraphs (by splitting on new


### PR DESCRIPTION
### What are you trying to do with this PR?
Exclude content in `<noscript>` tags from appearing in URL preview descriptions when there is no `og:description` meta tag on the page behind said URL.

### Why are you going with this approach?
Most websites use `<noscript>` tags to display a message along the lines of "JavaScript is required to view this page. Please enable JavaScript and try again.". Since such a tag is usually the first child of the `<body>` element, Synapse picks up these words to approximate the page preview description. By excluding `<noscript>` tags, Synapse is more likely to end up using words that are actually relevant to the page content.