### PR TITLE
Use a special matrix.to URL for room notifs

### DIFF
--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -244,8 +244,8 @@ BASE_APPEND_OVERRIDE_RULES = [
         'conditions': [
             {
                 'kind': 'event_match',
-                'key': 'content.body',
-                'pattern': '@room',
+                'key': 'content.formatted_body',
+                'pattern': '*https://matrix.to/#@room*',
                 '_id': '_roomnotif_content',
             },
             {


### PR DESCRIPTION
So you'll have to explicitly accept the pill completion to actually
do a room notification.

Note that this matches on formatted_body as the URL will only be
in the formatted_body. It could also match for only HTML bodies,
but the URL ought to be specific enough that it's sensible to match
whatever the format is?