### PR TITLE
remove obsolete webclient

### DIFF
--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -22,8 +22,6 @@ class ServerConfig(Config):
     def read_config(self, config):
         self.server_name = config["server_name"]
         self.pid_file = self.abspath(config.get("pid_file"))
-        self.web_client = config["web_client"]
-        self.web_client_location = config.get("web_client_location", None)
         self.soft_file_limit = config["soft_file_limit"]
         self.daemonize = config.get("daemonize")
         self.print_pidfile = config.get("print_pidfile")
@@ -73,7 +71,7 @@ class ServerConfig(Config):
             bind_host = config.get("bind_host", "")
             gzip_responses = config.get("gzip_responses", True)
 
-            names = ["client", "webclient"] if self.web_client else ["client"]
+            names = ["client"]
 
             self.listeners.append({
                 "port": bind_port,
@@ -176,15 +174,6 @@ class ServerConfig(Config):
         #
         # cpu_affinity: 0xFFFFFFFF
 
-        # Whether to serve a web client from the HTTP/HTTPS root resource.
-        web_client: True
-
-        # The root directory to server for the above web client.
-        # If left undefined, synapse will serve the matrix-angular-sdk web client.
-        # Make sure matrix-angular-sdk is installed with pip if web_client is True
-        # and web_client_location is undefined
-        # web_client_location: "/path/to/web/root"
-
         # The public-facing base URL for the client API (not including _matrix/...)
         # public_baseurl: https://example.com:8448/
 
@@ -237,7 +226,6 @@ class ServerConfig(Config):
                 # List of resources to host on this listener.
                 names:
                   - client     # The client-server APIs, both v1 and v2
-                  - webclient  # The bundled webclient.
 
                 # Should synapse compress HTTP responses to clients that support it?
                 # This should be disabled if running synapse behind a load balancer
@@ -257,7 +245,7 @@ class ServerConfig(Config):
             x_forwarded: false
 
             resources:
-              - names: [client, webclient]
+              - names: [client]
                 compress: true
               - names: [federation]
                 compress: false

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -42,9 +42,6 @@ REQUIREMENTS = {
     "phonenumbers>=8.2.0": ["phonenumbers"],
 }
 CONDITIONAL_REQUIREMENTS = {
-    "web_client": {
-        "matrix_angular_sdk>=0.6.8": ["syweb>=0.6.8"],
-    },
     "preview_url": {
         "netaddr>=0.7.18": ["netaddr"],
     },

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -122,7 +122,6 @@ class HomeServer(object):
         'client_resource',
         'resource_for_federation',
         'resource_for_static_content',
-        'resource_for_web_client',
         'resource_for_content_repo',
         'resource_for_server_key',
         'resource_for_server_key_v2',


### PR DESCRIPTION
This got requested several times as in #1527 

Open question: Which URL shall be used to forward the users to?
I have implemented `https://matrix.to/?hs=<server_name>`

This would close #1353, #1527, #1883, #2113 and indirectly #1250

Signed-Off-by: Matthias Kesler <krombel@krombel.de>