### PR TITLE
Break dependency of auth_handler on device_handler

### DIFF
--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -219,7 +219,6 @@ class LoginRestServlet(ClientV1RestServlet):
         )
         access_token = yield auth_handler.get_access_token_for_user_id(
             canonical_user_id, device_id,
-            login_submission.get("initial_device_display_name"),
         )
 
         result = {
@@ -241,7 +240,6 @@ class LoginRestServlet(ClientV1RestServlet):
         device_id = yield self._register_device(user_id, login_submission)
         access_token = yield auth_handler.get_access_token_for_user_id(
             user_id, device_id,
-            login_submission.get("initial_device_display_name"),
         )
         result = {
             "user_id": user_id,  # may have changed
@@ -284,7 +282,6 @@ class LoginRestServlet(ClientV1RestServlet):
             )
             access_token = yield auth_handler.get_access_token_for_user_id(
                 registered_user_id, device_id,
-                login_submission.get("initial_device_display_name"),
             )
 
             result = {

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -566,7 +566,6 @@ class RegisterRestServlet(RestServlet):
         access_token = (
             yield self.auth_handler.get_access_token_for_user_id(
                 user_id, device_id=device_id,
-                initial_display_name=params.get("initial_device_display_name")
             )
         )
 


### PR DESCRIPTION
I'm going to need to make the device_handler depend on the auth_handler, so I need to break this dependency to avoid a cycle.

It turns out that the auth_handler was only using the device_handler in one place which was an edge case which we can more elegantly handle by throwing an error rather than fixing it up.