### PR TITLE
Fix appservices being backlogged and not receiving new events due to a bug in notify_interested_services

### DIFF
--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -74,7 +74,7 @@ class ApplicationServicesHandler(object):
                 limit = 100
                 while True:
                     upper_bound, events = yield self.store.get_new_events_for_appservice(
-                        upper_bound, limit
+                        self.current_max, limit
                     )
 
                     if not events:
@@ -105,9 +105,6 @@ class ApplicationServicesHandler(object):
                             )
 
                     yield self.store.set_appservice_last_pos(upper_bound)
-
-                    if len(events) < limit:
-                        break
             finally:
                 self.is_processing = False
 

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -70,7 +70,6 @@ class ApplicationServicesHandler(object):
         with Measure(self.clock, "notify_interested_services"):
             self.is_processing = True
             try:
-                upper_bound = self.current_max
                 limit = 100
                 while True:
                     upper_bound, events = yield self.store.get_new_events_for_appservice(

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -53,7 +53,10 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             type="m.room.message",
             room_id="!foo:bar"
         )
-        self.mock_store.get_new_events_for_appservice.return_value = (0, [event])
+        self.mock_store.get_new_events_for_appservice.side_effect = [
+            (0, [event]),
+            (0, [])
+        ]
         self.mock_as_api.push = Mock()
         yield self.handler.notify_interested_services(0)
         self.mock_scheduler.submit_event_for_as.assert_called_once_with(
@@ -75,7 +78,10 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         )
         self.mock_as_api.push = Mock()
         self.mock_as_api.query_user = Mock()
-        self.mock_store.get_new_events_for_appservice.return_value = (0, [event])
+        self.mock_store.get_new_events_for_appservice.side_effect = [
+            (0, [event]),
+            (0, [])
+        ]
         yield self.handler.notify_interested_services(0)
         self.mock_as_api.query_user.assert_called_once_with(
             services[0], user_id
@@ -98,7 +104,10 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         )
         self.mock_as_api.push = Mock()
         self.mock_as_api.query_user = Mock()
-        self.mock_store.get_new_events_for_appservice.return_value = (0, [event])
+        self.mock_store.get_new_events_for_appservice.side_effect = [
+            (0, [event]),
+            (0, [])
+        ]
         yield self.handler.notify_interested_services(0)
         self.assertFalse(
             self.mock_as_api.query_user.called,


### PR DESCRIPTION
The bug is:

1. `get_new_events_for_appservice` returns max(event_id) for all retrieved rows
2. `get_new_events_for_appservice` accepts upper_bound and all retrieved rows have event_id <= upper_bound
3. since `notify_interested_services` sets upper_bound to whatever `get_new_events_for_appservice` returned, what happens is the `while True` loop at line 75 is executed only once when your server has more than 100 events: first, it gets 100 `events`, the next iteration it will always get 0
4. so if your server has a lot of unprocessed events, it will only process 100 at a time (e.g. when a message is sent) and it looks as if appservices are not getting events submitted to them

I saw this happen on my homeserver.

Changing it to `current_max` ensures that it always gets some events, until the backlog is clear.

The second change is removing the `len(events) < limit` check - I'm not sure why, but sometimes it returned 99 events for me, even while there were a lot of events backlogged. Since there's another check: `if not events`, this should not make things infloop.


Signed-off-by: Ilya Zhuravlev <whatever@xyz.is>