### PR TITLE
WIP: Return admins of a group first in the list of group users

### DIFF
--- a/synapse/groups/groups_server.py
+++ b/synapse/groups/groups_server.py
@@ -426,14 +426,15 @@ class GroupsServerHandler(object):
         for user_result in user_results:
             g_user_id = user_result["user_id"]
             is_public = user_result["is_public"]
+            is_admin = user_result["is_admin"]
 
             entry = {"user_id": g_user_id}
 
             profile = yield self.profile_handler.get_profile_from_cache(g_user_id)
             entry.update(profile)
 
-            if not is_public:
-                entry["is_public"] = False
+            entry["is_public"] = bool(is_public)
+            entry["is_admin"] = bool(is_admin)
 
             if not self.is_mine_id(g_user_id):
                 attestation = yield self.store.get_remote_attestation(group_id, g_user_id)

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -641,7 +641,8 @@ class SQLBaseStore(object):
         )
 
     @classmethod
-    def _simple_select_list_txn(cls, txn, table, keyvalues, retcols, order=None, order_asc=True):
+    def _simple_select_list_txn(cls, txn, table, keyvalues, retcols,
+                                order=None, order_asc=True):
         """Executes a SELECT query on the named table, which may return zero or
         more rows, returning the result as a list of dicts.
 

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -619,7 +619,7 @@ class SQLBaseStore(object):
         )
 
     def _simple_select_list(self, table, keyvalues, retcols,
-                            desc="_simple_select_list"):
+                            desc="_simple_select_list", order=None, order_asc=True):
         """Executes a SELECT query on the named table, which may return zero or
         more rows, returning the result as a list of dicts.
 
@@ -629,17 +629,19 @@ class SQLBaseStore(object):
                 column names and values to select the rows with, or None to not
                 apply a WHERE clause.
             retcols (iterable[str]): the names of the columns to return
+            order (str): order the select by this column
+            order_asc (bool): order ascending (if order specified). Default True.
         Returns:
             defer.Deferred: resolves to list[dict[str, Any]]
         """
         return self.runInteraction(
             desc,
             self._simple_select_list_txn,
-            table, keyvalues, retcols
+            table, keyvalues, retcols, order, order_asc
         )
 
     @classmethod
-    def _simple_select_list_txn(cls, txn, table, keyvalues, retcols):
+    def _simple_select_list_txn(cls, txn, table, keyvalues, retcols, order=None, order_asc=True):
         """Executes a SELECT query on the named table, which may return zero or
         more rows, returning the result as a list of dicts.
 
@@ -650,20 +652,28 @@ class SQLBaseStore(object):
                 column names and values to select the rows with, or None to not
                 apply a WHERE clause.
             retcols (iterable[str]): the names of the columns to return
+            order (str): order the select by this column
+            order_asc (bool): order ascending (if order specified). Default True.
         """
+        query_values = []
         if keyvalues:
             sql = "SELECT %s FROM %s WHERE %s" % (
                 ", ".join(retcols),
                 table,
                 " AND ".join("%s = ?" % (k, ) for k in keyvalues)
             )
-            txn.execute(sql, keyvalues.values())
+            query_values.extend(keyvalues.values())
         else:
             sql = "SELECT %s FROM %s" % (
                 ", ".join(retcols),
                 table
             )
-            txn.execute(sql)
+
+        if order:
+            sql = sql + " ORDER BY ? %s" % ("ASC" if order_asc else "DESC")
+            query_values.append(order)
+
+        txn.execute(sql, query_values)
 
         return cls.cursor_to_dict(txn)
 

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -670,8 +670,9 @@ class SQLBaseStore(object):
             )
 
         if order:
-            sql = sql + " ORDER BY ? %s" % ("ASC" if order_asc else "DESC")
-            query_values.append(order)
+            sql = sql + " ORDER BY %s %s" % (
+                order, "ASC" if order_asc else "DESC"
+            )
 
         txn.execute(sql, query_values)
 

--- a/synapse/storage/group_server.py
+++ b/synapse/storage/group_server.py
@@ -57,7 +57,7 @@ class GroupServerStore(SQLBaseStore):
             retcols=("user_id", "is_public", "is_admin",),
             desc="get_users_in_group",
             order="is_admin",
-            order_asc=False, # Order descending: admins first
+            order_asc=False,  # Order descending: admins first
         )
 
     def get_invited_users_in_group(self, group_id):

--- a/synapse/storage/group_server.py
+++ b/synapse/storage/group_server.py
@@ -54,8 +54,10 @@ class GroupServerStore(SQLBaseStore):
         return self._simple_select_list(
             table="group_users",
             keyvalues=keyvalues,
-            retcols=("user_id", "is_public",),
+            retcols=("user_id", "is_public", "is_admin",),
             desc="get_users_in_group",
+            order="is_admin",
+            order_asc=False, # Order descending: admins first
         )
 
     def get_invited_users_in_group(self, group_id):


### PR DESCRIPTION
This introduces a ORDER BY that can be optionally added to _simple_select_list transactions'