### PR TITLE
Start work on avoiding table locks for upserts

### DIFF
--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -503,7 +503,7 @@ class SQLBaseStore(object):
                     lock=lock
                 )
                 defer.returnValue(result)
-            except self.database_engine.IntegrityError as e:
+            except self.database_engine.module.IntegrityError as e:
                 # presumably we raced with another transaction: let's retry.
                 logger.warn(
                     "IntegrityError when upserting into %s; retrying: %s",


### PR DESCRIPTION
Add a loop to _simple_upsert so that it can be used without a lock in more
circumstances, and a PoC to demonstrate it in `add_pusher`.

WDYT?

Anyway, it's all very well but doesn't really help us for more complex
operations where we do more than one thing in the transaction (for example,
`delete_pusher_by_app_id_pushkey_user_id`). There we have a few options:

* decide that the delete from `pushers` and the upsert into `deleted_pushers`
  don't actually need to happen in a single transaction, and use
  `_simple_upsert` there too

* cargo-cult the loop from `_simple_upsert` into
  `delete_pusher_by_app_id_pushkey_user_id`

* factor out the loop to a `retry_on_integrity_error` or something and use that