### PR TITLE
Add automagical AS Publicised Group(s)

### DIFF
--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -143,7 +143,7 @@ class ApplicationService(object):
 
                     if get_domain_from_id(regex_obj.get("group_id")) != self.server_name:
                         raise ValueError(
-                            "Expected string for 'group_id' to be for this host in ns '%s'" % ns
+                            "Expected 'group_id' to be this host in ns '%s'" % ns
                         )
 
                 regex = regex_obj.get("regex")

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -127,19 +127,20 @@ class ApplicationService(object):
                     raise ValueError(
                         "Expected bool for 'exclusive' in ns '%s'" % ns
                     )
-                if regex_obj.get("group_id"):
-                    if not isinstance(regex_obj.get("group_id"), str):
+                group_id = regex_obj.get("group_id")
+                if group_id:
+                    if not isinstance(group_id, str):
                         raise ValueError(
                             "Expected string for 'group_id' in ns '%s'" % ns
                         )
                     try:
-                        GroupID.from_string(regex_obj.get("group_id"))
+                        GroupID.from_string(group_id)
                     except Exception:
                         raise ValueError(
                             "Expected valid group ID for 'group_id' in ns '%s'" % ns
                         )
 
-                    if get_domain_from_id(regex_obj.get("group_id")) != self.server_name:
+                    if get_domain_from_id(group_id) != self.server_name:
                         raise ValueError(
                             "Expected 'group_id' to be this host in ns '%s'" % ns
                         )

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -82,8 +82,6 @@ class ApplicationService(object):
     # values.
     NS_LIST = [NS_USERS, NS_ALIASES, NS_ROOMS]
 
-    GROUP_ID_REGEX = re.compile('\+.*:.+')
-
     def __init__(self, token, hostname, url=None, namespaces=None, hs_token=None,
                  sender=None, id=None, protocols=None, rate_limited=True):
         self.token = token

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -274,6 +274,12 @@ class ApplicationService(object):
 
     def get_groups_for_user(self, user_id):
         """Get the groups that this user is associated with by this AS
+
+        Args:
+            user_id (str): The ID of the user.
+
+        Returns:
+            iterable[str]: an iterable that yields group_id strings.
         """
         return (
             regex_obj["group_id"]

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -275,11 +275,11 @@ class ApplicationService(object):
     def get_groups_for_user(self, user_id):
         """Get the groups that this user is associated with by this AS
         """
-        return [
+        return (
             regex_obj["group_id"]
             for regex_obj in self.namespaces[ApplicationService.NS_USERS]
             if "group_id" in regex_obj and regex_obj["regex"].match(user_id)
-        ]
+        )
 
     def is_rate_limited(self):
         return self.rate_limited

--- a/synapse/config/appservice.py
+++ b/synapse/config/appservice.py
@@ -154,6 +154,7 @@ def _load_appservice(hostname, as_info, config_filename):
         )
     return ApplicationService(
         token=as_info["as_token"],
+        hostname=hostname,
         url=as_info["url"],
         namespaces=as_info["namespaces"],
         hs_token=as_info["hs_token"],

--- a/synapse/handlers/groups_local.py
+++ b/synapse/handlers/groups_local.py
@@ -375,6 +375,12 @@ class GroupsLocalHandler(object):
     def get_publicised_groups_for_user(self, user_id):
         if self.hs.is_mine_id(user_id):
             result = yield self.store.get_publicised_groups_for_user(user_id)
+
+            # Check AS associated groups for this user - this depends on the
+            # RegExps in the AS registration file (under `users`)
+            for app_service in self.store.get_app_services():
+                result.extend(app_service.get_groups_for_user(user_id))
+
             defer.returnValue({"groups": result})
         else:
             result = yield self.transport_client.get_publicised_groups_for_user(

--- a/synapse/handlers/groups_local.py
+++ b/synapse/handlers/groups_local.py
@@ -421,4 +421,9 @@ class GroupsLocalHandler(object):
                 uid
             )
 
+            # Check AS associated groups for this user - this depends on the
+            # RegExps in the AS registration file (under `users`)
+            for app_service in self.store.get_app_services():
+                results[uid].extend(app_service.get_groups_for_user(uid))
+
         defer.returnValue({"users": results})

--- a/tests/appservice/test_appservice.py
+++ b/tests/appservice/test_appservice.py
@@ -36,7 +36,7 @@ class ApplicationServiceTestCase(unittest.TestCase):
             id="unique_identifier",
             url="some_url",
             token="some_token",
-            hostname="matrix.org", # only used by get_groups_for_user
+            hostname="matrix.org",  # only used by get_groups_for_user
             namespaces={
                 ApplicationService.NS_USERS: [],
                 ApplicationService.NS_ROOMS: [],

--- a/tests/appservice/test_appservice.py
+++ b/tests/appservice/test_appservice.py
@@ -36,6 +36,7 @@ class ApplicationServiceTestCase(unittest.TestCase):
             id="unique_identifier",
             url="some_url",
             token="some_token",
+            hostname="matrix.org", # only used by get_groups_for_user
             namespaces={
                 ApplicationService.NS_USERS: [],
                 ApplicationService.NS_ROOMS: [],


### PR DESCRIPTION
via registration file "users" namespace:

```YAML
...
namespaces:
  users:
    - exclusive: true
      regex: '.*luke.*'
      group_id: '+all_the_lukes:hsdomain'
...
```

This is part of giving App Services their own groups for matching users. With this, ghost users will be given the appeareance that they are in a group and that they have publicised the fact, but _only_ from the perspective of the `get_publicised_groups_for_user` API.