### PR TITLE
Clean up dependency list

### DIFF
--- a/synapse/server.py
+++ b/synapse/server.py
@@ -90,17 +90,12 @@ class HomeServer(object):
     """
 
     DEPENDENCIES = [
-        'config',
-        'clock',
         'http_client',
         'db_pool',
-        'persistence_service',
         'replication_layer',
-        'datastore',
         'handlers',
         'v1auth',
         'auth',
-        'rest_servlet_factory',
         'state_handler',
         'presence_handler',
         'sync_handler',
@@ -118,18 +113,7 @@ class HomeServer(object):
         'device_message_handler',
         'profile_handler',
         'notifier',
-        'distributor',
-        'client_resource',
-        'resource_for_federation',
-        'resource_for_static_content',
-        'resource_for_web_client',
-        'resource_for_content_repo',
-        'resource_for_server_key',
-        'resource_for_server_key_v2',
-        'resource_for_media_repository',
-        'resource_for_metrics',
         'event_sources',
-        'ratelimiter',
         'keyring',
         'pusherpool',
         'event_builder_factory',
@@ -182,6 +166,21 @@ class HomeServer(object):
 
     def is_mine_id(self, string):
         return string.split(":", 1)[1] == self.hostname
+
+    def get_clock(self):
+        return self.clock
+
+    def get_datastore(self):
+        return self.datastore
+
+    def get_config(self):
+        return self.config
+
+    def get_distributor(self):
+        return self.distributor
+
+    def get_ratelimiter(self):
+        return self.ratelimiter
 
     def build_replication_layer(self):
         return initialize_http_replication(self)


### PR DESCRIPTION
remove those that aren't used at all, and replace the ones that don't have
builders with simple getters rather than dynamically-generated methods.