### PR TITLE
Avoid doing presence updates on replication reconnect

### DIFF
--- a/synapse/app/synchrotron.py
+++ b/synapse/app/synchrotron.py
@@ -215,6 +215,8 @@ class SynchrotronPresence(object):
         yield self.notify_from_replication(states, stream_id)
 
     def get_currently_syncing_users(self):
+        # presence is disabled on matrix.org, so we return the empty set
+        return set()
         return [
             user_id for user_id, count in self.user_to_num_current_syncs.iteritems()
             if count > 0

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -445,6 +445,7 @@ class PresenceHandler(object):
         Returns:
             set(str): A set of user_id strings.
         """
+        # presence is disabled on matrix.org, so we return the empty set
         return set()
         syncing_user_ids = {
             user_id for user_id, count in self.user_to_num_current_syncs.items()


### PR DESCRIPTION
Presence is supposed to be disabled on matrix.org, so we shouldn't send a load
of USER_SYNC commands every time the synchrotron reconnects to the master.

(NB this PR against matrix-org-hotfixes, hence test failures)