### PR TITLE
Add firewalld config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -630,6 +630,16 @@ largest boxes pause for thought.)
 
 .. __: `Connecting to Synapse from a client`_
 
+Adding a firewall rule
+----------------------
+
+If you are on a system which uses firewalld as a firewall service, import the
+rule to your system:
+
+    firewall-cmd --permanent --new-service-from-file=/contrib/firewalld/synapse.xml
+    firewall-cmd --permanent --add-service=synapse
+    systemctl reload firewalld.service
+
 Troubleshooting
 ---------------
 The typical failure mode with federation is that when you try to join a room,

--- a/contrib/firewalld/synapse.xml
+++ b/contrib/firewalld/synapse.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Matrix federation</short>
+  <description>Federation is the process by which users on different servers can participate in the same room.</description>
+  <port port="8448" protocol="tcp"/>
+</service>


### PR DESCRIPTION
Downstream can ship this in their packages for easier installation. The xml file is generated by the `firewallctl` tool.