### PR TITLE
mention federation tester more prominently in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -632,6 +632,11 @@ largest boxes pause for thought.)
 
 Troubleshooting
 ---------------
+
+You can use the federation tester to check if your homeserver is all set:
+``https://matrix.org/federationtester/api/report?server_name=<your_server_name>``
+If any of the attributes under "checks" is false, federation won't work.
+
 The typical failure mode with federation is that when you try to join a room,
 it is rejected with "401: Unauthorized". Generally this means that other
 servers in the room couldn't access yours. (Joining a room over federation is a


### PR DESCRIPTION
There is a pattern in Matrix HQ: Someone joins with federation problems, are pointed to the federation tester, and it solves their problem.

I added a link to that in a more prominent place in the readme, that should help a bit :)