### PR TITLE
Reinstate media download on thumbnail request

### DIFF
--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -198,6 +198,11 @@ class ThumbnailResource(Resource):
     @defer.inlineCallbacks
     def _respond_remote_thumbnail(self, request, server_name, media_id, width,
                                   height, method, m_type):
+        # TODO: Don't download the whole remote file
+        # We should proxy the thumbnail from the remote server instead of
+        # downloading the remote file and generating our own thumbnails.
+        yield self.media_repo.get_remote_media(server_name, media_id)
+
         thumbnail_infos = yield self.store.get_remote_media_thumbnails(
             server_name, media_id,
         )


### PR DESCRIPTION
We need to actually download the remote media when we get a request for a thumbnail.

Fixes https://github.com/matrix-org/synapse/issues/2776.