### PR TITLE
Reorganise request and block metrics

### DIFF
--- a/contrib/prometheus/consoles/synapse.html
+++ b/contrib/prometheus/consoles/synapse.html
@@ -9,7 +9,7 @@
 new PromConsole.Graph({
   node: document.querySelector("#process_resource_utime"),
   expr: "rate(process_cpu_seconds_total[2m]) * 100",
-  name: "[[job]]",  
+  name: "[[job]]",
   min: 0,
   max: 100,
   renderer: "line",
@@ -233,7 +233,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#synapse_http_server_response_time_avg"),
-  expr: "rate(synapse_http_server_response_time:total[2m]) / rate(synapse_http_server_response_time:count[2m]) / 1000",
+  expr: "rate(synapse_http_server_response_time_seconds[2m]) / rate(synapse_http_server_response_count[2m]) / 1000",
   name: "[[servlet]]",
   yAxisFormatter: PromConsole.NumberFormatter.humanize,
   yHoverFormatter: PromConsole.NumberFormatter.humanize,
@@ -276,7 +276,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#synapse_http_server_response_ru_utime"),
-  expr: "rate(synapse_http_server_response_ru_utime:total[2m])",
+  expr: "rate(synapse_http_server_response_ru_utime_seconds[2m])",
   name: "[[servlet]]",
   yAxisFormatter: PromConsole.NumberFormatter.humanize,
   yHoverFormatter: PromConsole.NumberFormatter.humanize,
@@ -291,7 +291,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#synapse_http_server_response_db_txn_duration"),
-  expr: "rate(synapse_http_server_response_db_txn_duration:total[2m])",
+  expr: "rate(synapse_http_server_response_db_txn_duration_seconds[2m])",
   name: "[[servlet]]",
   yAxisFormatter: PromConsole.NumberFormatter.humanize,
   yHoverFormatter: PromConsole.NumberFormatter.humanize,
@@ -306,7 +306,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#synapse_http_server_send_time_avg"),
-  expr: "rate(synapse_http_server_response_time:total{servlet='RoomSendEventRestServlet'}[2m]) / rate(synapse_http_server_response_time:count{servlet='RoomSendEventRestServlet'}[2m]) / 1000",
+  expr: "rate(synapse_http_server_response_time_seconds{servlet='RoomSendEventRestServlet'}[2m]) / rate(synapse_http_server_response_count{servlet='RoomSendEventRestServlet'}[2m]) / 1000",
   name: "[[servlet]]",
   yAxisFormatter: PromConsole.NumberFormatter.humanize,
   yHoverFormatter: PromConsole.NumberFormatter.humanize,

--- a/synapse/util/metrics.py
+++ b/synapse/util/metrics.py
@@ -27,25 +27,30 @@ logger = logging.getLogger(__name__)
 
 metrics = synapse.metrics.get_metrics_for(__name__)
 
-block_timer = metrics.register_distribution(
-    "block_timer",
+block_count = metrics.register_counter(
+    "block_count",
     labels=["block_name"]
 )
 
-block_ru_utime = metrics.register_distribution(
-    "block_ru_utime", labels=["block_name"]
+block_timer = metrics.register_counter(
+    "block_time_seconds",
+    labels=["block_name"]
 )
 
-block_ru_stime = metrics.register_distribution(
-    "block_ru_stime", labels=["block_name"]
+block_ru_utime = metrics.register_counter(
+    "block_ru_utime_seconds", labels=["block_name"]
 )
 
-block_db_txn_count = metrics.register_distribution(
+block_ru_stime = metrics.register_counter(
+    "block_ru_stime_seconds", labels=["block_name"]
+)
+
+block_db_txn_count = metrics.register_counter(
     "block_db_txn_count", labels=["block_name"]
 )
 
-block_db_txn_duration = metrics.register_distribution(
-    "block_db_txn_duration", labels=["block_name"]
+block_db_txn_duration = metrics.register_counter(
+    "block_db_txn_duration_seconds", labels=["block_name"]
 )
 
 
@@ -91,6 +96,8 @@ class Measure(object):
             return
 
         duration = self.clock.time_msec() - self.start
+
+        block_count.inc(self.name)
         block_timer.inc_by(duration, self.name)
 
         context = LoggingContext.current_context()


### PR DESCRIPTION
This PR is a spin-out of #2775. 

In order to circumvent the number of duplicate foo:count metrics increasing without bounds, it's time for a rearrangement.

The following are all removed, and replaced with synapse_util_metrics_block_count:
  synapse_util_metrics_block_timer:count
  synapse_util_metrics_block_ru_utime:count
  synapse_util_metrics_block_ru_stime:count
  synapse_util_metrics_block_db_txn_count:count
  synapse_util_metrics_block_db_txn_duration:count

The following are all removed, and replaced with synapse_http_server_response_count:
   synapse_http_server_requests
   synapse_http_server_response_time:count
   synapse_http_server_response_ru_utime:count
   synapse_http_server_response_ru_stime:count
   synapse_http_server_response_db_txn_count:count
   synapse_http_server_response_db_txn_duration:count

The following are renamed:
  synapse_util_metrics_block_timer:total -> synapse_util_metrics_block_time_seconds

  synapse_util_metrics_block_ru_utime:total -> synapse_util_metrics_block_ru_utime_seconds

  synapse_util_metrics_block_ru_stime:total -> synapse_util_metrics_block_ru_stime_seconds

  synapse_util_metrics_block_db_txn_count:total -> synapse_util_metrics_block_db_txn_count

  synapse_util_metrics_block_db_txn_duration:total -> synapse_util_metrics_block_db_txn_duration_seconds

  synapse_http_server_response_time:total -> synapse_http_server_response_time_seconds

  synapse_http_server_response_ru_utime:total -> synapse_http_server_response_ru_utime_seconds

  synapse_http_server_response_ru_stime:total -> synapse_http_server_response_ru_stime_seconds

   synapse_http_server_response_db_txn_count:total -> synapse_http_server_response_db_txn_count

   synapse_http_server_response_db_txn_duration:total -> synapse_http_server_response_db_txn_duration_seconds