### PR TITLE
Keep track of last access time for local media

### DIFF
--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -67,6 +67,7 @@ class ThumbnailResource(Resource):
                 yield self._respond_local_thumbnail(
                     request, media_id, width, height, method, m_type
                 )
+            self.media_repo.mark_recently_accessed(server_name, media_id)
         else:
             if self.dynamic_thumbnails:
                 yield self._select_or_generate_remote_thumbnail(
@@ -78,6 +79,7 @@ class ThumbnailResource(Resource):
                     request, server_name, media_id,
                     width, height, method, m_type
                 )
+            self.media_repo.mark_recently_accessed(None, media_id)
 
     @defer.inlineCallbacks
     def _respond_local_thumbnail(self, request, media_id, width, height,

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 # Remember to update this number every time a change is made to database
 # schema files, so the users will be informed on server restarts.
-SCHEMA_VERSION = 46
+SCHEMA_VERSION = 47
 
 dir_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/synapse/storage/schema/delta/47/last_access_media.sql
+++ b/synapse/storage/schema/delta/47/last_access_media.sql
@@ -1,0 +1,19 @@
+/* Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- drop the unique constraint on deleted_pushers so that we can just insert
+-- into it rather than upserting.
+
+ALTER TABLE local_media_repository ADD COLUMN last_access_ts BIGINT;

--- a/synapse/storage/schema/delta/47/last_access_media.sql
+++ b/synapse/storage/schema/delta/47/last_access_media.sql
@@ -13,7 +13,4 @@
  * limitations under the License.
  */
 
--- drop the unique constraint on deleted_pushers so that we can just insert
--- into it rather than upserting.
-
 ALTER TABLE local_media_repository ADD COLUMN last_access_ts BIGINT;


### PR DESCRIPTION
This keeps track of last active time for local media, as well as bumping access times when someone looks at a thumbnail. We may want to split out the last active time of thumbnails, but that can be done later if necessary.