### PR TITLE
Store state groups separately from events

### DIFF
--- a/synapse/events/snapshot.py
+++ b/synapse/events/snapshot.py
@@ -25,7 +25,9 @@ class EventContext(object):
             The current state map excluding the current event.
             (type, state_key) -> event_id
 
-        state_group (int): state group id
+        state_group (int|None): state group id, if the state has been stored
+            as a state group. This is usually only None if e.g. the event is
+            an outlier.
         rejected (bool|str): A rejection reason if the event was rejected, else
             False
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1926,7 +1926,8 @@ class FederationHandler(BaseHandler):
     @defer.inlineCallbacks
     def _update_context_for_auth_events(self, event, context, auth_events,
                                         event_key):
-        """Update the state_ids in an event context after auth event resolution
+        """Update the state_ids in an event context after auth event resolution,
+        storing the changes as a new state group.
 
         Args:
             event (Event): The event we're handling the context for

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1831,8 +1831,8 @@ class FederationHandler(BaseHandler):
                 current_state = set(e.event_id for e in auth_events.values())
                 different_auth = event_auth_events - current_state
 
-                self._update_context_for_auth_events(
-                    context, auth_events, event_key,
+                yield self._update_context_for_auth_events(
+                    event, context, auth_events, event_key,
                 )
 
         if different_auth and not event.internal_metadata.is_outlier():
@@ -1913,8 +1913,8 @@ class FederationHandler(BaseHandler):
                 # 4. Look at rejects and their proofs.
                 # TODO.
 
-                self._update_context_for_auth_events(
-                    context, auth_events, event_key,
+                yield self._update_context_for_auth_events(
+                    event, context, auth_events, event_key,
                 )
 
         try:
@@ -1923,11 +1923,14 @@ class FederationHandler(BaseHandler):
             logger.warn("Failed auth resolution for %r because %s", event, e)
             raise e
 
-    def _update_context_for_auth_events(self, context, auth_events,
+    @defer.inlineCallbacks
+    def _update_context_for_auth_events(self, event, context, auth_events,
                                         event_key):
         """Update the state_ids in an event context after auth event resolution
 
         Args:
+            event (Event): The event we're handling the context for
+
             context (synapse.events.snapshot.EventContext): event context
                 to be updated
 
@@ -1950,7 +1953,13 @@ class FederationHandler(BaseHandler):
         context.prev_state_ids.update({
             k: a.event_id for k, a in auth_events.iteritems()
         })
-        context.state_group = self.store.get_next_state_group()
+        context.state_group = yield self.store.store_state_group(
+            event.event_id,
+            event.room_id,
+            prev_group=context.prev_group,
+            delta_ids=context.delta_ids,
+            current_state_ids=context.current_state_ids,
+        )
 
     @defer.inlineCallbacks
     def construct_auth_difference(self, local_auth, remote_auth):

--- a/synapse/replication/slave/storage/events.py
+++ b/synapse/replication/slave/storage/events.py
@@ -19,7 +19,7 @@ from synapse.storage import DataStore
 from synapse.storage.event_federation import EventFederationStore
 from synapse.storage.event_push_actions import EventPushActionsStore
 from synapse.storage.roommember import RoomMemberStore
-from synapse.storage.state import StateGroupReadStore
+from synapse.storage.state import StateGroupWorkerStore
 from synapse.storage.stream import StreamStore
 from synapse.util.caches.stream_change_cache import StreamChangeCache
 from ._base import BaseSlavedStore
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 # the method descriptor on the DataStore and chuck them into our class.
 
 
-class SlavedEventStore(StateGroupReadStore, BaseSlavedStore):
+class SlavedEventStore(StateGroupWorkerStore, BaseSlavedStore):
 
     def __init__(self, db_conn, hs):
         super(SlavedEventStore, self).__init__(db_conn, hs)

--- a/synapse/state.py
+++ b/synapse/state.py
@@ -183,8 +183,15 @@ class StateHandler(object):
     def compute_event_context(self, event, old_state=None):
         """Build an EventContext structure for the event.
 
+        This works out what the current state should be for the event, and
+        generates a new state group if necessary.
+
         Args:
             event (synapse.events.EventBase):
+            old_state (dict|None): The state at the event if it can't be
+                calculated from existing events. This is normally only specified
+                when receiving an event from federation where we don't have the
+                prev events for, e.g. when backfilling.
         Returns:
             synapse.events.snapshot.EventContext:
         """
@@ -220,6 +227,10 @@ class StateHandler(object):
             defer.returnValue(context)
 
         if old_state:
+            # We already have the state, so we don't to calculate it.
+            # Lets just correctly fill out the context and create a
+            # new state group for it.
+
             context = EventContext()
             context.prev_state_ids = {
                 (s.type, s.state_key): s.event_id for s in old_state
@@ -257,6 +268,9 @@ class StateHandler(object):
         context = EventContext()
         context.prev_state_ids = curr_state
         if event.is_state():
+            # If this is a state event then we need to create a new state
+            # group for the state after this event.
+
             key = (event.type, event.state_key)
             if key in context.prev_state_ids:
                 replaces = context.prev_state_ids[key]
@@ -266,11 +280,15 @@ class StateHandler(object):
             context.current_state_ids[key] = event.event_id
 
             if entry.state_group:
+                # If the state at the event has a state group assigned then
+                # we can use that as the prev group
                 context.prev_group = entry.state_group
                 context.delta_ids = {
                     key: event.event_id
                 }
             elif entry.prev_group:
+                # If the state at the event only has a prev group, then we can
+                # use that as a prev group too.
                 context.prev_group = entry.prev_group
                 context.delta_ids = dict(entry.delta_ids)
                 context.delta_ids[key] = event.event_id
@@ -278,8 +296,8 @@ class StateHandler(object):
             context.state_group = yield self.store.store_state_group(
                 event.event_id,
                 event.room_id,
-                prev_group=entry.prev_group,
-                delta_ids=entry.delta_ids,
+                prev_group=context.prev_group,
+                delta_ids=context.delta_ids,
                 current_state_ids=context.current_state_ids,
             )
         else:

--- a/synapse/state.py
+++ b/synapse/state.py
@@ -216,13 +216,9 @@ class StateHandler(object):
                 context.prev_state_ids = {}
             context.prev_state_events = []
 
-            context.state_group = yield self.store.store_state_group(
-                event.event_id,
-                event.room_id,
-                prev_group=None,
-                delta_ids=None,
-                current_state_ids=context.current_state_ids,
-            )
+            # We don't store state for outliers, so we don't generate a state
+            # froup for it.
+            context.state_group = None
 
             defer.returnValue(context)
 

--- a/synapse/state.py
+++ b/synapse/state.py
@@ -227,8 +227,8 @@ class StateHandler(object):
             defer.returnValue(context)
 
         if old_state:
-            # We already have the state, so we don't to calculate it.
-            # Lets just correctly fill out the context and create a
+            # We already have the state, so we don't need to calculate it.
+            # Let's just correctly fill out the context and create a
             # new state group for it.
 
             context = EventContext()

--- a/synapse/storage/__init__.py
+++ b/synapse/storage/__init__.py
@@ -124,7 +124,6 @@ class DataStore(RoomMemberStore, RoomStore,
         )
 
         self._transaction_id_gen = IdGenerator(db_conn, "sent_transactions", "id")
-        self._state_groups_id_gen = IdGenerator(db_conn, "state_groups", "id")
         self._access_tokens_id_gen = IdGenerator(db_conn, "access_tokens", "id")
         self._event_reports_id_gen = IdGenerator(db_conn, "event_reports", "id")
         self._push_rule_id_gen = IdGenerator(db_conn, "push_rules", "id")

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -62,3 +62,9 @@ class PostgresEngine(object):
 
     def lock_table(self, txn, table):
         txn.execute("LOCK TABLE %s in EXCLUSIVE MODE" % (table,))
+
+    def get_next_state_group_id(self, txn):
+        """Returns an int that can be used as a new state_group ID
+        """
+        txn.execute("SELECT nextval('state_group_id_seq')")
+        return txn.fetchone()[0]

--- a/synapse/storage/engines/sqlite3.py
+++ b/synapse/storage/engines/sqlite3.py
@@ -16,6 +16,7 @@
 from synapse.storage.prepare_database import prepare_database
 
 import struct
+import threading
 
 
 class Sqlite3Engine(object):
@@ -23,6 +24,11 @@ class Sqlite3Engine(object):
 
     def __init__(self, database_module, database_config):
         self.module = database_module
+
+        # The current max state_group, or None if we haven't looked
+        # in the DB yet.
+        self._current_state_group_id = None
+        self._current_state_group_id_lock = threading.Lock()
 
     def check_database(self, txn):
         pass
@@ -42,6 +48,19 @@ class Sqlite3Engine(object):
 
     def lock_table(self, txn, table):
         return
+
+    def get_next_state_group_id(self, txn):
+        """Returns an int that can be used as a new state_group ID
+        """
+        # We do application locking here since if we're using sqlite then
+        # we are a single process synapse.
+        with self._current_state_group_id_lock:
+            if self._current_state_group_id is None:
+                txn.execute("SELECT COALESCE(max(id), 0) FROM state_groups")
+                self._current_state_group_id = txn.fetchone()[0]
+
+            self._current_state_group_id += 1
+            return self._current_state_group_id
 
 
 # Following functions taken from: https://github.com/coleifer/peewee

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -742,8 +742,7 @@ class EventsStore(SQLBaseStore):
             events_and_contexts=events_and_contexts,
         )
 
-        # Insert into the state_groups, state_groups_state, and
-        # event_to_state_groups tables.
+        # Insert into event_to_state_groups tables.
         self._store_event_state_mappings_txn(txn, events_and_contexts)
 
         # _store_rejected_events_txn filters out any events which were
@@ -979,8 +978,7 @@ class EventsStore(SQLBaseStore):
                 # an outlier in the database. We now have some state at that
                 # so we need to update the state_groups table with that state.
 
-                # insert into the state_group, state_groups_state and
-                # event_to_state_groups tables.
+                # insert into event_to_state_groups tables.
                 try:
                     self._store_event_state_mappings_txn(txn, ((event, context),))
                 except Exception:

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -744,7 +744,7 @@ class EventsStore(SQLBaseStore):
 
         # Insert into the state_groups, state_groups_state, and
         # event_to_state_groups tables.
-        self._store_mult_state_groups_txn(txn, events_and_contexts)
+        self._store_event_state_mappings_txn(txn, events_and_contexts)
 
         # _store_rejected_events_txn filters out any events which were
         # rejected, and returns the filtered list.
@@ -982,7 +982,7 @@ class EventsStore(SQLBaseStore):
                 # insert into the state_group, state_groups_state and
                 # event_to_state_groups tables.
                 try:
-                    self._store_mult_state_groups_txn(txn, ((event, context),))
+                    self._store_event_state_mappings_txn(txn, ((event, context),))
                 except Exception:
                     logger.exception("")
                     raise

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -742,7 +742,7 @@ class EventsStore(SQLBaseStore):
             events_and_contexts=events_and_contexts,
         )
 
-        # Insert into event_to_state_groups tables.
+        # Insert into event_to_state_groups.
         self._store_event_state_mappings_txn(txn, events_and_contexts)
 
         # _store_rejected_events_txn filters out any events which were
@@ -978,7 +978,7 @@ class EventsStore(SQLBaseStore):
                 # an outlier in the database. We now have some state at that
                 # so we need to update the state_groups table with that state.
 
-                # insert into event_to_state_groups tables.
+                # insert into event_to_state_groups.
                 try:
                     self._store_event_state_mappings_txn(txn, ((event, context),))
                 except Exception:

--- a/synapse/storage/schema/delta/47/state_group_seq.py
+++ b/synapse/storage/schema/delta/47/state_group_seq.py
@@ -17,7 +17,20 @@ from synapse.storage.engines import PostgresEngine
 
 def run_create(cur, database_engine, *args, **kwargs):
     if isinstance(database_engine, PostgresEngine):
-        cur.execute("CREATE SEQUENCE state_group_id_seq")
+        # if we already have some state groups, we want to start making new
+        # ones with a higher id.
+        cur.execute("SELECT max(id) FROM state_groups")
+        row = cur.fetchone()
+
+        if row[0] is None:
+            start_val = 1
+        else:
+            start_val = row[0] + 1
+
+        cur.execute(
+            "CREATE SEQUENCE state_group_id_seq START WITH %s",
+            (start_val, ),
+        )
 
 
 def run_upgrade(*args, **kwargs):

--- a/synapse/storage/schema/delta/47/state_group_seq.py
+++ b/synapse/storage/schema/delta/47/state_group_seq.py
@@ -1,0 +1,24 @@
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from synapse.storage.engines import PostgresEngine
+
+
+def run_create(cur, database_engine, *args, **kwargs):
+    if isinstance(database_engine, PostgresEngine):
+        cur.execute("CREATE SEQUENCE state_group_id_seq")
+
+
+def run_upgrade(*args, **kwargs):
+    pass

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -656,8 +656,7 @@ class StateStore(StateGroupReadStore, BackgroundUpdateStore):
                 )
                 return
 
-            # FIXME Replace this with Postgres/SQLITE specific ID generation
-            state_group = 456
+            state_group = self.database_engine.get_next_state_group_id(txn)
 
             self._simple_insert_txn(
                 txn,

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -553,7 +553,7 @@ class StateGroupWorkerStore(SQLBaseStore):
         Args:
             event_id (str): The event ID for which the state was calculated
             room_id (str)
-            prev_group (str|None): A previous state group for the room, optional.
+            prev_group (int|None): A previous state group for the room, optional.
             delta_ids (dict|None): The delta between state at `prev_group` and
                 `current_state_ids`, if `prev_group` was given. Same format as
                 `current_state_ids`.
@@ -561,7 +561,7 @@ class StateGroupWorkerStore(SQLBaseStore):
                 to event_id.
 
         Returns:
-            Deferred[str]: The state group ID
+            Deferred[int]: The state group ID
         """
         def _store_state_group_txn(txn):
             if current_state_ids is None:

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -42,11 +42,8 @@ class _GetStateGroupDelta(namedtuple("_GetStateGroupDelta", ("prev_group", "delt
         return len(self.delta_ids) if self.delta_ids else 0
 
 
-class StateGroupReadStore(SQLBaseStore):
-    """The read-only parts of StateGroupStore
-
-    None of these functions write to the state tables, so are suitable for
-    including in the SlavedStores.
+class StateGroupWorkerStore(SQLBaseStore):
+    """The parts of StateGroupStore that can be called from workers.
     """
 
     STATE_GROUP_DEDUPLICATION_UPDATE_NAME = "state_group_state_deduplication"
@@ -54,7 +51,7 @@ class StateGroupReadStore(SQLBaseStore):
     CURRENT_STATE_INDEX_UPDATE_NAME = "current_state_members_idx"
 
     def __init__(self, db_conn, hs):
-        super(StateGroupReadStore, self).__init__(db_conn, hs)
+        super(StateGroupWorkerStore, self).__init__(db_conn, hs)
 
         self._state_group_cache = DictionaryCache(
             "*stateGroupCache*", 100000 * CACHE_SIZE_FACTOR
@@ -659,7 +656,7 @@ class StateGroupReadStore(SQLBaseStore):
         return self.runInteraction("store_state_group", _store_state_group_txn)
 
 
-class StateStore(StateGroupReadStore, BackgroundUpdateStore):
+class StateStore(StateGroupWorkerStore, BackgroundUpdateStore):
     """ Keeps track of the state at a given event.
 
     This is done by the concept of `state groups`. Every event is a assigned

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -708,7 +708,7 @@ class StateStore(StateGroupReadStore, BackgroundUpdateStore):
         row = txn.fetchone()
         return row and row[0]
 
-    def _store_mult_state_groups_txn(self, txn, events_and_contexts):
+    def _store_event_state_mappings_txn(self, txn, events_and_contexts):
         state_groups = {}
         for event, context in events_and_contexts:
             if event.internal_metadata.is_outlier():

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -781,9 +781,6 @@ class StateStore(StateGroupReadStore, BackgroundUpdateStore):
 
             return count
 
-    def get_next_state_group(self):
-        return self._state_groups_id_gen.get_next()
-
     @defer.inlineCallbacks
     def _background_deduplicate_state(self, progress, batch_size):
         """This background update will slowly deduplicate state by reencoding

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -697,14 +697,6 @@ class StateStore(StateGroupWorkerStore, BackgroundUpdateStore):
             where_clause="type='m.room.member'",
         )
 
-    def _have_persisted_state_group_txn(self, txn, state_group):
-        txn.execute(
-            "SELECT count(*) FROM state_groups WHERE id = ?",
-            (state_group,)
-        )
-        row = txn.fetchone()
-        return row and row[0]
-
     def _store_event_state_mappings_txn(self, txn, events_and_contexts):
         state_groups = {}
         for event, context in events_and_contexts:

--- a/tests/replication/slave/storage/test_events.py
+++ b/tests/replication/slave/storage/test_events.py
@@ -226,11 +226,9 @@ class SlavedEventStoreTestCase(BaseSlavedStoreTestCase):
             context = EventContext()
             context.current_state_ids = state_ids
             context.prev_state_ids = state_ids
-        elif not backfill:
+        else:
             state_handler = self.hs.get_state_handler()
             context = yield state_handler.compute_event_context(event)
-        else:
-            context = EventContext()
 
         context.push_actions = push_actions
 


### PR DESCRIPTION
We want to be able to calculate and use state groups on workers other than the master process. To make this easier we store new state groups immediately from the state handler, rather than later when the event is stored.

This means that the state group IDs have to be generated in the DB rather than in process, since multiple workers will potentially be generating them. 