### PR TITLE
Log room when doing state resolution

### DIFF
--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -528,6 +528,12 @@ class EventsStore(SQLBaseStore):
                 # the events we have yet to persist, so we need a slightly more
                 # complicated event lookup function than simply looking the events
                 # up in the db.
+
+                logger.info(
+                    "Resolving state for %s with %i state sets",
+                    room_id, len(state_sets),
+                )
+
                 events_map = {ev.event_id: ev for ev, _ in events_context}
 
                 @defer.inlineCallbacks


### PR DESCRIPTION
Mostly because it helps figure out what is prompting the resolution