### PR TITLE
Add an admin route to get all the media in a room

### DIFF
--- a/docs/admin_api/media_admin_api.md
+++ b/docs/admin_api/media_admin_api.md
@@ -1,0 +1,23 @@
+# List all media in a room
+
+This API gets a list of known media in a room.
+
+The API is:
+```
+GET /_matrix/client/r0/admin/room/<room_id>/media
+```
+including an `access_token` of a server admin.
+
+It returns a JSON body like the following:
+```
+{
+    "local": [
+        "mxc://localhost/xwvutsrqponmlkjihgfedcba",
+        "mxc://localhost/abcdefghijklmnopqrstuvwx"
+    ],
+    "remote": [
+        "mxc://matrix.org/xwvutsrqponmlkjihgfedcba",
+        "mxc://matrix.org/abcdefghijklmnopqrstuvwx"
+    ]
+}
+```

--- a/synapse/storage/room.py
+++ b/synapse/storage/room.py
@@ -553,7 +553,7 @@ class RoomStore(SQLBaseStore):
         the associated media
         """
         def _quarantine_media_in_room(txn):
-            local_media_mxcs, remote_media_mxcs = self._get_media_ids_in_room(txn, room_id)
+            local_media_ids, remote_media_ids = self._get_media_ids_in_room(txn, room_id)
             total_media_quarantined = 0
 
             # Now update all the tables to set the quarantined_by flag
@@ -562,7 +562,7 @@ class RoomStore(SQLBaseStore):
                 UPDATE local_media_repository
                 SET quarantined_by = ?
                 WHERE media_id = ?
-            """, ((quarantined_by, media_id) for media_id in local_media_mxcs))
+            """, ((quarantined_by, media_id) for media_id in local_media_ids))
 
             txn.executemany(
                 """
@@ -572,12 +572,12 @@ class RoomStore(SQLBaseStore):
                 """,
                 (
                     (quarantined_by, origin, media_id)
-                    for origin, media_id in remote_media_mxcs
+                    for origin, media_id in remote_media_ids
                 )
             )
 
-            total_media_quarantined += len(local_media_mxcs)
-            total_media_quarantined += len(remote_media_mxcs)
+            total_media_quarantined += len(local_media_ids)
+            total_media_quarantined += len(remote_media_ids)
 
             return total_media_quarantined
 


### PR DESCRIPTION
Full disclsoure: I've written this so that the media repo I'm working on can grab all the media in a room and quarantine it internally. It should be generic enough to also be useful for admin tools to make use of it, if they wish.

I've moved the `_get_media_ids_in_room` function out to it's own thing so that both `get_media_mxcs_in_room` and `quarantine_media_in_room` can both make use of it. 