### PR TITLE
Support search expression (currently limited)

### DIFF
--- a/synapse/handlers/search.py
+++ b/synapse/handlers/search.py
@@ -157,7 +157,7 @@ class SearchHandler(BaseHandler):
 
         if order_by == "rank":
             search_result = yield self.store.search_msgs(
-                room_ids, search_term, keys
+                user.to_string(), room_ids, search_term, keys
             )
 
             count = search_result["count"]
@@ -205,7 +205,7 @@ class SearchHandler(BaseHandler):
             while len(room_events) < search_filter.limit() and i < 5:
                 i += 1
                 search_result = yield self.store.search_rooms(
-                    room_ids, search_term, keys, search_filter.limit() * 2,
+                    user.to_string(), room_ids, search_term, keys, search_filter.limit() * 2,
                     pagination_token=pagination_token,
                 )
 


### PR DESCRIPTION
As part of work to fix [riot-web issue 2928](https://github.com/vector-im/riot-web/issues/2938), add support of search expression to synapse.
See https://github.com/vector-im/riot-web/issues/4752 for discussion about this feature.
The search expression could contain 3 kind of expression:
  - plain word: to match against message content (same meaning as previous search term)
  - tag: to match against message tags, prefix tag with ':', e.g. ":starred"
  - key value pair: to match against message properties, e.g. "after:17/01/01"
Multiple expressions could be concated with white space, it means Expression1 AND Expression2...
Currently only ":starred" tag expression was handled, but it could be combined with plain words.