### PR TITLE
Fix server 500 on public rooms call when no rooms exist

### DIFF
--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -188,7 +188,7 @@ class RoomListHandler(BaseHandler):
 
         # bail if no rooms to work on
         if len(rooms_to_scan) == 0:
-            defer.returnValue([])
+            defer.returnValue({})
 
         # _append_room_entry_to_chunk will append to chunk but will stop if
         # len(chunk) > limit

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -205,6 +205,7 @@ class RoomListHandler(BaseHandler):
         else:
             # step cannot be zero
             step = len(rooms_to_scan) if len(rooms_to_scan) != 0 else 1
+
         chunk = []
         for i in xrange(0, len(rooms_to_scan), step):
             batch = rooms_to_scan[i:i + step]

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -186,7 +186,7 @@ class RoomListHandler(BaseHandler):
         logger.info("After sorting and filtering, %i rooms remain",
                     len(rooms_to_scan))
 
-        #bail if no rooms to work on
+        # bail if no rooms to work on
         if len(rooms_to_scan) == 0:
             defer.returnValue([])
 

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -190,7 +190,6 @@ class RoomListHandler(BaseHandler):
         if len(rooms_to_scan) == 0:
             defer.returnValue([])
 
-
         # _append_room_entry_to_chunk will append to chunk but will stop if
         # len(chunk) > limit
         #

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -186,6 +186,11 @@ class RoomListHandler(BaseHandler):
         logger.info("After sorting and filtering, %i rooms remain",
                     len(rooms_to_scan))
 
+        #bail if no rooms to work on
+        if len(rooms_to_scan) == 0:
+            defer.returnValue([])
+
+
         # _append_room_entry_to_chunk will append to chunk but will stop if
         # len(chunk) > limit
         #

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -186,10 +186,6 @@ class RoomListHandler(BaseHandler):
         logger.info("After sorting and filtering, %i rooms remain",
                     len(rooms_to_scan))
 
-        # bail if no rooms to work on
-        if len(rooms_to_scan) == 0:
-            defer.returnValue({})
-
         # _append_room_entry_to_chunk will append to chunk but will stop if
         # len(chunk) > limit
         #
@@ -207,8 +203,8 @@ class RoomListHandler(BaseHandler):
         if limit:
             step = limit + 1
         else:
-            step = len(rooms_to_scan)
-
+            # step cannot be zero
+            step = len(rooms_to_scan) if len(rooms_to_scan) != 0 else 1
         chunk = []
         for i in xrange(0, len(rooms_to_scan), step):
             batch = rooms_to_scan[i:i + step]


### PR DESCRIPTION
synapse 500s on a call to publicRooms in the case where the number of public rooms is zero, the specific cause is due to xrange trying to use a step value of zero, but if the total room number really is zero then it makes sense to just bail and save the extra processing (I don't believe that there are any other side effects occurring further down the method to worry about).


Signed-off-by: Neil Johnson Your Name <neil@fragile.org.uk>