### PR TITLE
Fix sql error in quarantine_media

### DIFF
--- a/synapse/storage/room.py
+++ b/synapse/storage/room.py
@@ -589,7 +589,7 @@ class RoomStore(SQLBaseStore):
                     """
                         UPDATE remote_media_cache
                         SET quarantined_by = ?
-                        WHERE media_origin AND media_id = ?
+                        WHERE media_origin = ? AND media_id = ?
                     """,
                     (
                         (quarantined_by, origin, media_id)


### PR DESCRIPTION
this got fixed in matrix-org-hotfixes in https://github.com/matrix-org/synapse/commit/f2db3e4856de94b91fdd13a7a90bf3b7db4d40f2#diff-a58b64edbeebf6b83f555ef2866a7db3R592
