### PR TITLE
Remove pointless ratelimit check

### DIFF
--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -403,11 +403,6 @@ class EventCreationHandler(object):
                 "Tried to send member event through non-member codepath"
             )
 
-        # We check here if we are currently being rate limited, so that we
-        # don't do unnecessary work. We check again just before we actually
-        # send the event.
-        yield self.base_handler.ratelimit(requester, update=False)
-
         user = UserID.from_string(event.sender)
 
         assert self.hs.is_mine(user), "User must be our own: %s" % (user,)


### PR DESCRIPTION
The intention was for the check to be called as early as possible in the
request, but actually was called just before the main ratelimit check,
so was fairly pointless.