### PR TITLE
README: add instruction for URL-Previews to install lxml and psycopg2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -833,8 +833,8 @@ your loopback and RFC1918 IP addresses are blacklisted.
 
 This also requires the optional lxml and netaddr python dependencies to be
 installed.  This in turn requires the libxml2 library to be available - on
-Debian/Ubuntu this means ``apt-get install libxml2-dev``, or equivalent for
-your OS.
+Debian/Ubuntu this means ``apt-get install libxml2-dev && pip install lxml psycopg2``,
+or equivalent for your OS.
 
 
 Password reset

--- a/README.rst
+++ b/README.rst
@@ -833,8 +833,9 @@ your loopback and RFC1918 IP addresses are blacklisted.
 
 This also requires the optional lxml and netaddr python dependencies to be
 installed.  This in turn requires the libxml2 library to be available - on
-Debian/Ubuntu this means ``apt-get install libxml2-dev && pip install lxml psycopg2``,
-or equivalent for your OS.
+Debian/Ubuntu this means ``apt-get install libxml2-dev && pip install lxml``,
+or equivalent for your OS (if you use PostgreSQL, you also need 
+``pip install psycopg2``).
 
 
 Password reset


### PR DESCRIPTION
On Debian, you need some more dependencies to enable URL-Preview:

    pip install lxml psycopg2

I added this to the Readme