### PR TITLE
Calculate stream_ordering_month_ago correctly on workers

### DIFF
--- a/synapse/replication/slave/storage/events.py
+++ b/synapse/replication/slave/storage/events.py
@@ -67,7 +67,6 @@ class SlavedEventStore(RoomMemberWorkerStore, EventPushActionsWorkerStore,
             "MembershipStreamChangeCache", events_max,
         )
 
-        self.stream_ordering_month_ago = 0
         self._stream_order_on_start = self.get_room_max_stream_ordering()
 
     # Cached functions can't be accessed through a class instance so we need

--- a/synapse/storage/__init__.py
+++ b/synapse/storage/__init__.py
@@ -20,7 +20,6 @@ from synapse.storage.devices import DeviceStore
 from .appservice import (
     ApplicationServiceStore, ApplicationServiceTransactionStore
 )
-from ._base import LoggingTransaction
 from .directory import DirectoryStore
 from .events import EventsStore
 from .presence import PresenceStore, UserPresenceState
@@ -226,20 +225,6 @@ class DataStore(RoomMemberStore, RoomStore,
         self._group_updates_stream_cache = StreamChangeCache(
             "_group_updates_stream_cache", min_group_updates_id,
             prefilled_cache=_group_updates_prefill,
-        )
-
-        cur = LoggingTransaction(
-            db_conn.cursor(),
-            name="_find_stream_orderings_for_times_txn",
-            database_engine=self.database_engine,
-            after_callbacks=[],
-            final_callbacks=[],
-        )
-        self._find_stream_orderings_for_times_txn(cur)
-        cur.close()
-
-        self.find_stream_orderings_looping_call = self._clock.looping_call(
-            self._find_stream_orderings_for_times, 10 * 60 * 1000
         )
 
         self._stream_order_on_start = self.get_room_max_stream_ordering()

--- a/synapse/storage/event_push_actions.py
+++ b/synapse/storage/event_push_actions.py
@@ -67,7 +67,7 @@ class EventPushActionsWorkerStore(SQLBaseStore):
     def __init__(self, db_conn, hs):
         super(EventPushActionsWorkerStore, self).__init__(db_conn, hs)
 
-        # These get correctly ste by _find_stream_orderings_for_times_txn
+        # These get correctly set by _find_stream_orderings_for_times_txn
         self.stream_ordering_month_ago = 0
         self.stream_ordering_day_ago = 0
 

--- a/synapse/storage/event_push_actions.py
+++ b/synapse/storage/event_push_actions.py
@@ -68,8 +68,8 @@ class EventPushActionsWorkerStore(SQLBaseStore):
         super(EventPushActionsWorkerStore, self).__init__(db_conn, hs)
 
         # These get correctly set by _find_stream_orderings_for_times_txn
-        self.stream_ordering_month_ago = 0
-        self.stream_ordering_day_ago = 0
+        self.stream_ordering_month_ago = None
+        self.stream_ordering_day_ago = None
 
         cur = LoggingTransaction(
             db_conn.cursor(),


### PR DESCRIPTION
I checked the logs and it doesn't look like it takes long at all to calculate these so I don't think it matters if we start calculating these on workers too.