### PR TITLE
Add room_id to the response of `rooms/{roomId}/join`

### DIFF
--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -625,7 +625,12 @@ class RoomMembershipRestServlet(ClientV1RestServlet):
             content=event_content,
         )
 
-        defer.returnValue((200, {}))
+        return_value = {}
+
+        if membership_action == "join":
+            return_value["room_id"] = room_id
+
+        defer.returnValue((200, return_value))
 
     def _has_3pid_invite_keys(self, content):
         for key in {"id_server", "medium", "address"}:


### PR DESCRIPTION
Fixes #2349 

This endpoint requires the room_id to be known on the client side anyway, so it might make sense to remove it in a future revision of the spec. If there is an easy way to propose small changes like this, let me know.