### PR TITLE
Split RoomMemberHandler into base and master class

### DIFF
--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import abc
+import logging
+
 from signedjson.key import decode_verify_key_bytes
 from signedjson.sign import verify_signed_json
 from twisted.internet import defer
@@ -27,9 +30,6 @@ from synapse.api.errors import AuthError, SynapseError, Codes
 from synapse.types import UserID, RoomID
 from synapse.util.async import Linearizer
 from synapse.util.distributor import user_left_room, user_joined_room
-
-import abc
-import logging
 
 
 logger = logging.getLogger(__name__)

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -70,6 +70,7 @@ class RoomMemberHandler(object):
         """Try and join a room that this server is not in
 
         Args:
+            requester (Requester)
             remote_room_hosts (list[str]): List of servers that can be used
                 to join via.
             room_id (str): Room that we are trying to join
@@ -88,6 +89,7 @@ class RoomMemberHandler(object):
         fail to do so we locally mark the invite as rejected.
 
         Args:
+            requester (Requester)
             remote_room_hosts (list[str]): List of servers to use to try and
                 reject invite
             room_id (str)
@@ -105,6 +107,7 @@ class RoomMemberHandler(object):
         one doesn't already exist.
 
         Args:
+            requester (Requester)
             medium (str)
             address (str)
             inviter_user_id (str): The user ID who is trying to invite the

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -388,7 +388,7 @@ class HomeServer(object):
 
     def build_room_member_handler(self):
         if self.config.worker_app:
-            return Exception("Can't use RoomMemberHandler on workers")
+            raise Exception("Can't use RoomMemberHandler on workers")
         return RoomMemberMasterHandler(self)
 
     def build_federation_registry(self):

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -46,7 +46,7 @@ from synapse.handlers.device import DeviceHandler
 from synapse.handlers.e2e_keys import E2eKeysHandler
 from synapse.handlers.presence import PresenceHandler
 from synapse.handlers.room_list import RoomListHandler
-from synapse.handlers.room_member import RoomMemberHandler
+from synapse.handlers.room_member import RoomMemberMasterHandler
 from synapse.handlers.set_password import SetPasswordHandler
 from synapse.handlers.sync import SyncHandler
 from synapse.handlers.typing import TypingHandler
@@ -387,7 +387,9 @@ class HomeServer(object):
         return SpamChecker(self)
 
     def build_room_member_handler(self):
-        return RoomMemberHandler(self)
+        if self.config.worker_app:
+            return Exception("Can't use RoomMemberHandler on workers")
+        return RoomMemberMasterHandler(self)
 
     def build_federation_registry(self):
         return FederationHandlerRegistry()


### PR DESCRIPTION
The intention here is to split the class into the bits that can be done
on workers and the bits that have to be done on the master.

In future there will also be a class that can be run on the worker,
which will delegate work to the master when necessary.