### PR TITLE
Only update remote profile cache on master

### DIFF
--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -38,7 +38,10 @@ class ProfileHandler(BaseHandler):
 
         self.user_directory_handler = hs.get_user_directory_handler()
 
-        self.clock.looping_call(self._update_remote_profile_cache, self.PROFILE_UPDATE_MS)
+        if hs.config.worker_app is None:
+            self.clock.looping_call(
+                self._update_remote_profile_cache, self.PROFILE_UPDATE_MS,
+            )
 
     @defer.inlineCallbacks
     def get_profile(self, user_id):


### PR DESCRIPTION
The updates get persisted and fetched from the DB, so this can and should only be run on master.