### PR TITLE
move handling of auto_join_rooms to RegisterHandler

### DIFF
--- a/tests/rest/client/v1/test_events.py
+++ b/tests/rest/client/v1/test_events.py
@@ -123,6 +123,7 @@ class EventStreamPermissionsTestCase(RestTestCase):
         self.ratelimiter.send_message.return_value = (True, 0)
         hs.config.enable_registration_captcha = False
         hs.config.enable_registration = True
+        hs.config.auto_join_rooms = []
 
         hs.get_handlers().federation_handler = Mock()
 


### PR DESCRIPTION
Currently the handling of `auto_join_rooms` only works when a user
registers itself via public register api. Registrations via
`registration_shared_secret` and ModuleApi do not work

This auto joins the users in the registration handler which enables
the auto join feature for all 3 registration paths.

This is related to issue #2725

Signed-Off-by: Matthias Kesler <krombel@krombel.de>