### PR TITLE
Add counter metrics for calculating state delta

### DIFF
--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -52,12 +52,19 @@ persist_event_counter = metrics.register_counter("persisted_events")
 event_counter = metrics.register_counter(
     "persisted_events_sep", labels=["type", "origin_type", "origin_entity"]
 )
+
+# The number of times we are recalculating the current state
 state_delta_counter = metrics.register_counter(
     "state_delta",
 )
+# The number of times we are recalculating state when there is only a
+# single forward extremity
 state_delta_single_event_counter = metrics.register_counter(
     "state_delta_single_event",
 )
+# The number of times we are reculating state when we could have resonably
+# calculated the delta when we calculated the state for an event we were
+# persisting.
 state_delta_reuse_delta_counter = metrics.register_counter(
     "state_delta_reuse_delta",
 )

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -423,7 +423,7 @@ class EventsStore(EventsWorkerStore):
                                     prev_event_ids = set(e for e, _ in ev.prev_events)
                                     if latest_event_ids == prev_event_ids:
                                         state_delta_reuse_delta_counter.inc()
-                                    break
+                                        break
 
                             logger.info(
                                 "Calculating state delta for room %s", room_id,

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -52,6 +52,15 @@ persist_event_counter = metrics.register_counter("persisted_events")
 event_counter = metrics.register_counter(
     "persisted_events_sep", labels=["type", "origin_type", "origin_entity"]
 )
+state_delta_counter = metrics.register_counter(
+    "state_delta",
+)
+state_delta_single_event_counter = metrics.register_counter(
+    "state_delta_single_event",
+)
+state_delta_reuse_delta_counter = metrics.register_counter(
+    "state_delta_reuse_delta",
+)
 
 
 def encode_json(json_object):
@@ -368,7 +377,8 @@ class EventsStore(EventsWorkerStore):
                                 room_id, ev_ctx_rm, latest_event_ids
                             )
 
-                            if new_latest_event_ids == set(latest_event_ids):
+                            latest_event_ids = set(latest_event_ids)
+                            if new_latest_event_ids == latest_event_ids:
                                 # No change in extremities, so no change in state
                                 continue
 
@@ -388,6 +398,25 @@ class EventsStore(EventsWorkerStore):
                                 # a long chain of single ancestor non-state events.
                                 if all_single_prev_not_state:
                                     continue
+
+                            state_delta_counter.inc()
+                            if len(new_latest_event_ids) == 1:
+                                state_delta_single_event_counter.inc()
+
+                                # This is a fairly handwavey check to see if we could
+                                # have guessed what the delta would have been when
+                                # processing one of these events.
+                                # What we're interested in is if the latest extremities
+                                # were the same when we created the event as they are
+                                # now. We guess this by looking at the prev events and
+                                # checking if they match up, as when this server creates
+                                # a new event it will use the extremities as the prev
+                                # events.
+                                for ev, _ in ev_ctx_rm:
+                                    prev_event_ids = set(e for e, _ in ev.prev_events)
+                                    if latest_event_ids == prev_event_ids:
+                                        state_delta_reuse_delta_counter.inc()
+                                    break
 
                             logger.info(
                                 "Calculating state delta for room %s", room_id,

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -415,10 +415,11 @@ class EventsStore(EventsWorkerStore):
                                 # processing one of these events.
                                 # What we're interested in is if the latest extremities
                                 # were the same when we created the event as they are
-                                # now. We guess this by looking at the prev events and
-                                # checking if they match up, as when this server creates
-                                # a new event it will use the extremities as the prev
-                                # events.
+                                # now. When this server creates a new event (as opposed
+                                # to receiving it over federation) it will use the
+                                # forward extremities as the prev_events, so we can
+                                # guess this by looking at the prev_events and checking
+                                # if they match the current forward extremities.
                                 for ev, _ in ev_ctx_rm:
                                     prev_event_ids = set(e for e, _ in ev.prev_events)
                                     if latest_event_ids == prev_event_ids:


### PR DESCRIPTION
This will allow us to measure how often we calculate state deltas in
event persistence that we would have been able to calculate at the same
time we calculated the state for the event.