### PR TITLE
use reraise instead of old-style raise arguments

### DIFF
--- a/synapse/rest/media/v1/media_storage.py
+++ b/synapse/rest/media/v1/media_storage.py
@@ -25,7 +25,6 @@ import contextlib
 import os
 import logging
 import shutil
-import sys
 
 
 logger = logging.getLogger(__name__)
@@ -114,12 +113,11 @@ class MediaStorage(object):
             with open(fname, "wb") as f:
                 yield f, fname, finish
         except Exception:
-            t, v, tb = sys.exc_info()
             try:
                 os.remove(fname)
             except Exception:
                 pass
-            raise t, v, tb
+            raise
 
         if not finished_called:
             raise Exception("Finished callback not called")


### PR DESCRIPTION
The 'old-style' `raise e, m, tb` is hard to understand (it comes from
the era before python exceptions were classes) and is also deprecated
and removed in python3, so few developers will be familiar with it.

Signed-off-by: Adrian Tschira <nota@notafile.com>