### PR TITLE
Add basic performance statistics to phone home

### DIFF
--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -48,6 +48,18 @@ returned by the Client-Server API:
     # configured on port 443.
     curl -kv https://<host.name>/_matrix/client/versions 2>&1 | grep "Server:"
 
+Upgrading to $NEXT_VERSION
+====================
+
+This release expands the anonymous usage stats sent if the opt-in
+``report_stats`` configuration is set to ``true``. We now capture RSS memory 
+and cpu use at a very coarse level. This requires administrators to install
+the optional ``psutil`` python module.
+
+We would appreciate it if you could assist by ensuring this module is available
+and ``report_stats`` is enabled. This will let us see if performance changes to
+synapse are having an impact to the general community.
+
 Upgrading to v0.15.0
 ====================
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -401,6 +401,9 @@ def run(hs):
     start_time = clock.time()
 
     stats = {}
+
+    # Contains the list of processes we will be monitoring
+    # currently either 0 or 1
     stats_process = []
 
     @defer.inlineCallbacks
@@ -428,13 +431,13 @@ def run(hs):
 
         daily_sent_messages = yield hs.get_datastore().count_daily_sent_messages()
         stats["daily_sent_messages"] = daily_sent_messages
+
         if len(stats_process) > 0:
             stats["memory_rss"] = 0
             stats["cpu_average"] = 0
             for process in stats_process:
-                with process.oneshot():
-                    stats["memory_rss"] += process.memory_info().rss
-                    stats["cpu_average"] += int(process.cpu_percent(interval=None))
+                stats["memory_rss"] += process.memory_info().rss
+                stats["cpu_average"] += int(process.cpu_percent(interval=None))
 
         logger.info("Reporting stats to matrix.org: %s" % (stats,))
         try:
@@ -459,8 +462,8 @@ def run(hs):
             logger.warn(
                 "report_stats enabled but psutil is not installed or incorrect version."
                 " Disabling reporting of memory/cpu stats."
-                " Ensuring psutil is available will help matrix track performance changes"
-                " across releases."
+                " Ensuring psutil is available will help matrix.org track performance"
+                " changes across releases."
             )
 
     if hs.config.report_stats:
@@ -469,7 +472,7 @@ def run(hs):
 
         # We need to defer this init for the cases that we daemonize
         # otherwise the process ID we get is that of the non-daemon process
-        clock.call_later(15, performance_stats_init)
+        clock.call_later(0, performance_stats_init)
 
         # We wait 5 minutes to send the first set of stats as the server can
         # be quite busy the first few minutes


### PR DESCRIPTION
To help identifying if code changes to performance changes are having an impact to homeservers deployed in the community, include statistics on memory used and average CPU use in the statistics we phone home every 3 hours.