### PR TITLE
sketch of an idea to reduce cache misses for get_users_in_room for ASes

### DIFF
--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -186,8 +186,13 @@ class ApplicationService(object):
 
     @cachedInlineCallbacks(num_args=1, cache_context=True)
     def _matches_user_in_member_list(self, room_id, store, cache_context):
+
+        def invalidate_only_when_as_users_change(room_id, member):
+            if self.is_interested_in_user(member):
+                cache_context.invalidate(room_id)
+
         member_list = yield store.get_users_in_room(
-            room_id, on_invalidate=cache_context.invalidate
+            room_id, on_invalidate=invalidate_only_when_as_users_change
         )
 
         # check joined member events

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -793,6 +793,13 @@ class EventsStore(EventsWorkerStore):
                     self._invalidate_cache_and_stream(
                         txn, self.get_rooms_for_user_with_stream_ordering, (member,)
                     )
+                    # we call this once for each member to allow AS workers to
+                    # only invalidate their caches when AS members change.
+                    # other folks naively using a cached get_users_in_rooms will
+                    # just get prodded multiple times and can ignore the member key.
+                    self._invalidate_cache_and_stream(
+                        txn, self.get_users_in_room, (room_id, member)
+                    )
 
                 for host in set(get_domain_from_id(u) for u in members_changed):
                     self._invalidate_cache_and_stream(
@@ -801,10 +808,6 @@ class EventsStore(EventsWorkerStore):
                     self._invalidate_cache_and_stream(
                         txn, self.was_host_joined, (room_id, host)
                     )
-
-                self._invalidate_cache_and_stream(
-                    txn, self.get_users_in_room, (room_id,)
-                )
 
                 self._invalidate_cache_and_stream(
                     txn, self.get_current_state_ids, (room_id,)


### PR DESCRIPTION
@richvdh spotted that get_users_in_room was using >90% db time on the AS worker, causing so much lag in the worker that messages would take >5 mins to get to the bridge and thus be dropped, causing https://twitter.com/matrixdotorg/status/979482445476171781.

This is a 3am experiment for a quick hack to only invalidate the get_users_in_room cache in the AS worker when a membership change occurs in the room for an AS user.  This means that rooms with no AS users in them will not keep getting checked for AS users, every time their membership happens to change.

However, it won't help checks in plumbed rooms with lots of AS users joining/parting, where each join/part will flush the cache and cause a whole new check.

The code is written blind, and probably doesn't work; committing it now for further discussion and in case it all breaks again and we want to consider rushing it into prod.