### PR TITLE
use PUT instead of POST for federating groups/m.join_policy

### DIFF
--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -864,7 +864,7 @@ class TransportLayerClient(object):
         """
         path = PREFIX + "/groups/%s/settings/m.join_policy" % (group_id,)
 
-        return self.client.post_json(
+        return self.client.put_json(
             destination=destination,
             path=path,
             args={"requester_user_id": requester_user_id},

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -1131,7 +1131,7 @@ class FederationGroupsSettingJoinPolicyServlet(BaseFederationServlet):
     PATH = "/groups/(?P<group_id>[^/]*)/settings/m.join_policy$"
 
     @defer.inlineCallbacks
-    def on_POST(self, origin, content, query, group_id):
+    def on_PUT(self, origin, content, query, group_id):
         requester_user_id = parse_string_from_args(query, "requester_user_id")
         if get_domain_from_id(requester_user_id) != origin:
             raise SynapseError(403, "requester_user_id doesn't match origin")

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -286,7 +286,8 @@ class MatrixFederationHttpClient(object):
         headers_dict[b"Authorization"] = auth_headers
 
     @defer.inlineCallbacks
-    def put_json(self, destination, path, data={}, json_data_callback=None,
+    def put_json(self, destination, path, args={}, data={},
+                 json_data_callback=None,
                  long_retries=False, timeout=None,
                  ignore_backoff=False,
                  backoff_on_404=False):
@@ -296,6 +297,7 @@ class MatrixFederationHttpClient(object):
             destination (str): The remote server to send the HTTP request
                 to.
             path (str): The HTTP path.
+            args (dict): query params
             data (dict): A dict containing the data that will be used as
                 the request body. This will be encoded as JSON.
             json_data_callback (callable): A callable returning the dict to
@@ -342,6 +344,7 @@ class MatrixFederationHttpClient(object):
             path,
             body_callback=body_callback,
             headers_dict={"Content-Type": ["application/json"]},
+            query_bytes=encode_query_args(args),
             long_retries=long_retries,
             timeout=timeout,
             ignore_backoff=ignore_backoff,
@@ -373,6 +376,7 @@ class MatrixFederationHttpClient(object):
                 giving up. None indicates no timeout.
             ignore_backoff (bool): true to ignore the historical backoff data and
                 try the request anyway.
+            args (dict): query params
         Returns:
             Deferred: Succeeds when we get a 2xx HTTP response. The result
             will be the decoded JSON body.


### PR DESCRIPTION
as mentioned e.g. in [#matrix-dev](https://matrix.to/#/!XqBunHwQIXUiqCaoxq:matrix.org/$152296224628HoVaX:msg-net.de)

Signed-Off-by: Matthias Kesler <krombel@krombel.de>