### PR TITLE
Partially revert "Remove non-existing files, add stop, use synctl".

### DIFF
--- a/contrib/systemd/synapse.service
+++ b/contrib/systemd/synapse.service
@@ -9,6 +9,7 @@ Description=Synapse Matrix homeserver
 Type=simple
 User=synapse
 Group=synapse
+EnvironmentFile=-/etc/sysconfig/synapse
 WorkingDirectory=/var/lib/synapse
 ExecStart=/usr/bin/python2.7 -m synapse.app.homeserver --config-path=/etc/synapse/homeserver.yaml
 ExecStop=/usr/bin/synctl stop /etc/synapse/homeserver.yaml


### PR DESCRIPTION
Restore using `/etc/sysconfig/synapse` config file.
The change being reverted here was causing high memory use and constant swapping on systems with low or moderate amount of memory despite cache factor being configured to avoid high memory use.

**Side note:** it's irresponsible to remove configuration files from `systemd` unit files because it breaks already configured systems. No matter whether your specific distribution has this file by default or not:
configured system can have this file and rely on its existence.
Causing breakage on upgrade is always harmful, but that particular change was especially sneaky: no error message, no prominent way to notify sysadmin about behaviour change, everything is still in place, just one configuration option stopped working despite being there.
I'm pretty sure that it caused significant frustration not ony to me, but also to other sysadmins of homeservers running on non-premium hardware.

This partially reverts commit 68f737702b5ce90425cbb77a3ce175225bf72086.