### PR TITLE
Clarify that SRV may not point to a CNAME

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -614,6 +614,9 @@ should have the format ``_matrix._tcp.<yourdomain.com> <ttl> IN SRV 10 0 <port>
     $ dig -t srv _matrix._tcp.example.com
     _matrix._tcp.example.com. 3600    IN      SRV     10 0 8448 synapse.example.com.
 
+Note that the server hostname cannot be an alias (CNAME record): it has to point
+directly to the server hosting the synapse instance.
+
 You can then configure your homeserver to use ``<yourdomain.com>`` as the domain in
 its user-ids, by setting ``server_name``::
 


### PR DESCRIPTION
I'm seeing a lot of the following in my logs:

```
synapse.http.endpoint - 398 - WARNING - - Ignoring unexpected DNS record type 5 for <host>
```

Some homeservers (about 100, based on my stats) have a host in the SRV record that is a CNAME to another host. It seems to be a relatively common misconfiguration.
This PR clarifies that it is not allowed.