### PR TITLE
Reject events which have lots of prev_events

### DIFF
--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -903,7 +903,6 @@ class FederationHandler(BaseHandler):
             logger.warn("Rejecting event %s which has %i auth_events",
                         ev.event_id, len(ev.auth_events))
             raise SynapseError(
-                "ERROR",
                 httplib.BAD_REQUEST,
                 "Too many auth_events",
             )

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -563,10 +563,15 @@ class FederationHandler(BaseHandler):
             extremities=extremities,
         )
 
-        # do some sanity-checking of the received events, before we go and
-        # do state resolution across 1000 events.
-        for ev in events:
-            self._sanity_check_event(ev)
+        # ideally we'd sanity check the events here for excess prev_events etc,
+        # but it's hard to reject events at this point without completely
+        # breaking backfill in the same way that it is currently broken by
+        # events whose signature we cannot verify (#3121).
+        #
+        # So for now we accept the events anyway. #3124 tracks this.
+        #
+        # for ev in events:
+        #     self._sanity_check_event(ev)
 
         # Don't bother processing events we already have.
         seen_events = yield self.store.have_events_in_timeline(


### PR DESCRIPTION
This PR adds some sanity-checking to events received over federation, via a pushed transaction, ~~or pulled via backfill~~.

~~Events that have "too many" prev_events will essentially be ignored, in the same way as events that fail their signature test. This is less than elegant, as it means we keep trying to refetch the invalid event. It might be better to record the fact that we have seen the event and rejected it, in the same way that we do for events which fail their auth checks. However, that sounds non-trivial, and it's a problem that already exists for events with an invalid signature, so I'm declaring the problem orthogonal for now.~~

As per https://github.com/matrix-org/synapse/pull/3118#issuecomment-383039612, now accepts the event when it gets backfilled. #3124 tracks the second half.