### PR TITLE
Prevent double group invites from breaking a group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changes in synapse v0.28.0-rc1 (2018-04-24)
 
 Minor performance improvement to federation sending and bug fixes.
 
-(Note: This release does not include state resolutions discussed in matrix live)
+(Note: This release does not include the delta state resolution implementation discussed in matrix live)
+
 
 Features:
 

--- a/synapse/storage/schema/delta/48/group_invite_unique.sql
+++ b/synapse/storage/schema/delta/48/group_invite_unique.sql
@@ -1,0 +1,2 @@
+DROP INDEX groups_invites_g_idx;
+CREATE UNIQUE INDEX groups_invites_g_idx ON group_invites(group_id, user_id);


### PR DESCRIPTION
Fixes #2633. This just changes a constraint in the database schema to be unique, so that any attempt to invite a user to a group twice will just return a 500 error, and not break the database.

I don't know what would happen if you applied this update to an already-broken database, though. Maybe there should be an SQL statement before this one that deletes any duplicate group invites before attempting to add the unique requirement?