### PR TITLE
Trap exceptions thrown within run_in_background

### DIFF
--- a/synapse/util/logcontext.py
+++ b/synapse/util/logcontext.py
@@ -308,7 +308,13 @@ def run_in_background(f, *args, **kwargs):
     on.
     """
     current = LoggingContext.current_context()
-    res = f(*args, **kwargs)
+    try:
+        res = f(*args, **kwargs)
+    except:   # noqa: E722
+        # the assumption here is that the caller doesn't want to be disturbed
+        # by synchronous exceptions, so let's turn them into Failures.
+        return defer.fail()
+
     if isinstance(res, defer.Deferred) and not res.called:
         # The function will have reset the context before returning, so
         # we need to restore it now.


### PR DESCRIPTION
I'm not completely convinced about this, and #3138 might make it redundant anyway; however:

It strikes me that there are two common usecases for run_in_background:

* doing a bunch of stuff in parallel with defer.gatherResults()
* firing off a thread you really don't care about.

In either case, it feels like having synchronous exceptions propagate outside run_in_background is unexpected. It feels better to have them turned into Failures so that they can either be handled by the defer.gatherResults(), or logged as unhandled errors for the background thread.