### PR TITLE
Apply depth rules stated by #2644

### DIFF
--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -75,6 +75,11 @@ def check(event, auth_events, do_sig_check=True, do_size_check=True):
 
     if event.type == EventTypes.Create:
         room_id_domain = get_domain_from_id(event.room_id)
+        if event.depth != 1:
+            raise AuthError(
+                403,
+                "Creation event's depth must be 1"
+            )
         if room_id_domain != sender_domain:
             raise AuthError(
                 403,
@@ -82,6 +87,14 @@ def check(event, auth_events, do_sig_check=True, do_size_check=True):
             )
         # FIXME
         return True
+
+    expected_depth = (max(event.prev_events, lambda x: x.depth) + 1)
+
+    if event.depth != expected_depth:
+        raise SynapseError(
+            403,
+            "Event depth %i MUST be %i" % (event.depth, expected_depth)
+        )
 
     creation_event = auth_events.get((EventTypes.Create, ""), None)
 

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -74,12 +74,13 @@ def check(event, auth_events, do_sig_check=True, do_size_check=True):
         return True
 
     if event.type == EventTypes.Create:
-        room_id_domain = get_domain_from_id(event.room_id)
-        if event.depth != 1:
+        # Depth used to be 0, but now SHOULD be 1.
+        if event.depth != 1 && event.depth != 0:
             raise AuthError(
                 403,
                 "Creation event's depth must be 1"
             )
+        room_id_domain = get_domain_from_id(event.room_id)
         if room_id_domain != sender_domain:
             raise AuthError(
                 403,

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -75,7 +75,7 @@ def check(event, auth_events, do_sig_check=True, do_size_check=True):
 
     if event.type == EventTypes.Create:
         # Depth used to be 0, but now SHOULD be 1.
-        if event.depth != 1 && event.depth != 0:
+        if event.depth != 1 and event.depth != 0:
             raise AuthError(
                 403,
                 "Creation event's depth must be 1"


### PR DESCRIPTION
I'll be honest, I have some reservations about line 91. It seems like it could be very flimsy. Also, seems like we *should* be looking for creation events with depth 1 but some are depth 0 from the ancient times and so we should be supporting that.

However, I do believe we should absolutely be validating depth so I need someone to look at the best approach.

(Would like a merge to master because it's already been exploited in the wild, so it really should be given it's own release)