### PR TITLE
add option to disable changes to the 3PIDs for an account.

### DIFF
--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -37,6 +37,9 @@ class RegistrationConfig(Config):
             "check_is_for_allowed_local_3pids", None
         )
         self.allow_invited_3pids = config.get("allow_invited_3pids", False)
+
+        self.disable_3pid_changes = config.get("disable_3pid_changes", False)
+
         self.registration_shared_secret = config.get("registration_shared_secret")
 
         self.bcrypt_rounds = config.get("bcrypt_rounds", 12)
@@ -88,6 +91,11 @@ class RegistrationConfig(Config):
         #       pattern: ".*@vector\\.im"
         #     - medium: msisdn
         #       pattern: "\\+44"
+
+        # If true, stop users from trying to change the 3PIDs associated with
+        # their accounts.
+        #
+        # disable_3pid_changes: True
 
         # If set, allows registration by anyone who also has the shared
         # secret, even if registration is otherwise disabled.

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -314,6 +314,9 @@ class ThreepidRestServlet(RestServlet):
     def on_POST(self, request):
         yield run_on_reactor()
 
+        if self.hs.config.disable_3pid_changes:
+            raise SynapseError(400, "3PID changes disabled on this server")
+
         body = parse_json_object_from_request(request)
 
         threePidCreds = body.get('threePidCreds')
@@ -366,6 +369,9 @@ class ThreepidDeleteRestServlet(RestServlet):
     @defer.inlineCallbacks
     def on_POST(self, request):
         yield run_on_reactor()
+
+        if self.hs.config.disable_3pid_changes:
+            raise SynapseError(400, "3PID changes disabled on this server")
 
         body = parse_json_object_from_request(request)
 


### PR DESCRIPTION
This only considers the /account/3pid API, which should be sufficient
as currently we can't change emails associated with push notifs
(which are provisioned at registration), and we can't directly create
mappings for accounts in an IS other than by answering an invite