### PR TITLE
Fix 'Unhandled Error' logs with Twisted 18.4

### DIFF
--- a/synapse/http/endpoint.py
+++ b/synapse/http/endpoint.py
@@ -113,10 +113,15 @@ class _WrappedConnection(object):
         if time.time() - self.last_request >= 2.5 * 60:
             self.abort()
             # Abort the underlying TLS connection. The abort() method calls
-            # loseConnection() on the underlying TLS connection which tries to
+            # loseConnection() on the TLS connection which tries to
             # shutdown the connection cleanly. We call abortConnection()
-            # since that will promptly close the underlying TCP connection.
-            self.transport.abortConnection()
+            # since that will promptly close the TLS connection.
+            #
+            # In Twisted >18.4; the TLS connection will be None if it has closed
+            # which will make abortConnection() throw. Check that the TLS connection
+            # is not None before trying to close it.
+            if self.transport.getHandle() is not None:
+                self.transport.abortConnection()
 
     def request(self, request):
         self.last_request = time.time()


### PR DESCRIPTION
Since the underlying connection in transport is set to ``None`` once the connection is lost, ``abortConnection()`` will throw if the connection has already been closed. This simply checks to see if the tlsconnection handle is still around before we try to close it.

Fixes the error spam in #3176, but I can't imagine it would fix the federation issues -- not that I've been able to reproduce them on half-shot.uk


Signed-off-by: Will Hunt will@half-shot.uk