### PR TITLE
Add GET media/v1/limits

### DIFF
--- a/synapse/rest/media/v1/limits_resource.py
+++ b/synapse/rest/media/v1/limits_resource.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Will Hunt <will@half-shot.uk>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import synapse.http.servlet
+
+from twisted.web.server import NOT_DONE_YET
+from twisted.web.resource import Resource
+from synapse.http.server import respond_with_json
+
+
+class MediaLimitsResource(Resource):
+    # isLeaf = True
+
+    def __init__(self, hs):
+        Resource.__init__(self)
+        self.limits_dict = {}
+        config = hs.get_config()
+        self.limits_dict["size"] = config.max_upload_size
+
+    def render_GET(self, request):
+        respond_with_json(request, 200, self.limits_dict)
+        return NOT_DONE_YET

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -25,6 +25,7 @@ from .download_resource import DownloadResource
 from .thumbnail_resource import ThumbnailResource
 from .identicon_resource import IdenticonResource
 from .preview_url_resource import PreviewUrlResource
+from .limits_resource import MediaLimitsResource
 from .filepath import MediaFilePaths
 from .thumbnailer import Thumbnailer
 from .storage_provider import StorageProviderWrapper
@@ -745,7 +746,6 @@ class MediaRepositoryResource(Resource):
         Resource.__init__(self)
 
         media_repo = hs.get_media_repository()
-
         self.putChild("upload", UploadResource(hs, media_repo))
         self.putChild("download", DownloadResource(hs, media_repo))
         self.putChild("thumbnail", ThumbnailResource(
@@ -756,3 +756,4 @@ class MediaRepositoryResource(Resource):
             self.putChild("preview_url", PreviewUrlResource(
                 hs, media_repo, media_repo.media_storage,
             ))
+        self.putChild("limits", MediaLimitsResource(hs))


### PR DESCRIPTION
Part of https://github.com/matrix-org/matrix-doc/pull/1189.
Exposes the /media/r0/limits endpoint 