### PR TITLE
notifications: Convert next_token to string according to the spec

### DIFF
--- a/synapse/rest/client/v2_alpha/notifications.py
+++ b/synapse/rest/client/v2_alpha/notifications.py
@@ -88,7 +88,7 @@ class NotificationsServlet(RestServlet):
                     pa["topological_ordering"], pa["stream_ordering"]
                 )
             returned_push_actions.append(returned_pa)
-            next_token = pa["stream_ordering"]
+            next_token = str(pa["stream_ordering"])
 
         defer.returnValue((200, {
             "notifications": returned_push_actions,


### PR DESCRIPTION
Currently the parameter is serialized as an integer.

https://matrix.org/speculator/spec/HEAD/client_server/unstable.html#get-matrix-client-r0-notifications