### PR TITLE
Refactor /context to reuse pagination storage functions

### DIFF
--- a/synapse/storage/stream.py
+++ b/synapse/storage/stream.py
@@ -796,7 +796,8 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
             limit_str = ""
 
         sql = (
-            "SELECT * FROM events"
+            "SELECT event_id, topological_ordering, stream_ordering"
+            " FROM events"
             " WHERE outlier = ? AND room_id = ? AND %(bounds)s"
             " ORDER BY topological_ordering %(order)s,"
             " stream_ordering %(order)s %(limit)s"


### PR DESCRIPTION
The aim here is to get all code that tries to return events in topological order going through the same storage function so that we can later change the way we order events in the DB.

This also removes a query optimisation for SQLite for `/context` API. Ideally we'd bump the minimum version of SQLite to 3.15 and use tuple comparison as we do for postgres, however that turns out to be faffy and can be done separately (if at all). Since we don't have this optimisation in place for `/messages` it feels acceptable to remove it for now.