### PR TITLE
Refactor request handling wrappers

### DIFF
--- a/synapse/http/additional_resource.py
+++ b/synapse/http/additional_resource.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from synapse.http.server import wrap_request_handler
+from synapse.http.server import wrap_json_request_handler
 from twisted.web.resource import Resource
 from twisted.web.server import NOT_DONE_YET
 
@@ -50,6 +50,6 @@ class AdditionalResource(Resource):
         self._async_render(request)
         return NOT_DONE_YET
 
-    @wrap_request_handler
+    @wrap_json_request_handler
     def _async_render(self, request):
         return self._handler(request)

--- a/synapse/http/request_metrics.py
+++ b/synapse/http/request_metrics.py
@@ -119,6 +119,8 @@ class RequestMetrics(object):
                 )
                 return
 
+        outgoing_responses_counter.inc(request.method, str(request.code))
+
         response_count.inc(request.method, self.name, tag)
 
         response_timer.inc_by(

--- a/synapse/http/request_metrics.py
+++ b/synapse/http/request_metrics.py
@@ -100,12 +100,12 @@ response_size = metrics.register_counter(
 
 
 class RequestMetrics(object):
-    def start(self, clock, name):
-        self.start = clock.time_msec()
+    def start(self, time_msec, name):
+        self.start = time_msec
         self.start_context = LoggingContext.current_context()
         self.name = name
 
-    def stop(self, clock, request):
+    def stop(self, time_msec, request):
         context = LoggingContext.current_context()
 
         tag = ""
@@ -122,7 +122,7 @@ class RequestMetrics(object):
         response_count.inc(request.method, self.name, tag)
 
         response_timer.inc_by(
-            clock.time_msec() - self.start, request.method,
+            time_msec - self.start, request.method,
             self.name, tag
         )
 

--- a/synapse/http/request_metrics.py
+++ b/synapse/http/request_metrics.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014-2016 OpenMarket Ltd
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import synapse.metrics
+from synapse.util.logcontext import LoggingContext
+
+logger = logging.getLogger(__name__)
+
+metrics = synapse.metrics.get_metrics_for("synapse.http.server")
+
+# total number of responses served, split by method/servlet/tag
+response_count = metrics.register_counter(
+    "response_count",
+    labels=["method", "servlet", "tag"],
+    alternative_names=(
+        # the following are all deprecated aliases for the same metric
+        metrics.name_prefix + x for x in (
+            "_requests",
+            "_response_time:count",
+            "_response_ru_utime:count",
+            "_response_ru_stime:count",
+            "_response_db_txn_count:count",
+            "_response_db_txn_duration:count",
+        )
+    )
+)
+
+requests_counter = metrics.register_counter(
+    "requests_received",
+    labels=["method", "servlet", ],
+)
+
+outgoing_responses_counter = metrics.register_counter(
+    "responses",
+    labels=["method", "code"],
+)
+
+response_timer = metrics.register_counter(
+    "response_time_seconds",
+    labels=["method", "servlet", "tag"],
+    alternative_names=(
+        metrics.name_prefix + "_response_time:total",
+    ),
+)
+
+response_ru_utime = metrics.register_counter(
+    "response_ru_utime_seconds", labels=["method", "servlet", "tag"],
+    alternative_names=(
+        metrics.name_prefix + "_response_ru_utime:total",
+    ),
+)
+
+response_ru_stime = metrics.register_counter(
+    "response_ru_stime_seconds", labels=["method", "servlet", "tag"],
+    alternative_names=(
+        metrics.name_prefix + "_response_ru_stime:total",
+    ),
+)
+
+response_db_txn_count = metrics.register_counter(
+    "response_db_txn_count", labels=["method", "servlet", "tag"],
+    alternative_names=(
+        metrics.name_prefix + "_response_db_txn_count:total",
+    ),
+)
+
+# seconds spent waiting for db txns, excluding scheduling time, when processing
+# this request
+response_db_txn_duration = metrics.register_counter(
+    "response_db_txn_duration_seconds", labels=["method", "servlet", "tag"],
+    alternative_names=(
+        metrics.name_prefix + "_response_db_txn_duration:total",
+    ),
+)
+
+# seconds spent waiting for a db connection, when processing this request
+response_db_sched_duration = metrics.register_counter(
+    "response_db_sched_duration_seconds", labels=["method", "servlet", "tag"]
+)
+
+# size in bytes of the response written
+response_size = metrics.register_counter(
+    "response_size", labels=["method", "servlet", "tag"]
+)
+
+
+class RequestMetrics(object):
+    def start(self, clock, name):
+        self.start = clock.time_msec()
+        self.start_context = LoggingContext.current_context()
+        self.name = name
+
+    def stop(self, clock, request):
+        context = LoggingContext.current_context()
+
+        tag = ""
+        if context:
+            tag = context.tag
+
+            if context != self.start_context:
+                logger.warn(
+                    "Context have unexpectedly changed %r, %r",
+                    context, self.start_context
+                )
+                return
+
+        response_count.inc(request.method, self.name, tag)
+
+        response_timer.inc_by(
+            clock.time_msec() - self.start, request.method,
+            self.name, tag
+        )
+
+        ru_utime, ru_stime = context.get_resource_usage()
+
+        response_ru_utime.inc_by(
+            ru_utime, request.method, self.name, tag
+        )
+        response_ru_stime.inc_by(
+            ru_stime, request.method, self.name, tag
+        )
+        response_db_txn_count.inc_by(
+            context.db_txn_count, request.method, self.name, tag
+        )
+        response_db_txn_duration.inc_by(
+            context.db_txn_duration_ms / 1000., request.method, self.name, tag
+        )
+        response_db_sched_duration.inc_by(
+            context.db_sched_duration_ms / 1000., request.method, self.name, tag
+        )
+
+        response_size.inc_by(request.sentLength, request.method, self.name, tag)

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -45,12 +45,7 @@ import simplejson
 logger = logging.getLogger(__name__)
 
 
-def request_handler():
-    """Decorator for ``wrap_request_handler``"""
-    return wrap_request_handler
-
-
-def wrap_request_handler(h):
+def wrap_json_request_handler(h):
     """Wraps a request handler method with exception handling.
 
     Also adds logging as per wrap_request_handler_with_logging.
@@ -213,7 +208,7 @@ class JsonResource(HttpServer, resource.Resource):
         self._async_render(request)
         return server.NOT_DONE_YET
 
-    @request_handler()
+    @wrap_json_request_handler
     @defer.inlineCallbacks
     def _async_render(self, request):
         """ This gets called from render() every time someone sends us a request.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -20,7 +20,6 @@ from synapse.api.errors import (
 )
 from synapse.http.request_metrics import (
     requests_counter,
-    outgoing_responses_counter,
 )
 from synapse.util.logcontext import LoggingContext, PreserveLoggingContext
 from synapse.util.caches import intern_dict
@@ -112,7 +111,6 @@ def wrap_request_handler(request_handler, include_metrics=False):
                             )
                         else:
                             logger.exception(e)
-                        outgoing_responses_counter.inc(request.method, str(code))
                         respond_with_json(
                             request, code, cs_exception(e), send_cors=True,
                             pretty_print=_request_user_agent_is_curl(request),
@@ -274,8 +272,6 @@ class JsonResource(HttpServer, resource.Resource):
 
     def _send_response(self, request, code, response_json_object,
                        response_code_message=None):
-        outgoing_responses_counter.inc(request.method, str(code))
-
         # TODO: Only enable CORS for the requests that need it.
         respond_with_json(
             request, code, response_json_object,

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -87,7 +87,7 @@ def wrap_request_handler(request_handler, include_metrics=False):
                 # JsonResource (or a subclass), and JsonResource._async_render
                 # will update it once it picks a servlet.
                 servlet_name = self.__class__.__name__
-                request_metrics.start(self.clock, name=servlet_name)
+                request_metrics.start(self.clock.time_msec(), name=servlet_name)
 
                 with request.processing():
                     try:
@@ -138,7 +138,7 @@ def wrap_request_handler(request_handler, include_metrics=False):
                     finally:
                         try:
                             request_metrics.stop(
-                                self.clock, request
+                                self.clock.time_msec(), request
                             )
                         except Exception as e:
                             logger.warn("Failed to stop metrics: %r", e)

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -22,6 +22,8 @@ import time
 
 ACCESS_TOKEN_RE = re.compile(br'(\?.*access(_|%5[Ff])token=)[^&]*(.*)$')
 
+_next_request_seq = 0
+
 
 class SynapseRequest(Request):
     def __init__(self, site, *args, **kw):
@@ -29,6 +31,10 @@ class SynapseRequest(Request):
         self.site = site
         self.authenticated_entity = None
         self.start_time = 0
+
+        global _next_request_seq
+        self.request_seq = _next_request_seq
+        _next_request_seq += 1
 
     def __repr__(self):
         # We overwrite this so that we don't log ``access_token``
@@ -40,6 +46,9 @@ class SynapseRequest(Request):
             self.clientproto,
             self.site.site_tag,
         )
+
+    def get_request_id(self):
+        return "%s-%i" % (self.method, self.request_seq)
 
     def get_redacted_uri(self):
         return ACCESS_TOKEN_RE.sub(

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from synapse.http.server import request_handler, respond_with_json_bytes
+from synapse.http.server import (
+    respond_with_json_bytes, wrap_json_request_handler,
+)
 from synapse.http.servlet import parse_integer, parse_json_object_from_request
 from synapse.api.errors import SynapseError, Codes
 from synapse.crypto.keyring import KeyLookupError
@@ -99,7 +101,7 @@ class RemoteKey(Resource):
         self.async_render_GET(request)
         return NOT_DONE_YET
 
-    @request_handler()
+    @wrap_json_request_handler
     @defer.inlineCallbacks
     def async_render_GET(self, request):
         if len(request.postpath) == 1:
@@ -124,7 +126,7 @@ class RemoteKey(Resource):
         self.async_render_POST(request)
         return NOT_DONE_YET
 
-    @request_handler()
+    @wrap_json_request_handler
     @defer.inlineCallbacks
     def async_render_POST(self, request):
         content = parse_json_object_from_request(request)

--- a/synapse/rest/media/v1/download_resource.py
+++ b/synapse/rest/media/v1/download_resource.py
@@ -12,16 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import synapse.http.servlet
-
-from ._base import parse_media_id, respond_404
-from twisted.web.resource import Resource
-from synapse.http.server import request_handler, set_cors_headers
-
-from twisted.web.server import NOT_DONE_YET
-from twisted.internet import defer
-
 import logging
+
+from twisted.internet import defer
+from twisted.web.resource import Resource
+from twisted.web.server import NOT_DONE_YET
+
+from synapse.http.server import (
+    set_cors_headers,
+    wrap_json_request_handler,
+)
+import synapse.http.servlet
+from ._base import parse_media_id, respond_404
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +45,7 @@ class DownloadResource(Resource):
         self._async_render_GET(request)
         return NOT_DONE_YET
 
-    @request_handler()
+    @wrap_json_request_handler
     @defer.inlineCallbacks
     def _async_render_GET(self, request):
         set_cors_headers(request)

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -40,8 +40,9 @@ from synapse.util.stringutils import random_string
 from synapse.util.caches.expiringcache import ExpiringCache
 from synapse.http.client import SpiderHttpClient
 from synapse.http.server import (
-    request_handler, respond_with_json_bytes,
+    respond_with_json_bytes,
     respond_with_json,
+    wrap_json_request_handler,
 )
 from synapse.util.async import ObservableDeferred
 from synapse.util.stringutils import is_ascii
@@ -90,7 +91,7 @@ class PreviewUrlResource(Resource):
         self._async_render_GET(request)
         return NOT_DONE_YET
 
-    @request_handler()
+    @wrap_json_request_handler
     @defer.inlineCallbacks
     def _async_render_GET(self, request):
 

--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -14,18 +14,21 @@
 # limitations under the License.
 
 
+import logging
+
+from twisted.internet import defer
+from twisted.web.resource import Resource
+from twisted.web.server import NOT_DONE_YET
+
+from synapse.http.server import (
+    set_cors_headers,
+    wrap_json_request_handler,
+)
+from synapse.http.servlet import parse_integer, parse_string
 from ._base import (
-    parse_media_id, respond_404, respond_with_file, FileInfo,
+    FileInfo, parse_media_id, respond_404, respond_with_file,
     respond_with_responder,
 )
-from twisted.web.resource import Resource
-from synapse.http.servlet import parse_string, parse_integer
-from synapse.http.server import request_handler, set_cors_headers
-
-from twisted.web.server import NOT_DONE_YET
-from twisted.internet import defer
-
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +51,7 @@ class ThumbnailResource(Resource):
         self._async_render_GET(request)
         return NOT_DONE_YET
 
-    @request_handler()
+    @wrap_json_request_handler
     @defer.inlineCallbacks
     def _async_render_GET(self, request):
         set_cors_headers(request)

--- a/synapse/rest/media/v1/upload_resource.py
+++ b/synapse/rest/media/v1/upload_resource.py
@@ -13,16 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from synapse.http.server import respond_with_json, request_handler
+import logging
+
+from twisted.internet import defer
+from twisted.web.resource import Resource
+from twisted.web.server import NOT_DONE_YET
 
 from synapse.api.errors import SynapseError
-
-from twisted.web.server import NOT_DONE_YET
-from twisted.internet import defer
-
-from twisted.web.resource import Resource
-
-import logging
+from synapse.http.server import (
+    respond_with_json,
+    wrap_json_request_handler,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ class UploadResource(Resource):
         respond_with_json(request, 200, {}, send_cors=True)
         return NOT_DONE_YET
 
-    @request_handler()
+    @wrap_json_request_handler
     @defer.inlineCallbacks
     def _async_render_POST(self, request):
         requester = yield self.auth.get_user_by_req(request)


### PR DESCRIPTION
The end goal here is to separate the logging bits and the exception handling
bits of the request_handler() decorator because (a) simplicity and (b) I'd like
to use the logging bits in places where JSON error handling is inappropriate.