### PR TITLE
[Docker docs] Fix macaroon key wrongly "mandatory"

### DIFF
--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -111,7 +111,7 @@ variables are available for configuration:
 * ``SYNAPSE_SERVER_NAME`` (mandatory), the current server public hostname.
 * ``SYNAPSE_REPORT_STATS``, (mandatory, ``yes`` or ``no``), enable anonymous
   statistics reporting back to the Matrix project which helps us to get funding.
-* ``SYNAPSE_MACAROON_SECRET_KEY`` (mandatory) secret for signing access tokens
+* ``SYNAPSE_MACAROON_SECRET_KEY`` secret for signing access tokens
   to the server, set this to a proper random key.
 * ``SYNAPSE_NO_TLS``, set this variable to disable TLS in Synapse (use this if
   you run your own TLS-capable reverse proxy).


### PR DESCRIPTION
The `SYNAPSE_MACAROON_SECRET_KEY` configuration variable is said to be mandatory in the Docker README, while it currently isn't. In fact, the example `docker-compose.yml` (https://github.com/Ezwen/synapse/blob/develop/contrib/docker/docker-compose.yml) does not even use this variable.

This PR just removes the word "mandatory" from the README :)