### PR TITLE
Make the synchrotrons send USER_SYNC commands

### DIFF
--- a/synapse/app/synchrotron.py
+++ b/synapse/app/synchrotron.py
@@ -115,7 +115,6 @@ class SynchrotronPresence(object):
         logger.info("Presence process_id is %r", self.process_id)
 
     def send_user_sync(self, user_id, is_syncing, last_sync_ms):
-        return
         self.hs.get_tcp_replication().send_user_sync(user_id, is_syncing, last_sync_ms)
 
     def mark_as_coming_online(self, user_id):

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -524,6 +524,8 @@ class PresenceHandler(object):
             is_syncing (bool): Whether or not the user is now syncing
             sync_time_msec(int): Time in ms when the user was last syncing
         """
+        # stub out presence
+        return
         with (yield self.external_sync_linearizer.queue(process_id)):
             prev_state = yield self.current_state_for_user(user_id)
 

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -221,8 +221,6 @@ class ReplicationStreamer(object):
         """A client has started/stopped syncing on a worker.
         """
         user_sync_counter.inc()
-        # stub out presence
-        return
         yield self.presence_handler.update_external_syncs_row(
             conn_id, user_id, is_syncing, last_sync_ms,
         )

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -221,6 +221,8 @@ class ReplicationStreamer(object):
         """A client has started/stopped syncing on a worker.
         """
         user_sync_counter.inc()
+        # stub out presence
+        return
         yield self.presence_handler.update_external_syncs_row(
             conn_id, user_id, is_syncing, last_sync_ms,
         )


### PR DESCRIPTION
... and instead do the presence stubbing on the master. I want to use this
command to drive some of the consent stuff.