### PR TITLE
docker: Allow customization of TLS cert/key/DH and signing key paths

### DIFF
--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -118,6 +118,10 @@ variables are available for configuration:
   statistics reporting back to the Matrix project which helps us to get funding.
 * ``SYNAPSE_NO_TLS``, set this variable to disable TLS in Synapse (use this if
   you run your own TLS-capable reverse proxy).
+* ``SYNAPSE_TLS_CERT_PATH``, path to the TLS certificate for Synapse's TLS port
+* ``SYNAPSE_TLS_KEY_PATH``, path to the TLS key for Synapse's TLS port
+* ``SYNAPSE_DH_PARAMS_PATH``, path to the DH params file for TLS
+* ``SYNAPSE_SIGNING_KEY_PATH``, path to your homeserver's signing key
 * ``SYNAPSE_ENABLE_REGISTRATION``, set this variable to enable registration on
   the Synapse instance.
 * ``SYNAPSE_ALLOW_GUEST``, set this variable to allow guest joining this server.

--- a/contrib/docker/conf/homeserver.yaml
+++ b/contrib/docker/conf/homeserver.yaml
@@ -1,10 +1,21 @@
 # vim:ft=yaml
 
 ## TLS ##
-
+{% if SYNAPSE_TLS_CERT_PATH is defined %}
+tls_certificate_path: "{{ SYNAPSE_TLS_CERT_PATH }}"
+{% else %}
 tls_certificate_path: "/data/{{ SYNAPSE_SERVER_NAME }}.tls.crt"
+{% endif %}
+{% if SYNAPSE_TLS_KEY_PATH is defined %}
+tls_private_key_path: "{{ SYNAPSE_TLS_KEY_PATH }}"
+{% else %}
 tls_private_key_path: "/data/{{ SYNAPSE_SERVER_NAME }}.tls.key"
+{% endif %}
+{% if SYNAPSE_DH_PARAMS_PATH is defined %}
+tls_dh_params_path: "{{ SYNAPSE_DH_PARAMS_PATH }}"
+{% else %}
 tls_dh_params_path: "/data/{{ SYNAPSE_SERVER_NAME }}.tls.dh"
+{% endif %}
 no_tls: {{ "True" if SYNAPSE_NO_TLS else "False" }}
 tls_fingerprints: []
 
@@ -186,7 +197,11 @@ expire_access_token: False
 
 ## Signing Keys ##
 
+{% if SYNAPSE_SIGNING_KEY_PATH is defined %}
+signing_key_path: "{{ SYNAPSE_SIGNING_KEY_PATH }}"
+{% else %}
 signing_key_path: "/data/{{ SYNAPSE_SERVER_NAME }}.signing.key"
+{% endif %}
 old_signing_keys: {}
 key_refresh_interval: "1d" # 1 Day.
 


### PR DESCRIPTION
I'm starting to move an existing Synapse installation into Kubernetes,
and it would be easier to manage if I could customize the paths for
Synapse's TLS cert/key/etc. Kubernetes allows you to mount a
`Secret` (possibly containing multiple files) as a volume in your
containers, but you can't mount one of these volumes on top of another
persistent volume.

Signed-off-by: Jonathan Frederickson <jonathan@terracrypt.net>