### PR TITLE
Add a 'has_consented' template var to consent forms

### DIFF
--- a/docs/privacy_policy_templates/README.md
+++ b/docs/privacy_policy_templates/README.md
@@ -9,7 +9,7 @@ form_secret: <unique but arbitrary secret>
 
 user_consent:
   template_dir: docs/privacy_policy_templates
-  default_version: 1.0
+  version: 1.0
 ```
 
 You should then be able to enable the `consent` resource under a `listener`

--- a/docs/privacy_policy_templates/en/1.0.html
+++ b/docs/privacy_policy_templates/en/1.0.html
@@ -4,6 +4,11 @@
     <title>Matrix.org Privacy policy</title>
   </head>
   <body>
+  {% if has_consented %}
+    <p>
+      Your base already belong to us.
+    </p>
+  {% else %}
     <p>
       All your base are belong to us.
     </p>
@@ -13,5 +18,6 @@
       <input type="hidden" name="h" value="{{userhmac}}"/>
       <input type="submit" value="Sure thing!"/>
     </form>
+  {% endif %}
   </body>
 </html>

--- a/synapse/rest/consent/consent_resource.py
+++ b/synapse/rest/consent/consent_resource.py
@@ -114,7 +114,10 @@ class ConsentResource(Resource):
             )
 
         loader = jinja2.FileSystemLoader(consent_template_directory)
-        self._jinja_env = jinja2.Environment(loader=loader)
+        self._jinja_env = jinja2.Environment(
+            loader=loader,
+            autoescape=jinja2.select_autoescape(['html', 'htm', 'xml']),
+        )
 
         if hs.config.form_secret is None:
             raise ConfigError(


### PR DESCRIPTION
fixes #3260

Also, enable auto-escaping for the consent templates to reduce the risk of somebody introducing an html injection attack