### PR TITLE
Use the localpart in the consent uri

### DIFF
--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -574,7 +574,9 @@ class EventCreationHandler(object):
         if u["consent_version"] == self.config.user_consent_version:
             return
 
-        consent_uri = self._consent_uri_builder.build_user_consent_uri(user_id)
+        consent_uri = self._consent_uri_builder.build_user_consent_uri(
+            requester.user.localpart,
+        )
         raise ConsentNotGivenError(
             msg=self.config.block_events_without_consent_error,
             consent_uri=consent_uri,


### PR DESCRIPTION
... because it's shorter.