### PR TITLE
Avoid sending consent notice to guest users

### DIFF
--- a/synapse/config/consent_config.py
+++ b/synapse/config/consent_config.py
@@ -78,7 +78,7 @@ class ConsentConfig(Config):
             "block_events_error",
         )
         self.user_consent_server_notice_to_guests = bool(consent_config.get(
-            "send_server_notice_to_guests", "False"
+            "send_server_notice_to_guests", False,
         ))
 
     def default_config(self, **kwargs):

--- a/synapse/config/consent_config.py
+++ b/synapse/config/consent_config.py
@@ -32,7 +32,8 @@ DEFAULT_CONFIG = """\
 #
 # 'server_notice_content', if enabled, will send a user a "Server Notice"
 # asking them to consent to the privacy policy. The 'server_notices' section
-# must also be configured for this to work.
+# must also be configured for this to work. Notices will *not* be sent to
+# guest users unless 'send_server_notice_to_guests' is set to true.
 #
 # 'block_events_error', if set, will block any attempts to send events
 # until the user consents to the privacy policy. The value of the setting is
@@ -46,6 +47,7 @@ DEFAULT_CONFIG = """\
 #     body: >-
 #       To continue using this homeserver you must review and agree to the
 #       terms and conditions at %(consent_uri)s
+#   send_server_notice_to_guests: True
 #   block_events_error: >-
 #     To continue using this homeserver you must review and agree to the
 #     terms and conditions at %(consent_uri)s
@@ -60,6 +62,7 @@ class ConsentConfig(Config):
         self.user_consent_version = None
         self.user_consent_template_dir = None
         self.user_consent_server_notice_content = None
+        self.user_consent_server_notice_to_guests = False
         self.block_events_without_consent_error = None
 
     def read_config(self, config):
@@ -74,6 +77,9 @@ class ConsentConfig(Config):
         self.block_events_without_consent_error = consent_config.get(
             "block_events_error",
         )
+        self.user_consent_server_notice_to_guests = bool(consent_config.get(
+            "send_server_notice_to_guests", "False"
+        ))
 
     def default_config(self, **kwargs):
         return DEFAULT_CONFIG

--- a/synapse/server_notices/consent_server_notices.py
+++ b/synapse/server_notices/consent_server_notices.py
@@ -42,6 +42,7 @@ class ConsentServerNotices(object):
 
         self._current_consent_version = hs.config.user_consent_version
         self._server_notice_content = hs.config.user_consent_server_notice_content
+        self._send_to_guests = hs.config.user_consent_server_notice_to_guests
 
         if self._server_notice_content is not None:
             if not self._server_notices_manager.is_enabled():
@@ -77,6 +78,10 @@ class ConsentServerNotices(object):
         self._users_in_progress.add(user_id)
         try:
             u = yield self._store.get_user_by_id(user_id)
+
+            if u["is_guest"] and not self._send_to_guests:
+                # don't send to guests
+                return
 
             if u["consent_version"] == self._current_consent_version:
                 # user has already consented


### PR DESCRIPTION
we think it makes sense not to send the notices to guest users.