### PR TITLE
extend tox testing for py3 to avoid regressions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,34 @@ usedevelop=true
 commands =
     /usr/bin/find "{toxinidir}" -name '*.pyc' -delete
     coverage run {env:COVERAGE_OPTS:} --source="{toxinidir}/synapse" \
-        "{envbindir}/trial" {env:TRIAL_FLAGS:} {posargs:tests/config} \
+        "{envbindir}/trial" {env:TRIAL_FLAGS:} {posargs:tests/config \
+		tests/appservice/test_scheduler.py \
+		tests/handlers/test_auth.py \
+		tests/handlers/test_presence.py \
+		tests/handlers/test_register.py \
+		tests/storage/test_appservice.py \
+		tests/storage/test_base.py \
+		tests/storage/test_client_ips.py \
+		tests/storage/test_devices.py \
+		tests/storage/test_end_to_end_keys.py \
+		tests/storage/test_event_push_actions.py \
+		tests/storage/test_profile.py \
+		tests/storage/test_room.py \
+		tests/test_distributor.py \
+		tests/test_dns.py \
+		tests/test_preview.py \
+		tests/test_test_utils.py \
+		tests/test_types.py \
+		tests/util/test_dict_cache.py \
+		tests/util/test_expiring_cache.py \
+		tests/util/test_file_consumer.py \
+		tests/util/test_limiter.py \
+		tests/util/test_linearizer.py \
+		tests/util/test_logcontext.py \
+		tests/util/test_logformatter.py \
+		tests/util/test_rwlock.py \
+		tests/util/test_snapshot_cache.py \
+		tests/util/test_wheel_timer.py} \
         {env:TOXSUFFIX:}
     {env:DUMP_COVERAGE_COMMAND:coverage report -m}
 


### PR DESCRIPTION
Just to avoid regressions regarding python 3 while doing further development.

This list is the current list of all succeeding tests.
It can be extended (or reduced to contain complete folders until we only have `tests`) while further development takes place.

Signed-Off-By: Matthias Kesler <krombel@krombel.de>