### PR TITLE
federation: fix LaterGauge usage

### DIFF
--- a/synapse/federation/send_queue.py
+++ b/synapse/federation/send_queue.py
@@ -75,7 +75,7 @@ class FederationRemoteSendQueue(object):
         # changes. ARGH.
         def register(name, queue):
             LaterGauge("synapse_federation_send_queue_%s_size" % (queue_name,),
-                       "", lambda: len(queue))
+                       "", [], lambda: len(queue))
 
         for queue_name in [
             "presence_map", "presence_changed", "keyed_edu", "keyed_edu_changed",


### PR DESCRIPTION
Fixes a startup crash due to commit df9f72d9e5fe264b86005208e0f096156eb03e4b.

```
twisted: [] Traceback (most recent call last):
twisted: []   File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
twisted: []     "__main__", fname, loader, pkg_name)
twisted: []   File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
twisted: []     exec code in run_globals
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/app/homeserver.py", line 539, in <module>
twisted: []     main()
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/app/homeserver.py", line 534, in main
twisted: []     hs = setup(sys.argv[1:])
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/app/homeserver.py", line 363, in setup
twisted: []     hs.start_listening()
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/app/homeserver.py", line 245, in start_listening
twisted: []     self._listener_http(config, listener)
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/app/homeserver.py", line 115, in _listener_http
twisted: []     name, res.get("compress", False),
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/app/homeserver.py", line 175, in _configure_named_resource
twisted: []     client_resource = ClientRestResource(self)
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/rest/__init__.py", line 66, in __init__
twisted: []     self.register_servlets(self, hs)
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/rest/__init__.py", line 73, in register_servlets
twisted: []     room.register_servlets(hs, client_resource)
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/rest/client/v1/room.py", line 833, in register_servlets
twisted: []     RoomTypingRestServlet(hs).register(http_server)
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/rest/client/v1/room.py", line 714, in __init__
twisted: []     self.presence_handler = hs.get_presence_handler()
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/server.py", line 449, in _get
twisted: []     dep = builder()
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/server.py", line 249, in build_presence_handler
twisted: []     return PresenceHandler(self)
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/handlers/presence.py", line 105, in __init__
twisted: []     self.federation = hs.get_federation_sender()
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/server.py", line 449, in _get
twisted: []     dep = builder()
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/server.py", line 366, in build_federation_sender
twisted: []     return FederationRemoteSendQueue(self)
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/federation/send_queue.py", line 84, in __init__
twisted: []     register(queue_name, getattr(self, queue_name))
twisted: []   File "/usr/lib/python2.7/site-packages/synapse/federation/send_queue.py", line 78, in register
twisted: []     "", lambda: len(queue))
twisted: [] TypeError: __init__() takes exactly 5 arguments (4 given)
```