### PR TITLE
Create an index on room_memberships(room_id, forgotten)

### DIFF
--- a/synapse/storage/schema/delta/50/update_room_memberships_room_id_idx.sql
+++ b/synapse/storage/schema/delta/50/update_room_memberships_room_id_idx.sql
@@ -1,0 +1,23 @@
+/* Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- add an index on (room_id, forgotten), to help with who_forgot_in_room
+INSERT into background_updates (update_name, progress_json)
+    VALUES ('room_memberships_room_id_forgotten_idx', '{}');
+
+-- once that completes, drop the old index
+INSERT into background_updates (update_name, progress_json, depends_on)
+    VALUES ('drop_room_memberships_room_id_idx', '{}',
+            'room_memberships_room_id_forgotten_idx');

--- a/synapse/storage/schema/full_schemas/11/im.sql
+++ b/synapse/storage/schema/full_schemas/11/im.sql
@@ -79,7 +79,9 @@ CREATE TABLE IF NOT EXISTS room_memberships(
 );
 
 CREATE INDEX room_memberships_event_id ON room_memberships (event_id);
-CREATE INDEX room_memberships_room_id ON room_memberships (room_id);
+-- we used to create an index on room_id, but no longer bother, as in schema
+-- v50, we replace it with one on (room_id, forgotten)
+-- CREATE INDEX room_memberships_room_id ON room_memberships (room_id);
 CREATE INDEX room_memberships_user_id ON room_memberships (user_id);
 
 CREATE TABLE IF NOT EXISTS feedback(

--- a/synapse/storage/schema/full_schemas/16/im.sql
+++ b/synapse/storage/schema/full_schemas/16/im.sql
@@ -83,7 +83,9 @@ CREATE TABLE IF NOT EXISTS room_memberships(
     UNIQUE (event_id)
 );
 
-CREATE INDEX room_memberships_room_id ON room_memberships (room_id);
+-- we used to create an index on room_id, but no longer bother, as in schema
+-- v50, we replace it with one on (room_id, forgotten)
+-- CREATE INDEX room_memberships_room_id ON room_memberships (room_id);
 CREATE INDEX room_memberships_user_id ON room_memberships (user_id);
 
 CREATE TABLE IF NOT EXISTS feedback(


### PR DESCRIPTION
Replace the existing index on room_id with one on (room_id, forgotten). This
means that we can handle `who_forgot_in_room` much more efficiently.

(This supercedes #3323.)