### PR TITLE
Fix federation backfill from sqlite servers

### DIFF
--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -272,7 +272,7 @@ class StateGroupWorkerStore(SQLBaseStore):
                 for typ in types:
                     if typ[1] is None:
                         where_clauses.append("(type = ?)")
-                        where_args.extend(typ[0])
+                        where_args.append(typ[0])
                         wildcard_types = True
                     else:
                         where_clauses.append("(type = ? AND state_key = ?)")


### PR DESCRIPTION
This fixes bug #3354.

If `_get_state_groups_from_groups` was called with a `(type, None)` entry in `types` (which is supposed to return all state of type `type`), it would explode with a sql error. I *think* this only happens for federation backfill.

I am deeply distressed that there is apparently no test coverage of this, but really can't afford to sort it out now :/