### PR TITLE
Remove event re-signing hacks

### DIFF
--- a/changelog.d/3367.misc
+++ b/changelog.d/3367.misc
@@ -1,0 +1,1 @@
+Remove unnecessary event re-signing hacks

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -938,16 +938,6 @@ class FederationHandler(BaseHandler):
             [auth_id for auth_id, _ in event.auth_events],
             include_given=True
         )
-
-        for event in auth:
-            event.signatures.update(
-                compute_event_signature(
-                    event,
-                    self.hs.hostname,
-                    self.hs.config.signing_key[0]
-                )
-            )
-
         defer.returnValue([e for e in auth])
 
     @log_function
@@ -1405,18 +1395,6 @@ class FederationHandler(BaseHandler):
                     del results[(event.type, event.state_key)]
 
             res = list(results.values())
-            for event in res:
-                # We sign these again because there was a bug where we
-                # incorrectly signed things the first time round
-                if self.is_mine_id(event.event_id):
-                    event.signatures.update(
-                        compute_event_signature(
-                            event,
-                            self.hs.hostname,
-                            self.hs.config.signing_key[0]
-                        )
-                    )
-
             defer.returnValue(res)
         else:
             defer.returnValue([])
@@ -1481,18 +1459,6 @@ class FederationHandler(BaseHandler):
         )
 
         if event:
-            if self.is_mine_id(event.event_id):
-                # FIXME: This is a temporary work around where we occasionally
-                # return events slightly differently than when they were
-                # originally signed
-                event.signatures.update(
-                    compute_event_signature(
-                        event,
-                        self.hs.hostname,
-                        self.hs.config.signing_key[0]
-                    )
-                )
-
             if do_auth:
                 in_room = yield self.auth.check_host_in_room(
                     event.room_id,
@@ -1759,15 +1725,6 @@ class FederationHandler(BaseHandler):
         ret = yield self.construct_auth_difference(
             local_auth_chain, remote_auth_chain
         )
-
-        for event in ret["auth_chain"]:
-            event.signatures.update(
-                compute_event_signature(
-                    event,
-                    self.hs.hostname,
-                    self.hs.config.signing_key[0]
-                )
-            )
 
         logger.debug("on_query_auth returning: %s", ret)
 


### PR DESCRIPTION
These "temporary fixes" have been here three and a half years, and I can't find
any events in the matrix.org database where the calculated signature differs
from what's in the db. It's time for them to go away.