### PR TITLE
Optimise state_group_cache update

### DIFF
--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -567,11 +567,7 @@ class StateGroupWorkerStore(SQLBaseStore):
             # from the database.
             for group, group_state_dict in iteritems(group_to_state_dict):
                 state_dict = results[group]
-
-                state_dict.update(
-                    ((intern_string(k[0]), intern_string(k[1])), to_ascii(v))
-                    for k, v in iteritems(group_state_dict)
-                )
+                state_dict.update(group_state_dict)
 
                 self._state_group_cache.update(
                     cache_seq_num,


### PR DESCRIPTION
(1) matrix-org-hotfixes has removed the intern calls; let's do the same here.
(2) remove redundant iteritems() so we can use an optimised db update.