### PR TITLE
Add m.login.application_service as a valid registration type

### DIFF
--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -221,7 +221,8 @@ class RegisterRestServlet(RestServlet):
                 raise SynapseError(400, "Invalid username")
             desired_username = body['username']
 
-        type = body.get("type", None)
+        auth = body.get("auth", {})
+        type = auth.get("type", None)
         appservice = None
         if has_access_token(request):
             appservice = yield self.auth.get_appservice_by_req(request)


### PR DESCRIPTION
This is a sort of middle ground for https://github.com/matrix-org/matrix-doc/issues/1312.
To sum it up:
- We now warn if you provide an AS token but don't specify the type as ``m.login.application_service``
  - We can be more extreme and mandate it, but that requires everyone to fix their code. Which would make sense going forward and a warning to devs should be given, but breaking appservices en masse seems a bit mean.
- We DO throw if you specify the type as ``m.login.application_service`` but don't specify a correct AS token.
  - This is definitely a good idea since anyone trying to register a virtual user will fail with a specific error for     appservices rather than a general error for users.