### PR TITLE
Add fast path to _filter_events_for_server

### DIFF
--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -460,6 +460,14 @@ class FederationHandler(BaseHandler):
     @measure_func("_filter_events_for_server")
     @defer.inlineCallbacks
     def _filter_events_for_server(self, server_name, room_id, events):
+        """Filter the given events for the given server, redacting those the
+        server can't see.
+
+        Assumes the server is currently in the room.
+
+        Returns
+            list[FrozenEvent]
+        """
         # First lets check to see if all the events have a history visibility
         # of "shared" or "world_readable". If thats the case then we don't
         # need to check membership (as we know the server is in the room).

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -481,10 +481,10 @@ class FederationHandler(BaseHandler):
         if not visibility_ids:
             defer.returnValue(events)
 
-        events = yield self.store.get_events(visibility_ids)
+        event_map = yield self.store.get_events(visibility_ids)
         all_open = all(
             e.content.get("history_visibility") in (None, "shared", "world_readable")
-            for e in events
+            for e in events.itervalues()
         )
 
         if all_open:

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -480,7 +480,7 @@ class FederationHandler(BaseHandler):
 
         visibility_ids = set()
         for sids in event_to_state_ids.itervalues():
-            hist = event_to_state_ids.get((EventTypes.RoomHistoryVisibility, ""))
+            hist = sids.get((EventTypes.RoomHistoryVisibility, ""))
             if hist:
                 visibility_ids.add(hist)
 
@@ -492,7 +492,7 @@ class FederationHandler(BaseHandler):
         event_map = yield self.store.get_events(visibility_ids)
         all_open = all(
             e.content.get("history_visibility") in (None, "shared", "world_readable")
-            for e in events.itervalues()
+            for e in event_map.itervalues()
         )
 
         if all_open:
@@ -505,7 +505,7 @@ class FederationHandler(BaseHandler):
             frozenset(e.event_id for e in events),
             types=(
                 (EventTypes.RoomHistoryVisibility, ""),
-                (EventTypes.Member, None)
+                (EventTypes.Member, None),
             )
         )
 


### PR DESCRIPTION
Most rooms have a trivial history visibility like "shared" or
"world_readable", especially large rooms, so lets not bother getting the
full membership of those rooms in that case.