### PR TITLE
Revert "Try to not use as much CPU in the StreamChangeCache"

### DIFF
--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -78,8 +78,7 @@ class StreamChangeCache(object):
             not_known_entities = set(entities) - set(self._entity_to_key)
 
             result = (
-                {self._cache[k] for k in self._cache.islice(
-                    start=self._cache.bisect_right(stream_pos))}
+                set(self._cache.values()[self._cache.bisect_right(stream_pos) :])
                 .intersection(entities)
                 .union(not_known_entities)
             )
@@ -114,8 +113,7 @@ class StreamChangeCache(object):
         assert type(stream_pos) is int
 
         if stream_pos >= self._earliest_known_stream_pos:
-            return [self._cache[k] for k in self._cache.islice(
-                start=self._cache.bisect_right(stream_pos))]
+            return self._cache.values()[self._cache.bisect_right(stream_pos) :]
         else:
             return None
 


### PR DESCRIPTION
Reverts matrix-org/synapse#3451 - it made synapse master's memory footprint explode (50GB in 5 minutes) and OOM