### PR TITLE
Timeout membership requests after 90s

### DIFF
--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -249,11 +249,11 @@ class RoomMemberHandler(object):
         then = self.clock.time_msec()
 
         with (yield self.member_limiter.queue(as_id)):
-           diff = self.clock.time_msec() - then
+            diff = self.clock.time_msec() - then
 
-           if diff > 90 * 1000:
-               # haproxy would have timed the request out anyway...
-               raise SynapseError(504, "took to long to process")
+            if diff > 90 * 1000:
+                # haproxy would have timed the request out anyway...
+                raise SynapseError(504, "took to long to process")
 
             with (yield self.member_linearizer.queue(key)):
                 diff = self.clock.time_msec() - then


### PR DESCRIPTION
This is a hacky fix to try and stop in flight requests from building up.

(This is against hotfixes as it relies on the addition of the AS limiter.)