### PR TITLE
Update Image Tag for Docker-Compose

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -6,7 +6,7 @@ version: '3'
 services:
 
   synapse:
-    image: docker.io/matrixdotorg/synapse:latest
+    image: matrixdotorg/synapse:develop
     # Since snyapse does not retry to connect to the database, restart upon
     # failure
     restart: unless-stopped


### PR DESCRIPTION
Docker.io is outdated - docker hub builds are typically referenced without a full URL.

Also, the latest tag doesn't exist (though I have an issue to discuss it here #3477), so switching to develop.