### PR TITLE
Reinstate lost run_on_reactor in unit test

### DIFF
--- a/changelog.d/3385.misc
+++ b/changelog.d/3385.misc
@@ -1,0 +1,1 @@
+Reinstate lost run_on_reactor in unit tests

--- a/tests/util/caches/test_descriptors.py
+++ b/tests/util/caches/test_descriptors.py
@@ -19,11 +19,17 @@ import logging
 import mock
 from synapse.api.errors import SynapseError
 from synapse.util import logcontext
-from twisted.internet import defer
+from twisted.internet import defer, reactor
 from synapse.util.caches import descriptors
 from tests import unittest
 
 logger = logging.getLogger(__name__)
+
+
+def run_on_reactor():
+    d = defer.Deferred()
+    reactor.callLater(0, d.callback, 0)
+    return logcontext.make_deferred_yieldable(d)
 
 
 class CacheTestCase(unittest.TestCase):
@@ -194,6 +200,8 @@ class DescriptorTestCase(unittest.TestCase):
             def fn(self, arg1):
                 @defer.inlineCallbacks
                 def inner_fn():
+                    # we want this to behave like an asynchronous function
+                    yield run_on_reactor()
                     raise SynapseError(400, "blah")
 
                 return inner_fn()
@@ -203,7 +211,12 @@ class DescriptorTestCase(unittest.TestCase):
             with logcontext.LoggingContext() as c1:
                 c1.name = "c1"
                 try:
-                    yield obj.fn(1)
+                    d = obj.fn(1)
+                    self.assertEqual(
+                        logcontext.LoggingContext.current_context(),
+                        logcontext.LoggingContext.sentinel,
+                    )
+                    yield d
                     self.fail("No exception thrown")
                 except SynapseError:
                     pass


### PR DESCRIPTION
a61738b removed a call to run_on_reactor from a unit test, but that call was
doing something useful, in making the function in question asynchronous.

Reinstate the call and add a check that we are testing what we wanted to be
testing.