### PR TITLE
Added possibilty to disable local password authentication

### DIFF
--- a/synapse/config/password.py
+++ b/synapse/config/password.py
@@ -31,7 +31,7 @@ class PasswordConfig(Config):
         # Enable password for login.
         password_config:
            enabled: true
-           # set to false if you do not want to authenticate 
+           # set to false if you do not want to authenticate
            # against the local db
            localdb: true
            # Uncomment and change to a secret random string for extra security.

--- a/synapse/config/password.py
+++ b/synapse/config/password.py
@@ -23,6 +23,7 @@ class PasswordConfig(Config):
     def read_config(self, config):
         password_config = config.get("password_config", {})
         self.password_enabled = password_config.get("enabled", True)
+        self.password_localdb = password_config.get("localdb", True)
         self.password_pepper = password_config.get("pepper", "")
 
     def default_config(self, config_dir_path, server_name, **kwargs):
@@ -30,6 +31,9 @@ class PasswordConfig(Config):
         # Enable password for login.
         password_config:
            enabled: true
+           # set to false if you do not want to authenticate 
+           # against the local db
+           localdb: true
            # Uncomment and change to a secret random string for extra security.
            # DO NOT CHANGE THIS AFTER INITIAL SETUP!
            #pepper: ""

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -682,7 +682,7 @@ class AuthHandler(BaseHandler):
             known_login_type = True
             if not self.hs.config.password_localdb:
                 raise LoginError(403, "Local DB Authentication Disabled",
-                    errcode=Codes.FORBIDDEN)
+                                 errcode=Codes.FORBIDDEN)
             else:
                 canonical_user_id = yield self._check_local_password(
                     qualified_user_id, password,

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -681,8 +681,8 @@ class AuthHandler(BaseHandler):
         if login_type == LoginType.PASSWORD:
             known_login_type = True
             if not self.hs.config.password_localdb:
-                raise LoginError(403, "Local DB Authentication Disabled", 
-                        errcode=Codes.FORBIDDEN)
+                raise LoginError(403, "Local DB Authentication Disabled",
+                    errcode=Codes.FORBIDDEN)
             else:
                 canonical_user_id = yield self._check_local_password(
                     qualified_user_id, password,

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -680,13 +680,15 @@ class AuthHandler(BaseHandler):
 
         if login_type == LoginType.PASSWORD:
             known_login_type = True
+            if not self.hs.config.password_localdb:
+                raise LoginError(403, "Local DB Authentication Disabled", errcode=Codes.FORBIDDEN )
+            else:
+                canonical_user_id = yield self._check_local_password(
+                    qualified_user_id, password,
+                )
 
-            canonical_user_id = yield self._check_local_password(
-                qualified_user_id, password,
-            )
-
-            if canonical_user_id:
-                defer.returnValue((canonical_user_id, None))
+                if canonical_user_id:
+                    defer.returnValue((canonical_user_id, None))
 
         if not known_login_type:
             raise SynapseError(400, "Unknown login type %s" % login_type)

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -681,7 +681,8 @@ class AuthHandler(BaseHandler):
         if login_type == LoginType.PASSWORD:
             known_login_type = True
             if not self.hs.config.password_localdb:
-                raise LoginError(403, "Local DB Authentication Disabled", errcode=Codes.FORBIDDEN )
+                raise LoginError(403, "Local DB Authentication Disabled", 
+                        errcode=Codes.FORBIDDEN)
             else:
                 canonical_user_id = yield self._check_local_password(
                     qualified_user_id, password,

--- a/synapse/handlers/set_password.py
+++ b/synapse/handlers/set_password.py
@@ -32,8 +32,9 @@ class SetPasswordHandler(BaseHandler):
     @defer.inlineCallbacks
     def set_password(self, user_id, newpassword, requester=None):
         if not self.hs.config.password_localdb:
-            raise SynapseError(403, "Local DB Authentication Disabled", 
-                    errcode=Codes.FORBIDDEN)
+            raise SynapseError(403, "Local DB Authentication Disabled",
+                errcode=Codes.FORBIDDEN)
+
         password_hash = yield self._auth_handler.hash(newpassword)
 
         except_device_id = requester.device_id if requester else None

--- a/synapse/handlers/set_password.py
+++ b/synapse/handlers/set_password.py
@@ -33,7 +33,7 @@ class SetPasswordHandler(BaseHandler):
     def set_password(self, user_id, newpassword, requester=None):
         if not self.hs.config.password_localdb:
             raise SynapseError(403, "Local DB Authentication Disabled",
-                errcode=Codes.FORBIDDEN)
+                               errcode=Codes.FORBIDDEN)
 
         password_hash = yield self._auth_handler.hash(newpassword)
 

--- a/synapse/handlers/set_password.py
+++ b/synapse/handlers/set_password.py
@@ -31,6 +31,8 @@ class SetPasswordHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def set_password(self, user_id, newpassword, requester=None):
+        if not self.hs.config.password_localdb:
+            raise SynapseError(403, "Local DB Authentication Disabled", errcode=Codes.FORBIDDEN )
         password_hash = yield self._auth_handler.hash(newpassword)
 
         except_device_id = requester.device_id if requester else None

--- a/synapse/handlers/set_password.py
+++ b/synapse/handlers/set_password.py
@@ -32,7 +32,8 @@ class SetPasswordHandler(BaseHandler):
     @defer.inlineCallbacks
     def set_password(self, user_id, newpassword, requester=None):
         if not self.hs.config.password_localdb:
-            raise SynapseError(403, "Local DB Authentication Disabled", errcode=Codes.FORBIDDEN )
+            raise SynapseError(403, "Local DB Authentication Disabled", 
+                    errcode=Codes.FORBIDDEN)
         password_hash = yield self._auth_handler.hash(newpassword)
 
         except_device_id = requester.device_id if requester else None


### PR DESCRIPTION
Dear all,

this is a small patch which provides the possibility to 
- disable local database authentication and the possibility to change the local password

this is useful for e.g.: If someone uses a password_provider (e.g. ldap) and does not want:
- that the users change the password outside the provider
- that if the account is disable in the auth provider the user is not able to login anymore

