### PR TITLE
Add explicit dependency on netaddr

### DIFF
--- a/changelog.d/3488.bugfix
+++ b/changelog.d/3488.bugfix
@@ -1,0 +1,1 @@
+Add explicit dependency on netaddr

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -58,14 +58,12 @@ REQUIREMENTS = {
     "six": ["six"],
     "prometheus_client": ["prometheus_client"],
     "attr": ["attr"],
+    "netaddr>=0.7.18": ["netaddr"],
 }
 
 CONDITIONAL_REQUIREMENTS = {
     "web_client": {
         "matrix_angular_sdk>=0.6.8": ["syweb>=0.6.8"],
-    },
-    "preview_url": {
-        "netaddr>=0.7.18": ["netaddr"],
     },
     "email.enable_notifs": {
         "Jinja2>=2.8": ["Jinja2>=2.8"],


### PR DESCRIPTION
#3465 added a dependency on netaddr, but this wasn't added to the dependencies file, causing failures on upgrade (and presumably for new installs).