### PR TITLE
Attempt to include db threads in cpu usage stats

### DIFF
--- a/changelog.d/3496.feature
+++ b/changelog.d/3496.feature
@@ -1,0 +1,1 @@
+Include CPU time from database threads in request/block metrics.

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -220,7 +220,7 @@ class SQLBaseStore(object):
         self._clock.looping_call(loop, 10000)
 
     def _new_transaction(self, conn, desc, after_callbacks, exception_callbacks,
-                         logging_context, func, *args, **kwargs):
+                         func, *args, **kwargs):
         start = time.time()
         txn_id = self._TXN_ID
 
@@ -284,8 +284,7 @@ class SQLBaseStore(object):
             end = time.time()
             duration = end - start
 
-            if logging_context is not None:
-                logging_context.add_database_transaction(duration)
+            LoggingContext.current_context().add_database_transaction(duration)
 
             transaction_logger.debug("[TXN END] {%s} %f sec", name, duration)
 
@@ -309,19 +308,15 @@ class SQLBaseStore(object):
         Returns:
             Deferred: The result of func
         """
-        current_context = LoggingContext.current_context()
-
         after_callbacks = []
         exception_callbacks = []
 
-        def inner_func(conn, *args, **kwargs):
-            return self._new_transaction(
-                conn, desc, after_callbacks, exception_callbacks, current_context,
-                func, *args, **kwargs
-            )
-
         try:
-            result = yield self.runWithConnection(inner_func, *args, **kwargs)
+            result = yield self.runWithConnection(
+                self._new_transaction,
+                desc, after_callbacks, exception_callbacks, func,
+                *args, **kwargs
+            )
 
             for after_callback, after_args, after_kwargs in after_callbacks:
                 after_callback(*after_args, **after_kwargs)
@@ -346,7 +341,10 @@ class SQLBaseStore(object):
         Returns:
             Deferred: The result of func
         """
-        current_context = LoggingContext.current_context()
+        if LoggingContext.current_context() == LoggingContext.sentinel:
+            logger.warn(
+                "Running db txn from sentinel context: metrics will be lost",
+            )
 
         start_time = time.time()
 
@@ -354,13 +352,11 @@ class SQLBaseStore(object):
             with LoggingContext("runWithConnection") as context:
                 sched_duration_sec = time.time() - start_time
                 sql_scheduling_timer.observe(sched_duration_sec)
-                current_context.add_database_scheduled(sched_duration_sec)
+                context.add_database_scheduled(sched_duration_sec)
 
                 if self.database_engine.is_connection_closed(conn):
                     logger.debug("Reconnecting closed database connection")
                     conn.reconnect()
-
-                current_context.copy_to(context)
 
                 return func(conn, *args, **kwargs)
 

--- a/synapse/storage/events_worker.py
+++ b/synapse/storage/events_worker.py
@@ -261,7 +261,8 @@ class EventsWorkerStore(SQLBaseStore):
                 ]
 
                 rows = self._new_transaction(
-                    conn, "do_fetch", [], [], None, self._fetch_event_rows, event_ids
+                    conn, "do_fetch", [], [],
+                    self._fetch_event_rows, event_ids,
                 )
 
                 row_dict = {

--- a/synapse/util/logcontext.py
+++ b/synapse/util/logcontext.py
@@ -271,12 +271,10 @@ class LoggingContext(object):
 
         # if we have a parent, pass our CPU usage stats on
         if self.parent_context is not None:
-            self.parent_context.ru_utime += self.ru_utime
-            self.parent_context.ru_stime += self.ru_stime
+            self.parent_context._resource_usage += self._resource_usage
 
             # reset them in case we get entered again
-            self.ru_utime = 0
-            self.ru_stime = 0
+            self._resource_usage.reset()
 
     def copy_to(self, record):
         """Copy logging fields from this context to a log record or


### PR DESCRIPTION
Let's try to include time spent in the DB threads in the per-request/block cpu
usage metrics.