### PR TITLE
Use more portable syntax using attrs package

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -22,7 +22,7 @@ class FakeChannel(object):
     wire).
     """
 
-    result = attr.ib(factory=dict)
+    result = attr.ib(default=attr.Factory(dict))
 
     @property
     def json_body(self):


### PR DESCRIPTION
Newer syntax
```
attr.ib(factory=dict)
```
is just a syntactic sugar for
```
attr.ib(default=attr.Factory(dict))
```
It was introduced in newest version of `attrs` package (18.1.0) and doesn't work with older versions.

We should either require minimum version of `attrs` to be 18.1.0, or use older (slightly more verbose) syntax.
Requiring newest version is not a good solution because Linux distributions may have older version of `attrs` (17.4.0 in Fedora 28), and requiring to build (and package) newer version just to use newer syntactic sugar in only one test is just too much.
It's much better to fix that test to use older syntax.