### PR TITLE
Use stream cache in get_linearized_receipts_for_room

### DIFF
--- a/changelog.d/3505.feature
+++ b/changelog.d/3505.feature
@@ -1,0 +1,1 @@
+Reduce database consumption when processing large numbers of receipts

--- a/synapse/replication/slave/storage/receipts.py
+++ b/synapse/replication/slave/storage/receipts.py
@@ -49,7 +49,7 @@ class SlavedReceiptsStore(ReceiptsWorkerStore, BaseSlavedStore):
 
     def invalidate_caches_for_receipt(self, room_id, receipt_type, user_id):
         self.get_receipts_for_user.invalidate((user_id, receipt_type))
-        self.get_linearized_receipts_for_room.invalidate_many((room_id,))
+        self._get_linearized_receipts_for_room.invalidate_many((room_id,))
         self.get_last_receipt_event_id_for_user.invalidate(
             (user_id, room_id, receipt_type)
         )

--- a/synapse/storage/receipts.py
+++ b/synapse/storage/receipts.py
@@ -140,7 +140,9 @@ class ReceiptsWorkerStore(SQLBaseStore):
         """
         room_ids = set(room_ids)
 
-        if from_key:
+        if from_key is not None:
+            # Only ask the database about rooms where there have been new
+            # receipts added since `from_key`
             room_ids = yield self._receipts_stream_cache.get_entities_changed(
                 room_ids, from_key
             )
@@ -163,7 +165,9 @@ class ReceiptsWorkerStore(SQLBaseStore):
         Returns:
             list: A list of receipts.
         """
-        if from_key:
+        if from_key is not None:
+            # Check the cache first to see if any new receipts have been added
+            # since`from_key`. If not we can no-op.
             if not self._receipts_stream_cache.has_entity_changed(room_id, from_key):
                 defer.succeed([])
 

--- a/synapse/storage/receipts.py
+++ b/synapse/storage/receipts.py
@@ -163,7 +163,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
                 from the start.
 
         Returns:
-            list: A list of receipts.
+            Deferred[list]: A list of receipts.
         """
         if from_key is not None:
             # Check the cache first to see if any new receipts have been added


### PR DESCRIPTION
This avoids us from uncessarily hitting the database when there has been
no change for the room