### PR TITLE
Add admin API to send a server_notice to one/all users

### DIFF
--- a/changelog.d/3531.feature
+++ b/changelog.d/3531.feature
@@ -1,0 +1,1 @@
+add simple query to send a server notice to all rooms

--- a/changelog.d/3531.feature
+++ b/changelog.d/3531.feature
@@ -1,1 +1,1 @@
-add simple query to send a server notice to all rooms
+add admin api to send a server notice to one or all users

--- a/docs/admin_api/server_notices.md
+++ b/docs/admin_api/server_notices.md
@@ -1,0 +1,35 @@
+# Server Notices
+
+The API to send notices is as follows:
+
+```
+POST /_matrix/client/r0/admin/send_server_notice/[<user_id>]
+```
+
+including an `access_token` of a server admin.
+
+If the user_id is missing, the message is meant to go to all users on the server.
+
+The request body should contain the following:
+
+```json
+{
+    "event": {
+        "msgtype":"m.text",
+        "body": "This is my message"
+    }
+}
+```
+or as shortcut you can also send
+```json
+{
+    "event_body": "This is my message"
+}
+```
+
+## Notes:
+1) You have to configure server notices in [homeserver.yaml](../server_notices.md) before
+you can use this API
+2) This query sends a message to all users (and creates a room for each one if it was not
+done before). So please be aware that you will put your server under heavy load if you
+have a large number of registered users.

--- a/docs/server_notices.md
+++ b/docs/server_notices.md
@@ -1,5 +1,4 @@
-Server Notices
-==============
+# Server Notices
 
 'Server Notices' are a new feature introduced in Synapse 0.30. They provide a
 channel whereby server administrators can send messages to users on the server.
@@ -11,8 +10,7 @@ they may also find a use for features such as "Message of the day".
 This is a feature specific to Synapse, but it uses standard Matrix
 communication mechanisms, so should work with any Matrix client.
 
-User experience
----------------
+## User experience
 
 When the user is first sent a server notice, they will get an invitation to a
 room (typically called 'Server Notices', though this is configurable in
@@ -29,8 +27,7 @@ levels.
 Having joined the room, the user can leave the room if they want. Subsequent
 server notices will then cause a new room to be created.
 
-Synapse configuration
----------------------
+## Synapse configuration
 
 Server notices come from a specific user id on the server. Server
 administrators are free to choose the user id - something like `server` is
@@ -58,26 +55,6 @@ room which will be created.
 `system_mxid_display_name` and `system_mxid_avatar_url` can be used to set the
 displayname and avatar of the Server Notices user.
 
-Sending notices
----------------
+## Sending notices
 
-As of the current version of synapse, there is no convenient interface for
-sending notices (other than the automated ones sent as part of consent
-tracking).
-
-In the meantime, it is possible to test this feature using the manhole. Having
-gone into the manhole as described in [manhole.md](manhole.md), a notice can be
-sent with something like:
-
-```
->>> hs.get_server_notices_manager().send_notice('@user:server.com', {'msgtype':'m.text', 'body':'foo'})
-```
-
-To send a notice to all users can be send with the following query:
-
-```
->>> hs.get_server_notices_manager().send_notice_to_all_users({'msgtype':'m.text', 'body':'foo'})
-```
-Note: This query sends a message to all users (with creating a room for each one
-if it was not done before). So please be aware that you will put your server unter heavy
-load if you have a lots of users
+To send server notices to users you can use the [admin_api](admin_api/server_notices.md).

--- a/docs/server_notices.md
+++ b/docs/server_notices.md
@@ -72,3 +72,12 @@ sent with something like:
 ```
 >>> hs.get_server_notices_manager().send_notice('@user:server.com', {'msgtype':'m.text', 'body':'foo'})
 ```
+
+To send a notice to all users can be send with the following query:
+
+```
+>>> hs.get_server_notices_manager().send_notice_to_all_users({'msgtype':'m.text', 'body':'foo'})
+```
+Note: This query sends a message to all users (with creating a room for each one
+if it was not done before). So please be aware that you will put your server unter heavy
+load if you have a lots of users

--- a/synapse/rest/client/v1/admin.py
+++ b/synapse/rest/client/v1/admin.py
@@ -557,7 +557,7 @@ class ResetPasswordRestServlet(ClientV1RestServlet):
     """Post request to allow an administrator reset password for a user.
     This needs user to have administrator access in Synapse.
         Example:
-            http://localhost:8008/_matrix/client/api/v1/admin/reset_password/
+            http://localhost:8008/_matrix/client/r0/admin/reset_password/
             @user:to_reset_password?access_token=admin_access_token
         JsonBodyToSend:
             {
@@ -603,7 +603,7 @@ class GetUsersPaginatedRestServlet(ClientV1RestServlet):
     """Get request to get specific number of users from Synapse.
     This needs user to have administrator access in Synapse.
         Example:
-            http://localhost:8008/_matrix/client/api/v1/admin/users_paginate/
+            http://localhost:8008/_matrix/client/r0/admin/users_paginate/
             @admin:user?access_token=admin_access_token&start=0&limit=10
         Returns:
             200 OK with json object {list[dict[str, Any]], count} or empty object.
@@ -652,7 +652,7 @@ class GetUsersPaginatedRestServlet(ClientV1RestServlet):
         """Post request to get specific number of users from Synapse..
         This needs user to have administrator access in Synapse.
         Example:
-            http://localhost:8008/_matrix/client/api/v1/admin/users_paginate/
+            http://localhost:8008/_matrix/client/r0/admin/users_paginate/
             @admin:user?access_token=admin_access_token
         JsonBodyToSend:
             {
@@ -687,7 +687,7 @@ class SearchUsersRestServlet(ClientV1RestServlet):
     search term.
     This needs user to have administrator access in Synapse.
         Example:
-            http://localhost:8008/_matrix/client/api/v1/admin/search_users/
+            http://localhost:8008/_matrix/client/r0/admin/search_users/
             @admin:user?access_token=admin_access_token&term=alice
         Returns:
             200 OK with json object {list[dict[str, Any]], count} or empty object.


### PR DESCRIPTION
In #3525 it got requested to have an easier way to send a server notice
to all users on the server.

Besides the query that got mentioned there this adds another command
which can be called via manhole to send those messages.

This PR adds admin API as follows:
```
http://localhost:8008/_matrix/client/api/v1/admin/send_server_notice/@dest:user?access_token=admin_access_token
JsonBodyToSend:
    {
        "event": {'msgtype':'m.text', 'body':'This is my message'}
    }
    or simply
    {
        'event_body': 'This is my message'
    }
```
`@dest:user` is optional

This would fix #3532 

Signed-Off-By: Matthias Kesler <krombel@krombel.de>