### PR TITLE
Fix perf regression in PR #3530

### DIFF
--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -80,10 +80,7 @@ class StreamChangeCache(object):
                 )
             }
 
-            result = {
-                e for e in entities
-                if e in changed_entities
-            }
+            result = changed_entities.intersection(entities)
 
             self.metrics.inc_hits()
         else:

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -74,10 +74,15 @@ class StreamChangeCache(object):
         assert type(stream_pos) is int
 
         if stream_pos >= self._earliest_known_stream_pos:
-            result = {
+            changed_entities = {
                 self._cache[k] for k in self._cache.islice(
                     start=self._cache.bisect_right(stream_pos),
                 )
+            }
+
+            result = {
+                e for e in entities
+                if e in changed_entities
             }
 
             self.metrics.inc_hits()

--- a/tests/util/test_stream_change_cache.py
+++ b/tests/util/test_stream_change_cache.py
@@ -178,6 +178,22 @@ class StreamChangeCacheTests(unittest.TestCase):
             ),
         )
 
+        # Query a subset of the entries mid-way through the stream. We should
+        # only get back the subset.
+        self.assertEqual(
+            cache.get_entities_changed(
+                [
+                    "bar@baz.net",
+                ],
+                stream_pos=2,
+            ),
+            set(
+                [
+                    "bar@baz.net",
+                ]
+            ),
+        )
+
     def test_max_pos(self):
         """
         StreamChangeCache.get_max_pos_of_last_change will return the most


### PR DESCRIPTION
The get_entities_changed function was changed to return all changed
entities since the given stream position, rather than only those changed
from a given list of entities. This resulted in the function incorrectly
returning large numbers of entities that, for example, caused large
increases in database usage.