### PR TITLE
Add IPv6 support for Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN cd /synapse \
  && pip install --upgrade pip setuptools psycopg2 lxml \
  && mkdir -p /synapse/cache \
  && pip install -f /synapse/cache --upgrade --process-dependency-links . \
+ # Update Twisted to add IPv6 support (see #3551)
+ && pip install Twisted>=17.1.0 \
  && mv /synapse/contrib/docker/start.py /synapse/contrib/docker/conf / \
  && rm -rf setup.py setup.cfg synapse
 

--- a/changelog.d/3551.bugfix
+++ b/changelog.d/3551.bugfix
@@ -1,0 +1,1 @@
+Add IPv6 support for Docker images


### PR DESCRIPTION
Currently, Synapse doesn't work using IPv6 (see #1002). A fix is described in #2088 and has been applied to the `Dockerfile` in this PR.

I understand that Debian doesn't have Twister 17 yet, but as this is a Docker image it doesn't really matter, so just install Twister 17 to make it work. The image size hasn't notably changed, as it's 492 MB before and after.

As Docker provides an IPv6 DNS server by default in custom networks (which are required to link containers since `--link` is deprecated) I think it's pretty important that IPv6 is supported in the images.

Thanks!