### PR TITLE
add config for pep8

### DIFF
--- a/changelog.d/3559.misc
+++ b/changelog.d/3559.misc
@@ -1,0 +1,1 @@
+add config for pep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,11 +14,16 @@ ignore =
     pylint.cfg
     tox.ini
 
-[flake8]
+[pep8]
 max-line-length = 90
-#  W503 requires that binary operators be at the end, not start, of lines. Erik doesn't like it.
-#  E203 is contrary to PEP8.
+#  W503 requires that binary operators be at the end, not start, of lines. Erik
+#  doesn't like it.  E203 is contrary to PEP8.
 ignore = W503,E203
+
+[flake8]
+# note that flake8 inherits the "ignore" settings from "pep8" (because it uses
+# pep8 to do those checks), but not the "max-line-length" setting
+max-line-length = 90
 
 [isort]
 line_length = 89


### PR DESCRIPTION
Since, for better or worse, we seem to have configured isort to generate
89-character lines, pycharm is now complaining at me that our lines are too
long.

So, let's configure pep8 to behave consistently with flake8.