### PR TITLE
Disable logcontext warning

### DIFF
--- a/changelog.d/3561.bugfix
+++ b/changelog.d/3561.bugfix
@@ -1,0 +1,1 @@
+Disable a noisy warning about logcontexts

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -343,9 +343,10 @@ class SQLBaseStore(object):
         """
         parent_context = LoggingContext.current_context()
         if parent_context == LoggingContext.sentinel:
-            logger.warn(
-                "Running db txn from sentinel context: metrics will be lost",
-            )
+            # warning disabled for 0.33.0 release; proper fixes will land imminently.
+            # logger.warn(
+            #    "Running db txn from sentinel context: metrics will be lost",
+            # )
             parent_context = None
 
         start_time = time.time()


### PR DESCRIPTION
Temporary workaround to #3518 while we release 0.33.0.