### PR TITLE
Only get cached state from context in persist_event

### DIFF
--- a/changelog.d/3584.misc
+++ b/changelog.d/3584.misc
@@ -1,0 +1,1 @@
+Lazily load state on master process when using workers to reduce DB consumption

--- a/synapse/events/snapshot.py
+++ b/synapse/events/snapshot.py
@@ -163,6 +163,9 @@ class EventContext(object):
         context._prev_state_id = input["prev_state_id"]
         context._event_type = input["event_type"]
         context._event_state_key = input["event_state_key"]
+
+        context._current_state_ids = None
+        context._prev_state_ids = None
         context._fetching_state_deferred = None
 
         context.state_group = input["state_group"]
@@ -213,6 +216,16 @@ class EventContext(object):
         yield make_deferred_yieldable(self._fetching_state_deferred)
 
         defer.returnValue(self._prev_state_ids)
+
+    def get_cached_current_state_ids(self):
+        """Gets the current state IDs if we have them already cached.
+
+        Returns:
+            dict[(str, str), str]|None: Returns None if state_group
+            is None, which happens when the associated event is an outlier.
+        """
+
+        return self._current_state_ids
 
     @defer.inlineCallbacks
     def _fill_out_state(self, store):

--- a/synapse/events/snapshot.py
+++ b/synapse/events/snapshot.py
@@ -221,8 +221,9 @@ class EventContext(object):
         """Gets the current state IDs if we have them already cached.
 
         Returns:
-            dict[(str, str), str]|None: Returns None if state_group
-            is None, which happens when the associated event is an outlier.
+            dict[(str, str), str]|None: Returns None if we haven't cached the
+            state or if state_group is None, which happens when the associated
+            event is an outlier.
         """
 
         return self._current_state_ids

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -549,7 +549,9 @@ class EventsStore(EventsWorkerStore):
             if ctx.state_group in state_groups_map:
                 continue
 
-            state_groups_map[ctx.state_group] = yield ctx.get_current_state_ids(self)
+            current_state_ids = ctx.get_cached_current_state_ids()
+            if current_state_ids is not None:
+                state_groups_map[ctx.state_group] = current_state_ids
 
         # We need to map the event_ids to their state groups. First, let's
         # check if the event is one we're persisting, in which case we can

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -549,6 +549,9 @@ class EventsStore(EventsWorkerStore):
             if ctx.state_group in state_groups_map:
                 continue
 
+            # We're only interested in pulling out state that has already
+            # been cached in the context. We'll pull stuff out of the DB later
+            # if necessary.
             current_state_ids = ctx.get_cached_current_state_ids()
             if current_state_ids is not None:
                 state_groups_map[ctx.state_group] = current_state_ids


### PR DESCRIPTION
We don't want to bother pulling out the current state from the DB since
until we know we have to. Checking the context for state is just an
optimisation.