### PR TITLE
Improve logging for exceptions when handling PDUs

### DIFF
--- a/changelog.d/3587.misc
+++ b/changelog.d/3587.misc
@@ -1,0 +1,1 @@
+Improve logging for exceptions when handling PDUs


### PR DESCRIPTION
when we get an exception handling a federation PDU, log the whole stacktrace.