### PR TITLE
Use deltas to calculate current state deltas

### DIFF
--- a/changelog.d/3595.misc
+++ b/changelog.d/3595.misc
@@ -1,0 +1,1 @@
+Attempt to reduce amount of state pulled out of DB during persist_events

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -557,6 +557,11 @@ class EventsStore(EventsWorkerStore):
             Returns a tuple of two state maps, the first being the full new current
             state and the second being the delta to the existing current state.
             If both are None then there has been no change.
+
+            If there has been a change then we only return the delta if its
+            already been calculated. Conversely if we do know the delta then
+            the new current state is only returned if we've already calculated
+            it.
         """
 
         if not new_latest_event_ids:

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -696,7 +696,7 @@ class EventsStore(EventsWorkerStore):
         existing_state = yield self.get_current_state_ids(room_id)
 
         to_delete = [
-            key for key, ev_id in iteritems(existing_state)
+            key for key in existing_state
             if key not in current_state
         ]
 


### PR DESCRIPTION
Most of the time when we're updating current state during persist_events loop its a simple transition from an old state group to a new one, where we already have the delta between the two (from an event context). If we have the delta then we may as well reuse it, rather than pulling out the old and new current state and comparing them in app.