### PR TITLE
Fix updating of cached remote profiles

### DIFF
--- a/changelog.d/3605.bugfix
+++ b/changelog.d/3605.bugfix
@@ -1,0 +1,1 @@
+Fix updating of cached remote profiles


### PR DESCRIPTION
_update_remote_profile_cache was missing its `defer.inlineCallbacks`, so when
it was called, would just return a generator object, without actually running
any of the method body.