### PR TITLE
Fix another logcontext leak in _persist_events

### DIFF
--- a/changelog.d/3606.misc
+++ b/changelog.d/3606.misc
@@ -1,0 +1,1 @@
+Fix some random logcontext leaks.

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -311,6 +311,12 @@ class SQLBaseStore(object):
         after_callbacks = []
         exception_callbacks = []
 
+        if LoggingContext.current_context() == LoggingContext.sentinel:
+            logger.warn(
+                "Starting db txn '%s' from sentinel context",
+                desc,
+            )
+
         try:
             result = yield self.runWithConnection(
                 self._new_transaction,


### PR DESCRIPTION
We need to run the errback in the sentinel context to avoid losing our own
context.

Also: add logging to runInteraction to help identify where "Starting db
connection from sentinel context" warnings are coming from