### PR TITLE
Fix occasional 'tuple index out of range' error

### DIFF
--- a/changelog.d/3607.bugfix
+++ b/changelog.d/3607.bugfix
@@ -1,0 +1,1 @@
+Fix 'tuple index out of range' error

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -1137,7 +1137,7 @@ class EventsStore(EventsWorkerStore):
         ):
             txn.executemany(
                 "DELETE FROM %s WHERE room_id = ? AND event_id = ?" % (table,),
-                [(ev.event_id,) for ev, _ in events_and_contexts]
+                [(ev.room_id, ev.event_id) for ev, _ in events_and_contexts]
             )
 
     def _store_event_txn(self, txn, events_and_contexts):


### PR DESCRIPTION
This fixes a bug in _delete_existing_rows_txn which was introduced in #3435
(though it's been on matrix-org-hotfixes for *years*). This code is only called
when there is some sort of conflict the first time we try to persist an event,
so it only happens rarely. Still, the exceptions are annoying.