### PR TITLE
Added more email notification settings to config file, also fixed issue with email notifications sometimes not sending because of roll-over effects.

### DIFF
--- a/changelog.d/3615.misc
+++ b/changelog.d/3615.misc
@@ -1,0 +1,1 @@
+Added more email notification settings to config file, also fixed issue with email notifications sometimes not sending because of roll-over effects.

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -16,7 +16,7 @@
 # This file can't be called email.py because if it is, we cannot:
 import email.utils
 
-from ._base import Config
+from ._base import Config, ConfigError
 
 
 class EmailConfig(Config):
@@ -49,13 +49,13 @@ class EmailConfig(Config):
                     missing.append(k)
 
             if (len(missing) > 0):
-                raise RuntimeError(
+                raise ConfigError(
                     "email.enable_notifs is True but required keys are missing: %s" %
                     (", ".join(["email." + k for k in missing]),)
                 )
 
             if config.get("public_baseurl") is None:
-                raise RuntimeError(
+                raise ConfigError(
                     "email.enable_notifs is True but no public_baseurl is set"
                 )
 
@@ -88,11 +88,8 @@ class EmailConfig(Config):
             # make sure it's valid
             parsed = email.utils.parseaddr(self.email_notif_from)
             if parsed[1] == '':
-                raise RuntimeError("Invalid notif_from address")
-        else:
-            self.email_enable_notifs = False
-            # Not much point setting defaults for the rest: it would be an
-            # error for them to be used.
+                raise ConfigError("Invalid notif_from address")
+        
 
     def default_config(self, config_dir_path, server_name, **kwargs):
         return """

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -117,6 +117,13 @@ class EmailConfig(Config):
             self.mail_throttle_reset_after_s = email_config.get(
                 "mail_throttle_reset_after_s", 43200
             )
+            
+            self.mail_ignore_rooms = []
+            ignore_rooms_string = email_config.get("mail_ignore_rooms", None)
+            
+            if ignore_rooms_string is not None:
+                ignore_room_string_fix = ignore_rooms_string.replace(" ", "")
+                self.mail_ignore_rooms = ignore_room_string_fix.split(",")
         
 
     def default_config(self, config_dir_path, server_name, **kwargs):
@@ -167,4 +174,6 @@ class EmailConfig(Config):
         #   # 12 hours - a gap of 12 hours in conversation is surely enough to merit a new
         #   # notification when things get going again...
         #   mail_throttle_reset_after_s : 43200
+        #   # Ignore these room ids for mail notifications (comma separated list).
+        #   #mail_ignore_rooms: "!QtykxKocfZaZOUrTwp:matrix.org, !DgvjtOljKujDBrxyHk:matrix.org"
         """

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -125,7 +125,6 @@ class EmailConfig(Config):
                 ignore_room_string_fix = ignore_rooms_string.replace(" ", "")
                 self.mail_ignore_rooms = ignore_room_string_fix.split(",")
 
-
     def default_config(self, config_dir_path, server_name, **kwargs):
         return """
         # Enable sending emails for notification events
@@ -151,19 +150,21 @@ class EmailConfig(Config):
         #   notif_for_new_users: True
         #   riot_base_url: "http://localhost/riot"
         #   # The max amount of notifications that should be contained in a mail
-        #   # (a mail includes the oldest amount/2 and most recent amount/2 notifications)
-        #   # (should be divisible by 2)
+        #   # (a mail includes the oldest amount/2 and
+        #   # most recent amount/2 notifications - should be divisible by 2)
         #   mail_notif_amount: 26
-        #   # The max amount of room invite notifications that should be contained in a mail
+        #   # The max amount of room invite notifications
+        #   # that should be contained in a mail
         #   # (should be divisible by 2, see mail_notif_amount explanation)
         #   mail_notif_inv_amount: 4
-        #   # The amount of time we always wait before ever emailing about a notification in seconds
+        #   # The amount of time we always wait
+        #   # before ever emailing about a notification in seconds
         #   # (to give the user a chance to respond to other push or notice the window)
         #   # (600s = 10 minutes)
         #   delay_before_mail_s : 600
-        #   # THROTTLE is the minimum time between mail notifications sent for a given room.
-        #   # Each room maintains its own throttle counter, but each new mail notification
-        #   # sends the pending notifications for all rooms.
+        #   # THROTTLE is the minimum time between mail notifications sent for
+        #   # a given room. Each room maintains its own throttle counter, but each new
+        #   # mail notification sends the pending notifications for all rooms.
         #   mail_throttle_start_s : 600
         #   # (86400 = 24 hours)
         #   mail_throttle_max_s : 86400
@@ -171,9 +172,9 @@ class EmailConfig(Config):
         #   mail_throttle_multiplier : 144
         #   # If no event triggers a notification for this long after the previous,
         #   # the throttle is released.
-        #   # 12 hours - a gap of 12 hours in conversation is surely enough to merit a new
-        #   # notification when things get going again...
+        #   # 12 hours - a gap of 12 hours in conversation is surely enough to merit
+        #   # a new notification when things get going again...
         #   mail_throttle_reset_after_s : 43200
         #   # Ignore these room ids for mail notifications (comma separated list).
-        #   #mail_ignore_rooms: "!QtykxKocfZaZOUrTwp:matrix.org, !DgvjtOljKujDBrxyHk:matrix.org"
+        #   #mail_ignore_rooms: "!QtykxKocfZaZOUrTwp:matrix.org"
         """

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -89,42 +89,42 @@ class EmailConfig(Config):
             parsed = email.utils.parseaddr(self.email_notif_from)
             if parsed[1] == '':
                 raise ConfigError("Invalid notif_from address")
-                
+
             self.mail_notif_amount = email_config.get(
                 "mail_notif_amount", 26
             )
-                
+
             self.mail_notif_inv_amount = email_config.get(
                 "mail_notif_inv_amount", 4
             )
-                
+
             self.delay_before_mail_s = email_config.get(
                 "delay_before_mail_s", 600
             )
-            
+
             self.mail_throttle_start_s = email_config.get(
                 "mail_throttle_start_s", 600
             )
-            
+
             self.mail_throttle_max_s = email_config.get(
                 "mail_throttle_max_s", 86400
             )
-            
+
             self.mail_throttle_multiplier = email_config.get(
                 "mail_throttle_multiplier", 144
             )
-            
+
             self.mail_throttle_reset_after_s = email_config.get(
                 "mail_throttle_reset_after_s", 43200
             )
-            
+
             self.mail_ignore_rooms = []
             ignore_rooms_string = email_config.get("mail_ignore_rooms", None)
-            
+
             if ignore_rooms_string is not None:
                 ignore_room_string_fix = ignore_rooms_string.replace(" ", "")
                 self.mail_ignore_rooms = ignore_room_string_fix.split(",")
-        
+
 
     def default_config(self, config_dir_path, server_name, **kwargs):
         return """

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -90,6 +90,14 @@ class EmailConfig(Config):
             if parsed[1] == '':
                 raise ConfigError("Invalid notif_from address")
                 
+            self.mail_notif_amount = email_config.get(
+                "mail_notif_amount", 26
+            )
+                
+            self.mail_notif_inv_amount = email_config.get(
+                "mail_notif_inv_amount", 4
+            )
+                
             self.delay_before_mail_s = email_config.get(
                 "delay_before_mail_s", 600
             )
@@ -135,6 +143,13 @@ class EmailConfig(Config):
         #   notif_template_text: notif_mail.txt
         #   notif_for_new_users: True
         #   riot_base_url: "http://localhost/riot"
+        #   # The max amount of notifications that should be contained in a mail
+        #   # (a mail includes the oldest amount/2 and most recent amount/2 notifications)
+        #   # (should be divisible by 2)
+        #   mail_notif_amount: 26
+        #   # The max amount of room invite notifications that should be contained in a mail
+        #   # (should be divisible by 2, see mail_notif_amount explanation)
+        #   mail_notif_inv_amount: 4
         #   # The amount of time we always wait before ever emailing about a notification in seconds
         #   # (to give the user a chance to respond to other push or notice the window)
         #   # (600s = 10 minutes)

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -89,6 +89,26 @@ class EmailConfig(Config):
             parsed = email.utils.parseaddr(self.email_notif_from)
             if parsed[1] == '':
                 raise ConfigError("Invalid notif_from address")
+                
+            self.delay_before_mail_s = email_config.get(
+                "delay_before_mail_s", 600
+            )
+            
+            self.mail_throttle_start_s = email_config.get(
+                "mail_throttle_start_s", 600
+            )
+            
+            self.mail_throttle_max_s = email_config.get(
+                "mail_throttle_max_s", 86400
+            )
+            
+            self.mail_throttle_multiplier = email_config.get(
+                "mail_throttle_multiplier", 144
+            )
+            
+            self.mail_throttle_reset_after_s = email_config.get(
+                "mail_throttle_reset_after_s", 43200
+            )
         
 
     def default_config(self, config_dir_path, server_name, **kwargs):
@@ -115,4 +135,21 @@ class EmailConfig(Config):
         #   notif_template_text: notif_mail.txt
         #   notif_for_new_users: True
         #   riot_base_url: "http://localhost/riot"
+        #   # The amount of time we always wait before ever emailing about a notification in seconds
+        #   # (to give the user a chance to respond to other push or notice the window)
+        #   # (600s = 10 minutes)
+        #   delay_before_mail_s : 600
+        #   # THROTTLE is the minimum time between mail notifications sent for a given room.
+        #   # Each room maintains its own throttle counter, but each new mail notification
+        #   # sends the pending notifications for all rooms.
+        #   mail_throttle_start_s : 600
+        #   # (86400 = 24 hours)
+        #   mail_throttle_max_s : 86400
+        #   # 10 mins, 24h - jump straight to 1 day
+        #   mail_throttle_multiplier : 144
+        #   # If no event triggers a notification for this long after the previous,
+        #   # the throttle is released.
+        #   # 12 hours - a gap of 12 hours in conversation is surely enough to merit a new
+        #   # notification when things get going again...
+        #   mail_throttle_reset_after_s : 43200
         """

--- a/synapse/push/emailpusher.py
+++ b/synapse/push/emailpusher.py
@@ -54,6 +54,9 @@ class EmailPusher(object):
 
         self.processing = False
         
+        self.mail_notif_amount = hs.config.mail_notif_amount;
+        self.mail_notif_inv_amount = hs.config.mail_notif_inv_amount;
+        
         self.delay_before_mail_ms = hs.config.delay_before_mail_s * 1000;
         self.mail_throttle_start_ms = hs.config.mail_throttle_start_s * 1000;
         self.mail_throttle_max_ms = hs.config.mail_throttle_max_s * 1000;
@@ -126,7 +129,7 @@ class EmailPusher(object):
         """
         start = 0 if INCLUDE_ALL_UNREAD_NOTIFS else self.last_stream_ordering
         fn = self.store.get_unread_push_actions_for_user_in_range_for_email
-        unprocessed = yield fn(self.user_id, start, self.max_stream_ordering)
+        unprocessed = yield fn(self.user_id, start, self.max_stream_ordering, self.mail_notif_amount, self.mail_notif_inv_amount)
 
         soonest_due_at = None
 

--- a/synapse/push/emailpusher.py
+++ b/synapse/push/emailpusher.py
@@ -53,16 +53,16 @@ class EmailPusher(object):
         self.max_stream_ordering = self.last_stream_ordering
 
         self.processing = False
-        
+
         self.mail_notif_amount = hs.config.mail_notif_amount;
         self.mail_notif_inv_amount = hs.config.mail_notif_inv_amount;
-        
+
         self.delay_before_mail_ms = hs.config.delay_before_mail_s * 1000;
         self.mail_throttle_start_ms = hs.config.mail_throttle_start_s * 1000;
         self.mail_throttle_max_ms = hs.config.mail_throttle_max_s * 1000;
         self.mail_throttle_multiplier = hs.config.mail_throttle_multiplier;
         self.mail_throttle_reset_after_ms = hs.config.mail_throttle_reset_after_s * 1000;
-        
+
         self.mail_ignore_rooms = hs.config.mail_ignore_rooms;
 
     @defer.inlineCallbacks

--- a/synapse/push/emailpusher.py
+++ b/synapse/push/emailpusher.py
@@ -54,16 +54,16 @@ class EmailPusher(object):
 
         self.processing = False
 
-        self.mail_notif_amount = hs.config.mail_notif_amount;
-        self.mail_notif_inv_amount = hs.config.mail_notif_inv_amount;
+        self.mail_notif_amount = hs.config.mail_notif_amount
+        self.mail_notif_inv_amount = hs.config.mail_notif_inv_amount
 
-        self.delay_before_mail_ms = hs.config.delay_before_mail_s * 1000;
-        self.mail_throttle_start_ms = hs.config.mail_throttle_start_s * 1000;
-        self.mail_throttle_max_ms = hs.config.mail_throttle_max_s * 1000;
-        self.mail_throttle_multiplier = hs.config.mail_throttle_multiplier;
-        self.mail_throttle_reset_after_ms = hs.config.mail_throttle_reset_after_s * 1000;
+        self.delay_before_mail_ms = hs.config.delay_before_mail_s * 1000
+        self.mail_throttle_start_ms = hs.config.mail_throttle_start_s * 1000
+        self.mail_throttle_max_ms = hs.config.mail_throttle_max_s * 1000
+        self.mail_throttle_multiplier = hs.config.mail_throttle_multiplier
+        self.mail_throttle_reset_after_ms = hs.config.mail_throttle_reset_after_s * 1000
 
-        self.mail_ignore_rooms = hs.config.mail_ignore_rooms;
+        self.mail_ignore_rooms = hs.config.mail_ignore_rooms
 
     @defer.inlineCallbacks
     def on_started(self):
@@ -131,7 +131,10 @@ class EmailPusher(object):
         """
         start = 0 if INCLUDE_ALL_UNREAD_NOTIFS else self.last_stream_ordering
         fn = self.store.get_unread_push_actions_for_user_in_range_for_email
-        unprocessed = yield fn(self.user_id, start, self.max_stream_ordering, self.mail_notif_amount, self.mail_notif_inv_amount, self.mail_ignore_rooms)
+        unprocessed = yield fn(
+            self.user_id, start, self.max_stream_ordering,
+            self.mail_notif_amount, self.mail_notif_inv_amount, self.mail_ignore_rooms
+            )
 
         soonest_due_at = None
 

--- a/synapse/push/emailpusher.py
+++ b/synapse/push/emailpusher.py
@@ -199,7 +199,7 @@ class EmailPusher(object):
         )
 
     def seconds_until(self, ts_msec):
-        secs = (ts_msec - self.clock.time_msec()) / 1000
+        secs = (ts_msec - self.clock.time_msec()) / 1000.0
         return max(secs, 0)
 
     def get_room_throttle_ms(self, room_id):

--- a/synapse/push/emailpusher.py
+++ b/synapse/push/emailpusher.py
@@ -50,8 +50,7 @@ class EmailPusher(object):
         self.timed_call = None
         self.throttle_params = None
 
-        # See httppusher
-        self.max_stream_ordering = None
+        self.max_stream_ordering = self.last_stream_ordering
 
         self.processing = False
         

--- a/synapse/push/emailpusher.py
+++ b/synapse/push/emailpusher.py
@@ -62,6 +62,8 @@ class EmailPusher(object):
         self.mail_throttle_max_ms = hs.config.mail_throttle_max_s * 1000;
         self.mail_throttle_multiplier = hs.config.mail_throttle_multiplier;
         self.mail_throttle_reset_after_ms = hs.config.mail_throttle_reset_after_s * 1000;
+        
+        self.mail_ignore_rooms = hs.config.mail_ignore_rooms;
 
     @defer.inlineCallbacks
     def on_started(self):
@@ -129,7 +131,7 @@ class EmailPusher(object):
         """
         start = 0 if INCLUDE_ALL_UNREAD_NOTIFS else self.last_stream_ordering
         fn = self.store.get_unread_push_actions_for_user_in_range_for_email
-        unprocessed = yield fn(self.user_id, start, self.max_stream_ordering, self.mail_notif_amount, self.mail_notif_inv_amount)
+        unprocessed = yield fn(self.user_id, start, self.max_stream_ordering, self.mail_notif_amount, self.mail_notif_inv_amount, self.mail_ignore_rooms)
 
         soonest_due_at = None
 

--- a/synapse/storage/event_push_actions.py
+++ b/synapse/storage/event_push_actions.py
@@ -284,7 +284,8 @@ class EventPushActionsWorkerStore(SQLBaseStore):
 
     @defer.inlineCallbacks
     def get_unread_push_actions_for_user_in_range_for_email(
-        self, user_id, min_stream_ordering, max_stream_ordering, msglimit=26, invlimit=4, room_ignore_list=[]
+        self, user_id, min_stream_ordering, max_stream_ordering,
+        msglimit=26, invlimit=4, room_ignore_list=[]
     ):
         """Get a list of the oldest and most recent unread push actions for a given user,
         within the given stream ordering range. Called by the emailpusher
@@ -389,7 +390,10 @@ class EventPushActionsWorkerStore(SQLBaseStore):
                 "stream_ordering": row[2],
                 "actions": _deserialize_action(row[3], row[4]),
                 "received_ts": row[5],
-            } for row in after_read_receipt_desc + after_read_receipt_asc + no_read_receipt_desc + no_read_receipt_asc
+            } for row in (
+                after_read_receipt_desc + after_read_receipt_asc
+                + no_read_receipt_desc + no_read_receipt_asc
+                )
         ]
 
         # Remove duplicates

--- a/synapse/storage/event_push_actions.py
+++ b/synapse/storage/event_push_actions.py
@@ -284,9 +284,9 @@ class EventPushActionsWorkerStore(SQLBaseStore):
 
     @defer.inlineCallbacks
     def get_unread_push_actions_for_user_in_range_for_email(
-        self, user_id, min_stream_ordering, max_stream_ordering, limit=20
+        self, user_id, min_stream_ordering, max_stream_ordering, msglimit=26, invlimit=4
     ):
-        """Get a list of the most recent unread push actions for a given user,
+        """Get a list of the oldest and most recent unread push actions for a given user,
         within the given stream ordering range. Called by the emailpusher
 
         Args:
@@ -295,15 +295,17 @@ class EventPushActionsWorkerStore(SQLBaseStore):
                 stream ordering of event push actions to fetch.
             max_stream_ordering(int): The inclusive upper bound on the
                 stream ordering of event push actions to fetch.
-            limit (int): The maximum number of rows to return.
+            msglimit (int): The maximum number of message push actions to return.
+            invlimit (int): The maximum number of invite push actions to return.
         Returns:
             A promise which resolves to a list of dicts with the keys "event_id",
             "room_id", "stream_ordering", "actions", "received_ts".
             The list will be ordered by descending received_ts.
-            The list will have between 0~limit entries.
-        """
+            The list will have between 0~(msglimit+invlimit) entries.
+        """        
         # find rooms that have a read receipt in them and return the most recent
-        # push actions
+        # as well as the oldest push actions (otherwise we might never send notifications
+        # because of roll-over effects)
         def get_after_receipt(txn):
             sql = (
                 "SELECT ep.event_id, ep.room_id, ep.stream_ordering, ep.actions,"
@@ -324,21 +326,27 @@ class EventPushActionsWorkerStore(SQLBaseStore):
                 "   AND ep.user_id = ?"
                 "   AND ep.stream_ordering > ?"
                 "   AND ep.stream_ordering <= ?"
-                " ORDER BY ep.stream_ordering DESC LIMIT ?"
+                " ORDER BY ep.stream_ordering " + order + " LIMIT ?"
             )
             args = [
                 user_id, user_id,
-                min_stream_ordering, max_stream_ordering, limit,
+                min_stream_ordering, max_stream_ordering, msglimit/2,
             ]
             txn.execute(sql, args)
             return txn.fetchall()
-        after_read_receipt = yield self.runInteraction(
+        
+        order = "DESC"        
+        after_read_receipt_desc = yield self.runInteraction(
             "get_unread_push_actions_for_user_in_range_email_arr", get_after_receipt
         )
+        order = "ASC"
+        after_read_receipt_asc = yield self.runInteraction(
+            "get_unread_push_actions_for_user_in_range_email_arr", get_after_receipt
+            )
 
         # There are rooms with push actions in them but you don't have a read receipt in
-        # them e.g. rooms you've been invited to, so get push actions for rooms which do
-        # not have read receipts in them too.
+        # them (rooms you've been invited to), so get push actions for rooms which do
+        # not have read receipts in them too. Again, get oldest and most recent.
         def get_no_receipt(txn):
             sql = (
                 "SELECT ep.event_id, ep.room_id, ep.stream_ordering, ep.actions,"
@@ -354,37 +362,52 @@ class EventPushActionsWorkerStore(SQLBaseStore):
                 "   AND ep.user_id = ?"
                 "   AND ep.stream_ordering > ?"
                 "   AND ep.stream_ordering <= ?"
-                " ORDER BY ep.stream_ordering DESC LIMIT ?"
+                " ORDER BY ep.stream_ordering " + order + " LIMIT ?"
             )
             args = [
                 user_id, user_id,
-                min_stream_ordering, max_stream_ordering, limit,
+                min_stream_ordering, max_stream_ordering, invlimit/2,
             ]
             txn.execute(sql, args)
             return txn.fetchall()
-        no_read_receipt = yield self.runInteraction(
+        order = "DESC"    
+        no_read_receipt_desc = yield self.runInteraction(
+            "get_unread_push_actions_for_user_in_range_email_nrr", get_no_receipt
+        )
+        order = "ASC"    
+        no_read_receipt_asc = yield self.runInteraction(
             "get_unread_push_actions_for_user_in_range_email_nrr", get_no_receipt
         )
 
-        # Make a list of dicts from the two sets of results.
-        notifs = [
+        # Make a list of dicts from the sets of results.
+        notifs_duplicates = [
             {
                 "event_id": row[0],
                 "room_id": row[1],
                 "stream_ordering": row[2],
                 "actions": _deserialize_action(row[3], row[4]),
                 "received_ts": row[5],
-            } for row in after_read_receipt + no_read_receipt
+            } for row in after_read_receipt_desc + after_read_receipt_asc + no_read_receipt_desc + no_read_receipt_asc
         ]
-
+         
+        # Remove duplicates
+        notifs = []
+        event_ids = []
+        for notif in notifs_duplicates:
+            if notif["event_id"] in event_ids:
+                continue
+            notifs.append(notif)
+            event_ids.append(notif["event_id"])
+        
         # Now sort it so it's ordered correctly, since currently it will
         # contain results from the first query, correctly ordered, followed
         # by results from the second query, but we want them all ordered
         # by received_ts (most recent first)
         notifs.sort(key=lambda r: -(r['received_ts'] or 0))
 
-        # Now return the first `limit`
-        defer.returnValue(notifs[:limit])
+        # We can return the whole list because it will never be greater than
+        # (msglimit+invlimit)
+        defer.returnValue(notifs)
 
     def add_push_actions_to_staging(self, event_id, user_id_actions):
         """Add the push actions for the event to the push action staging area.


### PR DESCRIPTION
Email notification settings should probably be configurable per user and possibly per room, but until then at least give homeserver admins the chance to influence the settings locally.

Also fixed a bug where email notifications do not send if you have a larger window (i.e. mail only after 24 hours) and a channel keeps being busy. The old code had a 20 most-recent push notification limit which resulted in the email notification condition never firing when a room had constant activity because it would "roll-over" the old notifications.

Signed-off-by: Sebastian Plesch <mail@chaosgrid.net>