### PR TITLE
Only import secrets when available

### DIFF
--- a/changelog.d/3626.bugfix
+++ b/changelog.d/3626.bugfix
@@ -1,0 +1,1 @@
+Only import secrets when available (fix for py < 3.6)

--- a/synapse/secrets.py
+++ b/synapse/secrets.py
@@ -20,17 +20,16 @@ See https://docs.python.org/3/library/secrets.html#module-secrets for the API
 used in Python 3.6, and the API emulated in Python 2.7.
 """
 
-import six
+import sys
 
-if six.PY3:
+# secrets is available since python 3.6
+if sys.version_info[0:2] >= (3, 6):
     import secrets
 
     def Secrets():
         return secrets
 
-
 else:
-
     import os
     import binascii
 


### PR DESCRIPTION
secrets got introduced in python 3.6 so this class is not available
in 3.5 and before.

This now checks for the current running version and only tries using
secrets if the version is 3.6 or above

This fixes an import error for synapse running e.g. on 3.5

Signed-Off-By: Matthias Kesler <krombel@krombel.de>