### PR TITLE
Log the real number of failures on a transaction

### DIFF
--- a/changelog.d/3627.misc
+++ b/changelog.d/3627.misc
@@ -1,0 +1,1 @@
+Log the real number of failures on a transaction

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -287,7 +287,7 @@ class FederationSendServlet(BaseFederationServlet):
                 transaction_id, origin,
                 len(transaction_data.get("pdus", [])),
                 len(transaction_data.get("edus", [])),
-                len(transaction_data.get("failures", [])),
+                len(transaction_data.get("pdu_failures", [])),
             )
 
             # We should ideally be getting this from the security layer.


### PR DESCRIPTION
Throughout the remaining send and receive code for transactions the term `pdu_failures` is used. This is the only instance of `failures`, and has always reported as zero in logs.