### PR TITLE
rename replication_layer to federation_client

### DIFF
--- a/changelog.d/3634.misc
+++ b/changelog.d/3634.misc
@@ -1,0 +1,1 @@
+rename replication_layer to federation_client


### PR DESCRIPTION
I have HAD ENOUGH of trying to remember wtf a replication layer is in terms of
classes.