### PR TITLE
Mention the word "newsfragment" in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -51,7 +51,7 @@ makes it horribly hard to review otherwise.
 Changelog
 ~~~~~~~~~
 
-All changes, even minor ones, need a corresponding changelog
+All changes, even minor ones, need a corresponding changelog / newsfragment
 entry. These are managed by Towncrier
 (https://github.com/hawkowl/towncrier).
 

--- a/changelog.d/3645.misc
+++ b/changelog.d/3645.misc
@@ -1,0 +1,1 @@
+Update CONTRIBUTING to mention newsfragments.


### PR DESCRIPTION
The travis check that fails when there is no new changelog.d entry is called "check-newsfragment".

This PR adds the word "newsfragment" in the appropriate section of CONTRIBUTING, so that a contributor who receives the failure can [search](https://github.com/matrix-org/synapse/search?q=newsfragment) for "newsfragment" and be more likely to quickly find the instructions about what they need to do.