### PR TITLE
update docker base-image to alpine 3.8

### DIFF
--- a/changelog.d/3669.misc
+++ b/changelog.d/3669.misc
@@ -1,0 +1,1 @@
+Update docker base image from alpine 3.7 to 3.8.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:2-alpine3.7
+FROM docker.io/python:2-alpine3.8
 
 RUN apk add --no-cache --virtual .nacl_deps \
         build-base \


### PR DESCRIPTION
This PR updates the base image to alpine 3.8, tested locally, works fine.