### PR TITLE
Fix linearizer cancellation on twisted < 18.7

### DIFF
--- a/changelog.d/3676.bugfix
+++ b/changelog.d/3676.bugfix
@@ -1,0 +1,1 @@
+Make the tests pass on Twisted < 18.7.0


### PR DESCRIPTION
Turns out that cancellation of inlineDeferreds didn't really work properly
until Twisted 18.7. This PR refactors Linearizer.queue to avoid
inlineCallbacks.