### PR TITLE
Fix inbound federation on reader worker

### DIFF
--- a/changelog.d/3705.bugfix
+++ b/changelog.d/3705.bugfix
@@ -1,0 +1,1 @@
+Support more federation endpoints on workers

--- a/synapse/app/federation_reader.py
+++ b/synapse/app/federation_reader.py
@@ -32,6 +32,7 @@ from synapse.http.site import SynapseSite
 from synapse.metrics import RegistryProxy
 from synapse.metrics.resource import METRICS_PREFIX, MetricsResource
 from synapse.replication.slave.storage._base import BaseSlavedStore
+from synapse.replication.slave.storage.account_data import SlavedAccountDataStore
 from synapse.replication.slave.storage.appservice import SlavedApplicationServiceStore
 from synapse.replication.slave.storage.directory import DirectoryStore
 from synapse.replication.slave.storage.events import SlavedEventStore
@@ -54,6 +55,7 @@ logger = logging.getLogger("synapse.app.federation_reader")
 
 
 class FederationReaderSlavedStore(
+    SlavedAccountDataStore,
     SlavedProfileStore,
     SlavedApplicationServiceStore,
     SlavedPusherStore,


### PR DESCRIPTION
Inbound federation requires calculating push, which in turn relies on
having access to account data.