### PR TITLE
Use get_cache_factor_for function for `state_cache`

### DIFF
--- a/changelog.d/3719.bugfix
+++ b/changelog.d/3719.bugfix
@@ -1,0 +1,1 @@
+Fix bug where `state_cache` cache factor ignored environment variables

--- a/synapse/state.py
+++ b/synapse/state.py
@@ -29,7 +29,7 @@ from synapse.api.constants import EventTypes
 from synapse.api.errors import AuthError
 from synapse.events.snapshot import EventContext
 from synapse.util.async_helpers import Linearizer
-from synapse.util.caches import CACHE_SIZE_FACTOR
+from synapse.util.caches import get_cache_factor_for
 from synapse.util.caches.expiringcache import ExpiringCache
 from synapse.util.logutils import log_function
 from synapse.util.metrics import Measure
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 KeyStateTuple = namedtuple("KeyStateTuple", ("context", "type", "state_key"))
 
 
-SIZE_OF_CACHE = int(100000 * CACHE_SIZE_FACTOR)
+SIZE_OF_CACHE = 100000 * get_cache_factor_for("state_cache")
 EVICTION_TIMEOUT_SECONDS = 60 * 60
 
 


### PR DESCRIPTION
This allows the cache factor for `state_cache` to be individually
specified in the enviroment