### PR TITLE
Allow guests to use /rooms/:roomId/event/:eventId

### DIFF
--- a/changelog.d/3724.feature
+++ b/changelog.d/3724.feature
@@ -1,0 +1,1 @@
+Allow guests to use /rooms/:roomId/event/:eventId

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -531,7 +531,7 @@ class RoomEventServlet(ClientV1RestServlet):
 
     @defer.inlineCallbacks
     def on_GET(self, request, room_id, event_id):
-        requester = yield self.auth.get_user_by_req(request)
+        requester = yield self.auth.get_user_by_req(request, allow_guest=True)
         event = yield self.event_handler.get_event(requester.user, room_id, event_id)
 
         time_now = self.clock.time_msec()


### PR DESCRIPTION
Fixes #3721 