### PR TITLE
Don't log exceptions when failing to fetch server keys

### DIFF
--- a/changelog.d/3727.misc
+++ b/changelog.d/3727.misc
@@ -1,0 +1,1 @@
+Log failure to authenticate remote servers as warnings (without stack traces)

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -261,10 +261,10 @@ class BaseFederationServlet(object):
             except NoAuthenticationError:
                 origin = None
                 if self.REQUIRE_AUTH:
-                    logger.warn("authenticate_request failed")
+                    logger.warn("authenticate_request failed: missing authentication")
                     raise
-            except Exception:
-                logger.warn("authenticate_request failed")
+            except Exception as e:
+                logger.warn("authenticate_request failed: %s", e)
                 raise
 
             if origin:

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -261,10 +261,10 @@ class BaseFederationServlet(object):
             except NoAuthenticationError:
                 origin = None
                 if self.REQUIRE_AUTH:
-                    logger.exception("authenticate_request failed")
+                    logger.warn("authenticate_request failed")
                     raise
             except Exception:
-                logger.exception("authenticate_request failed")
+                logger.warn("authenticate_request failed")
                 raise
 
             if origin:


### PR DESCRIPTION
Not being able to resolve or connect to remote servers is an expected
error, so we shouldn't log at ERROR with stacktraces.