### PR TITLE
Fix MAU invalidation due to missing yield

### DIFF
--- a/changelog.d/3746.misc
+++ b/changelog.d/3746.misc
@@ -1,0 +1,1 @@
+Fix MAU cache invalidation due to missing yield

--- a/synapse/storage/monthly_active_users.py
+++ b/synapse/storage/monthly_active_users.py
@@ -147,6 +147,7 @@ class MonthlyActiveUsersStore(SQLBaseStore):
             return count
         return self.runInteraction("count_users", _count_users)
 
+    @defer.inlineCallbacks
     def upsert_monthly_active_user(self, user_id):
         """
             Updates or inserts monthly active user member
@@ -155,7 +156,7 @@ class MonthlyActiveUsersStore(SQLBaseStore):
             Deferred[bool]: True if a new entry was created, False if an
                 existing one was updated.
         """
-        is_insert = self._simple_upsert(
+        is_insert = yield self._simple_upsert(
             desc="upsert_monthly_active_user",
             table="monthly_active_users",
             keyvalues={


### PR DESCRIPTION
Also, we forgot to add a `tests/server_notices/__init__.py` and so the tests don't get run