### PR TITLE
Fix bug where we broke sync when using limit_usage_by_mau

### DIFF
--- a/changelog.d/3753.bugfix
+++ b/changelog.d/3753.bugfix
@@ -1,0 +1,1 @@
+Fix bug where we broke sync when using limit_usage_by_mau but hadn't configured server notices

--- a/synapse/server_notices/resource_limits_server_notices.py
+++ b/synapse/server_notices/resource_limits_server_notices.py
@@ -66,6 +66,10 @@ class ResourceLimitsServerNotices(object):
         if self._config.limit_usage_by_mau is False:
             return
 
+        if not self._server_notices_manager.is_enabled():
+            # Don't try and send server notices unles they've been enabled
+            return
+
         timestamp = yield self._store.user_last_seen_monthly_active(user_id)
         if timestamp is None:
             # This user will be blocked from receiving the notice anyway.


### PR DESCRIPTION
We assumed that we always had service notices configured, but that is
not always true