### PR TITLE
Fix up tagging server notice rooms.

### DIFF
--- a/changelog.d/3755.bugfix
+++ b/changelog.d/3755.bugfix
@@ -1,0 +1,1 @@
+Fix tagging of server notice rooms

--- a/synapse/server_notices/resource_limits_server_notices.py
+++ b/synapse/server_notices/resource_limits_server_notices.py
@@ -46,6 +46,8 @@ class ResourceLimitsServerNotices(object):
         self._message_handler = hs.get_message_handler()
         self._state = hs.get_state_handler()
 
+        self._notifier = hs.get_notifier()
+
     @defer.inlineCallbacks
     def maybe_send_server_notice_to_user(self, user_id):
         """Check if we need to send a notice to this user, this will be true in
@@ -152,8 +154,11 @@ class ResourceLimitsServerNotices(object):
                 # tag already present, nothing to do here
                 need_to_set_tag = False
         if need_to_set_tag:
-            yield self._store.add_tag_to_room(
+            max_id = yield self._store.add_tag_to_room(
                 user_id, room_id, SERVER_NOTICE_ROOM_TAG, {}
+            )
+            self._notifier.on_new_event(
+                "account_data_key", max_id, users=[user_id]
             )
 
     @defer.inlineCallbacks

--- a/synapse/server_notices/resource_limits_server_notices.py
+++ b/synapse/server_notices/resource_limits_server_notices.py
@@ -153,7 +153,7 @@ class ResourceLimitsServerNotices(object):
                 need_to_set_tag = False
         if need_to_set_tag:
             yield self._store.add_tag_to_room(
-                user_id, room_id, SERVER_NOTICE_ROOM_TAG, None
+                user_id, room_id, SERVER_NOTICE_ROOM_TAG, {}
             )
 
     @defer.inlineCallbacks

--- a/synapse/server_notices/server_notices_manager.py
+++ b/synapse/server_notices/server_notices_manager.py
@@ -39,6 +39,8 @@ class ServerNoticesManager(object):
         self._event_creation_handler = hs.get_event_creation_handler()
         self._is_mine_id = hs.is_mine_id
 
+        self._notifier = hs.get_notifier()
+
     def is_enabled(self):
         """Checks if server notices are enabled on this server.
 
@@ -153,8 +155,12 @@ class ServerNoticesManager(object):
             creator_join_profile=join_profile,
         )
         room_id = info['room_id']
-        yield self._store.add_tag_to_room(
+
+        max_id = yield self._store.add_tag_to_room(
             user_id, room_id, SERVER_NOTICE_ROOM_TAG, {},
+        )
+        self._notifier.on_new_event(
+            "account_data_key", max_id, users=[user_id]
         )
 
         logger.info("Created server notices room %s for %s", room_id, user_id)

--- a/synapse/server_notices/server_notices_manager.py
+++ b/synapse/server_notices/server_notices_manager.py
@@ -154,7 +154,7 @@ class ServerNoticesManager(object):
         )
         room_id = info['room_id']
         yield self._store.add_tag_to_room(
-            user_id, room_id, SERVER_NOTICE_ROOM_TAG, None
+            user_id, room_id, SERVER_NOTICE_ROOM_TAG, {},
         )
 
         logger.info("Created server notices room %s for %s", room_id, user_id)


### PR DESCRIPTION
1. Set the tag contents to be an empty object, rather than null, as older riot clients are unhappy.
2. Ensure that we call the notifier after setting tags, as otherwise we won't wake up the sync stream