### PR TITLE
fix #3445 - do not use itervalues() on SortedDict()

### DIFF
--- a/changelog.d/3445.bugfix
+++ b/changelog.d/3445.bugfix
@@ -1,1 +1,0 @@
-do not use six.itervalues() on SortedDict()

--- a/changelog.d/3445.bugfix
+++ b/changelog.d/3445.bugfix
@@ -1,0 +1,1 @@
+do not use six.itervalues() on SortedDict()

--- a/changelog.d/3768.bugfix
+++ b/changelog.d/3768.bugfix
@@ -1,0 +1,1 @@
+Fix bug in sending presence over federation

--- a/synapse/federation/send_queue.py
+++ b/synapse/federation/send_queue.py
@@ -32,7 +32,7 @@ Events are replicated via a separate events stream.
 import logging
 from collections import namedtuple
 
-from six import iteritems, itervalues
+from six import iteritems
 
 from sortedcontainers import SortedDict
 
@@ -117,7 +117,7 @@ class FederationRemoteSendQueue(object):
 
             user_ids = set(
                 user_id
-                for uids in itervalues(self.presence_changed)
+                for uids in self.presence_changed.values()
                 for user_id in uids
             )
 


### PR DESCRIPTION
itervalues(d) calls d.itervalues() [PY2] and d.values() [PY3]
but SortedDict only implements d.values()

Signed-Off-by: Matthias Kesler <krombel@krombel.de>