### PR TITLE
remove synctl from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,5 @@ Dockerfile
 .gitignore
 demo/etc
 tox.ini
-synctl
 .git/*
 .tox/*

--- a/changelog.d/3802.misc
+++ b/changelog.d/3802.misc
@@ -1,0 +1,1 @@
+Unignore synctl in .dockerignore to fix docker builds


### PR DESCRIPTION
We can't build the docker images without synctl currently, so this unignores synctl again.