### PR TITLE
Only start postgres instance for postgres tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ before_script:
   - git remote set-branches --add origin develop
   - git fetch origin develop
 
-services:
-  - postgresql
-
 matrix:
   fast_finish: true
   include:
@@ -25,6 +22,8 @@ matrix:
 
   - python: 2.7
     env: TOX_ENV=py27-postgres TRIAL_FLAGS="-j 4"
+    services:
+      - postgresql
 
   - python: 3.6
     env: TOX_ENV=py36

--- a/changelog.d/3806.misc
+++ b/changelog.d/3806.misc
@@ -1,0 +1,1 @@
+Only start postgres instance for postgres tests on Travis CI


### PR DESCRIPTION
This should cut the time it takes to run each job by a few seconds