### PR TITLE
Send existing room tags down sync on join

### DIFF
--- a/changelog.d/3810.bugfix
+++ b/changelog.d/3810.bugfix
@@ -1,0 +1,1 @@
+Fix existing room tags not coming down sync when joining a room

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1575,6 +1575,14 @@ class SyncHandler(object):
             newly_joined_room=newly_joined,
         )
 
+        # When we join the room (or the client requests full_state), we should
+        # send down any existing tags. Usually the user won't have tags in a
+        # newly joined room, unless either a) they've joined before or b) the
+        # tag was added by synapse e.g. for server notice rooms.
+        if full_state:
+            user_id = sync_result_builder.sync_config.user.to_string()
+            tags = yield self.store.get_tags_for_room(user_id, room_id)
+
         account_data_events = []
         if tags is not None:
             account_data_events.append({

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1583,6 +1583,11 @@ class SyncHandler(object):
             user_id = sync_result_builder.sync_config.user.to_string()
             tags = yield self.store.get_tags_for_room(user_id, room_id)
 
+            # If there aren't any tags, don't send the empty tags list down
+            # sync
+            if not tags:
+                tags = None
+
         account_data_events = []
         if tags is not None:
             account_data_events.append({


### PR DESCRIPTION
When a user joined a room any existing tags were not sent down the sync
stream. Ordinarily this isn't a problem because the user needs to be in
the room to have set tags in it, however synapse will sometimes add tags
for a user to a room, e.g. for server notices, which need to come down
sync.

c.c. @neilisfragile 