### PR TITLE
Remove build requirements after building docker image

### DIFF
--- a/changelog.d/3834.misc
+++ b/changelog.d/3834.misc
@@ -1,0 +1,1 @@
+Improved Dockerfile to remove build requirements after building reducing the image size.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,9 @@ RUN cd /synapse \
  && rm -rf \
         setup.cfg \
         setup.py \
-        synapse
-
+        synapse \
+ && apk del .nacl_deps
+ 
 VOLUME ["/data"]
 
 EXPOSE 8008/tcp 8448/tcp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/python:2-alpine3.8
 
 COPY . /synapse
 
-RUN apk add --no-cache --virtual .nacl_deps \
+RUN apk add --no-cache --virtual .build_deps \
         build-base \
         libffi-dev \
         libjpeg-turbo-dev \
@@ -10,11 +10,16 @@ RUN apk add --no-cache --virtual .nacl_deps \
         libxslt-dev \
         linux-headers \
         postgresql-dev \
-        su-exec \
         zlib-dev \
-   
-# A wheel cache may be provided in ./cache for faster build
  && cd /synapse \
+ && apk add --no-cache --virtual .runtime_deps \
+ 	libffi \
+        libjpeg-turbo \
+	libressl \
+	libxslt \
+	libpq \
+	zlib \
+	su-exec \
  && pip install --upgrade \
         lxml \
         pip \
@@ -27,7 +32,7 @@ RUN apk add --no-cache --virtual .nacl_deps \
         setup.cfg \
         setup.py \
         synapse \
- && apk del .nacl_deps
+ && apk del .build_deps
  
 VOLUME ["/data"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker.io/python:2-alpine3.8
 
+COPY . /synapse
+
 RUN apk add --no-cache --virtual .nacl_deps \
         build-base \
         libffi-dev \
@@ -9,12 +11,10 @@ RUN apk add --no-cache --virtual .nacl_deps \
         linux-headers \
         postgresql-dev \
         su-exec \
-        zlib-dev
-
-COPY . /synapse
-
+        zlib-dev \
+   
 # A wheel cache may be provided in ./cache for faster build
-RUN cd /synapse \
+ && cd /synapse \
  && pip install --upgrade \
         lxml \
         pip \


### PR DESCRIPTION
This should reduce the size of the image.
Note that I did test this and the container builds and runs successfully, but I haven't tested it with postgresql.

Signed-off-by: Mathijs van Gorcum <mvgorcum@gmail.com>