### PR TITLE
Timeout reading body for outbound HTTP requests

### DIFF
--- a/changelog.d/3845.bugfix
+++ b/changelog.d/3845.bugfix
@@ -1,0 +1,1 @@
+Fix outbound requests occasionally wedging, which can result in federation breaking between servers.


### PR DESCRIPTION
This is a fairly hacky PR to try and ensure that these deferreds don't get completely wedged for eternity.

May or may not be related to #3842