### PR TITLE
Log outbound requests when we retry

### DIFF
--- a/changelog.d/3853.misc
+++ b/changelog.d/3853.misc
@@ -1,0 +1,1 @@
+Log when we retry outbound requests


### PR DESCRIPTION
Currently we log just once even if we're retrying a bunch of times