### PR TITLE
Make purge history slightly faster

### DIFF
--- a/changelog.d/3856.misc
+++ b/changelog.d/3856.misc
@@ -1,0 +1,1 @@
+Speed up purge history for rooms that have been previously purged

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -1953,7 +1953,6 @@ class EventsStore(EventFederationStore, EventsWorkerStore, BackgroundUpdateStore
             " ON events_to_purge(event_id)",
         )
 
-
         txn.execute(
             "SELECT event_id, should_delete FROM events_to_purge"
         )

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -1916,6 +1916,8 @@ class EventsStore(EventFederationStore, EventsWorkerStore, BackgroundUpdateStore
         should_delete_params = ()
         if not delete_local_events:
             should_delete_expr += " AND event_id NOT LIKE ?"
+
+            # We include the parameter twice since we use the expression twice
             should_delete_params += (
                 "%:" + self.hs.hostname,
                 "%:" + self.hs.hostname,

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -1890,20 +1890,6 @@ class EventsStore(EventFederationStore, EventsWorkerStore, BackgroundUpdateStore
             ")"
         )
 
-        # create an index on should_delete because later we'll be looking for
-        # the should_delete / shouldn't_delete subsets
-        txn.execute(
-            "CREATE INDEX events_to_purge_should_delete"
-            " ON events_to_purge(should_delete)",
-        )
-
-        # We do joins against events_to_purge for e.g. calculating state
-        # groups to purge, etc., so lets make an index.
-        txn.execute(
-            "CREATE INDEX events_to_purge_id"
-            " ON events_to_purge(event_id)",
-        )
-
         # First ensure that we're not about to delete all the forward extremeties
         txn.execute(
             "SELECT e.event_id, e.depth FROM events as e "
@@ -1950,6 +1936,24 @@ class EventsStore(EventFederationStore, EventsWorkerStore, BackgroundUpdateStore
             ),
             should_delete_params,
         )
+
+        # We create the indices *after* insertion as that's a lot faster.
+
+        # create an index on should_delete because later we'll be looking for
+        # the should_delete / shouldn't_delete subsets
+        txn.execute(
+            "CREATE INDEX events_to_purge_should_delete"
+            " ON events_to_purge(should_delete)",
+        )
+
+        # We do joins against events_to_purge for e.g. calculating state
+        # groups to purge, etc., so lets make an index.
+        txn.execute(
+            "CREATE INDEX events_to_purge_id"
+            " ON events_to_purge(event_id)",
+        )
+
+
         txn.execute(
             "SELECT event_id, should_delete FROM events_to_purge"
         )


### PR DESCRIPTION
Don't pull out events that are outliers and won't be deleted, as nothing
should happen to them.

The only things we really do for events that aren't going to be deleted are to mark them as outliers (since outlier events don't have state groups.)