### PR TITLE
Fix handling of redacted events from federation

### DIFF
--- a/changelog.d/3859.bugfix
+++ b/changelog.d/3859.bugfix
@@ -1,0 +1,1 @@
+Fix handling of redacted events from federation

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
+
 from synapse.util.caches import intern_dict
 from synapse.util.frozenutils import freeze
 
@@ -146,6 +148,9 @@ class EventBase(object):
 
     def items(self):
         return list(self._event_dict.items())
+
+    def keys(self):
+        return six.iterkeys(self._event_dict)
 
 
 class FrozenEvent(EventBase):

--- a/synapse/federation/federation_base.py
+++ b/synapse/federation/federation_base.py
@@ -153,7 +153,7 @@ class FederationBase(object):
                     # *actual* redacted copy to be on the safe side.)
                     redacted_event = prune_event(pdu)
                     if (
-                        set(six.iterkeys(redacted_event)) == set(six.iterkeys(pdu)) and
+                        set(redacted_event.keys()) == set(pdu.keys()) and
                         set(six.iterkeys(redacted_event.content))
                             == set(six.iterkeys(pdu.content))
                     ):


### PR DESCRIPTION
If we receive an event that doesn't pass their content hash check (e.g.
due to already being redacted) then we hit a bug which causes an
exception to be raised, which then promplty stops the event (and
request) from being processed.

This effects all sorts of federation APIs, including joining rooms with
a redacted state event.