### PR TITLE
don't filter membership events based on history visibility

### DIFF
--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -269,6 +269,7 @@ class PaginationHandler(object):
 
             if state_ids:
                 state = yield self.store.get_events(list(state_ids.values()))
+                state = state.values()
 
         time_now = self.clock.time_msec()
 

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -270,14 +270,6 @@ class PaginationHandler(object):
             if state_ids:
                 state = yield self.store.get_events(list(state_ids.values()))
 
-            if state:
-                state = yield filter_events_for_client(
-                    self.store,
-                    user_id,
-                    state.values(),
-                    is_peeking=(member_event_id is None),
-                )
-
         time_now = self.clock.time_msec()
 
         chunk = {


### PR DESCRIPTION
as we will already have filtered the messages in the timeline, and state events
are always visible.

and because @erikjohnston said so.