### PR TITLE
Add variable for changing the max upload size in Docker container

### DIFF
--- a/changelog.d/3883.feature
+++ b/changelog.d/3883.feature
@@ -1,0 +1,1 @@
+Adding the ability to change MAX_UPLOAD_SIZE for the docker container variables.

--- a/docker/README.md
+++ b/docker/README.md
@@ -88,7 +88,7 @@ variables are available for configuration:
 * ``SYNAPSE_TURN_URIS``, set this variable to the coma-separated list of TURN
   uris to enable TURN for this homeserver.
 * ``SYNAPSE_TURN_SECRET``, set this to the TURN shared secret if required.
-* ``SYNAPSE_MAX_UPLOAD_SIZE``, the max upload size [default `10M`].
+* ``SYNAPSE_MAX_UPLOAD_SIZE``, set this variable to change the max upload size [default `10M`].
 
 Shared secrets, that will be initialized to random values if not set:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -88,6 +88,7 @@ variables are available for configuration:
 * ``SYNAPSE_TURN_URIS``, set this variable to the coma-separated list of TURN
   uris to enable TURN for this homeserver.
 * ``SYNAPSE_TURN_SECRET``, set this to the TURN shared secret if required.
+* ``SYNAPSE_MAX_UPLOAD_SIZE``, the max upload size [default `10M`].
 
 Shared secrets, that will be initialized to random values if not set:
 

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -85,7 +85,7 @@ federation_rc_concurrent: 3
 
 media_store_path: "/data/media"
 uploads_path: "/data/uploads"
-max_upload_size: "10M"
+max_upload_size: "{{ SYNAPSE_MAX_UPLOAD_SIZE or "10M" }}"
 max_image_pixels: "32M"
 dynamic_thumbnails: false
 


### PR DESCRIPTION
This will resolve #3869 

Adding the ability to change MAX_UPLOAD_SIZE for the docker container variables.

Signed-off-by: Simon Dwyer <simon@thedwyers.co>