### PR TITLE
Use directory server for room joins

### DIFF
--- a/changelog.d/3899.bugfix
+++ b/changelog.d/3899.bugfix
@@ -1,0 +1,1 @@
+When we join a room, always try the server we used for the alias lookup first.

--- a/changelog.d/3899.bugfix
+++ b/changelog.d/3899.bugfix
@@ -1,1 +1,1 @@
-When we join a room, always try the server we used for the alias lookup first.
+When we join a room, always try the server we used for the alias lookup first, to avoid unresponsive and out-of-date servers.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -583,6 +583,11 @@ class RoomMemberHandler(object):
         room_id = mapping["room_id"]
         servers = mapping["servers"]
 
+        # put the server which owns the alias at the front of the server list.
+        if room_alias.domain in servers:
+            servers.remove(room_alias.domain)
+        servers.insert(0, room_alias.domain)
+
         defer.returnValue((RoomID.from_string(room_id), servers))
 
     @defer.inlineCallbacks


### PR DESCRIPTION
When we do a join, always try the server we used for the alias lookup first.

Fixes #2418