### PR TITLE
Allow m.room.summary and m.room.encryption state events on invites

### DIFF
--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -70,6 +70,8 @@ class EventTypes(object):
     RoomHistoryVisibility = "m.room.history_visibility"
     CanonicalAlias = "m.room.canonical_alias"
     RoomAvatar = "m.room.avatar"
+    RoomSummary = "m.room.summary"
+    RoomEncryption = "m.room.encryption"
     GuestAccess = "m.room.guest_access"
 
     # These are used for validation

--- a/synapse/config/api.py
+++ b/synapse/config/api.py
@@ -24,6 +24,8 @@ class ApiConfig(Config):
             EventTypes.JoinRules,
             EventTypes.CanonicalAlias,
             EventTypes.RoomAvatar,
+            EventTypes.RoomSummary,
+            EventTypes.RoomEncryption,
             EventTypes.Name,
         ])
 
@@ -36,5 +38,7 @@ class ApiConfig(Config):
             - "{JoinRules}"
             - "{CanonicalAlias}"
             - "{RoomAvatar}"
+            - "{RoomSummary}"
+            - "{RoomEncryption}"
             - "{Name}"
         """.format(**vars(EventTypes))

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -314,7 +314,7 @@ class RoomListHandler(BaseHandler):
                 EventTypes.CanonicalAlias,
                 EventTypes.RoomHistoryVisibility,
                 EventTypes.GuestAccess,
-                "m.room.avatar",
+                EventTypes.RoomAvatar,
             )
         ])
 
@@ -367,7 +367,7 @@ class RoomListHandler(BaseHandler):
             guest = guest_event.content.get("guest_access", None)
         result["guest_can_join"] = guest == "can_join"
 
-        avatar_event = current_state.get(("m.room.avatar", ""))
+        avatar_event = current_state.get((EventTypes.RoomAvatar, ""))
         if avatar_event:
             avatar_url = avatar_event.content.get("url", None)
             if avatar_url:


### PR DESCRIPTION
to provide better UX for clients receiving invites, so they can show a padlock icon or correct avatars on the inbound invite.