### PR TITLE
admin api fallback for compare_digest for python < 2.7.7

### DIFF
--- a/synapse/rest/client/v1/admin.py
+++ b/synapse/rest/client/v1/admin.py
@@ -44,6 +44,7 @@ else:
     def compare_digest(a, b):
         return a == b
 
+
 class UsersRestServlet(ClientV1RestServlet):
     PATTERNS = client_path_patterns("/admin/users/(?P<user_id>[^/]*)")
 

--- a/synapse/rest/client/v1/admin.py
+++ b/synapse/rest/client/v1/admin.py
@@ -37,6 +37,12 @@ from .base import ClientV1RestServlet, client_path_patterns
 
 logger = logging.getLogger(__name__)
 
+# use hmac.compare_digest if we have it (python 2.7.7), else just use equality
+if hasattr(hmac, "compare_digest"):
+    compare_digest = hmac.compare_digest
+else:
+    def compare_digest(a, b):
+        return a == b
 
 class UsersRestServlet(ClientV1RestServlet):
     PATTERNS = client_path_patterns("/admin/users/(?P<user_id>[^/]*)")
@@ -173,7 +179,7 @@ class UserRegisterServlet(ClientV1RestServlet):
         want_mac.update(b"admin" if admin else b"notadmin")
         want_mac = want_mac.hexdigest()
 
-        if not hmac.compare_digest(
+        if not compare_digest(
                 want_mac.encode('ascii'),
                 got_mac.encode('ascii')
         ):


### PR DESCRIPTION
Right now the admin api fails running on python < 2.7.7 as `compare_digest(a, b)` is new in 2.7.7.
This adds the same fallback as used elsewhere to make it work.

Trying to fix this to make our e2e run again on python 2.7.6 (CI server) after making use of the admin register api.