### PR TITLE
Set SNI to the server_name, not whatever was in the SRV record

### DIFF
--- a/changelog.d/3907.bugfix
+++ b/changelog.d/3907.bugfix
@@ -1,0 +1,1 @@
+Fix incorrect server-name indication for outgoing federation requests


### PR DESCRIPTION
Fixes #3843