### PR TITLE
Fix matrixfederationclient.py logging: Destination is a string

### DIFF
--- a/changelog.d/3909.misc
+++ b/changelog.d/3909.misc
@@ -1,0 +1,1 @@
+Fix log format error in matrixfederationclient.py

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -150,14 +150,14 @@ def _handle_json_response(reactor, timeout_sec, request, response):
         body = yield make_deferred_yieldable(d)
     except Exception as e:
         logger.warn(
-            "{%s} [%d] Error reading response: %s",
+            "{%s} [%s] Error reading response: %s",
             request.txn_id,
             request.destination,
             e,
         )
         raise
     logger.info(
-        "{%s} [%d] Completed: %d %s",
+        "{%s} [%s] Completed: %d %s",
         request.txn_id,
         request.destination,
         response.code,
@@ -707,14 +707,14 @@ class MatrixFederationHttpClient(object):
             length = yield make_deferred_yieldable(d)
         except Exception as e:
             logger.warn(
-                "{%s} [%d] Error reading response: %s",
+                "{%s} [%s] Error reading response: %s",
                 request.txn_id,
                 request.destination,
                 e,
             )
             raise
         logger.info(
-            "{%s} [%d] Completed: %d %s [%d bytes]",
+            "{%s} [%s] Completed: %d %s [%d bytes]",
             request.txn_id,
             request.destination,
             response.code,


### PR DESCRIPTION
Fixes:
```
homeserver_1 - 2018-09-18 21:23:03,084 - twisted - 243 - ERROR - PUT-466 - Traceback (most recent call last):
homeserver_1 - 2018-09-18 21:23:03,084 - twisted - 243 - ERROR - PUT-466 -   File "/usr/lib/python2.7/logging/handlers.py", line 76, in emit
homeserver_1 - 2018-09-18 21:23:03,085 - twisted - 243 - ERROR - PUT-466 -     if self.shouldRollover(record):
homeserver_1 - 2018-09-18 21:23:03,086 - twisted - 243 - ERROR - PUT-466 -   File "/usr/lib/python2.7/logging/handlers.py", line 156, in shouldRollover
homeserver_1 - 2018-09-18 21:23:03,087 - twisted - 243 - ERROR - PUT-466 -     msg = "%s\n" % self.format(record)
homeserver_1 - 2018-09-18 21:23:03,088 - twisted - 243 - ERROR - PUT-466 -   File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
homeserver_1 - 2018-09-18 21:23:03,088 - twisted - 243 - ERROR - PUT-466 -     return fmt.format(record)
homeserver_1 - 2018-09-18 21:23:03,089 - twisted - 243 - ERROR - PUT-466 -   File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
homeserver_1 - 2018-09-18 21:23:03,090 - twisted - 243 - ERROR - PUT-466 -     record.message = record.getMessage()
homeserver_1 - 2018-09-18 21:23:03,090 - twisted - 243 - ERROR - PUT-466 -   File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
homeserver_1 - 2018-09-18 21:23:03,091 - twisted - 243 - ERROR - PUT-466 -     msg = msg % self.args
homeserver_1 - 2018-09-18 21:23:03,092 - twisted - 243 - ERROR - PUT-466 - TypeError: %d format: a number is required, not unicode
homeserver_1 - 2018-09-18 21:23:03,092 - twisted - 243 - ERROR - PUT-466 - Logged from file matrixfederationclient.py, line 164
homeserver_1 - 2018-09-18 21:23:03,093 - twisted - 243 - ERROR - PUT-466 - Traceback (most recent call last):
homeserver_1 - 2018-09-18 21:23:03,094 - twisted - 243 - ERROR - PUT-466 -   File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
homeserver_1 - 2018-09-18 21:23:03,095 - twisted - 243 - ERROR - PUT-466 -     msg = self.format(record)
homeserver_1 - 2018-09-18 21:23:03,095 - twisted - 243 - ERROR - PUT-466 -   File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
homeserver_1 - 2018-09-18 21:23:03,096 - twisted - 243 - ERROR - PUT-466 -     return fmt.format(record)
homeserver_1 - 2018-09-18 21:23:03,096 - twisted - 243 - ERROR - PUT-466 -   File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
homeserver_1 - 2018-09-18 21:23:03,097 - twisted - 243 - ERROR - PUT-466 -     record.message = record.getMessage()
homeserver_1 - 2018-09-18 21:23:03,098 - twisted - 243 - ERROR - PUT-466 -   File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
homeserver_1 - 2018-09-18 21:23:03,098 - twisted - 243 - ERROR - PUT-466 -     msg = msg % self.args
homeserver_1 - 2018-09-18 21:23:03,099 - twisted - 243 - ERROR - PUT-466 - TypeError: %d format: a number is required, not unicode
homeserver_1 - 2018-09-18 21:23:03,099 - twisted - 243 - ERROR - PUT-466 - Logged from file matrixfederationclient.py, line 164
```

Introduced by https://github.com/matrix-org/synapse/pull/3906