### PR TITLE
Remove get_destination_retry_timings cache

### DIFF
--- a/changelog.d/3914.bugfix
+++ b/changelog.d/3914.bugfix
@@ -1,1 +1,1 @@
-Fix bug where outboud federation would stop talking to some servers when using workers
+Fix bug where outbound federation would stop talking to some servers when using workers

--- a/changelog.d/3914.bugfix
+++ b/changelog.d/3914.bugfix
@@ -1,0 +1,1 @@
+Fix bug where outboud federation would stop talking to some servers when using workers

--- a/synapse/storage/transactions.py
+++ b/synapse/storage/transactions.py
@@ -196,8 +196,6 @@ class TransactionStore(SQLBaseStore):
             retry_interval (int) - how long until next retry in ms
         """
 
-        # XXX: we could chose to not bother persisting this if our cache thinks
-        # this is a NOOP
         return self.runInteraction(
             "set_destination_retry_timings",
             self._set_destination_retry_timings,

--- a/synapse/storage/transactions.py
+++ b/synapse/storage/transactions.py
@@ -23,7 +23,6 @@ from canonicaljson import encode_canonical_json
 from twisted.internet import defer
 
 from synapse.metrics.background_process_metrics import run_as_background_process
-from synapse.util.caches.descriptors import cached
 
 from ._base import SQLBaseStore, db_to_json
 

--- a/synapse/storage/transactions.py
+++ b/synapse/storage/transactions.py
@@ -156,7 +156,6 @@ class TransactionStore(SQLBaseStore):
         """
         pass
 
-    @cached(max_entries=10000)
     def get_destination_retry_timings(self, destination):
         """Gets the current retry timings (if any) for a given destination.
 
@@ -211,10 +210,6 @@ class TransactionStore(SQLBaseStore):
     def _set_destination_retry_timings(self, txn, destination,
                                        retry_last_ts, retry_interval):
         self.database_engine.lock_table(txn, "destinations")
-
-        self._invalidate_cache_and_stream(
-            txn, self.get_destination_retry_timings, (destination,)
-        )
 
         # We need to be careful here as the data may have changed from under us
         # due to a worker setting the timings.


### PR DESCRIPTION
Currently we rely on the master to invalidate this cache promptly.
However, after having moved most federation endpoints off of master this
no longer happens, causing outbound fedeariont to get blackholed.

Fixes #3798