### PR TITLE
Fix spurious exceptions when client closes conncetion

### DIFF
--- a/changelog.d/3925.misc
+++ b/changelog.d/3925.misc
@@ -1,0 +1,1 @@
+Fix spurious exceptions when remote http client closes conncetion


### PR DESCRIPTION
If a HTTP handler throws an exception while processing a request we
automatically write a JSON error response. If the handler had already
started writing a response twisted throws an exception.

We should check for this case and simple abort the connection if there
was an error after the response had started being written.