### PR TITLE
only try to LL members after a non-gappy incr sync if the timeline has events

### DIFF
--- a/changelog.d/3936.bugfix
+++ b/changelog.d/3936.bugfix
@@ -1,0 +1,1 @@
+Fix out-of-bounds error when LLing yourself

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -794,7 +794,7 @@ class SyncHandler(object):
             else:
                 state_ids = {}
                 if lazy_load_members:
-                    if types:
+                    if types and batch.events:
                         # We're returning an incremental sync, with no
                         # "gap" since the previous sync, so normally there would be
                         # no state to return.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -713,10 +713,6 @@ class SyncHandler(object):
                     )
                 ]
 
-                # always make sure we LL ourselves so we know we're in the room
-                # (if we are), to fix https://github.com/vector-im/riot-web/issues/7209
-                types.append((EventTypes.Member, sync_config.user.to_string()))
-
                 # only apply the filtering to room members
                 filtered_types = [EventTypes.Member]
 
@@ -726,6 +722,13 @@ class SyncHandler(object):
             }
 
             if full_state:
+                if lazy_load_members:
+                    # always make sure we LL ourselves so we know we're in the room
+                    # (if we are) to fix https://github.com/vector-im/riot-web/issues/7209
+                    # We only need apply this on full state syncs given we disabled
+                    # LL for incr syncs in #3840.
+                    types.append((EventTypes.Member, sync_config.user.to_string()))
+
                 if batch:
                     current_state_ids = yield self.store.get_state_ids_for_event(
                         batch.events[-1].event_id, types=types,


### PR DESCRIPTION
This was okay until we started to try to LL ourselves, which would then cause
us to try to add LL members even if the timeline was empty.  This caused an
out of bounds exception