### PR TITLE
Fix compatibility issue with older Twisted in tests

### DIFF
--- a/tests/http/test_fedclient.py
+++ b/tests/http/test_fedclient.py
@@ -54,7 +54,7 @@ class FederationClientTests(HomeserverTestCase):
     def test_client_never_connect(self):
         """
         If the HTTP request is not connected and is timed out, it'll give a
-        ConnectingCancelledError.
+        ConnectingCancelledError or TimeoutError.
         """
         d = self.cl.get_json("testserv:8008", "foo/bar", timeout=10000)
 
@@ -76,7 +76,7 @@ class FederationClientTests(HomeserverTestCase):
         self.reactor.advance(10.5)
         f = self.failureResultOf(d)
 
-        self.assertIsInstance(f.value, ConnectingCancelledError)
+        self.assertIsInstance(f.value, (ConnectingCancelledError, TimeoutError))
 
     def test_client_connect_no_response(self):
         """


### PR DESCRIPTION
Older Twisted (18.4.0) returns `TimeoutError` instead of `ConnectingCancelledError` when connection times out.
This change allows tests to be compatible with this behaviour.