### PR TITLE
Build and push docker image to hub automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     steps:
       - checkout
       - run: docker build -f docker/Dockerfile -t matrixdotorg/synapse:$CIRCLE_TAG .
-      - run: docker login --username matrixdotorg --password $DOCKER_HUB_PASSWORD
+      - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
       - run: docker push
   sytestpy2:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,21 @@
 version: 2
 jobs:
-  dockerhubupload:
+  dockerhubuploadrelease:
     machine: true
     steps:
       - checkout
       - run: docker build -f docker/Dockerfile -t matrixdotorg/synapse:$CIRCLE_TAG .
       - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
-      - run: docker push
+      - run: docker push matrixdotorg/synapse:$CIRCLE_TAG
+  dockerhubuploadlatest:
+    machine: true
+    steps:
+      - checkout
+      - run: docker build -f docker/Dockerfile -t matrixdotorg/synapse:$CIRCLE_SHA1 .
+      - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
+      - run: docker tag matrixdotorg/synapse:$CIRCLE_SHA1 matrixdotorg/synapse:latest
+      - run: docker push matrixdotorg/synapse:$CIRCLE_SHA1
+      - run: docker push matrixdotorg/synapse:latest
   sytestpy2:
     machine: true
     steps:
@@ -138,9 +147,13 @@ workflows:
           filters:
             branches:
               ignore: /develop|master|release-.*/
-      - dockerhubupload:
+      - dockerhubuploadrelease:
           filters:
             tags:
               only: /^v[0-9].[0-9]+.[0-9]+(.[0-9]+)?/
             branches:
               ignore: /.*/
+      - dockerhubuploadlatest:
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ workflows:
           filters:
             branches:
               ignore: /develop|master|release-.*/
-      - dockerhub:
+      - dockerhubupload:
           filters:
             tags:
               only: /v[0-9].[0-9]+.[0-9]+(.[0-9]+)?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,12 @@
 version: 2
 jobs:
+  dockerhubupload:
+    machine: true
+    steps:
+      - checkout
+      - run: docker build -f docker/Dockerfile -t matrixdotorg/synapse:$CIRCLE_TAG .
+      - run: docker login --username matrixdotorg --password $DOCKER_HUB_PASSWORD
+      - run: docker push
   sytestpy2:
     machine: true
     steps:
@@ -131,3 +138,7 @@ workflows:
           filters:
             branches:
               ignore: /develop|master|release-.*/
+      - dockerhub:
+          filters:
+            tags:
+              only: /v[0-9].[0-9]+.[0-9]+(.[0-9]+)?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,4 +141,6 @@ workflows:
       - dockerhubupload:
           filters:
             tags:
-              only: /v[0-9].[0-9]+.[0-9]+(.[0-9]+)?/
+              only: /^v[0-9].[0-9]+.[0-9]+(.[0-9]+)?/
+            branches:
+              ignore: /.*/

--- a/changelog.d/3946.misc
+++ b/changelog.d/3946.misc
@@ -1,0 +1,1 @@
+Automate pushes to docker hub


### PR DESCRIPTION
Automate pushing docker images.

Questions - do we want to build any other tags? Is that regex good enough for tags we want to build or do we have a more precise naming scheme. I was hesitant to just look for all tags starting "v" in case we tag something "very_broken_build". 