### PR TITLE
Run notify_app_services as a bg process

### DIFF
--- a/changelog.d/3965.misc
+++ b/changelog.d/3965.misc
@@ -1,0 +1,1 @@
+Run notify_app_services as a bg process


### PR DESCRIPTION
This ensures that its resource usage metrics get recorded somewhere rather
than getting lost.

(It also fixes an error when called from a nested logging context which
completes before the bg process)