### PR TITLE
Clarifications in FederationHandler

### DIFF
--- a/changelog.d/3967.misc
+++ b/changelog.d/3967.misc
@@ -1,0 +1,1 @@
+Clarifications in FederationHandler

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -209,8 +209,6 @@ class FederationClient(FederationBase):
         Will attempt to get the PDU from each destination in the list until
         one succeeds.
 
-        This will persist the PDU locally upon receipt.
-
         Args:
             destinations (list): Which home servers to query
             event_id (str): event to fetch

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -341,10 +341,9 @@ class FederationHandler(BaseHandler):
                         )
 
                         with logcontext.nested_logging_context(p):
-                            # XXX if any of the missing prevs share missing state or auth
-                            # events, we'll end up requesting those missing events for
-                            # *each* missing prev, contributing to the hammering of /event
-                            # as per https://github.com/matrix-org/synapse/issues/2164.
+                            # note that if any of the missing prevs share missing state or
+                            # auth events, the requests to fetch those events are deduped
+                            # by the get_pdu_cache in federation_client.
                             remote_state, got_auth_chain = (
                                 yield self.federation_client.get_state_for_room(
                                     origin, room_id, p,


### PR DESCRIPTION
* add some comments on things that look a bit bogus
* rename this `state` variable to avoid confusion with the `state` used elsewhere in this function. (There was no actual conflict, but it was a confusing bit of spaghetti.)

~~[builds on #3959]~~