### PR TITLE
Further reduce the size of the docker image

### DIFF
--- a/changelog.d/3972.misc
+++ b/changelog.d/3972.misc
@@ -1,0 +1,1 @@
+Further reduce the docker image size

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,22 +5,9 @@ ARG PYTHON_VERSION=2
 ###
 FROM docker.io/python:${PYTHON_VERSION}-alpine3.8 as builder
 
-# first of all, install the runtime deps; this layer can then be used in the
-# final stage as well.
+# install the OS build deps
 
-RUN apk add --no-cache --virtual .runtime_deps \
-        libffi \
-        libjpeg-turbo \
-        libressl \
-        libxslt \
-        libpq \
-        zlib \
-        su-exec
-
-# install the OS build deps, and build wheels for the python libs which have
-# slow build steps, as more layers which can be cached independently
-
-RUN apk add --no-cache --virtual .build_deps \
+RUN apk add \
         build-base \
         libffi-dev \
         libjpeg-turbo-dev \
@@ -30,18 +17,24 @@ RUN apk add --no-cache --virtual .build_deps \
         postgresql-dev \
         zlib-dev
 
+# build things which have slow build steps, before we copy synapse, so that
+# the layer can be cached.
+#
+# (we really just care about caching a wheel here, as the "pip install" below
+# will install them again.)
+
 RUN pip install --prefix="/install" --no-warn-script-location \
         cryptography \
-        lxml \
         msgpack-python \
         pillow \
-        psycopg2 \
         pynacl
 
 # now install synapse and all of the python deps to /install.
 
 COPY . /synapse
 RUN pip install --prefix="/install" --no-warn-script-location \
+        lxml \
+        psycopg2 \
         /synapse
 
 ###

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,24 @@
 ARG PYTHON_VERSION=2
-FROM docker.io/python:${PYTHON_VERSION}-alpine3.8
 
-COPY . /synapse
+###
+### Stage 0: builder
+###
+FROM docker.io/python:${PYTHON_VERSION}-alpine3.8 as builder
+
+# first of all, install the runtime deps; this layer can then be used in the
+# final stage as well.
+
+RUN apk add --no-cache --virtual .runtime_deps \
+        libffi \
+        libjpeg-turbo \
+        libressl \
+        libxslt \
+        libpq \
+        zlib \
+        su-exec
+
+# install the OS build deps, and build wheels for the python libs which have
+# slow build steps, as more layers which can be cached independently
 
 RUN apk add --no-cache --virtual .build_deps \
         build-base \
@@ -11,27 +28,40 @@ RUN apk add --no-cache --virtual .build_deps \
         libxslt-dev \
         linux-headers \
         postgresql-dev \
-        zlib-dev \
- && cd /synapse \
- && apk add --no-cache --virtual .runtime_deps \
+        zlib-dev
+
+RUN pip install --prefix="/install" --no-warn-script-location \
+        cryptography \
+        lxml \
+        msgpack-python \
+        pillow \
+        psycopg2 \
+        pynacl
+
+# now install synapse and all of the python deps to /install.
+
+COPY . /synapse
+RUN pip install --prefix="/install" --no-warn-script-location \
+        /synapse
+
+###
+### Stage 1: runtime
+###
+
+FROM docker.io/python:${PYTHON_VERSION}-alpine3.8
+
+RUN apk add --no-cache --virtual .runtime_deps \
         libffi \
         libjpeg-turbo \
         libressl \
         libxslt \
         libpq \
         zlib \
-        su-exec \
- && pip install --upgrade \
-        lxml \
-        pip \
-        psycopg2 \
-        setuptools \
- && mkdir -p /synapse/cache \
- && pip install -f /synapse/cache --upgrade --process-dependency-links . \
- && mv /synapse/docker/start.py /synapse/docker/conf / \
- && rm -rf /synapse \
- && rm -rf /root/.cache \
- && apk del .build_deps
+        su-exec
+
+COPY --from=builder /install /usr/local
+COPY ./docker/start.py /start.py
+COPY ./docker/conf /conf
 
 VOLUME ["/data"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,13 +14,13 @@ RUN apk add --no-cache --virtual .build_deps \
         zlib-dev \
  && cd /synapse \
  && apk add --no-cache --virtual .runtime_deps \
- 	libffi \
+        libffi \
         libjpeg-turbo \
-	libressl \
-	libxslt \
-	libpq \
-	zlib \
-	su-exec \
+        libressl \
+        libxslt \
+        libpq \
+        zlib \
+        su-exec \
  && pip install --upgrade \
         lxml \
         pip \
@@ -29,12 +29,10 @@ RUN apk add --no-cache --virtual .build_deps \
  && mkdir -p /synapse/cache \
  && pip install -f /synapse/cache --upgrade --process-dependency-links . \
  && mv /synapse/docker/start.py /synapse/docker/conf / \
- && rm -rf \
-        setup.cfg \
-        setup.py \
-        synapse \
+ && rm -rf /synapse \
+ && rm -rf /root/.cache \
  && apk del .build_deps
- 
+
 VOLUME ["/data"]
 
 EXPOSE 8008/tcp 8448/tcp


### PR DESCRIPTION
* get rid of the pip wheel cache
* get rid of /synapse (everything we need ends up in /usr/local/lib/python2.7/site-packages