### PR TITLE
Remove redundant call to start_get_pdu_cache

### DIFF
--- a/changelog.d/3980.bugfix
+++ b/changelog.d/3980.bugfix
@@ -1,0 +1,1 @@
+Fix some instances of ExpiringCache not expiring cache items

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -386,7 +386,6 @@ def setup(config_options):
         hs.get_pusherpool().start()
         hs.get_datastore().start_profiling()
         hs.get_datastore().start_doing_background_updates()
-        hs.get_federation_client().start_get_pdu_cache()
 
     reactor.callWhenRunning(start)
 


### PR DESCRIPTION
I think this got forgotten in #3932. We were getting away with it because it
was the last call in this function.