### PR TITLE
ISSUE_TEMPLATE.md: Get synapse version

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -39,9 +39,9 @@ those (please be careful to remove any personal or private data). Please surroun
 
 If not matrix.org:
 - **Version**:        What version of Synapse is running? <!-- 
-You can find the Synapse version by inspecting the server headers (replace matrix.org with
+You can find the Synapse version by requesting this page (replace matrix.org with
 your own homeserver domain):
-$ curl -v https://matrix.org/_matrix/client/versions 2>&1 | grep "Server:"
+$ curl https://matrix.org/_matrix/federation/v1/version 2>&1 | grep "version"
 -->
 - **Install method**: package manager/git clone/pip      
 - **Platform**:       Tell us about the environment in which your homeserver is operating


### PR DESCRIPTION
Reading the version from the response http server header does not work when a reverse proxy is used. Use /_matrix/federation/v1/version instead.