### PR TITLE
Fix exception handling in fetching remote profiles

### DIFF
--- a/changelog.d/3997.bugfix
+++ b/changelog.d/3997.bugfix
@@ -1,0 +1,1 @@
+Fix exception handling in fetching remote profiles

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -142,10 +142,8 @@ class BaseProfileHandler(BaseHandler):
                 if e.code != 404:
                     logger.exception("Failed to get displayname")
                 raise
-            except Exception:
-                logger.exception("Failed to get displayname")
-            else:
-                defer.returnValue(result["displayname"])
+
+            defer.returnValue(result["displayname"])
 
     @defer.inlineCallbacks
     def set_displayname(self, target_user, requester, new_displayname, by_admin=False):
@@ -199,8 +197,6 @@ class BaseProfileHandler(BaseHandler):
                 if e.code != 404:
                     logger.exception("Failed to get avatar_url")
                 raise
-            except Exception:
-                logger.exception("Failed to get avatar_url")
 
             defer.returnValue(result["avatar_url"])
 


### PR DESCRIPTION
We were just catching the exceptions, logging and dropping them on the floor. This meant that in the case of fetching display name we returned a `None` rather than raising an exception, and for avatars we'd throw an `UnboundLocalError` due to trying to return `result["avatar_url"]`  despite not having `result`.

We will still log the exceptions, but just further up the stack