### PR TITLE
Docker build all tags starting vX.Y.Z, including release candidates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ workflows:
       - dockerhubuploadrelease:
           filters:
             tags:
-              only: /^v[0-9].[0-9]+.[0-9]+(.[0-9]+)?/
+              only: /v[0-9].[0-9]+.[0-9]+.*/
             branches:
               ignore: /.*/
       - dockerhubuploadlatest:


### PR DESCRIPTION
Note the regex must match the complete string anyway, so the leading ^ was useless.