### PR TITLE
Log looping call exceptions

### DIFF
--- a/changelog.d/4008.misc
+++ b/changelog.d/4008.misc
@@ -1,0 +1,1 @@
+Log exceptions in looping calls

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -28,24 +28,13 @@ from synapse.metrics import (
     event_processing_loop_room_count,
 )
 from synapse.metrics.background_process_metrics import run_as_background_process
-from synapse.util import make_log_failure_errback
+from synapse.util import log_failure
 from synapse.util.logcontext import make_deferred_yieldable, run_in_background
 from synapse.util.metrics import Measure
 
 logger = logging.getLogger(__name__)
 
 events_processed_counter = Counter("synapse_handlers_appservice_events_processed", "")
-
-
-def log_failure(failure):
-    logger.error(
-        "Application Services Failure",
-        exc_info=(
-            failure.type,
-            failure.value,
-            failure.getTracebackObject()
-        )
-    )
 
 
 class ApplicationServicesHandler(object):
@@ -114,10 +103,9 @@ class ApplicationServicesHandler(object):
                         if not self.started_scheduler:
                             def start_scheduler():
                                 return self.scheduler.start().addErrback(
-                                    make_log_failure_errback(
-                                        "Application Services Failure",
-                                    )
+                                    log_failure, "Application Services Failure",
                                 )
+
                             run_as_background_process("as_scheduler", start_scheduler)
                             self.started_scheduler = True
 

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -28,6 +28,7 @@ from synapse.metrics import (
     event_processing_loop_room_count,
 )
 from synapse.metrics.background_process_metrics import run_as_background_process
+from synapse.util import make_log_failure_errback
 from synapse.util.logcontext import make_deferred_yieldable, run_in_background
 from synapse.util.metrics import Measure
 
@@ -112,7 +113,11 @@ class ApplicationServicesHandler(object):
 
                         if not self.started_scheduler:
                             def start_scheduler():
-                                return self.scheduler.start().addErrback(log_failure)
+                                return self.scheduler.start().addErrback(
+                                    make_log_failure_errback(
+                                        "Application Services Failure",
+                                    )
+                                )
                             run_as_background_process("as_scheduler", start_scheduler)
                             self.started_scheduler = True
 


### PR DESCRIPTION
If a looping call function errors, then it kills the loop entirely.
Currently it throws away the exception logs, so we should make it
actually log them.

Fixes #3929