### PR TITLE
user_directory.defer_to_id_server should be an URL, not a hostname

### DIFF
--- a/synapse/config/user_directory.py
+++ b/synapse/config/user_directory.py
@@ -49,5 +49,5 @@ class UserDirectoryConfig(Config):
         #   If this is set, user search will be delegated to this ID server instead
         #   of synapse performing the search itself.
         #   This is an experimental API.
-        #   defer_to_id_server: id.example.com
+        #   defer_to_id_server: https://id.example.com
         """

--- a/synapse/rest/client/v2_alpha/user_directory.py
+++ b/synapse/rest/client/v2_alpha/user_directory.py
@@ -66,7 +66,7 @@ class UserDirectorySearchRestServlet(RestServlet):
 
         if self.hs.config.user_directory_defer_to_id_server:
             signed_body = sign_json(body, self.hs.hostname, self.hs.config.signing_key[0])
-            url = "http://%s/_matrix/identity/api/v1/user_directory/search" % (
+            url = "%s/_matrix/identity/api/v1/user_directory/search" % (
                 self.hs.config.user_directory_defer_to_id_server,
             )
             resp = yield self.http_client.post_json_get_json(url, signed_body)


### PR DESCRIPTION
The "defer_to_id_server" configuration simply provided a hostname, which we string manipulated to add a http:// on the front. 

We should instead require the whole to be passed in, and so allow specification of http vs https as part of the configuration - or even custom ports.

This needs a synchronized change to the configuration file in order to deploy cleanly.