### PR TITLE
Use the right python when starting workers

### DIFF
--- a/changelog.d/4057.bugfix
+++ b/changelog.d/4057.bugfix
@@ -1,0 +1,1 @@
+synctl will use the right python executable to run worker processes

--- a/synctl
+++ b/synctl
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2014-2016 OpenMarket Ltd
+# Copyright 2018 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -86,7 +87,7 @@ def start(configfile):
 
 def start_worker(app, configfile, worker_configfile):
     args = [
-        "python", "-B",
+        sys.executable, "-B",
         "-m", app,
         "-c", configfile,
         "-c", worker_configfile


### PR DESCRIPTION
We should use the same python to start the workers as we do for the main
synapse (ie, the same one used to run synctl.)