### PR TITLE
Correctly account for cpu usage by background threads

### DIFF
--- a/changelog.d/4074.bugfix
+++ b/changelog.d/4074.bugfix
@@ -1,0 +1,1 @@
+Correctly account for cpu usage by background threads

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -22,7 +22,7 @@ import bcrypt
 import pymacaroons
 from canonicaljson import json
 
-from twisted.internet import defer, threads
+from twisted.internet import defer
 from twisted.web.client import PartialDownloadError
 
 import synapse.util.stringutils as stringutils
@@ -37,8 +37,8 @@ from synapse.api.errors import (
 )
 from synapse.module_api import ModuleApi
 from synapse.types import UserID
+from synapse.util import logcontext
 from synapse.util.caches.expiringcache import ExpiringCache
-from synapse.util.logcontext import make_deferred_yieldable
 
 from ._base import BaseHandler
 
@@ -884,10 +884,8 @@ class AuthHandler(BaseHandler):
                 bcrypt.gensalt(self.bcrypt_rounds),
             ).decode('ascii')
 
-        return make_deferred_yieldable(
-            threads.deferToThreadPool(
-                self.hs.get_reactor(), self.hs.get_reactor().getThreadPool(), _do_hash
-            ),
+        return logcontext.defer_to_threadpool(
+            self.hs.get_reactor(), self.hs.get_reactor().getThreadPool(), _do_hash,
         )
 
     def validate_hash(self, password, stored_hash):
@@ -913,12 +911,10 @@ class AuthHandler(BaseHandler):
             if not isinstance(stored_hash, bytes):
                 stored_hash = stored_hash.encode('ascii')
 
-            return make_deferred_yieldable(
-                threads.deferToThreadPool(
-                    self.hs.get_reactor(),
-                    self.hs.get_reactor().getThreadPool(),
-                    _do_validate_hash,
-                ),
+            return logcontext.defer_to_threadpool(
+                self.hs.get_reactor(),
+                self.hs.get_reactor().getThreadPool(),
+                _do_validate_hash,
             )
         else:
             return defer.succeed(False)

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -884,9 +884,7 @@ class AuthHandler(BaseHandler):
                 bcrypt.gensalt(self.bcrypt_rounds),
             ).decode('ascii')
 
-        return logcontext.defer_to_threadpool(
-            self.hs.get_reactor(), self.hs.get_reactor().getThreadPool(), _do_hash,
-        )
+        return logcontext.defer_to_thread(self.hs.get_reactor(), _do_hash)
 
     def validate_hash(self, password, stored_hash):
         """Validates that self.hash(password) == stored_hash.
@@ -911,11 +909,7 @@ class AuthHandler(BaseHandler):
             if not isinstance(stored_hash, bytes):
                 stored_hash = stored_hash.encode('ascii')
 
-            return logcontext.defer_to_threadpool(
-                self.hs.get_reactor(),
-                self.hs.get_reactor().getThreadPool(),
-                _do_validate_hash,
-            )
+            return logcontext.defer_to_thread(self.hs.get_reactor(), _do_validate_hash)
         else:
             return defer.succeed(False)
 

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -492,9 +492,8 @@ class MediaRepository(object):
         ))
 
         thumbnailer = Thumbnailer(input_path)
-        t_byte_source = yield logcontext.defer_to_threadpool(
+        t_byte_source = yield logcontext.defer_to_thread(
             self.hs.get_reactor(),
-            self.hs.get_reactor().getThreadPool(),
             self._generate_thumbnail,
             thumbnailer, t_width, t_height, t_method, t_type
         )
@@ -536,9 +535,8 @@ class MediaRepository(object):
         ))
 
         thumbnailer = Thumbnailer(input_path)
-        t_byte_source = yield logcontext.defer_to_threadpool(
+        t_byte_source = yield logcontext.defer_to_thread(
             self.hs.get_reactor(),
-            self.hs.get_reactor().getThreadPool(),
             self._generate_thumbnail,
             thumbnailer, t_width, t_height, t_method, t_type
         )
@@ -624,16 +622,14 @@ class MediaRepository(object):
         for (t_width, t_height, t_type), t_method in iteritems(thumbnails):
             # Generate the thumbnail
             if t_method == "crop":
-                t_byte_source = yield logcontext.defer_to_threadpool(
+                t_byte_source = yield logcontext.defer_to_thread(
                     self.hs.get_reactor(),
-                    self.hs.get_reactor().getThreadPool(),
                     thumbnailer.crop,
                     t_width, t_height, t_type,
                 )
             elif t_method == "scale":
-                t_byte_source = yield logcontext.defer_to_threadpool(
+                t_byte_source = yield logcontext.defer_to_thread(
                     self.hs.get_reactor(),
-                    self.hs.get_reactor().getThreadPool(),
                     thumbnailer.scale,
                     t_width, t_height, t_type,
                 )

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -25,7 +25,7 @@ from six.moves.urllib import parse as urlparse
 
 import twisted.internet.error
 import twisted.web.http
-from twisted.internet import defer, threads
+from twisted.internet import defer
 from twisted.web.resource import Resource
 
 from synapse.api.errors import (
@@ -36,8 +36,8 @@ from synapse.api.errors import (
 )
 from synapse.http.matrixfederationclient import MatrixFederationHttpClient
 from synapse.metrics.background_process_metrics import run_as_background_process
+from synapse.util import logcontext
 from synapse.util.async_helpers import Linearizer
-from synapse.util.logcontext import make_deferred_yieldable
 from synapse.util.retryutils import NotRetryingDestination
 from synapse.util.stringutils import is_ascii, random_string
 
@@ -492,10 +492,12 @@ class MediaRepository(object):
         ))
 
         thumbnailer = Thumbnailer(input_path)
-        t_byte_source = yield make_deferred_yieldable(threads.deferToThread(
+        t_byte_source = yield logcontext.defer_to_threadpool(
+            self.hs.get_reactor(),
+            self.hs.get_reactor().getThreadPool(),
             self._generate_thumbnail,
             thumbnailer, t_width, t_height, t_method, t_type
-        ))
+        )
 
         if t_byte_source:
             try:
@@ -534,10 +536,12 @@ class MediaRepository(object):
         ))
 
         thumbnailer = Thumbnailer(input_path)
-        t_byte_source = yield make_deferred_yieldable(threads.deferToThread(
+        t_byte_source = yield logcontext.defer_to_threadpool(
+            self.hs.get_reactor(),
+            self.hs.get_reactor().getThreadPool(),
             self._generate_thumbnail,
             thumbnailer, t_width, t_height, t_method, t_type
-        ))
+        )
 
         if t_byte_source:
             try:
@@ -620,15 +624,19 @@ class MediaRepository(object):
         for (t_width, t_height, t_type), t_method in iteritems(thumbnails):
             # Generate the thumbnail
             if t_method == "crop":
-                t_byte_source = yield make_deferred_yieldable(threads.deferToThread(
+                t_byte_source = yield logcontext.defer_to_threadpool(
+                    self.hs.get_reactor(),
+                    self.hs.get_reactor().getThreadPool(),
                     thumbnailer.crop,
                     t_width, t_height, t_type,
-                ))
+                )
             elif t_method == "scale":
-                t_byte_source = yield make_deferred_yieldable(threads.deferToThread(
+                t_byte_source = yield logcontext.defer_to_threadpool(
+                    self.hs.get_reactor(),
+                    self.hs.get_reactor().getThreadPool(),
                     thumbnailer.scale,
                     t_width, t_height, t_type,
-                ))
+                )
             else:
                 logger.error("Unrecognized method: %r", t_method)
                 continue

--- a/synapse/rest/media/v1/media_storage.py
+++ b/synapse/rest/media/v1/media_storage.py
@@ -21,9 +21,10 @@ import sys
 
 import six
 
-from twisted.internet import defer, threads
+from twisted.internet import defer
 from twisted.protocols.basic import FileSender
 
+from synapse.util import logcontext
 from synapse.util.file_consumer import BackgroundFileConsumer
 from synapse.util.logcontext import make_deferred_yieldable
 
@@ -64,9 +65,11 @@ class MediaStorage(object):
 
         with self.store_into_file(file_info) as (f, fname, finish_cb):
             # Write to the main repository
-            yield make_deferred_yieldable(threads.deferToThread(
+            yield logcontext.defer_to_threadpool(
+                self.hs.get_reactor(),
+                self.hs.get_reactor().getThreadPool(),
                 _write_file_synchronously, source, f,
-            ))
+            )
             yield finish_cb()
 
         defer.returnValue(fname)

--- a/synapse/rest/media/v1/media_storage.py
+++ b/synapse/rest/media/v1/media_storage.py
@@ -65,9 +65,8 @@ class MediaStorage(object):
 
         with self.store_into_file(file_info) as (f, fname, finish_cb):
             # Write to the main repository
-            yield logcontext.defer_to_threadpool(
+            yield logcontext.defer_to_thread(
                 self.hs.get_reactor(),
-                self.hs.get_reactor().getThreadPool(),
                 _write_file_synchronously, source, f,
             )
             yield finish_cb()

--- a/synapse/rest/media/v1/storage_provider.py
+++ b/synapse/rest/media/v1/storage_provider.py
@@ -17,9 +17,10 @@ import logging
 import os
 import shutil
 
-from twisted.internet import defer, threads
+from twisted.internet import defer
 
 from synapse.config._base import Config
+from synapse.util import logcontext
 from synapse.util.logcontext import run_in_background
 
 from .media_storage import FileResponder
@@ -120,7 +121,9 @@ class FileStorageProviderBackend(StorageProvider):
         if not os.path.exists(dirname):
             os.makedirs(dirname)
 
-        return threads.deferToThread(
+        return logcontext.defer_to_threadpool(
+            self.hs.get_reactor(),
+            self.hs.get_reactor().getThreadPool(),
             shutil.copyfile, primary_fname, backup_fname,
         )
 

--- a/synapse/rest/media/v1/storage_provider.py
+++ b/synapse/rest/media/v1/storage_provider.py
@@ -121,9 +121,8 @@ class FileStorageProviderBackend(StorageProvider):
         if not os.path.exists(dirname):
             os.makedirs(dirname)
 
-        return logcontext.defer_to_threadpool(
+        return logcontext.defer_to_thread(
             self.hs.get_reactor(),
-            self.hs.get_reactor().getThreadPool(),
             shutil.copyfile, primary_fname, backup_fname,
         )
 

--- a/synapse/util/logcontext.py
+++ b/synapse/util/logcontext.py
@@ -598,7 +598,7 @@ def defer_to_threadpool(reactor, threadpool, f, *args, **kwargs):
 
     def g():
         with LoggingContext(parent_context=logcontext):
-            f(*args, **kwargs)
+            return f(*args, **kwargs)
 
     return make_deferred_yieldable(
         threads.deferToThreadPool(reactor, threadpool, g)

--- a/synapse/util/logcontext.py
+++ b/synapse/util/logcontext.py
@@ -562,6 +562,38 @@ def _set_context_cb(result, context):
     return result
 
 
+def defer_to_thread(reactor, f, *args, **kwargs):
+    """
+    Calls the function `f` using a thread from the reactor's default threadpool and
+    returns the result as a Deferred.
+
+    Creates a new logcontext for `f`, which is created as a child of the current
+    logcontext (so its CPU usage metrics will get attributed to the current
+    logcontext). `f` should preserve the logcontext it is given.
+
+    The result deferred follows the Synapse logcontext rules: you should `yield`
+    on it.
+
+    Args:
+        reactor (twisted.internet.base.ReactorBase): The reactor in whose main thread
+            the Deferred will be invoked, and whose threadpool we should use for the
+            function.
+
+            Normally this will be hs.get_reactor().
+
+        f (callable): The function to call.
+
+        args: positional arguments to pass to f.
+
+        kwargs: keyword arguments to pass to f.
+
+    Returns:
+        Deferred: A Deferred which fires a callback with the result of `f`, or an
+            errback if `f` throws an exception.
+    """
+    return defer_to_threadpool(reactor, reactor.getThreadPool(), f, *args, **kwargs)
+
+
 def defer_to_threadpool(reactor, threadpool, f, *args, **kwargs):
     """
     A wrapper for twisted.internet.threads.deferToThreadpool, which handles

--- a/synapse/util/logcontext.py
+++ b/synapse/util/logcontext.py
@@ -25,7 +25,7 @@ See doc/log_contexts.rst for details on how this works.
 import logging
 import threading
 
-from twisted.internet import defer
+from twisted.internet import defer, threads
 
 logger = logging.getLogger(__name__)
 
@@ -562,58 +562,44 @@ def _set_context_cb(result, context):
     return result
 
 
-# modules to ignore in `logcontext_tracer`
-_to_ignore = [
-    "synapse.util.logcontext",
-    "synapse.http.server",
-    "synapse.storage._base",
-    "synapse.util.async_helpers",
-]
-
-
-def logcontext_tracer(frame, event, arg):
-    """A tracer that logs whenever a logcontext "unexpectedly" changes within
-    a function. Probably inaccurate.
-
-    Use by calling `sys.settrace(logcontext_tracer)` in the main thread.
+def defer_to_threadpool(reactor, threadpool, f, *args, **kwargs):
     """
-    if event == 'call':
-        name = frame.f_globals["__name__"]
-        if name.startswith("synapse"):
-            if name == "synapse.util.logcontext":
-                if frame.f_code.co_name in ["__enter__", "__exit__"]:
-                    tracer = frame.f_back.f_trace
-                    if tracer:
-                        tracer.just_changed = True
+    A wrapper for twisted.internet.threads.deferToThreadpool, which handles
+    logcontexts correctly.
 
-            tracer = frame.f_trace
-            if tracer:
-                return tracer
+    Calls the function `f` using a thread from the given threadpool and returns
+    the result as a Deferred.
 
-            if not any(name.startswith(ig) for ig in _to_ignore):
-                return LineTracer()
+    Creates a new logcontext for `f`, which is created as a child of the current
+    logcontext (so its CPU usage metrics will get attributed to the current
+    logcontext). `f` should preserve the logcontext it is given.
 
+    The result deferred follows the Synapse logcontext rules: you should `yield`
+    on it.
 
-class LineTracer(object):
-    __slots__ = ["context", "just_changed"]
+    Args:
+        reactor (twisted.internet.base.ReactorBase): The reactor in whose main thread
+            the Deferred will be invoked. Normally this will be hs.get_reactor().
 
-    def __init__(self):
-        self.context = LoggingContext.current_context()
-        self.just_changed = False
+        threadpool (twisted.python.threadpool.ThreadPool): The threadpool to use for
+            running `f`. Normally this will be hs.get_reactor().getThreadPool().
 
-    def __call__(self, frame, event, arg):
-        if event in 'line':
-            if self.just_changed:
-                self.context = LoggingContext.current_context()
-                self.just_changed = False
-            else:
-                c = LoggingContext.current_context()
-                if c != self.context:
-                    logger.info(
-                        "Context changed! %s -> %s, %s, %s",
-                        self.context, c,
-                        frame.f_code.co_filename, frame.f_lineno
-                    )
-                    self.context = c
+        f (callable): The function to call.
 
-        return self
+        args: positional arguments to pass to f.
+
+        kwargs: keyword arguments to pass to f.
+
+    Returns:
+        Deferred: A Deferred which fires a callback with the result of `f`, or an
+            errback if `f` throws an exception.
+    """
+    logcontext = LoggingContext.current_context()
+
+    def g():
+        with LoggingContext(parent_context=logcontext):
+            f(*args, **kwargs)
+
+    return make_deferred_yieldable(
+        threads.deferToThreadPool(reactor, threadpool, g)
+    )


### PR DESCRIPTION
Wrap calls to deferToThread() in a thing which uses a child logcontext to
attribute CPU usage to the right request.

While we're in the area, remove the logcontext_tracer stuff, which is never
used, and afaik doesn't work.

Fixes #4064