### PR TITLE
 Refactor to allow event signing to depend on room version

### DIFF
--- a/changelog.d/4080.misc
+++ b/changelog.d/4080.misc
@@ -1,0 +1,1 @@
+Refactor to allow event signing to depend on room version

--- a/synapse/crypto/event_signing/__init__.py
+++ b/synapse/crypto/event_signing/__init__.py
@@ -23,18 +23,50 @@ from synapse.crypto.event_signing import v1
 def check_event_content_hash(
     event, hash_algorithm=hashlib.sha256, room_version=RoomVersions.V1
 ):
-    """Check whether the hash for this PDU matches the contents"""
+    """Check whether the hash for this PDU matches the contents
+
+    Args:
+        event (EventBase)
+        hash_algorithm (hashlib.hash)
+        room_version (RoomVersions)
+
+    Returns
+        bool
+    """
     return v1.check_event_content_hash(event, hash_algorithm)
 
 
 def compute_event_reference_hash(
     event, hash_algorithm=hashlib.sha256, room_version=RoomVersions.V1
 ):
+    """Compute the event reference hash
+
+    Args:
+        event (EventBase)
+        hash_algorithm (hashlib.hash)
+        room_version (RoomVersions)
+
+    Returns
+        tuple[str, bytes]: Tuple of hash name and digest bytes
+    """
     return v1.compute_event_reference_hash(event, hash_algorithm)
 
 
 def compute_event_signature(event, signature_name, signing_key,
                             room_version=RoomVersions.V1):
+    """Returns signature for the event with given name and key.
+
+    Args:
+        event (EventBase)
+        signature_name (str): The name of the entity signing, usually the
+            server name.
+        signing_key: A signing key for the entity, as returned by `signedjson`
+        room_version (RoomVersions)
+
+    Returns:
+        dict[str, dict[str, str]]: Dictionary that contains the event
+        signature. Maps from entity name to key ID to base64 encoded signature.
+    """
     return v1.compute_event_signature(
         event, signature_name, signing_key,
     )
@@ -47,6 +79,16 @@ def add_hashes_and_signatures(
     hash_algorithm=hashlib.sha256,
     room_version=RoomVersions.V1,
 ):
+    """Adds content hash and signature to the event
+
+    Args:
+        event (EventBuilder)
+        signature_name (str): The name of the entity signing, usually the
+            server name.
+        signing_key: A signing key for the entity, as returned by `signedjson`
+        hash_algorithm (hashlib.hash)
+        room_version (RoomVersions)
+    """
     return v1.add_hashes_and_signatures(
         event, signature_name, signing_key, hash_algorithm
     )

--- a/synapse/crypto/event_signing/__init__.py
+++ b/synapse/crypto/event_signing/__init__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+
+from synapse.api.constants import RoomVersions
+from synapse.crypto.event_signing import v1
+
+
+def check_event_content_hash(
+    event, hash_algorithm=hashlib.sha256, room_version=RoomVersions.V1
+):
+    """Check whether the hash for this PDU matches the contents"""
+    return v1.check_event_content_hash(event, hash_algorithm)
+
+
+def compute_event_reference_hash(
+    event, hash_algorithm=hashlib.sha256, room_version=RoomVersions.V1
+):
+    return v1.compute_event_reference_hash(event, hash_algorithm)
+
+
+def compute_event_signature(event, signature_name, signing_key,
+                            room_version=RoomVersions.V1):
+    return v1.compute_event_signature(
+        event, signature_name, signing_key,
+    )
+
+
+def add_hashes_and_signatures(
+    event,
+    signature_name,
+    signing_key,
+    hash_algorithm=hashlib.sha256,
+    room_version=RoomVersions.V1,
+):
+    return v1.add_hashes_and_signatures(
+        event, signature_name, signing_key, hash_algorithm
+    )

--- a/synapse/crypto/event_signing/v1.py
+++ b/synapse/crypto/event_signing/v1.py
@@ -29,7 +29,16 @@ logger = logging.getLogger(__name__)
 
 
 def check_event_content_hash(event, hash_algorithm=hashlib.sha256):
-    """Check whether the hash for this PDU matches the contents"""
+    """Check whether the hash for this PDU matches the contents
+
+    Args:
+        event (EventBase)
+        hash_algorithm (hashlib.hash)
+        room_version (RoomVersions)
+
+    Returns
+        bool
+    """
     name, expected_hash = _compute_content_hash(event, hash_algorithm)
     logger.debug("Expecting hash: %s", encode_base64(expected_hash))
 
@@ -71,6 +80,16 @@ def _compute_content_hash(event, hash_algorithm):
 
 
 def compute_event_reference_hash(event, hash_algorithm=hashlib.sha256):
+    """Compute the event reference hash
+
+    Args:
+        event (EventBase)
+        hash_algorithm (hashlib.hash)
+        room_version (RoomVersions)
+
+    Returns
+        tuple[str, bytes]: Tuple of hash name and digest bytes
+    """
     tmp_event = prune_event(event)
     event_json = tmp_event.get_pdu_json()
     event_json.pop("signatures", None)
@@ -82,6 +101,19 @@ def compute_event_reference_hash(event, hash_algorithm=hashlib.sha256):
 
 
 def compute_event_signature(event, signature_name, signing_key):
+    """Returns signature for the event with given name and key.
+
+    Args:
+        event (EventBase)
+        signature_name (str): The name of the entity signing, usually the
+            server name.
+        signing_key: A signing key for the entity, as returned by `signedjson`
+        room_version (RoomVersions)
+
+    Returns:
+        dict[str, dict[str, str]]: Dictionary that contains the event
+        signature. Maps from entity name to key ID to base64 encoded signature.
+    """
     tmp_event = prune_event(event)
     redact_json = tmp_event.get_pdu_json()
     redact_json.pop("age_ts", None)
@@ -95,14 +127,16 @@ def compute_event_signature(event, signature_name, signing_key):
 def add_hashes_and_signatures(
     event, signature_name, signing_key, hash_algorithm=hashlib.sha256
 ):
-    # if hasattr(event, "old_state_events"):
-    #     state_json_bytes = encode_canonical_json(
-    #         [e.event_id for e in event.old_state_events.values()]
-    #     )
-    #     hashed = hash_algorithm(state_json_bytes)
-    #     event.state_hash = {
-    #         hashed.name: encode_base64(hashed.digest())
-    #     }
+    """Adds content hash and signature to the event
+
+    Args:
+        event (EventBuilder)
+        signature_name (str): The name of the entity signing, usually the
+            server name.
+        signing_key: A signing key for the entity, as returned by `signedjson`
+        hash_algorithm (hashlib.hash)
+        room_version (RoomVersions)
+    """
 
     name, digest = _compute_content_hash(event, hash_algorithm=hash_algorithm)
 


### PR DESCRIPTION
In the futures we'll want to be able to change the event formats, and so
we will want to be able to change the way we sign and hash events.

In particular we want to be able to change event IDs to be the same as
their reference hashes, and so the reference hashes have to remove the
event ID field before hashing.