### PR TITLE
Add the ability to setup server notice and manhole in Docker

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -89,6 +89,11 @@ variables are available for configuration:
   uris to enable TURN for this homeserver.
 * ``SYNAPSE_TURN_SECRET``, set this to the TURN shared secret if required.
 * ``SYNAPSE_MAX_UPLOAD_SIZE``, set this variable to change the max upload size [default `10M`].
+* ``SYNAPSE_ENABLE_MANHOLE``, set this variable to enable the manhole interface.
+* ``SYNAPSE_NOTICE_LOCALPART``, set this if required to the localpart of the
+  server notice user (the user must be available)
+* ``SYNAPSE_NOTICE_NAME``, set this to the preferred displayname for the server
+  notice user
 
 Shared secrets, that will be initialized to random values if not set:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -94,6 +94,7 @@ variables are available for configuration:
   server notice user (the user must be available)
 * ``SYNAPSE_NOTICE_NAME``, set this to the preferred displayname for the server
   notice user
+* ``SYNAPSE_NOTICE_AVATAR``, set this to the mxc:// URI of the notice user avatar.
 
 Shared secrets, that will be initialized to random values if not set:
 

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -44,6 +44,12 @@ listeners:
       - names: [federation]
         compress: false
 
+  {% if SYNAPSE_ENABLE_MANHOLE %}
+  - port: 9000
+    bind_addresses: ['::1', '127.0.0.1']
+    type: manhole
+  {% endif %}
+
 ## Database ##
 
 {% if POSTGRES_PASSWORD %}
@@ -200,6 +206,14 @@ perspectives:
 
 password_config:
    enabled: true
+
+{% if SYNAPSE_NOTICE_LOCALPART %}
+server_notices:
+  system_mxid_localpart: {{ SYNAPSE_NOTICE_LOCALPART }}
+  system_mxid_display_name: "{{ SYNAPSE_NOTICE_NAME or 'Server Notice' }}"
+  system_mxid_avatar_url: "mxc://server.com/oumMVlgDnLYFaPVkExemNVVZ"
+  room_name: "{{ SYNAPSE_NOTICE_NAME or 'Server Notice' }}"
+{% endif %}
 
 {% if SYNAPSE_SMTP_HOST %}
 email:

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -211,7 +211,7 @@ password_config:
 server_notices:
   system_mxid_localpart: {{ SYNAPSE_NOTICE_LOCALPART }}
   system_mxid_display_name: "{{ SYNAPSE_NOTICE_NAME or 'Server Notice' }}"
-  system_mxid_avatar_url: "mxc://server.com/oumMVlgDnLYFaPVkExemNVVZ"
+  system_mxid_avatar_url: "{{ SYNAPSE_NOTICE_AVATAR }}"
   room_name: "{{ SYNAPSE_NOTICE_NAME or 'Server Notice' }}"
 {% endif %}
 


### PR DESCRIPTION
This provides the ability to setup server notices and manhole debugging for synapse, using environment variables.

It is related to #3284.