### PR TITLE
Attempt to fix tox installs

### DIFF
--- a/changelog.d/4124.misc
+++ b/changelog.d/4124.misc
@@ -1,0 +1,1 @@
+Fix `tox` failure on old systems

--- a/jenkins/prepare_synapse.sh
+++ b/jenkins/prepare_synapse.sh
@@ -14,22 +14,3 @@ fi
 
 # set up the virtualenv
 tox -e py27 --notest -v
-
-TOX_BIN=$TOX_DIR/py27/bin
-
-# cryptography 2.2 requires setuptools >= 18.5.
-#
-# older versions of virtualenv (?) give us a virtualenv with the same version
-# of setuptools as is installed on the system python (and tox runs virtualenv
-# under python3, so we get the version of setuptools that is installed on that).
-#
-# anyway, make sure that we have a recent enough setuptools.
-$TOX_BIN/pip install 'setuptools>=18.5'
-
-# we also need a semi-recent version of pip, because old ones fail to install
-# the "enum34" dependency of cryptography.
-$TOX_BIN/pip install 'pip>=10'
-
-{ python synapse/python_dependencies.py
-  echo lxml
-} | xargs $TOX_BIN/pip install

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,20 @@ deps =
     # needed by some of the tests
     lxml
 
+    # cyptography 2.2 requires setuptools >= 18.5
+    #
+    # older versions of virtualenv (?) give us a virtualenv with the same
+    # version of setuptools as is installed on the system python (and tox runs
+    # virtualenv under python3, so we get the version of setuptools that is
+    # installed on that).
+    #
+    # anyway, make sure that we have a recent enough setuptools.
+    setuptools>=18.5
+
+    # we also need a semi-recent version of pip, because old ones fail to
+    # install the "enum34" dependency of cryptography.
+    pip>=10
+
 setenv =
     PYTHONDONTWRITEBYTECODE = no_byte_code
 


### PR DESCRIPTION
It seems that, at some point, the ability to run tox on old servers (with
old setuptools) got broken - and it was only working on our Jenkins
instance by dint of reusing the tox environments.

Let's try to get tox to do the right thing, and remove the guff from
jenkins/prepare_synapse.sh.

(There is a separate question about whether the jenkins builds should be
using tox to prepare the virtualenv at all here, but that is somewhat
orthogonal).