### PR TITLE
Add config variables for enabling terms auth and the policy name

### DIFF
--- a/changelog.d/4004.feature
+++ b/changelog.d/4004.feature
@@ -1,1 +1,1 @@
-Add `m.login.terms` to the registration flow when consent tracking is enabled. **This makes the template arguments conditionally optional on a new `public_version` variable - update your privacy templates to support this.**
+Include flags to optionally add `m.login.terms` to the registration flow when consent tracking is enabled.

--- a/changelog.d/4133.feature
+++ b/changelog.d/4133.feature
@@ -1,1 +1,1 @@
-Add `m.login.terms` to the registration flow when consent tracking is enabled. **This makes the template arguments conditionally optional on a new `public_version` variable - update your privacy templates to support this.**
+Include flags to optionally add `m.login.terms` to the registration flow when consent tracking is enabled.

--- a/changelog.d/4142.feature
+++ b/changelog.d/4142.feature
@@ -1,1 +1,1 @@
-Add configuration options for enabling consent at registration and changing the policy name.
+Include flags to optionally add `m.login.terms` to the registration flow when consent tracking is enabled.

--- a/changelog.d/4142.feature
+++ b/changelog.d/4142.feature
@@ -1,0 +1,1 @@
+Add configuration options for enabling consent at registration and changing the policy name.

--- a/docs/consent_tracking.md
+++ b/docs/consent_tracking.md
@@ -81,9 +81,40 @@ should be a matter of `pip install Jinja2`. On debian, try `apt-get install
 python-jinja2`.
 
 Once this is complete, and the server has been restarted, try visiting
-`https://<server>/_matrix/consent`. If correctly configured, you should see a
-default policy document. It is now possible to manually construct URIs where
-users can give their consent.
+`https://<server>/_matrix/consent`. If correctly configured, this should give
+an error "Missing string query parameter 'u'". It is now possible to manually
+construct URIs where users can give their consent.
+
+### Enabling consent tracking at registration
+
+1. Add the following to your configuration:
+
+   ```yaml
+   user_consent:
+     require_at_registration: true
+     policy_name: "Privacy Policy" # or whatever you'd like to call the policy
+   ```
+
+2. In your consent templates, make use of the `public_version` variable to
+   see if an unauthenticated user is viewing the page. This is typically
+   wrapped around the form that would be used to actually agree to the document:
+
+   ```
+   {% if not public_version %}
+     <!-- The variables used here are only provided when the 'u' param is given to the homeserver -->
+     <form method="post" action="consent">
+       <input type="hidden" name="v" value="{{version}}"/>
+       <input type="hidden" name="u" value="{{user}}"/>
+       <input type="hidden" name="h" value="{{userhmac}}"/>
+       <input type="submit" value="Sure thing!"/>
+     </form>
+   {% endif %}
+   ```
+
+3. Restart Synapse to apply the changes.
+
+Visiting `https://<server>/_matrix/consent` should now give you a view of the privacy
+document. This is what users will be able to see when registering for accounts.
 
 ### Constructing the consent URI
 
@@ -108,7 +139,8 @@ query parameters:
 
 Note that not providing a `u` parameter will be interpreted as wanting to view
 the document from an unauthenticated perspective, such as prior to registration.
-Therefore, the `h` parameter is not required in this scenario.
+Therefore, the `h` parameter is not required in this scenario. To enable this
+behaviour, set `require_at_registration` to `true` in your `user_consent` config.
 
 
 Sending users a server notice asking them to agree to the policy

--- a/synapse/config/consent_config.py
+++ b/synapse/config/consent_config.py
@@ -46,9 +46,9 @@ DEFAULT_CONFIG = """\
 # process, similar to how captcha works. Users will be required to accept the
 # policy before their account is created.
 #
-# 'policy_name' is the name of the policy users will see when registering for
-# an account. Defaults to "Privacy Policy" and requires require_at_registration
-# to be enabled.
+# 'policy_name' is the display name of the policy users will see when registering
+# for an account. Has no effect unless `require_at_registration` is enabled.
+# Defaults to "Privacy Policy".
 #
 # user_consent:
 #   template_dir: res/templates/privacy

--- a/synapse/config/consent_config.py
+++ b/synapse/config/consent_config.py
@@ -42,6 +42,14 @@ DEFAULT_CONFIG = """\
 # until the user consents to the privacy policy. The value of the setting is
 # used as the text of the error.
 #
+# 'require_at_registration', if enabled, will add a step to the registration
+# process, similar to how captcha works. Users will be required to accept the
+# policy before their account is created.
+#
+# 'policy_name' is the name of the policy users will see when registering for
+# an account. Defaults to "Privacy Policy" and requires require_at_registration
+# to be enabled.
+#
 # user_consent:
 #   template_dir: res/templates/privacy
 #   version: 1.0
@@ -54,6 +62,8 @@ DEFAULT_CONFIG = """\
 #   block_events_error: >-
 #     To continue using this homeserver you must review and agree to the
 #     terms and conditions at %(consent_uri)s
+#   require_at_registration: False
+#   policy_name: Privacy Policy
 #
 """
 
@@ -67,6 +77,8 @@ class ConsentConfig(Config):
         self.user_consent_server_notice_content = None
         self.user_consent_server_notice_to_guests = False
         self.block_events_without_consent_error = None
+        self.user_consent_at_registration = False
+        self.user_consent_policy_name = "Privacy Policy"
 
     def read_config(self, config):
         consent_config = config.get("user_consent")
@@ -83,6 +95,12 @@ class ConsentConfig(Config):
         self.user_consent_server_notice_to_guests = bool(consent_config.get(
             "send_server_notice_to_guests", False,
         ))
+        self.user_consent_at_registration = bool(consent_config.get(
+            "require_at_registration", False,
+        ))
+        self.user_consent_policy_name = consent_config.get(
+            "policy_name", "Privacy Policy",
+        )
 
     def default_config(self, **kwargs):
         return DEFAULT_CONFIG

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -472,7 +472,7 @@ class AuthHandler(BaseHandler):
                 "privacy_policy": {
                     "version": self.hs.config.user_consent_version,
                     "en": {
-                        "name": "Privacy Policy",
+                        "name": self.hs.config.user_consent_policy_name,
                         "url": "%s/_matrix/consent?v=%s" % (
                             self.hs.config.public_baseurl,
                             self.hs.config.user_consent_version,

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -360,7 +360,7 @@ class RegisterRestServlet(RestServlet):
                 ])
 
         # Append m.login.terms to all flows if we're requiring consent
-        if self.hs.config.block_events_without_consent_error is not None:
+        if self.hs.config.user_consent_at_registration:
             new_flows = []
             for flow in flows:
                 flow.append(LoginType.TERMS)

--- a/synapse/rest/consent/consent_resource.py
+++ b/synapse/rest/consent/consent_resource.py
@@ -142,7 +142,7 @@ class ConsentResource(Resource):
         userhmac = None
         has_consented = False
         public_version = username == ""
-        if not public_version:
+        if not public_version or not self.hs.config.user_consent_at_registration:
             userhmac = parse_string(request, "h", required=True, encoding=None)
 
             self._check_hash(username, userhmac)

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -42,7 +42,8 @@ class TermsTestCase(unittest.HomeserverTestCase):
         hs.config.enable_registration_captcha = False
 
     def test_ui_auth(self):
-        self.hs.config.block_events_without_consent_error = True
+        self.hs.config.user_consent_at_registration = True
+        self.hs.config.user_consent_policy_name = "My Cool Privacy Policy"
         self.hs.config.public_baseurl = "https://example.org"
         self.hs.config.user_consent_version = "1.0"
 
@@ -66,7 +67,7 @@ class TermsTestCase(unittest.HomeserverTestCase):
                 "policies": {
                     "privacy_policy": {
                         "en": {
-                            "name": "Privacy Policy",
+                            "name": "My Cool Privacy Policy",
                             "url": "https://example.org/_matrix/consent?v=1.0",
                         },
                         "version": "1.0"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -123,6 +123,8 @@ def default_config(name):
     config.user_directory_search_all_users = False
     config.user_consent_server_notice_content = None
     config.block_events_without_consent_error = None
+    config.user_consent_at_registration = False
+    config.user_consent_policy_name = "Privacy Policy"
     config.media_storage_providers = []
     config.autocreate_auto_join_rooms = True
     config.auto_join_rooms = []


### PR DESCRIPTION
So people can still collect consent the old way if they want to. The config for the policy name is something Tom wanted because "Privacy Policy" doesn't work for his use case.