### PR TITLE
Fix encoding error for consent form on python3

### DIFF
--- a/changelog.d/4163.bugfix
+++ b/changelog.d/4163.bugfix
@@ -1,0 +1,1 @@
+Generating the user consent URI no longer fails on Python 3.

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -121,16 +121,15 @@ def parse_string(request, name, default=None, required=False,
 
     Args:
         request: the twisted HTTP request.
-        name (bytes/unicode): the name of the query parameter.
-        default (bytes/unicode|None): value to use if the parameter is absent,
+        name (bytes|unicode): the name of the query parameter.
+        default (bytes|unicode|None): value to use if the parameter is absent,
             defaults to None. Must be bytes if encoding is None.
         required (bool): whether to raise a 400 SynapseError if the
             parameter is absent, defaults to False.
-        allowed_values (list[bytes/unicode]): List of allowed values for the
+        allowed_values (list[bytes|unicode]): List of allowed values for the
             string, or None if any value is allowed, defaults to None. Must be
             the same type as name, if given.
-        encoding: The encoding to decode the name to, and decode the string
-            content with.
+        encoding (str|None): The encoding to decode the string content with.
 
     Returns:
         bytes/unicode|None: A string value or the default. Unicode if encoding

--- a/synapse/rest/consent/consent_resource.py
+++ b/synapse/rest/consent/consent_resource.py
@@ -160,7 +160,9 @@ class ConsentResource(Resource):
         try:
             self._render_template(
                 request, "%s.html" % (version,),
-                user=username, userhmac=userhmac, version=version,
+                user=username,
+                userhmac=userhmac.decode('ascii'),
+                version=version,
                 has_consented=has_consented, public_version=public_version,
             )
         except TemplateNotFound:


### PR DESCRIPTION
The form was rendering this as "b'01234....'".