### PR TITLE
Fix noop checks when updating device keys

### DIFF
--- a/changelog.d/4164.bugfix
+++ b/changelog.d/4164.bugfix
@@ -1,0 +1,1 @@
+Fix noop checks when updating device keys, reducing spurious device list update notifications.

--- a/synapse/storage/end_to_end_keys.py
+++ b/synapse/storage/end_to_end_keys.py
@@ -40,6 +40,11 @@ class EndToEndKeyStore(SQLBaseStore):
                 allow_none=True,
             )
 
+            if old_key_json and not isinstance(old_key_json, bytes):
+                # In py3 we need old_key_json to match new_key_json type. The DB
+                # returns unicode while encode_canonical_json returns bytes
+                old_key_json = old_key_json.encode("utf-8")
+
             new_key_json = encode_canonical_json(device_keys)
             if old_key_json == new_key_json:
                 return False

--- a/synapse/storage/end_to_end_keys.py
+++ b/synapse/storage/end_to_end_keys.py
@@ -40,12 +40,10 @@ class EndToEndKeyStore(SQLBaseStore):
                 allow_none=True,
             )
 
-            if old_key_json and not isinstance(old_key_json, bytes):
-                # In py3 we need old_key_json to match new_key_json type. The DB
-                # returns unicode while encode_canonical_json returns bytes
-                old_key_json = old_key_json.encode("utf-8")
+            # In py3 we need old_key_json to match new_key_json type. The DB
+            # returns unicode while encode_canonical_json returns bytes.
+            new_key_json = encode_canonical_json(device_keys).decode("utf-8")
 
-            new_key_json = encode_canonical_json(device_keys)
             if old_key_json == new_key_json:
                 return False
 

--- a/tests/storage/test_end_to_end_keys.py
+++ b/tests/storage/test_end_to_end_keys.py
@@ -45,6 +45,21 @@ class EndToEndKeyStoreTestCase(tests.unittest.TestCase):
         self.assertDictContainsSubset({"keys": json, "device_display_name": None}, dev)
 
     @defer.inlineCallbacks
+    def test_reupload_key(self):
+        now = 1470174257070
+        json = {"key": "value"}
+
+        yield self.store.store_device("user", "device", None)
+
+        changed = yield self.store.set_e2e_device_keys("user", "device", now, json)
+        self.assertTrue(changed)
+
+        # If we try to upload the same key then we should be told nothing
+        # changed
+        changed = yield self.store.set_e2e_device_keys("user", "device", now, json)
+        self.assertFalse(changed)
+
+    @defer.inlineCallbacks
     def test_get_key_with_device_name(self):
         now = 1470174257070
         json = {"key": "value"}


### PR DESCRIPTION
Clients often reupload their device keys (for some reason) so its
important for the server to check for no-ops before sending out device
list update notifications.

The check is broken in python 3 due to the fact comparing bytes and
unicode always fails, and that we write bytes to the DB but get unicode
when we read.