### PR TITLE
Drop incoming events from federation for unknown rooms

### DIFF
--- a/changelog.d/4165.misc
+++ b/changelog.d/4165.misc
@@ -1,0 +1,1 @@
+Drop incoming events from federation for unknown rooms

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -162,8 +162,30 @@ class FederationServer(FederationBase):
                 p["age_ts"] = request_time - int(p["age"])
                 del p["age"]
 
+            # We try and pull out an event ID so that if latter checks fail we
+            # can log something sensible. We don't mandate an event ID here in
+            # case future event formats get rid of the key.
+            possible_event_id = p.get("event_id", "<Unknown>")
+
+            # Now we get the room ID so that we can check that we know the
+            # version of the room.
+            room_id = p.get("room_id")
+            if not room_id:
+                logger.info(
+                    "Ignoring PDU as does not have a room_id. Event ID: %s",
+                    possible_event_id,
+                )
+                continue
+
+            try:
+                # In future we will actually use the room version to parse the
+                # PDU into an event.
+                yield self.store.get_room_version(room_id)
+            except NotFoundError:
+                logger.info("Ignoring PUD for unknown room_id: %s", room_id)
+                continue
+
             event = event_from_pdu_json(p)
-            room_id = event.room_id
             pdus_by_room.setdefault(room_id, []).append(event)
 
         pdu_results = {}

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -182,7 +182,7 @@ class FederationServer(FederationBase):
                 # PDU into an event.
                 yield self.store.get_room_version(room_id)
             except NotFoundError:
-                logger.info("Ignoring PUD for unknown room_id: %s", room_id)
+                logger.info("Ignoring PDU for unknown room_id: %s", room_id)
                 continue
 
             event = event_from_pdu_json(p)

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -162,7 +162,7 @@ class FederationServer(FederationBase):
                 p["age_ts"] = request_time - int(p["age"])
                 del p["age"]
 
-            # We try and pull out an event ID so that if latter checks fail we
+            # We try and pull out an event ID so that if later checks fail we
             # can log something sensible. We don't mandate an event ID here in
             # case future event formats get rid of the key.
             possible_event_id = p.get("event_id", "<Unknown>")


### PR DESCRIPTION
We need to do this as in future we'll need to know the version of the room before being able to parse the event fully.