### PR TITLE
Fix PyPy compatibility in adbapi init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,14 @@ matrix:
     services:
       - postgresql
 
+  - python: "pypy3.5"
+    env: TOX_ENV=pypy
+
+  - python: "pypy3.5"
+    env: TOX_ENV=pypy-postgres TRIAL_FLAGS="-j 4"
+    services:
+      - postgresql
+
   - # we only need to check for the newsfragment if it's a PR build
     if: type = pull_request
     python: 3.6

--- a/changelog.d/4174.misc
+++ b/changelog.d/4174.misc
@@ -1,0 +1,1 @@
+Use psycopg2cffi consistently if running on PyPy

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -21,6 +21,7 @@
 # Imports required for the default HomeServer() implementation
 import abc
 import logging
+import platform
 
 from twisted.enterprise import adbapi
 from twisted.mail.smtp import sendmail
@@ -366,6 +367,9 @@ class HomeServer(object):
 
     def build_db_pool(self):
         name = self.db_config["name"]
+
+        if (name == "psycopg2" and platform.python_implementation() == "PyPy"):
+            name = "psycopg2cffi"
 
         return adbapi.ConnectionPool(
             name,

--- a/synapse/storage/search.py
+++ b/synapse/storage/search.py
@@ -186,7 +186,11 @@ class SearchStore(BackgroundUpdateStore):
                 # have an event_search_fts_idx; unfortunately postgres 9.4
                 # doesn't support CREATE INDEX IF EXISTS so we just catch the
                 # exception and ignore it.
-                import psycopg2
+                import platform
+                if platform.python_implementation() == "PyPy":
+                    import psycopg2cffi as psycopg2
+                else:
+                    import psycopg2
                 try:
                     c.execute(
                         "CREATE INDEX CONCURRENTLY event_search_fts_idx"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -252,7 +252,11 @@ def setup_test_homeserver(
         else:
             # We need to do cleanup on PostgreSQL
             def cleanup():
-                import psycopg2
+                import platform
+                if platform.python_implementation() == "PyPy":
+                    import psycopg2cffi as psycopg2
+                else:
+                    import psycopg2
 
                 # Close all the db pools
                 hs.get_db_pool().close()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = packaging, py27, py36, pep8, check_isort
+envlist = packaging, py27, py36, pypy, pep8, check_isort
 
 [base]
 deps =
@@ -110,6 +110,17 @@ setenv =
     {[base]setenv}
     SYNAPSE_POSTGRES = 1
 
+[testenv:pypy]
+usedevelop=true
+
+[testenv:pypy-postgres]
+usedevelop=true
+deps =
+    {[base]deps}
+     psycopg2cffi
+setenv =
+    {[base]setenv}
+    SYNAPSE_POSTGRES = 1
 
 [testenv:packaging]
 deps =


### PR DESCRIPTION
Following up to #2760 (and with #3098 fixed), this PR adds the simple required fix for the database initialization with adbapi to be able to run on pypy again.

I also added pypy35 to the tox and travis configs - let's see if that works :)

Signed-Off-By: Vincent Breitmoser <look@my.amazin.horse> 