### PR TITLE
Fix an internal server error when viewing the public privacy policy

### DIFF
--- a/changelog.d/4184.feature
+++ b/changelog.d/4184.feature
@@ -1,0 +1,1 @@
+Include flags to optionally add `m.login.terms` to the registration flow when consent tracking is enabled.

--- a/synapse/rest/consent/consent_resource.py
+++ b/synapse/rest/consent/consent_resource.py
@@ -142,7 +142,7 @@ class ConsentResource(Resource):
         userhmac = None
         has_consented = False
         public_version = username == ""
-        if not public_version or not self.hs.config.user_consent_at_registration:
+        if not public_version:
             userhmac_bytes = parse_string(request, "h", required=True, encoding=None)
 
             self._check_hash(username, userhmac_bytes)

--- a/synapse/rest/consent/consent_resource.py
+++ b/synapse/rest/consent/consent_resource.py
@@ -143,9 +143,9 @@ class ConsentResource(Resource):
         has_consented = False
         public_version = username == ""
         if not public_version or not self.hs.config.user_consent_at_registration:
-            userhmac = parse_string(request, "h", required=True, encoding=None)
+            userhmac_bytes = parse_string(request, "h", required=True, encoding=None)
 
-            self._check_hash(username, userhmac)
+            self._check_hash(username, userhmac_bytes)
 
             if username.startswith('@'):
                 qualified_user_id = username
@@ -155,15 +155,18 @@ class ConsentResource(Resource):
             u = yield self.store.get_user_by_id(qualified_user_id)
             if u is None:
                 raise NotFoundError("Unknown user")
+
             has_consented = u["consent_version"] == version
+            userhmac = userhmac_bytes.decode("ascii")
 
         try:
             self._render_template(
                 request, "%s.html" % (version,),
                 user=username,
-                userhmac=userhmac.decode('ascii'),
+                userhmac=userhmac,
                 version=version,
-                has_consented=has_consented, public_version=public_version,
+                has_consented=has_consented,
+                public_version=public_version,
             )
         except TemplateNotFound:
             raise NotFoundError("Unknown policy version")

--- a/tests/rest/client/test_consent.py
+++ b/tests/rest/client/test_consent.py
@@ -60,6 +60,13 @@ class ConsentResourceTestCase(unittest.HomeserverTestCase):
         hs = self.setup_test_homeserver(config=config)
         return hs
 
+    def test_render_public_consent(self):
+        """You can observe the terms form without specifying a user"""
+        resource = consent_resource.ConsentResource(self.hs)
+        request, channel = self.make_request("GET", "/consent?v=1", shorthand=False)
+        render(request, resource, self.reactor)
+        self.assertEqual(channel.code, 200)
+
     def test_accept_consent(self):
         """
         A user can use the consent form to accept the terms.


### PR DESCRIPTION
For the new accept-the-terms-during-consent flow, we need to be able to see the privacy policy without a registered user.