### PR TITLE
Remove duplicate slashes in generated consent URLs

### DIFF
--- a/changelog.d/4192.bugfix
+++ b/changelog.d/4192.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where public consent URLs had two slashes.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -473,7 +473,7 @@ class AuthHandler(BaseHandler):
                     "version": self.hs.config.user_consent_version,
                     "en": {
                         "name": self.hs.config.user_consent_policy_name,
-                        "url": "%s/_matrix/consent?v=%s" % (
+                        "url": "%s_matrix/consent?v=%s" % (
                             self.hs.config.public_baseurl,
                             self.hs.config.user_consent_version,
                         ),

--- a/synapse/rest/client/v2_alpha/auth.py
+++ b/synapse/rest/client/v2_alpha/auth.py
@@ -161,7 +161,7 @@ class AuthRestServlet(RestServlet):
 
             html = TERMS_TEMPLATE % {
                 'session': session,
-                'terms_url': "%s/_matrix/consent?v=%s" % (
+                'terms_url': "%s_matrix/consent?v=%s" % (
                     self.hs.config.public_baseurl,
                     self.hs.config.user_consent_version,
                 ),
@@ -242,7 +242,7 @@ class AuthRestServlet(RestServlet):
             else:
                 html = TERMS_TEMPLATE % {
                     'session': session,
-                    'terms_url': "%s/_matrix/consent?v=%s" % (
+                    'terms_url': "%s_matrix/consent?v=%s" % (
                         self.hs.config.public_baseurl,
                         self.hs.config.user_consent_version,
                     ),

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -43,7 +43,7 @@ class TermsTestCase(unittest.HomeserverTestCase):
     def test_ui_auth(self):
         self.hs.config.user_consent_at_registration = True
         self.hs.config.user_consent_policy_name = "My Cool Privacy Policy"
-        self.hs.config.public_baseurl = "https://example.org"
+        self.hs.config.public_baseurl = "https://example.org/"
         self.hs.config.user_consent_version = "1.0"
 
         # Do a UI auth request


### PR DESCRIPTION
`public_baseurl` will get a trailing slash when the config is read.