### PR TITLE
Add a note saying you need to manually reclaim disk space

### DIFF
--- a/changelog.d/4200.misc
+++ b/changelog.d/4200.misc
@@ -1,0 +1,1 @@
+Add a note saying you need to manually reclaim disk space after using the Purge History API

--- a/docs/admin_api/purge_history_api.rst
+++ b/docs/admin_api/purge_history_api.rst
@@ -61,3 +61,11 @@ the following:
     }
 
 The status will be one of ``active``, ``complete``, or ``failed``.
+
+Reclaim disk space (Postgres)
+-----------------------------
+
+To reclaim the disk space and return it to the operating system, you need to run
+`VACUUM FULL;` on the database.
+
+https://www.postgresql.org/docs/current/sql-vacuum.html


### PR DESCRIPTION
People keep asking why their database hasn't gotten smaller after using the Purge History API.