### PR TITLE
Fix logcontext leak from test_sync

### DIFF
--- a/changelog.d/4213.misc
+++ b/changelog.d/4213.misc
@@ -1,0 +1,1 @@
+Fix logcontext leaks in EmailPusher and in tests


### PR DESCRIPTION
Avoid timing out the request, which for long and complicated reasons causes logcontext leaks.