### PR TITLE
Proof of concept for auto-accepting invites on merged accounts

### DIFF
--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -105,6 +105,7 @@ class FederationHandler(BaseHandler):
 
         self.hs = hs
 
+        self.clock = hs.get_clock()
         self.store = hs.get_datastore()  # type: synapse.storage.DataStore
         self.federation_client = hs.get_federation_client()
         self.state_handler = hs.get_state_handler()
@@ -1326,7 +1327,7 @@ class FederationHandler(BaseHandler):
             except Exception:
                 # We're going to retry, but we should log the error
                 logger.exception("Error auto-accepting invite on attempt %d" % attempt)
-                yield self.hs.get_clock().sleep(1)
+                yield self.clock.sleep(1)
         if not joined:
             logger.error("Giving up on trying to auto-accept invite: too many attempts")
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -54,7 +54,7 @@ from synapse.replication.http.federation import (
 )
 from synapse.replication.http.membership import ReplicationUserJoinedLeftRoomRestServlet
 from synapse.state import StateResolutionStore, resolve_events_with_store
-from synapse.types import UserID, get_domain_from_id
+from synapse.types import UserID, get_domain_from_id, create_requester
 from synapse.util import logcontext, unwrapFirstError
 from synapse.util.async_helpers import Linearizer
 from synapse.util.distributor import user_joined_room
@@ -1300,7 +1300,36 @@ class FederationHandler(BaseHandler):
         context = yield self.state_handler.compute_event_context(event)
         yield self.persist_events_and_notify([(event, context)])
 
+        sender = UserID.from_string(event.sender)
+        target = UserID.from_string(event.state_key)
+        if (sender.localpart == target.localpart):
+            logcontext.run_in_background(
+                self._auto_accept_invite,
+                sender, target, event.room_id,
+            )
+
         defer.returnValue(event)
+
+    @defer.inlineCallbacks
+    def _auto_accept_invite(self, sender, target, room_id):
+        joined = False
+        for attempt in range(0, 10):
+            try:
+                yield self.hs.get_room_member_handler().update_membership(
+                    requester=create_requester(target.to_string()),
+                    target=target,
+                    room_id=room_id,
+                    action="join",
+                )
+                joined = True
+                break
+            except Exception:
+                # We're going to retry, but we should log the error
+                logger.exception("Error auto-accepting invite on attempt %d" % attempt)
+                yield self.hs.get_clock().sleep(1)
+        if not joined:
+            logger.error("Giving up on trying to auto-accept invite: too many attempts")
+
 
     @defer.inlineCallbacks
     def do_remotely_reject_invite(self, target_hosts, room_id, user_id):

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -48,6 +48,7 @@ from synapse.crypto.event_signing import (
     compute_event_signature,
 )
 from synapse.events.validator import EventValidator
+from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.replication.http.federation import (
     ReplicationCleanRoomRestServlet,
     ReplicationFederationSendEventsRestServlet,
@@ -1304,7 +1305,8 @@ class FederationHandler(BaseHandler):
         sender = UserID.from_string(event.sender)
         target = UserID.from_string(event.state_key)
         if (sender.localpart == target.localpart):
-            logcontext.run_in_background(
+            run_as_background_process(
+                "_auto_accept_invite",
                 self._auto_accept_invite,
                 sender, target, event.room_id,
             )


### PR DESCRIPTION
**This is for demonstration purposes only - not intended for live usage.** This also means that all the tests are broken (sorry).

Complements https://github.com/matrix-org/matrix-react-sdk/pull/2285

For the purposes of the demo, users are merged by their localpart. By utilizing the same profile approach described in https://github.com/matrix-org/matrix-react-sdk/pull/2285 (aka https://docs.google.com/document/d/15gkImnuNZhQItk2chm0mryfxU3RF74j5s-TzrqcpLUY/edit# for internal reviewers), this determines who needs to be sent an invite. For expedience in accepting the invite, we just check the localpart instead of hunting down the profile.

The same assumptions from https://github.com/matrix-org/matrix-react-sdk/pull/2285 apply here: user accounts are expected to exist, and so is the state event/room. Joins are retried because the first one is guaranteed to fail because the invite request to the remote server hasn't been completed yet.

This is very much a bad hack to solve this problem: please look at it for obvious breaking behaviour (such as me doing python/twisted wrong) and not so much how crude the solution is.