### PR TITLE
Add note to UPGRADE.rst about removing riot.im from list of trusted identity servers

### DIFF
--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -48,6 +48,15 @@ returned by the Client-Server API:
     # configured on port 443.
     curl -kv https://<host.name>/_matrix/client/versions 2>&1 | grep "Server:"
 
+Upgrading to v0.34.0
+====================
+
+This release removes the ``riot.im`` from the default list of trusted identity servers.
+
+If ``riot.im`` is in your homeserver's list of ``trusted_third_party_id_servers``,
+you should remove it. It was added in case a hypothetical future identity server was
+put there. If you don't remove it, users may be unable to deactivate their accounts.
+
 Upgrading to v0.33.7
 ====================
 

--- a/changelog.d/4224.misc
+++ b/changelog.d/4224.misc
@@ -1,0 +1,1 @@
+Add note to UPGRADE.rst about removing riot.im from list of trusted identity servers


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/7717

Yes it isn't really related to v0.34.0 but I think that's probably the best way to add that to the file. 