### PR TITLE
Do a GC after each test to fix logcontext leaks

### DIFF
--- a/changelog.d/4227.misc
+++ b/changelog.d/4227.misc
@@ -1,0 +1,1 @@
+Garbage-collect after each unit test to fix logcontext leaks


### PR DESCRIPTION
This replaces an earlier attempt to fix these leaks on #4213.

This feels like an awful hack, but perhaps it's the least bad option