### PR TITLE
Add an option to disable search for homeservers which may not be interested in it

### DIFF
--- a/changelog.d/4230.feature
+++ b/changelog.d/4230.feature
@@ -1,0 +1,1 @@
+Add an option to disable search for homeservers that may not be interested in it.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -62,6 +62,11 @@ class ServerConfig(Config):
         # master, potentially causing inconsistency.
         self.enable_media_repo = config.get("enable_media_repo", True)
 
+        # whether to enable search. If disabled, new entries will not be inserted
+        # into the search tables and they will not be indexed. Users will receive
+        # errors when attempting to search for messages.
+        self.enable_search = config.get("enable_search", True)
+
         self.filter_timeline_limit = config.get("filter_timeline_limit", -1)
 
         # Whether we should block invites sent to users on this server
@@ -384,7 +389,12 @@ class ServerConfig(Config):
           # mau_limit_reserved_threepids:
           # - medium: 'email'
           #   address: 'reserved_user@example.com'
-
+          #
+          # Room searching
+          #
+          # If disabled, new messages will not be indexed for searching and users
+          # will receive errors when searching for messages. Defaults to enabled.
+          # enable_search: true
         """ % locals()
 
     def read_arguments(self, args):

--- a/synapse/handlers/search.py
+++ b/synapse/handlers/search.py
@@ -50,6 +50,9 @@ class SearchHandler(BaseHandler):
             dict to be returned to the client with results of search
         """
 
+        if not self.hs.config.enable_search:
+            raise SynapseError(400, "Search is disabled on this homeserver")
+
         batch_group = None
         batch_group_key = None
         batch_token = None

--- a/synapse/storage/search.py
+++ b/synapse/storage/search.py
@@ -46,7 +46,7 @@ class SearchStore(BackgroundUpdateStore):
     def __init__(self, db_conn, hs):
         super(SearchStore, self).__init__(db_conn, hs)
 
-        if hs.config.enable_search:
+        if not hs.config.enable_search:
             return
 
         self.register_background_update_handler(

--- a/synapse/storage/search.py
+++ b/synapse/storage/search.py
@@ -45,27 +45,29 @@ class SearchStore(BackgroundUpdateStore):
 
     def __init__(self, db_conn, hs):
         super(SearchStore, self).__init__(db_conn, hs)
-        self.register_background_update_handler(
-            self.EVENT_SEARCH_UPDATE_NAME, self._background_reindex_search
-        )
-        self.register_background_update_handler(
-            self.EVENT_SEARCH_ORDER_UPDATE_NAME,
-            self._background_reindex_search_order
-        )
 
-        # we used to have a background update to turn the GIN index into a
-        # GIST one; we no longer do that (obviously) because we actually want
-        # a GIN index. However, it's possible that some people might still have
-        # the background update queued, so we register a handler to clear the
-        # background update.
-        self.register_noop_background_update(
-            self.EVENT_SEARCH_USE_GIST_POSTGRES_NAME,
-        )
+        if hs.config.enable_search:
+            self.register_background_update_handler(
+                self.EVENT_SEARCH_UPDATE_NAME, self._background_reindex_search
+            )
+            self.register_background_update_handler(
+                self.EVENT_SEARCH_ORDER_UPDATE_NAME,
+                self._background_reindex_search_order
+            )
 
-        self.register_background_update_handler(
-            self.EVENT_SEARCH_USE_GIN_POSTGRES_NAME,
-            self._background_reindex_gin_search
-        )
+            # we used to have a background update to turn the GIN index into a
+            # GIST one; we no longer do that (obviously) because we actually want
+            # a GIN index. However, it's possible that some people might still have
+            # the background update queued, so we register a handler to clear the
+            # background update.
+            self.register_noop_background_update(
+                self.EVENT_SEARCH_USE_GIST_POSTGRES_NAME,
+            )
+
+            self.register_background_update_handler(
+                self.EVENT_SEARCH_USE_GIN_POSTGRES_NAME,
+                self._background_reindex_gin_search
+            )
 
     @defer.inlineCallbacks
     def _background_reindex_search(self, progress, batch_size):
@@ -316,6 +318,8 @@ class SearchStore(BackgroundUpdateStore):
             entries (iterable[SearchEntry]):
                 entries to be added to the table
         """
+        if not self.hs.config.enable_search:
+            return
         if isinstance(self.database_engine, PostgresEngine):
             sql = (
                 "INSERT INTO event_search"

--- a/synapse/storage/search.py
+++ b/synapse/storage/search.py
@@ -47,27 +47,29 @@ class SearchStore(BackgroundUpdateStore):
         super(SearchStore, self).__init__(db_conn, hs)
 
         if hs.config.enable_search:
-            self.register_background_update_handler(
-                self.EVENT_SEARCH_UPDATE_NAME, self._background_reindex_search
-            )
-            self.register_background_update_handler(
-                self.EVENT_SEARCH_ORDER_UPDATE_NAME,
-                self._background_reindex_search_order
-            )
+            return
 
-            # we used to have a background update to turn the GIN index into a
-            # GIST one; we no longer do that (obviously) because we actually want
-            # a GIN index. However, it's possible that some people might still have
-            # the background update queued, so we register a handler to clear the
-            # background update.
-            self.register_noop_background_update(
-                self.EVENT_SEARCH_USE_GIST_POSTGRES_NAME,
-            )
+        self.register_background_update_handler(
+            self.EVENT_SEARCH_UPDATE_NAME, self._background_reindex_search
+        )
+        self.register_background_update_handler(
+            self.EVENT_SEARCH_ORDER_UPDATE_NAME,
+            self._background_reindex_search_order
+        )
 
-            self.register_background_update_handler(
-                self.EVENT_SEARCH_USE_GIN_POSTGRES_NAME,
-                self._background_reindex_gin_search
-            )
+        # we used to have a background update to turn the GIN index into a
+        # GIST one; we no longer do that (obviously) because we actually want
+        # a GIN index. However, it's possible that some people might still have
+        # the background update queued, so we register a handler to clear the
+        # background update.
+        self.register_noop_background_update(
+            self.EVENT_SEARCH_USE_GIST_POSTGRES_NAME,
+        )
+
+        self.register_background_update_handler(
+            self.EVENT_SEARCH_USE_GIN_POSTGRES_NAME,
+            self._background_reindex_gin_search
+        )
 
     @defer.inlineCallbacks
     def _background_reindex_search(self, progress, batch_size):


### PR DESCRIPTION
This is useful for homeservers not intended for users, such as bot-only homeservers or ones that only process IoT data.

This was done with a community hat on:
Signed-off-by: Travis Ralston <travis@t2bot.io>