### PR TITLE
Workaround for non-ascii event ids

### DIFF
--- a/changelog.d/4241.bugfix
+++ b/changelog.d/4241.bugfix
@@ -1,0 +1,1 @@
+Fix exception caused by non-ascii event IDs

--- a/synapse/state/v1.py
+++ b/synapse/state/v1.py
@@ -298,6 +298,8 @@ def _resolve_normal_events(events, auth_events):
 
 def _ordered_events(events):
     def key_func(e):
-        return -int(e.depth), hashlib.sha1(e.event_id.encode('ascii')).hexdigest()
+        # we have to use utf-8 rather than ascii here because it turns out we allow
+        # people to send us events with non-ascii event IDs :/
+        return -int(e.depth), hashlib.sha1(e.event_id.encode('utf-8')).hexdigest()
 
     return sorted(events, key=key_func)


### PR DESCRIPTION
It turns out that we accept events with non-ascii IDs, which would later cause
an explosion during state res.

Fixes #4226