### PR TITLE
Add an option to disable the user directory

### DIFF
--- a/changelog.d/4259.feature
+++ b/changelog.d/4259.feature
@@ -1,0 +1,1 @@
+Add an option to disable the user directory for homeservers that may not be interested in it.

--- a/synapse/config/user_directory.py
+++ b/synapse/config/user_directory.py
@@ -23,10 +23,14 @@ class UserDirectoryConfig(Config):
 
     def read_config(self, config):
         self.user_directory_search_all_users = False
+        self.user_directory_enabled = True
         user_directory_config = config.get("user_directory", None)
         if user_directory_config:
             self.user_directory_search_all_users = (
                 user_directory_config.get("search_all_users", False)
+            )
+            self.user_directory_enabled = (
+                user_directory_config.get("enabled", True)
             )
 
     def default_config(self, config_dir_path, server_name, **kwargs):
@@ -39,6 +43,12 @@ class UserDirectoryConfig(Config):
         # UPDATE user_directory_stream_pos SET stream_id = NULL;
         # on your database to tell it to rebuild the user_directory search indexes.
         #
+        # 'enabled' when false will disable the user directory entirely. Users will not
+        # be indexed and users will receive errors when searching for users (often done
+        # while finding people to invite to a room) when the directory is disabled. This
+        # defaults to enabled.
+        #
         #user_directory:
+        #   enabled: true
         #   search_all_users: false
         """


### PR DESCRIPTION
For homeservers that may not be interested in it.

This is useful for homeservers not intended for users, such as bot-only homeservers or ones that only process IoT data.

This was done with a community hat on:
Signed-off-by: Travis Ralston <travis@t2bot.io>