### PR TITLE
Remove obsolete settings from docker homeserver.yaml

### DIFF
--- a/changelog.d/4261.misc
+++ b/changelog.d/4261.misc
@@ -1,0 +1,1 @@
+Remove obsolete `verbose` and `log_file` settings from `homeserver.yaml` for Docker image.

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -14,6 +14,7 @@ server_name: "{{ SYNAPSE_SERVER_NAME }}"
 pid_file: /homeserver.pid
 web_client: False
 soft_file_limit: 0
+log_config: "/compiled/log.config"
 
 ## Ports ##
 
@@ -67,9 +68,6 @@ database:
 ## Performance ##
 
 event_cache_size: "{{ SYNAPSE_EVENT_CACHE_SIZE or "10K" }}"
-verbose: 0
-log_file: "/data/homeserver.log"
-log_config: "/compiled/log.config"
 
 ## Ratelimiting ##
 


### PR DESCRIPTION
These aren't used, because we have a `log_config` setting.