### PR TITLE
Prevent crash on pagination.

### DIFF
--- a/changelog.d/4263.bugfix
+++ b/changelog.d/4263.bugfix
@@ -1,0 +1,1 @@
+Prevent crash on pagination.

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -253,7 +253,7 @@ class PaginationHandler(object):
         )
 
         state = None
-        if event_filter and event_filter.lazy_load_members():
+        if event_filter and event_filter.lazy_load_members() and len(events) > 0:
             # TODO: remove redundant members
 
             # FIXME: we also care about invite targets etc.


### PR DESCRIPTION
Today I've got pagination stuck on scrolling back and this was in the log:
```
2018-12-05 09:22:58,198 - synapse.http.server - 112 - ERROR - GET-8313- Failed handle request
via <function _async_render at 0x7f7d18ff8de8>: <SynapseRequest at 0x7f7ccb48d680
method=u'GET' uri=u'/_matrix/client/r0/rooms/<...>/messages?from=t361589-2272987_8803529_88_1180453_319160_392_21245_28472_14&
limit=20&dir=b&filter=%7B%22lazy_load_members%22%3Atrue%7D' clientproto=u'HTTP/1.0' site=8009>: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 654, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1475, in gotResult
    _inlineCallbacks(r, g, status)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/usr/lib/python2.7/dist-packages/twisted/python/failure.py", line 491, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
--- <exception caught here> ---
  File "/usr/lib/python2.7/dist-packages/synapse/http/server.py", line 81, in wrapped_request_handler
    yield h(self, request)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/usr/lib/python2.7/dist-packages/twisted/python/failure.py", line 491, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/usr/lib/python2.7/dist-packages/synapse/http/server.py", line 316, in _async_render
    callback_return = yield callback(request, **kwargs)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/usr/lib/python2.7/dist-packages/twisted/python/failure.py", line 491, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/usr/lib/python2.7/dist-packages/synapse/rest/client/v1/room.py", line 479, in on_GET
    event_filter=event_filter,
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/usr/lib/python2.7/dist-packages/synapse/handlers/pagination.py", line 266, in get_messages
    events[0].event_id, state_filter=state_filter,
exceptions.IndexError: list index out of range
```
So I added a check if `events` actually has something and then pagination worked again. No idea why it broke, I have some ignored users so maybe that's why.