### PR TITLE
Update docker-compose.yml

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -32,12 +32,12 @@ services:
     # In order to expose Synapse, remove one of the following, you might for
     # instance expose the TLS port directly:
     ports:
-      - 8448:8448/tcp
+      - 8008:8008/tcp
     # ... or use a reverse proxy, here is an example for traefik:
     labels:
       - traefik.enable=true
       - traefik.frontend.rule=Host:my.matrix.Host
-      - traefik.port=8448
+      - traefik.port=8008
 
   db:
     image: docker.io/postgres:10-alpine


### PR DESCRIPTION
Hi, this docker-compose file does not work by default.
I did stuggle to find out that TLS ports are used by default, forcing user to know they should append HTTPS:// while using localhost or fail without notice when traefik already does TLS. Double TLS of course does not work.
Using non TLS port by default makes more sense to me.