### PR TITLE
Update docker-compose.yml

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.frontend.rule=Host:my.matrix.Host
-      - traefik.port=8448
+      - traefik.port=8008
 
   db:
     image: docker.io/postgres:10-alpine


### PR DESCRIPTION
Hi, the original docker-compose file did not work by default.
You get federation port working but no client port.

My proposal is to let federation port work as it is by default (8448) and let traefik handle client http/https traffic.