### PR TITLE
Make Prometheus snippet less confusing on the metrics collection page

### DIFF
--- a/docs/metrics-howto.rst
+++ b/docs/metrics-howto.rst
@@ -48,7 +48,10 @@ How to monitor Synapse metrics using Prometheus
     - job_name: "synapse"
       metrics_path: "/_synapse/metrics"
       static_configs:
-        - targets: ["my.server.here:9092"]
+        - targets: ["my.server.here:port"]
+
+   where ``my.server.here`` is the IP address of Synapse, and ``port`` is the listener port
+   configured with the ``metrics`` resource.
 
    If your prometheus is older than 1.5.2, you will need to replace
    ``static_configs`` in the above with ``target_groups``.


### PR DESCRIPTION
The port number used in the example is completely different from what is used in the synapse config snippets.

Signed-off-by: Gergely Polonkai <gergely@polonkai.eu>