### PR TITLE
Log roomid along with Unknown room

### DIFF
--- a/changelog.d/4297.misc
+++ b/changelog.d/4297.misc
@@ -1,0 +1,1 @@
+Log room_id in Unknown room errors

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -432,7 +432,7 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
         create_id = state_ids.get((EventTypes.Create, ""))
 
         if not create_id:
-            raise NotFoundError("Unknown room")
+            raise NotFoundError("Unknown room %s" % (room_id))
 
         create_event = yield self.get_event(create_id)
         defer.returnValue(create_event.content.get("room_version", "1"))


### PR DESCRIPTION
This error blew up on me in #4296, and there isn't any obvious way to tell which room is blowing up. We should really at least log which room it is.