### PR TITLE
ensure can report mau stats when hs.config.mau_stats_only is set

### DIFF
--- a/changelog.d/4305.bugfix
+++ b/changelog.d/4305.bugfix
@@ -1,0 +1,1 @@
+The metric synapse_admin_mau:current previously did not update when config.mau_stats_only was set to True

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -537,7 +537,7 @@ def run(hs):
         )
 
     start_generate_monthly_active_users()
-    if hs.config.limit_usage_by_mau:
+    if hs.config.limit_usage_by_mauor or hs.config.mau_stats_only:
         clock.looping_call(start_generate_monthly_active_users, 5 * 60 * 1000)
     # End of monthly active user settings
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -537,7 +537,7 @@ def run(hs):
         )
 
     start_generate_monthly_active_users()
-    if hs.config.limit_usage_by_mauor or hs.config.mau_stats_only:
+    if hs.config.limit_usage_by_mau or hs.config.mau_stats_only:
         clock.looping_call(start_generate_monthly_active_users, 5 * 60 * 1000)
     # End of monthly active user settings
 


### PR DESCRIPTION
Metric synapse_admin_mau:current is stuck at 0 when config.mau_stats_only is True, where it ought to track the number of mau users

Fixes #4229