### PR TITLE
Fix test_metrics.py compatibility prometheus_client 0.5

### DIFF
--- a/changelog.d/4317.bugfix
+++ b/changelog.d/4317.bugfix
@@ -1,0 +1,1 @@
+Fix test_metric.py compatibility with prometheus_client 0.5. Contributed by Maarten de Vries <maarten@de-vri.es>.


### PR DESCRIPTION
`prometheus_client 0.5` has a named-tuple `Sample` type with more member than the old plain tuple had. This PR makes sure the unit test detects this and changes the way it reads the sample.

It may be a bit much for a simple test, but it beats being stuck with `0.4` purely because a test fails.

The relevant change in `prometheus_client` can be found here:
https://github.com/prometheus/client_python/commit/b339d211a462b5318569b4926b649a9758134aba#diff-3b69664ac91a714e3e457f238848dee0R38

