### PR TITLE
Avoid packaging _trial_temp directory

### DIFF
--- a/changelog.d/4326.bugfix
+++ b/changelog.d/4326.bugfix
@@ -1,0 +1,2 @@
+Avoid packaging _trial_temp directory in -py3 debian packages
+

--- a/debian/build_virtualenv
+++ b/debian/build_virtualenv
@@ -41,8 +41,7 @@ tmpdir=`mktemp -d`
 trap "rm -r $tmpdir" EXIT
 
 cp -r tests "$tmpdir"
-cd debian/matrix-synapse-py3
 
 PYTHONPATH="$tmpdir" \
-    ./opt/venvs/matrix-synapse/bin/python \
+    debian/matrix-synapse-py3/opt/venvs/matrix-synapse/bin/python \
         -B -m twisted.trial --reporter=text -j2 tests


### PR DESCRIPTION
Make sure we don't put the _trial_temp directory in the package target
directory.

Fixes https://github.com/matrix-org/synapse/issues/4322