### PR TITLE
Fix index error if lazy_load_members but no events

### DIFF
--- a/changelog.d/4335.bugfix
+++ b/changelog.d/4335.bugfix
@@ -1,0 +1,1 @@
+Fix IndexError on pagination when using lazy member loading but there is no event.

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -253,7 +253,7 @@ class PaginationHandler(object):
         )
 
         state = None
-        if event_filter and event_filter.lazy_load_members():
+        if events and event_filter and event_filter.lazy_load_members():
             # TODO: remove redundant members
 
             # FIXME: we also care about invite targets etc.


### PR DESCRIPTION
I got the following `IndexError`:

```
2018-12-28 13:28:58,712 - synapse.http.server - 112 - ERROR - GET-565- Failed handle request via <function _async_render at 0x7f22fa949a28>: <XForwardedForRequest at 0x7f22acf08ef0 method=u'GET' uri=u'/_matrix/client/r0/rooms/!hUXVblRFCyynXMImeV:iiens.net/messages?from=t133592-3043003_41918178_53053_1733512_446400_976_1490_178292_19&dir=b&limit=30&filter=%7B%22lazy_load_members%22%3Atrue%7D' clientproto=u'HTTP/1.1' site=8008>: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 653, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1442, in gotResult
    _inlineCallbacks(r, g, deferred)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1384, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/usr/lib/python2.7/dist-packages/twisted/python/failure.py", line 422, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
--- <exception caught here> ---
  File "/usr/lib/python2.7/dist-packages/synapse/http/server.py", line 81, in wrapped_request_handler
    yield h(self, request)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1384, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/usr/lib/python2.7/dist-packages/twisted/python/failure.py", line 422, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/usr/lib/python2.7/dist-packages/synapse/http/server.py", line 316, in _async_render
    callback_return = yield callback(request, **kwargs)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1384, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/usr/lib/python2.7/dist-packages/twisted/python/failure.py", line 422, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/usr/lib/python2.7/dist-packages/synapse/rest/client/v1/room.py", line 479, in on_GET
    event_filter=event_filter,
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1386, in _inlineCallbacks
    result = g.send(result)
  File "/usr/lib/python2.7/dist-packages/synapse/handlers/pagination.py", line 266, in get_messages
    events[0].event_id, state_filter=state_filter,
exceptions.IndexError: list index out of range
```

This PR fixes it.

Signed-off-by: Alexandre Morignot <erdnaxeli@gmail.com>