### PR TITLE
Add "git" to prerequisites on ubuntu or debian

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Installing prerequisites on Ubuntu or Debian::
 
     sudo apt-get install build-essential python3-dev libffi-dev \
                          python-pip python-setuptools sqlite3 \
-                         libssl-dev python-virtualenv libjpeg-dev libxslt1-dev
+                         libssl-dev python-virtualenv libjpeg-dev libxslt1-dev git
 
 Installing prerequisites on ArchLinux::
 


### PR DESCRIPTION
### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](CONTRIBUTING.rst#changelog)
* [ ] Pull request includes a [sign off](CONTRIBUTING.rst#sign-off)

By default `git` is not installed on a headless debian 9 installation with only "standart system utilities", if you do not install it you will get an error on `synctl start`.

Note, I know this is not signed off nor has a changelog because it is a single very small README edit. Cloning the full repo with my bandwidth takes ages, this is not worth it. If you do not accept this without, please feel free to add it yourself.