### PR TITLE
Update README to use new virtualenv (#4328)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -796,8 +796,7 @@ A manual password reset can be done via direct database access as follows.
 
 First calculate the hash of the new password::
 
-    $ source ~/synapse/env/bin/activate
-    $ ./scripts/hash_password
+    $ ~/synapse/env/bin/hash_password
     Password:
     Confirm password:
     $2a$12$xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/README.rst
+++ b/README.rst
@@ -184,7 +184,7 @@ Configuring Synapse
 Before you can start Synapse, you will need to generate a configuration
 file. To do this, run (in your virtualenv, as before)::
 
-    cd ~/.synapse
+    cd ~/synapse
     python -m synapse.app.homeserver \
         --server-name my.domain.name \
         --config-path homeserver.yaml \
@@ -796,7 +796,7 @@ A manual password reset can be done via direct database access as follows.
 
 First calculate the hash of the new password::
 
-    $ source ~/.synapse/bin/activate
+    $ source ~/synapse/env/bin/activate
     $ ./scripts/hash_password
     Password:
     Confirm password:

--- a/changelog.d/4342.misc
+++ b/changelog.d/4342.misc
@@ -1,0 +1,1 @@
+Update README to use the new virtualenv everywhere


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](CONTRIBUTING.rst#sign-off)

Fixes #4328

Should I also update the password reset section to assume you installed Synapse via pypi, so the location of hash_password would be `./env/bin/hash_password` instead of `./scripts/hash_password`?
