### PR TITLE
Update debian Conflicts specifications

### DIFF
--- a/changelog.d/4349.misc
+++ b/changelog.d/4349.misc
@@ -1,0 +1,1 @@
+Update debian packaging for compatibility with transitional package

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+matrix-synapse-py3 (0.34.0.1) UNRELEASED; urgency=medium
+
+  * Update Conflicts specifications to allow installation alongside our
+    matrix-synapse transitional package.
+
+ -- Synapse Packaging team <packages@matrix.org>  Wed, 02 Jan 2019 17:48:40 +0000
+
 matrix-synapse-py3 (0.34.0) stable; urgency=medium
 
   * New synapse release 0.34.0.

--- a/debian/control
+++ b/debian/control
@@ -13,12 +13,16 @@ Build-Depends:
  python3-pip,
  python3-venv,
  tar,
-Standards-Version: 3.9.5
+Standards-Version: 3.9.8
 Homepage: https://github.com/matrix-org/synapse
 
 Package: matrix-synapse-py3
 Architecture: amd64
-Conflicts: matrix-synapse
+Provides: matrix-synapse
+Breaks:
+ matrix-synapse-ldap3,
+ matrix-synapse (<< 0.34.0-0matrix2),
+ matrix-synapse (>= 0.34.0-1),
 Pre-Depends: dpkg (>= 1.16.1)
 Depends:
  adduser,


### PR DESCRIPTION
...  to allow installation alongside our matrix-synapse transitional package.

(counterpart to https://github.com/matrix-org/package-synapse-debian/pull/41)