### PR TITLE
Silence travis-ci build warnings by removing non-functional python3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,13 @@ matrix:
 
 install:
   - pip install tox
+  
+  # if we don't have python3.6 in this environment, travis unhelpfully gives us
+  # a `python3.6` on our path which does nothing but spit out a warning. Tox
+  # tries to run it (even if we're not running a py36 env), so the build logs
+  # then have warnings which look like errors. To reduce the noise, remove the
+  # non-functional python3.6.
+  - ( ! command -v python3.6 || python3.6 --version ) &>/dev/null || rm -f $(command -v python3.6)
 
 script:
   - tox -e $TOX_ENV

--- a/changelog.d/4377.misc
+++ b/changelog.d/4377.misc
@@ -1,0 +1,1 @@
+Silence travis-ci build warnings by removing non-functional python3.6


### PR DESCRIPTION
see the comments for why this is a not-completely-insane thing to do.