### PR TITLE
limit remote device lists to 1000 entries per user

### DIFF
--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -532,6 +532,20 @@ class DeviceListEduUpdater(object):
 
                 stream_id = result["stream_id"]
                 devices = result["devices"]
+
+                # Emergency hack to prevent DoS from
+                # @bot:oliviervandertoorn.nl and @bot:matrix-beta.igalia.com
+                # on Jan 15 2019: only store the most recent 1000 devices for
+                # a given user.  (We assume we receive them in chronological
+                # order, which is dubious given _get_e2e_device_keys_txn does
+                # not explicitly order its results).  Otherwise it can take
+                # longer than 60s to persist the >100K devices, at which point
+                # the internal replication request to handle the
+                # m.device_list_update EDU times out, causing the remote
+                # server to retry the transaction and thus DoS synapse master
+                # CPU and DB.
+                devices = devices[-1000:]
+
                 yield self.store.update_remote_device_list_cache(
                     user_id, devices, stream_id,
                 )


### PR DESCRIPTION
Emergency hack to prevent DoS from
`@bot:oliviervandertoorn.nl` and `@bot:matrix-beta.igalia.com`
on Jan 15 2019: only store the most recent 1000 devices for
a given user.  (We assume we receive them in chronological
order, which is dubious given _get_e2e_device_keys_txn does
not explicitly order its results).  Otherwise it can take
longer than 60s to persist the >100K devices, at which point
the internal replication request to handle the
m.device_list_update EDU times out, causing the remote
server to retry the transaction and thus DoS synapse master
CPU and DB.