### PR TITLE
don't store more remote device lists if they have more than 1K devices

### DIFF
--- a/changelog.d/4397.bugfix
+++ b/changelog.d/4397.bugfix
@@ -1,0 +1,1 @@
+Fix high CPU usage due to remote devicelist updates

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -533,7 +533,7 @@ class DeviceListEduUpdater(object):
                 stream_id = result["stream_id"]
                 devices = result["devices"]
 
-                # If the remote server has more than ~10000 devices for this user
+                # If the remote server has more than ~1000 devices for this user
                 # we assume that something is going horribly wrong (e.g. a bot
                 # that logs in and creates a new device every time it tries to
                 # send a message).  Maintaining lots of devices per user in the
@@ -544,7 +544,7 @@ class DeviceListEduUpdater(object):
                 # server to retry, causing a DoS.  So in this scenario we give
                 # up on storing the total list of devices and only handle the
                 # delta instead.
-                if len(devices) > 10000:
+                if len(devices) > 1000:
                     devices = []
 
                 yield self.store.update_remote_device_list_cache(

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -532,6 +532,20 @@ class DeviceListEduUpdater(object):
 
                 stream_id = result["stream_id"]
                 devices = result["devices"]
+
+                # Emergency hack to prevent DoS from
+                # @bot:oliviervandertoorn.nl and @bot:matrix-beta.igalia.com
+                # on Jan 15 2019: only store the most recent 1000 devices for
+                # a given user.  (We assume we receive them in chronological
+                # order, which is dubious given _get_e2e_device_keys_txn does
+                # not explicitly order its results).  Otherwise it can take
+                # longer than 60s to persist the >100K devices, at which point
+                # the internal replication request to handle the
+                # m.device_list_update EDU times out, causing the remote
+                # server to retry the transaction and thus DoS synapse master
+                # CPU and DB.
+                devices = devices[-1000:]
+
                 yield self.store.update_remote_device_list_cache(
                     user_id, devices, stream_id,
                 )

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -545,6 +545,10 @@ class DeviceListEduUpdater(object):
                 # up on storing the total list of devices and only handle the
                 # delta instead.
                 if len(devices) > 1000:
+                    logger.warn(
+                        "Ignoring device list snapshot for %s as it has >1K devs (%d)",
+                        user_id, len(devices)
+                    )
                     devices = []
 
                 yield self.store.update_remote_device_list_cache(


### PR DESCRIPTION
Backport of #4396 to develop.

If the remote server has more than ~1000 devices for this user we assume that something is going horribly wrong (e.g. a bot that logs in and creates a new device every time it tries to send a message). Maintaining lots of devices per user in the cache can cause serious performance issues as if this request takes more than 60s to complete, internal replication from the inbound federation worker to the synapse master may time out causing the inbound federation to fail and causing the remote server to retry, causing a DoS. So in this scenario we give up on storing the total list of devices and only handle the delta instead. 
