### PR TITLE
Tweak code coverage settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,9 +3,13 @@ comment:
 
 coverage:
   status:
-    patch:
-      default:
-        target: 0  # Target % coverage, can be auto. Turned off for now
     project:
       default:
+        target: 0  # Target % coverage, can be auto. Turned off for now
+        threshold: null
+        base: auto
+    patch:
+      default:
         target: 0
+        threshold: null
+        base: auto

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+comment:
+  layout: "diff"
+
+coverage:
+  status:
+    patch:
+      default:
+        target: 0  # Target % coverage, can be auto. Turned off for now
+    project:
+      default:
+        target: 0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -37,6 +37,7 @@ prune docker
 prune .circleci
 prune .coveragerc
 prune debian
+prune .codecov.yml
 
 exclude jenkins*
 recursive-exclude jenkins *.sh

--- a/changelog.d/4400.misc
+++ b/changelog.d/4400.misc
@@ -1,0 +1,1 @@
+Tweak codecov settings to make them less loud.


### PR DESCRIPTION
They were quite verbose, for not a lot of benefit. Also adds two commit statuses:

- Project status: the total coverage of the total project
- Patch status: the total coverage of the diff

Currently they always pass, but we can set a minimum absolute threshold for coverage, or set it so that coverage must be better than the base branch. 