### PR TITLE
Allow for Synapse to run through a http relay

### DIFF
--- a/changelog.d/4406.feature
+++ b/changelog.d/4406.feature
@@ -1,0 +1,1 @@
+Added a simple HTTP proxy option for Synapse to send federation traffic through before reaching other servers.

--- a/changelog.d/4406.feature
+++ b/changelog.d/4406.feature
@@ -1,1 +1,1 @@
-Added a simple HTTP proxy option for Synapse to send federation traffic through before reaching other servers.
+Add a simple HTTP proxy option for Synapse to send federation traffic through before reaching other servers.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -107,11 +107,22 @@ class ServerConfig(Config):
         federation_domain_whitelist = config.get(
             "federation_domain_whitelist", None
         )
+
+        # Optional proxy address for federation traffic
+        self.proxy_federation_requests_address = config.get(
+            "proxy_federation_requests_address", None
+        )
+
         # turn the whitelist into a hash for speed of lookup
         if federation_domain_whitelist is not None:
             self.federation_domain_whitelist = {}
             for domain in federation_domain_whitelist:
                 self.federation_domain_whitelist[domain] = True
+
+        if self.proxy_federation_requests_address is not None:
+            # Ensure proxy address is correctly formatted
+            if len(self.proxy_federation_requests_address.split(':')) != 2:
+                self.proxy_federation_requests_address = None
 
         if self.public_baseurl is not None:
             if self.public_baseurl[-1] != '/':
@@ -288,6 +299,9 @@ class ServerConfig(Config):
         #  - lon.example.com
         #  - nyc.example.com
         #  - syd.example.com
+
+        # Proxy outbound federation requests through a seperate HTTP proxy.
+        # proxy_federation_requests_address: localhost:1234
 
         # List of ports that Synapse should listen on, their purpose and their
         # configuration.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -109,8 +109,8 @@ class ServerConfig(Config):
         )
 
         # Optional proxy address for federation traffic
-        self.proxy_federation_requests_address = config.get(
-            "proxy_federation_requests_address", None
+        self.federation_request_gateway_addr = config.get(
+            "federation_request_gateway_addr", None
         )
 
         # turn the whitelist into a hash for speed of lookup
@@ -119,10 +119,10 @@ class ServerConfig(Config):
             for domain in federation_domain_whitelist:
                 self.federation_domain_whitelist[domain] = True
 
-        if self.proxy_federation_requests_address is not None:
+        if self.federation_request_gateway_addr is not None:
             # Ensure proxy address is correctly formatted
-            if len(self.proxy_federation_requests_address.split(':')) != 2:
-                self.proxy_federation_requests_address = None
+            if len(self.federation_request_gateway_addr.split(':')) != 2:
+                self.federation_request_gateway_addr = None
 
         if self.public_baseurl is not None:
             if self.public_baseurl[-1] != '/':
@@ -300,8 +300,10 @@ class ServerConfig(Config):
         #  - nyc.example.com
         #  - syd.example.com
 
-        # Proxy outbound federation requests through a seperate HTTP proxy.
-        # proxy_federation_requests_address: localhost:1234
+        # Send outbound federation requests through a seperate traffic gateway.
+        # Not intended to be used with a SOCKS proxy, but rather a relay for
+        # HTTP traffic.
+        # federation_request_gateway_addr: localhost:1234
 
         # List of ports that Synapse should listen on, their purpose and their
         # configuration.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -108,16 +108,16 @@ class ServerConfig(Config):
             "federation_domain_whitelist", None
         )
 
-        # Optional proxy address for federation traffic
-        self.federation_request_gateway_addr = config.get(
-            "federation_request_gateway_addr", None
-        )
-
         # turn the whitelist into a hash for speed of lookup
         if federation_domain_whitelist is not None:
             self.federation_domain_whitelist = {}
             for domain in federation_domain_whitelist:
                 self.federation_domain_whitelist[domain] = True
+
+        # Optional proxy address for federation traffic
+        self.federation_request_gateway_addr = config.get(
+            "federation_request_gateway_addr", None
+        )
 
         if self.federation_request_gateway_addr is not None:
             # Ensure proxy address is correctly formatted

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -69,11 +69,10 @@ class ProxyMatrixFederationEndpointFactory(object):
     def __init__(self, hs):
         self.reactor = hs.get_reactor()
         self.tls_client_options_factory = hs.tls_client_options_factory
-        self.federation_request_gateway_addr = hs.config.federation_request_gateway_addr
 
     def endpointForURI(self, uri):
         return matrix_federation_endpoint(
-            self.reactor, self.federation_request_gateway_addr, timeout=10,
+            self.reactor, self.hs.config.federation_request_gateway_addr, timeout=10,
             tls_client_options_factory=None
         )
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -71,7 +71,7 @@ class ProxyMatrixFederationEndpointFactory(object):
 
     def endpointForURI(self, uri):
         return matrix_federation_endpoint(
-            self.reactor, self.hs.proxy_federation_requests_address, timeout=10,
+            self.reactor, self.hs.federation_request_gateway_addr, timeout=10,
             tls_client_options_factory=None
         )
 
@@ -196,14 +196,14 @@ class MatrixFederationHttpClient(object):
         self.hs = hs
         self.signing_key = hs.config.signing_key[0]
         self.server_name = hs.hostname
-        self.proxy_addr = hs.config.proxy_federation_requests_address
+        self.gateway_addr = hs.config.federation_request_gateway_addr
         reactor = hs.get_reactor()
         pool = HTTPConnectionPool(reactor)
         pool.retryAutomatically = False
         pool.maxPersistentPerHost = 5
         pool.cachedConnectionTimeout = 2 * 60
 
-        if self.proxy_addr:
+        if self.gateway_addr:
             self.agent = Agent.usingEndpointFactory(
                 reactor, ProxyMatrixFederationEndpointFactory(hs), pool=pool
             )

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -69,10 +69,11 @@ class ProxyMatrixFederationEndpointFactory(object):
     def __init__(self, hs):
         self.reactor = hs.get_reactor()
         self.tls_client_options_factory = hs.tls_client_options_factory
+        self.gateway_addr = hs.config.federation_request_gateway_addr
 
     def endpointForURI(self, uri):
         return matrix_federation_endpoint(
-            self.reactor, self.hs.config.federation_request_gateway_addr, timeout=10,
+            self.reactor, self.gateway_addr, timeout=10,
             tls_client_options_factory=None
         )
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -64,6 +64,7 @@ if PY3:
 else:
     MAXINT = sys.maxint
 
+
 class ProxyMatrixFederationEndpointFactory(object):
     def __init__(self, hs):
         self.reactor = hs.get_reactor()

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -69,10 +69,11 @@ class ProxyMatrixFederationEndpointFactory(object):
     def __init__(self, hs):
         self.reactor = hs.get_reactor()
         self.tls_client_options_factory = hs.tls_client_options_factory
+        self.federation_request_gateway_addr = hs.config.federation_request_gateway_addr
 
     def endpointForURI(self, uri):
         return matrix_federation_endpoint(
-            self.reactor, self.hs.federation_request_gateway_addr, timeout=10,
+            self.reactor, self.federation_request_gateway_addr, timeout=10,
             tls_client_options_factory=None
         )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -115,6 +115,7 @@ def default_config(name):
     config.email_enable_notifs = False
     config.block_non_admin_invites = False
     config.federation_domain_whitelist = None
+    config.federation_request_gateway_addr = None
     config.federation_rc_reject_limit = 10
     config.federation_rc_sleep_limit = 10
     config.federation_rc_sleep_delay = 100


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Adds a simple (non-SOCKS) HTTP federation traffic proxy that allows you to tunnel federation requests made by Synapse to other servers through an external service.

Configuration is done through `homeserver.yaml` by setting a flag to an address in the form of `hostname:port`.