### PR TITLE
Remove redundant WrappedConnection

### DIFF
--- a/changelog.d/4409.misc
+++ b/changelog.d/4409.misc
@@ -1,0 +1,1 @@
+Remove redundant federation connection wrapping code

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -320,23 +320,23 @@ class MatrixFederationHttpClient(object):
                         url_str,
                     )
 
-                    # we don't want all the fancy cookie and redirect handling that
-                    # treq.request gives: just use the raw Agent.
-                    request_deferred = self.agent.request(
-                        method_bytes,
-                        url_bytes,
-                        headers=Headers(headers_dict),
-                        bodyProducer=producer,
-                    )
-
-                    request_deferred = timeout_deferred(
-                        request_deferred,
-                        timeout=_sec_timeout,
-                        reactor=self.hs.get_reactor(),
-                    )
-
                     try:
                         with Measure(self.clock, "outbound_request"):
+                            # we don't want all the fancy cookie and redirect handling
+                            # that treq.request gives: just use the raw Agent.
+                            request_deferred = self.agent.request(
+                                method_bytes,
+                                url_bytes,
+                                headers=Headers(headers_dict),
+                                bodyProducer=producer,
+                            )
+
+                            request_deferred = timeout_deferred(
+                                request_deferred,
+                                timeout=_sec_timeout,
+                                reactor=self.hs.get_reactor(),
+                            )
+
                             response = yield make_deferred_yieldable(
                                 request_deferred,
                             )

--- a/tests/http/test_fedclient.py
+++ b/tests/http/test_fedclient.py
@@ -200,6 +200,7 @@ class FederationClientTests(HomeserverTestCase):
         self.assertEqual(content, b'{"a":"b"}')
 
     def test_closes_connection(self):
+        """Check that the client closes unused HTTP connections"""
         d = self.cl.get_json("testserv:8008", "foo/bar")
 
         self.pump()


### PR DESCRIPTION
The matrix federation client uses an HTTP connection pool, which times out its idle HTTP connections, so there is no need for any of this business.