### PR TITLE
New listener resource for the federation API "openid/userinfo" endpoint

### DIFF
--- a/changelog.d/4420.feature
+++ b/changelog.d/4420.feature
@@ -1,0 +1,13 @@
+New listener resource for the federation API "openid/userinfo" endpoint
+
+Integration managers use the OpenID userinfo endpoint in the federation API to verify that user
+OpenID access tokens are valid. If the federation resource is disabled, integration managers will not be able
+to verify the access token, causing a broken experience for users. The OpenID userinfo endpoint has now been split
+to a separate `openid` resource, which is enabled by default in newly generated configuration. It is also enabled
+automatically if the federation resource is enabled.
+
+If your homeserver runs federation enabled, this change does not require any actions.
+
+If you run a homeserver with federation disabled, we recommend adding the `openid` resource to your homeserver
+configuration in the `type: http` listener `resources` list to allow your users access to
+integration manager features.

--- a/changelog.d/4420.feature
+++ b/changelog.d/4420.feature
@@ -1,13 +1,1 @@
-New listener resource for the federation API "openid/userinfo" endpoint
-
-Integration managers use the OpenID userinfo endpoint in the federation API to verify that user
-OpenID access tokens are valid. If the federation resource is disabled, integration managers will not be able
-to verify the access token, causing a broken experience for users. The OpenID userinfo endpoint has now been split
-to a separate `openid` resource, which is enabled by default in newly generated configuration. It is also enabled
-automatically if the federation resource is enabled.
-
-If your homeserver runs federation enabled, this change does not require any actions.
-
-If you run a homeserver with federation disabled, we recommend adding the `openid` resource to your homeserver
-configuration in the `type: http` listener `resources` list to allow your users access to
-integration manager features.
+Federation OpenID listener resource can now be activated even if federation is disabled

--- a/synapse/app/federation_reader.py
+++ b/synapse/app/federation_reader.py
@@ -87,6 +87,13 @@ class FederationReaderServer(HomeServer):
                     resources.update({
                         FEDERATION_PREFIX: TransportLayerServer(self),
                     })
+                if name == "openid" and "federation" not in res["names"]:
+                    # Only load the openid resource separately if federation resource
+                    # is not specified since federation resource includes openid
+                    # resource.
+                    resources.update({
+                        FEDERATION_PREFIX: TransportLayerServer(self, servlet_groups=["openid"]),
+                    })
 
         root_resource = create_resource_tree(resources, NoResource())
 

--- a/synapse/app/federation_reader.py
+++ b/synapse/app/federation_reader.py
@@ -99,7 +99,8 @@ class FederationReaderServer(HomeServer):
                 listener_config,
                 root_resource,
                 self.version_string,
-            )
+            ),
+            reactor=self.get_reactor()
         )
 
         logger.info("Synapse federation reader now listening on port %d", port)

--- a/synapse/app/federation_reader.py
+++ b/synapse/app/federation_reader.py
@@ -92,7 +92,10 @@ class FederationReaderServer(HomeServer):
                     # is not specified since federation resource includes openid
                     # resource.
                     resources.update({
-                        FEDERATION_PREFIX: TransportLayerServer(self, servlet_groups=["openid"]),
+                        FEDERATION_PREFIX: TransportLayerServer(
+                            self,
+                            servlet_groups=["openid"],
+                        ),
                     })
 
         root_resource = create_resource_tree(resources, NoResource())

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -95,6 +95,10 @@ class SynapseHomeServer(HomeServer):
         resources = {}
         for res in listener_config["resources"]:
             for name in res["names"]:
+                if name == "openid" and "federation" in res["names"]:
+                    # Skip loading openid resource if federation is defined
+                    # since federation resource will include openid
+                    continue
                 resources.update(self._configure_named_resource(
                     name, res.get("compress", False),
                 ))
@@ -190,6 +194,11 @@ class SynapseHomeServer(HomeServer):
         if name == "federation":
             resources.update({
                 FEDERATION_PREFIX: TransportLayerServer(self),
+            })
+
+        if name == "openid":
+            resources.update({
+                FEDERATION_PREFIX: TransportLayerServer(self, servlet_groups=["openid"]),
             })
 
         if name in ["static", "client"]:

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -130,6 +130,7 @@ class SynapseHomeServer(HomeServer):
                     self.version_string,
                 ),
                 self.tls_server_context_factory,
+                reactor=self.get_reactor(),
             )
 
         else:
@@ -142,7 +143,8 @@ class SynapseHomeServer(HomeServer):
                     listener_config,
                     root_resource,
                     self.version_string,
-                )
+                ),
+                reactor=self.get_reactor(),
             )
         logger.info("Synapse now listening on port %d", port)
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -330,7 +330,7 @@ class ServerConfig(Config):
 
               - names: [federation]  # Federation APIs
                 compress: false
-                
+
               # # If federation is disabled synapse can still expose the open ID endpoint
               # # to allow integrations to authenticate users
               # - names: [openid]

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -151,7 +151,7 @@ class ServerConfig(Config):
                         "compress": gzip_responses,
                     },
                     {
-                        "names": ["federation"],
+                        "names": ["federation", "openid"],
                         "compress": False,
                     }
                 ]
@@ -170,7 +170,7 @@ class ServerConfig(Config):
                             "compress": gzip_responses,
                         },
                         {
-                            "names": ["federation"],
+                            "names": ["federation", "openid"],
                             "compress": False,
                         }
                     ]
@@ -328,7 +328,7 @@ class ServerConfig(Config):
                 # that can do automatic compression.
                 compress: true
 
-              - names: [federation]  # Federation APIs
+              - names: [federation, openid]  # Federation APIs
                 compress: false
 
             # optional list of additional endpoints which can be loaded via
@@ -350,7 +350,7 @@ class ServerConfig(Config):
             resources:
               - names: [client]
                 compress: true
-              - names: [federation]
+              - names: [federation, openid]
                 compress: false
 
           # Turn on the twisted ssh manhole service on localhost on the given
@@ -477,6 +477,7 @@ KNOWN_RESOURCES = (
     'keys',
     'media',
     'metrics',
+    'openid',
     'replication',
     'static',
     'webclient',

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -151,7 +151,7 @@ class ServerConfig(Config):
                         "compress": gzip_responses,
                     },
                     {
-                        "names": ["federation", "openid"],
+                        "names": ["federation"],
                         "compress": False,
                     }
                 ]
@@ -170,7 +170,7 @@ class ServerConfig(Config):
                             "compress": gzip_responses,
                         },
                         {
-                            "names": ["federation", "openid"],
+                            "names": ["federation"],
                             "compress": False,
                         }
                     ]
@@ -328,8 +328,13 @@ class ServerConfig(Config):
                 # that can do automatic compression.
                 compress: true
 
-              - names: [federation, openid]  # Federation APIs
+              - names: [federation]  # Federation APIs
                 compress: false
+                
+              # # If federation is disabled synapse can still expose the open ID endpoint
+              # # to allow integrations to authenticate users
+              # - names: [openid]
+              #   compress: false
 
             # optional list of additional endpoints which can be loaded via
             # dynamic modules
@@ -350,8 +355,12 @@ class ServerConfig(Config):
             resources:
               - names: [client]
                 compress: true
-              - names: [federation, openid]
+              - names: [federation]
                 compress: false
+              # # If federation is disabled synapse can still expose the open ID endpoint
+              # # to allow integrations to authenticate users
+              # - names: [openid]
+              #   compress: false
 
           # Turn on the twisted ssh manhole service on localhost on the given
           # port.

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -44,6 +44,16 @@ class TransportLayerServer(JsonResource):
     """Handles incoming federation HTTP requests"""
 
     def __init__(self, hs, servlet_groups=None):
+        """Initialize the TransportLayerServer
+
+        Will by default register all servlets. For custom behaviour, pass in
+        a list of servlet_groups to register.
+
+        Args:
+            hs (synapse.server.HomeServer): homeserver
+            servlet_groups (list[str], optional): List of servlet groups to register.
+                Defaults to ``DEFAULT_SERVLET_GROUPS``.
+        """
         self.hs = hs
         self.clock = hs.get_clock()
         self.servlet_groups = servlet_groups
@@ -1365,6 +1375,19 @@ DEFAULT_SERVLET_GROUPS = (
 
 
 def register_servlets(hs, resource, authenticator, ratelimiter, servlet_groups=None):
+    """Initialize and register servlet classes.
+
+    Will by default register all servlets. For custom behaviour, pass in
+    a list of servlet_groups to register.
+
+    Args:
+        hs (synapse.server.HomeServer): homeserver
+        resource (TransportLayerServer): resource class to register to
+        authenticator (Authenticator): authenticator to use
+        ratelimiter (util.ratelimitutils.FederationRateLimiter): ratelimiter to use
+        servlet_groups (list[str], optional): List of servlet groups to register.
+            Defaults to ``DEFAULT_SERVLET_GROUPS``.
+    """
     if not servlet_groups:
         servlet_groups = DEFAULT_SERVLET_GROUPS
 

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -81,7 +81,7 @@ CONDITIONAL_REQUIREMENTS = {
 
     "saml2": ["pysaml2>=4.5.0"],
     "url_preview": ["lxml>=3.5.0"],
-    "test": ["mock>=2.0"],
+    "test": ["mock>=2.0", "parameterized"],
 }
 
 

--- a/tests/app/test_frontend_proxy.py
+++ b/tests/app/test_frontend_proxy.py
@@ -59,7 +59,7 @@ class FrontendProxyTests(HomeserverTestCase):
 
     def test_listen_http_with_presence_disabled(self):
         """
-        When presence is on, the stub servlet will register.
+        When presence is off, the stub servlet will register.
         """
         # Presence is off
         self.hs.config.use_presence = False

--- a/tests/app/test_openid_listener.py
+++ b/tests/app/test_openid_listener.py
@@ -12,7 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import patch, Mock
+from mock import Mock, patch
+
 from parameterized import parameterized
 
 from synapse.app.federation_reader import FederationReaderServer
@@ -21,7 +22,6 @@ from synapse.app.homeserver import SynapseHomeServer
 from tests.unittest import HomeserverTestCase
 
 
-@patch("synapse.app.homeserver.KeyApiV2Resource", new=Mock())
 class FederationReaderOpenIDListenerTests(HomeserverTestCase):
     def make_homeserver(self, reactor, clock):
         hs = self.setup_test_homeserver(

--- a/tests/app/test_openid_listener.py
+++ b/tests/app/test_openid_listener.py
@@ -54,7 +54,7 @@ class FederationReaderOpenIDListenerTests(HomeserverTestCase):
         site = self.reactor.tcpServers[0][1]
         try:
             self.resource = (
-                site.resource.children[b"_matrix"].children[b"federation"].children[b"v1"]
+                site.resource.children[b"_matrix"].children[b"federation"]
             )
         except KeyError:
             if expectation == "no_resource":
@@ -100,7 +100,7 @@ class SynapseHomeserverOpenIDListenerTests(HomeserverTestCase):
         site = self.reactor.tcpServers[0][1]
         try:
             self.resource = (
-                site.resource.children[b"_matrix"].children[b"federation"].children[b"v1"]
+                site.resource.children[b"_matrix"].children[b"federation"]
             )
         except KeyError:
             if expectation == "no_resource":

--- a/tests/app/test_openid_listener.py
+++ b/tests/app/test_openid_listener.py
@@ -61,7 +61,10 @@ class FederationReaderOpenIDListenerTests(HomeserverTestCase):
                 return
             raise
 
-        request, channel = self.make_request("GET", "/_matrix/federation/v1/openid/userinfo")
+        request, channel = self.make_request(
+            "GET",
+            "/_matrix/federation/v1/openid/userinfo",
+        )
         self.render(request)
 
         self.assertEqual(channel.code, 401)
@@ -107,7 +110,10 @@ class SynapseHomeserverOpenIDListenerTests(HomeserverTestCase):
                 return
             raise
 
-        request, channel = self.make_request("GET", "/_matrix/federation/v1/openid/userinfo")
+        request, channel = self.make_request(
+            "GET",
+            "/_matrix/federation/v1/openid/userinfo",
+        )
         self.render(request)
 
         self.assertEqual(channel.code, 401)

--- a/tests/app/test_openid_listener.py
+++ b/tests/app/test_openid_listener.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018 New Vector Ltd
+# Copyright 2019 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ from mock import patch, Mock
 from parameterized import parameterized
 
 from synapse.app.federation_reader import FederationReaderServer
+from synapse.app.homeserver import SynapseHomeServer
 
 from tests.unittest import HomeserverTestCase
 
@@ -48,6 +49,52 @@ class FederationReaderOpenIDListenerTests(HomeserverTestCase):
 
         # Listen with the config
         self.hs._listen_http(config)
+
+        # Grab the resource from the site that was told to listen
+        site = self.reactor.tcpServers[0][1]
+        try:
+            self.resource = (
+                site.resource.children[b"_matrix"].children[b"federation"].children[b"v1"]
+            )
+        except KeyError:
+            if expectation == "no_resource":
+                return
+            raise
+
+        request, channel = self.make_request("GET", "/_matrix/federation/v1/openid/userinfo")
+        self.render(request)
+
+        self.assertEqual(channel.code, 401)
+
+
+@patch("synapse.app.homeserver.KeyApiV2Resource", new=Mock())
+class SynapseHomeserverOpenIDListenerTests(HomeserverTestCase):
+    def make_homeserver(self, reactor, clock):
+        hs = self.setup_test_homeserver(
+            http_client=None, homeserverToUse=SynapseHomeServer,
+        )
+        return hs
+
+    @parameterized.expand([
+        (["federation"], "auth_fail"),
+        ([], "no_resource"),
+        (["openid", "federation"], "auth_fail"),
+        (["openid"], "auth_fail"),
+    ])
+    def test_openid_listener(self, names, expectation):
+        """
+        Test different openid listener configurations.
+
+        401 is success here since it means we hit the handler and auth failed.
+        """
+        config = {
+            "port": 8080,
+            "bind_addresses": ["0.0.0.0"],
+            "resources": [{"names": names}],
+        }
+
+        # Listen with the config
+        self.hs._listener_http(config, config)
 
         # Grab the resource from the site that was told to listen
         site = self.reactor.tcpServers[0][1]

--- a/tests/app/test_openid_listener.py
+++ b/tests/app/test_openid_listener.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mock import patch, Mock
+from parameterized import parameterized
+
+from synapse.app.federation_reader import FederationReaderServer
+
+from tests.unittest import HomeserverTestCase
+
+
+@patch("synapse.app.homeserver.KeyApiV2Resource", new=Mock())
+class FederationReaderOpenIDListenerTests(HomeserverTestCase):
+    def make_homeserver(self, reactor, clock):
+        hs = self.setup_test_homeserver(
+            http_client=None, homeserverToUse=FederationReaderServer,
+        )
+        return hs
+
+    @parameterized.expand([
+        (["federation"], "auth_fail"),
+        ([], "no_resource"),
+        (["openid", "federation"], "auth_fail"),
+        (["openid"], "auth_fail"),
+    ])
+    def test_openid_listener(self, names, expectation):
+        """
+        Test different openid listener configurations.
+
+        401 is success here since it means we hit the handler and auth failed.
+        """
+        config = {
+            "port": 8080,
+            "bind_addresses": ["0.0.0.0"],
+            "resources": [{"names": names}],
+        }
+
+        # Listen with the config
+        self.hs._listen_http(config)
+
+        # Grab the resource from the site that was told to listen
+        site = self.reactor.tcpServers[0][1]
+        try:
+            self.resource = (
+                site.resource.children[b"_matrix"].children[b"federation"].children[b"v1"]
+            )
+        except KeyError:
+            if expectation == "no_resource":
+                return
+            raise
+
+        request, channel = self.make_request("GET", "/_matrix/federation/v1/openid/userinfo")
+        self.render(request)
+
+        self.assertEqual(channel.code, 401)

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     python-subunit
     junitxml
     coverage
+    parameterized
 
     # cyptography 2.2 requires setuptools >= 18.5
     #


### PR DESCRIPTION
Integration managers use the OpenID userinfo endpoint in the federation API to verify that user OpenID access tokens are valid. If the federation resource is disabled, integration managers will not be able to verify the access token, causing a broken experience for users. The OpenID userinfo endpoint has now been split to a separate `openid` resource, which is enabled by default in newly generated configuration. It is also enabled automatically if the federation resource is enabled.

Requires no actions on homeservers which have federation listener enabled. For homeservers with federation listener disabled, the `openid` listener resource needs to be manually added to the existing configuration, if the resource is wanted to be enabled. New installations will adopt the default of activating the resource even if federation resource is disabled.

Add also `parameterized` Python module to be able to easily parameterize test runs.