### PR TITLE
debian package: symlink to python-3.X

### DIFF
--- a/changelog.d/4433.misc
+++ b/changelog.d/4433.misc
@@ -1,0 +1,1 @@
+debian package: symlink to explicit python version

--- a/debian/build_virtualenv
+++ b/debian/build_virtualenv
@@ -6,7 +6,16 @@
 set -e
 
 export DH_VIRTUALENV_INSTALL_ROOT=/opt/venvs
-SNAKE=/usr/bin/python3
+
+# make sure that the virtualenv links to the specific version of python, by
+# dereferencing the python3 symlink.
+#
+# Otherwise, if somebody tries to install (say) the stretch package on buster,
+# they will get a confusing error about "No module named 'synapse'", because
+# python won't look in the right directory. At least this way, the error will
+# be a *bit* more obvious.
+#
+SNAKE=`readlink -e /usr/bin/python3`
 
 # try to set the CFLAGS so any compiled C extensions are compiled with the most
 # generic as possible x64 instructions, so that compiling it on a new Intel chip
@@ -46,3 +55,7 @@ cp -r tests "$tmpdir"
 PYTHONPATH="$tmpdir" \
     debian/matrix-synapse-py3/opt/venvs/matrix-synapse/bin/python \
         -B -m twisted.trial --reporter=text -j2 tests
+
+# add a dependency on the right version of python to substvars.
+PYPKG=`basename $SNAKE`
+echo "synapse:pydepends=$PYPKG" >> debian/matrix-synapse-py3.substvars

--- a/debian/control
+++ b/debian/control
@@ -27,8 +27,8 @@ Depends:
  adduser,
  debconf,
  python3-distutils|libpython3-stdlib (<< 3.6),
- python3,
  ${misc:Depends},
+ ${synapse:pydepends},
 # some of our scripts use perl, but none of them are important,
 # so we put perl:Depends in Suggests rather than Depends.
 Suggests:


### PR DESCRIPTION
In the debian package, make the virtualenv symlink python to /usr/bin/python3.X rather than /usr/bin/python3. Also make sure we depend on the right python3.x package.

This might help a bit with subtle failures when people install a package from the wrong distro (https://github.com/matrix-org/synapse/issues/4431).

(aside: this stuff really ought to go into the debian changelog, rather than the main changelog. how hard would it be to make the CI check if `debian/changelog` is updated when the `debian` directory is updated, instead of `changelog.d`?)