### PR TITLE
Neilj/fix threepid auth check

### DIFF
--- a/changelog.d/4435.bugfix
+++ b/changelog.d/4435.bugfix
@@ -1,1 +1,1 @@
-Fix None guard in config.server.is_threepid_reserved
+Fix None guard in calling config.server.is_threepid_reserved

--- a/changelog.d/4435.bugfix
+++ b/changelog.d/4435.bugfix
@@ -1,0 +1,1 @@
+Fix None guard in config.server.is_threepid_reserved

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -819,7 +819,9 @@ class Auth(object):
             elif threepid:
                 # If the user does not exist yet, but is signing up with a
                 # reserved threepid then pass auth check
-                if is_threepid_reserved(self.hs.config, threepid):
+                if is_threepid_reserved(
+                    self.hs.config.mau_limits_reserved_threepids, threepid
+                ):
                     return
             # Else if there is no room in the MAU bucket, bail
             current_mau = yield self.store.get_monthly_active_count()

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -420,19 +420,20 @@ class ServerConfig(Config):
                                   " service on the given port.")
 
 
-def is_threepid_reserved(config, threepid):
+def is_threepid_reserved(reserved_threepids, threepid):
     """Check the threepid against the reserved threepid config
     Args:
-        config(ServerConfig) - to access server config attributes
+        reserved_threepids([dict]) - list of reserved threepids
         threepid(dict) - The threepid to test for
 
     Returns:
         boolean Is the threepid undertest reserved_user
     """
+    if not threepid:
+        return False
 
-    for tp in config.mau_limits_reserved_threepids:
-        if (threepid['medium'] == tp['medium']
-                and threepid['address'] == tp['address']):
+    for tp in reserved_threepids:
+        if (threepid['medium'] == tp['medium'] and threepid['address'] == tp['address']):
             return True
     return False
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -429,8 +429,6 @@ def is_threepid_reserved(reserved_threepids, threepid):
     Returns:
         boolean Is the threepid undertest reserved_user
     """
-    if not threepid:
-        return False
 
     for tp in reserved_threepids:
         if (threepid['medium'] == tp['medium'] and threepid['address'] == tp['address']):

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -416,10 +416,11 @@ class RegisterRestServlet(RestServlet):
             )
             # Necessary due to auth checks prior to the threepid being
             # written to the db
-            if is_threepid_reserved(
-                self.hs.config.mau_limits_reserved_threepids, threepid
-            ):
-                yield self.store.upsert_monthly_active_user(registered_user_id)
+            if threepid:
+                if is_threepid_reserved(
+                    self.hs.config.mau_limits_reserved_threepids, threepid
+                ):
+                    yield self.store.upsert_monthly_active_user(registered_user_id)
 
             # remember that we've now registered that user account, and with
             #  what user ID (since the user may not have specified)

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -416,7 +416,9 @@ class RegisterRestServlet(RestServlet):
             )
             # Necessary due to auth checks prior to the threepid being
             # written to the db
-            if is_threepid_reserved(self.hs.config, threepid):
+            if is_threepid_reserved(
+                self.hs.config.mau_limits_reserved_threepids, threepid
+            ):
                 yield self.store.upsert_monthly_active_user(registered_user_id)
 
             # remember that we've now registered that user account, and with

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -154,7 +154,9 @@ def default_config(name):
     config.update_user_directory = False
 
     def is_threepid_reserved(threepid):
-        return ServerConfig.is_threepid_reserved(config, threepid)
+        return ServerConfig.is_threepid_reserved(
+            config.mau_limits_reserved_threepids, threepid
+        )
 
     config.is_threepid_reserved.side_effect = is_threepid_reserved
 


### PR DESCRIPTION
If mau_limits_reserved_threepids is populated but the threepid to test is None the method will barf. This PRs adds a guard to prevent this.
