### PR TITLE
Add support for persisting event format versions

### DIFF
--- a/changelog.d/4437.misc
+++ b/changelog.d/4437.misc
@@ -1,0 +1,1 @@
+Add support for persisting event format versions in the database

--- a/changelog.d/4437.misc
+++ b/changelog.d/4437.misc
@@ -1,1 +1,1 @@
-Add support for persisting event format versions in the database
+Add infrastructure to support different event formats

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -120,6 +120,19 @@ KNOWN_ROOM_VERSIONS = {
     RoomVersions.STATE_V2_TEST,
 }
 
+
+class EventFormatVersions(object):
+    """This is an internal enum for tracking the version of the event format,
+    independently from the room version.
+    """
+    V1 = 1
+
+
+KNOWN_EVENT_FORMAT_VERSIONS = {
+    EventFormatVersions.V1,
+}
+
+
 ServerNoticeMsgType = "m.server_notice"
 ServerNoticeLimitReached = "m.server_notice.usage_limit_reached"
 

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -18,6 +18,9 @@ from distutils.util import strtobool
 
 import six
 
+from synapse.api.constants import (
+    EventFormatVersions,
+)
 from synapse.util.caches import intern_dict
 from synapse.util.frozenutils import freeze
 
@@ -179,6 +182,8 @@ class EventBase(object):
 
 
 class FrozenEvent(EventBase):
+    format_version = EventFormatVersions.V1  # All events of this type are V1
+
     def __init__(self, event_dict, internal_metadata_dict={}, rejected_reason=None):
         event_dict = dict(event_dict)
 

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -18,9 +18,7 @@ from distutils.util import strtobool
 
 import six
 
-from synapse.api.constants import (
-    EventFormatVersions,
-)
+from synapse.api.constants import EventFormatVersions
 from synapse.util.caches import intern_dict
 from synapse.util.frozenutils import freeze
 

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -1268,6 +1268,7 @@ class EventsStore(StateGroupWorkerStore, EventFederationStore, EventsWorkerStore
                         event.internal_metadata.get_dict()
                     ),
                     "json": encode_json(event_dict(event)),
+                    "format_version": event.format_version,
                 }
                 for event, _ in events_and_contexts
             ],

--- a/synapse/storage/events_worker.py
+++ b/synapse/storage/events_worker.py
@@ -23,9 +23,9 @@ from twisted.internet import defer
 
 from synapse.api.constants import EventFormatVersions
 from synapse.api.errors import NotFoundError
+from synapse.events import FrozenEvent
 # these are only included to make the type annotations work
 from synapse.events.snapshot import EventContext  # noqa: F401
-from synapse.events import FrozenEvent
 from synapse.events.utils import prune_event
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.util.logcontext import (

--- a/synapse/storage/schema/delta/53/event_format_version.sql
+++ b/synapse/storage/schema/delta/53/event_format_version.sql
@@ -1,0 +1,16 @@
+/* Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE event_json ADD COLUMN format_version INTEGER;


### PR DESCRIPTION
Currently we only have the one event format version defined, but this
adds the necessary infrastructure to persist and fetch the format
versions alongside the events.

We specify the format version rather than the room version as:

1. We don't necessarily know the room version, existing events may be
   either v1 or v2.
2. We'd need to be careful to prevent/handle correctly if different
   events in the same room reported to be of different versions, which
   sounds annoying.
