### PR TITLE
Clarify docs for public_baseurl

### DIFF
--- a/changelog.d/4458.misc
+++ b/changelog.d/4458.misc
@@ -1,0 +1,1 @@
+Clarify documentation for the `public_baseurl` config param

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -256,7 +256,11 @@ class ServerConfig(Config):
         #
         # web_client_location: "/path/to/web/root"
 
-        # The public-facing base URL for the client API (not including _matrix/...)
+        # The public-facing base URL that clients use to access this HS
+        # (not including _matrix/...). This is the same URL a user would
+        # enter into the 'custom HS URL' field on their client. If you
+        # use synapse with a reverse proxy, this should be the URL to reach
+        # synapse via the proxy.
         # public_baseurl: https://example.com:8448/
 
         # Set the soft limit on the number of file descriptors synapse can use


### PR DESCRIPTION
This is leading to problems with people upgrading to clients that
support MSC1730 because people have this misconfigured, so try
to make the docs completely unambiguous.

NB. In a world without ACME support I probably would have also remove the 8448 from the example URL as this would never have worked, being a self-signed cert, but I guess now this is a plausible default, although it still feels like it's directing you towards it being the internal URL. wdyt?