### PR TITLE
Fix UnboundLocalError in post_urlencoded_get_json

### DIFF
--- a/changelog.d/4460.bugfix
+++ b/changelog.d/4460.bugfix
@@ -1,0 +1,1 @@
+Fix UnboundLocalError in post_urlencoded_get_json

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -333,9 +333,10 @@ class SimpleHttpClient(object):
             "POST", uri, headers=Headers(actual_headers), data=query_bytes
         )
 
+        body = yield make_deferred_yieldable(readBody(response))
+
         if 200 <= response.code < 300:
-            body = yield make_deferred_yieldable(treq.json_content(response))
-            defer.returnValue(body)
+            defer.returnValue(json.loads(body))
         else:
             raise HttpResponseException(response.code, response.phrase, body)
 


### PR DESCRIPTION
This could cause exceptions if the id server returned 4xx responses.

(it got broken in 2d2828dcb)