### PR TITLE
Add a 60s timeout to filtered room directory queries

### DIFF
--- a/changelog.d/4461.bugfix
+++ b/changelog.d/4461.bugfix
@@ -1,0 +1,1 @@
+Add a timeout to filtered room directory queries.

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -94,7 +94,7 @@ class RoomListHandler(BaseHandler):
     def _get_public_room_list(self, limit=None, since_token=None,
                               search_filter=None,
                               network_tuple=EMPTY_THIRD_PARTY_ID,
-                              timeout=0,):
+                              timeout=None,):
         if since_token and since_token != "END":
             since_token = RoomListNextBatch.from_token(since_token)
         else:

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -15,7 +15,6 @@
 
 import logging
 from collections import namedtuple
-from datetime import datetime, timedelta
 
 from six import PY3, iteritems
 from six.moves import range
@@ -78,7 +77,7 @@ class RoomListHandler(BaseHandler):
             # XXX: Quick hack to stop room directory queries taking too long.
             # Timeout request after 60s. Probably want a more fundamental
             # solution at some point
-            timeout = datetime.now() + timedelta(seconds=60)
+            timeout = self.clock.time() + 60
             return self._get_public_room_list(
                 limit, since_token, search_filter,
                 network_tuple=network_tuple, timeout=timeout,
@@ -95,7 +94,7 @@ class RoomListHandler(BaseHandler):
     def _get_public_room_list(self, limit=None, since_token=None,
                               search_filter=None,
                               network_tuple=EMPTY_THIRD_PARTY_ID,
-                              timeout=None,):
+                              timeout=0,):
         if since_token and since_token != "END":
             since_token = RoomListNextBatch.from_token(since_token)
         else:
@@ -210,7 +209,7 @@ class RoomListHandler(BaseHandler):
 
         chunk = []
         for i in range(0, len(rooms_to_scan), step):
-            if timeout and datetime.now() > timeout:
+            if timeout and self.clock.time() > timeout:
                 raise Exception("Timed out searching room directory")
 
             batch = rooms_to_scan[i:i + step]

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -15,6 +15,7 @@
 
 import logging
 from collections import namedtuple
+from datetime import datetime, timedelta
 
 from six import PY3, iteritems
 from six.moves import range
@@ -31,7 +32,6 @@ from synapse.util.caches.descriptors import cachedInlineCallbacks
 from synapse.util.caches.response_cache import ResponseCache
 
 from ._base import BaseHandler
-from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -80,7 +80,8 @@ class RoomListHandler(BaseHandler):
             # solution at some point
             timeout = datetime.now() + timedelta(seconds=60)
             return self._get_public_room_list(
-                limit, since_token, search_filter, network_tuple=network_tuple, timeout=timeout,
+                limit, since_token, search_filter,
+                network_tuple=network_tuple, timeout=timeout,
             )
 
         key = (limit, since_token, network_tuple)

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -31,6 +31,7 @@ from synapse.util.caches.descriptors import cachedInlineCallbacks
 from synapse.util.caches.response_cache import ResponseCache
 
 from ._base import BaseHandler
+from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -73,8 +74,13 @@ class RoomListHandler(BaseHandler):
             # We explicitly don't bother caching searches or requests for
             # appservice specific lists.
             logger.info("Bypassing cache as search request.")
+
+            # XXX: Quick hack to stop room directory queries taking too long.
+            # Timeout request after 60s. Probably want a more fundamental
+            # solution at some point
+            timeout = datetime.now() + timedelta(seconds=60)
             return self._get_public_room_list(
-                limit, since_token, search_filter, network_tuple=network_tuple,
+                limit, since_token, search_filter, network_tuple=network_tuple, timeout=timeout,
             )
 
         key = (limit, since_token, network_tuple)
@@ -87,7 +93,8 @@ class RoomListHandler(BaseHandler):
     @defer.inlineCallbacks
     def _get_public_room_list(self, limit=None, since_token=None,
                               search_filter=None,
-                              network_tuple=EMPTY_THIRD_PARTY_ID,):
+                              network_tuple=EMPTY_THIRD_PARTY_ID,
+                              timeout=None,):
         if since_token and since_token != "END":
             since_token = RoomListNextBatch.from_token(since_token)
         else:
@@ -202,6 +209,9 @@ class RoomListHandler(BaseHandler):
 
         chunk = []
         for i in range(0, len(rooms_to_scan), step):
+            if timeout and datetime.now() > timeout:
+                raise Exception("Timed out searching room directory")
+
             batch = rooms_to_scan[i:i + step]
             logger.info("Processing %i rooms for result", len(batch))
             yield concurrently_execute(


### PR DESCRIPTION
Protects against longstanding queries piling up in the background and blocking new ones.