### PR TITLE
Filter user directory state query to a subset of state events

### DIFF
--- a/changelog.d/4462.misc
+++ b/changelog.d/4462.misc
@@ -1,0 +1,1 @@
+Change the user directory state query to use a filtered call to the db instead of a generic one.


### PR DESCRIPTION
Don't request all state events from a room, just those we need.

Should help slightly with DB hammering from the user directory.