### PR TITLE
Don't require sqlite3 when using postgres

### DIFF
--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -15,7 +15,6 @@
 
 import struct
 import threading
-from sqlite3 import sqlite_version_info
 
 from synapse.storage.prepare_database import prepare_database
 
@@ -37,7 +36,7 @@ class Sqlite3Engine(object):
         Do we support native UPSERTs? This requires SQLite3 3.24+, plus some
         more work we haven't done yet to tell what was inserted vs updated.
         """
-        return sqlite_version_info >= (3, 24, 0)
+        return self.module.sqlite_version_info >= (3, 24, 0)
 
     def check_database(self, txn):
         pass


### PR DESCRIPTION
There's no need to import and use sqlite3 if you're using postgres as your db backend.