### PR TITLE
snap: Add snapcraft support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,9 @@ env/
 .ropeproject/
 *.deb
 /debs
+
+*.snap
+parts/
+prime/
+snap/.snapcraft/
+stage/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -69,3 +69,6 @@ Serban Constantin <serban.constantin at gmail dot com>
 
 Jason Robinson <jasonr at matrix.org>
  * Minor fixes
+
+Marco Trevisan <marco at ubuntu dot com>
+ * Snapcraft packaging support

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -39,5 +39,7 @@ prune .coveragerc
 prune debian
 prune .codecov.yml
 
+prune snap
+
 exclude jenkins*
 recursive-exclude jenkins *.sh

--- a/changelog.d/4484.feature
+++ b/changelog.d/4484.feature
@@ -1,0 +1,1 @@
+Add snapcraft packaging support

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,60 @@
+name: matrix-synapse
+version: git
+summary: Synapse, Matrix reference homeserver
+description: |
+  Matrix is an ambitious new ecosystem for open federated Instant Messaging and
+  VoIP. The basics you need to know to get up and running are:
+
+  Everything in Matrix happens in a room. Rooms are distributed and do not
+  exist on any single server. Rooms can be located using convenience aliases
+  like #matrix:matrix.org or #test:localhost:8448. Matrix user IDs look like
+  @matthew:matrix.org (although in the future you will normally refer to
+  yourself and others using a third party identifier (3PID): email address,
+  phone number, etc rather than manipulating Matrix user IDs)
+
+  The overall architecture is:
+  client <----> homeserver <=====================> homeserver <----> client
+      https://somewhere.org/_matrix        https://elsewhere.net/_matrix
+
+  #matrix:matrix.org is the official support room for Matrix, and can be
+  accessed by any client from https://matrix.org/docs/projects/try-matrix-now.html
+  or via IRC bridge at irc://irc.freenode.net/matrix.
+
+  Synapse is currently in rapid development, but as of version 0.5 we believe
+  it is sufficiently stable to be run as an internet-facing service for real
+  usage!
+
+grade: stable
+confinement: strict
+
+parts:
+  synapse:
+    plugin: python
+    source: .
+    build-packages:
+      - build-essential
+      - libffi-dev
+      - libjpeg-dev
+      - libssl-dev
+      - libxslt1-dev
+      - python3-dev
+      - sqlite3
+    python-packages:
+      - setuptools
+      - matrix-synapse
+      - Jinja2
+
+apps:
+  matrix-synapse:
+    command: synctl
+    plugs:
+      - network
+      - network-bind
+
+  homeserver:
+    command: python3 -B -m synapse.app.homeserver
+
+  register-new-matrix-user:
+    command: register_new_matrix_user
+    plugs:
+      - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,15 +46,46 @@ parts:
 
 apps:
   matrix-synapse:
-    command: synctl
+    daemon: simple
+    command: |
+      sh -c 'cd $SNAP_COMMON &&
+      mkdir -p $SNAP_COMMON/config.d &&
+      [ -f $SNAP_COMMON/homeserver.yaml ] && \
+      python3 -B -m synapse.app.homeserver \
+        --config-path $SNAP_COMMON/homeserver.yaml \
+        --config-path $SNAP_COMMON/config.d \
+        --keys-directory $SNAP_COMMON \
+        -d $SNAP_COMMON/homeserver.db ||
+      echo Missing conifiguration in $SNAP_COMMON/homeserver.yaml, use sudo $SNAP_NAME.generate-config &&
+      exit 0'
+    restart-condition: on-failure
+    plugs:
+      - network
+      - network-bind
+
+  synctl:
+    command: sh -c 'cd $SNAP_COMMON && synctl $*'
     plugs:
       - network
       - network-bind
 
   homeserver:
-    command: python3 -B -m synapse.app.homeserver
+    command: |
+      sh -c 'cd $SNAP_COMMON &&
+             python3 -B -m synapse.app.homeserver \
+             -c $SNAP_COMMON/homeserver.yaml $*'
+    plugs:
+      - network
+      - network-bind
+
+  generate-config:
+    command: |
+      sh -c 'cd $SNAP_COMMON &&
+             python3 -B -m synapse.app.homeserver \
+             --generate-config \
+             -c $SNAP_COMMON/homeserver.yaml $*'
 
   register-new-matrix-user:
-    command: register_new_matrix_user
+    command: register_new_matrix_user -c $SNAP_COMMON/homeserver.yaml
     plugs:
       - network


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Supports [snapcraft](http://snapcraft.io/) packaging system to easily distribute synapse in most of linux distributions as a self-contained package.

Ideally this should be maintened by upstream, by doing releases. So you should register `matrix-synapse` name at snapcraft so that you keep the ownership of this package.

You can use [build.snapcraft.io](http://build.snapcraft.io/) to generate automatic builds that lands immediately to the edge channel, once master has changed, while you can manually promote builds to stable or beta.
