### PR TITLE
Remove --process-dependency-links from UPGRADE.rst

### DIFF
--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -18,7 +18,7 @@ instructions that may be required are listed later in this document.
 
    .. code:: bash
 
-       pip install --upgrade --process-dependency-links matrix-synapse
+       pip install --upgrade matrix-synapse
 
        # restart synapse
        synctl restart

--- a/changelog.d/4485.misc
+++ b/changelog.d/4485.misc
@@ -1,0 +1,1 @@
+Remove deprecated --process-dependency-links option from UPGRADE.rst


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

pip 19.0 finally removed that option https://pip.readthedocs.io/en/latest/news/#id4 so you get an error if you try to use it https://matrix.to/#/!QtykxKocfZaZOUrTwp:matrix.org/$15486036393651Rugay:disroot.org?via=matrix.org&via=half-shot.uk&via=linuxgaming.life
