### PR TITLE
Split up event validation between event and builder

### DIFF
--- a/changelog.d/4494.misc
+++ b/changelog.d/4494.misc
@@ -1,0 +1,1 @@
+Add infrastructure to support different event formats

--- a/synapse/events/validator.py
+++ b/synapse/events/validator.py
@@ -21,8 +21,14 @@ from synapse.types import EventID, RoomID, UserID
 
 
 class EventValidator(object):
+    def validate_new(self, event):
+        """Validates the event has roughly the right format
 
-    def validate(self, event):
+        Args:
+            event (FrozenEvent)
+        """
+        self.validate_builder(event)
+
         EventID.from_string(event.event_id)
 
         required = [
@@ -40,32 +46,21 @@ class EventValidator(object):
                 raise SynapseError(400, "Event does not have key %s" % (k,))
 
         # Check that the following keys have string values
-        strings = [
+        event_strings = [
             "origin",
         ]
 
-        for s in strings:
+        for s in event_strings:
             if not isinstance(getattr(event, s), string_types):
                 raise SynapseError(400, "Not '%s' a string type" % (s,))
 
-    def validate_new(self, event):
-        """Validates the event has roughly the right format
-
-        Args:
-            event (FrozenEvent)
-        """
-        self.validate_builder(event)
-        self.validate(event)
-
-        UserID.from_string(event.sender)
-
         if event.type == EventTypes.Message:
-            strings = [
+            content_strings = [
                 "body",
                 "msgtype",
             ]
 
-            self._ensure_strings(event.content, strings)
+            self._ensure_strings(event.content, content_strings)
 
         elif event.type == EventTypes.Topic:
             self._ensure_strings(event.content, ["topic"])

--- a/synapse/events/validator.py
+++ b/synapse/events/validator.py
@@ -52,7 +52,7 @@ class EventValidator(object):
 
         for s in event_strings:
             if not isinstance(getattr(event, s), string_types):
-                raise SynapseError(400, "Not '%s' a string type" % (s,))
+                raise SynapseError(400, "'%s' not a string type" % (s,))
 
         if event.type == EventTypes.Message:
             content_strings = [
@@ -119,4 +119,4 @@ class EventValidator(object):
             if s not in d:
                 raise SynapseError(400, "'%s' not in content" % (s,))
             if not isinstance(d[s], string_types):
-                raise SynapseError(400, "Not '%s' a string type" % (s,))
+                raise SynapseError(400, "'%s' not a string type" % (s,))

--- a/synapse/events/validator.py
+++ b/synapse/events/validator.py
@@ -54,20 +54,6 @@ class EventValidator(object):
             if not isinstance(getattr(event, s), string_types):
                 raise SynapseError(400, "'%s' not a string type" % (s,))
 
-        if event.type == EventTypes.Message:
-            content_strings = [
-                "body",
-                "msgtype",
-            ]
-
-            self._ensure_strings(event.content, content_strings)
-
-        elif event.type == EventTypes.Topic:
-            self._ensure_strings(event.content, ["topic"])
-
-        elif event.type == EventTypes.Name:
-            self._ensure_strings(event.content, ["name"])
-
     def validate_builder(self, event):
         """Validates that the builder/event has roughly the right format. Only
         checks values that we expect a proto event to have, rather than all the

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2278,7 +2278,7 @@ class FederationHandler(BaseHandler):
             room_version = yield self.store.get_room_version(room_id)
             builder = self.event_builder_factory.new(room_version, event_dict)
 
-            EventValidator().validate_new(builder)
+            EventValidator().validate_builder(builder)
             event, context = yield self.event_creation_handler.create_new_client_event(
                 builder=builder
             )
@@ -2286,6 +2286,8 @@ class FederationHandler(BaseHandler):
             event, context = yield self.add_display_name_to_third_party_invite(
                 room_version, event_dict, event, context
             )
+
+            EventValidator().validate_new(event)
 
             try:
                 yield self.auth.check_from_context(event, context)
@@ -2372,10 +2374,11 @@ class FederationHandler(BaseHandler):
             # auth check code will explode appropriately.
 
         builder = self.event_builder_factory.new(room_version, event_dict)
-        EventValidator().validate_new(builder)
+        EventValidator().validate_builder(builder)
         event, context = yield self.event_creation_handler.create_new_client_event(
             builder=builder,
         )
+        EventValidator().validate_new(event)
         defer.returnValue((event, context))
 
     @defer.inlineCallbacks

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -288,7 +288,7 @@ class EventCreationHandler(object):
 
         builder = self.event_builder_factory.new(room_version, event_dict)
 
-        self.validator.validate_new(builder)
+        self.validator.validate_builder(builder)
 
         if builder.type == EventTypes.Member:
             membership = builder.content.get("membership", None)
@@ -325,6 +325,8 @@ class EventCreationHandler(object):
             requester=requester,
             prev_events_and_hashes=prev_events_and_hashes,
         )
+
+        self.validator.validate_new(event)
 
         defer.returnValue((event, context))
 


### PR DESCRIPTION
The validator was being run on the EventBuilder objects, and so the
validator only checked a subset of fields. With the upcoming
EventBuilder refactor even fewer fields will be there to validate.

To get around this we split the validation into those that can be run
against an EventBuilder and those run against a fully fledged event.