### PR TITLE
Reject large transactions on federation

### DIFF
--- a/changelog.d/4513.misc
+++ b/changelog.d/4513.misc
@@ -1,0 +1,1 @@
+Reject federation transactions if they include more than 50 PDUs or 100 EDUs.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -151,26 +151,18 @@ class FederationServer(FederationBase):
         # Reject if PDU count > 50 and EDU count > 100
         if (len(transaction.pdus) > 50
                 or (hasattr(transaction, "edus") and len(transaction.edus) > 100)):
-            response = {
-                "pdus": {}
-            }
 
-            for pdu_key in transaction["pdus"].keys():
-                response["pdus"][pdu_key] = {
-                    "error": "Processing failed. More than 50 PDUs or 100 EDUs sent."
-                }
-
-            logger.debug(
-                "Transaction PDU or EDU count too large. Returning: %s", str(response)
+            logger.info(
+                "Transaction PDU or EDU count too large. Returning 400",
             )
 
+            response = {}
             yield self.transaction_actions.set_response(
                 origin,
                 transaction,
                 400, response
             )
             defer.returnValue((400, response))
-            return
 
         received_pdus_counter.inc(len(transaction.pdus))
 

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -148,6 +148,31 @@ class FederationServer(FederationBase):
 
         logger.debug("[%s] Transaction is new", transaction.transaction_id)
 
+        # Reject if PDU count > 50 and EDU count > 100
+        if (len(transaction.pdus) > 50
+            or (hasattr(transaction, "edus") and len(transaction.edus) > 100)
+        ):
+            response = {
+                "pdus": {}
+            }
+
+            for pdu_key in transaction["pdus"].keys():
+                response["pdus"][pdu_key] = {
+                    "error": "Processing failed. More than 50 PDUs or 100 EDUs sent."
+                }
+
+            logger.debug(
+                "Transaction PDU or EDU count too large. Returning: %s", str(response)
+            )
+
+            yield self.transaction_actions.set_response(
+                origin,
+                transaction,
+                400, response
+            )
+            defer.returnValue((400, response))
+            return
+
         received_pdus_counter.inc(len(transaction.pdus))
 
         origin_host, _ = parse_server_name(origin)

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -150,8 +150,7 @@ class FederationServer(FederationBase):
 
         # Reject if PDU count > 50 and EDU count > 100
         if (len(transaction.pdus) > 50
-            or (hasattr(transaction, "edus") and len(transaction.edus) > 100)
-        ):
+                or (hasattr(transaction, "edus") and len(transaction.edus) > 100)):
             response = {
                 "pdus": {}
             }


### PR DESCRIPTION
Rejects a transaction if it has more than 50 PDUs and/or 100 EDUs as per https://github.com/matrix-org/matrix-doc/pull/1581/files

Sytest PR: https://github.com/matrix-org/sytest/pull/555/