### PR TITLE
Fix replication for room v3

### DIFF
--- a/changelog.d/4523.feature
+++ b/changelog.d/4523.feature
@@ -1,0 +1,1 @@
+Add support for room version 3

--- a/synapse/replication/http/_base.py
+++ b/synapse/replication/http/_base.py
@@ -127,7 +127,10 @@ class ReplicationEndpoint(object):
         def send_request(**kwargs):
             data = yield cls._serialize_payload(**kwargs)
 
-            url_args = [urllib.parse.quote(kwargs[name]) for name in cls.PATH_ARGS]
+            url_args = [
+                urllib.parse.quote(kwargs[name], safe='')
+                for name in cls.PATH_ARGS
+            ]
 
             if cls.CACHE:
                 txn_id = random_string(10)


### PR DESCRIPTION
We were not correctly quoting the path fragments over http replication,
which meant that it exploded when the event IDs had a slash in them

