### PR TITLE
Copy over non-federatable trait on room upgrade

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -263,6 +263,20 @@ class RoomCreationHandler(BaseHandler):
             }
         }
 
+        # Check if old room was non-federatable
+
+        # Get old room's create event
+        old_room_create_event_ids = yield self.store.get_filtered_current_state_ids(
+            old_room_id, StateFilter.from_types(((EventTypes.Create, ""),)),
+        )
+        old_room_create_event_dict = yield self.store.get_events(old_room_create_event_ids.values())
+        old_room_create_event = list(old_room_create_event_dict.values())[0]
+
+        # Check if the create event specified a non-federatable room
+        if old_room_create_event.content.get("m.federate", True) == False:
+            # If so, mark the new room as non-federatable as well
+            creation_content["m.federate"] = False
+
         initial_state = dict()
 
         # Replicate relevant room events


### PR DESCRIPTION
This PR fixes the bug where if you upgraded a room that was set to be unable to federate, the upgraded room could still federate.