### PR TITLE
Treat an invalid .well-known the same as an absent one

### DIFF
--- a/changelog.d/4544.misc
+++ b/changelog.d/4544.misc
@@ -1,0 +1,1 @@
+Treat an invalid .well-known file the same as an absent one


### PR DESCRIPTION
... basically, carry on and fall back to SRV etc.

Turns out a bunch of people return 200s to .well-known requests, but don't serve up valid .well-knowns