### PR TITLE
Avoid redundant URL encoding

### DIFF
--- a/changelog.d/4555.bugfix
+++ b/changelog.d/4555.bugfix
@@ -1,2 +1,1 @@
-Avoid redundant URL encoding of redirect URL for SSO login in the fallback login page.
-Fixes a regression introduced in 925a074a7373090b712a1da4788d181819878bd1.
+Avoid redundant URL encoding of redirect URL for SSO login in the fallback login page. Fixes a regression introduced in [#4220](https://github.com/matrix-org/synapse/pull/4220). Contributed by Marcel Fabian Krüger ("[zaugin](https://github.com/zauguin)").

--- a/changelog.d/4555.bugfix
+++ b/changelog.d/4555.bugfix
@@ -1,0 +1,2 @@
+Avoid redundant URL encoding of redirect URL for SSO login in the fallback login page.
+Fixes a regression introduced in 925a074a7373090b712a1da4788d181819878bd1.

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -49,7 +49,7 @@ var show_login = function() {
     $("#loading").hide();
 
     var this_page = window.location.origin + window.location.pathname;
-    $("#sso_redirect_url").val(encodeURIComponent(this_page));
+    $("#sso_redirect_url").val(this_page);
 
     if (matrixLogin.serverAcceptsPassword) {
         $("#password_flow").show();


### PR DESCRIPTION
The redirect URL for SSO logins is transmitted using a HTML form field, therefore the browser takes care of proper URL encoding. We should therefore not encode the value because otherwise the redirect URL is "double-encoded" and no longer usable.

This fixes a regression introduced by #4220.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)