### PR TITLE
Docker: only copy what we need to the build image

### DIFF
--- a/changelog.d/4562.misc
+++ b/changelog.d/4562.misc
@@ -1,0 +1,1 @@
+Docker: only copy what we need to the build image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,10 @@ RUN pip install --prefix="/install" --no-warn-script-location \
 
 # now install synapse and all of the python deps to /install.
 
-COPY . /synapse
+COPY synapse /synapse/synapse/
+COPY scripts /synapse/scripts/
+COPY MANIFEST.in README.rst setup.py synctl /synapse/
+
 RUN pip install --prefix="/install" --no-warn-script-location \
         /synapse[all]
 


### PR DESCRIPTION
There are two reasons this is a good thing:

 * first, it means that you don't end up with stuff kicking around your working
   copy ending up in the build image by mistake (which can upset the pip
   install process)

 * second: it means that the docker image cache is more effective, and we can
   reuse docker images when iterating on the docker stuff.
