### PR TITLE
Clean up default listener configuration

### DIFF
--- a/changelog.d/4586.misc
+++ b/changelog.d/4586.misc
@@ -1,0 +1,1 @@
+Clean up default listener configuration

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -25,8 +25,8 @@ from ._base import Config, ConfigError
 logger = logging.Logger(__name__)
 
 # by default, we attempt to listen on both '::' *and* '0.0.0.0' because some OSes
-# (windows? old linux? those where net.ipv6.bindv6only is set?) will only listen
-# on IPv6 when ':' is set.
+# (Windows, macOS, other BSD/Linux where net.ipv6.bindv6only is set) will only listen
+# on IPv6 when '::' is set.
 #
 # We later check for errors when binding to 0.0.0.0 and ignore them if :: is also in
 # in the list.
@@ -384,7 +384,7 @@ class ServerConfig(Config):
           # For when matrix traffic passes through a reverse-proxy that unwraps TLS.
           - port: %(unsecure_port)s
             tls: false
-            bind_addresses: ['127.0.0.1']
+            bind_addresses: ['::1', '127.0.0.1']
             type: http
             x_forwarded: true
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -130,12 +130,15 @@ class ServerConfig(Config):
 
         for listener in self.listeners:
             bind_address = listener.pop("bind_address", None)
-            bind_addresses = listener.setdefault(
-                "bind_addresses", list(DEFAULT_BIND_ADDRESSES)
-            )
+            bind_addresses = listener.setdefault("bind_addresses", [])
 
+            # if bind_address was specified, add it to the list of addresses
             if bind_address:
                 bind_addresses.append(bind_address)
+
+            # if we still have an empty list of addresses, use the default list
+            if not bind_addresses:
+                bind_addresses.extend(DEFAULT_BIND_ADDRESSES)
 
         if not self.web_client_location:
             _warn_if_webclient_configured(self.listeners)


### PR DESCRIPTION
Rearrange the comments to try to clarify them, and expand on what some of it
means.

Use a sensible default 'bind_addresses' setting.

For the insecure port, only bind to localhost, and enable x_forwarded, since
apparently it's for use behind a load-balancer.