### PR TITLE
Fix 'no unique or exclusion constraint' error

### DIFF
--- a/changelog.d/4591.bugfix
+++ b/changelog.d/4591.bugfix
@@ -1,0 +1,1 @@
+Fix 'no unique or exclusion constraint' error


### PR DESCRIPTION
Add more tables to the list of tables which need a background update to
complete before we can upsert into them, which fixes a race against the
background updates.