### PR TITLE
Infer no_tls from presence of TLS listeners

### DIFF
--- a/changelog.d/4613.feature
+++ b/changelog.d/4613.feature
@@ -1,0 +1,1 @@
+There is no longer any need to specify `no_tls`: it is inferred from the absence of TLS listeners

--- a/changelog.d/4615.feature
+++ b/changelog.d/4615.feature
@@ -1,0 +1,1 @@
+There is no longer any need to specify `no_tls`: it is inferred from the absence of TLS listeners

--- a/changelog.d/4615.misc
+++ b/changelog.d/4615.misc
@@ -1,1 +1,0 @@
-Logging improvements around TLS certs

--- a/changelog.d/4616.misc
+++ b/changelog.d/4616.misc
@@ -1,0 +1,1 @@
+Fail cleanly if listener config lacks a 'port'

--- a/changelog.d/4617.feature
+++ b/changelog.d/4617.feature
@@ -1,0 +1,1 @@
+There is no longer any need to specify `no_tls`: it is inferred from the absence of TLS listeners

--- a/changelog.d/4617.misc
+++ b/changelog.d/4617.misc
@@ -1,1 +1,0 @@
-Don't create server contexts when TLS is disabled

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -215,7 +215,7 @@ def refresh_certificate(hs):
     """
     hs.config.read_certificate_from_disk()
 
-    if hs.config.no_tls:
+    if not hs.config.has_tls_listener():
         # nothing else to do here
         return
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -90,11 +90,6 @@ class SynapseHomeServer(HomeServer):
         tls = listener_config.get("tls", False)
         site_tag = listener_config.get("tag", port)
 
-        if tls and config.no_tls:
-            raise ConfigError(
-                "Listener on port %i has TLS enabled, but no_tls is set" % (port,),
-            )
-
         resources = {}
         for res in listener_config["resources"]:
             for name in res["names"]:

--- a/synapse/config/homeserver.py
+++ b/synapse/config/homeserver.py
@@ -42,7 +42,7 @@ from .voip import VoipConfig
 from .workers import WorkerConfig
 
 
-class HomeServerConfig(TlsConfig, ServerConfig, DatabaseConfig, LoggingConfig,
+class HomeServerConfig(ServerConfig, TlsConfig, DatabaseConfig, LoggingConfig,
                        RatelimitConfig, ContentRepositoryConfig, CaptchaConfig,
                        VoipConfig, RegistrationConfig, MetricsConfig, ApiConfig,
                        AppServiceConfig, KeyConfig, SAML2Config, CasConfig,

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -126,13 +126,21 @@ class ServerConfig(Config):
                 self.public_baseurl += '/'
         self.start_pushers = config.get("start_pushers", True)
 
-        self.listeners = config.get("listeners", [])
-
-        for listener in self.listeners:
+        self.listeners = []
+        for listener in config.get("listeners", []):
             if not isinstance(listener.get("port", None), int):
                 raise ConfigError(
                     "Listener configuration is lacking a valid 'port' option"
                 )
+
+            if listener.setdefault("tls", False):
+                # no_tls is not really supported any more, but let's grandfather it in
+                # here.
+                if config.get("no_tls", False):
+                    logger.info(
+                        "Ignoring TLS-enabled listener on port %i due to no_tls"
+                    )
+                    continue
 
             bind_address = listener.pop("bind_address", None)
             bind_addresses = listener.setdefault("bind_addresses", [])
@@ -145,6 +153,8 @@ class ServerConfig(Config):
             if not bind_addresses:
                 bind_addresses.extend(DEFAULT_BIND_ADDRESSES)
 
+            self.listeners.append(listener)
+
         if not self.web_client_location:
             _warn_if_webclient_configured(self.listeners)
 
@@ -152,6 +162,9 @@ class ServerConfig(Config):
 
         bind_port = config.get("bind_port")
         if bind_port:
+            if config.get("no_tls", False):
+                raise ConfigError("no_tls is incompatible with bind_port")
+
             self.listeners = []
             bind_host = config.get("bind_host", "")
             gzip_responses = config.get("gzip_responses", True)
@@ -198,6 +211,7 @@ class ServerConfig(Config):
                 "port": manhole,
                 "bind_addresses": ["127.0.0.1"],
                 "type": "manhole",
+                "tls": False,
             })
 
         metrics_port = config.get("metrics_port")
@@ -222,6 +236,9 @@ class ServerConfig(Config):
             })
 
         _check_resource_config(self.listeners)
+
+    def has_tls_listener(self):
+        return any(l["tls"] for l in self.listeners)
 
     def default_config(self, server_name, data_dir_path, **kwargs):
         _, bind_port = parse_and_validate_server_name(server_name)

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -129,6 +129,11 @@ class ServerConfig(Config):
         self.listeners = config.get("listeners", [])
 
         for listener in self.listeners:
+            if not isinstance(listener.get("port", None), int):
+                raise ConfigError(
+                    "Listener configuration is lacking a valid 'port' option"
+                )
+
             bind_address = listener.pop("bind_address", None)
             bind_addresses = listener.setdefault("bind_addresses", [])
 

--- a/synapse/config/tls.py
+++ b/synapse/config/tls.py
@@ -111,7 +111,7 @@ class TlsConfig(Config):
         """
         self.tls_certificate = self.read_tls_certificate()
 
-        if not self.no_tls:
+        if self.has_tls_listener():
             self.tls_private_key = self.read_tls_private_key()
 
         self.tls_fingerprints = list(self._original_tls_fingerprints)

--- a/synapse/config/tls.py
+++ b/synapse/config/tls.py
@@ -51,7 +51,6 @@ class TlsConfig(Config):
             self._original_tls_fingerprints = []
 
         self.tls_fingerprints = list(self._original_tls_fingerprints)
-        self.no_tls = config.get("no_tls", False)
 
         # This config option applies to non-federation HTTP clients
         # (e.g. for talking to recaptcha, identity servers, and such)
@@ -141,6 +140,8 @@ class TlsConfig(Config):
 
         return (
             """\
+        ## TLS ##
+
         # PEM-encoded X509 certificate for TLS.
         # This certificate, as of Synapse 1.0, will need to be a valid and verifiable
         # certificate, signed by a recognised Certificate Authority.
@@ -200,13 +201,6 @@ class TlsConfig(Config):
             # How many days remaining on a certificate before it is renewed.
             #
             # reprovision_threshold: 30
-
-        # If your server runs behind a reverse-proxy which terminates TLS connections
-        # (for both client and federation connections), it may be useful to disable
-        # All TLS support for incoming connections. Setting no_tls to True will
-        # do so (and avoid the need to give synapse a TLS private key).
-        #
-        # no_tls: True
 
         # List of allowed TLS fingerprints for this server to publish along
         # with the signing keys for this server. Other matrix servers that

--- a/tests/config/test_tls.py
+++ b/tests/config/test_tls.py
@@ -20,6 +20,11 @@ from synapse.config.tls import TlsConfig
 from tests.unittest import TestCase
 
 
+class TestConfig(TlsConfig):
+    def has_tls_listener(self):
+        return False
+
+
 class TLSConfigTests(TestCase):
 
     def test_warn_self_signed(self):
@@ -55,11 +60,10 @@ s4niecZKPBizL6aucT59CsunNmmb5Glq8rlAcU+1ZTZZzGYqVYhF6axB9Qg=
 
         config = {
             "tls_certificate_path": os.path.join(config_dir, "cert.pem"),
-            "no_tls": True,
             "tls_fingerprints": []
         }
 
-        t = TlsConfig()
+        t = TestConfig()
         t.read_config(config)
         t.read_certificate_from_disk()
 


### PR DESCRIPTION
Rather than have to specify `no_tls` explicitly, infer whether we need to load
the TLS keys etc from whether we have any TLS-enabled listeners.

Based on #4615, #4616, #4617 