### PR TITLE
Disable TLS by default

### DIFF
--- a/changelog.d/4614.feature
+++ b/changelog.d/4614.feature
@@ -1,0 +1,1 @@
+The default configuration no longer requires TLS certificates.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -365,28 +365,24 @@ class ServerConfig(Config):
         #   webclient: A web client. Requires web_client_location to be set.
         #
         listeners:
-          # Main HTTPS listener.
-          # For when matrix traffic is sent directly to synapse.
-          - port: %(bind_port)s
-            type: http
-            tls: true
+          # TLS-enabled listener: for when matrix traffic is sent directly to synapse.
+          #
+          # Disabled by default. To enable it, uncomment the following. (Note that you
+          # will also need to give Synapse a TLS key and certificate: see the TLS section
+          # below.)
+          #
+          # - port: %(bind_port)s
+          #   type: http
+          #   tls: true
+          #   resources:
+          #     - names: [client, federation]
 
-            # List of HTTP resources to serve on this listener.
-            resources:
-              - names: [client]
-                compress: true
-              - names: [federation]
-                compress: false
-
-            # example addional_resources:
-            #
-            # additional_resources:
-            #   "/_matrix/my/custom/endpoint":
-            #     module: my_module.CustomRequestHandler
-            #     config: {}
-
-          # Unsecure HTTP listener
-          # For when matrix traffic passes through a reverse-proxy that unwraps TLS.
+          # Unsecure HTTP listener: for when matrix traffic passes through a reverse proxy
+          # that unwraps TLS.
+          #
+          # If you plan to use a reverse proxy, please see
+          # https://github.com/matrix-org/synapse/blob/master/docs/reverse_proxy.rst.
+          #
           - port: %(unsecure_port)s
             tls: false
             bind_addresses: ['::1', '127.0.0.1']
@@ -394,17 +390,21 @@ class ServerConfig(Config):
             x_forwarded: true
 
             resources:
-              - names: [client]
-                compress: true
-              - names: [federation]
+              - names: [client, federation]
                 compress: false
+
+            # example additonal_resources:
+            #
+            # additional_resources:
+            #   "/_matrix/my/custom/endpoint":
+            #     module: my_module.CustomRequestHandler
+            #     config: {}
 
           # Turn on the twisted ssh manhole service on localhost on the given
           # port.
           # - port: 9000
           #   bind_addresses: ['::1', '127.0.0.1']
           #   type: manhole
-
 
         # Homeserver blocking
         #

--- a/synapse/config/tls.py
+++ b/synapse/config/tls.py
@@ -158,10 +158,10 @@ class TlsConfig(Config):
         # See 'ACME support' below to enable auto-provisioning this certificate via
         # Let's Encrypt.
         #
-        tls_certificate_path: "%(tls_certificate_path)s"
+        # tls_certificate_path: "%(tls_certificate_path)s"
 
         # PEM-encoded private key for TLS
-        tls_private_key_path: "%(tls_private_key_path)s"
+        # tls_private_key_path: "%(tls_private_key_path)s"
 
         # ACME support: This will configure Synapse to request a valid TLS certificate
         # for your configured `server_name` via Let's Encrypt.
@@ -186,7 +186,7 @@ class TlsConfig(Config):
         #
         acme:
             # ACME support is disabled by default. Uncomment the following line
-            # to enable it.
+            # (and tls_certificate_path and tls_private_key_path above) to enable it.
             #
             # enabled: true
 


### PR DESCRIPTION
This needs #4613 to work properly, and a bunch of documentation work, but the
idea here is that the default configuration no longer has TLS enabled, so you
can get Synapse running without needing a TLS certificate.