### PR TITLE
Fail cleanly if listener config lacks a 'port'

### DIFF
--- a/changelog.d/4616.misc
+++ b/changelog.d/4616.misc
@@ -1,0 +1,1 @@
+Fail cleanly if listener config lacks a 'port'

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -129,6 +129,11 @@ class ServerConfig(Config):
         self.listeners = config.get("listeners", [])
 
         for listener in self.listeners:
+            if not isinstance(listener.get("port", None), int):
+                raise ConfigError(
+                    "Listener configuration is lacking a valid 'port' option"
+                )
+
             bind_address = listener.pop("bind_address", None)
             bind_addresses = listener.setdefault("bind_addresses", [])
 


### PR DESCRIPTION
... otherwise we would fail with a mysterious KeyError or something later.