### PR TITLE
implement `reload` by sending the HUP signal

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+matrix-synapse-py3 (0.99.1) UNRELEASED; urgency=medium
+
+  * Added ExecReload= in service unit file to send a HUP signal
+
+ -- Damjan Georgievski <gdamjan@gmail.com>  Thu, 14 Feb 2019 12:53:13 +0000
+
 matrix-synapse-py3 (0.99.0) stable; urgency=medium
 
   * New synapse release 0.99.0

--- a/debian/matrix-synapse.service
+++ b/debian/matrix-synapse.service
@@ -8,6 +8,7 @@ WorkingDirectory=/var/lib/matrix-synapse
 EnvironmentFile=/etc/default/matrix-synapse
 ExecStartPre=/opt/venvs/matrix-synapse/bin/python -m synapse.app.homeserver --config-path=/etc/matrix-synapse/homeserver.yaml --config-path=/etc/matrix-synapse/conf.d/ --generate-keys
 ExecStart=/opt/venvs/matrix-synapse/bin/python -m synapse.app.homeserver --config-path=/etc/matrix-synapse/homeserver.yaml --config-path=/etc/matrix-synapse/conf.d/
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=3
 


### PR DESCRIPTION
According to the 0.99 [release info](https://github.com/matrix-org/synapse/releases/tag/v0.99.0) synapse now uses the HUP signal to reload certificates:
> Synapse will now reload TLS certificates from disk upon SIGHUP. (#4495, #4524)

So the matrix-synapse.service unit file should include a reload directive.



