### PR TITLE
Reduce user_ips bloat during dedupe background update

### DIFF
--- a/changelog.d/4626.misc
+++ b/changelog.d/4626.misc
@@ -1,0 +1,1 @@
+Improve 'user_ips' table deduplication background update


### PR DESCRIPTION
The background update to remove duplicate rows naively deleted and
reinserted the duplicates. For large tables with a large number of
duplicates this causes a lot of bloat (with postgres), as the inserted
rows are appended to the table, since deleted rows will not be
overwritten until a VACUUM has happened.

This should hopefully also help ensure that the query in the last batch
uses the correct index, as inserting a large number of new rows without
analyzing will upset the query planner.
