### PR TITLE
Analyze user_ips before running deduplication

### DIFF
--- a/changelog.d/4627.misc
+++ b/changelog.d/4627.misc
@@ -1,0 +1,1 @@
+Improve 'user_ips' table deduplication background update

--- a/synapse/storage/client_ips.py
+++ b/synapse/storage/client_ips.py
@@ -124,7 +124,7 @@ class ClientIpStore(background_updates.BackgroundUpdateStore):
         def user_ips_analyze(txn):
             txn.execute("ANALYZE user_ips")
 
-        end_last_seen = yield self.runInteraction(
+        yield self.runInteraction(
             "user_ips_analyze", user_ips_analyze
         )
 

--- a/synapse/storage/schema/delta/53/user_ips_index.sql
+++ b/synapse/storage/schema/delta/53/user_ips_index.sql
@@ -13,9 +13,13 @@
  * limitations under the License.
  */
 
--- delete duplicates
+ -- analyze user_ips, to help ensure the correct indices are used
 INSERT INTO background_updates (update_name, progress_json) VALUES
-  ('user_ips_remove_dupes', '{}');
+  ('user_ips_analyze', '{}');
+
+-- delete duplicates
+INSERT INTO background_updates (update_name, progress_json, depends_on) VALUES
+  ('user_ips_remove_dupes', '{}', 'user_ips_analyze');
 
 -- add a new unique index to user_ips table
 INSERT INTO background_updates (update_name, progress_json, depends_on) VALUES


### PR DESCRIPTION
Due to the table locks taken out by the naive upsert, the table
statistics may be out of date. During deduplication it is important that
the correct index is used as otherwise a full table scan may be
incorrectly used, which can end up thrashing the database badly.
