### PR TITLE
Add basic optional sentry.io integration

### DIFF
--- a/changelog.d/4632.feature
+++ b/changelog.d/4632.feature
@@ -1,1 +1,1 @@
-Add basic optional sentry.io integration
+Add basic optional sentry integration

--- a/changelog.d/4632.feature
+++ b/changelog.d/4632.feature
@@ -1,0 +1,1 @@
+Add basic optional sentry.io integration

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -25,10 +25,12 @@ from daemonize import Daemonize
 from twisted.internet import error, reactor
 from twisted.protocols.tls import TLSMemoryBIOFactory
 
+import synapse
 from synapse.app import check_bind_error
 from synapse.crypto import context_factory
 from synapse.util import PreserveLoggingContext
 from synapse.util.rlimit import change_resource_limit
+from synapse.util.versionstring import get_version_string
 
 logger = logging.getLogger(__name__)
 
@@ -266,9 +268,29 @@ def start(hs, listeners=None):
         # It is now safe to start your Synapse.
         hs.start_listening(listeners)
         hs.get_datastore().start_profiling()
+
+        setup_sentry_io(hs)
     except Exception:
         traceback.print_exc(file=sys.stderr)
         reactor = hs.get_reactor()
         if reactor.running:
             reactor.stop()
         sys.exit(1)
+
+
+def setup_sentry_io(hs):
+    if not hs.config.sentry_enabled:
+        return
+
+    import sentry_sdk
+    sentry_sdk.init(
+        dsn=hs.config.sentry_dsn,
+        release=get_version_string(synapse),
+    )
+    with sentry_sdk.configure_scope() as scope:
+        scope.set_tag("matrix_server_name", hs.config.server_name)
+
+        app = hs.config.worker_app if hs.config.worker_app else "synapse.app.homeserver"
+        name = hs.config.worker_name if hs.config.worker_name else "master"
+        scope.set_tag("worker_app", app)
+        scope.set_tag("worker_name", name)

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -279,6 +279,12 @@ def start(hs, listeners=None):
 
 
 def setup_sentry_io(hs):
+    """Enable sentry.io integration, if enabled in configuration
+
+    Args:
+        hs (synapse.server.HomeServer)
+    """
+
     if not hs.config.sentry_enabled:
         return
 
@@ -287,6 +293,8 @@ def setup_sentry_io(hs):
         dsn=hs.config.sentry_dsn,
         release=get_version_string(synapse),
     )
+
+    # We set some default tags that give some context to this instance
     with sentry_sdk.configure_scope() as scope:
         scope.set_tag("matrix_server_name", hs.config.server_name)
 

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -269,7 +269,7 @@ def start(hs, listeners=None):
         hs.start_listening(listeners)
         hs.get_datastore().start_profiling()
 
-        setup_sentry_io(hs)
+        setup_sentry(hs)
     except Exception:
         traceback.print_exc(file=sys.stderr)
         reactor = hs.get_reactor()
@@ -278,8 +278,8 @@ def start(hs, listeners=None):
         sys.exit(1)
 
 
-def setup_sentry_io(hs):
-    """Enable sentry.io integration, if enabled in configuration
+def setup_sentry(hs):
+    """Enable sentry integration, if enabled in configuration
 
     Args:
         hs (synapse.server.HomeServer)

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -16,7 +16,7 @@
 from ._base import Config, ConfigError
 
 MISSING_SENTRY = (
-    """Missing sentry_sdk library. This is required for enable sentry
+    """Missing sentry_sdk library. This is required to enable sentry
     integration.
 
     Install by running:

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -13,7 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._base import Config
+from ._base import Config, ConfigError
+
+MISSING_SENTRY = (
+    """Missing sentry_sdk library. This is required for enable sentry.io
+    integration.
+
+    Install by running:
+        pip install sentry_sdk
+    """
+)
 
 
 class MetricsConfig(Config):
@@ -25,6 +34,11 @@ class MetricsConfig(Config):
 
         self.sentry_enabled = "sentry" in config
         if self.sentry_enabled:
+            try:
+                import sentry_sdk  # noqa F401
+            except ImportError:
+                raise ConfigError(MISSING_SENTRY)
+
             self.sentry_dsn = config["sentry"]["dsn"]
 
     def default_config(self, report_stats=None, **kwargs):

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -16,11 +16,8 @@
 from ._base import Config, ConfigError
 
 MISSING_SENTRY = (
-    """Missing sentry_sdk library. This is required to enable sentry
+    """Missing sentry-sdk library. This is required to enable sentry
     integration.
-
-    Install by running:
-        pip install sentry_sdk
     """
 )
 
@@ -39,7 +36,11 @@ class MetricsConfig(Config):
             except ImportError:
                 raise ConfigError(MISSING_SENTRY)
 
-            self.sentry_dsn = config["sentry"]["dsn"]
+            self.sentry_dsn = config["sentry"].get("dsn")
+            if not self.sentry_dsn:
+                raise ConfigError(
+                    "sentry.dsn field is required when sentry integration is enabled",
+                )
 
     def default_config(self, report_stats=None, **kwargs):
         res = """\

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -16,7 +16,7 @@
 from ._base import Config, ConfigError
 
 MISSING_SENTRY = (
-    """Missing sentry_sdk library. This is required for enable sentry.io
+    """Missing sentry_sdk library. This is required for enable sentry
     integration.
 
     Install by running:
@@ -48,7 +48,12 @@ class MetricsConfig(Config):
         # Enable collection and rendering of performance metrics
         enable_metrics: False
 
-        # Enable sentry.io integration
+        # Enable sentry integration
+        # NOTE: While attempts are made to ensure that the logs don't contain
+        # any sensitive information, this cannot be guaranteed. By enabling
+        # this option the sentry server may therefore receive sensitive
+        # information, and it in turn may then diseminate sensitive information
+        # through insecure notification channels if so configured.
         #sentry:
         #    dsn: "..."
         """

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -23,12 +23,20 @@ class MetricsConfig(Config):
         self.metrics_port = config.get("metrics_port")
         self.metrics_bind_host = config.get("metrics_bind_host", "127.0.0.1")
 
+        self.sentry_enabled = "sentry" in config
+        if self.sentry_enabled:
+            self.sentry_dsn = config["sentry"]["dsn"]
+
     def default_config(self, report_stats=None, **kwargs):
         res = """\
         ## Metrics ###
 
         # Enable collection and rendering of performance metrics
         enable_metrics: False
+
+        # Enable sentry.io integration
+        #sentry:
+        #    dsn: "..."
         """
 
         if report_stats is None:

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -86,6 +86,7 @@ CONDITIONAL_REQUIREMENTS = {
     "saml2": ["pysaml2>=4.5.0"],
     "url_preview": ["lxml>=3.5.0"],
     "test": ["mock>=2.0", "parameterized"],
+    "sentry": ["sentry-sdk>=0.7.2"],
 }
 
 


### PR DESCRIPTION
I've found sentry.io quite useful to see what errors synapse is producing on jki.re, so I think its worth adding. This is *very* bare-bones, but is enough to be useful.

By default, sentry will upload all records logged at `error` or above, plus the last few log lines for context (called "breadcrumbs").

Future extensions:
- Only upload log lines from the same logging context (I have a patch that does this, but probably needs some cleaning up).
- Fill out the context a bit more, things like authenticated user and remote IP are recommended.