### PR TITLE
Correctly handle RequestSendFailed exceptions

### DIFF
--- a/changelog.d/4643.misc
+++ b/changelog.d/4643.misc
@@ -1,0 +1,1 @@
+Reduce number of exceptions we log

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -35,7 +35,7 @@ from unpaddedbase64 import decode_base64
 
 from twisted.internet import defer
 
-from synapse.api.errors import Codes, SynapseError
+from synapse.api.errors import Codes, RequestSendFailed, SynapseError
 from synapse.util import logcontext, unwrapFirstError
 from synapse.util.logcontext import (
     LoggingContext,
@@ -656,7 +656,7 @@ def _handle_key_deferred(verify_request):
     try:
         with PreserveLoggingContext():
             _, key_id, verify_key = yield verify_request.deferred
-    except IOError as e:
+    except (IOError, RequestSendFailed) as e:
         logger.warn(
             "Got IOError when downloading keys for %s: %s %s",
             server_name, type(e).__name__, str(e),

--- a/synapse/groups/attestations.py
+++ b/synapse/groups/attestations.py
@@ -42,7 +42,7 @@ from signedjson.sign import sign_json
 
 from twisted.internet import defer
 
-from synapse.api.errors import SynapseError
+from synapse.api.errors import RequestSendFailed, SynapseError
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.types import get_domain_from_id
 from synapse.util.logcontext import run_in_background
@@ -190,6 +190,11 @@ class GroupAttestionRenewer(object):
 
                 yield self.store.update_attestation_renewal(
                     group_id, user_id, attestation
+                )
+            except RequestSendFailed as e:
+                logger.warning(
+                    "Failed to renew attestation of %r in %r: %s",
+                    user_id, group_id, e,
                 )
             except Exception:
                 logger.exception("Error renewing attestation of %r in %r",

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -20,7 +20,7 @@ from twisted.internet import defer
 
 from synapse.api import errors
 from synapse.api.constants import EventTypes
-from synapse.api.errors import FederationDeniedError
+from synapse.api.errors import FederationDeniedError, RequestSendFailed
 from synapse.types import RoomStreamToken, get_domain_from_id
 from synapse.util import stringutils
 from synapse.util.async_helpers import Linearizer
@@ -504,7 +504,7 @@ class DeviceListEduUpdater(object):
                 origin = get_domain_from_id(user_id)
                 try:
                     result = yield self.federation.query_user_devices(origin, user_id)
-                except NotRetryingDestination:
+                except (NotRetryingDestination, RequestSendFailed):
                     # TODO: Remember that we are now out of sync and try again
                     # later
                     logger.warn(


### PR DESCRIPTION
This mainly reduces the number of exceptions we log.