### PR TITLE
 set CORS on .well-known URI to unbreak modular

### DIFF
--- a/changelog.d/4651.bugfix
+++ b/changelog.d/4651.bugfix
@@ -1,0 +1,1 @@
+set CORS headers on .well-known requests

--- a/changelog.d/4651.bugfix
+++ b/changelog.d/4651.bugfix
@@ -1,1 +1,1 @@
-set CORS headers on .well-known requests
+Set CORS headers on .well-known requests

--- a/synapse/rest/well_known.py
+++ b/synapse/rest/well_known.py
@@ -17,6 +17,7 @@ import json
 import logging
 
 from twisted.web.resource import Resource
+from synapse.http.server import set_cors_headers
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/rest/well_known.py
+++ b/synapse/rest/well_known.py
@@ -59,6 +59,7 @@ class WellKnownResource(Resource):
         self._well_known_builder = WellKnownBuilder(hs)
 
     def render_GET(self, request):
+	set_cors_headers(request)
         r = self._well_known_builder.get_well_known()
         if not r:
             request.setResponseCode(404)

--- a/synapse/rest/well_known.py
+++ b/synapse/rest/well_known.py
@@ -59,7 +59,7 @@ class WellKnownResource(Resource):
         self._well_known_builder = WellKnownBuilder(hs)
 
     def render_GET(self, request):
-	set_cors_headers(request)
+        set_cors_headers(request)
         r = self._well_known_builder.get_well_known()
         if not r:
             request.setResponseCode(404)

--- a/synapse/rest/well_known.py
+++ b/synapse/rest/well_known.py
@@ -17,6 +17,7 @@ import json
 import logging
 
 from twisted.web.resource import Resource
+
 from synapse.http.server import set_cors_headers
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
otherwise a riot/web running on foo.riot.im can't query the .well-known on foo.modular.im...
