### PR TITLE
Batch cache invalidation over replication

### DIFF
--- a/changelog.d/4671.misc
+++ b/changelog.d/4671.misc
@@ -1,0 +1,1 @@
+Improve replication performance by reducing cache invalidation traffic.

--- a/docs/tcp_replication.rst
+++ b/docs/tcp_replication.rst
@@ -240,3 +240,8 @@ However, there are times when a number of caches need to be invalidated at the
 same time with the same key. To reduce traffic we batch those invalidations into
 a single poke by defining a special cache name that workers understand to mean
 to expand to invalidate the correct caches.
+
+Currently the special cache names are declared in ``synapse/storage/_base.py``
+and are:
+
+1. ``cs_cache_fake`` ─ invalidates caches that depend on the current state

--- a/docs/tcp_replication.rst
+++ b/docs/tcp_replication.rst
@@ -137,7 +137,6 @@ for each stream so that on reconneciton it can start streaming from the correct
 place. Note: not all RDATA have valid tokens due to batching. See
 ``RdataCommand`` for more details.
 
-
 Example
 ~~~~~~~
 
@@ -221,3 +220,23 @@ SYNC (S, C)
 
 See ``synapse/replication/tcp/commands.py`` for a detailed description and the
 format of each command.
+
+
+Cache Invalidation Stream
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The cache invalidation stream is used to inform workers when they need to
+invalidate any of their caches in the data store. This is done by streaming all
+cache invalidations done on master down to the workers, assuming that any caches
+on the workers also exist on the master.
+
+Each individual cache invalidation results in a row being sent down replication,
+which includes the cache name (the name of the function) and they key to
+invalidate. For example::
+
+    > RDATA caches 550953771 ["get_user_by_id", ["@bob:example.com"], 1550574873251]
+
+However, there are times when a number of caches need to be invalidated at the
+same time with the same key. To reduce traffic we batch those invalidations into
+a single poke by defining a special cache name that workers understand to mean
+to expand to invalidate the correct caches.

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -1199,8 +1199,8 @@ class SQLBaseStore(object):
 
         Args:
             txn
-            room_id (str): Room were state changed
-            members_changed (set[str]): The user_ids of members that have changed
+            room_id (str): Room where state changed
+            members_changed (Iterable[str]): The user_ids of members that have changed
         """
         txn.call_after(self._invalidate_state_caches, room_id, members_changed)
 
@@ -1215,7 +1215,7 @@ class SQLBaseStore(object):
         not stream invalidations down replication.
 
         Args:
-            room_id (str): Room were state changed
+            room_id (str): Room where state changed
             members_changed (set[str]): The user_ids of members that have changed
         """
         for member in members_changed:
@@ -1237,7 +1237,7 @@ class SQLBaseStore(object):
         Args:
             txn
             cache_name (str)
-            keys (list[str])
+            keys (iterable[str])
         """
 
         if isinstance(self.database_engine, PostgresEngine):

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -1201,7 +1201,7 @@ class SQLBaseStore(object):
         Args:
             txn
             room_id (str): Room where state changed
-            members_changed (Iterable[str]): The user_ids of members that have changed
+            members_changed (iterable[str]): The user_ids of members that have changed
         """
         txn.call_after(self._invalidate_state_caches, room_id, members_changed)
 
@@ -1216,7 +1216,8 @@ class SQLBaseStore(object):
 
         Args:
             room_id (str): Room where state changed
-            members_changed (set[str]): The user_ids of members that have changed
+            members_changed (iterable[str]): The user_ids of members that have
+                changed
         """
         for member in members_changed:
             self.get_rooms_for_user_with_stream_ordering.invalidate((member,))

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import itertools
 import logging
 import sys
 import threading
@@ -1204,8 +1205,7 @@ class SQLBaseStore(object):
         """
         txn.call_after(self._invalidate_state_caches, room_id, members_changed)
 
-        keys = [room_id]
-        keys.extend(members_changed)
+        keys = itertools.chain([room_id], members_changed)
         self._send_invalidation_to_replication(
             txn, _CURRENT_STATE_CACHE_NAME, keys,
         )

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -979,30 +979,7 @@ class EventsStore(StateGroupWorkerStore, EventFederationStore, EventsWorkerStore
                 if ev_type == EventTypes.Member
             )
 
-            for member in members_changed:
-                self._invalidate_cache_and_stream(
-                    txn, self.get_rooms_for_user_with_stream_ordering, (member,)
-                )
-
-            for host in set(get_domain_from_id(u) for u in members_changed):
-                self._invalidate_cache_and_stream(
-                    txn, self.is_host_joined, (room_id, host)
-                )
-                self._invalidate_cache_and_stream(
-                    txn, self.was_host_joined, (room_id, host)
-                )
-
-            self._invalidate_cache_and_stream(
-                txn, self.get_users_in_room, (room_id,)
-            )
-
-            self._invalidate_cache_and_stream(
-                txn, self.get_room_summary, (room_id,)
-            )
-
-            self._invalidate_cache_and_stream(
-                txn, self.get_current_state_ids, (room_id,)
-            )
+            self._invalidate_state_caches_and_stream(txn, room_id, members_changed)
 
     def _update_forward_extremities_txn(self, txn, new_forward_extremities,
                                         max_stream_order):


### PR DESCRIPTION
Currently whenever the current state changes in a room invalidate a lot
of caches, which cause *a lot* of traffic over replication. Instead,
lets batch up all those invalidations and send a single poke down
the replication streams.

Hopefully this will reduce load on the master process by substantially
reducing traffic.
