### PR TITLE
Run unit tests against python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   fast_finish: true
   include:
   - name: "pep8"
-    python: 3.7
+    python: 3.6
     env: TOX_ENV="pep8,check_isort,packaging"
 
   - name: "py2.7 / sqlite"
@@ -77,7 +77,7 @@ matrix:
   - # we only need to check for the newsfragment if it's a PR build
     if: type = pull_request
     name: "check-newsfragment"
-    python: 3.7
+    python: 3.6
     env: TOX_ENV=check-newsfragment
     script:
       - git remote set-branches --add origin develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+dist: xenial
 language: python
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   fast_finish: true
   include:
   - name: "pep8"
-    python: 3.6
+    python: 3.7
     env: TOX_ENV="pep8,check_isort,packaging"
 
   - name: "py2.7 / sqlite"
@@ -54,30 +54,30 @@ matrix:
     python: 3.5
     env: TOX_ENV=py35,codecov TRIAL_FLAGS="-j 2"
 
-  - name: "py3.6 / sqlite"
-    python: 3.6
-    env: TOX_ENV=py36,codecov TRIAL_FLAGS="-j 2"
+  - name: "py3.7 / sqlite"
+    python: 3.7
+    env: TOX_ENV=py37,codecov TRIAL_FLAGS="-j 2"
 
-  - name: "py3.6 / postgres9.4"
-    python: 3.6
+  - name: "py3.7 / postgres9.4"
+    python: 3.7
     addons:
       postgresql: "9.4"
-    env: TOX_ENV=py36-postgres TRIAL_FLAGS="-j 4"
+    env: TOX_ENV=py37-postgres TRIAL_FLAGS="-j 4"
     services:
       - postgresql
 
-  - name: "py3.6 / postgres9.5"
-    python: 3.6
+  - name: "py3.7 / postgres9.5"
+    python: 3.7
     addons:
       postgresql: "9.5"
-    env: TOX_ENV=py36-postgres,codecov TRIAL_FLAGS="-j 4"
+    env: TOX_ENV=py37-postgres,codecov TRIAL_FLAGS="-j 4"
     services:
       - postgresql
 
   - # we only need to check for the newsfragment if it's a PR build
     if: type = pull_request
     name: "check-newsfragment"
-    python: 3.6
+    python: 3.7
     env: TOX_ENV=check-newsfragment
     script:
       - git remote set-branches --add origin develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ matrix:
 
 install:
   # this just logs the postgres version we will be testing against (if any)
-  - psql -At -U postgres -c 'select version();'
+  - psql -At -U postgres -c 'select version();' || true
 
   - pip install tox
   

--- a/changelog.d/4677.misc
+++ b/changelog.d/4677.misc
@@ -1,0 +1,1 @@
+Run unit tests against python 3.7.

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = packaging, py27, py36, pep8, check_isort
 
 [base]
 deps =
-    Twisted>=17.1
     mock
     python-subunit
     junitxml
@@ -38,6 +37,7 @@ whitelist_externals =
 
 setenv =
     {[base]setenv}
+    postgres: SYNAPSE_POSTGRES = 1
 
 passenv = *
 
@@ -46,8 +46,6 @@ commands =
     # Add this so that coverage will run on subprocesses
     sh -c 'echo "import coverage; coverage.process_startup()" > {envsitepackagesdir}/../sitecustomize.py'
     {envbindir}/coverage run "{envbindir}/trial" {env:TRIAL_FLAGS:} {posargs:tests} {env:TOXSUFFIX:}
-
-[testenv:py27]
 
 # As of twisted 16.4, trial tries to import the tests as a package (previously
 # it loaded the files explicitly), which means they need to be on the
@@ -72,14 +70,7 @@ commands =
 # )
 usedevelop=true
 
-[testenv:py27-postgres]
-usedevelop=true
-deps =
-    {[base]deps}
-    psycopg2
-setenv =
-    {[base]setenv}
-    SYNAPSE_POSTGRES = 1
+
 
 # A test suite for the oldest supported versions of Python libraries, to catch
 # any uses of APIs not available in them.
@@ -100,22 +91,6 @@ commands =
     # Install Synapse itself. This won't update any libraries.
     pip install -e .
     {envbindir}/trial {env:TRIAL_FLAGS:} {posargs:tests} {env:TOXSUFFIX:}
-
-[testenv:py35]
-usedevelop=true
-
-[testenv:py36]
-usedevelop=true
-
-[testenv:py36-postgres]
-usedevelop=true
-deps =
-    {[base]deps}
-    psycopg2
-setenv =
-    {[base]setenv}
-    SYNAPSE_POSTGRES = 1
-
 
 [testenv:packaging]
 skip_install=True


### PR DESCRIPTION
... so that we span the full range of our supported python versions

Note that this entails switching from trusty to xenial. (The `sudo: false` was being ignored anyway: cf https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures)