### PR TITLE
[DINSIC] Use internal-info for identity server

### DIFF
--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -55,7 +55,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
         if not (yield check_3pid_allowed(self.hs, "email", body['email'])):
             raise SynapseError(
                 403,
-                "Your email domain is not authorized on this server",
+                "Your email is not authorized on this server",
                 Codes.THREEPID_DENIED,
             )
 
@@ -271,7 +271,7 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
         if not (yield check_3pid_allowed(self.hs, "email", body['email'])):
             raise SynapseError(
                 403,
-                "Your email domain is not authorized on this server",
+                "Your email is not authorized on this server",
                 Codes.THREEPID_DENIED,
             )
 

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -78,7 +78,7 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
         if not (yield check_3pid_allowed(self.hs, "email", body['email'])):
             raise SynapseError(
                 403,
-                "Your email domain is not authorized to register on this server",
+                "Your email is not authorized to register on this server",
                 Codes.THREEPID_DENIED,
             )
 

--- a/synapse/util/threepids.py
+++ b/synapse/util/threepids.py
@@ -43,17 +43,19 @@ def check_3pid_allowed(hs, medium, address):
             {'medium': medium, 'address': address}
         )
 
-        # Assume false if invalid response
-        if 'hs' not in data:
+        # Check for invalid response
+        if 'hs' not in data and 'shadow_hs' not in data:
+            defer.returnValue(False)
+
+        # Check if this user is intended to register for this homeserver
+        if data['hs'] != hs.config.server_name and data['shadow_hs'] != hs.config.server_name:
             defer.returnValue(False)
 
         if data.get('requires_invite', False) and data.get('invited', False) == False:
             # Requires an invite but hasn't been invited
             defer.returnValue(False)
-        if hs.config.allow_invited_3pids and data.get('invited'):
-            defer.returnValue(True)
-        else:
-            defer.returnValue(data['hs'] == hs.config.server_name)
+
+        defer.returnValue(True)
 
     if hs.config.allowed_local_3pids:
         for constraint in hs.config.allowed_local_3pids:


### PR DESCRIPTION
Switches Synapse to use Sydent's new /internal-info API for information about 3PIDs when registering a new user.

Uses the new `requires_invite` field to check if a registration should be allowed.

Sydent PR: https://github.com/matrix-org/sydent/pull/106