### PR TITLE
Fixup generated metrics config

### DIFF
--- a/changelog.d/4694.feature
+++ b/changelog.d/4694.feature
@@ -1,0 +1,1 @@
+Add basic optional sentry integration

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -57,6 +57,8 @@ class MetricsConfig(Config):
         # through insecure notification channels if so configured.
         #sentry:
         #    dsn: "..."
+
+        # Whether or not to report anonymized homeserver usage statistics.
         """
 
         if report_stats is None:


### PR DESCRIPTION
Now looks like:

```yaml
## Metrics ###

# Enable collection and rendering of performance metrics
enable_metrics: False

# Enable sentry integration
# NOTE: While attempts are made to ensure that the logs don't contain
# any sensitive information, this cannot be guaranteed. By enabling
# this option the sentry server may therefore receive sensitive
# information, and it in turn may then diseminate sensitive information
# through insecure notification channels if so configured.
#sentry:
#    dsn: "..."

# Whether or not to report anonymized homeserver usage statistics.
report_stats: true
```

Broke by #4632