### PR TITLE
Migration Script: consider e2e_room_keys.is_verified column as boolean

### DIFF
--- a/changelog.d/4680.bugfix
+++ b/changelog.d/4680.bugfix
@@ -1,0 +1,3 @@
+Fix an issue in the database migration script where the 
+`e2e_room_keys.is_verified` column wasn't considered as 
+a boolean

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -53,6 +53,7 @@ BOOLEAN_COLUMNS = {
     "group_summary_users": ["is_public"],
     "group_roles": ["is_public"],
     "local_group_membership": ["is_publicised", "is_admin"],
+    "e2e_room_keys": ["is_verified"],
 }
 
 


### PR DESCRIPTION
This column was considered as an int, crashing the whole
migration process

Signed-off-by: Eric <eric@pedr0.net>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
