### PR TITLE
[DINSIC] Config option to prevent showing non-fed rooms in fed /publicRooms

### DIFF
--- a/synapse/config/room_directory.py
+++ b/synapse/config/room_directory.py
@@ -27,6 +27,10 @@ class RoomDirectoryConfig(Config):
             for rule in alias_creation_rules
         ]
 
+        self.allow_non_federated_in_public_rooms = config.get(
+            "allow_non_federated_in_public_rooms", True,
+        )
+
     def default_config(self, config_dir_path, server_name, **kwargs):
         return """
         # The `alias_creation` option controls who's allowed to create aliases
@@ -42,6 +46,13 @@ class RoomDirectoryConfig(Config):
             - user_id: "*"
               alias: "*"
               action: allow
+
+        # Specify whether rooms that only allow local users to join should be
+        # shown in the federation public room directory.
+        # 
+        # Note that this does not affect the room directory shown to users on
+        # this homeserver, only those on other homeservers.
+        #allow_non_federated_in_public_rooms: True
         """
 
     def is_alias_creation_allowed(self, user_id, alias):

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -697,7 +697,8 @@ class PublicRoomList(BaseFederationServlet):
 
         data = yield self.handler.get_local_public_room_list(
             limit, since_token,
-            network_tuple=network_tuple
+            network_tuple=network_tuple,
+            from_federation=True,
         )
         defer.returnValue((200, data))
 

--- a/synapse/groups/groups_server.py
+++ b/synapse/groups/groups_server.py
@@ -113,7 +113,7 @@ class GroupsServerHandler(object):
             room_id = room_entry["room_id"]
             joined_users = yield self.store.get_users_in_room(room_id)
             entry = yield self.room_list_handler.generate_room_entry(
-                room_id, len(joined_users),
+                room_id, True, len(joined_users),
                 with_alias=False, allow_private=True,
             )
             entry = dict(entry)  # so we don't change whats cached
@@ -544,7 +544,7 @@ class GroupsServerHandler(object):
 
             joined_users = yield self.store.get_users_in_room(room_id)
             entry = yield self.room_list_handler.generate_room_entry(
-                room_id, len(joined_users),
+                room_id, True, len(joined_users),
                 with_alias=False, allow_private=True,
             )
 

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -302,9 +302,22 @@ class RoomListHandler(BaseHandler):
             chunk.append(result)
 
     @cachedInlineCallbacks(num_args=2, cache_context=True)
-    def generate_room_entry(self, room_id, allow_federated, num_joined_users, 
+    def generate_room_entry(self, room_id, allow_non_federated, num_joined_users,
                             cache_context, with_alias=True, allow_private=False):
         """Returns the entry for a room
+
+        Args:
+            room_id (str): The room's ID.
+            allow_non_federated (bool): Whether rooms with federation
+            disabled should be shown.
+            num_joined_users (int): Number of users in the room.
+            cache_context: Information for cached responses.
+            with_alias (bool): Whether to return the room's aliases in the result.
+            allow_private (bool): Whether invite-only rooms should be shown.
+
+        Returns:
+            Deferred[dict|None]: Returns a room entry as a dictionary, or None if this
+            room was determined not to be shown publicly.
         """
         result = {
             "room_id": room_id,
@@ -342,7 +355,7 @@ class RoomListHandler(BaseHandler):
             if not allow_private and join_rule and join_rule != JoinRules.PUBLIC:
                 defer.returnValue(None)
 
-        if not allow_federated:
+        if not allow_non_federated:
             # Disallow non-federated from appearing
             create_event = current_state.get((EventTypes.Create, ""))
             if create_event:


### PR DESCRIPTION
Adds a config option to prevent showing rooms that have `m.federate` set to False from showing in the federation request to /publicRooms. By default not changing the config does not change any behaviour.