### PR TITLE
Fix backfill storing incorrect state for events

### DIFF
--- a/changelog.d/4718.bugfix
+++ b/changelog.d/4718.bugfix
@@ -1,1 +1,1 @@
-Fix paginating over federation persisting incorrect state
+Fix paginating over federation persisting incorrect state.

--- a/changelog.d/4718.bugfix
+++ b/changelog.d/4718.bugfix
@@ -1,0 +1,1 @@
+Fix paginating over federation persisting incorrect state

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -782,6 +782,7 @@ class FederationHandler(BaseHandler):
         # auth chain. Caution must therefore be taken to ensure that they are
         # not accidentally marked as outliers.
 
+        # Step 1a: persist auth events that *don't* appear in the chunk
         ev_infos = []
         for a in auth_events.values():
             # We only want to persist auth events as outliers that we haven't
@@ -800,6 +801,8 @@ class FederationHandler(BaseHandler):
                 }
             })
 
+        # Step 1b: persist the events in the chunk we fetched state for (i.e.
+        # the backwards extremities) as non-outliers.
         for e_id in events_to_state:
             # For paranoia we ensure that these events are marked as
             # non-outliers
@@ -822,6 +825,7 @@ class FederationHandler(BaseHandler):
             backfilled=True,
         )
 
+        # Step 2: Persist the rest of the events in the chunk one by one
         events.sort(key=lambda e: e.depth)
 
         for event in events:

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -804,7 +804,7 @@ class FederationHandler(BaseHandler):
             # For paranoia we ensure that these events are marked as
             # non-outliers
             ev = event_map[e_id]
-            ev.internal_metadata.outlier = False
+            assert(not event.internal_metadata.is_outlier())
 
             ev_infos.append({
                 "event": ev,
@@ -830,7 +830,7 @@ class FederationHandler(BaseHandler):
 
             # For paranoia we ensure that these events are marked as
             # non-outliers
-            event.internal_metadata.outlier = False
+            assert(not event.internal_metadata.is_outlier())
 
             # We store these one at a time since each event depends on the
             # previous to work out the state.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -807,7 +807,7 @@ class FederationHandler(BaseHandler):
             # For paranoia we ensure that these events are marked as
             # non-outliers
             ev = event_map[e_id]
-            assert(not event.internal_metadata.is_outlier())
+            assert(not ev.internal_metadata.is_outlier())
 
             ev_infos.append({
                 "event": ev,

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -772,8 +772,11 @@ class FederationHandler(BaseHandler):
 
         ev_infos = []
         for a in auth_events.values():
-            if a.event_id in seen_events:
+            # We only want to persist auth events as outliers that we haven't
+            # seen and aren't about to persist as part of the backfilled chunk.
+            if a.event_id in seen_events or a.event_id in event_map:
                 continue
+
             a.internal_metadata.outlier = True
             ev_infos.append({
                 "event": a,


### PR DESCRIPTION
Broadly, we were going through marking all fetched "auth events" as outliers, even if they appeared in the main backfill chunk of events. This led to state getting very confused when we tried to persist events that referenced outliers.