### PR TITLE
make 'event_id' a required parameter in federated state requests

### DIFF
--- a/changelog.d/4740.bugfix
+++ b/changelog.d/4740.bugfix
@@ -1,0 +1,1 @@
+'event_id' is now a required parameter in federated state requests, as per the matrix spec.

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -393,7 +393,7 @@ class FederationStateServlet(BaseFederationServlet):
         return self.handler.on_context_state_request(
             origin,
             context,
-            parse_string_from_args(query, "event_id", None),
+            parse_string_from_args(query, "event_id", None, required=True),
         )
 
 


### PR DESCRIPTION
As per the spec: https://matrix.org/docs/spec/server_server/r0.1.1.html#id40

Closes #3646

Signed-off-by: Joseph Weston <joseph@weston.cloud>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
