### PR TITLE
Make 'event_id' a required parameter in federated state requests

### DIFF
--- a/changelog.d/4740.bugfix
+++ b/changelog.d/4740.bugfix
@@ -1,0 +1,1 @@
+'event_id' is now a required parameter in federated state requests, as per the matrix spec.

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -393,7 +393,7 @@ class FederationStateServlet(BaseFederationServlet):
         return self.handler.on_context_state_request(
             origin,
             context,
-            parse_string_from_args(query, "event_id", None),
+            parse_string_from_args(query, "event_id", None, required=True),
         )
 
 

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -404,7 +404,7 @@ class FederationStateIdsServlet(BaseFederationServlet):
         return self.handler.on_state_ids_request(
             origin,
             room_id,
-            parse_string_from_args(query, "event_id", None),
+            parse_string_from_args(query, "event_id", None, required=True),
         )
 
 


### PR DESCRIPTION
Paired with https://github.com/matrix-org/sytest/pull/566, replaces https://github.com/matrix-org/synapse/pull/4740

Closes #3646

From the original PR:
```
As per the spec: https://matrix.org/docs/spec/server_server/r0.1.1.html#id40

Closes #3646

Signed-off-by: Joseph Weston [joseph@weston.cloud](mailto:joseph@weston.cloud)
```