### PR TITLE
Limit cache invalidation replication line length

### DIFF
--- a/changelog.d/4748.misc
+++ b/changelog.d/4748.misc
@@ -1,0 +1,1 @@
+Improve replication performance by reducing cache invalidation traffic.


### PR DESCRIPTION
This fixes a bug where replication completely wedges if the server tries to send a cache invalidation that serialises to a line that is longer than the max line length.

Introduced in #4671