### PR TITLE
Fix tightloop over connecting to replication server

### DIFF
--- a/changelog.d/4749.bugfix
+++ b/changelog.d/4749.bugfix
@@ -1,0 +1,1 @@
+Fix tightloop over connecting to replication server.

--- a/docs/tcp_replication.rst
+++ b/docs/tcp_replication.rst
@@ -188,7 +188,9 @@ RDATA (S)
     A single update in a stream
 
 POSITION (S)
-    The position of the stream has been updated
+    The position of the stream has been updated. Sent to the client after all
+    missing updates for a stream have been sent to the client and they're now
+    up to date.
 
 ERROR (S, C)
     There was an error

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -39,7 +39,7 @@ class ReplicationClientFactory(ReconnectingClientFactory):
     Accepts a handler that will be called when new data is available or data
     is required.
     """
-    maxDelay = 5  # Try at least once every N seconds
+    maxDelay = 30  # Try at least once every N seconds
 
     def __init__(self, hs, client_name, handler):
         self.client_name = client_name

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -89,11 +89,6 @@ class ReplicationClientHandler(object):
         # Used for tests.
         self.awaiting_syncs = {}
 
-        # Set of stream names that have been subscribe to, but haven't yet
-        # caught up with. This is used to track when the client has been fully
-        # connected to the remote.
-        self.streams_connecting = None
-
         # The factory used to create connections.
         self.factory = None
 
@@ -122,12 +117,6 @@ class ReplicationClientHandler(object):
 
         Can be overriden in subclasses to handle more.
         """
-        # When we get a `POSITION` command it means we've finished getting
-        # missing updates for the given stream, and are now up to date.
-        self.streams_connecting.discard(stream_name)
-        if not self.streams_connecting:
-            self.finished_connecting()
-
         return self.store.process_replication_rows(stream_name, token, [])
 
     def on_sync(self, data):
@@ -153,9 +142,6 @@ class ReplicationClientHandler(object):
             args["account_data"] = user_account_data
         elif room_account_data:
             args["account_data"] = room_account_data
-
-        # Record which streams we're in the process of subscribing to
-        self.streams_connecting = set(args.keys())
 
         return args
 
@@ -221,10 +207,6 @@ class ReplicationClientHandler(object):
             for cmd in self.pending_commands:
                 connection.send_command(cmd)
             self.pending_commands = []
-
-            # This will happen if we don't actually subscribe to any streams
-            if not self.streams_connecting:
-                self.finished_connecting()
 
     def finished_connecting(self):
         """Called when we have successfully subscribed and caught up to all

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -127,8 +127,11 @@ class RdataCommand(Command):
 
 
 class PositionCommand(Command):
-    """Sent by the client to tell the client the stream postition without
+    """Sent by the server to tell the client the stream postition without
     needing to send an RDATA.
+
+    Sent to the client after all missing updates for a stream have been sent
+    to the client and they're now up to date.
     """
     NAME = "POSITION"
 


### PR DESCRIPTION
If the client failed to process incoming commands during the initial set
up of the replication connection it would immediately disconnect and
reconnect, resulting in a tightloop.

This can happen, for example, when subscribing to a stream that has a
row that is too long in the backlog.

The fix here is to not consider the connection successfully set up until
the client has succesfully subscribed and caught up with the streams.
This ensures that the retry logic timers aren't reset until then,
meaning that if an error does happen during start up the client will
continue backing off before retrying again.