### PR TITLE
Minor docstring fixes for MatrixFederationAgent

### DIFF
--- a/changelog.d/4765.misc
+++ b/changelog.d/4765.misc
@@ -1,0 +1,1 @@
+Minor docstring fixes for MatrixFederationAgent.

--- a/synapse/http/federation/matrix_federation_agent.py
+++ b/synapse/http/federation/matrix_federation_agent.py
@@ -68,8 +68,12 @@ class MatrixFederationAgent(object):
             TLS policy to use for fetching .well-known files. None to use a default
             (browser-like) implementation.
 
-        srv_resolver (SrvResolver|None):
+        _srv_resolver (SrvResolver|None):
             SRVResolver impl to use for looking up SRV records. None to use a default
+            implementation.
+
+        _well_known_cache (TTLCache|None):
+            TTLCache impl for storing cached well-known lookups. None to use a default
             implementation.
     """
 


### PR DESCRIPTION
Typo in docstring name and undocumented arg.
