### PR TITLE
Remove #4733 debug

### DIFF
--- a/changelog.d/4734.misc
+++ b/changelog.d/4734.misc
@@ -1,1 +1,0 @@
-Add some debug to help with #4733.

--- a/synapse/replication/tcp/protocol.py
+++ b/synapse/replication/tcp/protocol.py
@@ -52,7 +52,6 @@ indicate which side is sending, these are *not* included on the wire::
 import fcntl
 import logging
 import struct
-import traceback
 from collections import defaultdict
 
 from six import iteritems, iterkeys
@@ -242,7 +241,6 @@ class BaseReplicationStreamProtocol(LineOnlyReceiver):
     def send_error(self, error_string, *args):
         """Send an error to remote and close the connection.
         """
-        logger.error("[%s] Sending error: %s", self.id(), error_string % args)
         self.send_command(ErrorCommand(error_string % args))
         self.close()
 
@@ -335,8 +333,6 @@ class BaseReplicationStreamProtocol(LineOnlyReceiver):
         we or the remote has closed the connection)
         """
         logger.info("[%s] Stop producing", self.id())
-        # debug for #4733
-        logger.info("Traceback: %s", "".join(traceback.format_stack()))
         self.on_connection_closed()
 
     def connectionLost(self, reason):


### PR DESCRIPTION
We don't need any of this stuff now; this brings protocol.py back into line
with develop for the hotfixes branch.

Fixes #4754.