### PR TITLE
Fix incorrect log about not persisting duplicate state event.

### DIFF
--- a/changelog.d/4776.bugfix
+++ b/changelog.d/4776.bugfix
@@ -1,0 +1,1 @@
+Fix incorrect log about not persisting duplicate state event.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -436,10 +436,11 @@ class EventCreationHandler(object):
 
         if event.is_state():
             prev_state = yield self.deduplicate_state_event(event, context)
-            logger.info(
-                "Not bothering to persist duplicate state event %s", event.event_id,
-            )
             if prev_state is not None:
+                logger.info(
+                    "Not bothering to persist state event %s duplicated by %s",
+                    event.event_id, prev_state.event_id,
+                )
                 defer.returnValue(prev_state)
 
         yield self.handle_new_client_event(


### PR DESCRIPTION
We were logging this when it was not true.