### PR TITLE
Support batch updates in the worker sender 

### DIFF
--- a/changelog.d/4792.bugfix
+++ b/changelog.d/4792.bugfix
@@ -1,0 +1,1 @@
+Handle batch updates in worker replication protocol.


### PR DESCRIPTION
We added the ability to batch updates but didn't handle this correctly in the communication between Synapse master and worker processes. Marking updates as batched included setting their `token`s to None which the relevant code choked on. This PR change this to handle them correctly.

Fixes https://github.com/matrix-org/synapse/issues/4705