### PR TITLE
Remove reference to that no longer exists in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,9 +117,9 @@ recommended to also set up CAPTCHA - see `<docs/CAPTCHA_SETUP.rst>`_.)
 Once ``enable_registration`` is set to ``true``, it is possible to register a
 user via `riot.im <https://riot.im/app/#/register>`_ or other Matrix clients.
 
-Your new user name will be formed partly from the ``server_name`` (see
-`Configuring synapse`_), and partly from a localpart you specify when you
-create the account. Your name will take the form of::
+Your new user name will be formed partly from the ``server_name``, and partly
+from a localpart you specify when you create the account. Your name will take
+the form of::
 
     @localpart:my.domain.name
 

--- a/changelog.d/4795.misc
+++ b/changelog.d/4795.misc
@@ -1,0 +1,1 @@
+Remove link to deleted title in README.


### PR DESCRIPTION
README had a reference to a title that was removed in 0.99 shenanigans.