### PR TITLE
Remove redundant changes from synapse/replication/tcp/streams.py

### DIFF
--- a/synapse/replication/tcp/streams.py
+++ b/synapse/replication/tcp/streams.py
@@ -265,8 +265,8 @@ class PresenceStream(Stream):
         store = hs.get_datastore()
         presence_handler = hs.get_presence_handler()
 
-        self.current_token = lambda: 0
-        self.update_function = lambda _a, _b: []
+        self.current_token = store.get_current_presence_token
+        self.update_function = presence_handler.get_all_presence_updates
 
         super(PresenceStream, self).__init__(hs)
 


### PR DESCRIPTION
This was some hacky code (introduced in c10c71e70d) to make the presence stream
do nothing on hotfixes. We now ensure that no replication clients subscribe to
the presence stream, so this is redundant.