### PR TITLE
When re-syncing device lists reset the state

### DIFF
--- a/changelog.d/4829.bugfix
+++ b/changelog.d/4829.bugfix
@@ -1,0 +1,1 @@
+Fix potential race in handling missing updates in device list updates.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -566,6 +566,10 @@ class DeviceListEduUpdater(object):
                 )
                 device_ids = [device["device_id"] for device in devices]
                 yield self.device_handler.notify_device_update(user_id, device_ids)
+
+                # We clobber the seen updates since we've re-synced from a given
+                # point.
+                self._seen_updates[user_id] = set([stream_id])
             else:
                 # Simply update the single device, since we know that is the only
                 # change (because of the single prev_id matching the current cache)
@@ -578,9 +582,9 @@ class DeviceListEduUpdater(object):
                     user_id, [device_id for device_id, _, _, _ in pending_updates]
                 )
 
-            self._seen_updates.setdefault(user_id, set()).update(
-                stream_id for _, stream_id, _, _ in pending_updates
-            )
+                self._seen_updates.setdefault(user_id, set()).update(
+                    stream_id for _, stream_id, _, _ in pending_updates
+                )
 
     @defer.inlineCallbacks
     def _need_to_do_resync(self, user_id, updates):


### PR DESCRIPTION
We keep track of what stream IDs we've seen so that we know what updates
we've handled or missed. If we re-sync we don't know if the updates
we've seen are included in the re-sync (there may be a race), so we
should reset the seen updates.

Potentially helps #4827