### PR TITLE
Change documentation to support API without trailing slashes

### DIFF
--- a/changelog.d/4835.misc
+++ b/changelog.d/4835.misc
@@ -1,0 +1,1 @@
+Update documentation to remove trailing slashes at the end of API endpoints.

--- a/docs/ancient_architecture_notes.rst
+++ b/docs/ancient_architecture_notes.rst
@@ -40,7 +40,7 @@ Where the bottom (the transport layer) is what talks to the internet via HTTP, a
 3. Transaction Layer
     This layer makes incoming requests idempotent. I.e., it stores which transaction id's we have seen and what our response were. If we have already seen a message with the given transaction id, we do not notify higher levels but simply respond with the previous response.
 
-transaction_id is from "GET /send/<tx_id>/"
+transaction_id is from "GET /send/<tx_id>"
 
     It's also responsible for batching PDUs into single transaction for sending to remote destinations, so that we only ever have one transaction in flight to a given destination at any one time.
 

--- a/docs/workers.rst
+++ b/docs/workers.rst
@@ -166,28 +166,28 @@ Note this worker cannot be load-balanced: only one instance should be active.
 Handles a subset of federation endpoints. In particular, it can handle REST
 endpoints matching the following regular expressions::
 
-    ^/_matrix/federation/v1/event/
-    ^/_matrix/federation/v1/state/
-    ^/_matrix/federation/v1/state_ids/
-    ^/_matrix/federation/v1/backfill/
-    ^/_matrix/federation/v1/get_missing_events/
+    ^/_matrix/federation/v1/event
+    ^/_matrix/federation/v1/state
+    ^/_matrix/federation/v1/state_ids
+    ^/_matrix/federation/v1/backfill
+    ^/_matrix/federation/v1/get_missing_events
     ^/_matrix/federation/v1/publicRooms
-    ^/_matrix/federation/v1/query/
-    ^/_matrix/federation/v1/make_join/
-    ^/_matrix/federation/v1/make_leave/
-    ^/_matrix/federation/v1/send_join/
-    ^/_matrix/federation/v1/send_leave/
-    ^/_matrix/federation/v1/invite/
-    ^/_matrix/federation/v1/query_auth/
-    ^/_matrix/federation/v1/event_auth/
-    ^/_matrix/federation/v1/exchange_third_party_invite/
-    ^/_matrix/federation/v1/send/
+    ^/_matrix/federation/v1/query
+    ^/_matrix/federation/v1/make_join
+    ^/_matrix/federation/v1/make_leave
+    ^/_matrix/federation/v1/send_join
+    ^/_matrix/federation/v1/send_leave
+    ^/_matrix/federation/v1/invite
+    ^/_matrix/federation/v1/query_auth
+    ^/_matrix/federation/v1/event_auth
+    ^/_matrix/federation/v1/exchange_third_party_invite
+    ^/_matrix/federation/v1/send
     ^/_matrix/key/v2/query
 
 The above endpoints should all be routed to the federation_reader worker by the
 reverse-proxy configuration.
 
-The `^/_matrix/federation/v1/send/` endpoint must only be handled by a single
+The `^/_matrix/federation/v1/send` endpoint must only be handled by a single
 instance.
 
 ``synapse.app.federation_sender``
@@ -274,8 +274,8 @@ Handles some event creation. It can handle REST endpoints matching::
 
     ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/send
     ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/(join|invite|leave|ban|unban|kick)$
-    ^/_matrix/client/(api/v1|r0|unstable)/join/
-    ^/_matrix/client/(api/v1|r0|unstable)/profile/
+    ^/_matrix/client/(api/v1|r0|unstable)/join
+    ^/_matrix/client/(api/v1|r0|unstable)/profile
 
 It will create events locally and then send them on to the main synapse
 instance to be persisted and handled.


### PR DESCRIPTION
Some documentation changes to not give people the wrong idea about having trailing slashes on their API requests.

To be paired with #4793.