### PR TITLE
Disable captcha registration by default in tests

### DIFF
--- a/changelog.d/4839.misc
+++ b/changelog.d/4839.misc
@@ -1,0 +1,1 @@
+Disable captcha registration by default in unit tests.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -115,6 +115,7 @@ def default_config(name):
     config.signing_key = [MockKey()]
     config.event_cache_size = 1
     config.enable_registration = True
+    config.enable_registration_captcha = False
     config.macaroon_secret_key = "not even a little secret"
     config.expire_access_token = False
     config.server_name = name


### PR DESCRIPTION
It can be confusing that you have to explicitly disable recaptcha auth when writing tests, as it's not the default in Synapse (`enable_registration_captcha` is set to `false` in our config file). This just bit @babolivier as he spent a while debugging a new test he had written.

Suggest we set this to false by default to prevent the same from happening again.