### PR TITLE
Add ratelimiting on failed login attempts

### DIFF
--- a/changelog.d/4865.feature
+++ b/changelog.d/4865.feature
@@ -1,0 +1,1 @@
+Add configurable rate limiting to the /login endpoint.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -392,6 +392,9 @@ rc_message_burst_count: 10.0
 #     address.
 #   - one for login that ratelimits login requests based on the account the
 #     client is attempting to log into.
+#   - one for login that ratelimits login requests based on the account the
+#     client is attempting to log into, based on the amount of failed login
+#     attempts for this account.
 #
 # The defaults are as shown below.
 #
@@ -404,6 +407,9 @@ rc_message_burst_count: 10.0
 #    per_second: 0.17
 #    burst_count: 3
 #  account:
+#    per_second: 0.17
+#    burst_count: 3
+#  failed_attempts:
 #    per_second: 0.17
 #    burst_count: 3
 

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -32,6 +32,9 @@ class RatelimitConfig(Config):
         rc_login_config = config.get("rc_login", {})
         self.rc_login_address = RateLimitConfig(rc_login_config.get("address", {}))
         self.rc_login_account = RateLimitConfig(rc_login_config.get("account", {}))
+        self.rc_login_failed_attempts = RateLimitConfig(
+            rc_login_config.get("failed_attempts", {}),
+        )
 
         self.federation_rc_window_size = config["federation_rc_window_size"]
         self.federation_rc_sleep_limit = config["federation_rc_sleep_limit"]
@@ -64,6 +67,9 @@ class RatelimitConfig(Config):
         #     address.
         #   - one for login that ratelimits login requests based on the account the
         #     client is attempting to log into.
+        #   - one for login that ratelimits login requests based on the account the
+        #     client is attempting to log into, based on the amount of failed login
+        #     attempts for this account.
         #
         # The defaults are as shown below.
         #
@@ -76,6 +82,9 @@ class RatelimitConfig(Config):
         #    per_second: 0.17
         #    burst_count: 3
         #  account:
+        #    per_second: 0.17
+        #    burst_count: 3
+        #  failed_attempts:
         #    per_second: 0.17
         #    burst_count: 3
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -157,6 +157,8 @@ def default_config(name):
     config.rc_login_address.burst_count = 10000
     config.rc_login_account.per_second = 10000
     config.rc_login_account.burst_count = 10000
+    config.rc_login_failed_attempts.per_second = 10000
+    config.rc_login_failed_attempts.burst_count = 10000
     config.saml2_enabled = False
     config.public_baseurl = None
     config.default_identity_server = None


### PR DESCRIPTION
Depends on #4821 

Add a ratelimiter that denies login requests for a given amount of time if there's been too many failed login attempts for the account the client is trying to log into.
