### PR TITLE
Add a default .m.rule.tombstone push rule

### DIFF
--- a/changelog.d/4867.feature
+++ b/changelog.d/4867.feature
@@ -1,1 +1,1 @@
-Add a default .m.rule.tombstone push rule
+Add a default .m.rule.tombstone push rule.

--- a/changelog.d/4867.feature
+++ b/changelog.d/4867.feature
@@ -1,0 +1,1 @@
+Add a default .m.rule.tombstone push rule

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -261,6 +261,23 @@ BASE_APPEND_OVERRIDE_RULES = [
                 'value': True,
             }
         ]
+    },
+    {
+        'rule_id': 'global/override/.m.rule.tombstone',
+        'conditions': [
+            {
+                'kind': 'event_match',
+                'key': 'type',
+                'pattern': 'm.room.tombstone',
+                '_id': '_tombstone',
+            }
+        ],
+        'actions': [
+            'notify', {
+                'set_tweak': 'highlight',
+                'value': True,
+            }
+        ]
     }
 ]
 


### PR DESCRIPTION
In support of MSC1930: https://github.com/matrix-org/matrix-doc/pull/1930
See also https://github.com/matrix-org/matrix-react-sdk/pull/2798
