### PR TITLE
Add a config option for torture-testing worker replication.

### DIFF
--- a/changelog.d/4902.misc
+++ b/changelog.d/4902.misc
@@ -1,0 +1,1 @@
+Add a config option for torture-testing worker replication.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -126,6 +126,11 @@ class ServerConfig(Config):
                 self.public_baseurl += '/'
         self.start_pushers = config.get("start_pushers", True)
 
+        # (undocumented) option for torturing the worker-mode replication a bit,
+        # for testing. The value defines the number of milliseconds to pause before
+        # sending out any replication updates.
+        self.replication_torture_level = config.get("replication_torture_level")
+
         self.listeners = []
         for listener in config.get("listeners", []):
             if not isinstance(listener.get("port", None), int):

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -16,6 +16,7 @@
 """
 
 import logging
+import random
 
 from six import itervalues
 
@@ -73,6 +74,8 @@ class ReplicationStreamer(object):
         self.clock = hs.get_clock()
         self.notifier = hs.get_notifier()
         self._server_notices_sender = hs.get_server_notices_sender()
+
+        self._replication_torture_level = hs.config.replication_torture_level
 
         # Current connections.
         self.connections = []
@@ -157,9 +160,22 @@ class ReplicationStreamer(object):
                     for stream in self.streams:
                         stream.advance_current_token()
 
-                    for stream in self.streams:
+                    all_streams = self.streams
+
+                    if self._replication_torture_level is not None:
+                        # there is no guarantee about ordering between the streams,
+                        # so let's shuffle them around a bit when we are in torture mode.
+                        all_streams = list(all_streams)
+                        random.shuffle(all_streams)
+
+                    for stream in all_streams:
                         if stream.last_token == stream.upto_token:
                             continue
+
+                        if self._replication_torture_level:
+                            yield self.clock.sleep(
+                                self._replication_torture_level / 1000.0
+                            )
 
                         logger.debug(
                             "Getting stream: %s: %s -> %s",


### PR DESCRIPTION
Setting this to 50 or so makes a bunch of sytests fail in worker mode.