### PR TITLE
Fix sync bug when accepting invites

### DIFF
--- a/changelog.d/4903.bugfix
+++ b/changelog.d/4903.bugfix
@@ -1,0 +1,1 @@
+Fix sync bug which made accepting invites unreliable in worker-mode synapses.

--- a/synapse/replication/slave/storage/events.py
+++ b/synapse/replication/slave/storage/events.py
@@ -118,4 +118,6 @@ class SlavedEventStore(EventFederationWorkerStore,
             self._membership_stream_cache.entity_has_changed(
                 state_key, stream_ordering
             )
-            self.get_invited_rooms_for_user.invalidate((state_key,))
+            if not backfilled:
+                self.get_invited_rooms_for_user.invalidate((state_key,))
+                self.get_rooms_for_user_with_stream_ordering.invalidate((state_key,))

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -1355,11 +1355,6 @@ class SQLBaseStore(object):
             members_changed (iterable[str]): The user_ids of members that have
                 changed
         """
-        for member in members_changed:
-            self._attempt_to_invalidate_cache(
-                "get_rooms_for_user_with_stream_ordering", (member,),
-            )
-
         for host in set(get_domain_from_id(u) for u in members_changed):
             self._attempt_to_invalidate_cache(
                 "is_host_joined", (room_id, host,),

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -587,7 +587,8 @@ class RoomMemberStore(RoomMemberWorkerStore):
                 self.get_invited_rooms_for_user.invalidate, (event.state_key,)
             )
             txn.call_after(
-                self.get_rooms_for_user_with_stream_ordering, (event.state_key,)
+                self.get_rooms_for_user_with_stream_ordering.invalidate,
+                (event.state_key,),
             )
 
             # We update the local_invites table only if the event is "current",

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -586,6 +586,9 @@ class RoomMemberStore(RoomMemberWorkerStore):
             txn.call_after(
                 self.get_invited_rooms_for_user.invalidate, (event.state_key,)
             )
+            txn.call_after(
+                self.get_rooms_for_user_with_stream_ordering, (event.state_key,)
+            )
 
             # We update the local_invites table only if the event is "current",
             # i.e., its something that has just happened. If the event is an


### PR DESCRIPTION
*Hopefully* this will fix #4422: essentially we need to make sure that the
cache on `get_rooms_for_user_with_stream_ordering` is invalidated *before* the
SyncHandler is notified for the new events. Doing so on the `events` stream
rather than the `caches` stream achieves this, and should be safe because the
only time we need to invalidate this cache is when we persist an event.