### PR TITLE
Log requests which are simulated by the unit tests.

### DIFF
--- a/changelog.d/4905.misc
+++ b/changelog.d/4905.misc
@@ -1,0 +1,1 @@
+Log requests which are simulated by the unit tests.

--- a/tests/server.py
+++ b/tests/server.py
@@ -119,14 +119,7 @@ class FakeSite:
 
     server_version_string = b"1"
     site_tag = "test"
-
-    @property
-    def access_logger(self):
-        class FakeLogger:
-            def info(self, *args, **kwargs):
-                pass
-
-        return FakeLogger()
+    access_logger = logging.getLogger("synapse.access.http.fake")
 
 
 def make_request(


### PR DESCRIPTION
Rather than stubbing out the access_log, make it actually log the requests,
which makes it a lot more obvious what is going on during tests.