### PR TITLE
Fix nginx example in ACME doc.

### DIFF
--- a/changelog.d/4923.misc
+++ b/changelog.d/4923.misc
@@ -1,0 +1,1 @@
+Fix nginx example in ACME doc.

--- a/docs/ACME.md
+++ b/docs/ACME.md
@@ -67,7 +67,7 @@ For nginx users, add the following line to your existing `server` block:
 
 ```
 location /.well-known/acme-challenge {
-    proxy_pass http://localhost:8009/;
+    proxy_pass http://localhost:8009;
 }
 ```
 


### PR DESCRIPTION
Ref: #4922

nginx will replace the path with that specified in `proxy_pass` if one is given. This change brings the doc into line with that in https://github.com/matrix-org/synapse/blob/master/docs/reverse_proxy.rst.