### PR TITLE
rest/media: Don't call finish in case of error

### DIFF
--- a/synapse/rest/media/v1/_base.py
+++ b/synapse/rest/media/v1/_base.py
@@ -185,13 +185,14 @@ def respond_with_responder(request, responder, media_type, file_size, upload_nam
     try:
         with responder:
             yield responder.write_to_consumer(request)
+
+        finish_request(request)
     except Exception as e:
         # The majority of the time this will be due to the client having gone
         # away. Unfortunately, Twisted simply throws a generic exception at us
         # in that case.
-        logger.warning("Failed to write to consumer: %s %s", type(e), e)
-
-    finish_request(request)
+        if str(e) != "Consumer asked us to stop producing":
+            logger.warning("Failed to write to consumer: %s %s", type(e), e)
 
 
 class Responder(object):


### PR DESCRIPTION
When an exception occurs during the sending of data, the request doesn't
needs a finishing, otherwise twisted complains `Producer was not
unregistered for b'/_matrix/media/v1/thumbnail/…'`.

Fixes #4933

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Signed-off-by: Jörg Sommer <<joerg@jo-so.de>>