### PR TITLE
Allow password providers to bind emails

### DIFF
--- a/changelog.d/4947.feature
+++ b/changelog.d/4947.feature
@@ -1,0 +1,1 @@
+Add ability for password provider modules to bind email addresses to users upon registration.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -264,13 +264,13 @@ class RegistrationHandler(BaseHandler):
             yield self._auto_join_rooms(user_id)
 
         # Bind any specified emails to this account
-        validated_at = self.hs.get_clock().time_msec()
+        current_time = self.hs.get_clock().time_msec()
         for email in bind_emails:
             # generate threepid dict
             threepid_dict = {
                 "medium": "email",
                 "address": email,
-                "validated_at": validated_at,
+                "validated_at": current_time,
             }
 
             # Bind email to new account

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -74,14 +74,14 @@ class ModuleApi(object):
         return self._auth_handler.check_user_exists(user_id)
 
     @defer.inlineCallbacks
-    def register(self, localpart, displayname=None):
+    def register(self, localpart, displayname=None, emails=[]):
         """Registers a new user with given localpart and optional
-           displayname.
+           displayname, emails.
 
         Args:
             localpart (str): The localpart of the new user.
-            displayname (str|None): The displayname of the new user. If None,
-                the user's displayname will default to `localpart`.
+            displayname (str|None): The displayname of the new user.
+            emails (List[str]): Emails to bind to the new user.
 
         Returns:
             Deferred: a 2-tuple of (user_id, access_token)
@@ -90,6 +90,7 @@ class ModuleApi(object):
         reg = self.hs.get_registration_handler()
         user_id, access_token = yield reg.register(
             localpart=localpart, default_display_name=displayname,
+            bind_emails=emails,
         )
 
         defer.returnValue((user_id, access_token))


### PR DESCRIPTION
This PR allows password provider modules to bind email addresses when a user is registering and is motivated by https://github.com/matrix-org/matrix-synapse-ldap3/pull/58