### PR TITLE
Transfer related groups on room upgrade

### DIFF
--- a/changelog.d/4990.bugfix
+++ b/changelog.d/4990.bugfix
@@ -1,0 +1,1 @@
+Transfer related groups on room upgrade.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -69,6 +69,7 @@ class EventTypes(object):
     Redaction = "m.room.redaction"
     ThirdPartyInvite = "m.room.third_party_invite"
     Encryption = "m.room.encryption"
+    RelatedGroups = "m.room.related_groups"
 
     RoomHistoryVisibility = "m.room.history_visibility"
     CanonicalAlias = "m.room.canonical_alias"

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -280,6 +280,7 @@ class RoomCreationHandler(BaseHandler):
             (EventTypes.RoomAvatar, ""),
             (EventTypes.Encryption, ""),
             (EventTypes.ServerACL, ""),
+            (EventTypes.RelatedGroups, ""),
         )
 
         old_room_state_ids = yield self.store.get_filtered_current_state_ids(


### PR DESCRIPTION
Transfers the `m.room.related_groups` state event on room upgrade.

Sytest PR: https://github.com/matrix-org/sytest/pull/596

Closes https://github.com/matrix-org/synapse/issues/4633