### PR TITLE
Prevent kicking users who aren't in the room

### DIFF
--- a/changelog.d/4999.bugfix
+++ b/changelog.d/4999.bugfix
@@ -1,0 +1,1 @@
+Prevent the ability to kick users from a room they aren't in.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -446,6 +446,9 @@ class RoomMemberHandler(object):
                 if same_sender and same_membership and same_content:
                     defer.returnValue(old_state)
 
+            if old_membership in ["ban", "leave"] and action == "kick":
+                raise AuthError(403, "The target user is not in the room")
+
             # we don't allow people to reject invites to the server notice
             # room, but they can leave it once they are joined.
             if (
@@ -459,6 +462,9 @@ class RoomMemberHandler(object):
                         "You cannot reject this invite",
                         errcode=Codes.CANNOT_LEAVE_SERVER_NOTICE_ROOM,
                     )
+        else:
+            if action == "kick":
+                raise AuthError(403, "The target user is not in the room")
 
         is_host_in_room = yield self._is_host_in_room(current_state_ids)
 

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -421,6 +421,9 @@ class RoomMemberHandler(object):
             room_id, latest_event_ids=latest_event_ids,
         )
 
+        # TODO: Refactor into dictionary of explicitly allowed transitions
+        # between old and new state, with specific error messages for some
+        # transitions and generic otherwise
         old_state_id = current_state_ids.get((EventTypes.Member, target.to_string()))
         if old_state_id:
             old_state = yield self.store.get_event(old_state_id, allow_none=True)


### PR DESCRIPTION
Prevent kick events from succeeding if the user is not currently in the room.

Closes https://github.com/matrix-org/synapse/issues/4973

Sytest PR: https://github.com/matrix-org/sytest/pull/602