### PR TITLE
Rewrite more internal IS urls.

### DIFF
--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -70,7 +70,8 @@ class RoomMemberHandler(object):
         self.clock = hs.get_clock()
         self.spam_checker = hs.get_spam_checker()
         self._server_notices_mxid = self.config.server_notices_mxid
-        self.rewrite_identity_server_urls = config.get("rewrite_identity_server_urls", {}) 
+        self.rewrite_identity_server_urls = self.config.get("rewrite_identity_server_urls", {})
+
     @abc.abstractmethod
     def _remote_join(self, requester, remote_room_hosts, room_id, user, content):
         """Try and join a room that this server is not in
@@ -779,10 +780,11 @@ class RoomMemberHandler(object):
                 inviter,
                 txn_id=txn_id
             )
+
     def _get_id_server_target(self, id_server):
         """Looks up an id_server's actual http endpoint
 
-        Args: 
+        Args:
             id_server (str): the server name to lookup.
 
         Returns:
@@ -792,7 +794,6 @@ class RoomMemberHandler(object):
             return self.rewrite_identity_server_urls[id_server]
 
         return id_server
-
 
     @defer.inlineCallbacks
     def _lookup_3pid(self, id_server, medium, address):

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -71,7 +71,6 @@ class RoomMemberHandler(object):
         self.spam_checker = hs.get_spam_checker()
         self._server_notices_mxid = self.config.server_notices_mxid
         self.rewrite_identity_server_urls = self.config.rewrite_identity_server_urls
-        )
 
     @abc.abstractmethod
     def _remote_join(self, requester, remote_room_hosts, room_id, user, content):

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -70,7 +70,9 @@ class RoomMemberHandler(object):
         self.clock = hs.get_clock()
         self.spam_checker = hs.get_spam_checker()
         self._server_notices_mxid = self.config.server_notices_mxid
-        self.rewrite_identity_server_urls = self.config.get("rewrite_identity_server_urls", {})
+        self.rewrite_identity_server_urls = self.config.get(
+            "rewrite_identity_server_urls", {}
+        )
 
     @abc.abstractmethod
     def _remote_join(self, requester, remote_room_hosts, room_id, user, content):

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -70,7 +70,7 @@ class RoomMemberHandler(object):
         self.clock = hs.get_clock()
         self.spam_checker = hs.get_spam_checker()
         self._server_notices_mxid = self.config.server_notices_mxid
-
+        self.rewrite_identity_server_urls = config.get("rewrite_identity_server_urls", {}) 
     @abc.abstractmethod
     def _remote_join(self, requester, remote_room_hosts, room_id, user, content):
         """Try and join a room that this server is not in
@@ -779,6 +779,20 @@ class RoomMemberHandler(object):
                 inviter,
                 txn_id=txn_id
             )
+    def _get_id_server_target(self, id_server):
+        """Looks up an id_server's actual http endpoint
+
+        Args: 
+            id_server (str): the server name to lookup.
+
+        Returns:
+            the http endpoint to connect to.
+        """
+        if id_server in self.rewrite_identity_server_urls:
+            return self.rewrite_identity_server_urls[id_server]
+
+        return id_server
+
 
     @defer.inlineCallbacks
     def _lookup_3pid(self, id_server, medium, address):
@@ -794,8 +808,9 @@ class RoomMemberHandler(object):
             str: the matrix ID of the 3pid, or None if it is not recognized.
         """
         try:
+            target = self._get_id_server_target(id_server)
             data = yield self.simple_http_client.get_json(
-                "%s%s/_matrix/identity/api/v1/lookup" % (id_server_scheme, id_server,),
+                "%s%s/_matrix/identity/api/v1/lookup" % (id_server_scheme, target,),
                 {
                     "medium": medium,
                     "address": address,
@@ -817,9 +832,10 @@ class RoomMemberHandler(object):
         if server_hostname not in data["signatures"]:
             raise AuthError(401, "No signature from server %s" % (server_hostname,))
         for key_name, signature in data["signatures"][server_hostname].items():
+            target = self._get_id_server_target(server_hostname)
             key_data = yield self.simple_http_client.get_json(
                 "%s%s/_matrix/identity/api/v1/pubkey/%s" %
-                (id_server_scheme, server_hostname, key_name,),
+                (id_server_scheme, target, key_name,),
             )
             if "public_key" not in key_data:
                 raise AuthError(401, "No public key named %s from %s" %
@@ -956,8 +972,9 @@ class RoomMemberHandler(object):
                     user.
         """
 
+        target = self._get_id_server_target(id_server)
         is_url = "%s%s/_matrix/identity/api/v1/store-invite" % (
-            id_server_scheme, id_server,
+            id_server_scheme, target,
         )
 
         invite_config = {
@@ -997,7 +1014,7 @@ class RoomMemberHandler(object):
             fallback_public_key = {
                 "public_key": data["public_key"],
                 "key_validity_url": "%s%s/_matrix/identity/api/v1/pubkey/isvalid" % (
-                    id_server_scheme, id_server,
+                    id_server_scheme, target,
                 ),
             }
         else:

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -70,8 +70,7 @@ class RoomMemberHandler(object):
         self.clock = hs.get_clock()
         self.spam_checker = hs.get_spam_checker()
         self._server_notices_mxid = self.config.server_notices_mxid
-        self.rewrite_identity_server_urls = self.config.get(
-            "rewrite_identity_server_urls", {}
+        self.rewrite_identity_server_urls = self.config.rewrite_identity_server_urls
         )
 
     @abc.abstractmethod


### PR DESCRIPTION
In a previous PR (#4393) we rewrote requests from synapse to IS's to be able to change the HTTP endpoint if required. 

That PR did not cover enough of the usecases, so adding the remaining ones here.