### PR TITLE
Add config option to block users from looking up 3PIDs

### DIFF
--- a/changelog.d/5010.feature
+++ b/changelog.d/5010.feature
@@ -1,0 +1,1 @@
+Add config option to block users from looking up 3PIDs.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -665,6 +665,10 @@ uploads_path: "DATADIR/uploads"
 #  - medium: msisdn
 #    pattern: '\+44'
 
+# Disable 3PIDs lookup requests to identity servers from this server.
+#
+#disable_3pid_lookup: false
+
 # If set, allows registration of standard or admin accounts by anyone who
 # has the shared secret, even if registration is otherwise disabled.
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -665,9 +665,9 @@ uploads_path: "DATADIR/uploads"
 #  - medium: msisdn
 #    pattern: '\+44'
 
-# Disable 3PIDs lookup requests to identity servers from this server.
+# Enable 3PIDs lookup requests to identity servers from this server.
 #
-#disable_3pid_lookup: false
+#enable_3pid_lookup: true
 
 # If set, allows registration of standard or admin accounts by anyone who
 # has the shared secret, even if registration is otherwise disabled.

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -33,7 +33,7 @@ class RegistrationConfig(Config):
 
         self.registrations_require_3pid = config.get("registrations_require_3pid", [])
         self.allowed_local_3pids = config.get("allowed_local_3pids", [])
-        self.disable_3pid_lookup = config.get("disable_3pid_lookup", False)
+        self.enable_3pid_lookup = config.get("enable_3pid_lookup", True)
         self.registration_shared_secret = config.get("registration_shared_secret")
 
         self.bcrypt_rounds = config.get("bcrypt_rounds", 12)
@@ -98,9 +98,9 @@ class RegistrationConfig(Config):
         #  - medium: msisdn
         #    pattern: '\\+44'
 
-        # Disable 3PIDs lookup requests to identity servers from this server.
+        # Enable 3PIDs lookup requests to identity servers from this server.
         #
-        #disable_3pid_lookup: false
+        #enable_3pid_lookup: true
 
         # If set, allows registration of standard or admin accounts by anyone who
         # has the shared secret, even if registration is otherwise disabled.

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -33,6 +33,7 @@ class RegistrationConfig(Config):
 
         self.registrations_require_3pid = config.get("registrations_require_3pid", [])
         self.allowed_local_3pids = config.get("allowed_local_3pids", [])
+        self.disable_3pid_lookup = config.get("disable_3pid_lookup", False)
         self.registration_shared_secret = config.get("registration_shared_secret")
 
         self.bcrypt_rounds = config.get("bcrypt_rounds", 12)
@@ -96,6 +97,10 @@ class RegistrationConfig(Config):
         #    pattern: '.*@vector\\.im'
         #  - medium: msisdn
         #    pattern: '\\+44'
+
+        # Disable 3PIDs lookup requests to identity servers from this server.
+        #
+        #disable_3pid_lookup: false
 
         # If set, allows registration of standard or admin accounts by anyone who
         # has the shared secret, even if registration is otherwise disabled.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -70,7 +70,7 @@ class RoomMemberHandler(object):
         self.clock = hs.get_clock()
         self.spam_checker = hs.get_spam_checker()
         self._server_notices_mxid = self.config.server_notices_mxid
-        self._disable_lookup = hs.config.disable_3pid_lookup
+        self._enable_lookup = hs.config.enable_3pid_lookup
 
     @abc.abstractmethod
     def _remote_join(self, requester, remote_room_hosts, room_id, user, content):
@@ -730,7 +730,7 @@ class RoomMemberHandler(object):
         Returns:
             str: the matrix ID of the 3pid, or None if it is not recognized.
         """
-        if self._disable_lookup:
+        if not self._enable_lookup:
             raise SynapseError(
                 403, "Looking up third-party identifiers is denied from this server",
             )

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -70,6 +70,7 @@ class RoomMemberHandler(object):
         self.clock = hs.get_clock()
         self.spam_checker = hs.get_spam_checker()
         self._server_notices_mxid = self.config.server_notices_mxid
+        self._disable_lookup = hs.config.disable_3pid_lookup
 
     @abc.abstractmethod
     def _remote_join(self, requester, remote_room_hosts, room_id, user, content):
@@ -729,6 +730,10 @@ class RoomMemberHandler(object):
         Returns:
             str: the matrix ID of the 3pid, or None if it is not recognized.
         """
+        if self._disable_lookup:
+            raise SynapseError(
+                403, "Looking up third-party identifiers is denied from this server",
+            )
         try:
             data = yield self.simple_http_client.get_json(
                 "%s%s/_matrix/identity/api/v1/lookup" % (id_server_scheme, id_server,),

--- a/tests/rest/client/test_identity.py
+++ b/tests/rest/client/test_identity.py
@@ -13,14 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
-import hmac
 import json
 
-from mock import Mock
-
-from synapse.api.constants import UserTypes
-from synapse.rest.client.v1 import admin, room, login
+from synapse.rest.client.v1 import admin, login, room
 
 from tests import unittest
 
@@ -47,7 +42,9 @@ class IdentityTestCase(unittest.HomeserverTestCase):
         self.register_user("kermit", "monkey")
         tok = self.login("kermit", "monkey")
 
-        request, channel = self.make_request(b"POST", "/createRoom", b"{}", access_token=tok)
+        request, channel = self.make_request(
+            b"POST", "/createRoom", b"{}", access_token=tok,
+        )
         self.render(request)
         self.assertEquals(channel.result["code"], b"200", channel.result)
         room_id = channel.json_body["room_id"]
@@ -61,6 +58,8 @@ class IdentityTestCase(unittest.HomeserverTestCase):
         request_url = (
             "/rooms/%s/invite" % (room_id)
         ).encode('ascii')
-        request, channel = self.make_request(b"POST", request_url, request_data, access_token=tok)
+        request, channel = self.make_request(
+            b"POST", request_url, request_data, access_token=tok,
+        )
         self.render(request)
         self.assertEquals(channel.result["code"], b"403", channel.result)

--- a/tests/rest/client/test_identity.py
+++ b/tests/rest/client/test_identity.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import hmac
+import json
+
+from mock import Mock
+
+from synapse.api.constants import UserTypes
+from synapse.rest.client.v1 import admin, room, login
+
+from tests import unittest
+
+
+class IdentityTestCase(unittest.HomeserverTestCase):
+
+    servlets = [
+        admin.register_servlets,
+        room.register_servlets,
+        login.register_servlets,
+    ]
+
+    def make_homeserver(self, reactor, clock):
+
+        config = self.default_config()
+        config.enable_3pid_lookup = False
+        self.hs = self.setup_test_homeserver(config=config)
+
+        return self.hs
+
+    def test_3pid_lookup_disabled(self):
+        self.hs.config.enable_3pid_lookup = False
+
+        self.register_user("kermit", "monkey")
+        tok = self.login("kermit", "monkey")
+
+        request, channel = self.make_request(b"POST", "/createRoom", b"{}", access_token=tok)
+        self.render(request)
+        self.assertEquals(channel.result["code"], b"200", channel.result)
+        room_id = channel.json_body["room_id"]
+
+        params = {
+            "id_server": "testis",
+            "medium": "email",
+            "address": "test@example.com",
+        }
+        request_data = json.dumps(params)
+        request_url = (
+            "/rooms/%s/invite" % (room_id)
+        ).encode('ascii')
+        request, channel = self.make_request(b"POST", request_url, request_data, access_token=tok)
+        self.render(request)
+        self.assertEquals(channel.result["code"], b"403", channel.result)

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -410,7 +410,7 @@ class HomeserverTestCase(TestCase):
             "POST", "/_matrix/client/r0/login", json.dumps(body).encode('utf8')
         )
         self.render(request)
-        self.assertEqual(channel.code, 200)
+        self.assertEqual(channel.code, 200, channel.result)
 
         access_token = channel.json_body["access_token"]
         return access_token


### PR DESCRIPTION
Not sure this config option belongs to `register.py` since it has nothing to do with registration, however there's no `identity.py` file and all of the IS settings are there, so I figured I'd put that in there as well.