### PR TITLE
Fix from_server buglet in get_keys_from_perspectives

### DIFF
--- a/changelog.d/5024.misc
+++ b/changelog.d/5024.misc
@@ -1,0 +1,1 @@
+Store the notary server name correctly in server_keys_json.

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -652,7 +652,7 @@ class Keyring(object):
                     self.store.store_server_keys_json,
                     server_name=server_name,
                     key_id=key_id,
-                    from_server=server_name,
+                    from_server=from_server,
                     ts_now_ms=time_now_ms,
                     ts_expires_ms=ts_valid_until_ms,
                     key_json_bytes=signed_key_json_bytes,

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -324,6 +324,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
         self.assertEqual(len(res), 1)
         res = res[0]
         self.assertEqual(res["key_id"], testverifykey_id)
+        self.assertEqual(res["from_server"], self.mock_perspective_server.server_name)
         self.assertEqual(res["ts_added_ms"], self.reactor.seconds() * 1000)
         self.assertEqual(res["ts_valid_until_ms"], VALID_UNTIL_TS)
 


### PR DESCRIPTION
make sure we store the name of the server the keys came from, rather than the
origin server, after doing a fetch-from-perspectives.