### PR TITLE
Bump psycopg requirement

### DIFF
--- a/changelog.d/5032.bugfix
+++ b/changelog.d/5032.bugfix
@@ -1,0 +1,1 @@
+Fix "cannot import name execute_batch" error with postgres.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -74,7 +74,9 @@ REQUIREMENTS = [
 CONDITIONAL_REQUIREMENTS = {
     "email.enable_notifs": ["Jinja2>=2.9", "bleach>=1.4.2"],
     "matrix-synapse-ldap3": ["matrix-synapse-ldap3>=0.1"],
-    "postgres": ["psycopg2>=2.6"],
+
+    # we use execute_batch, which arrived in psycopg 2.7.
+    "postgres": ["psycopg2>=2.7"],
 
     # ConsentResource uses select_autoescape, which arrived in jinja 2.9
     "resources.consent": ["Jinja2>=2.9"],


### PR DESCRIPTION
We use execute_batch, which only arrived in psycopg 2.7.