### PR TITLE
Fix disappearing exceptions in manhole.

### DIFF
--- a/changelog.d/5035.bugfix
+++ b/changelog.d/5035.bugfix
@@ -1,0 +1,1 @@
+Fix disappearing exceptions in manhole.


### PR DESCRIPTION
Avoid sending syntax errors from the manhole to sentry.

Fixes #4768.