### PR TITLE
Limit in flight DNS requests

### DIFF
--- a/changelog.d/5037.bugfix
+++ b/changelog.d/5037.bugfix
@@ -1,0 +1,1 @@
+Workaround bug in twisted where attempting too many concurrent DNS requests could cause it to hang due to running out of file descriptors.


### PR DESCRIPTION
This is to work around a bug in twisted where a large number of
concurrent DNS requests cause it to tight loop forever.

c.f. https://twistedmatrix.com/trac/ticket/9620#ticket
