### PR TITLE
Fix bug in presence handling deleted current state

### DIFF
--- a/changelog.d/5041.bugfix
+++ b/changelog.d/5041.bugfix
@@ -1,0 +1,1 @@
+Fix bug where presence updates were sent to all servers in a room when a new server joined, rather than to just the new server.

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -828,6 +828,11 @@ class PresenceHandler(object):
             if typ != EventTypes.Member:
                 continue
 
+            if not event_id:
+                # Member no longer part of current state, equivalent to a
+                # "leave" state. Since we only care about joins, continue.
+                continue
+
             event = yield self.store.get_event(event_id)
             if event.content.get("membership") != Membership.JOIN:
                 # We only care about joins


### PR DESCRIPTION
Entries in current state can be "deleted", so we need to handle the case
where the new event_id is None.

Introduced in #4942.