### PR TITLE
Feature/fix cas

### DIFF
--- a/changelog.d/5044.bugfix
+++ b/changelog.d/5044.bugfix
@@ -1,0 +1,1 @@
+Fixes CAS service validation issue. Initial patch provided by mijutu. Contributed by Lukas Bloder.

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -388,7 +388,8 @@ class CasRedirectServlet(RestServlet):
         }).encode('ascii')
         hs_redirect_url = (self.cas_service_url +
                            b"/_matrix/client/api/v1/login/cas/ticket")
-        self.hs.config.cas_service_url_complete = b"%s?%s" % (hs_redirect_url, client_redirect_url_param)
+        self.hs.config.cas_service_url_complete = (b"%s?%s" % 
+            (hs_redirect_url, client_redirect_url_param))
         service_param = urllib.parse.urlencode({
             b"service": self.hs.config.cas_service_url_complete
         }).encode('ascii')

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -388,8 +388,12 @@ class CasRedirectServlet(RestServlet):
         }).encode('ascii')
         hs_redirect_url = (self.cas_service_url +
                            b"/_matrix/client/api/v1/login/cas/ticket")
-        self.hs.config.cas_service_url_complete = (b"%s?%s" % 
-            (hs_redirect_url, client_redirect_url_param))
+
+        self.hs.config.cas_service_url_complete = (
+            b"%s?%s" %
+            (hs_redirect_url, client_redirect_url_param)
+        )
+
         service_param = urllib.parse.urlencode({
             b"service": self.hs.config.cas_service_url_complete
         }).encode('ascii')


### PR DESCRIPTION
Fixes #2639 
Applied the diff provided by @mijutu with minor changes
Sends the full initial service url to proxyValidate, previously only the host was sent.
Now works as specified in https://apereo.github.io/cas/5.0.x/protocol/CAS-Protocol-Specification.html#head2.6
The fix was tested on the CAS reference implementation (https://github.com/apereo/cas)

Signed-off-by: Lukas Bloder <lukas.bloder@bytepoets.com>

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
