### PR TITLE
Allow upgrading a room only once

### DIFF
--- a/changelog.d/5045.bugfix
+++ b/changelog.d/5045.bugfix
@@ -1,0 +1,1 @@
+Prevent the abiltiy to upgrade the same room more than once.


### PR DESCRIPTION
Prevents a room from being upgraded more than once, and also prevents a room upgrade for a room if one is currently ongoing. Returns a `400` with the message "This room has already been upgraded" in either case.

Fixes https://github.com/matrix-org/synapse/issues/4583