### PR TITLE
Replaced GAIResolver with twisted.names.client for the default resolver

### DIFF
--- a/changelog.d/5053.misc
+++ b/changelog.d/5053.misc
@@ -1,0 +1,1 @@
+Replace blocking getaddrinfo hostname resolver with the non-blocking resolver from twisted.names.client.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -46,6 +46,12 @@ pid_file: DATADIR/homeserver.pid
 #
 #cpu_affinity: 0xFFFFFFFF
 
+# Whether to use the default system resolver (getaddrinfo) instead of the twisted
+# asynchronous dns resolver. Using the async resolver can potentially improve
+# performance, but may also behave different from getaddrinfo.
+# Defaults to True. Uncomment to use the twisted resolver instead.
+#use_getaddrinfo_for_dns: False
+
 # The path to the web client which will be served at /_matrix/client/
 # if 'webclient' is configured under the 'listeners' configuration.
 #

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -71,7 +71,7 @@ def start_worker_reactor(appname, config):
         daemonize=config.worker_daemonize,
         cpu_affinity=config.worker_cpu_affinity,
         print_pidfile=config.print_pidfile,
-        no_getaddrinfo=config.no_getaddrinfo,
+        use_getaddrinfo_for_dns=config.use_getaddrinfo_for_dns,
         logger=logger,
     )
 
@@ -84,7 +84,7 @@ def start_reactor(
         daemonize,
         cpu_affinity,
         print_pidfile,
-        no_getaddrinfo,
+        use_getaddrinfo_for_dns,
         logger,
 ):
     """ Run the reactor in the main process
@@ -99,7 +99,7 @@ def start_reactor(
         pid_file (str): name of pid file to write to if daemonize is True
         daemonize (bool): true to run the reactor in a background process
         cpu_affinity (int|None): cpu affinity mask
-        no_getaddrinfo (bool): use async hostname resolver instead of getaddrinfo
+        use_getaddrinfo_for_dns (bool): use getaddrinfo instead of async resolver
         print_pidfile (bool): whether to print the pid file, if daemonize is True
         logger (logging.Logger): logger instance to pass to Daemonize
     """
@@ -132,7 +132,7 @@ def start_reactor(
             if gc_thresholds:
                 gc.set_threshold(*gc_thresholds)
 
-            if no_getaddrinfo:
+            if use_getaddrinfo_for_dns:
                 reactor.installResolver(twisted.names.client)
 
             reactor.run()

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -22,6 +22,7 @@ import traceback
 import psutil
 from daemonize import Daemonize
 
+import twisted.names
 from twisted.internet import defer, error, reactor
 from twisted.protocols.tls import TLSMemoryBIOFactory
 
@@ -127,6 +128,10 @@ def start_reactor(
             change_resource_limit(soft_file_limit)
             if gc_thresholds:
                 gc.set_threshold(*gc_thresholds)
+
+            # change the default resolver to avoid blocking getaddrinfo calls
+            reactor.installResolver(twisted.names.client)
+
             reactor.run()
 
     if daemonize:

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -71,6 +71,7 @@ def start_worker_reactor(appname, config):
         daemonize=config.worker_daemonize,
         cpu_affinity=config.worker_cpu_affinity,
         print_pidfile=config.print_pidfile,
+        no_getaddrinfo=config.no_getaddrinfo,
         logger=logger,
     )
 
@@ -83,6 +84,7 @@ def start_reactor(
         daemonize,
         cpu_affinity,
         print_pidfile,
+        no_getaddrinfo,
         logger,
 ):
     """ Run the reactor in the main process
@@ -97,6 +99,7 @@ def start_reactor(
         pid_file (str): name of pid file to write to if daemonize is True
         daemonize (bool): true to run the reactor in a background process
         cpu_affinity (int|None): cpu affinity mask
+        no_getaddrinfo (bool): use async hostname resolver instead of getaddrinfo
         print_pidfile (bool): whether to print the pid file, if daemonize is True
         logger (logging.Logger): logger instance to pass to Daemonize
     """
@@ -129,8 +132,8 @@ def start_reactor(
             if gc_thresholds:
                 gc.set_threshold(*gc_thresholds)
 
-            # change the default resolver to avoid blocking getaddrinfo calls
-            reactor.installResolver(twisted.names.client)
+            if no_getaddrinfo:
+                reactor.installResolver(twisted.names.client)
 
             reactor.run()
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -647,7 +647,7 @@ def run(hs):
         daemonize=hs.config.daemonize,
         cpu_affinity=hs.config.cpu_affinity,
         print_pidfile=hs.config.print_pidfile,
-        no_getaddrinfo=hs.config.no_getaddrinfo,
+        use_getaddrinfo_for_dns=hs.config.use_getaddrinfo_for_dns,
         logger=logger,
     )
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -647,6 +647,7 @@ def run(hs):
         daemonize=hs.config.daemonize,
         cpu_affinity=hs.config.cpu_affinity,
         print_pidfile=hs.config.print_pidfile,
+        no_getaddrinfo=hs.config.no_getaddrinfo,
         logger=logger,
     )
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -56,6 +56,10 @@ class ServerConfig(Config):
         self.public_baseurl = config.get("public_baseurl")
         self.cpu_affinity = config.get("cpu_affinity")
 
+        # Whether to use the asynchronous DNS resolver instead of getaddrinfo.
+        # This can potentially improve performance.
+        self.no_getaddrinfo = config.get("no_getaddrinfo", False)
+
         # Whether to send federation traffic out in this process. This only
         # applies to some federation traffic, and so shouldn't be used to
         # "disable" federation

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -56,9 +56,11 @@ class ServerConfig(Config):
         self.public_baseurl = config.get("public_baseurl")
         self.cpu_affinity = config.get("cpu_affinity")
 
-        # Whether to use the asynchronous DNS resolver instead of getaddrinfo.
-        # This can potentially improve performance.
-        self.no_getaddrinfo = config.get("no_getaddrinfo", False)
+        # Whether to use the getaddrinfo instead of the asynchronous DNS
+        # resolver. Disabling this can potentially improve performance.
+        self.use_getaddrinfo_for_dns = config.get(
+            "use_getaddrinfo_for_dns", True
+        )
 
         # Whether to send federation traffic out in this process. This only
         # applies to some federation traffic, and so shouldn't be used to


### PR DESCRIPTION
I profiled synapse for a relatively small homeserver that is in several large rooms, and found that a huge chunk of time was being taken up by calls to `getaddrinfo`:

![before changes](https://ftp.chronicembetterment.org/profile.svg)

It turns out that twisted defaults to using `twisted.internet._resolver.GAIResolver` for resolving hostnames. This is implemented with blocking `getaddrinfo` calls on a thread pool, but python appears to not allow running concurrent `getaddrinfo` anyway. This pull request replaces the default relsover with `twisted.names.client`, which is a user space non-blocking resolver.

![after changes](https://ftp.chronicembetterment.org/profile-modified.svg)

Signed-off-by: Benjamin Lee <benjamin.fik.lee@gmail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
