### PR TITLE
Adding libpq-dev to prerequisites for Raspbian

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,12 +99,12 @@ run (e.g. `~/synapse`), and::
 
 #### Debian/Ubuntu/Raspbian
 
-Installing prerequisites on Ubuntu or Debian:
+Installing prerequisites on Ubuntu, Debian or Raspbian:
 
 ```
 sudo apt-get install build-essential python3-dev libffi-dev \
                      python-pip python-setuptools sqlite3 \
-                     libssl-dev python-virtualenv libjpeg-dev libxslt1-dev
+                     libssl-dev python-virtualenv libjpeg-dev libxslt1-dev libpq-dev
 ```
 
 #### ArchLinux

--- a/changelog.d/5106.misc
+++ b/changelog.d/5106.misc
@@ -1,0 +1,1 @@
+INSTALL.md update: Added libpq-dev to prerequisites for Raspbian.


### PR DESCRIPTION
The package `libpq-dev` is required in order to install from source on Raspbian/Raspberry Pi. 

On a fresh install of Raspbian on a Raspberry Pi, the source install will fail on the `psycopg2` step:

```
Collecting psycopg2>=2.6; extra == "all" (from matrix-synapse[all])
  Using cached https://files.pythonhosted.org/packages/23/7e/93c325482c328619870b6cd09370f6dbe1148283daca65115cd63642e60f/psycopg2-2.8.2.tar.gz
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    
    Error: pg_config executable not found.
    
    pg_config is required to build psycopg2 from source.  Please add the directory
    containing pg_config to the $PATH or specify the full executable path with the
    option:
    
        python setup.py build_ext --pg-config /path/to/pg_config build ...
    
    or with the pg_config option in 'setup.cfg'.
    
    If you prefer to avoid building psycopg2 from source, please install the PyPI
    'psycopg2-binary' package instead.
    
    For further information please check the 'doc/src/install.rst' file (also at
    <http://initd.org/psycopg/docs/install.html>).
    
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-l2ooiex9/psycopg2/
```

The solution is to install the package `libpq-dev` with `sudo apt-get install libpq-dev` since this is where the `pg_config` executable is found.

Signed-off-by: Audun Utengen <audun@symplur.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

- [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

