### PR TITLE
Fix erroneous behavior of pip

### DIFF
--- a/changelog.d/5107.bugfix
+++ b/changelog.d/5107.bugfix
@@ -1,0 +1,1 @@
+Fix erroneous behavior of pip

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,8 @@ commands =
 # )
 usedevelop=true
 
-
+# pip is currently broken wrt downward compatibility. We need to hack around this.
+install_command = pip install --exists-action w -e {toxinidir}[all] {opts} --no-use-pep517 {packages}
 
 # A test suite for the oldest supported versions of Python libraries, to catch
 # any uses of APIs not available in them.


### PR DESCRIPTION
Later versions of PIP abide by PEP517 by default. This breaks the test
setup conducted by tox.
This fix adds '--no-use-pep517' to the install_command and therefore
fixes the behavior.

Signed-off-by: Maximilian Seifert <max.seifert@drglitch.net>
