### PR TITLE
Switch Dockerfile to python 3

### DIFF
--- a/changelog.d/5132.feature
+++ b/changelog.d/5132.feature
@@ -1,0 +1,1 @@
+Docker container now builds with Python 3.7.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@
 #    docker build -f docker/Dockerfile --build-arg PYTHON_VERSION=3.6 .
 #
 
-ARG PYTHON_VERSION=3
+ARG PYTHON_VERSION=3.7
 
 ###
 ### Stage 0: builder

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@
 #    docker build -f docker/Dockerfile --build-arg PYTHON_VERSION=3.6 .
 #
 
-ARG PYTHON_VERSION=2
+ARG PYTHON_VERSION=3
 
 ###
 ### Stage 0: builder


### PR DESCRIPTION
per blog: "We plan on ending mainstream support on 1st April 2019, where upon Python 3.5+ will be the only officially supported platform"
https://matrix.org/blog/2018/12/21/porting-synapse-to-python-3/