### PR TITLE
Limit the number of EDUs in transactions to 100 as expected by receiver

### DIFF
--- a/changelog.d/5138.bugfix
+++ b/changelog.d/5138.bugfix
@@ -1,1 +1,1 @@
-Limit the number of EDUs in transactions to 100 as expected by synapse.
+Limit the number of EDUs in transactions to 100 as expected by synapse. Thanks to @superboum for this work!

--- a/changelog.d/5138.bugfix
+++ b/changelog.d/5138.bugfix
@@ -1,0 +1,1 @@
+Limit the number of EDUs in transactions to 100 as expected by synapse.

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -217,17 +217,21 @@ class PerDestinationQueue(object):
                 pending_edus = []
 
                 pending_edus.extend(self._get_rr_edus(force_flush=False))
+                pending_edus.extend(device_message_edus[:99])
 
                 # We can only include at most 100 EDUs per transactions
-                pending_edus.extend(self._pop_pending_edus(100 - len(pending_edus)))
+                # But we should keep one slot free for presence
+                to_remove = []
+                for key, val in self._pending_edus_keyed.items():
+                    if (len(pending_edus) >= 99): break
+                    pending_edus.append(val)
+                    to_remove.append(key)
 
-                pending_edus.extend(
-                    self._pending_edus_keyed.values()
-                )
+                for key in to_remove:
+                    del self._pending_edus_keyed[key]
 
-                self._pending_edus_keyed = {}
 
-                pending_edus.extend(device_message_edus)
+                pending_edus.extend(self._pop_pending_edus(99 - len(pending_edus)))
 
                 pending_presence = self._pending_presence
                 self._pending_presence = {}

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -238,7 +238,7 @@ class PerDestinationQueue(object):
                         )
                     )
 
-                pending_edus.extend(device_message_edus) # @FIXME Size not yet limited
+                pending_edus.extend(device_message_edus)
                 pending_edus.extend(self._pop_pending_edus(100 - len(pending_edus)))
                 while len(pending_edus) < 100:
                     _, val = self._pending_edus_keyed.popitem()

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -362,6 +362,8 @@ class PerDestinationQueue(object):
             for content in results
         ]
 
+        assert len(edus) <= limit, "get_devices_by_remote returned too many EDUs"
+
         last_device_stream_id = self._last_device_stream_id
         to_device_stream_id = self._store.get_to_device_stream_token()
         contents, stream_id = yield self._store.get_new_device_msgs_for_remote(

--- a/synapse/storage/deviceinbox.py
+++ b/synapse/storage/deviceinbox.py
@@ -118,7 +118,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
         defer.returnValue(count)
 
     def get_new_device_msgs_for_remote(
-        self, destination, last_stream_id, current_stream_id, limit=100
+        self, destination, last_stream_id, current_stream_id, limit
     ):
         """
         Args:


### PR DESCRIPTION
### Goal

I have observed this problem on my server:

```
2019-05-04 06:16:57,274 - synapse.federation.sender.transaction_manager - 87 - INFO - federation_transaction_transmission_loop-678370- TX [matrix.livda.fr] {1556878459543} Sending transaction [1556878459543], (PDUs: 0, EDUs: 103)
2019-05-04 06:16:57,338 - synapse.http.matrixfederationclient - 356 - INFO - federation_transaction_transmission_loop-678370- {PUT-O-448448} [matrix.livda.fr] Sending request: PUT matrix://matrix.livda.fr/_matrix/federation/v1/send/1556878459543; timeout 60.000000s
2019-05-04 06:16:57,339 - synapse.http.federation.matrix_federation_agent - 373 - INFO - federation_transaction_transmission_loop-678370- Connecting to matrix.livda.fr:443
[...]
2019-05-04 06:17:08,409 - synapse.http.matrixfederationclient - 388 - INFO - federation_transaction_transmission_loop-678370- {PUT-O-448448} [matrix.livda.fr] Got response headers: 400 Bad Request
2019-05-04 06:17:08,410 - synapse.http.matrixfederationclient - 472 - WARNING - federation_transaction_transmission_loop-678370- {PUT-O-448448} [matrix.livda.fr] Request failed: PUT matrix://matrix.livda.fr/_matrix/federation/v1/send/1556878459543: HttpResponseException("400: b'Bad Request'",)
2019-05-04 06:17:08,411 - synapse.federation.sender.transaction_manager - 123 - INFO - federation_transaction_transmission_loop-678370- TX [matrix.livda.fr] {1556878459543} got 400 response
```

The corresponding issue seems to be *Synapse is not limiting the number of EDUs in a transaction* #3951.
It is a blocker since *Reject large transactions on federation* #4513 as it blocks the federation between two servers.
In my case, the bug was caused by `device_message_edus` that was containing 103 entries.
 
**I don't know synapse internals and just wrote this quick fix to bring back federations. I might have written some wrong/dangerous things.**

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [X] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
