### PR TITLE
Fix bogus imports in tests

### DIFF
--- a/changelog.d/5154.bugfix
+++ b/changelog.d/5154.bugfix
@@ -1,1 +1,1 @@
-Fix bogus imports.
+Fix bogus imports in unit tests.

--- a/changelog.d/5154.bugfix
+++ b/changelog.d/5154.bugfix
@@ -1,0 +1,1 @@
+Fix bogus imports.

--- a/tests/rest/client/v1/test_directory.py
+++ b/tests/rest/client/v1/test_directory.py
@@ -15,7 +15,7 @@
 
 import json
 
-from synapse.rest.admin import register_servlets
+from synapse.rest import admin
 from synapse.rest.client.v1 import directory, login, room
 from synapse.types import RoomAlias
 from synapse.util.stringutils import random_string
@@ -26,7 +26,7 @@ from tests import unittest
 class DirectoryTestCase(unittest.HomeserverTestCase):
 
     servlets = [
-        register_servlets,
+        admin.register_servlets_for_client_rest_resource,
         directory.register_servlets,
         login.register_servlets,
         room.register_servlets,

--- a/tests/rest/client/v1/test_profile.py
+++ b/tests/rest/client/v1/test_profile.py
@@ -20,7 +20,8 @@ from twisted.internet import defer
 
 import synapse.types
 from synapse.api.errors import AuthError, SynapseError
-from synapse.rest.client.v1 import admin, login, profile, room
+from synapse.rest import admin
+from synapse.rest.client.v1 import login, profile, room
 
 from tests import unittest
 
@@ -161,7 +162,7 @@ class ProfileTestCase(unittest.TestCase):
 class ProfilesRestrictedTestCase(unittest.HomeserverTestCase):
 
     servlets = [
-        admin.register_servlets,
+        admin.register_servlets_for_client_rest_resource,
         login.register_servlets,
         profile.register_servlets,
         room.register_servlets,

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -909,7 +909,7 @@ class RoomSearchTestCase(unittest.HomeserverTestCase):
 class PublicRoomsRestrictedTestCase(unittest.HomeserverTestCase):
 
     servlets = [
-        admin.register_servlets,
+        synapse.rest.admin.register_servlets_for_client_rest_resource,
         room.register_servlets,
         login.register_servlets,
     ]


### PR DESCRIPTION
Looks like I should have merged develop into my branches before merging #5083 and #5128 as it didn't keep up with the recent changes to the admin API code.