### PR TITLE
Added start command for systemd users

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -419,7 +419,8 @@ users. This can be done as follows:
 
 ```
 $ source ~/synapse/env/bin/activate
-$ synctl start # if not already running
+$ synctl start # if not already running (installed from source)
+$ service matrix-synapse start # if not already running (installed from pre-built package)
 $ register_new_matrix_user -c homeserver.yaml http://localhost:8008
 New user localpart: erikj
 Password:


### PR DESCRIPTION
I (and others) had trouble getting my synapse service started/restarted following this guide due to using systemd from the pre-built package instead of a pidfile that can be started with synctl.

Signed-off-by: Zachary Smith <zach.smith@tamu.edu>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
