### PR TITLE
Add option to disable 3PID invites to public rooms

### DIFF
--- a/synapse/rulecheck/domain_rule_checker.py
+++ b/synapse/rulecheck/domain_rule_checker.py
@@ -53,6 +53,9 @@ class DomainRuleChecker(object):
           # Allow third party invites
           can_invite_by_third_party_id: true
 
+          # Allow third party invites to rooms published in the room directory.
+          can_invite_by_third_party_id_to_published_rooms: false
+
     Don't forget to consider if you can invite users from your own domain.
     """
 
@@ -75,6 +78,9 @@ class DomainRuleChecker(object):
         self.domains_prevented_from_being_invited_to_published_rooms = config.get(
             "domains_prevented_from_being_invited_to_published_rooms", [],
         )
+        self.can_invite_by_third_party_id_to_published_rooms = config.get(
+            "can_invite_by_third_party_id_to_published_rooms", False,
+        )
 
     def check_event_for_spam(self, event):
         """Implements synapse.events.SpamChecker.check_event_for_spam
@@ -89,6 +95,12 @@ class DomainRuleChecker(object):
             return False
 
         if not self.can_invite_by_third_party_id and third_party_invite:
+            return False
+
+        if (
+            published_room and third_party_invite is not None and
+            not self.can_invite_by_third_party_id_to_published_rooms
+        ):
             return False
 
         # This is a third party invite (without a bound mxid), so unless we have

--- a/synapse/server.pyi
+++ b/synapse/server.pyi
@@ -18,7 +18,6 @@ import synapse.server_notices.server_notices_sender
 import synapse.state
 import synapse.storage
 
-
 class HomeServer(object):
     @property
     def config(self) -> synapse.config.homeserver.HomeServerConfig:

--- a/tests/rulecheck/test_domainrulecheck.py
+++ b/tests/rulecheck/test_domainrulecheck.py
@@ -32,7 +32,8 @@ class DomainRuleCheckerTestCase(unittest.TestCase):
                 "source_one": ["target_one", "target_two"],
                 "source_two": ["target_two"],
             },
-            "domains_prevented_from_being_invited_to_published_rooms": ["target_two"]
+            "domains_prevented_from_being_invited_to_published_rooms": ["target_two"],
+            "can_invite_by_third_party_id_to_published_rooms": True,
         }
         check = DomainRuleChecker(config)
         self.assertTrue(
@@ -62,6 +63,28 @@ class DomainRuleCheckerTestCase(unittest.TestCase):
         self.assertTrue(
             check.user_may_invite(
                 "test:source_one", "test:target_two", None, "room", False, False,
+            )
+        )
+
+        # User can invite another user to a published room via a 3PID invite
+        self.assertTrue(
+            check.user_may_invite(
+                "test:source_one", "test1:target_one", {
+                    "medium": "email",
+                    "address": "test1@target_one",
+                },
+                "room", False, True,
+            )
+        )
+
+        # User can invite another user to a non-published room via a 3PID invite
+        self.assertTrue(
+            check.user_may_invite(
+                "test:source_one", "test1:target_one", {
+                    "medium": "email",
+                    "address": "test1@target_one",
+                },
+                "room", False, False,
             )
         )
 
@@ -100,6 +123,28 @@ class DomainRuleCheckerTestCase(unittest.TestCase):
         self.assertTrue(
             check.user_may_invite(
                 "test:source_one", "test:target_two", None, "room", False, True,
+            )
+        )
+
+        # User cannot invite another user to a published room via a 3PID invite
+        self.assertFalse(
+            check.user_may_invite(
+                "test:source_one", "test1:target_one", {
+                    "medium": "email",
+                    "address": "test1@target_one",
+                },
+                "room", False, True,
+            )
+        )
+
+        # User can invite another user to a non-published room via a 3PID invite
+        self.assertTrue(
+            check.user_may_invite(
+                "test:source_one", "test1:target_one", {
+                    "medium": "email",
+                    "address": "test1@target_one",
+                },
+                "room", False, False,
             )
         )
 


### PR DESCRIPTION
Adds a `can_invite_by_third_party_id_to_published_rooms` config option to the domain rule checker that prevents 3PID invites to public rooms. Defaults to `false`.