### PR TITLE
Use correct config option for ratelimiting in tests

### DIFF
--- a/changelog.d/5185.misc
+++ b/changelog.d/5185.misc
@@ -1,0 +1,1 @@
+Update tests to consistently be configured via the same code that is used when loading from configuration files.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -156,7 +156,8 @@ def default_config(name, parse=False):
         "mau_stats_only": False,
         "mau_limits_reserved_threepids": [],
         "admin_contact": None,
-        "rc_message": {"per_second": 10000, "burst_count": 10000},
+        "rc_messages_per_second": 10000,
+        "rc_message_burst_count": 10000,
         "rc_registration": {"per_second": 10000, "burst_count": 10000},
         "rc_login": {
             "address": {"per_second": 10000, "burst_count": 10000},


### PR DESCRIPTION
This doesn't actually break any unit tests currently (surprisingly), but does break unit tests on my branch.

Broke in #5171