### PR TITLE
Only check 3pids not in use when registering

### DIFF
--- a/changelog.d/5187.bugfix
+++ b/changelog.d/5187.bugfix
@@ -1,1 +1,1 @@
-Fix register endpoint returning a previously registered account.
+Fix a bug where the register endpoint would fail with M_THREEPID_IN_USE instead of returning an account previously registered in the same session.

--- a/changelog.d/5187.bugfix
+++ b/changelog.d/5187.bugfix
@@ -1,0 +1,1 @@
+Fix register endpoint returning a previously registered account.

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -391,13 +391,6 @@ class RegisterRestServlet(RestServlet):
         # the user-facing checks will probably already have happened in
         # /register/email/requestToken when we requested a 3pid, but that's not
         # guaranteed.
-        #
-        # Also check that we're not trying to register a 3pid that's already
-        # been registered.
-        #
-        # This has probably happened in /register/email/requestToken as well,
-        # but if a user hits this endpoint twice then clicks on each link from
-        # the two activation emails, they would register the same 3pid twice.
 
         if auth_result:
             for login_type in [LoginType.EMAIL_IDENTITY, LoginType.MSISDN]:
@@ -411,17 +404,6 @@ class RegisterRestServlet(RestServlet):
                             "Third party identifiers (email/phone numbers)" +
                             " are not authorized on this server",
                             Codes.THREEPID_DENIED,
-                        )
-
-                    existingUid = yield self.store.get_user_id_by_threepid(
-                        medium, address,
-                    )
-
-                    if existingUid is not None:
-                        raise SynapseError(
-                            400,
-                            "%s is already in use" % medium,
-                            Codes.THREEPID_IN_USE,
                         )
 
         if registered_user_id is not None:
@@ -445,6 +427,28 @@ class RegisterRestServlet(RestServlet):
             threepid = None
             if auth_result:
                 threepid = auth_result.get(LoginType.EMAIL_IDENTITY)
+
+                # Also check that we're not trying to register a 3pid that's already
+                # been registered.
+                #
+                # This has probably happened in /register/email/requestToken as well,
+                # but if a user hits this endpoint twice then clicks on each link from
+                # the two activation emails, they would register the same 3pid twice.
+                for login_type in [LoginType.EMAIL_IDENTITY, LoginType.MSISDN]:
+                    if login_type in auth_result:
+                        medium = auth_result[login_type]['medium']
+                        address = auth_result[login_type]['address']
+
+                        existingUid = yield self.store.get_user_id_by_threepid(
+                            medium, address,
+                        )
+
+                        if existingUid is not None:
+                            raise SynapseError(
+                                400,
+                                "%s is already in use" % medium,
+                                Codes.THREEPID_IN_USE,
+                            )
 
             (registered_user_id, _) = yield self.registration_handler.register(
                 localpart=desired_username,


### PR DESCRIPTION
We checked that 3pids were not already in use before we checked if
we were going to return the account previously registered in the
same UI auth session, in which case the 3pids will definitely
be in use.

https://github.com/vector-im/riot-web/issues/9586
