### PR TITLE
Limit UserIds to a length that fits in a state key

### DIFF
--- a/changelog.d/5198.bugfix
+++ b/changelog.d/5198.bugfix
@@ -1,0 +1,1 @@
+Prevent registration for user ids that are to long to fit into a state key. Contributed by Reid Anderson.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -23,6 +23,9 @@ MAX_DEPTH = 2**63 - 1
 # the maximum length for a room alias is 255 characters
 MAX_ALIAS_LENGTH = 255
 
+# the maximum length for a user id is 255 characters
+MAX_USERID_LENGTH = 255
+
 
 class Membership(object):
 

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -19,7 +19,7 @@ import logging
 from twisted.internet import defer
 
 from synapse import types
-from synapse.api.constants import MAX_USER_ID_LENGTH, LoginType
+from synapse.api.constants import MAX_USERID_LENGTH, LoginType
 from synapse.api.errors import (
     AuthError,
     Codes,

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -126,11 +126,11 @@ class RegistrationHandler(BaseHandler):
 
         self.check_user_id_not_appservice_exclusive(user_id)
 
-        if len(user_id) > MAX_ALIAS_LENGTH:
+        if len(user_id) > MAX_USERID_LENGTH:
             raise SynapseError(
                 400,
                 "User ID may not be longer than %s characters" % (
-                    MAX_ALIAS_LENGTH,
+                    MAX_USERID_LENGTH,
                 ),
                 Codes.INVALID_USERNAME
             )

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -19,7 +19,10 @@ import logging
 from twisted.internet import defer
 
 from synapse import types
-from synapse.api.constants import LoginType
+from synapse.api.constants import (
+    LoginType,
+    MAX_USERID_LENGTH
+)
 from synapse.api.errors import (
     AuthError,
     Codes,
@@ -123,10 +126,12 @@ class RegistrationHandler(BaseHandler):
 
         self.check_user_id_not_appservice_exclusive(user_id)
 
-        if len(user_id) > 256:
+        if len(user_id) > MAX_ALIAS_LENGTH:
             raise SynapseError(
                 400,
-                "User ID may not be longer than 256 characters",
+                "User ID may not be longer than %s characters" % (
+                    MAX_ALIAS_LENGTH,
+                ),
                 Codes.INVALID_USERNAME
             )
 

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -126,7 +126,8 @@ class RegistrationHandler(BaseHandler):
         if len(user_id) > 256:
             raise SynapseError(
                 400,
-                "User ID may not be longer than 256 characters"
+                "User ID may not be longer than 256 characters",
+                Codes.INVALID_USERNAME
             )
 
         users = yield self.store.get_users_by_id_case_insensitive(user_id)

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -123,6 +123,12 @@ class RegistrationHandler(BaseHandler):
 
         self.check_user_id_not_appservice_exclusive(user_id)
 
+        if len(user_id) > 256:
+            raise SynapseError(
+                400,
+                "User ID may not be longer than 256 characters"
+            )
+
         users = yield self.store.get_users_by_id_case_insensitive(user_id)
         if users:
             if not guest_access_token:

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -19,10 +19,7 @@ import logging
 from twisted.internet import defer
 
 from synapse import types
-from synapse.api.constants import (
-    LoginType,
-    MAX_USERID_LENGTH
-)
+from synapse.api.constants import MAX_USER_ID_LENGTH, LoginType
 from synapse.api.errors import (
     AuthError,
     Codes,

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -228,3 +228,9 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
     def test_register_not_support_user(self):
         res = self.get_success(self.handler.register(localpart='user'))
         self.assertFalse(self.store.is_support_user(res[0]))
+
+    def test_invalid_user_id_length(self):
+        invalid_user_id = "x"*257
+        res = self.get_failure(
+            self.handler.register(localpart=invalid_user_id)
+        )

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -232,5 +232,6 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
     def test_invalid_user_id_length(self):
         invalid_user_id = "x"*257
         res = self.get_failure(
-            self.handler.register(localpart=invalid_user_id)
+            self.handler.register(localpart=invalid_user_id),
+            SynapseError
         )

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -230,8 +230,8 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
         self.assertFalse(self.store.is_support_user(res[0]))
 
     def test_invalid_user_id_length(self):
-        invalid_user_id = "x"*257
-        res = self.get_failure(
+        invalid_user_id = "x" * 256
+        self.get_failure(
             self.handler.register(localpart=invalid_user_id),
             SynapseError
         )


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Hello, this is my first PR that I've made against anything Matrix related. So definitely let me know if I've gone wrong anywhere, more than happy to make some changes (or if this is the wrong place entirely for the validation).

This should fix https://github.com/matrix-org/synapse/issues/5057, and require that user ids be no more than 256 characters.

And based off the contributing doc, it sounds like this goes here:

Signed-off-by: Reid Anderson