### PR TITLE
expose SlavedProfileStore to ClientReaderSlavedStore

### DIFF
--- a/changelog.d/5200.bugfix
+++ b/changelog.d/5200.bugfix
@@ -1,0 +1,1 @@
+Fix worker registration bug caused by ClientReaderSlavedStore being unable to see get_profileinfo

--- a/changelog.d/5200.bugfix
+++ b/changelog.d/5200.bugfix
@@ -1,1 +1,1 @@
-Fix worker registration bug caused by ClientReaderSlavedStore being unable to see get_profileinfo
+Fix worker registration bug caused by ClientReaderSlavedStore being unable to see get_profileinfo.

--- a/synapse/app/client_reader.py
+++ b/synapse/app/client_reader.py
@@ -29,6 +29,7 @@ from synapse.http.server import JsonResource
 from synapse.http.site import SynapseSite
 from synapse.metrics import RegistryProxy
 from synapse.metrics.resource import METRICS_PREFIX, MetricsResource
+from synapse.replication.slave.storage import SlavedProfileStore
 from synapse.replication.slave.storage._base import BaseSlavedStore
 from synapse.replication.slave.storage.account_data import SlavedAccountDataStore
 from synapse.replication.slave.storage.appservice import SlavedApplicationServiceStore
@@ -83,6 +84,7 @@ class ClientReaderSlavedStore(
     SlavedTransactionStore,
     SlavedClientIpStore,
     BaseSlavedStore,
+    SlavedProfileStore,
 ):
     pass
 


### PR DESCRIPTION
When running a ClientReader worker and set config ```search_all_users: true``` then registration requests fail with
```AttributeError: 'ClientReaderSlavedStore' object has no attribute 'get_profileinfo'```

Standard config of ```search_all_users: false``` unaffected.

This PR exposes ```ProfileWorkerStore``` to ```ClientReaderSlavedStore``` to address