### PR TITLE
Only count aggregations from distinct senders

### DIFF
--- a/changelog.d/5203.feature
+++ b/changelog.d/5203.feature
@@ -1,0 +1,1 @@
+Add experimental support for relations (aka reactions and edits).

--- a/synapse/storage/relations.py
+++ b/synapse/storage/relations.py
@@ -280,7 +280,7 @@ class RelationsWorkerStore(SQLBaseStore):
             having_clause = ""
 
         sql = """
-            SELECT type, aggregation_key, COUNT(*), MAX(stream_ordering)
+            SELECT type, aggregation_key, COUNT(DISTINCT sender), MAX(stream_ordering)
             FROM event_relations
             INNER JOIN events USING (event_id)
             WHERE {where_clause}


### PR DESCRIPTION
Based on #5195

Otherwise users can send multiple multiple reactions, and that seems silly.

Separately, we want to 4xx on the CS API if a user tries to react with the same emoji multiple times.
