### PR TITLE
Add SYNAPSE_REVERSE_PROXY variable for Docker

### DIFF
--- a/changelog.d/5206.feature
+++ b/changelog.d/5206.feature
@@ -1,0 +1,1 @@
+Add `SYNAPSE_REVERSE_PROXY` variable to accept `X-Forwarded-*` headers when using generated configuration in Docker.

--- a/docker/README.md
+++ b/docker/README.md
@@ -65,7 +65,7 @@ Synapse requires a valid TLS certificate. You can do one of the following:
 
  * Use a reverse proxy to terminate incoming TLS, and forward the plain http
    traffic to port 8008 in the container. In this case you should set `-e
-   SYNAPSE_NO_TLS=1`.
+   SYNAPSE_NO_TLS=1` and `-e SYNAPSE_REVERSE_PROXY=1`.
 
  * Use the ACME (Let's Encrypt) support built into Synapse. This requires
    `${SYNAPSE_SERVER_NAME}` port 80 to be forwarded to port 8009 in the
@@ -102,9 +102,12 @@ when ``SYNAPSE_CONFIG_PATH`` is not set.
 * ``SYNAPSE_SERVER_NAME`` (mandatory), the server public hostname.
 * ``SYNAPSE_REPORT_STATS``, (mandatory, ``yes`` or ``no``), enable anonymous
   statistics reporting back to the Matrix project which helps us to get funding.
-* `SYNAPSE_NO_TLS`, (accepts `true`, `false`, `on`, `off`, `1`, `0`, `yes`, `no`]): disable
+* `SYNAPSE_NO_TLS`, (accepts `true`, `false`, `on`, `off`, `1`, `0`, `yes`, `no`): disable
   TLS in Synapse (use this if you run your own TLS-capable reverse proxy). Defaults
   to `false` (ie, TLS is enabled by default).
+* `SYNAPSE_REVERSE_PROXY`, (accepts `true`, `false`, `on`, `off`, `1`, `0`, `yes`, `no`): enable
+  reverse proxy support in Synapse (use this to accept `X-Forwarded-*` headers). Defaults
+  to `false` (ie, reverse proxy support is disabled by default).
 * ``SYNAPSE_ENABLE_REGISTRATION``, set this variable to enable registration on
   the Synapse instance.
 * ``SYNAPSE_ALLOW_GUEST``, set this variable to allow guest joining this server.

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -32,7 +32,7 @@ listeners:
     bind_addresses: ['::']
     type: http
     tls: true
-    x_forwarded: false
+    x_forwarded: {{ "True" if SYNAPSE_REVERSE_PROXY else "False" }}
     resources:
       - names: [client]
         compress: true
@@ -44,7 +44,7 @@ listeners:
     tls: false
     bind_addresses: ['::']
     type: http
-    x_forwarded: false
+    x_forwarded: {{ "True" if SYNAPSE_REVERSE_PROXY else "False" }}
 
     resources:
       - names: [client]

--- a/docker/start.py
+++ b/docker/start.py
@@ -28,6 +28,20 @@ def generate_secrets(environ, secrets):
                 with open(filename, "w") as handle: handle.write(value)
             environ[secret] = value
 
+def environ_to_bool(environ, key):
+    # Convert an environment variable to boolean if exists
+    if key not in environ:
+        return
+
+    tlsanswerstring = str.lower(environ[key])
+    if tlsanswerstring in ("true", "on", "1", "yes"):
+        environ[key] = True
+    else if tlsanswerstring in ("false", "off", "0", "no"):
+        environ[key] = False
+    else:
+        print("Environment variable \"" + key + "\" found but value \"" + tlsanswerstring + "\" unrecognized; exiting.")
+        sys.exit(2)
+
 # Prepare the configuration
 mode = sys.argv[1] if len(sys.argv) > 1 else None
 environ = os.environ.copy()
@@ -60,17 +74,8 @@ else:
 
         config_path = "/compiled/homeserver.yaml"
         
-        # Convert SYNAPSE_NO_TLS to boolean if exists
-        if "SYNAPSE_NO_TLS" in environ:
-            tlsanswerstring = str.lower(environ["SYNAPSE_NO_TLS"])
-            if tlsanswerstring in ("true", "on", "1", "yes"):
-                environ["SYNAPSE_NO_TLS"] = True
-            else:
-                if tlsanswerstring in ("false", "off", "0", "no"):
-                    environ["SYNAPSE_NO_TLS"] = False
-                else:
-                    print("Environment variable \"SYNAPSE_NO_TLS\" found but value \"" + tlsanswerstring + "\" unrecognized; exiting.")
-                    sys.exit(2)
+        environ_to_bool(environ, "SYNAPSE_NO_TLS")
+        environ_to_bool(environ, "SYNAPSE_REVERSE_PROXY")
 
         convert("/conf/homeserver.yaml", config_path, environ)
         convert("/conf/log.config", "/compiled/log.config", environ)


### PR DESCRIPTION
### Pull Request Checklist

* [X] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Currently, no `X-Forwarded-*` headers are accepted by Synapse when using the Docker image with generated configuration. So everyone seems to be logged in from the same IP address (the IP address of my reverse proxy).

Add an option to accept these headers.