### PR TITLE
Rename relation types to match MSC

### DIFF
--- a/changelog.d/5211.feature
+++ b/changelog.d/5211.feature
@@ -1,0 +1,1 @@
+Add experimental support for relations (aka reactions and edits).

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -125,5 +125,5 @@ class RelationTypes(object):
     """The types of relations known to this server.
     """
     ANNOTATION = "m.annotation"
-    REPLACES = "m.replaces"
-    REFERENCES = "m.references"
+    REPLACE = "m.replace"
+    REFERENCE = "m.reference"

--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -355,7 +355,7 @@ class EventClientSerializer(object):
                 event_id,
             )
             references = yield self.store.get_relations_for_event(
-                event_id, RelationTypes.REFERENCES, direction="f",
+                event_id, RelationTypes.REFERENCE, direction="f",
             )
 
             if annotations.chunk:
@@ -364,7 +364,7 @@ class EventClientSerializer(object):
 
             if references.chunk:
                 r = serialized_event["unsigned"].setdefault("m.relations", {})
-                r[RelationTypes.REFERENCES] = references.to_dict()
+                r[RelationTypes.REFERENCE] = references.to_dict()
 
             edit = None
             if event.type == EventTypes.Message:
@@ -382,7 +382,7 @@ class EventClientSerializer(object):
                     serialized_event["content"].pop("m.relates_to", None)
 
                 r = serialized_event["unsigned"].setdefault("m.relations", {})
-                r[RelationTypes.REPLACES] = {
+                r[RelationTypes.REPLACE] = {
                     "event_id": edit.event_id,
                 }
 

--- a/synapse/storage/relations.py
+++ b/synapse/storage/relations.py
@@ -351,7 +351,7 @@ class RelationsWorkerStore(SQLBaseStore):
 
         def _get_applicable_edit_txn(txn):
             txn.execute(
-                sql, (event_id, RelationTypes.REPLACES,)
+                sql, (event_id, RelationTypes.REPLACE,)
             )
             row = txn.fetchone()
             if row:
@@ -384,8 +384,8 @@ class RelationsStore(RelationsWorkerStore):
         rel_type = relation.get("rel_type")
         if rel_type not in (
             RelationTypes.ANNOTATION,
-            RelationTypes.REFERENCES,
-            RelationTypes.REPLACES,
+            RelationTypes.REFERENCE,
+            RelationTypes.REPLACE,
         ):
             # Unknown relation type
             return
@@ -413,7 +413,7 @@ class RelationsStore(RelationsWorkerStore):
             self.get_aggregation_groups_for_event.invalidate_many, (parent_id,)
         )
 
-        if rel_type == RelationTypes.REPLACES:
+        if rel_type == RelationTypes.REPLACE:
             txn.call_after(self.get_applicable_edit.invalidate, (parent_id,))
 
     def _handle_redaction(self, txn, redacted_event_id):

--- a/tests/rest/client/v2_alpha/test_relations.py
+++ b/tests/rest/client/v2_alpha/test_relations.py
@@ -363,8 +363,8 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
         request, channel = self.make_request(
             "GET",
-            "/_matrix/client/unstable/rooms/%s/aggregations/%s/m.replace?limit=1"
-            % (self.room, self.parent_id),
+            "/_matrix/client/unstable/rooms/%s/aggregations/%s/%s?limit=1"
+            % (self.room, self.parent_id, RelationTypes.REPLACE),
             access_token=self.user_token,
         )
         self.render(request)
@@ -386,11 +386,11 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "b")
         self.assertEquals(200, channel.code, channel.json_body)
 
-        channel = self._send_relation(RelationTypes.REFERENCES, "m.room.test")
+        channel = self._send_relation(RelationTypes.REFERENCE, "m.room.test")
         self.assertEquals(200, channel.code, channel.json_body)
         reply_1 = channel.json_body["event_id"]
 
-        channel = self._send_relation(RelationTypes.REFERENCES, "m.room.test")
+        channel = self._send_relation(RelationTypes.REFERENCE, "m.room.test")
         self.assertEquals(200, channel.code, channel.json_body)
         reply_2 = channel.json_body["event_id"]
 
@@ -411,7 +411,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                         {"type": "m.reaction", "key": "b", "count": 1},
                     ]
                 },
-                RelationTypes.REFERENCES: {
+                RelationTypes.REFERENCE: {
                     "chunk": [{"event_id": reply_1}, {"event_id": reply_2}]
                 },
             },
@@ -423,7 +423,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
         new_body = {"msgtype": "m.text", "body": "I've been edited!"}
         channel = self._send_relation(
-            RelationTypes.REPLACES,
+            RelationTypes.REPLACE,
             "m.room.message",
             content={"msgtype": "m.text", "body": "foo", "m.new_content": new_body},
         )
@@ -443,7 +443,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
         self.assertEquals(
             channel.json_body["unsigned"].get("m.relations"),
-            {RelationTypes.REPLACES: {"event_id": edit_event_id}},
+            {RelationTypes.REPLACE: {"event_id": edit_event_id}},
         )
 
     def test_multi_edit(self):
@@ -452,7 +452,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         """
 
         channel = self._send_relation(
-            RelationTypes.REPLACES,
+            RelationTypes.REPLACE,
             "m.room.message",
             content={
                 "msgtype": "m.text",
@@ -464,7 +464,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
         new_body = {"msgtype": "m.text", "body": "I've been edited!"}
         channel = self._send_relation(
-            RelationTypes.REPLACES,
+            RelationTypes.REPLACE,
             "m.room.message",
             content={"msgtype": "m.text", "body": "foo", "m.new_content": new_body},
         )
@@ -473,7 +473,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         edit_event_id = channel.json_body["event_id"]
 
         channel = self._send_relation(
-            RelationTypes.REPLACES,
+            RelationTypes.REPLACE,
             "m.room.message.WRONG_TYPE",
             content={
                 "msgtype": "m.text",
@@ -495,7 +495,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
         self.assertEquals(
             channel.json_body["unsigned"].get("m.relations"),
-            {RelationTypes.REPLACES: {"event_id": edit_event_id}},
+            {RelationTypes.REPLACE: {"event_id": edit_event_id}},
         )
 
     def _send_relation(


### PR DESCRIPTION
Because apparently I can't read.