### PR TITLE
Fix get_max_topological_token to never return None

### DIFF
--- a/changelog.d/5221.bugfix
+++ b/changelog.d/5221.bugfix
@@ -1,0 +1,1 @@
+Fix race when backfilling in rooms with worker mode.

--- a/synapse/storage/stream.py
+++ b/synapse/storage/stream.py
@@ -592,7 +592,7 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
         )
 
     def get_max_topological_token(self, room_id, stream_key):
-        """Get the max topological token in a room that before given stream
+        """Get the max topological token in a room before the given stream
         ordering.
 
         Args:

--- a/synapse/storage/stream.py
+++ b/synapse/storage/stream.py
@@ -592,8 +592,18 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
         )
 
     def get_max_topological_token(self, room_id, stream_key):
+        """Get the max topological token in a room that before given stream
+        ordering.
+
+        Args:
+            room_id (str)
+            stream_key (int)
+
+        Returns:
+            Deferred[int]
+        """
         sql = (
-            "SELECT max(topological_ordering) FROM events"
+            "SELECT coalesce(max(topological_ordering), 0) FROM events"
             " WHERE room_id = ? AND stream_ordering < ?"
         )
         return self._execute(


### PR DESCRIPTION
This fixes a failure in the worker sytest.