### PR TITLE
Fix appservice timestamp massaging

### DIFF
--- a/changelog.d/5233.bugfix
+++ b/changelog.d/5233.bugfix
@@ -1,0 +1,1 @@
+Fix appservice timestamp massaging.

--- a/synapse/events/builder.py
+++ b/synapse/events/builder.py
@@ -76,6 +76,7 @@ class EventBuilder(object):
     # someone tries to get them when they don't exist.
     _state_key = attr.ib(default=None)
     _redacts = attr.ib(default=None)
+    _origin_server_ts = attr.ib(default=None)
 
     internal_metadata = attr.ib(default=attr.Factory(lambda: _EventInternalMetadata({})))
 
@@ -141,6 +142,9 @@ class EventBuilder(object):
 
         if self._redacts is not None:
             event_dict["redacts"] = self._redacts
+
+        if self._origin_server_ts is not None:
+            event_dict["origin_server_ts"] = self._origin_server_ts
 
         defer.returnValue(
             create_local_event_from_event_dict(
@@ -209,6 +213,7 @@ class EventBuilderFactory(object):
             content=key_values.get("content", {}),
             unsigned=key_values.get("unsigned", {}),
             redacts=key_values.get("redacts", None),
+            origin_server_ts=key_values.get("origin_server_ts", None),
         )
 
 
@@ -245,7 +250,7 @@ def create_local_event_from_event_dict(clock, hostname, signing_key,
         event_dict["event_id"] = _create_event_id(clock, hostname)
 
     event_dict["origin"] = hostname
-    event_dict["origin_server_ts"] = time_now
+    event_dict.setdefault("origin_server_ts", time_now)
 
     event_dict.setdefault("unsigned", {})
     age = event_dict["unsigned"].pop("age", 0)


### PR DESCRIPTION
The API part of handling timestamp massaging is still at https://github.com/matrix-org/synapse/blob/develop/synapse/rest/client/v1/room.py#L211-L212 and works fine, but some event builder changes made it so that origin_server_ts value wasn't passed through all the way to the final event. This pull request should fix the event builder so it passes through origin_server_ts if it already exists.