### PR TITLE
Show correct error when logging out and access token is missing

### DIFF
--- a/changelog.d/5256.bugfix
+++ b/changelog.d/5256.bugfix
@@ -1,0 +1,1 @@
+Show the correct error when logging out and access token is missing.

--- a/synapse/rest/client/v1/logout.py
+++ b/synapse/rest/client/v1/logout.py
@@ -17,8 +17,6 @@ import logging
 
 from twisted.internet import defer
 
-from synapse.api.errors import AuthError
-
 from .base import ClientV1RestServlet, client_path_patterns
 
 logger = logging.getLogger(__name__)

--- a/synapse/rest/client/v1/logout.py
+++ b/synapse/rest/client/v1/logout.py
@@ -40,11 +40,11 @@ class LogoutRestServlet(ClientV1RestServlet):
     def on_POST(self, request):
         try:
             requester = yield self.auth.get_user_by_req(request)
-        except AuthError:
+        except AuthError as e:
             # this implies the access token has already been deleted.
-            defer.returnValue((401, {
-                "errcode": "M_UNKNOWN_TOKEN",
-                "error": "Access Token unknown or expired"
+            defer.returnValue((e.code, {
+                "errcode": e.errcode,
+                "error": e.msg
             }))
         else:
             if requester.device_id is None:

--- a/synapse/rest/client/v1/logout.py
+++ b/synapse/rest/client/v1/logout.py
@@ -38,23 +38,16 @@ class LogoutRestServlet(ClientV1RestServlet):
 
     @defer.inlineCallbacks
     def on_POST(self, request):
-        try:
-            requester = yield self.auth.get_user_by_req(request)
-        except AuthError as e:
-            # this implies the access token has already been deleted.
-            defer.returnValue((e.code, {
-                "errcode": e.errcode,
-                "error": e.msg
-            }))
+        requester = yield self.auth.get_user_by_req(request)
+
+        if requester.device_id is None:
+            # the acccess token wasn't associated with a device.
+            # Just delete the access token
+            access_token = self._auth.get_access_token_from_request(request)
+            yield self._auth_handler.delete_access_token(access_token)
         else:
-            if requester.device_id is None:
-                # the acccess token wasn't associated with a device.
-                # Just delete the access token
-                access_token = self._auth.get_access_token_from_request(request)
-                yield self._auth_handler.delete_access_token(access_token)
-            else:
-                yield self._device_handler.delete_device(
-                    requester.user.to_string(), requester.device_id)
+            yield self._device_handler.delete_device(
+                requester.user.to_string(), requester.device_id)
 
         defer.returnValue((200, {}))
 


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Fixes #5255

```
⟩ curl -XPOST "http://localhost:8700/_matrix/client/r0/logout"
{
    "errcode": "M_MISSING_TOKEN",
    "error": "Missing access token."
}
```

```
⟩ curl -XPOST "http://localhost:8700/_matrix/client/r0/logout?access_token=test"

{
    "errcode": "M_UNKNOWN_TOKEN",
    "error": "Invalid macaroon passed."
}
```