### PR TITLE
Downgrade crypto exception to a warning

### DIFF
--- a/changelog.d/5265.misc
+++ b/changelog.d/5265.misc
@@ -1,0 +1,1 @@
+Downgrade no key crypto exception from an error to a warning. Contributed by Reid Anderson.

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -730,7 +730,7 @@ def _handle_key_deferred(verify_request):
             502, "Error downloading keys for %s" % (server_name,), Codes.UNAUTHORIZED
         )
     except Exception as e:
-        logger.exception(
+        logger.warn(
             "Got Exception when downloading keys for %s: %s %s",
             server_name,
             type(e).__name__,


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)


I was looking through issues and this should fix https://github.com/matrix-org/synapse/issues/4728. It was straightforward enough I thought I would just open a PR for it.

With that said, I'm not sure if this is actually something that's a _good_ idea. There weren't any concerns raised on the issue, but obviously there can be a lot more to it than that. If assuming the generic exception should be treated as a warning is a no-go, or there's another reason why this isn't ideal feel free to just close the PR.

