### PR TITLE
Correctly filter out extremities with soft failed prevs

### DIFF
--- a/changelog.d/5274.bugfix
+++ b/changelog.d/5274.bugfix
@@ -1,0 +1,1 @@
+Fix bug where we leaked extremities when we soft failed events, leading to performance degradation.

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -616,9 +616,10 @@ class EventsStore(
     def _get_prevs_before_rejected(self, event_ids):
         """Get soft-failed ancestors to remove from the extremities.
 
-        Given a set of events recursively find all prev events that have
-        been soft-failed or rejected. Then return those soft failed events
-        and their prev events.
+        Given a set of events, find all those that have been soft-failed or
+        rejected. Returns those soft failed/rejected events and their prev
+        events (whether soft-failed/rejected or not), and recurses up the
+        prev-event graph until it finds no more soft-failed/rejected events.
 
         This is used to find extremities that are ancestors of new events, but
         are separated by soft failed events.

--- a/synapse/storage/events.py
+++ b/synapse/storage/events.py
@@ -602,7 +602,8 @@ class EventsStore(
 
         for chunk in batch_iter(event_ids, 100):
             yield self.runInteraction(
-                "_get_events_which_are_prevs", _get_events_which_are_prevs_txn,
+                "_get_events_which_are_prevs", 
+                _get_events_which_are_prevs_txn,
                 chunk,
             )
 


### PR DESCRIPTION
When we receive a soft failed event we, correctly, *do not* update the
forward extremity table with the event. However, if we later receive an
event that references the soft failed event we then need to remove the
soft failed events prev events from the forward extremities table,
otherwise we just build up forward extremities.

Fixes #5269 