### PR TITLE
Allow configuring a range for the account validity startup job

### DIFF
--- a/changelog.d/5276.feature
+++ b/changelog.d/5276.feature
@@ -1,0 +1,1 @@
+Allow configuring a range for the account validity startup job.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -755,11 +755,18 @@ uploads_path: "DATADIR/uploads"
 # after that the validity period changes and Synapse is restarted, the users'
 # expiration dates won't be updated unless their account is manually renewed.
 #
+# If set, the ``startup_job_max_delta`` optional setting will make the startup job
+# described above set a random expiration date between t + period  and
+# t + period + startup_job_max_delta, t being the date and time at which the job
+# sets the expiration date for a given user. This is useful for server admins that
+# want to avoid Synapse sending a lot of renewal emails at once.
+#
 #account_validity:
 #  enabled: True
 #  period: 6w
 #  renew_at: 1w
 #  renew_email_subject: "Renew your %(app)s account"
+#  startup_job_max_delta: 2d
 
 # The user must provide all of the below types of 3PID when registering.
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -753,20 +753,15 @@ uploads_path: "DATADIR/uploads"
 # This means that, if a validity period is set, and Synapse is restarted (it will
 # then derive an expiration date from the current validity period), and some time
 # after that the validity period changes and Synapse is restarted, the users'
-# expiration dates won't be updated unless their account is manually renewed.
-#
-# If set, the ``startup_job_max_delta`` optional setting will make the startup job
-# described above set a random expiration date between t + period  and
-# t + period + startup_job_max_delta, t being the date and time at which the job
-# sets the expiration date for a given user. This is useful for server admins that
-# want to avoid Synapse sending a lot of renewal emails at once.
+# expiration dates won't be updated unless their account is manually renewed. This
+# date will be randomly selected within a range [now + period ; now + period + d],
+# where d is equal to 10% of the validity period.
 #
 #account_validity:
 #  enabled: True
 #  period: 6w
 #  renew_at: 1w
 #  renew_email_subject: "Renew your %(app)s account"
-#  startup_job_max_delta: 2d
 
 # The user must provide all of the below types of 3PID when registering.
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -754,7 +754,7 @@ uploads_path: "DATADIR/uploads"
 # then derive an expiration date from the current validity period), and some time
 # after that the validity period changes and Synapse is restarted, the users'
 # expiration dates won't be updated unless their account is manually renewed. This
-# date will be randomly selected within a range [now + period ; now + period + d],
+# date will be randomly selected within a range [now + period - d ; now + period],
 # where d is equal to 10% of the validity period.
 #
 #account_validity:

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -133,7 +133,7 @@ class RegistrationConfig(Config):
         # after that the validity period changes and Synapse is restarted, the users'
         # expiration dates won't be updated unless their account is manually renewed. This
         # date will be randomly selected within a range [now + period ; now + period + d],
-        # where d is equal to 10% of the validity period.
+        # where d is equal to 10%% of the validity period.
         #
         #account_validity:
         #  enabled: True

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -132,7 +132,7 @@ class RegistrationConfig(Config):
         # then derive an expiration date from the current validity period), and some time
         # after that the validity period changes and Synapse is restarted, the users'
         # expiration dates won't be updated unless their account is manually renewed. This
-        # date will be randomly selected within a range [now + period ; now + period + d],
+        # date will be randomly selected within a range [now + period - d ; now + period],
         # where d is equal to 10%% of the validity period.
         #
         #account_validity:

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -39,6 +39,10 @@ class AccountValidityConfig(Config):
             else:
                 self.renew_email_subject = "Renew your %(app)s account"
 
+            self.startup_job_max_delta = self.parse_duration(
+                config.get("startup_job_max_delta", 0),
+            )
+
         if self.renew_by_email_enabled and "public_baseurl" not in synapse_config:
             raise ConfigError("Can't send renewal emails without 'public_baseurl'")
 
@@ -131,11 +135,18 @@ class RegistrationConfig(Config):
         # after that the validity period changes and Synapse is restarted, the users'
         # expiration dates won't be updated unless their account is manually renewed.
         #
+        # If set, the ``startup_job_max_delta`` optional setting will make the startup job
+        # described above set a random expiration date between t + period  and
+        # t + period + startup_job_max_delta, t being the date and time at which the job
+        # sets the expiration date for a given user. This is useful for server admins that
+        # want to avoid Synapse sending a lot of renewal emails at once.
+        #
         #account_validity:
         #  enabled: True
         #  period: 6w
         #  renew_at: 1w
         #  renew_email_subject: "Renew your %%(app)s account"
+        #  startup_job_max_delta: 2d
 
         # The user must provide all of the below types of 3PID when registering.
         #

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -39,9 +39,7 @@ class AccountValidityConfig(Config):
             else:
                 self.renew_email_subject = "Renew your %(app)s account"
 
-            self.startup_job_max_delta = self.parse_duration(
-                config.get("startup_job_max_delta", 0),
-            )
+            self.startup_job_max_delta = self.period * 10. / 100.
 
         if self.renew_by_email_enabled and "public_baseurl" not in synapse_config:
             raise ConfigError("Can't send renewal emails without 'public_baseurl'")
@@ -133,20 +131,15 @@ class RegistrationConfig(Config):
         # This means that, if a validity period is set, and Synapse is restarted (it will
         # then derive an expiration date from the current validity period), and some time
         # after that the validity period changes and Synapse is restarted, the users'
-        # expiration dates won't be updated unless their account is manually renewed.
-        #
-        # If set, the ``startup_job_max_delta`` optional setting will make the startup job
-        # described above set a random expiration date between t + period  and
-        # t + period + startup_job_max_delta, t being the date and time at which the job
-        # sets the expiration date for a given user. This is useful for server admins that
-        # want to avoid Synapse sending a lot of renewal emails at once.
+        # expiration dates won't be updated unless their account is manually renewed. This
+        # date will be randomly selected within a range [now + period ; now + period + d],
+        # where d is equal to 10% of the validity period.
         #
         #account_validity:
         #  enabled: True
         #  period: 6w
         #  renew_at: 1w
         #  renew_email_subject: "Renew your %%(app)s account"
-        #  startup_job_max_delta: 2d
 
         # The user must provide all of the below types of 3PID when registering.
         #

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -329,14 +329,13 @@ class SQLBaseStore(object):
              user_id (str): User ID to set an expiration date for.
              use_delta (bool): If set to False, the expiration date for the user will be
                 now + validity period. If set to True, this expiration date will be a
-                random value in the [now + period; now + period + max_delta] range,
-                max_delta being the configured value for the size of the range, unless
-                delta is 0, in which case it sets it to now + period.
+                random value in the [now + period; now + period + d] range, d being a
+                delta equal to 10% of the validity period.
         """
         now_ms = self._clock.time_msec()
         expiration_ts = now_ms + self._account_validity.period
 
-        if use_delta and self._account_validity.startup_job_max_delta:
+        if use_delta:
             expiration_ts = self.rand.randrange(
                 expiration_ts,
                 expiration_ts + self._account_validity.startup_job_max_delta,

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -329,7 +329,7 @@ class SQLBaseStore(object):
              user_id (str): User ID to set an expiration date for.
              use_delta (bool): If set to False, the expiration date for the user will be
                 now + validity period. If set to True, this expiration date will be a
-                random value in the [now + period; now + period + d] range, d being a
+                random value in the [now + period - d ; now + period] range, d being a
                 delta equal to 10% of the validity period.
         """
         now_ms = self._clock.time_msec()
@@ -337,8 +337,8 @@ class SQLBaseStore(object):
 
         if use_delta:
             expiration_ts = self.rand.randrange(
+                expiration_ts - self._account_validity.startup_job_max_delta,
                 expiration_ts,
-                expiration_ts + self._account_validity.startup_job_max_delta,
             )
 
         self._simple_insert_txn(

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 import itertools
 import logging
+import random
 import sys
 import threading
 import time
@@ -247,6 +248,8 @@ class SQLBaseStore(object):
                 self._check_safe_to_upsert,
             )
 
+        self.rand = random.SystemRandom()
+
         if self._account_validity.enabled:
             self._clock.call_later(
                 0.0,
@@ -308,21 +311,37 @@ class SQLBaseStore(object):
             res = self.cursor_to_dict(txn)
             if res:
                 for user in res:
-                    self.set_expiration_date_for_user_txn(txn, user["name"])
+                    self.set_expiration_date_for_user_txn(
+                        txn,
+                        user["name"],
+                        use_delta=True,
+                    )
 
         yield self.runInteraction(
             "get_users_with_no_expiration_date",
             select_users_with_no_expiration_date_txn,
         )
 
-    def set_expiration_date_for_user_txn(self, txn, user_id):
+    def set_expiration_date_for_user_txn(self, txn, user_id, use_delta=False):
         """Sets an expiration date to the account with the given user ID.
 
         Args:
              user_id (str): User ID to set an expiration date for.
+             use_delta (bool): If set to False, the expiration date for the user will be
+                now + validity period. If set to True, this expiration date will be a
+                random value in the [now + period; now + period + max_delta] range,
+                max_delta being the configured value for the size of the range, unless
+                delta is 0, in which case it sets it to now + period.
         """
         now_ms = self._clock.time_msec()
         expiration_ts = now_ms + self._account_validity.period
+
+        if use_delta and self._account_validity.startup_job_max_delta:
+            expiration_ts = self.rand.randrange(
+                expiration_ts,
+                expiration_ts + self._account_validity.startup_job_max_delta,
+            )
+
         self._simple_insert_txn(
             txn,
             "account_validity",

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -436,6 +436,7 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
 
     def make_homeserver(self, reactor, clock):
         self.validity_period = 10
+        self.max_delta = 10
 
         config = self.default_config()
 
@@ -459,8 +460,28 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
         """
         user_id = self.register_user("kermit", "user")
 
+        self.hs.config.account_validity.startup_job_max_delta = 0
+
         now_ms = self.hs.clock.time_msec()
         self.get_success(self.store._set_expiration_date_when_missing())
 
         res = self.get_success(self.store.get_expiration_ts_for_user(user_id))
         self.assertEqual(res, now_ms + self.validity_period)
+
+    def test_background_job_with_max_delta(self):
+        """
+        Tests the same thing as test_background_job, except that it sets the
+        startup_job_max_delta parameter and checks that the expiration date is within the
+        allowed range.
+        """
+        user_id = self.register_user("kermit_delta", "user")
+
+        self.hs.config.account_validity.startup_job_max_delta = self.max_delta
+
+        now_ms = self.hs.clock.time_msec()
+        self.get_success(self.store._set_expiration_date_when_missing())
+
+        res = self.get_success(self.store.get_expiration_ts_for_user(user_id))
+
+        self.assertLessEqual(res, now_ms + self.validity_period + self.delta)
+        self.assertGreaterEqual(res, now_ms + self.validity_period)

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -483,5 +483,5 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
 
         res = self.get_success(self.store.get_expiration_ts_for_user(user_id))
 
-        self.assertLessEqual(res, now_ms + self.validity_period + self.delta)
+        self.assertLessEqual(res, now_ms + self.validity_period + self.max_delta)
         self.assertGreaterEqual(res, now_ms + self.validity_period)

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -467,5 +467,5 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
 
         res = self.get_success(self.store.get_expiration_ts_for_user(user_id))
 
-        self.assertLessEqual(res, now_ms + self.validity_period + self.max_delta)
-        self.assertGreaterEqual(res, now_ms + self.validity_period)
+        self.assertGreaterEqual(res, now_ms + self.validity_period - self.max_delta)
+        self.assertLessEqual(res, now_ms + self.validity_period)

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -436,7 +436,7 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
 
     def make_homeserver(self, reactor, clock):
         self.validity_period = 10
-        self.max_delta = 10
+        self.max_delta = self.validity_period * 10. / 100.
 
         config = self.default_config()
 
@@ -453,22 +453,6 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
         return self.hs
 
     def test_background_job(self):
-        """
-        Tests whether the account validity startup background job does the right thing,
-        which is sticking an expiration date to every account that doesn't already have
-        one.
-        """
-        user_id = self.register_user("kermit", "user")
-
-        self.hs.config.account_validity.startup_job_max_delta = 0
-
-        now_ms = self.hs.clock.time_msec()
-        self.get_success(self.store._set_expiration_date_when_missing())
-
-        res = self.get_success(self.store.get_expiration_ts_for_user(user_id))
-        self.assertEqual(res, now_ms + self.validity_period)
-
-    def test_background_job_with_max_delta(self):
         """
         Tests the same thing as test_background_job, except that it sets the
         startup_job_max_delta parameter and checks that the expiration date is within the


### PR DESCRIPTION
When enabling the account validity feature, Synapse will look at startup for registered account without an expiration date, and will set one equals to `now + validity_period` for them. On large servers, it can mean that a large number of users will have the same expiration date, which means that they will all be sent a renewal email at the same time, which isn't ideal.

In order to mitigate this, this PR allows server admins to define a `max_delta` so that the expiration date is a random value in the `[now + validity_period ; now + validity_period + max_delta]` range. This allows renewal emails to be progressively sent over a configured period instead of being sent all in one big batch.
