### PR TITLE
Add index to temp bg update extremity table

### DIFF
--- a/changelog.d/5291.bugfix
+++ b/changelog.d/5291.bugfix
@@ -1,0 +1,1 @@
+Fix bug where we leaked extremities when we soft failed events, leading to performance degradation.

--- a/synapse/storage/schema/delta/54/delete_forward_extremities.sql
+++ b/synapse/storage/schema/delta/54/delete_forward_extremities.sql
@@ -20,3 +20,4 @@ INSERT INTO background_updates (update_name, progress_json) VALUES
 
 DROP TABLE IF EXISTS _extremities_to_check;  -- To make this delta schema file idempotent.
 CREATE TABLE _extremities_to_check AS SELECT event_id FROM event_forward_extremities;
+CREATE INDEX _extremities_to_check_id ON _extremities_to_check(event_id);


### PR DESCRIPTION
Fixes slow background update introduced in #5278