### PR TITLE
Remove some pointless exception handling

### DIFF
--- a/changelog.d/5296.misc
+++ b/changelog.d/5296.misc
@@ -1,0 +1,1 @@
+Refactor keyring.VerifyKeyRequest to use attr.s.

--- a/changelog.d/5300.bugfix
+++ b/changelog.d/5300.bugfix
@@ -1,0 +1,1 @@
+Fix noisy 'no key for server' logs.

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -15,12 +15,12 @@
 # limitations under the License.
 
 import logging
-from collections import namedtuple
 
 import six
 from six import raise_from
 from six.moves import urllib
 
+import attr
 from signedjson.key import (
     decode_verify_key_bytes,
     encode_verify_key_base64,
@@ -57,22 +57,26 @@ from synapse.util.retryutils import NotRetryingDestination
 logger = logging.getLogger(__name__)
 
 
-VerifyKeyRequest = namedtuple(
-    "VerifyRequest", ("server_name", "key_ids", "json_object", "deferred")
-)
-"""
-A request for a verify key to verify a JSON object.
+@attr.s(slots=True, cmp=False)
+class VerifyKeyRequest(object):
+    """
+    A request for a verify key to verify a JSON object.
 
-Attributes:
-    server_name(str): The name of the server to verify against.
-    key_ids(set(str)): The set of key_ids to that could be used to verify the
-        JSON object
-    json_object(dict): The JSON object to verify.
-    deferred(Deferred[str, str, nacl.signing.VerifyKey]):
-        A deferred (server_name, key_id, verify_key) tuple that resolves when
-        a verify key has been fetched. The deferreds' callbacks are run with no
-        logcontext.
-"""
+    Attributes:
+        server_name(str): The name of the server to verify against.
+        key_ids(set[str]): The set of key_ids to that could be used to verify the
+            JSON object
+        json_object(dict): The JSON object to verify.
+        deferred(Deferred[str, str, nacl.signing.VerifyKey]):
+            A deferred (server_name, key_id, verify_key) tuple that resolves when
+            a verify key has been fetched. The deferreds' callbacks are run with no
+            logcontext.
+    """
+
+    server_name = attr.ib()
+    key_ids = attr.ib()
+    json_object = attr.ib()
+    deferred = attr.ib()
 
 
 class KeyLookupError(ValueError):


### PR DESCRIPTION
The verify_request deferred already returns a suitable SynapseError, so I
don't really know what we expect to achieve by doing more wrapping, other
than log spam.

Fixes #4728.

Based on #5296.