### PR TITLE
Stop overwriting server keys with other keys

### DIFF
--- a/changelog.d/5307.bugfix
+++ b/changelog.d/5307.bugfix
@@ -1,0 +1,1 @@
+Fix bug where a notary server would sometimes forget old keys.


### PR DESCRIPTION
Fix a bug where we would discard a key result which the origin server is no
longer returning. Fixes #5305.