### PR TITLE
Send password reset from HS: database stuff

### DIFF
--- a/changelog.d/5308.feature
+++ b/changelog.d/5308.feature
@@ -1,0 +1,1 @@
+Add ability to perform password reset via email without trusting the identity server.

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -339,6 +339,15 @@ class UnsupportedRoomVersionError(SynapseError):
         )
 
 
+class ThreepidValidationError(SynapseError):
+    """An error raised when there was a problem authorising an event."""
+
+    def __init__(self, *args, **kwargs):
+        if "errcode" not in kwargs:
+            kwargs["errcode"] = Codes.FORBIDDEN
+        super(ThreepidValidationError, self).__init__(*args, **kwargs)
+
+
 class IncompatibleRoomVersionError(SynapseError):
     """A server is trying to join a room whose version it does not support.
 

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 # Remember to update this number every time a change is made to database
 # schema files, so the users will be informed on server restarts.
-SCHEMA_VERSION = 54
+SCHEMA_VERSION = 55
 
 dir_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -1025,7 +1025,7 @@ class RegistrationStore(
         def get_threepid_validation_session_txn(txn):
             sql = "SELECT %s FROM threepid_validation_session WHERE %s" % (
                 ", ".join(cols_to_return),
-                " AND ".join("%s = ?" % k for k in iterkeys(keyvalues))
+                " AND ".join("%s = ?" % k for k in iterkeys(keyvalues)),
             )
 
             if validated is not None:

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -1023,8 +1023,10 @@ class RegistrationStore(
         ]
 
         def get_threepid_validation_session_txn(txn):
-            sql = "SELECT %s FROM threepid_validation_session" % ", ".join(cols_to_return)
-            sql += " WHERE %s" % " AND ".join("%s = ?" % k for k in iterkeys(keyvalues))
+            sql = "SELECT %s FROM threepid_validation_session WHERE %s" % (
+                ", ".join(cols_to_return),
+                " AND ".join("%s = ?" % k for k in iterkeys(keyvalues))
+            )
 
             if validated is not None:
                 sql += " AND validated_at IS " + ("NOT NULL" if validated else "NULL")

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -1156,3 +1156,18 @@ class RegistrationStore(
             updatevalues={"validated": 1},
             desc="mark_threepid_session_as_valid",
         )
+
+    @defer.inlineCallbacks
+    def delete_threepid_session(self, session_id):
+        """Removes a threepid validation session from the database. This can
+        be done after validation has been performed and whatever action was
+        waiting on it has been carried out
+
+        Args:
+            session_id (str): The ID of the session to delete
+        """
+        yield self._simple_delete(
+            table="threepid_validation_session",
+            keyvalues={"session_id": session_id},
+            desc="delete_threepid_session",
+        )

--- a/synapse/storage/schema/delta/54/track_threepid_validations.sql
+++ b/synapse/storage/schema/delta/54/track_threepid_validations.sql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS threepid_validation_session (
 
 CREATE TABLE IF NOT EXISTS threepid_validation_token (
     token TEXT PRIMARY KEY,
-    session_id TEXT,
+    session_id TEXT NOT NULL,
     next_link TEXT,
     expires BIGINT NOT NULL
 );

--- a/synapse/storage/schema/delta/54/track_threepid_validations.sql
+++ b/synapse/storage/schema/delta/54/track_threepid_validations.sql
@@ -1,0 +1,34 @@
+/* Copyright 2019 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+CREATE TABLE IF NOT EXISTS threepid_validation_session (
+    session_id TEXT PRIMARY KEY,
+    medium TEXT NOT NULL,
+    address TEXT NOT NULL,
+    client_secret TEXT NOT NULL,
+    last_send_attempt BIGINT NOT NULL,
+    validated BOOL DEFAULT 0 NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS threepid_validation_token (
+    token TEXT PRIMARY KEY,
+    session_id TEXT,
+    next_link TEXT,
+    expires BIGINT NOT NULL
+);
+
+CREATE INDEX threepid_validations_session_id ON threepid_validation_session(session_id);
+
+CREATE INDEX threepid_validation_token_session_id ON threepid_validation_token(session_id);
+CREATE INDEX threepid_validation_expires ON threepid_validation_token(expires);

--- a/synapse/storage/schema/delta/54/track_threepid_validations.sql
+++ b/synapse/storage/schema/delta/54/track_threepid_validations.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS threepid_validation_session (
     address TEXT NOT NULL,
     client_secret TEXT NOT NULL,
     last_send_attempt BIGINT NOT NULL,
-    validated BOOL DEFAULT 0 NOT NULL
+    validated BOOL DEFAULT false NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS threepid_validation_token (

--- a/synapse/storage/schema/delta/55/track_threepid_validations.sql
+++ b/synapse/storage/schema/delta/55/track_threepid_validations.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS threepid_validation_session (
     address TEXT NOT NULL,
     client_secret TEXT NOT NULL,
     last_send_attempt BIGINT NOT NULL,
-    validated BOOL DEFAULT false NOT NULL
+    validated_at BIGINT
 );
 
 CREATE TABLE IF NOT EXISTS threepid_validation_token (

--- a/synapse/storage/schema/delta/55/track_threepid_validations.sql
+++ b/synapse/storage/schema/delta/55/track_threepid_validations.sql
@@ -28,7 +28,4 @@ CREATE TABLE IF NOT EXISTS threepid_validation_token (
     expires BIGINT NOT NULL
 );
 
-CREATE INDEX threepid_validations_session_id ON threepid_validation_session(session_id);
-
 CREATE INDEX threepid_validation_token_session_id ON threepid_validation_token(session_id);
-CREATE INDEX threepid_validation_expires ON threepid_validation_token(expires);


### PR DESCRIPTION
Database component of new behaviour of sending password reset emails from Synapse instead of Sydent.

Allows one to store threepid validation sessions along with password reset token attempts and retrieve them again.

Relevant spec bits:

https://matrix.org/docs/spec/client_server/unstable.html#post-matrix-client-r0-account-password-email-requesttoken
https://matrix.org/docs/spec/identity_service/r0.1.0.html#post-matrix-identity-api-v1-validate-email-submittoken

Essentially the flow is:

* A request to `/requestToken` is made with an email address, a client secret and a send_attempt to the homeserver
* We create a new session if one doesn't already exist, but if it does check that the send_attempt is higher than the last one in the session. If it is, overwrite it.
* We send out an email. In that email is a link containing the client secret, session id and a newly generated token
* The user then clicks that link which leads to `/submitToken` on the homeserver, and we check if those three vars match up with a session and a validation request
* If so, the user's threepid session is marked as valid and is shown a happy validation page