### PR TITLE
Update HAProxy example rules

### DIFF
--- a/changelog.d/5313.misc
+++ b/changelog.d/5313.misc
@@ -1,0 +1,1 @@
+Update example haproxy config to a more compatible setup.

--- a/docs/reverse_proxy.rst
+++ b/docs/reverse_proxy.rst
@@ -89,8 +89,10 @@ Let's assume that we expect clients to connect to our server at
         bind :::443 v4v6 ssl crt /etc/ssl/haproxy/ strict-sni alpn h2,http/1.1
 
         # Matrix client traffic
-        acl matrix hdr(host) -i matrix.example.com
-        use_backend matrix if matrix
+        acl matrix-host hdr(host) -i matrix.example.com
+        acl matrix-path path_beg /_matrix
+
+        use_backend matrix if matrix-host matrix-path
 
       frontend matrix-federation
         bind :::8448 v4v6 ssl crt /etc/ssl/haproxy/synapse.pem alpn h2,http/1.1


### PR DESCRIPTION
These new rules allow a user to instead route only matrix traffic, allowing them to run matrix on a domain without affecting their existing websites

Signed-off-by: Ike Johnson <complaints@ikejohnson.id.au>