### PR TITLE
Fix handling of failures when calling /event_auth.

### DIFF
--- a/changelog.d/5317.bugfix
+++ b/changelog.d/5317.bugfix
@@ -1,0 +1,1 @@
+Fix handling of failures when processing incoming events where calling `/event_auth` on remote server fails.


### PR DESCRIPTION
When processing an incoming event over federation, we may try and
resolve any unexpected differences in auth events. This is a
non-essential process and so should not stop the processing of the event
if it fails (e.g. due to the remote disappearing or not implementing the
necessary endpoints).

Fixes #3330
