### PR TITLE
Don't do long retries when calling the key notary server.

### DIFF
--- a/changelog.d/5334.bugfix
+++ b/changelog.d/5334.bugfix
@@ -1,0 +1,1 @@
+Fix bug which would make certain operations (such as room joins) block for 20 minutes while attemoting to fetch verification keys.

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -638,7 +638,6 @@ class PerspectivesKeyFetcher(BaseV2KeyFetcher):
                         for server_name, server_keys in keys_to_fetch.items()
                     }
                 },
-                long_retries=True,
             )
         except (NotRetryingDestination, RequestSendFailed) as e:
             raise_from(KeyLookupError("Failed to connect to remote server"), e)


### PR DESCRIPTION
It takes at least 20 minutes to work through the long_retries schedule (11
attempts, each with a 60 second timeout, and 60 seconds between each request),
so if the notary server isn't returning within the timeout, we'll just end up
blocking whatever request is happening for 20 minutes.

Ain't nobody got time for that.