### PR TITLE
Make account validity renewal emails work when email notifs are disabled

### DIFF
--- a/changelog.d/5341.bugfix
+++ b/changelog.d/5341.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where account validity renewal emails could only be sent when email notifs were enabled.

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -138,7 +138,6 @@ class EmailConfig(Config):
                 if not os.path.isfile(p):
                     raise ConfigError("Unable to find email template file %s" % (p, ))
 
-
     def default_config(self, config_dir_path, server_name, **kwargs):
         return """
         # Enable sending emails for notification events or expiry notices

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -51,10 +51,11 @@ class EmailConfig(Config):
             self.email_app_name = "Matrix"
 
         self.email_notif_from = email_config.get("notif_from", None)
-        # make sure it's valid
-        parsed = email.utils.parseaddr(self.email_notif_from)
-        if self.email_notif_from and parsed[1] == '':
-            raise RuntimeError("Invalid notif_from address")
+        if self.email_notif_from is not None:
+            # make sure it's valid
+            parsed = email.utils.parseaddr(self.email_notif_from)
+            if parsed[1] == '':
+                raise RuntimeError("Invalid notif_from address")
 
         template_dir = email_config.get("template_dir")
         # we need an absolute path, because we change directory after starting (and


### PR DESCRIPTION
This is a quick fix to the email config only being loaded when email notifs are enabled.

A better long-term solution would be to properly separate email config from notifs and account validity configs.