### PR TITLE
Fix failure to fetch batches of PDUs

### DIFF
--- a/changelog.d/5342.bugfix
+++ b/changelog.d/5342.bugfix
@@ -1,0 +1,1 @@
+Fix failure when fetching batches of events during backfill, etc.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -280,6 +280,7 @@ class FederationClient(FederationBase):
                     "Failed to get PDU %s from %s because %s",
                     event_id, destination, e,
                 )
+                continue
             except NotRetryingDestination as e:
                 logger.info(str(e))
                 continue


### PR DESCRIPTION
FederationClient.get_pdu is called in a loop to fetch a batch of PDUs. A
failure to fetch one should not result in a failure of the whole batch. Add the
missing `continue`.