### PR TITLE
Rename get_events->get_events_from_store_or_dest

### DIFF
--- a/changelog.d/5344.misc
+++ b/changelog.d/5344.misc
@@ -1,1 +1,1 @@
-Clean up FederationClient.get_events for clarity
+Clean up FederationClient.get_events for clarity.

--- a/changelog.d/5344.misc
+++ b/changelog.d/5344.misc
@@ -1,0 +1,1 @@
+Clean up FederationClient.get_events for clarity


### PR DESCRIPTION
We have too many things called get_event, and it's hard to figure out what we
mean. Also remove some unused params from the signature, and add some logging.