### PR TITLE
Include left members in room summaries' heroes

### DIFF
--- a/changelog.d/5355.bugfix
+++ b/changelog.d/5355.bugfix
@@ -1,0 +1,1 @@
+Include left members in room summaries' heroes

--- a/changelog.d/5355.bugfix
+++ b/changelog.d/5355.bugfix
@@ -1,1 +1,1 @@
-Include left members in room summaries' heroes
+Include left members in room summaries' heroes.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/4926 by filtering out our own user ID before we check whether we should select heroes from the joined members or the parted ones. Otherwise, `if (joined_user_ids or invited_user_ids)` will always match since we're a joined member in the room.