### PR TITLE
Fix `federation_custom_ca_list` configuration option.

### DIFF
--- a/changelog.d/5362.bugfix
+++ b/changelog.d/5362.bugfix
@@ -1,0 +1,1 @@
+Fix `federation_custom_ca_list` configuration option.

--- a/synapse/config/tls.py
+++ b/synapse/config/tls.py
@@ -107,7 +107,7 @@ class TlsConfig(Config):
             certs = []
             for ca_file in custom_ca_list:
                 logger.debug("Reading custom CA certificate file: %s", ca_file)
-                content = self.read_file(ca_file)
+                content = self.read_file(ca_file, "federation_custom_ca_list")
 
                 # Parse the CA certificates
                 try:


### PR DESCRIPTION
Previously, setting this option would cause an exception at startup.