### PR TITLE
Don't check whether the user's account is expired on /send_mail requests

### DIFF
--- a/changelog.d/5363.feature
+++ b/changelog.d/5363.feature
@@ -1,1 +1,1 @@
-Allow expired user to trigger renewal email sending manually
+Allow expired user to trigger renewal email sending manually.

--- a/changelog.d/5363.feature
+++ b/changelog.d/5363.feature
@@ -1,0 +1,1 @@
+Allow expired user to trigger renewal email sending manually

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -184,7 +184,13 @@ class Auth(object):
         return event_auth.get_public_keys(invite_event)
 
     @defer.inlineCallbacks
-    def get_user_by_req(self, request, allow_guest=False, rights="access"):
+    def get_user_by_req(
+        self,
+        request,
+        allow_guest=False,
+        rights="access",
+        allow_expired=False,
+    ):
         """ Get a registered user's ID.
 
         Args:
@@ -229,7 +235,7 @@ class Auth(object):
             is_guest = user_info["is_guest"]
 
             # Deny the request if the user account has expired.
-            if self._account_validity.enabled:
+            if self._account_validity.enabled and not allow_expired:
                 user_id = user.to_string()
                 expiration_ts = yield self.store.get_expiration_ts_for_user(user_id)
                 if expiration_ts is not None and self.clock.time_msec() >= expiration_ts:

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -195,6 +195,11 @@ class Auth(object):
 
         Args:
             request - An HTTP request with an access_token query parameter.
+            allow_expired - Whether to allow the request through even if the account is
+                expired. If true, Synapse will still require the access token to be
+                provided but won't check if the account it belongs to has expired. This
+                works thanks to /login delivering access tokens regardless of accounts'
+                expiration.
         Returns:
             defer.Deferred: resolves to a ``synapse.types.Requester`` object
         Raises:

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -196,7 +196,7 @@ class Auth(object):
         Args:
             request - An HTTP request with an access_token query parameter.
             allow_expired - Whether to allow the request through even if the account is
-                expired. If true, Synapse will still require the access token to be
+                expired. If true, Synapse will still require an access token to be
                 provided but won't check if the account it belongs to has expired. This
                 works thanks to /login delivering access tokens regardless of accounts'
                 expiration.

--- a/synapse/rest/client/v2_alpha/account_validity.py
+++ b/synapse/rest/client/v2_alpha/account_validity.py
@@ -79,7 +79,7 @@ class AccountValiditySendMailServlet(RestServlet):
         if not self.account_validity.renew_by_email_enabled:
             raise AuthError(403, "Account renewal via email is disabled on this server.")
 
-        requester = yield self.auth.get_user_by_req(request)
+        requester = yield self.auth.get_user_by_req(request, allow_expired=True)
         user_id = requester.user.to_string()
         yield self.account_activity_handler.send_renewal_email_to_user(user_id)
 


### PR DESCRIPTION
A renewal email can be lost if flagged as spam or accidentally deleted. If a user notices too late (once its account has expired) that they don't have the email, we should allow them to request a new one so they don't get locked out until an admin decides to renew their account manually.