### PR TITLE
Fix missing logcontext for PresenceHandler.on_shutdown.

### DIFF
--- a/changelog.d/5369.bugfix
+++ b/changelog.d/5369.bugfix
@@ -1,0 +1,1 @@
+Fix missing logcontext warnings on shutdown.

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -158,7 +158,13 @@ class PresenceHandler(object):
         # have not yet been persisted
         self.unpersisted_users_changes = set()
 
-        hs.get_reactor().addSystemEventTrigger("before", "shutdown", self._on_shutdown)
+        hs.get_reactor().addSystemEventTrigger(
+            "before",
+            "shutdown",
+            run_as_background_process,
+            "presence.on_shutdown",
+            self._on_shutdown,
+        )
 
         self.serial_to_user = {}
         self._next_serial = 1


### PR DESCRIPTION
Fixes some warnings, and a scary-looking stacktrace when sytest kills the
process.