### PR TITLE
Regen sample config before kicking off agents

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,8 +36,6 @@ steps:
           image: "python:3.6"
           propagate-environment: true
 
-  - wait
-
   - command:
       - "python -m pip install tox"
       - "tox -e check-sampleconfig"
@@ -45,6 +43,8 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "python:3.6"
+
+  - wait
 
   - command:
       - "python -m pip install tox"

--- a/changelog.d/5370.misc
+++ b/changelog.d/5370.misc
@@ -1,0 +1,1 @@
+Don't run CI build checks until sample config check has passed.


### PR DESCRIPTION
Often times I find myself forgetting to do this, and starting up agents unnecessarily because of it, as I'll push a commit directly afterwards fixing it, canceling all the long-running build jobs. I'd rather they don't run until the sample config is correct.