### PR TITLE
Add a sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# One username per supported platform and one custom link
+patreon: matrixdotorg
+custom: https://liberapay.com/matrixdotorg

--- a/changelog.d/5382.misc
+++ b/changelog.d/5382.misc
@@ -1,0 +1,1 @@
+Add a sponsor button to the repo.


### PR DESCRIPTION
Add a sponsor button with links to matrixdotorg's patreon and liberapay accounts.

Ref: https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository