### PR TITLE
Liberapay is now officially recognised, update FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 # One username per supported platform and one custom link
 patreon: matrixdotorg
 liberapay: matrixdotorg
+custom: https://paypal.me/matrixdotorg

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # One username per supported platform and one custom link
 patreon: matrixdotorg
-custom: https://liberapay.com/matrixdotorg
+liberapay: matrixdotorg

--- a/changelog.d/5386.misc
+++ b/changelog.d/5386.misc
@@ -1,0 +1,1 @@
+Update FUNDING.yml to move liberapay from custom to official link

--- a/changelog.d/5386.misc
+++ b/changelog.d/5386.misc
@@ -1,1 +1,1 @@
-Update FUNDING.yml to move liberapay from custom to official link.
+Add a sponsor button to the repo.

--- a/changelog.d/5386.misc
+++ b/changelog.d/5386.misc
@@ -1,1 +1,1 @@
-Update FUNDING.yml to move liberapay from custom to official link
+Update FUNDING.yml to move liberapay from custom to official link.


### PR DESCRIPTION
Update the funding document to move Liberapay from a custom link to a supported link.

Yay, Github recognise them!

If we want to add something else as the custom link now do shout.