### PR TITLE
Only start background group attestation renewals on master

### DIFF
--- a/changelog.d/5389.bugfix
+++ b/changelog.d/5389.bugfix
@@ -1,0 +1,1 @@
+Fix exceptions in federation reader worker caused by attempting to renew attestations, which should only happen on master worker.

--- a/synapse/groups/attestations.py
+++ b/synapse/groups/attestations.py
@@ -132,9 +132,10 @@ class GroupAttestionRenewer(object):
         self.is_mine_id = hs.is_mine_id
         self.attestations = hs.get_groups_attestation_signing()
 
-        self._renew_attestations_loop = self.clock.looping_call(
-            self._start_renew_attestations, 30 * 60 * 1000,
-        )
+        if not hs.config.worker_app:
+            self._renew_attestations_loop = self.clock.looping_call(
+                self._start_renew_attestations, 30 * 60 * 1000,
+            )
 
     @defer.inlineCallbacks
     def on_renew_attestation(self, group_id, user_id, content):


### PR DESCRIPTION
This fixes repeated `'FederationReaderSlavedStore' object has no attribute 'get_attestations_need_renewals'` exceptions in the federation reader worker.