### PR TITLE
Don't log exception when failing to fetch remote content.

### DIFF
--- a/changelog.d/5390.bugfix
+++ b/changelog.d/5390.bugfix
@@ -1,0 +1,1 @@
+Fix handling of failures fetching remote content to not log failures as exceptions.

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -386,8 +386,10 @@ class MediaRepository(object):
                 raise SynapseError(502, "Failed to fetch remote media")
 
             except SynapseError:
-                logger.exception("Failed to fetch remote media %s/%s",
-                                 server_name, media_id)
+                logger.warn(
+                    "Failed to fetch remote media %s/%s",
+                    server_name, media_id,
+                )
                 raise
             except NotRetryingDestination:
                 logger.warn("Not retrying destination %r", server_name)


### PR DESCRIPTION
In particular, let's not log stack traces when we stop processing
because the response body was too large.

