### PR TITLE
Improve startup checks for insecure notary configs

### DIFF
--- a/changelog.d/5392.bugfix
+++ b/changelog.d/5392.bugfix
@@ -1,1 +1,1 @@
-Remove redundant warning about key server response validation..
+Remove redundant warning about key server response validation.

--- a/changelog.d/5392.bugfix
+++ b/changelog.d/5392.bugfix
@@ -1,0 +1,1 @@
+Remove redundant warning about key server response validation..

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -750,13 +750,6 @@ class PerspectivesKeyFetcher(BaseV2KeyFetcher):
                 verify_signed_json(response, perspective_name, perspective_keys[key_id])
                 verified = True
 
-                if perspective_name == "matrix.org" and key_id == "ed25519:auto":
-                    logger.warning(
-                        "Trusting trusted_key_server responses signed by the "
-                        "compromised matrix.org signing key 'ed25519:auto'. "
-                        "This is a placebo."
-                    )
-
         if not verified:
             raise KeyLookupError(
                 "Response not signed with a known key: signed with: %r, known keys: %r"


### PR DESCRIPTION
It's not really a problem to trust notary responses signed by the old key so
long as we are also doing TLS validation.

This commit adds a check to the config parsing code at startup to check that
we do not have the insecure matrix.org key without tls validation, and refuses
to start without it.

This allows us to remove the rather alarming-looking warning which happens at
runtime.