### PR TITLE
Update reverse_proxy.rst

### DIFF
--- a/changelog.d/5397.doc
+++ b/changelog.d/5397.doc
@@ -1,0 +1,1 @@
+Add information about nginx normalisation to reverse_proxy.rst. Contributed by @skalarproduktraum - thanks!

--- a/changelog.d/5397.misc
+++ b/changelog.d/5397.misc
@@ -1,1 +1,0 @@
-Add information about nginx normalisation to reverse_proxy.rst.

--- a/changelog.d/5397.misc
+++ b/changelog.d/5397.misc
@@ -1,1 +1,1 @@
-Add information about nginx normalisation to reverse_proxy.rst
+Add information about nginx normalisation to reverse_proxy.rst.

--- a/changelog.d/5397.misc
+++ b/changelog.d/5397.misc
@@ -1,0 +1,1 @@
+Add information about nginx normalisation to reverse_proxy.rst

--- a/docs/reverse_proxy.rst
+++ b/docs/reverse_proxy.rst
@@ -48,6 +48,8 @@ Let's assume that we expect clients to connect to our server at
               proxy_set_header X-Forwarded-For $remote_addr;
           }
       }
+      
+  Do not add a `/` after the port in `proxy_pass`, otherwise nginx will canonicalise/normalise the URI.
 
 * Caddy::
 


### PR DESCRIPTION
Hi! This PR updates reverse_proxy.rst with information about nginx' URI normalisation. I hit a problem with my nginx config where I thought I did everything according to reverse_proxy.rst, but there was a slash too much -- that info however was only in #3294, and not in the docs.

Signed-off-by: Ulrik Guenther <hello@ulrik.is>

### Pull Request Checklist

* [X] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [X] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
