### PR TITLE
Fix bug sending federation transactions with lots of EDUs

### DIFF
--- a/changelog.d/5418.bugfix
+++ b/changelog.d/5418.bugfix
@@ -1,1 +1,1 @@
-Fix bug where attemptint to send transactions with large number of EDUs can fail.
+Fix bug where attempting to send transactions with large number of EDUs can fail.

--- a/changelog.d/5418.bugfix
+++ b/changelog.d/5418.bugfix
@@ -1,0 +1,1 @@
+Fix bug where attemptint to send transactions with large number of EDUs can fail.

--- a/synapse/storage/deviceinbox.py
+++ b/synapse/storage/deviceinbox.py
@@ -138,6 +138,10 @@ class DeviceInboxWorkerStore(SQLBaseStore):
         if not has_changed or last_stream_id == current_stream_id:
             return defer.succeed(([], current_stream_id))
 
+        if limit <= 0:
+            # This can happen if we run out of room for EDUs in the transaction.
+            return defer.succeed(([], last_stream_id))
+
         def get_new_messages_for_remote_destination_txn(txn):
             sql = (
                 "SELECT stream_id, messages_json FROM device_federation_outbox"


### PR DESCRIPTION
If we try and send a transaction with lots of EDUs and we run out of
space, we call get_new_device_msgs_for_remote with a limit of 0, which
then failed.