### PR TITLE
Move SyTest to Buildkite

### DIFF
--- a/.buildkite/format_tap.py
+++ b/.buildkite/format_tap.py
@@ -10,17 +10,23 @@ in_error = False
 
 for line in p.parse_file(sys.argv[1]):
     if isinstance(line, Result):
+        if in_error:
+            out.append("</pre></code></details>")
+            out.append("")
+            out.append("----")
+            out.append("")
         in_error = False
 
         if not line.ok and not line.todo:
             in_error = True
 
-            out.append("- FAILURE Test #%d: %s" % (line.number, line.description))
+            out.append("FAILURE Test #%d: ``%s``" % (line.number, line.description))
             out.append("")
+            out.append("<details><summary>Show log</summary><code><pre>")
 
     elif isinstance(line, Diagnostic) and in_error:
-        out.append((" " * 7) + line.text)
+        out.append(line.text)
 
-
-for line in out:
-    print(line)
+if out:
+    for line in out[:-3]:
+        print(line)

--- a/.buildkite/format_tap.py
+++ b/.buildkite/format_tap.py
@@ -1,0 +1,26 @@
+import sys
+from tap.parser import Parser
+from tap.line import Result, Unknown, Diagnostic
+
+out = []
+
+p = Parser()
+
+in_error = False
+
+for line in p.parse_file(sys.argv[1]):
+    if isinstance(line, Result):
+        in_error = False
+
+        if not line.ok and not line.todo:
+            in_error = True
+
+            out.append("- FAILURE Test #%d: %s" % (line.number, line.description))
+            out.append("")
+
+    elif isinstance(line, Diagnostic) and in_error:
+        out.append((" " * 7) + line.text)
+
+
+for line in out:
+    print(line)

--- a/.buildkite/format_tap.py
+++ b/.buildkite/format_tap.py
@@ -2,7 +2,7 @@ import sys
 from tap.parser import Parser
 from tap.line import Result, Unknown, Diagnostic
 
-out = []
+out = ["### TAP Output for " + sys.argv[2]]
 
 p = Parser()
 
@@ -11,6 +11,7 @@ in_error = False
 for line in p.parse_file(sys.argv[1]):
     if isinstance(line, Result):
         if in_error:
+            out.append("")
             out.append("</pre></code></details>")
             out.append("")
             out.append("----")

--- a/.buildkite/merge_base_branch.sh
+++ b/.buildkite/merge_base_branch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 if [[ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"]]
 then

--- a/.buildkite/merge_base_branch.sh
+++ b/.buildkite/merge_base_branch.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+if [[ "$BUILDKITE_BRANCH" =~ ^(develop|master|dinsic|shhs|release-*)$ ]]; then
+    echo "Not merging forward, as this is a release branch"
+    exit 0
+fi
+
 if [[ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"]]
 then
     echo "Not a pull request, or hasn't had a PR opened yet..."

--- a/.buildkite/merge_base_branch.sh
+++ b/.buildkite/merge_base_branch.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-if [[ "$BUILDKITE_BRANCH" =~ ^(develop|master|dinsic|shhs|release-*)$ ]]; then
+if [[ "$BUILDKITE_BRANCH" =~ ^(develop|master|dinsic|shhs|release-.*)$ ]]; then
     echo "Not merging forward, as this is a release branch"
     exit 0
 fi

--- a/.buildkite/merge_base_branch.sh
+++ b/.buildkite/merge_base_branch.sh
@@ -2,21 +2,16 @@
 
 set -e
 
-# CircleCI doesn't give CIRCLE_PR_NUMBER in the environment for non-forked PRs. Wonderful.
-# In this case, we just need to do some ~shell magic~ to strip it out of the PULL_REQUEST URL.
-echo 'export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"' >> $BASH_ENV
-source $BASH_ENV
-
-if [[ -z "${CIRCLE_PR_NUMBER}" ]]
+if [[ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"]]
 then
-    echo "Can't figure out what the PR number is! Assuming merge target is develop."
+    echo "Not a pull request, or hasn't had a PR opened yet..."
 
     # It probably hasn't had a PR opened yet. Since all PRs land on develop, we
     # can probably assume it's based on it and will be merged into it.
     GITBASE="develop"
 else
     # Get the reference, using the GitHub API
-    GITBASE=`wget -O- https://api.github.com/repos/matrix-org/synapse/pulls/${CIRCLE_PR_NUMBER} | jq -r '.base.ref'`
+    GITBASE=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
 fi
 
 # Show what we are before

--- a/.buildkite/merge_base_branch.sh
+++ b/.buildkite/merge_base_branch.sh
@@ -7,8 +7,7 @@ if [[ "$BUILDKITE_BRANCH" =~ ^(develop|master|dinsic|shhs|release-.*)$ ]]; then
     exit 0
 fi
 
-if [[ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"]]
-then
+if [[ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]]; then
     echo "Not a pull request, or hasn't had a PR opened yet..."
 
     # It probably hasn't had a PR opened yet. Since all PRs land on develop, we

--- a/.buildkite/merge_base_branch.sh
+++ b/.buildkite/merge_base_branch.sh
@@ -7,7 +7,7 @@ if [[ "$BUILDKITE_BRANCH" =~ ^(develop|master|dinsic|shhs|release-.*)$ ]]; then
     exit 0
 fi
 
-if [[ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]]; then
+if [[ -z $BUILDKITE_PULL_REQUEST_BASE_BRANCH ]]; then
     echo "Not a pull request, or hasn't had a PR opened yet..."
 
     # It probably hasn't had a PR opened yet. Since all PRs land on develop, we

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,8 +44,6 @@ steps:
       - docker#v3.0.1:
           image: "python:3.6"
 
-  - wait
-
   - label: "SyTest - :python: 3.6 / SQLite"
     command:
       - "bash .buildkite/merge_base_branch.sh"
@@ -60,6 +58,9 @@ steps:
           limit: 2
         - exit_status: 2
           limit: 2
+
+  - wait
+
 
   - command:
       - "python -m pip install tox"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,13 +45,10 @@ steps:
           image: "python:3.6"
 
   - label: "SyTest - :python: 3.6 / SQLite"
-    command:
-      - "bash .buildkite/merge_base_branch.sh"
-      - "bash .buildkite/synapse_sytest.sh"
     plugins:
       - docker#v3.0.1:
           image: "matrixdotorg/sytest-synapsepy3"
-          entrypoint: "false"
+          entrypoint: "bash -c 'bash .buildkite/merge_base_branch.sh && bash .buildkite/synapse_sytest.sh'""
           propagate-environment: true
     retry:
       automatic:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,10 +45,13 @@ steps:
           image: "python:3.6"
 
   - label: "SyTest - :python: 3.6 / SQLite"
+    command:
+      - "bash .buildkite/merge_base_branch.sh"
+      - "bash .buildkite/synapse_sytest.sh"
     plugins:
       - docker#v3.0.1:
           image: "matrixdotorg/sytest-synapsepy3"
-          entrypoint: "bash -c 'bash .buildkite/merge_base_branch.sh && bash .buildkite/synapse_sytest.sh'"
+          entrypoint: "bash -c"
           propagate-environment: true
     retry:
       automatic:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,7 +51,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "matrixdotorg/sytest-synapsepy3"
-          entrypoint: "bash -c"
+          entrypoint: "/bin/bash -c"
           propagate-environment: true
     retry:
       automatic:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,22 @@ env:
   CODECOV_TOKEN: "2dd7eb9b-0eda-45fe-a47c-9b5ac040045f"
 
 steps:
+
+  - label: "SyTest - :python: 3.5 / SQLite"
+    command:
+      - "bash .buildkite/merge_base_branch.sh"
+      - "bash .buildkite/synapse_sytest.sh"
+    plugins:
+      - docker#v3.0.1:
+          image: "matrixdotorg/sytest-synapse:py35"
+          propagate-environment: true
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 2
+          limit: 2
+
   - command:
       - "python -m pip install tox"
       - "tox -e pep8"
@@ -43,21 +59,6 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "python:3.6"
-
-  - label: "SyTest - :python: 3.6 / SQLite"
-    command:
-      - "bash .buildkite/merge_base_branch.sh"
-      - "bash .buildkite/synapse_sytest.sh"
-    plugins:
-      - docker#v3.0.1:
-          image: "matrixdotorg/sytest"
-          propagate-environment: true
-    retry:
-      automatic:
-        - exit_status: -1
-          limit: 2
-        - exit_status: 2
-          limit: 2
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,7 +51,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "matrixdotorg/sytest-synapsepy3"
-          entrypoint: "bash -c"
+          entrypoint: "exec bash -c"
           propagate-environment: true
     retry:
       automatic:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,11 +48,12 @@ steps:
 
   - label: "SyTest - :python: 3.6 / SQLite"
     command:
-      - "bash .circleci/merge_base_branch.sh"
+      - "bash .buildkite/merge_base_branch.sh"
       - "bash /synapse_sytest.sh"
     plugins:
       - docker#v3.0.1:
           image: "matrixdotorg/sytest-synapsepy3"
+          propagate-environment: true
     retry:
       automatic:
         - exit_status: -1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,7 +48,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "matrixdotorg/sytest-synapsepy3"
-          entrypoint: "bash -c 'bash .buildkite/merge_base_branch.sh && bash .buildkite/synapse_sytest.sh'""
+          entrypoint: "bash -c 'bash .buildkite/merge_base_branch.sh && bash .buildkite/synapse_sytest.sh'"
           propagate-environment: true
     retry:
       automatic:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,8 +50,7 @@ steps:
       - "bash .buildkite/synapse_sytest.sh"
     plugins:
       - docker#v3.0.1:
-          image: "matrixdotorg/sytest-synapsepy3"
-          entrypoint: "/bin/bash -c"
+          image: "matrixdotorg/sytest"
           propagate-environment: true
     retry:
       automatic:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,6 +51,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "matrixdotorg/sytest-synapsepy3"
+          entrypoint: "false"
           propagate-environment: true
     retry:
       automatic:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,7 +51,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "matrixdotorg/sytest-synapsepy3"
-          entrypoint: "exec bash -c"
+          entrypoint: "bash -c"
           propagate-environment: true
     retry:
       automatic:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,8 @@ env:
 steps:
 
   - label: "SyTest - :python: 3.5 / SQLite"
+    agents:
+      queue: "medium"
     command:
       - "bash .buildkite/merge_base_branch.sh"
       - "bash .buildkite/synapse_sytest.sh"
@@ -17,6 +19,8 @@ steps:
           limit: 2
         - exit_status: 2
           limit: 2
+
+  - wait
 
   - command:
       - "python -m pip install tox"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,25 +3,6 @@ env:
 
 steps:
 
-  - label: "SyTest - :python: 3.5 / SQLite"
-    agents:
-      queue: "medium"
-    command:
-      - "bash .buildkite/merge_base_branch.sh"
-      - "bash .buildkite/synapse_sytest.sh"
-    plugins:
-      - docker#v3.0.1:
-          image: "matrixdotorg/sytest-synapse:py35"
-          propagate-environment: true
-    retry:
-      automatic:
-        - exit_status: -1
-          limit: 2
-        - exit_status: 2
-          limit: 2
-
-  - wait
-
   - command:
       - "python -m pip install tox"
       - "tox -e pep8"
@@ -196,6 +177,64 @@ steps:
           run: testenv
           config:
             - .buildkite/docker-compose.py37.pg11.yaml
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 2
+          limit: 2
+
+
+  - label: "SyTest - :python: 3.5 / SQLite / Monolith"
+    agents:
+      queue: "medium"
+    command:
+      - "bash .buildkite/merge_base_branch.sh"
+      - "bash .buildkite/synapse_sytest.sh"
+    plugins:
+      - docker#v3.0.1:
+          image: "matrixdotorg/sytest-synapse:py35"
+          propagate-environment: true
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 2
+          limit: 2
+
+  - label: "SyTest - :python: 3.5 / :postgres: 9.6 / Monolith"
+    agents:
+      queue: "medium"
+    env:
+      POSTGRES: "1"
+    command:
+      - "bash .buildkite/merge_base_branch.sh"
+      - "bash .buildkite/synapse_sytest.sh"
+    plugins:
+      - docker#v3.0.1:
+          image: "matrixdotorg/sytest-synapse:py35"
+          propagate-environment: true
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 2
+          limit: 2
+
+  - label: "SyTest - :python: 3.5 / :postgres: 9.6 / Workers"
+    agents:
+      queue: "medium"
+    env:
+      POSTGRES: "1"
+      WORKERS: "1"
+    command:
+      - "bash .buildkite/merge_base_branch.sh"
+      - "bash .buildkite/synapse_sytest.sh"
+    plugins:
+      - docker#v3.0.1:
+          image: "matrixdotorg/sytest-synapse:py35"
+          propagate-environment: true
+    soft_fail: true
     retry:
       automatic:
         - exit_status: -1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,6 +46,22 @@ steps:
 
   - wait
 
+  - label: "SyTest - :python: 3.6 / SQLite"
+    env:
+      TRIAL_FLAGS: "-j 4"
+    command:
+      - "bash .circleci/merge_base_branch.sh"
+      - "bash -c '/synapse_sytest.sh'"
+    plugins:
+      - docker-compose#v2.1.0:
+          image: "matrixdotorg/sytest-synapsepy3"
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 2
+          limit: 2
+
   - command:
       - "python -m pip install tox"
       - "tox -e py35-old,codecov"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,13 +47,11 @@ steps:
   - wait
 
   - label: "SyTest - :python: 3.6 / SQLite"
-    env:
-      TRIAL_FLAGS: "-j 4"
     command:
       - "bash .circleci/merge_base_branch.sh"
-      - "bash -c '/synapse_sytest.sh'"
+      - "bash /synapse_sytest.sh"
     plugins:
-      - docker-compose#v2.1.0:
+      - docker#v3.0.1:
           image: "matrixdotorg/sytest-synapsepy3"
     retry:
       automatic:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,7 +49,7 @@ steps:
   - label: "SyTest - :python: 3.6 / SQLite"
     command:
       - "bash .buildkite/merge_base_branch.sh"
-      - "bash /synapse_sytest.sh"
+      - "bash .buildkite/synapse_sytest.sh"
     plugins:
       - docker#v3.0.1:
           image: "matrixdotorg/sytest-synapsepy3"

--- a/.buildkite/synapse_sytest.sh
+++ b/.buildkite/synapse_sytest.sh
@@ -137,7 +137,7 @@ then
 
     if [ $TEST_STATUS -ne 0 ]; then
         # Annotate, if failure
-        cat /logs/results.tap | tap-markdown | ./buildkite-agent annotate --style="error" --context="$BUILDKITE_LABEL"
+        cat /logs/results.tap | tap-markdown --no-tidy | ./buildkite-agent annotate --style="error" --context="$BUILDKITE_LABEL"
     fi
 fi
 

--- a/.buildkite/synapse_sytest.sh
+++ b/.buildkite/synapse_sytest.sh
@@ -5,16 +5,9 @@
 
 set -ex
 
-echo `pwd`
-echo $BUILDKITE
-
 if [ -n "$BUILDKITE" ]
 then
-    mkdir -p /src
-    /venv/bin/python setup.py sdist
-    cp dist/*.tar.gz /src
-    cd /src
-    tar xvf --strip-components=1 *.tar.gz
+    SYNAPSE_DIR=`pwd`
 else
     SYNAPSE_DIR="/src"
 fi

--- a/.buildkite/synapse_sytest.sh
+++ b/.buildkite/synapse_sytest.sh
@@ -6,6 +6,7 @@
 set -ex
 
 echo `pwd`
+echo $BUILDKITE
 
 if [ -n "$BUILDKITE" ]
 then

--- a/.buildkite/synapse_sytest.sh
+++ b/.buildkite/synapse_sytest.sh
@@ -137,7 +137,7 @@ then
 
     if [ $TEST_STATUS -ne 0 ]; then
         # Annotate, if failure
-        /venv/bin/python $SYNAPSE_DIR/.buildkite/format_tap.py /logs/results.tap | ./buildkite-agent annotate --style="error" --context="$BUILDKITE_LABEL"
+        /venv/bin/python $SYNAPSE_DIR/.buildkite/format_tap.py /logs/results.tap "$BUILDKITE_LABEL" | ./buildkite-agent annotate --style="error" --context="$BUILDKITE_LABEL"
     fi
 fi
 

--- a/.buildkite/synapse_sytest.sh
+++ b/.buildkite/synapse_sytest.sh
@@ -132,7 +132,8 @@ then
     chmod +x ./buildkite-agent
 
     # Upload the files
-    ./buildkite-agent artifact upload "/logs/**/*.log*" "/logs/results.tap"
+    ./buildkite-agent artifact upload "/logs/**/*.log*"
+    ./buildkite-agent artifact upload "/logs/results.tap"
 
     if [ $TEST_STATUS -ne 0 ]; then
         # Annotate, if failure

--- a/.buildkite/synapse_sytest.sh
+++ b/.buildkite/synapse_sytest.sh
@@ -82,7 +82,7 @@ else
     # deps.
     /venv/bin/pip install -q --upgrade --no-cache-dir -e $SYNAPSE_DIR
     /venv/bin/pip install -q --upgrade --no-cache-dir \
-        lxml psycopg2 coverage codecov
+        lxml psycopg2 coverage codecov tap.py
 
     # Make sure all Perl deps are installed -- this is done in the docker build
     # so will only install packages added since the last Docker build
@@ -137,7 +137,7 @@ then
 
     if [ $TEST_STATUS -ne 0 ]; then
         # Annotate, if failure
-        cat /logs/results.tap | tap-markdown --no-tidy | ./buildkite-agent annotate --style="error" --context="$BUILDKITE_LABEL"
+        /venv/bin/python $SYNAPSE_DIR/.buildkite/format_tap.py /logs/results.tap | ./buildkite-agent annotate --style="error" --context="$BUILDKITE_LABEL"
     fi
 fi
 

--- a/.buildkite/synapse_sytest.sh
+++ b/.buildkite/synapse_sytest.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# Fetch sytest, and then run the tests for synapse. The entrypoint for the
+# sytest-synapse docker images.
+
+set -ex
+
+if [-n "$BUILDKITE"]
+then
+    SYNAPSE_DIR=`pwd`
+else
+    SYNAPSE_DIR="/src"
+fi
+
+# Attempt to find a sytest to use.
+# If /sytest exists, it means that a SyTest checkout has been mounted into the Docker image.
+if [ -d "/sytest" ]; then
+    # If the user has mounted in a SyTest checkout, use that.
+    echo "Using local sytests..."
+
+    # create ourselves a working directory and dos2unix some scripts therein
+    mkdir -p /work/jenkins
+    for i in install-deps.pl run-tests.pl tap-to-junit-xml.pl jenkins/prep_sytest_for_postgres.sh; do
+        dos2unix -n "/sytest/$i" "/work/$i"
+    done
+    ln -sf /sytest/tests /work
+    ln -sf /sytest/keys /work
+    SYTEST_LIB="/sytest/lib"
+else
+    # Otherwise, try and find out what the branch that the Synapse checkout is using. Fall back to develop if it's not a branch.
+    branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
+
+    # Try and fetch the branch
+    echo "Trying to get same-named sytest branch..."
+    wget -q https://github.com/matrix-org/sytest/archive/$branch_name.tar.gz -O sytest.tar.gz || {
+        # Probably a 404, fall back to develop
+        echo "Using develop instead..."
+        wget -q https://github.com/matrix-org/sytest/archive/develop.tar.gz -O sytest.tar.gz
+    }
+
+    mkdir -p /work
+    tar -C /work --strip-components=1 -xf sytest.tar.gz
+    SYTEST_LIB="/work/lib"
+fi
+
+cd /work
+
+# PostgreSQL setup
+if [ -n "$POSTGRES" ]
+then
+    export PGUSER=postgres
+    export POSTGRES_DB_1=pg1
+    export POSTGRES_DB_2=pg2
+
+    # Start the database
+    su -c 'eatmydata /usr/lib/postgresql/9.6/bin/pg_ctl -w -D /var/lib/postgresql/data start' postgres
+
+    # Use the Jenkins script to write out the configuration for a PostgreSQL using Synapse
+    jenkins/prep_sytest_for_postgres.sh
+
+    # Make the test databases for the two Synapse servers that will be spun up
+    su -c 'psql -c "CREATE DATABASE pg1;"' postgres
+    su -c 'psql -c "CREATE DATABASE pg2;"' postgres
+
+fi
+
+if [ -n "$OFFLINE" ]; then
+    # if we're in offline mode, just put synapse into the virtualenv, and
+    # hope that the deps are up-to-date.
+    #
+    # (`pip install -e` likes to reinstall setuptools even if it's already installed,
+    # so we just run setup.py explicitly.)
+    #
+    (cd $SYNAPSE_DIR && /venv/bin/python setup.py -q develop)
+else
+    # We've already created the virtualenv, but lets double check we have all
+    # deps.
+    /venv/bin/pip install -q --upgrade --no-cache-dir -e $SYNAPSE_DIR
+    /venv/bin/pip install -q --upgrade --no-cache-dir \
+        lxml psycopg2 coverage codecov
+
+    # Make sure all Perl deps are installed -- this is done in the docker build
+    # so will only install packages added since the last Docker build
+    ./install-deps.pl
+fi
+
+
+# Run the tests
+>&2 echo "+++ Running tests"
+
+RUN_TESTS=(
+    perl -I "$SYTEST_LIB" ./run-tests.pl --python=/venv/bin/python --synapse-directory=$SYNAPSE_DIR --coverage -O tap --all
+)
+
+TEST_STATUS=0
+
+if [ -n "$WORKERS" ]; then
+    RUN_TESTS+=(-I Synapse::ViaHaproxy --dendron-binary=/pydron.py)
+else
+    RUN_TESTS+=(-I Synapse)
+fi
+
+"${RUN_TESTS[@]}" "$@" > results.tap || TEST_STATUS=$?
+
+if [ $TEST_STATUS -ne 0 ]; then
+    >&2 echo -e "run-tests \e[31mFAILED\e[0m: exit code $TEST_STATUS"
+else
+    >&2 echo -e "run-tests \e[32mPASSED\e[0m"
+fi
+
+>&2 echo "--- Copying assets"
+
+# Copy out the logs
+mkdir -p /logs
+cp results.tap /logs/results.tap
+rsync --ignore-missing-args -av server-0 server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
+
+# Write out JUnit
+mkdir -p /logs/sytest
+perl ./tap-to-junit-xml.pl --puretap --input=/logs/results.tap --output=/logs/sytest/results.xml "SyTest"
+
+# Upload coverage to codecov and upload files, if running on Buildkite
+if [ -n "$BUILDKITE" ]
+then
+    /venv/bin/coverage combine || true
+    /venv/bin/coverage xml || true
+    /venv/bin/codecov -X gcov -f coverage.xml
+
+    wget -O buildkite.tar.gz https://github.com/buildkite/agent/releases/download/v3.13.0/buildkite-agent-linux-amd64-3.13.0.tar.gz
+    tar xvf buildkite.tar.gz
+    chmod +x ./buildkite-agent
+    ./buildkite-agent upload "/logs/**/*"
+fi
+
+
+exit $TEST_STATUS

--- a/.buildkite/synapse_sytest.sh
+++ b/.buildkite/synapse_sytest.sh
@@ -5,9 +5,15 @@
 
 set -ex
 
-if [-n "$BUILDKITE"]
+echo `pwd`
+
+if [ -n "$BUILDKITE" ]
 then
-    SYNAPSE_DIR=`pwd`
+    mkdir -p /src
+    /venv/bin/python setup.py sdist
+    cp dist/*.tar.gz /src
+    cd /src
+    tar xvf --strip-components=1 *.tar.gz
 else
     SYNAPSE_DIR="/src"
 fi
@@ -27,8 +33,13 @@ if [ -d "/sytest" ]; then
     ln -sf /sytest/keys /work
     SYTEST_LIB="/sytest/lib"
 else
-    # Otherwise, try and find out what the branch that the Synapse checkout is using. Fall back to develop if it's not a branch.
-    branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
+    if [ -n "BUILDKITE_BRANCH" ]
+    then
+        branch_name=$BUILDKITE_BRANCH
+    else
+        # Otherwise, try and find out what the branch that the Synapse checkout is using. Fall back to develop if it's not a branch.
+        branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
+    fi
 
     # Try and fetch the branch
     echo "Trying to get same-named sytest branch..."

--- a/.buildkite/synapse_sytest.sh
+++ b/.buildkite/synapse_sytest.sh
@@ -134,7 +134,7 @@ then
     wget -O buildkite.tar.gz https://github.com/buildkite/agent/releases/download/v3.13.0/buildkite-agent-linux-amd64-3.13.0.tar.gz
     tar xvf buildkite.tar.gz
     chmod +x ./buildkite-agent
-    ./buildkite-agent upload "/logs/**/*"
+    ./buildkite-agent artifact upload "/logs/**/*"
 fi
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,77 +17,10 @@ jobs:
       - run: docker push matrixdotorg/synapse:latest
       - run: docker push matrixdotorg/synapse:latest-py3
 
-  sytestpy3:
-    docker:
-      - image: matrixdotorg/sytest-synapsepy3
-    working_directory: /src
-    steps:
-      - checkout
-      - run: /synapse_sytest.sh
-      - store_artifacts:
-          path: /logs
-          destination: logs
-      - store_test_results:
-          path: /logs
-  sytestpy3postgres:
-    docker:
-      - image: matrixdotorg/sytest-synapsepy3
-    working_directory: /src
-    steps:
-      - checkout
-      - run: POSTGRES=1 /synapse_sytest.sh
-      - store_artifacts:
-          path: /logs
-          destination: logs
-      - store_test_results:
-          path: /logs
-  sytestpy3merged:
-    docker:
-      - image: matrixdotorg/sytest-synapsepy3
-    working_directory: /src
-    steps:
-      - checkout
-      - run: bash .circleci/merge_base_branch.sh
-      - run: /synapse_sytest.sh
-      - store_artifacts:
-          path: /logs
-          destination: logs
-      - store_test_results:
-          path: /logs
-  sytestpy3postgresmerged:
-    docker:
-      - image: matrixdotorg/sytest-synapsepy3
-    working_directory: /src
-    steps:
-      - checkout
-      - run: bash .circleci/merge_base_branch.sh
-      - run: POSTGRES=1 /synapse_sytest.sh
-      - store_artifacts:
-          path: /logs
-          destination: logs
-      - store_test_results:
-          path: /logs
-
 workflows:
   version: 2
   build:
     jobs:
-      - sytestpy3:
-          filters:
-            branches:
-              only: /develop|master|release-.*/
-      - sytestpy3postgres:
-          filters:
-            branches:
-              only: /develop|master|release-.*/
-      - sytestpy3merged:
-          filters:
-            branches:
-              ignore: /develop|master|release-.*/
-      - sytestpy3postgresmerged:
-          filters:
-            branches:
-              ignore: /develop|master|release-.*/
       - dockerhubuploadrelease:
           filters:
             tags:

--- a/changelog.d/5459.misc
+++ b/changelog.d/5459.misc
@@ -1,0 +1,1 @@
+SyTest has been moved to Buildkite.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/3930

This copies in `.buildkite/synapse_sytest.sh` as to not break sytests on 1.0 which will still be on CircleCI.