### PR TITLE
Add third party rules hook for 3PID invites

### DIFF
--- a/changelog.d/5477.feature
+++ b/changelog.d/5477.feature
@@ -1,0 +1,1 @@
+Allow server admins to define implementations of extra rules for allowing or denying incoming events.

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -85,6 +85,7 @@ class ThirdPartyEventRules(object):
             requester, config, is_requester_admin
         )
 
+    @defer.inlineCallbacks
     def check_threepid_can_be_invited(self, medium, address, room_id):
         """Check if a provided 3PID can be invited in the given room.
 

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -72,6 +72,7 @@ class RoomMemberHandler(object):
 
         self.clock = hs.get_clock()
         self.spam_checker = hs.get_spam_checker()
+        self.third_party_event_rules = hs.get_third_party_event_rules()
         self._server_notices_mxid = self.config.server_notices_mxid
         self._enable_lookup = hs.config.enable_3pid_lookup
         self.allow_per_room_profiles = self.config.allow_per_room_profiles
@@ -722,6 +723,15 @@ class RoomMemberHandler(object):
         # We need to rate limit *before* we send out any 3PID invites, so we
         # can't just rely on the standard ratelimiting of events.
         yield self.base_handler.ratelimit(requester)
+
+        can_invite = yield self.third_party_event_rules.check_threepid_can_be_invited(
+            medium, address, room_id,
+        )
+        if not can_invite:
+            raise SynapseError(
+                403, "This third-party identifier can not be invited in this room",
+                Codes.FORBIDDEN,
+            )
 
         invitee = yield self._lookup_3pid(
             id_server, medium, address


### PR DESCRIPTION
Allow the 3rd party rules module to deny a 3PID invite based on the 3PID.
Also gives an HTTP client to the rules module.