### PR TITLE
Fix typo in deactivation background job

### DIFF
--- a/changelog.d/5493.misc
+++ b/changelog.d/5493.misc
@@ -1,0 +1,1 @@
+Track deactivated accounts in the database.

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -662,7 +662,7 @@ class RegistrationStore(
 
             for user in rows:
                 if not user["count_tokens"] and not user["count_threepids"]:
-                    self.set_user_deactivated_status_txn(txn, user["user_id"], True)
+                    self.set_user_deactivated_status_txn(txn, user["name"], True)
                     rows_processed_nb += 1
 
             logger.info("Marked %d rows as deactivated", rows_processed_nb)


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/matrix-org/synapse/pull/5378