### PR TITLE
Fix "Unexpected entry in 'full_schemas'" log warning

### DIFF
--- a/changelog.d/5509.misc
+++ b/changelog.d/5509.misc
@@ -1,0 +1,1 @@
+Fix "Unexpected entry in 'full_schemas'" log warning.

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -133,7 +133,7 @@ def _setup_new_database(cur, database_engine):
             if ver <= SCHEMA_VERSION:
                 valid_dirs.append((ver, abs_path))
         else:
-            logger.warn("Unexpected entry in 'full_schemas': %s", filename)
+            logger.debug("Ignoring entry '%s' in 'full_schemas'", filename)
 
     if not valid_dirs:
         raise PrepareDatabaseException(


### PR DESCRIPTION
There is a README.txt which always sets off this warning, which is a bit
alarming when you first start synapse. I don't think we need to warn about
this.