### PR TITLE
Fix /messages on worker when no token supplied

### DIFF
--- a/changelog.d/5513.feature
+++ b/changelog.d/5513.feature
@@ -1,0 +1,1 @@
+Add support for handling pagination APIs on client reader worker.

--- a/synapse/app/client_reader.py
+++ b/synapse/app/client_reader.py
@@ -37,6 +37,7 @@ from synapse.replication.slave.storage.deviceinbox import SlavedDeviceInboxStore
 from synapse.replication.slave.storage.devices import SlavedDeviceStore
 from synapse.replication.slave.storage.directory import DirectoryStore
 from synapse.replication.slave.storage.events import SlavedEventStore
+from synapse.replication.slave.storage.groups import SlavedGroupServerStore
 from synapse.replication.slave.storage.keys import SlavedKeyStore
 from synapse.replication.slave.storage.profile import SlavedProfileStore
 from synapse.replication.slave.storage.push_rule import SlavedPushRuleStore
@@ -75,6 +76,7 @@ class ClientReaderSlavedStore(
     SlavedDeviceStore,
     SlavedReceiptsStore,
     SlavedPushRuleStore,
+    SlavedGroupServerStore,
     SlavedAccountDataStore,
     SlavedEventStore,
     SlavedKeyStore,


### PR DESCRIPTION
Introduced in #5505.

Fixes error:

```
EXCEPTION(most recent call first)
AttributeError: 'ClientReaderSlavedStore' object has no attribute 'get_group_stream_token'
  File "/home/synapse/src/synapse/http/server.py", line 81, in wrapped_request_handler
  File "/home/synapse/src/synapse/http/server.py", line 314, in _async_render
  File "/home/synapse/src/synapse/rest/client/v1/room.py", line 487, in on_GET
  File "/home/synapse/src/synapse/handlers/pagination.py", line 184, in get_messages
  File "/home/synapse/env-py37/lib/python3.7/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
  File "/home/synapse/src/synapse/streams/events.py", line 66, in get_current_token_for_room
```