### PR TITLE
Allow configuration of the path used for ACME account keys.

### DIFF
--- a/changelog.d/5516.feature
+++ b/changelog.d/5516.feature
@@ -1,0 +1,1 @@
+Allow configuration of the path used for ACME account keys.

--- a/changelog.d/5521.feature
+++ b/changelog.d/5521.feature
@@ -1,0 +1,1 @@
+Allow configuration of the path used for ACME account keys.

--- a/changelog.d/5521.misc
+++ b/changelog.d/5521.misc
@@ -1,1 +1,0 @@
-Factor acme bits out to a separate file.

--- a/changelog.d/5522.feature
+++ b/changelog.d/5522.feature
@@ -1,0 +1,1 @@
+Allow configuration of the path used for ACME account keys.

--- a/changelog.d/5522.misc
+++ b/changelog.d/5522.misc
@@ -1,1 +1,0 @@
-Pass config_dir_path and data_dir_path into Config.read_config.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -402,6 +402,13 @@ acme:
     #
     #domain: matrix.example.com
 
+    # file to use for the account key. This will be generated if it doesn't
+    # exist.
+    #
+    # If unspecified, we will use CONFDIR/client.key.
+    #
+    account_key_file: DATADIR/acme_account.key
+
 # List of allowed TLS fingerprints for this server to publish along
 # with the signing keys for this server. Other matrix servers that
 # make HTTPS requests to this server will check that the TLS

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -414,9 +414,6 @@ class Config(object):
 
         Returns: dict
         """
-        # FIXME: get rid of this
-        self.config_dir_path = config_dir_path
-
         # first we read the config files into a dict
         specified_config = {}
         for config_file in config_files:

--- a/synapse/handlers/acme.py
+++ b/synapse/handlers/acme.py
@@ -47,7 +47,7 @@ class AcmeHandler(object):
         self._issuer = acme_issuing_service.create_issuing_service(
             self.reactor,
             acme_url=self.hs.config.acme_url,
-            pem_path=self.hs.config.config_dir_path,
+            account_key_file=self.hs.config.acme_account_key_file,
             well_known_resource=well_known,
         )
 


### PR DESCRIPTION
Because sticking it in the same place as the config isn't necessarily the
right thing to do.

based on #5521 and #5522.