### PR TITLE
Add SYNAPSE_PUBLIC_BASEURL as a docker option

### DIFF
--- a/changelog.d/5519.bugfix
+++ b/changelog.d/5519.bugfix
@@ -1,0 +1,1 @@
+Add `SYNAPSE_PUBLIC_BASEURL` as a environment variable for the docker container as a temporary fix to allow docker containers with `SYNAPSE_SMTP_*` to start. If `SYNAPSE_SMTP_*` is set, please ensure `SYNPASE_PUBLIC_BASEURL` is set as well.

--- a/docker/README.md
+++ b/docker/README.md
@@ -118,7 +118,8 @@ when ``SYNAPSE_CONFIG_PATH`` is not set.
 * ``SYNAPSE_TURN_SECRET``, set this to the TURN shared secret if required.
 * ``SYNAPSE_MAX_UPLOAD_SIZE``, set this variable to change the max upload size
   [default `10M`].
-* ``SYNAPSE_ACME``: set this to enable the ACME certificate renewal support.
+* ``SYNAPSE_ACME``, set this to enable the ACME certificate renewal support.
+* ``SYNAPSE_PUBLIC_BASEURL``, set this to configure the base URL when sending out email notifications (must be set to allow local password resets).
 
 Shared secrets, that will be initialized to random values if not set:
 

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -22,6 +22,9 @@ pid_file: /homeserver.pid
 web_client: False
 soft_file_limit: 0
 log_config: "/compiled/log.config"
+{% if SYNAPSE_PUBLIC_BASEURL %}
+public_baseurl: "{{ SYNAPSE_PUBLIC_BASEURL }}"
+{% endif %}
 
 ## Ports ##
 


### PR DESCRIPTION
Helps address https://github.com/matrix-org/synapse/issues/5430 as a quick, hacky fix.