### PR TITLE
Add info about black to code_style.rst

### DIFF
--- a/changelog.d/5537.misc
+++ b/changelog.d/5537.misc
@@ -1,0 +1,1 @@
+Add information about how to install and run `black` on the codebase to code_style.rst.

--- a/docs/code_style.rst
+++ b/docs/code_style.rst
@@ -1,5 +1,62 @@
-- Everything should comply with PEP8. Code should pass
-  ``pep8 --max-line-length=100`` without any warnings.
+# Code Style
+
+The Synapse codebase uses a number of code formatting tools in order to
+quickly and automatically check for formatting (and sometimes logical) errors
+in code.
+
+The necessary tools are detailed below.
+
+## Formatting tools
+
+The Synapse codebase uses [black](https://pypi.org/project/black/) as an
+opinionated code formatter, ensuring all comitted code is properly
+formatted.
+
+First install ``black`` with::
+
+  pip install --upgrade black
+
+Have ``black`` auto-format your code (it shouldn't change any
+functionality) with::
+
+  black --check . --exclude="\.tox|build|env"
+
+- **flake8**
+
+  ``flake8`` is a code checking tool. We require code to pass ``flake8`` before being merged into the codebase.
+
+  Install ``flake8`` with::
+
+    pip install --upgrade flake8
+
+  Check all application and test code with::
+
+    flake 8 synapse tests
+
+- **isort**
+
+  ``isort`` ensures imports are nicely formatted, and can suggest and
+  auto-fix issues such as double-importing.
+
+  Install ``isort`` with::
+
+    pip install --upgrade isort
+
+  Auto-fix imports with::
+
+    isort -rc synapse tests
+
+  ``-rc`` means to recursively search the given directories.
+
+It's worth noting that modern IDEs and text editors can run these tools
+automatically on save. It may be worth looking into whether this
+functionality is supported in your editor for a more convenient development
+workflow. It is not, however, recommended to run ``flake8`` on save as it
+takes a while and is very resource intensive.
+
+## General rules
+
+These rules are useful to keep in mind while programming, but be aware that the above tools will handle most of this for you
 
 - **Indenting**:
 
@@ -32,9 +89,7 @@
 
 - **Line length**:
 
-  Max line length is 79 chars (with flexibility to overflow by a "few chars" if
-  the overflowing content is not semantically significant and avoids an
-  explosion of vertical whitespace).
+  Max line length is 90 chars.
 
   Use parentheses instead of ``\`` for line continuation where ever possible
   (which is pretty much everywhere).
@@ -76,7 +131,7 @@
 
 - **Imports**:
 
-  - Prefer to import classes and functions than packages or modules.
+  - Prefer to import classes and functions rather than packages or modules.
 
     Example::
 
@@ -117,23 +172,3 @@
 
   - Avoid wildcard imports (``from synapse.types import *``) and relative
     imports (``from .types import UserID``).
-
-- **Running ``black`` on your code
-
-  The Synapse codebase uses [black](https://pypi.org/project/black/) as an
-  opinionated code formatter, ensuring all comitted code is properly
-  formatted.
-
-  First install ``black`` with::
-
-    pip install --upgrade black
-
-  Have ``black`` auto-format your code (it shouldn't change any
-  functionality) with::
-
-    black --check . --exclude="\.tox|build|env"
-
-  It's worth noting that modern IDEs and text editors can run ``black``
-  automatically on save. It may be worth looking into whether this
-  functionality is supported in your editor for a more convenient development
-  workflow.

--- a/docs/code_style.rst
+++ b/docs/code_style.rst
@@ -56,8 +56,6 @@ takes a while and is very resource intensive.
 
 ## General rules
 
-These rules are useful to keep in mind while programming, but be aware that the above tools will handle most of this for you
-
 - **Naming**:
 
   - Use camel case for class and type names

--- a/docs/code_style.rst
+++ b/docs/code_style.rst
@@ -19,7 +19,7 @@ First install ``black`` with::
 Have ``black`` auto-format your code (it shouldn't change any
 functionality) with::
 
-  black --check . --exclude="\.tox|build|env"
+  black . --exclude="\.tox|build|env"
 
 - **flake8**
 
@@ -31,7 +31,7 @@ functionality) with::
 
   Check all application and test code with::
 
-    flake 8 synapse tests
+    flake8 synapse tests
 
 - **isort**
 
@@ -58,68 +58,12 @@ takes a while and is very resource intensive.
 
 These rules are useful to keep in mind while programming, but be aware that the above tools will handle most of this for you
 
-- **Indenting**:
-
-  - NEVER tabs. 4 spaces to indent.
-
-  - follow PEP8; either hanging indent or multiline-visual indent depending
-    on the size and shape of the arguments and what makes more sense to the
-    author. In other words, both this::
-
-      print("I am a fish %s" % "moo")
-
-    and this::
-
-      print("I am a fish %s" %
-            "moo")
-
-    and this::
-
-        print(
-            "I am a fish %s" %
-            "moo",
-        )
-
-    ...are valid, although given each one takes up 2x more vertical space than
-    the previous, it's up to the author's discretion as to which layout makes
-    most sense for their function invocation.  (e.g. if they want to add
-    comments per-argument, or put expressions in the arguments, or group
-    related arguments together, or want to deliberately extend or preserve
-    vertical/horizontal space)
-
-- **Line length**:
-
-  Max line length is 90 chars.
-
-  Use parentheses instead of ``\`` for line continuation where ever possible
-  (which is pretty much everywhere).
-
 - **Naming**:
 
   - Use camel case for class and type names
   - Use underscores for functions and variables.
 
 - Use double quotes ``"foo"`` rather than single quotes ``'foo'``.
-
-- **Blank lines**:
-
-  - There should be max a single new line between:
-
-    - statements
-    - functions in a class
-
-  - There should be two new lines between:
-
-    - definitions in a module (e.g., between different classes)
-
-- **Whitespace**:
-
-  There should be spaces where spaces should be and not where there shouldn't
-  be:
-
-  - a single space after a comma
-  - a single space before and after for '=' when used as assignment
-  - no spaces before and after for '=' for default values and keyword arguments.
 
 - **Comments**: should follow the `google code style
   <http://google.github.io/styleguide/pyguide.html?showone=Comments#Comments>`_.

--- a/docs/code_style.rst
+++ b/docs/code_style.rst
@@ -117,3 +117,23 @@
 
   - Avoid wildcard imports (``from synapse.types import *``) and relative
     imports (``from .types import UserID``).
+
+- **Running ``black`` on your code
+
+  The Synapse codebase uses [black](https://pypi.org/project/black/) as an
+  opinionated code formatter, ensuring all comitted code is properly
+  formatted.
+
+  First install ``black`` with::
+
+    pip install --upgrade black
+
+  Have ``black`` auto-format your code (it shouldn't change any
+  functionality) with::
+
+    black --check . --exclude="\.tox|build|env"
+
+  It's worth noting that modern IDEs and text editors can run ``black``
+  automatically on save. It may be worth looking into whether this
+  functionality is supported in your editor for a more convenient development
+  workflow.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/5533

Adds information about how to install and run `black` on the codebase.