### PR TITLE
Make it clearer that the template dir is relative to synapse's root dir

### DIFF
--- a/changelog.d/5543.misc
+++ b/changelog.d/5543.misc
@@ -1,0 +1,1 @@
+Make the config clearer in that email.template_dir was relative to the project's root directory, not the `synapse/` folder.

--- a/changelog.d/5543.misc
+++ b/changelog.d/5543.misc
@@ -1,1 +1,1 @@
-Make the config clearer in that email.template_dir was relative to the project's root directory, not the `synapse/` folder.
+Make the config clearer in that email.template_dir is relative to the Synapse's root directory, not the `synapse/` folder within it.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1352,4 +1352,3 @@ password_config:
 #  module: "my_custom_project.SuperRulesSet"
 #  config:
 #    example_option: 'things'
-

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1070,11 +1070,13 @@ password_config:
 #   app_name: Matrix
 #
 #   # Enable email notifications by default
+#   #
 #   notif_for_new_users: True
 #
 #   # Defining a custom URL for Riot is only needed if email notifications
 #   # should contain links to a self-hosted installation of Riot; when set
 #   # the "app_name" setting is ignored
+#   #
 #   riot_base_url: "http://localhost/riot"
 #
 #   # Enable sending password reset emails via the configured, trusted
@@ -1087,18 +1089,24 @@ password_config:
 #   #
 #   # If this option is set to false and SMTP options have not been
 #   # configured, resetting user passwords via email will be disabled
+#   #
 #   #trust_identity_server_for_password_resets: false
 #
 #   # Configure the time that a validation email or text message code
 #   # will expire after sending
 #   #
 #   # This is currently used for password resets
+#   #
 #   #validation_token_lifetime: 1h
 #
 #   # Template directory. All template files should be stored within this
 #   # directory
 #   #
-#   #template_dir: synapse/res/templates
+#   # If not set, the default location is `(location of Synapse's
+#   # virtualenv)/res/templates`. Using an absolute path is recommended
+#   # when changing this option from the default.
+#   #
+#   #template_dir: synapse-env/res/templates
 #
 #   # Templates for email notifications
 #   #
@@ -1120,7 +1128,6 @@ password_config:
 #   #
 #   #password_reset_template_success_html: password_reset_success.html
 #   #password_reset_template_failure_html: password_reset_failure.html
-
 
 #password_providers:
 #    - module: "ldap_auth_provider.LdapAuthProvider"

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1100,13 +1100,13 @@ password_config:
 #   #validation_token_lifetime: 1h
 #
 #   # Template directory. All template files should be stored within this
-#   # directory
+#   # directory. If not set, default templates from within the Synapse
+#   # package will be used
 #   #
-#   # If not set, the default location is `(location of Synapse's
-#   # virtualenv)/res/templates`. Using an absolute path is recommended
-#   # when changing this option from the default.
+#   # For the list of default templates, please see
+#   # https://github.com/matrix-org/synapse/tree/master/synapse/res/templates
 #   #
-#   #template_dir: synapse-env/res/templates
+#   #template_dir: res/templates
 #
 #   # Templates for email notifications
 #   #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1129,6 +1129,7 @@ password_config:
 #   #password_reset_template_success_html: password_reset_success.html
 #   #password_reset_template_failure_html: password_reset_failure.html
 
+
 #password_providers:
 #    - module: "ldap_auth_provider.LdapAuthProvider"
 #      config:

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -23,29 +23,6 @@ server_name: "SERVERNAME"
 #
 pid_file: DATADIR/homeserver.pid
 
-# CPU affinity mask. Setting this restricts the CPUs on which the
-# process will be scheduled. It is represented as a bitmask, with the
-# lowest order bit corresponding to the first logical CPU and the
-# highest order bit corresponding to the last logical CPU. Not all CPUs
-# may exist on a given system but a mask may specify more CPUs than are
-# present.
-#
-# For example:
-#    0x00000001  is processor #0,
-#    0x00000003  is processors #0 and #1,
-#    0xFFFFFFFF  is all processors (#0 through #31).
-#
-# Pinning a Python process to a single CPU is desirable, because Python
-# is inherently single-threaded due to the GIL, and can suffer a
-# 30-40% slowdown due to cache blow-out and thread context switching
-# if the scheduler happens to schedule the underlying threads across
-# different cores. See
-# https://www.mirantis.com/blog/improve-performance-python-programs-restricting-single-cpu/.
-#
-# This setting requires the affinity package to be installed!
-#
-#cpu_affinity: 0xFFFFFFFF
-
 # The path to the web client which will be served at /_matrix/client/
 # if 'webclient' is configured under the 'listeners' configuration.
 #
@@ -77,11 +54,15 @@ pid_file: DATADIR/homeserver.pid
 #
 #require_auth_for_profile_requests: true
 
-# If set to 'true', requires authentication to access the server's
-# public rooms directory through the client API, and forbids any other
-# homeserver to fetch it via federation. Defaults to 'false'.
+# If set to 'false', requires authentication to access the server's public rooms
+# directory through the client API. Defaults to 'true'.
 #
-#restrict_public_rooms_to_local_users: true
+#allow_public_rooms_without_auth: false
+
+# If set to 'false', forbids any other homeserver to fetch the server's public
+# rooms directory via federation. Defaults to 'true'.
+#
+#allow_public_rooms_over_federation: false
 
 # The default room version for newly created rooms.
 #
@@ -424,6 +405,13 @@ acme:
     # If not set, defaults to your 'server_name'.
     #
     #domain: matrix.example.com
+
+    # file to use for the account key. This will be generated if it doesn't
+    # exist.
+    #
+    # If unspecified, we will use CONFDIR/client.key.
+    #
+    account_key_file: DATADIR/acme_account.key
 
 # List of allowed TLS fingerprints for this server to publish along
 # with the signing keys for this server. Other matrix servers that
@@ -1110,7 +1098,7 @@ password_config:
 #   # Template directory. All template files should be stored within this
 #   # directory
 #   #
-#   #template_dir: res/templates
+#   #template_dir: synapse/res/templates
 #
 #   # Templates for email notifications
 #   #
@@ -1351,3 +1339,17 @@ password_config:
 #    alias: "*"
 #    room_id: "*"
 #    action: allow
+
+
+# Server admins can define a Python module that implements extra rules for
+# allowing or denying incoming events. In order to work, this module needs to
+# override the methods defined in synapse/events/third_party_rules.py.
+#
+# This feature is designed to be used in closed federations only, where each
+# participating server enforces the same rules.
+#
+#third_party_event_rules:
+#  module: "my_custom_project.SuperRulesSet"
+#  config:
+#    example_option: 'things'
+

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -23,6 +23,29 @@ server_name: "SERVERNAME"
 #
 pid_file: DATADIR/homeserver.pid
 
+# CPU affinity mask. Setting this restricts the CPUs on which the
+# process will be scheduled. It is represented as a bitmask, with the
+# lowest order bit corresponding to the first logical CPU and the
+# highest order bit corresponding to the last logical CPU. Not all CPUs
+# may exist on a given system but a mask may specify more CPUs than are
+# present.
+#
+# For example:
+#    0x00000001  is processor #0,
+#    0x00000003  is processors #0 and #1,
+#    0xFFFFFFFF  is all processors (#0 through #31).
+#
+# Pinning a Python process to a single CPU is desirable, because Python
+# is inherently single-threaded due to the GIL, and can suffer a
+# 30-40% slowdown due to cache blow-out and thread context switching
+# if the scheduler happens to schedule the underlying threads across
+# different cores. See
+# https://www.mirantis.com/blog/improve-performance-python-programs-restricting-single-cpu/.
+#
+# This setting requires the affinity package to be installed!
+#
+#cpu_affinity: 0xFFFFFFFF
+
 # The path to the web client which will be served at /_matrix/client/
 # if 'webclient' is configured under the 'listeners' configuration.
 #
@@ -54,15 +77,11 @@ pid_file: DATADIR/homeserver.pid
 #
 #require_auth_for_profile_requests: true
 
-# If set to 'false', requires authentication to access the server's public rooms
-# directory through the client API. Defaults to 'true'.
+# If set to 'true', requires authentication to access the server's
+# public rooms directory through the client API, and forbids any other
+# homeserver to fetch it via federation. Defaults to 'false'.
 #
-#allow_public_rooms_without_auth: false
-
-# If set to 'false', forbids any other homeserver to fetch the server's public
-# rooms directory via federation. Defaults to 'true'.
-#
-#allow_public_rooms_over_federation: false
+#restrict_public_rooms_to_local_users: true
 
 # The default room version for newly created rooms.
 #
@@ -405,13 +424,6 @@ acme:
     # If not set, defaults to your 'server_name'.
     #
     #domain: matrix.example.com
-
-    # file to use for the account key. This will be generated if it doesn't
-    # exist.
-    #
-    # If unspecified, we will use CONFDIR/client.key.
-    #
-    account_key_file: DATADIR/acme_account.key
 
 # List of allowed TLS fingerprints for this server to publish along
 # with the signing keys for this server. Other matrix servers that
@@ -1339,16 +1351,3 @@ password_config:
 #    alias: "*"
 #    room_id: "*"
 #    action: allow
-
-
-# Server admins can define a Python module that implements extra rules for
-# allowing or denying incoming events. In order to work, this module needs to
-# override the methods defined in synapse/events/third_party_rules.py.
-#
-# This feature is designed to be used in closed federations only, where each
-# participating server enforces the same rules.
-#
-#third_party_event_rules:
-#  module: "my_custom_project.SuperRulesSet"
-#  config:
-#    example_option: 'things'

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -66,6 +66,7 @@ class EmailConfig(Config):
         # work for the same reason.)
         if not template_dir:
             template_dir = pkg_resources.resource_filename("synapse", "res/templates")
+            raise ConfigError(template_dir)
 
         self.email_template_dir = os.path.abspath(template_dir)
 
@@ -233,11 +234,13 @@ class EmailConfig(Config):
         #   app_name: Matrix
         #
         #   # Enable email notifications by default
+        #   #
         #   notif_for_new_users: True
         #
         #   # Defining a custom URL for Riot is only needed if email notifications
         #   # should contain links to a self-hosted installation of Riot; when set
         #   # the "app_name" setting is ignored
+        #   #
         #   riot_base_url: "http://localhost/riot"
         #
         #   # Enable sending password reset emails via the configured, trusted
@@ -250,18 +253,24 @@ class EmailConfig(Config):
         #   #
         #   # If this option is set to false and SMTP options have not been
         #   # configured, resetting user passwords via email will be disabled
+        #   #
         #   #trust_identity_server_for_password_resets: false
         #
         #   # Configure the time that a validation email or text message code
         #   # will expire after sending
         #   #
         #   # This is currently used for password resets
+        #   #
         #   #validation_token_lifetime: 1h
         #
         #   # Template directory. All template files should be stored within this
         #   # directory
         #   #
-        #   #template_dir: synapse/res/templates
+        #   # If not set, the default location is `(location of Synapse's
+        #   # virtualenv)/res/templates`. Using an absolute path is recommended
+        #   # when changing this option from the default.
+        #   #
+        #   #template_dir: synapse-env/res/templates
         #
         #   # Templates for email notifications
         #   #

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -66,7 +66,6 @@ class EmailConfig(Config):
         # work for the same reason.)
         if not template_dir:
             template_dir = pkg_resources.resource_filename("synapse", "res/templates")
-            raise ConfigError(template_dir)
 
         self.email_template_dir = os.path.abspath(template_dir)
 

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -261,7 +261,7 @@ class EmailConfig(Config):
         #   # Template directory. All template files should be stored within this
         #   # directory
         #   #
-        #   #template_dir: res/templates
+        #   #template_dir: synapse/res/templates
         #
         #   # Templates for email notifications
         #   #

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -263,13 +263,13 @@ class EmailConfig(Config):
         #   #validation_token_lifetime: 1h
         #
         #   # Template directory. All template files should be stored within this
-        #   # directory
+        #   # directory. If not set, default templates from within the Synapse
+        #   # package will be used
         #   #
-        #   # If not set, the default location is `(location of Synapse's
-        #   # virtualenv)/res/templates`. Using an absolute path is recommended
-        #   # when changing this option from the default.
+        #   # For the list of default templates, please see
+        #   # https://github.com/matrix-org/synapse/tree/master/synapse/res/templates
         #   #
-        #   #template_dir: synapse-env/res/templates
+        #   #template_dir: res/templates
         #
         #   # Templates for email notifications
         #   #


### PR DESCRIPTION
Simply uncommenting the line would cause Synapse not to start, as the path is relative to Synapse's root directory, where this folder was at `synapse-checkout/synapse/res/templates`.

Helps address https://github.com/matrix-org/synapse/issues/5444