### PR TITLE
Fix JWT login

### DIFF
--- a/changelog.d/5555.bugfix
+++ b/changelog.d/5555.bugfix
@@ -1,0 +1,1 @@
+Fixed m.login.jwt using unregistred user_id and added conditional dependencies for jwt.

--- a/changelog.d/5555.bugfix
+++ b/changelog.d/5555.bugfix
@@ -1,1 +1,1 @@
-Fixed m.login.jwt using unregistred user_id and added conditional dependencies for jwt.
+Fixed m.login.jwt using unregistred user_id and added pyjwt>=1.6.4 as jwt conditional dependencies. Contributed by Pau Rodriguez-Estivill.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -95,6 +95,7 @@ CONDITIONAL_REQUIREMENTS = {
     "url_preview": ["lxml>=3.5.0"],
     "test": ["mock>=2.0", "parameterized"],
     "sentry": ["sentry-sdk>=0.7.2"],
+    "jwt": ["pyjwt>=1.6.4"],
 }
 
 ALL_OPTIONAL_REQUIREMENTS = set()

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -336,7 +336,7 @@ class LoginRestServlet(RestServlet):
             }
         else:
             user_id, access_token = (
-                yield self.handlers.registration_handler.register(localpart=user)
+                yield self.registration_handler.register(localpart=user)
             )
 
             device_id = login_submission.get("device_id")


### PR DESCRIPTION
Fixed login with new user id (register) using `m.login.jwt`.
Added conditional dependency `jwt` to allow using JWT at all.

### Pull Request Checklist

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [X] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
