### PR TITLE
Docker: only run --generate-keys when generating config on-the-fly.

### DIFF
--- a/changelog.d/5561.feature
+++ b/changelog.d/5561.feature
@@ -1,0 +1,1 @@
+Update Docker image to deprecate the use of environment variables for configuration, and make the use of a static configuration the default.

--- a/changelog.d/5562.feature
+++ b/changelog.d/5562.feature
@@ -1,0 +1,1 @@
+Update Docker image to deprecate the use of environment variables for configuration, and make the use of a static configuration the default.

--- a/docker/start.py
+++ b/docker/start.py
@@ -1,11 +1,12 @@
 #!/usr/local/bin/python
 
-import jinja2
-import os
-import sys
-import subprocess
-import glob
 import codecs
+import glob
+import os
+import subprocess
+import sys
+
+import jinja2
 
 
 # Utility functions

--- a/docker/start.py
+++ b/docker/start.py
@@ -129,16 +129,15 @@ def run_generate_config(environ):
     os.execv("/usr/local/bin/python", args)
 
 
-# Prepare the configuration
-mode = sys.argv[1] if len(sys.argv) > 1 else None
-ownership = "{}:{}".format(environ.get("UID", 991), environ.get("GID", 991))
+def main(args, environ):
+    mode = args[1] if len(args) > 1 else None
+    ownership = "{}:{}".format(environ.get("UID", 991), environ.get("GID", 991))
 
-# In generate mode, generate a configuration, missing keys, then exit
-if mode == "generate":
-    run_generate_config(environ)
+    # In generate mode, generate a configuration, missing keys, then exit
+    if mode == "generate":
+        return run_generate_config(environ)
 
-# In normal mode, generate missing keys if any, then run synapse
-else:
+    # In normal mode, generate missing keys if any, then run synapse
     if "SYNAPSE_CONFIG_PATH" in environ:
         config_path = environ["SYNAPSE_CONFIG_PATH"]
     else:
@@ -158,3 +157,7 @@ else:
     # Generate missing keys and start synapse
     subprocess.check_output(args + ["--generate-keys"])
     os.execv("/sbin/su-exec", ["su-exec", ownership] + args)
+
+
+if __name__ == "__main__":
+    main(sys.argv, os.environ)

--- a/docker/start.py
+++ b/docker/start.py
@@ -67,10 +67,11 @@ def generate_config_from_template(environ, ownership):
             # generate a new secret and write it to a file
 
             if os.path.exists(filename):
+                log("Reading %s from %s" % (secret, filename))
                 with open(filename) as handle:
                     value = handle.read()
             else:
-                log("Generating a random secret for {}".format(name))
+                log("Generating a random secret for {}".format(secret))
                 value = codecs.encode(os.urandom(32), "hex").decode()
                 with open(filename, "w") as handle:
                     handle.write(value)


### PR DESCRIPTION
For context, `--generate-keys` makes synapse generate (a) a signing key and (b) a log config (no, really) if either are missing.

We don't want to generate either of these when running from a precanned config, because if they are missing, that suggests a configuration error which the admin should fix, rather than something we should attempt to recover from.

(There's a strong argument that we don't want to do this at all, since generating a new signing key on each invocation sounds disasterous, but I don't fancy unpicking that for now.)

(based on #5561)