### PR TITLE
Docker: generate our own log config

### DIFF
--- a/changelog.d/5561.feature
+++ b/changelog.d/5561.feature
@@ -1,0 +1,1 @@
+Update Docker image to deprecate the use of environment variables for configuration, and make the use of a static configuration the default.

--- a/changelog.d/5563.bugfix
+++ b/changelog.d/5563.bugfix
@@ -1,0 +1,1 @@
+Docker: Use a sensible location for data files when generating a config file.

--- a/changelog.d/5565.feature
+++ b/changelog.d/5565.feature
@@ -1,0 +1,1 @@
+Docker: Send synapse logs to the docker logging system, by default.

--- a/docker/README.md
+++ b/docker/README.md
@@ -186,6 +186,8 @@ The following environment variables are supported in this mode:
 * `SYNAPSE_REPORT_STATS` (mandatory, `yes` or `no`): whether to enable
   anonymous statistics reporting.
 * `SYNAPSE_CONFIG_PATH` (mandatory): path to the file to be generated.
+* `SYNAPSE_CONFIG_DIR`: where additional config files (such as the log config
+  and event signing key) will be stored. Defaults to `/data`.
 * `SYNAPSE_DATA_DIR`: where the generated config will put persistent data
   such as the datatase and media store. Defaults to `/data`.
 * `UID`, `GID`: the user id and group id to use for creating the data

--- a/docker/README.md
+++ b/docker/README.md
@@ -186,3 +186,7 @@ The following environment variables are supported in this mode:
 * `SYNAPSE_REPORT_STATS` (mandatory, `yes` or `no`): whether to enable
   anonymous statistics reporting.
 * `SYNAPSE_CONFIG_PATH` (mandatory): path to the file to be generated.
+* `SYNAPSE_DATA_DIR`: where the generated config will put persistent data
+  such as the datatase and media store. Defaults to `/data`.
+* `UID`, `GID`: the user id and group id to use for creating the data
+  directories. Defaults to `991`, `991`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -179,3 +179,10 @@ docker run -d --name synapse \
     -e SYNAPSE_CONFIG_PATH=/data/homeserver.yaml \
     matrixdotorg/synapse:latest
 ```
+
+The following environment variables are supported in this mode:
+
+* `SYNAPSE_SERVER_NAME` (mandatory): the server public hostname.
+* `SYNAPSE_REPORT_STATS` (mandatory, `yes` or `no`): whether to enable
+  anonymous statistics reporting.
+* `SYNAPSE_CONFIG_PATH` (mandatory): path to the file to be generated.

--- a/docker/start.py
+++ b/docker/start.py
@@ -1,11 +1,12 @@
 #!/usr/local/bin/python
 
-import jinja2
-import os
-import sys
-import subprocess
-import glob
 import codecs
+import glob
+import os
+import subprocess
+import sys
+
+import jinja2
 
 
 # Utility functions

--- a/docker/start.py
+++ b/docker/start.py
@@ -129,16 +129,15 @@ def run_generate_config(environ):
     os.execv("/usr/local/bin/python", args)
 
 
-# Prepare the configuration
-mode = sys.argv[1] if len(sys.argv) > 1 else None
-ownership = "{}:{}".format(environ.get("UID", 991), environ.get("GID", 991))
+def main(args, environ):
+    mode = args[1] if len(args) > 1 else None
+    ownership = "{}:{}".format(environ.get("UID", 991), environ.get("GID", 991))
 
-# In generate mode, generate a configuration, missing keys, then exit
-if mode == "generate":
-    run_generate_config(environ)
+    # In generate mode, generate a configuration, missing keys, then exit
+    if mode == "generate":
+        return run_generate_config(environ)
 
-# In normal mode, generate missing keys if any, then run synapse
-else:
+    # In normal mode, generate missing keys if any, then run synapse
     if "SYNAPSE_CONFIG_PATH" in environ:
         config_path = environ["SYNAPSE_CONFIG_PATH"]
     else:
@@ -158,3 +157,7 @@ else:
     # Generate missing keys and start synapse
     subprocess.check_output(args + ["--generate-keys"])
     os.execv("/sbin/su-exec", ["su-exec", ownership] + args)
+
+
+if __name__ == "__main__":
+    main(sys.argv, os.environ)

--- a/docker/start.py
+++ b/docker/start.py
@@ -116,6 +116,7 @@ def run_generate_config(environ, ownership):
         if v not in environ:
             error("Environment variable '%s' is mandatory in `generate` mode." % (v,))
 
+    config_dir = environ.get("SYNAPSE_CONFIG_DIR", "/data")
     data_dir = environ.get("SYNAPSE_DATA_DIR", "/data")
 
     # make sure that synapse has perms to write to the data dir.
@@ -131,6 +132,8 @@ def run_generate_config(environ, ownership):
         environ["SYNAPSE_REPORT_STATS"],
         "--config-path",
         environ["SYNAPSE_CONFIG_PATH"],
+        "--config-directory",
+        config_dir,
         "--data-directory",
         data_dir,
         "--generate-config",

--- a/docker/start.py
+++ b/docker/start.py
@@ -103,17 +103,23 @@ def generate_config_from_template(environ, ownership):
     return config_path
 
 
-def run_generate_config(environ):
+def run_generate_config(environ, ownership):
     """Run synapse with a --generate-config param to generate a template config file
 
     Args:
-        environ (dict): environment dictionary
+        environ (dict): env var dict
+        ownership (str): "userid:groupid" arg for chmod
 
     Never returns.
     """
     for v in ("SYNAPSE_SERVER_NAME", "SYNAPSE_REPORT_STATS", "SYNAPSE_CONFIG_PATH"):
         if v not in environ:
             error("Environment variable '%s' is mandatory in `generate` mode." % (v,))
+
+    data_dir = environ.get("SYNAPSE_DATA_DIR", "/data")
+
+    # make sure that synapse has perms to write to the data dir.
+    subprocess.check_output(["chown", ownership, data_dir])
 
     args = [
         "python",
@@ -125,8 +131,11 @@ def run_generate_config(environ):
         environ["SYNAPSE_REPORT_STATS"],
         "--config-path",
         environ["SYNAPSE_CONFIG_PATH"],
+        "--data-directory",
+        data_dir,
         "--generate-config",
     ]
+    # log("running %s" % (args, ))
     os.execv("/usr/local/bin/python", args)
 
 
@@ -134,9 +143,9 @@ def main(args, environ):
     mode = args[1] if len(args) > 1 else None
     ownership = "{}:{}".format(environ.get("UID", 991), environ.get("GID", 991))
 
-    # In generate mode, generate a configuration, missing keys, then exit
+    # In generate mode, generate a configuration and missing keys, then exit
     if mode == "generate":
-        return run_generate_config(environ)
+        return run_generate_config(environ, ownership)
 
     # In normal mode, generate missing keys if any, then run synapse
     if "SYNAPSE_CONFIG_PATH" in environ:

--- a/docker/start.py
+++ b/docker/start.py
@@ -116,8 +116,15 @@ def run_generate_config(environ, ownership):
         if v not in environ:
             error("Environment variable '%s' is mandatory in `generate` mode." % (v,))
 
+    server_name = environ["SYNAPSE_SERVER_NAME"]
     config_dir = environ.get("SYNAPSE_CONFIG_DIR", "/data")
     data_dir = environ.get("SYNAPSE_DATA_DIR", "/data")
+
+    # create a suitable log config from our template
+    log_config_file = "%s/%s.log.config" % (config_dir, server_name)
+    if not os.path.exists(log_config_file):
+        log("Creating log config %s" % (log_config_file,))
+        convert("/conf/log.config", log_config_file, environ)
 
     # make sure that synapse has perms to write to the data dir.
     subprocess.check_output(["chown", ownership, data_dir])
@@ -127,7 +134,7 @@ def run_generate_config(environ, ownership):
         "-m",
         "synapse.app.homeserver",
         "--server-name",
-        environ["SYNAPSE_SERVER_NAME"],
+        server_name,
         "--report-stats",
         environ["SYNAPSE_REPORT_STATS"],
         "--config-path",


### PR DESCRIPTION
When running under docker, we want to use docker's own logging stuff rather
than losing the logs somewhere on the container's filesystem, so let's use
log configs that spit logs out to stdout instead.

Based on #5563.