### PR TITLE
Fix new 3PID bindings being associated with rewritten IS's server names instead of the original one

### DIFF
--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -129,14 +129,19 @@ class IdentityHandler(BaseHandler):
             client_secret = creds['clientSecret']
         else:
             raise SynapseError(400, "No client_secret in creds")
+
         # if we have a rewrite rule set for the identity server,
-        # apply it now.
+        # apply it now, but only for sending the request (not
+        # storing in the database).
         if id_server in self.rewrite_identity_server_urls:
-            id_server = self.rewrite_identity_server_urls[id_server]
+            id_server_host = self.rewrite_identity_server_urls[id_server]
+        else:
+            id_server_host = id_server
+
         try:
             data = yield self.http_client.post_urlencoded_get_json(
                 "https://%s%s" % (
-                    id_server, "/_matrix/identity/api/v1/3pid/bind"
+                    id_server_host, "/_matrix/identity/api/v1/3pid/bind"
                 ),
                 {
                     'sid': creds['sid'],


### PR DESCRIPTION
This would make unbind requests fail because Synapse is using the server name it has in DB as `destination_is` to generate signature, and Sydent uses its own server name there when verifying it, so if a mismatch happens, which is the case if the name gets rewritten for routing purposes, the unbind requests fail on the signature verification.