### PR TITLE
Don't update the ratelimiter before sending a 3PID invite

### DIFF
--- a/changelog.d/5576.bugfix
+++ b/changelog.d/5576.bugfix
@@ -1,0 +1,1 @@
+Fix a bug that would cause invited users to receive several emails for a single 3PID invite in case the inviter is rate limited.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -676,7 +676,7 @@ class RoomMemberHandler(object):
 
         # We need to rate limit *before* we send out any 3PID invites, so we
         # can't just rely on the standard ratelimiting of events.
-        yield self.base_handler.ratelimit(requester)
+        yield self.base_handler.ratelimit(requester, update=False)
 
         can_invite = yield self.third_party_event_rules.check_threepid_can_be_invited(
             medium, address, room_id

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -676,7 +676,7 @@ class RoomMemberHandler(object):
 
         # We need to rate limit *before* we send out any 3PID invites, so we
         # can't just rely on the standard ratelimiting of events.
-        yield self.base_handler.ratelimit(requester, update=False)
+        yield self.base_handler.ratelimit(requester)
 
         can_invite = yield self.third_party_event_rules.check_threepid_can_be_invited(
             medium, address, room_id
@@ -823,6 +823,7 @@ class RoomMemberHandler(object):
                 "sender": user.to_string(),
                 "state_key": token,
             },
+            ratelimit=False,
             txn_id=txn_id,
         )
 


### PR DESCRIPTION
This would cause emails being sent, but Synapse responding with a 429 when creating the event. The client would then retry, and with bad timing the same scenario would happen again. Some testing I did ended up sending me 10 emails for one single invite because of this.
Broadly, we shouldn't update the ratelimiter's counter until the very last time we check it before responding.