### PR TITLE
Fix JWT login with new users

### DIFF
--- a/changelog.d/5586.bugfix
+++ b/changelog.d/5586.bugfix
@@ -1,0 +1,1 @@
+Fix JWT login with new users.

--- a/changelog.d/5586.bugfix
+++ b/changelog.d/5586.bugfix
@@ -1,1 +1,1 @@
-Fix JWT login with new users.
+Fixed m.login.jwt using unregistred user_id and added pyjwt>=1.6.4 as jwt conditional dependencies. Contributed by Pau Rodriguez-Estivill.

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -319,12 +319,12 @@ class LoginRestServlet(RestServlet):
             raise LoginError(401, "Invalid JWT", errcode=Codes.UNAUTHORIZED)
 
         user_id = UserID(user, self.hs.hostname).to_string()
+        device_id = login_submission.get("device_id")
+        initial_display_name = login_submission.get("initial_device_display_name")
 
         auth_handler = self.auth_handler
         registered_user_id = yield auth_handler.check_user_exists(user_id)
         if registered_user_id:
-            device_id = login_submission.get("device_id")
-            initial_display_name = login_submission.get("initial_device_display_name")
             device_id, access_token = yield self.registration_handler.register_device(
                 registered_user_id, device_id, initial_display_name
             )
@@ -338,11 +338,8 @@ class LoginRestServlet(RestServlet):
             user_id, access_token = (
                 yield self.registration_handler.register(localpart=user)
             )
-
-            device_id = login_submission.get("device_id")
-            initial_display_name = login_submission.get("initial_device_display_name")
             device_id, access_token = yield self.registration_handler.register_device(
-                registered_user_id, device_id, initial_display_name
+                user_id, device_id, initial_display_name
             )
 
             result = {


### PR DESCRIPTION
There are still issues after the #5555 fix.

With that fix it work every second time issuing an error about generating a new `device_id` (when not specified).
I thought it might be another error in develop branch, but now I found the issue in the same function.
Sorry I didn't saw it earlier.

I also did some code clean since some lines where dupped inside the function.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [X] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
