### PR TITLE
Implement new restrictions on power levels

### DIFF
--- a/changelog.d/5610.feature
+++ b/changelog.d/5610.feature
@@ -1,0 +1,1 @@
+Implement new custom event rules for power levels.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -92,18 +92,18 @@ class RoomAccessRules(object):
 
                 # Make sure the event has a valid content.
                 if rule is None:
-                    raise SynapseError(400, "Invalid access rule",)
+                    raise SynapseError(400, "Invalid access rule")
 
                 # Make sure the rule name is valid.
                 if rule not in VALID_ACCESS_RULES:
-                    raise SynapseError(400, "Invalid access rule", )
+                    raise SynapseError(400, "Invalid access rule")
 
                 # Make sure the rule is "direct" if the room is a direct chat.
                 if (
                     (is_direct and rule != ACCESS_RULE_DIRECT)
                     or (rule == ACCESS_RULE_DIRECT and not is_direct)
                 ):
-                    raise SynapseError(400, "Invalid access rule",)
+                    raise SynapseError(400, "Invalid access rule")
 
         # If there's no rules event in the initial state, create one with the default
         # setting.
@@ -189,29 +189,17 @@ class RoomAccessRules(object):
         Checks the event's type and the current rule and calls the right function to
         determine whether the event can be allowed.
         """
-        # Special-case the access rules event.
         if event.type == ACCESS_RULES_TYPE:
             return self._on_rules_change(event, state_events)
 
+        # We need to know the rule to apply when processing the event types below.
         rule = self._get_rule_from_state(state_events)
 
-        # Special-case the power levels event because it makes more sense to check it
-        # here.
         if event.type == EventTypes.PowerLevels:
             return self._is_power_level_content_allowed(event.content, rule)
 
-        if rule == ACCESS_RULE_RESTRICTED:
-            ret = self._apply_restricted(event)
-        elif rule == ACCESS_RULE_UNRESTRICTED:
-            ret = self._apply_unrestricted()
-        elif rule == ACCESS_RULE_DIRECT:
-            ret = self._apply_direct(event, state_events)
-        else:
-            # We currently apply the default (restricted) if we don't know the rule, we
-            # might want to change that in the future.
-            ret = self._apply_restricted(event)
-
-        return ret
+        if event.type == EventTypes.Member or event.type == EventTypes.ThirdPartyInvite:
+            return self._on_membership_or_invite(event, rule, state_events)
 
     def _on_rules_change(self, event, state_events):
         """Implement the checks and behaviour specified on allowing or forbidding a new
@@ -254,34 +242,66 @@ class RoomAccessRules(object):
 
         return False
 
-    def _apply_restricted(self, event):
+    def _on_membership_or_invite(self, event, rule, state_events):
+        """Applies the correct rule for incoming m.room.member and
+        m.room.third_party_invite events.
+
+        Args:
+            event (synapse.events.EventBase): The event to check.
+            rule (str): The name of the rule to apply.
+            state_events (dict[tuple[event type, state key], EventBase]): The state of the
+                room before the event was sent.
+        Returns:
+            bool, True if the event can be allowed, False otherwise.
+        """
+        if rule == ACCESS_RULE_RESTRICTED:
+            ret = self._on_membership_or_invite_restricted(event)
+        elif rule == ACCESS_RULE_UNRESTRICTED:
+            ret = self._on_membership_or_invite_unrestricted()
+        elif rule == ACCESS_RULE_DIRECT:
+            ret = self._on_membership_or_invite_direct(event, state_events)
+        else:
+            # We currently apply the default (restricted) if we don't know the rule, we
+            # might want to change that in the future.
+            ret = self._on_membership_or_invite_restricted(event)
+
+        return ret
+
+    def _on_membership_or_invite_restricted(self, event):
         """Implements the checks and behaviour specified for the "restricted" rule.
+
+        "restricted" currently means that users can only invite users if their server is
+        included in a limited list of domains.
 
         Args:
             event (synapse.events.EventBase): The event to check.
         Returns:
             bool, True if the event can be allowed, False otherwise.
         """
-        # "restricted" currently means that users can only invite users if their server is
-        # included in a limited list of domains.
-        # We're not filtering on m.room.third_party_member events here because the
-        # filtering on threepids is done in check_threepid_can_be_invited.
-        if event.type != EventTypes.Member:
+        # We're not applying the rules on m.room.third_party_member events here because
+        # the filtering on threepids is done in check_threepid_can_be_invited, which is
+        # called before check_event_allowed.
+        if event.type == EventTypes.ThirdPartyInvite:
             return True
         invitee_domain = get_domain_from_id(event.state_key)
         return invitee_domain not in self.domains_forbidden_when_restricted
 
-    def _apply_unrestricted(self):
+    def _on_membership_or_invite_unrestricted(self):
         """Implements the checks and behaviour specified for the "unrestricted" rule.
+
+        "unrestricted" currently means that every event is allowed.
 
         Returns:
             bool, True if the event can be allowed, False otherwise.
         """
-        # "unrestricted" currently means that every event is allowed.
         return True
 
-    def _apply_direct(self, event, state_events):
+    def _on_membership_or_invite_direct(self, event, state_events):
         """Implements the checks and behaviour specified for the "direct" rule.
+
+        "direct" currently means that no member is allowed apart from the two initial
+        members the room was created for (i.e. the room's creator and their first
+        invitee).
 
         Args:
             event (synapse.events.EventBase): The event to check.
@@ -290,12 +310,6 @@ class RoomAccessRules(object):
         Returns:
             bool, True if the event can be allowed, False otherwise.
         """
-        # "direct" currently means that no member is allowed apart from the two initial
-        # members the room was created for (i.e. the room's creator and their first
-        # invitee).
-        if event.type != EventTypes.Member and event.type != EventTypes.ThirdPartyInvite:
-            return True
-
         # Get the room memberships and 3PID invite tokens from the room's state.
         existing_members, threepid_tokens = self._get_members_and_tokens_from_state(
             state_events,

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -34,12 +34,16 @@ VALID_ACCESS_RULES = (
 )
 
 # Rules to which we need to apply the power levels restrictions.
-# These are all of the rules that don't forbid users to join based on a server blacklist
-# (except for the rules targetting direct chats, because both users should be able to be
-# room admins in a direct chat created with the "trusted_private_chat" preset).
-# The current restrictions forbid users that would be forbidden from joining under more
-# restrictive rules from being given a non-default PL, and the default PL from being set
-# to a non-0 value.
+#
+# These are all of the rules that neither:
+#  * forbid users from joining based on a server blacklist (which means that there
+#     is no need to apply power level restrictions), nor
+#  * target direct chats (since we allow both users to be room admins in this case).
+#
+# The power-level restrictions, when they are applied, prevent the following:
+#  * the default power level for users (users_default) being set to anything other than 0.
+#  * a non-default power level being assigned to any user which would be forbidden from
+#     joining a restricted room.
 RULES_WITH_RESTRICTED_POWER_LEVELS = (
     ACCESS_RULE_UNRESTRICTED,
 )

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -201,6 +201,8 @@ class RoomAccessRules(object):
         if event.type == EventTypes.Member or event.type == EventTypes.ThirdPartyInvite:
             return self._on_membership_or_invite(event, rule, state_events)
 
+        return True
+
     def _on_rules_change(self, event, state_events):
         """Implement the checks and behaviour specified on allowing or forbidding a new
         im.vector.room.access_rules event.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -33,6 +33,11 @@ VALID_ACCESS_RULES = (
     ACCESS_RULE_UNRESTRICTED,
 )
 
+# Rules to which we need to apply the power levels restrictions.
+RULES_WITH_RESTRICTED_POWER_LEVELS = (
+    ACCESS_RULE_UNRESTRICTED,
+)
+
 
 class RoomAccessRules(object):
     """Implementation of the ThirdPartyEventRules module API that allows federation admins
@@ -369,9 +374,8 @@ class RoomAccessRules(object):
             bool, True if the event can be allowed, False otherwise.
 
         """
-        # Blacklisted servers shouldn't have any restriction in "direct" mode, so always
-        # accept the event.
-        if access_rule == ACCESS_RULE_DIRECT:
+        # Check if we need to apply the restrictions with the current rule.
+        if access_rule not in RULES_WITH_RESTRICTED_POWER_LEVELS:
             return True
 
         # If users_default is explicitly set to a non-0 value, deny the event.

--- a/tests/handlers/test_identity.py
+++ b/tests/handlers/test_identity.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import Mock
+
+from twisted.internet import defer
+
+import synapse.rest.admin
+from synapse.rest.client.v1 import login
+from synapse.rest.client.v2_alpha import account
+
+from tests import unittest
+
+
+class ThreepidISRewrittenURLTestCase(unittest.HomeserverTestCase):
+
+    servlets = [
+        synapse.rest.admin.register_servlets_for_client_rest_resource,
+        login.register_servlets,
+        account.register_servlets,
+    ]
+
+    def make_homeserver(self, reactor, clock):
+        self.address = "test@test"
+        self.is_server_name = "testis"
+        self.rewritten_is_url = "int.testis"
+
+        config = self.default_config()
+        config["trusted_third_party_id_servers"] = [
+            self.is_server_name,
+        ]
+        config["rewrite_identity_server_urls"] = {
+            self.is_server_name: self.rewritten_is_url,
+        }
+
+        mock_http_client = Mock(spec=[
+            "post_urlencoded_get_json",
+        ])
+        mock_http_client.post_urlencoded_get_json.return_value = defer.succeed({
+            "address": self.address,
+            "medium": "email",
+        })
+
+        self.hs = self.setup_test_homeserver(
+            config=config,
+            simple_http_client=mock_http_client,
+        )
+
+        return self.hs
+
+    def prepare(self, reactor, clock, hs):
+        self.user_id = self.register_user("kermit", "monkey")
+
+    def test_rewritten_id_server(self):
+        """
+        Tests that, when validating a 3PID association while rewriting the IS's server
+        name:
+        * the bind request is done against the rewritten hostname
+        * the original, non-rewritten, server name is stored in the database
+        """
+        handler = self.hs.get_handlers().identity_handler
+        post_urlenc_get_json = self.hs.get_simple_http_client().post_urlencoded_get_json
+        store = self.hs.get_datastore()
+
+        creds = {
+            "sid": "123",
+            "client_secret": "some_secret",
+        }
+
+        # Make sure processing the mocked response goes through.
+        data = self.get_success(handler.bind_threepid(
+            {
+                "id_server": self.is_server_name,
+                "client_secret": creds["client_secret"],
+                "sid": creds["sid"],
+            },
+            self.user_id,
+        ))
+        self.assertEqual(data.get("address"), self.address)
+
+        # Check that the request was done against the rewritten server name.
+        post_urlenc_get_json.assert_called_once_with(
+            "https://%s/_matrix/identity/api/v1/3pid/bind" % self.rewritten_is_url,
+            {
+                'sid': creds['sid'],
+                'client_secret': creds["client_secret"],
+                'mxid': self.user_id,
+            }
+        )
+
+        # Check that the original server name is saved in the database instead of the
+        # rewritten one.
+        id_servers = self.get_success(store.get_id_servers_user_bound(
+            self.user_id, "email", self.address
+        ))
+        self.assertEqual(id_servers, [self.is_server_name])


### PR DESCRIPTION
Implement new rules for `unrestricted` mode that restrict the power level one can set to users that would have been forbidden from joining the room in `restricted` mode.

These rules are:

* one can't change the default PL to a non-0 value.
* one can't change the PL for a user that would have been forbidden from joining the room in `restricted` mode to a non-default value.

This PR also restructures a bit the `RoomAccessRules` module's code to make it less confusing now that we're not processing only memberships and 3PID invites anymore.