### PR TITLE
Include the original event in /relations

### DIFF
--- a/changelog.d/5626.feature
+++ b/changelog.d/5626.feature
@@ -1,0 +1,1 @@
+Include the original event when asking for its relations.

--- a/synapse/rest/client/v2_alpha/relations.py
+++ b/synapse/rest/client/v2_alpha/relations.py
@@ -145,9 +145,9 @@ class RelationPaginationServlet(RestServlet):
             room_id, requester.user.to_string()
         )
 
-        # This checks that a) the event exists and b) the user is allowed to
-        # view it.
-        yield self.event_handler.get_event(requester.user, room_id, parent_id)
+        # This gets the original event and checks that a) the event exists and
+        # b) the user is allowed to view it.
+        event = yield self.event_handler.get_event(requester.user, room_id, parent_id)
 
         limit = parse_integer(request, "limit", default=5)
         from_token = parse_string(request, "from")
@@ -173,10 +173,12 @@ class RelationPaginationServlet(RestServlet):
         )
 
         now = self.clock.time_msec()
+        original_event = yield self._event_serializer.serialize_events(event, now)
         events = yield self._event_serializer.serialize_events(events, now)
 
         return_value = result.to_dict()
         return_value["chunk"] = events
+        return_value["original_event"] = original_event
 
         defer.returnValue((200, return_value))
 

--- a/synapse/rest/client/v2_alpha/relations.py
+++ b/synapse/rest/client/v2_alpha/relations.py
@@ -173,7 +173,7 @@ class RelationPaginationServlet(RestServlet):
         )
 
         now = self.clock.time_msec()
-        original_event = yield self._event_serializer.serialize_events(event, now)
+        original_event = yield self._event_serializer.serialize_event(event, now)
         events = yield self._event_serializer.serialize_events(events, now)
 
         return_value = result.to_dict()

--- a/synapse/storage/relations.py
+++ b/synapse/storage/relations.py
@@ -60,7 +60,7 @@ class PaginationChunk(object):
 class RelationPaginationToken(object):
     """Pagination token for relation pagination API.
 
-    As the results are order by topological ordering, we can use the
+    As the results are in topological order, we can use the
     `topological_ordering` and `stream_ordering` fields of the events at the
     boundaries of the chunk as pagination tokens.
 

--- a/tests/rest/client/v2_alpha/test_relations.py
+++ b/tests/rest/client/v2_alpha/test_relations.py
@@ -127,7 +127,9 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         )
 
         # We also expect to get the original event (the id of which is self.parent_id)
-        self.assertEquals(channel.json_body["original_event"]["event_id"], self.parent_id)
+        self.assertEquals(
+            channel.json_body["original_event"]["event_id"], self.parent_id
+        )
 
         # Make sure next_batch has something in it that looks like it could be a
         # valid token.

--- a/tests/rest/client/v2_alpha/test_relations.py
+++ b/tests/rest/client/v2_alpha/test_relations.py
@@ -126,6 +126,9 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             channel.json_body["chunk"][0],
         )
 
+        # We also expect to get the original event (the id of which is self.parent_id)
+        self.assertEquals(channel.json_body["original_event"]["event_id"], self.parent_id)
+
         # Make sure next_batch has something in it that looks like it could be a
         # valid token.
         self.assertIsInstance(


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/5595

When asking for the relations of an event, include the original event in the response. This will mostly be used for efficiently showing edit history, but could be useful in other circumstances.