### PR TITLE
Unblacklist some user_directory sytests

### DIFF
--- a/changelog.d/5637.misc
+++ b/changelog.d/5637.misc
@@ -1,0 +1,1 @@
+Unblacklist some user_directory sytests.

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -24,10 +24,6 @@ Newly created users see their own presence in /initialSync (SYT-34)
 # Blacklisted due to https://github.com/matrix-org/synapse/issues/1396
 Should reject keys claiming to belong to a different user
 
-# Blacklisted due to https://github.com/matrix-org/synapse/issues/2306
-Users appear/disappear from directory when join_rules are changed
-Users appear/disappear from directory when history_visibility are changed
-
 # Blacklisted due to https://github.com/matrix-org/synapse/issues/1531
 Enabling an unknown default rule fails with 404
 


### PR DESCRIPTION
Now that the userdir has been rewritten (#4537 etc), I reckon there's a good
chance of these tests working right. Let's find out.

Fixes https://github.com/matrix-org/synapse/issues/2306
