### PR TITLE
Don't bundle aggregations when retrieving the original event

### DIFF
--- a/changelog.d/5654.bugfix
+++ b/changelog.d/5654.bugfix
@@ -1,0 +1,1 @@
+Fix bug in #5626 that prevented the original_event field from actually having the contents of the original event in a call to `/relations`.

--- a/synapse/rest/client/v2_alpha/relations.py
+++ b/synapse/rest/client/v2_alpha/relations.py
@@ -173,8 +173,18 @@ class RelationPaginationServlet(RestServlet):
         )
 
         now = self.clock.time_msec()
-        original_event = yield self._event_serializer.serialize_event(event, now)
-        events = yield self._event_serializer.serialize_events(events, now)
+        # We set bundle_aggregations to False when retrieving the original
+        # event because we want the content before relations were applied to
+        # it.
+        original_event = yield self._event_serializer.serialize_event(
+            event, now, bundle_aggregations=False,
+        )
+        # Similarly, we don't allow relations to be applied to relations, so we
+        # return the original relations without any aggregations on top of them
+        # here.
+        events = yield self._event_serializer.serialize_events(
+            events, now, bundle_aggregations=False,
+        )
 
         return_value = result.to_dict()
         return_value["chunk"] = events

--- a/synapse/rest/client/v2_alpha/relations.py
+++ b/synapse/rest/client/v2_alpha/relations.py
@@ -177,13 +177,13 @@ class RelationPaginationServlet(RestServlet):
         # event because we want the content before relations were applied to
         # it.
         original_event = yield self._event_serializer.serialize_event(
-            event, now, bundle_aggregations=False,
+            event, now, bundle_aggregations=False
         )
         # Similarly, we don't allow relations to be applied to relations, so we
         # return the original relations without any aggregations on top of them
         # here.
         events = yield self._event_serializer.serialize_events(
-            events, now, bundle_aggregations=False,
+            events, now, bundle_aggregations=False
         )
 
         return_value = result.to_dict()


### PR DESCRIPTION
A fix for PR #5626, which returned the original event content as part of a call to `/relations`.

Only problem was that we were attempting to aggregate the relations on top of it when we did so. We now set `bundle_aggregations` to False in the `get_event` call.

We also do this when pulling the relation events as well, because edits of edits are not something we'd like to support here.