### PR TITLE
Inline issue_access_token

### DIFF
--- a/changelog.d/5659.misc
+++ b/changelog.d/5659.misc
@@ -1,0 +1,1 @@
+Inline issue_access_token.

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -244,7 +244,7 @@ class AuthTestCase(unittest.TestCase):
         USER_ID = "@percy:matrix.org"
         self.store.add_access_token_to_user = Mock()
 
-        token = yield self.hs.handlers.auth_handler.issue_access_token(
+        token = yield self.hs.handlers.auth_handler.get_access_token_for_user_id(
             USER_ID, "DEVICE"
         )
         self.store.add_access_token_to_user.assert_called_with(USER_ID, token, "DEVICE")


### PR DESCRIPTION
this is only used in one place, so it's clearer if we inline it and reduce the
API surface.

Also, fixes a buglet where we would create an access token even if we were
about to block the user (we would never return the AT, so the user could never
use it, but it was still created and added to the db.)