### PR TITLE
 Improved docs on setting up Postgresql

### DIFF
--- a/changelog.d/5661.docs
+++ b/changelog.d/5661.docs
@@ -1,0 +1,1 @@
+Improvements to Postgres setup instructions. Contributed by @Lrizika - thanks!

--- a/changelog.d/5661.misc
+++ b/changelog.d/5661.misc
@@ -1,3 +1,0 @@
-Updated postgres.rst
-Added that synapse_user needs a database to access before it can auth
-Noted you'll need to enable password auth, linked to pg_hba.conf docs

--- a/changelog.d/5661.misc
+++ b/changelog.d/5661.misc
@@ -1,0 +1,3 @@
+Updated postgres.rst
+Added that synapse_user needs a database to access before it can auth
+Noted you'll need to enable password auth, linked to pg_hba.conf docs

--- a/docs/postgres.rst
+++ b/docs/postgres.rst
@@ -34,6 +34,12 @@ Assuming your PostgreSQL database user is called ``postgres``, create a user
    su - postgres
    createuser --pwprompt synapse_user
 
+Before you can authenticate with the ``synapse_user``, you must create a 
+database that it can access. Connect to the database with your database user:
+
+   su - postgres
+   psql
+
 The PostgreSQL database used *must* have the correct encoding set, otherwise it
 would not be able to store UTF8 strings. To create a database with the correct
 encoding use, e.g.::
@@ -47,6 +53,9 @@ encoding use, e.g.::
 
 This would create an appropriate database named ``synapse`` owned by the
 ``synapse_user`` user (which must already exist).
+
+You may need to enable password authentication so ``synapse_user`` can connect
+to the database. See https://www.postgresql.org/docs/11/auth-pg-hba-conf.html
 
 Tuning Postgres
 ===============

--- a/docs/postgres.rst
+++ b/docs/postgres.rst
@@ -35,7 +35,7 @@ Assuming your PostgreSQL database user is called ``postgres``, create a user
    createuser --pwprompt synapse_user
 
 Before you can authenticate with the ``synapse_user``, you must create a 
-database that it can access. Connect to the database with your database user:
+database that it can access. Connect to the database with your database user::
 
    su - postgres
    psql

--- a/docs/postgres.rst
+++ b/docs/postgres.rst
@@ -35,14 +35,13 @@ Assuming your PostgreSQL database user is called ``postgres``, create a user
    createuser --pwprompt synapse_user
 
 Before you can authenticate with the ``synapse_user``, you must create a 
-database that it can access. Connect to the database with your database user::
+database that it can access. To create a database, first connect to the database
+with your database user::
 
    su - postgres
    psql
 
-The PostgreSQL database used *must* have the correct encoding set, otherwise it
-would not be able to store UTF8 strings. To create a database with the correct
-encoding use, e.g.::
+and then run::
 
    CREATE DATABASE synapse
     ENCODING 'UTF8'
@@ -52,10 +51,13 @@ encoding use, e.g.::
     OWNER synapse_user;
 
 This would create an appropriate database named ``synapse`` owned by the
-``synapse_user`` user (which must already exist).
+``synapse_user`` user (which must already have been created as above).
+
+Note that the PostgreSQL database *must* have the correct encoding set (as 
+shown above), otherwise it will not be able to store UTF8 strings.
 
 You may need to enable password authentication so ``synapse_user`` can connect
-to the database. See https://www.postgresql.org/docs/11/auth-pg-hba-conf.html
+to the database. See https://www.postgresql.org/docs/11/auth-pg-hba-conf.html.
 
 Tuning Postgres
 ===============


### PR DESCRIPTION
Added that synapse_user needs a database to access before it can auth
Noted you'll need to enable password auth, linked to pg_hba.conf docs

Signed-off-by: Logan Rizika <lrizika-git@lrizika.com>

### Pull Request Checklist
* [x]  Pull request is based on the develop branch
* [x]  Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x]  Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)