### PR TITLE
Use /src for checking out synapse during sytests 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -179,6 +179,7 @@ steps:
           image: "matrixdotorg/sytest-synapse:py35"
           propagate-environment: true
           always-pull: true
+          workdir: "/src"
     retry:
       automatic:
         - exit_status: -1
@@ -199,6 +200,7 @@ steps:
           image: "matrixdotorg/sytest-synapse:py35"
           propagate-environment: true
           always-pull: true
+          workdir: "/src"
     retry:
       automatic:
         - exit_status: -1
@@ -220,6 +222,7 @@ steps:
           image: "matrixdotorg/sytest-synapse:py35"
           propagate-environment: true
           always-pull: true
+          workdir: "/src"
     soft_fail: true
     retry:
       automatic:

--- a/changelog.d/5664.misc
+++ b/changelog.d/5664.misc
@@ -1,0 +1,1 @@
+Update the sytest BuildKite configuration to checkout Synapse in `/src`.


### PR DESCRIPTION
This cleans up some code in https://github.com/matrix-org/sytest/pull/639 and makes it more consistent with manual runs.