### PR TITLE
Return a different error from Invalid Password when a user is deactivated

### DIFF
--- a/changelog.d/5674.feature
+++ b/changelog.d/5674.feature
@@ -1,0 +1,1 @@
+Return "This account has been deactivated" when a deactivated user tries to login.

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -154,9 +154,6 @@ class UserDeactivatedError(SynapseError):
             code=http_client.FORBIDDEN, msg=msg, errcode=Codes.UNKNOWN
         )
 
-    def error_dict(self):
-        return cs_error(self.msg, self.errcode)
-
 
 class RegistrationError(SynapseError):
     """An error raised when a registration event fails."""

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -138,6 +138,7 @@ class ConsentNotGivenError(SynapseError):
     def error_dict(self):
         return cs_error(self.msg, self.errcode, consent_uri=self._consent_uri)
 
+
 class UserDeactivatedError(SynapseError):
     """The error returned to the client when the user attempted to access an
     authenticated endpoint, but the account has been deactivated.

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -138,6 +138,24 @@ class ConsentNotGivenError(SynapseError):
     def error_dict(self):
         return cs_error(self.msg, self.errcode, consent_uri=self._consent_uri)
 
+class UserDeactivatedError(SynapseError):
+    """The error returned to the client when the user attempted to access an
+    authenticated endpoint, but the account has been deactivated.
+    """
+
+    def __init__(self, msg):
+        """Constructs a UserDeactivatedError
+
+        Args:
+            msg (str): The human-readable error message
+        """
+        super(UserDeactivatedError, self).__init__(
+            code=http_client.FORBIDDEN, msg=msg, errcode=Codes.UNKNOWN
+        )
+
+    def error_dict(self):
+        return cs_error(self.msg, self.errcode)
+
 
 class RegistrationError(SynapseError):
     """An error raised when a registration event fails."""

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -34,6 +34,7 @@ from synapse.api.errors import (
     LoginError,
     StoreError,
     SynapseError,
+    UserDeactivatedError,
 )
 from synapse.api.ratelimiting import Ratelimiter
 from synapse.logging.context import defer_to_thread
@@ -610,6 +611,7 @@ class AuthHandler(BaseHandler):
         Raises:
             LimitExceededError if the ratelimiter's login requests count for this
                 user is too high too proceed.
+            UserDeactivatedError if a user is found but is deactivated.
         """
         self.ratelimit_login_per_account(user_id)
         res = yield self._find_user_id_and_pwd_hash(user_id)
@@ -825,6 +827,15 @@ class AuthHandler(BaseHandler):
         if not lookupres:
             defer.returnValue(None)
         (user_id, password_hash) = lookupres
+
+        # If the password hash is None, the account has likely been deactivated
+        if not password_hash:
+            deactivated = yield self.store.get_user_deactivated_status(user_id)
+            if deactivated:
+                raise UserDeactivatedError(
+                    "This account has been deactivated"
+                )
+
         result = yield self.validate_hash(password, password_hash)
         if not result:
             logger.warn("Failed password login for user %s", user_id)

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -832,9 +832,7 @@ class AuthHandler(BaseHandler):
         if not password_hash:
             deactivated = yield self.store.get_user_deactivated_status(user_id)
             if deactivated:
-                raise UserDeactivatedError(
-                    "This account has been deactivated"
-                )
+                raise UserDeactivatedError("This account has been deactivated")
 
         result = yield self.validate_hash(password, password_hash)
         if not result:


### PR DESCRIPTION
Return `This account has been deactivated` instead of `Invalid password` when a user is deactivated.

Riot web still displays `Incorrect username and/or password.` as I believe it does that for any `403` error returned by the server.

Unfortunately, Riot-web will need to match on the `error` field to show an error properly. Let me know if there's a better way this can be done (HTTP code, new errcode [requires MSC]).

Also note: this allows anyone to figure out that an account was deactivated. There's no way to gatekeep this behind requiring the correct password, as we remove user's password hashes upon deactivation.