### PR TITLE
Make Jaeger fully configurable

### DIFF
--- a/changelog.d/5694.misc
+++ b/changelog.d/5694.misc
@@ -1,1 +1,1 @@
-Makeaeger fully configurable Jaeger fully configurable.
+Make Jaeger fully configurable.

--- a/changelog.d/5694.misc
+++ b/changelog.d/5694.misc
@@ -1,0 +1,1 @@
+Makeaeger fully configurable Jaeger fully configurable.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1440,3 +1440,18 @@ opentracing:
     #
     #homeserver_whitelist:
     #  - ".*"
+
+    # Jaeger can be configured to sample traces at different rates.
+    # All configuration options provided by Jaeger can be set here.
+    # Jaeger's configuration mostly related to sampling which is documented here:
+    # https://www.jaegertracing.io/docs/1.13/sampling/.
+    #
+    #jaeger_config:
+    #  sampler:
+    #    type: const
+    #    param: 1
+
+    #  Logging whether spans were started and reported
+    #
+    #  logging:
+    #    false

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1433,7 +1433,8 @@ opentracing:
 
     # Jaeger can be configured to sample traces at different rates.
     # All configuration options provided by Jaeger can be set here.
-    # Jaeger's configuration mostly related to sampling which is documented here:
+    # Jaeger's configuration mostly related to trace sampling which
+    # is documented here:
     # https://www.jaegertracing.io/docs/1.13/sampling/.
     #
     #jaeger_config:

--- a/synapse/config/tracer.py
+++ b/synapse/config/tracer.py
@@ -23,6 +23,12 @@ class TracerConfig(Config):
             opentracing_config = {}
 
         self.opentracer_enabled = opentracing_config.get("enabled", False)
+
+        self.jaeger_config = config.tracer_config.get(
+            "jaeger_config",
+            {"sampler": {"type": "const", "param": 1}, "logging": False},
+        )
+
         if not self.opentracer_enabled:
             return
 
@@ -66,4 +72,19 @@ class TracerConfig(Config):
             #
             #homeserver_whitelist:
             #  - ".*"
+
+            # Jaeger can be configured to sample traces at different rates.
+            # All configuration options provided by Jaeger can be set here.
+            # Jaeger's configuration mostly related to sampling which is documented here:
+            # https://www.jaegertracing.io/docs/1.13/sampling/.
+            #
+            #jaeger_config:
+            #  sampler:
+            #    type: const
+            #    param: 1
+
+            #  Logging whether spans were started and reported
+            #
+            #  logging:
+            #    false
         """

--- a/synapse/config/tracer.py
+++ b/synapse/config/tracer.py
@@ -24,7 +24,7 @@ class TracerConfig(Config):
 
         self.opentracer_enabled = opentracing_config.get("enabled", False)
 
-        self.jaeger_config = config.tracer_config.get(
+        self.jaeger_config = opentracing_config.get(
             "jaeger_config",
             {"sampler": {"type": "const", "param": 1}, "logging": False},
         )
@@ -65,7 +65,8 @@ class TracerConfig(Config):
 
             # Jaeger can be configured to sample traces at different rates.
             # All configuration options provided by Jaeger can be set here.
-            # Jaeger's configuration mostly related to sampling which is documented here:
+            # Jaeger's configuration mostly related to trace sampling which
+            # is documented here:
             # https://www.jaegertracing.io/docs/1.13/sampling/.
             #
             #jaeger_config:

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -122,9 +122,12 @@ def init_tracer(config):
     # Include the worker name
     name = config.worker_name if config.worker_name else "master"
 
+    # Pull out the jaeger config if it was given. Otherwise set it to something sensible.
+    # See https://github.com/jaegertracing/jaeger-client-python/blob/master/jaeger_client/config.py
+
     set_homeserver_whitelist(config.opentracer_whitelist)
     jaeger_config = JaegerConfig(
-        config={"sampler": {"type": "const", "param": 1}, "logging": True},
+        config=config.jaeger_config,
         service_name="{} {}".format(config.server_name, name),
         scope_manager=LogContextScopeManager(config),
     )

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -251,12 +251,12 @@ def init_tracer(config):
     # See https://github.com/jaegertracing/jaeger-client-python/blob/master/jaeger_client/config.py
 
     set_homeserver_whitelist(config.opentracer_whitelist)
-    jaeger_config = JaegerConfig(
+
+    JaegerConfig(
         config=config.jaeger_config,
         service_name="{} {}".format(config.server_name, name),
         scope_manager=LogContextScopeManager(config),
-    )
-    jaeger_config.initialize_tracer()
+    ).initialize_tracer()
 
     # Set up tags to be opentracing's tags
     global tags


### PR DESCRIPTION
This completely exposes jaeger's configuration under the jaeger_config setting.