### PR TITLE
Refactor `get_events_as_list`

### DIFF
--- a/changelog.d/5699.bugfix
+++ b/changelog.d/5699.bugfix
@@ -1,0 +1,1 @@
+Fix some problems with authenticating redactions in recent room versions.


### PR DESCRIPTION
A couple of changes here:

* get rid of a redundant `allow_rejected` condition - we should already have filtered out any rejected events before we get to that point in the code, and the redundancy is confusing. Instead, let's stick in an assertion just to make double-sure we aren't leaking rejected events by mistake.
* factor out a `_get_events_from_cache_or_db` method, which is going to be important for a forthcoming fix to redactions.