### PR TITLE
Delegate to cached version when using get_filtered_current_state_ids

### DIFF
--- a/changelog.d/5713.misc
+++ b/changelog.d/5713.misc
@@ -1,0 +1,1 @@
+Improve caching when fetching `get_filtered_current_state_ids`.


### PR DESCRIPTION
In the case where it gets called with `StateFilter.all()`