### PR TITLE
Don't accept opentracing data from clients.

### DIFF
--- a/changelog.d/5715.misc
+++ b/changelog.d/5715.misc
@@ -1,0 +1,1 @@
+Don't accept opentracing data from clients.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -340,8 +340,7 @@ def trace_servlet(servlet_name, func):
     @wraps(func)
     @defer.inlineCallbacks
     def _trace_servlet_inner(request, *args, **kwargs):
-        with start_active_span_from_context(
-            request.requestHeaders,
+        with start_active_span(
             "incoming-client-request",
             tags={
                 "request_id": request.get_request_id(),


### PR DESCRIPTION
@richvdh raised the question about whether clients were affected by the opentracing whitelist. We decided that clients should not send us span contexts until we've provisioned for it.