### PR TITLE
Use upsert when updating destination retry interval

### DIFF
--- a/changelog.d/5720.misc
+++ b/changelog.d/5720.misc
@@ -1,0 +1,1 @@
+Improve database query performance when recording retry intervals for remote hosts.


### PR DESCRIPTION
The lock shows up on the matrix.org postgres stats quite a bit, so probably indicates that there is a bunch of contention there.