### PR TITLE
Add `user_type` to returned fields in admin API user list endpoints

### DIFF
--- a/changelog.d/5731.misc
+++ b/changelog.d/5731.misc
@@ -1,0 +1,1 @@
+Return 'user_type' in admin API user endpoints results.

--- a/synapse/storage/__init__.py
+++ b/synapse/storage/__init__.py
@@ -469,7 +469,7 @@ class DataStore(
         return self._simple_select_list(
             table="users",
             keyvalues={},
-            retcols=["name", "password_hash", "is_guest", "admin"],
+            retcols=["name", "password_hash", "is_guest", "admin", "user_type"],
             desc="get_users",
         )
 
@@ -494,7 +494,7 @@ class DataStore(
             orderby=order,
             start=start,
             limit=limit,
-            retcols=["name", "password_hash", "is_guest", "admin"],
+            retcols=["name", "password_hash", "is_guest", "admin", "user_type"],
         )
         count = yield self.runInteraction("get_users_paginate", self.get_user_count_txn)
         retval = {"users": users, "total": count}
@@ -514,7 +514,7 @@ class DataStore(
             table="users",
             term=term,
             col="name",
-            retcols=["name", "password_hash", "is_guest", "admin"],
+            retcols=["name", "password_hash", "is_guest", "admin", "user_type"],
             desc="search_users",
         )
 


### PR DESCRIPTION
Mostly user type will be empty (normal user) but there is also the
"support" user type.

I considered at the same time documenting the admin user API endpoints, but it doesn't seem clear how the API's should behave. For example `/_synapse/admin/v1/users/<user_id>` the "user_id" doesn't seem to be used except to check it's local but it doesn't actually 1) get that user or 2) filter as a pattern. Happy to document the missing API's though in some way if that would be good in this PR.

Signed-off-by: Jason Robinson <jasonr@matrix.org>
