### PR TITLE
Speed up current state background update.

### DIFF
--- a/changelog.d/5738.misc
+++ b/changelog.d/5738.misc
@@ -1,0 +1,1 @@
+Reduce database IO usage by optimising queries for current membership.


### PR DESCRIPTION
Turns out that storing huge JSON arrays in the progress JSON isn't something that postgres particularly likes, so lets instead iterate through all rooms in alphabetical order.

Fixes up PR #5706.
