### PR TITLE
Remove some more joins on room_memberships

### DIFF
--- a/changelog.d/5752.misc
+++ b/changelog.d/5752.misc
@@ -1,0 +1,1 @@
+Reduce database IO usage by optimising queries for current membership.

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -678,6 +678,11 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             # to see if any have subsequently been updated. This is done so that
             # we can use a partial index on `forgotten = 1` on the assumption
             # that few users will actually forget many rooms.
+            #
+            # Note that a room is considered "forgotten" if *all* membership
+            # events for that user and room have the forgotten field set (as
+            # when a user forgets a room we update all rows for that user and
+            # room, not just the current one).
             sql = """
                 SELECT room_id, (
                     SELECT count(*) FROM room_memberships

--- a/synapse/storage/schema/delta/56/room_membership_idx.sql
+++ b/synapse/storage/schema/delta/56/room_membership_idx.sql
@@ -13,13 +13,6 @@
  * limitations under the License.
  */
 
--- We add membership to current state so that we don't need to join against
--- room_memberships, which can be surprisingly costly (we do such queries
--- very frequently).
--- This will be null for non-membership events and the content.membership key
--- for membership events. (Will also be null for membership events until the
--- background update job has finished).
-
 -- Adds an index on room_memberships for fetching all forgotten rooms for a user
 INSERT INTO background_updates (update_name, progress_json) VALUES
   ('room_membership_forgotten_idx', '{}');

--- a/synapse/storage/schema/delta/56/room_membership_idx.sql
+++ b/synapse/storage/schema/delta/56/room_membership_idx.sql
@@ -1,0 +1,25 @@
+/* Copyright 2019 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- We add membership to current state so that we don't need to join against
+-- room_memberships, which can be surprisingly costly (we do such queries
+-- very frequently).
+-- This will be null for non-membership events and the content.membership key
+-- for membership events. (Will also be null for membership events until the
+-- background update job has finished).
+
+-- Adds an index on room_memberships for fetching all forgotten rooms for a user
+INSERT INTO background_updates (update_name, progress_json) VALUES
+  ('room_membership_forgotten_idx', '{}');


### PR DESCRIPTION
This involves changing the way we filter out forgotten rooms, which needed a new index. 

These commits are independently reviewable.