### PR TITLE
Force the access rule to be "restricted" if the join rule is "public"

### DIFF
--- a/changelog.d/5760.feature
+++ b/changelog.d/5760.feature
@@ -1,1 +1,1 @@
-Force the access rule to be "restricted" if the join rule is "public"
+Force the access rule to be "restricted" if the join rule is "public".

--- a/changelog.d/5760.feature
+++ b/changelog.d/5760.feature
@@ -1,0 +1,1 @@
+Force the access rule to be "restricted" if the join rule is "public"

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -128,12 +128,11 @@ class RoomAccessRules(object):
             # rule, the access rule must be "restricted"). We don't need to check that if
             # there's no access rule provided, as in this case the access rule will
             # default to "restricted", with which any join rule is allowed.
-            if join_rule == JoinRules.PUBLIC and access_rule != ACCESS_RULE_RESTRICTED:
-                raise SynapseError(400, "Invalid access rule")
-
             if (
-                preset == RoomCreationPreset.PUBLIC_CHAT
-                and access_rule != ACCESS_RULE_RESTRICTED
+                (
+                    join_rule == JoinRules.PUBLIC
+                    or preset == RoomCreationPreset.PUBLIC_CHAT
+                ) and access_rule != ACCESS_RULE_RESTRICTED
             ):
                 raise SynapseError(400, "Invalid access rule")
         else:

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -122,18 +122,18 @@ class RoomAccessRules(object):
             if event["type"] == EventTypes.JoinRules:
                 join_rule = event["content"].get("join_rule")
 
-        if join_rule == JoinRules.PUBLIC and access_rule != ACCESS_RULE_RESTRICTED:
-            raise SynapseError(400, "Invalid access rule")
+        if access_rule:
+            if join_rule == JoinRules.PUBLIC and access_rule != ACCESS_RULE_RESTRICTED:
+                raise SynapseError(400, "Invalid access rule")
 
-        if (
-            preset == RoomCreationPreset.PUBLIC_CHAT
-            and access_rule != ACCESS_RULE_RESTRICTED
-        ):
-            raise SynapseError(400, "Invalid access rule")
-
-        # If there's no rules event in the initial state, create one with the default
-        # setting.
-        if not access_rule:
+            if (
+                preset == RoomCreationPreset.PUBLIC_CHAT
+                and access_rule != ACCESS_RULE_RESTRICTED
+            ):
+                raise SynapseError(400, "Invalid access rule")
+        else:
+            # If there's no rules event in the initial state, create one with the default
+            # setting.
             if is_direct:
                 default_rule = ACCESS_RULE_DIRECT
             else:

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -438,6 +438,10 @@ class RoomAccessRules(object):
         """Check whether a join rule change is allowed. A join rule change is always
         allowed unless the new join rule is "public" and the current access rule isn't
         "restricted".
+        The rationale is that external users (those whose server would be denied access
+        to rooms enforcing the "restricted" access rule) should always rely on non-
+        external users for access to rooms, therefore they shouldn't be able to access
+        rooms that don't require an invite to be joined.
 
         Note that we currently rely on the default access rule being "restricted": during
         room creation, the m.room.join_rules event will be sent *before* the

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -484,15 +484,13 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         )
 
     def create_room(
-        self, direct=False, rule=None, preset=None, initial_state=None,
-        expected_code=200,
+        self, direct=False, rule=None, preset=RoomCreationPreset.TRUSTED_PRIVATE_CHAT,
+        initial_state=None, expected_code=200,
     ):
         content = {
             "is_direct": direct,
+            "preset": preset,
         }
-
-        if preset:
-            content["preset"] = preset
 
         if rule:
             content["initial_state"] = [{

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -22,7 +22,7 @@ from mock import Mock
 
 from twisted.internet import defer
 
-from synapse.api.constants import EventTypes
+from synapse.api.constants import EventTypes, JoinRules, RoomCreationPreset
 from synapse.rest import admin
 from synapse.rest.client.v1 import login, room
 from synapse.third_party_rules.access_rules import (
@@ -155,6 +155,84 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         """Tests that creating a direct room with an invalid rule will fail.
         """
         self.create_room(direct=True, rule=ACCESS_RULE_RESTRICTED, expected_code=400)
+
+    def test_public_room(self):
+        """Tests that it's not possible to have a room with the public join rule and an
+        access rule that's not restricted.
+        """
+        # Creating a room with the public_chat preset should succeed and set the access
+        # rule to restricted.
+        preset_room_id = self.create_room(preset=RoomCreationPreset.PUBLIC_CHAT)
+        self.assertEqual(
+            self.current_rule_in_room(preset_room_id), ACCESS_RULE_RESTRICTED,
+        )
+
+        # Creating a room with the public join rule in its initial state should succeed
+        # and set the access rule to restricted.
+        init_state_room_id = self.create_room(initial_state=[{
+            "type": "m.room.join_rules",
+            "content": {
+                "join_rule": JoinRules.PUBLIC,
+            },
+        }])
+        self.assertEqual(
+            self.current_rule_in_room(init_state_room_id), ACCESS_RULE_RESTRICTED,
+        )
+
+        # Changing access rule to unrestricted should fail.
+        self.change_rule_in_room(
+            preset_room_id, ACCESS_RULE_UNRESTRICTED, expected_code=400,
+        )
+        self.change_rule_in_room(
+            init_state_room_id, ACCESS_RULE_UNRESTRICTED, expected_code=400,
+        )
+
+        # Changing access rule to direct should fail.
+        self.change_rule_in_room(
+            preset_room_id, ACCESS_RULE_DIRECT, expected_code=400,
+        )
+        self.change_rule_in_room(
+            init_state_room_id, ACCESS_RULE_DIRECT, expected_code=400,
+        )
+
+        # Changing join rule to public in an unrestricted room should fail.
+        self.change_join_rule_in_room(
+            self.unrestricted_room, JoinRules.PUBLIC, expected_code=400,
+        )
+        # Changing join rule to public in an direct room should fail.
+        self.change_join_rule_in_room(
+            self.direct_rooms[0], JoinRules.PUBLIC, expected_code=400,
+        )
+
+        # Creating a new room with the public_chat preset and an access rule that isn't
+        # restricted should fail.
+        self.create_room(
+            preset=RoomCreationPreset.PUBLIC_CHAT, rule=ACCESS_RULE_UNRESTRICTED,
+            expected_code=400,
+        )
+        self.create_room(
+            preset=RoomCreationPreset.PUBLIC_CHAT, rule=ACCESS_RULE_DIRECT,
+            expected_code=400,
+        )
+
+        # Creating a room with the public join rule in its initial state and an access
+        # rule that isn't restricted should fail.
+        self.create_room(
+            initial_state=[{
+                "type": "m.room.join_rules",
+                "content": {
+                    "join_rule": JoinRules.PUBLIC,
+                },
+            }], rule=ACCESS_RULE_UNRESTRICTED, expected_code=400,
+        )
+        self.create_room(
+            initial_state=[{
+                "type": "m.room.join_rules",
+                "content": {
+                    "join_rule": JoinRules.PUBLIC,
+                },
+            }], rule=ACCESS_RULE_DIRECT, expected_code=400,
+        )
 
     def test_restricted(self):
         """Tests that in restricted mode we're unable to invite users from blacklisted
@@ -405,10 +483,16 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
             expected_code=403,
         )
 
-    def create_room(self, direct=False, rule=None, expected_code=200):
+    def create_room(
+        self, direct=False, rule=None, preset=None, initial_state=None,
+        expected_code=200,
+    ):
         content = {
             "is_direct": direct,
         }
+
+        if preset:
+            content["preset"] = preset
 
         if rule:
             content["initial_state"] = [{
@@ -418,6 +502,12 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
                     "rule": rule,
                 }
             }]
+
+        if initial_state:
+            if "initial_state" not in content:
+                content["initial_state"] = []
+
+            content["initial_state"] += initial_state
 
         request, channel = self.make_request(
             "POST",
@@ -450,6 +540,20 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         request, channel = self.make_request(
             "PUT",
             "/_matrix/client/r0/rooms/%s/state/%s" % (room_id, ACCESS_RULES_TYPE),
+            json.dumps(data),
+            access_token=self.tok,
+        )
+        self.render(request)
+
+        self.assertEqual(channel.code, expected_code, channel.result)
+
+    def change_join_rule_in_room(self, room_id, new_join_rule, expected_code=200):
+        data = {
+            "join_rule": new_join_rule,
+        }
+        request, channel = self.make_request(
+            "PUT",
+            "/_matrix/client/r0/rooms/%s/state/%s" % (room_id, EventTypes.JoinRules),
             json.dumps(data),
             access_token=self.tok,
         )

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -181,27 +181,27 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
 
         # Changing access rule to unrestricted should fail.
         self.change_rule_in_room(
-            preset_room_id, ACCESS_RULE_UNRESTRICTED, expected_code=400,
+            preset_room_id, ACCESS_RULE_UNRESTRICTED, expected_code=403,
         )
         self.change_rule_in_room(
-            init_state_room_id, ACCESS_RULE_UNRESTRICTED, expected_code=400,
+            init_state_room_id, ACCESS_RULE_UNRESTRICTED, expected_code=403,
         )
 
         # Changing access rule to direct should fail.
         self.change_rule_in_room(
-            preset_room_id, ACCESS_RULE_DIRECT, expected_code=400,
+            preset_room_id, ACCESS_RULE_DIRECT, expected_code=403,
         )
         self.change_rule_in_room(
-            init_state_room_id, ACCESS_RULE_DIRECT, expected_code=400,
+            init_state_room_id, ACCESS_RULE_DIRECT, expected_code=403,
         )
 
         # Changing join rule to public in an unrestricted room should fail.
         self.change_join_rule_in_room(
-            self.unrestricted_room, JoinRules.PUBLIC, expected_code=400,
+            self.unrestricted_room, JoinRules.PUBLIC, expected_code=403,
         )
         # Changing join rule to public in an direct room should fail.
         self.change_join_rule_in_room(
-            self.direct_rooms[0], JoinRules.PUBLIC, expected_code=400,
+            self.direct_rooms[0], JoinRules.PUBLIC, expected_code=403,
         )
 
         # Creating a new room with the public_chat preset and an access rule that isn't


### PR DESCRIPTION
If the join rule for a room is "public", then we must only allow the "restricted" access rule to be enforced.

Each commit should be reviewable independently.