### PR TITLE
Opentracing across workers

### DIFF
--- a/changelog.d/5771.feature
+++ b/changelog.d/5771.feature
@@ -1,1 +1,1 @@
-Opentracing in worker mode.
+Make Opentracing work in worker mode.

--- a/changelog.d/5771.feature
+++ b/changelog.d/5771.feature
@@ -1,0 +1,1 @@
+Opentracing in worker mode.

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -293,7 +293,7 @@ class BaseFederationServlet(object):
                 logger.warn("authenticate_request failed: %s", e)
                 raise
 
-            _tags = {
+            request_tags = {
                 "request_id": request.get_request_id(),
                 tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER,
                 tags.HTTP_METHOD: request.get_method(),
@@ -307,10 +307,10 @@ class BaseFederationServlet(object):
             # and whitelisted
             if origin and whitelisted_homeserver(origin):
                 scope = start_active_span_from_request(
-                    request, "incoming-federation-request", tags=_tags
+                    request, "incoming-federation-request", tags=request_tags
                 )
             else:
-                scope = start_active_span("incoming-federation-request", tags=_tags)
+                scope = start_active_span("incoming-federation-request", tags=request_tags)
 
             with scope:
                 if origin:

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -310,7 +310,7 @@ class BaseFederationServlet(object):
                     request, "incoming-federation-request", tags=_tags
                 )
             else:
-                scope = start_active_span("incoming-federation-request", tags=tags)
+                scope = start_active_span("incoming-federation-request", tags=_tags)
 
             with scope:
                 if origin:

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -39,9 +39,9 @@ from synapse.http.servlet import (
 )
 from synapse.logging.context import run_in_background
 from synapse.logging.opentracing import (
+    get_tags,
     start_active_span,
     start_active_span_from_request,
-    tags,
     whitelisted_homeserver,
 )
 from synapse.types import ThirdPartyInstanceID, get_domain_from_id
@@ -293,6 +293,7 @@ class BaseFederationServlet(object):
                 logger.warn("authenticate_request failed: %s", e)
                 raise
 
+            tags = get_tags()
             _tags = {
                 "request_id": request.get_request_id(),
                 tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER,

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -39,9 +39,9 @@ from synapse.http.servlet import (
 )
 from synapse.logging.context import run_in_background
 from synapse.logging.opentracing import (
-    get_tags,
     start_active_span,
     start_active_span_from_request,
+    tags,
     whitelisted_homeserver,
 )
 from synapse.types import ThirdPartyInstanceID, get_domain_from_id
@@ -293,7 +293,6 @@ class BaseFederationServlet(object):
                 logger.warn("authenticate_request failed: %s", e)
                 raise
 
-            tags = get_tags()
             _tags = {
                 "request_id": request.get_request_id(),
                 tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER,

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -38,7 +38,12 @@ from synapse.http.servlet import (
     parse_string_from_args,
 )
 from synapse.logging.context import run_in_background
-from synapse.logging.opentracing import start_active_span_from_context, tags
+from synapse.logging.opentracing import (
+    start_active_span,
+    start_active_span_from_request,
+    tags,
+    whitelisted_homeserver,
+)
 from synapse.types import ThirdPartyInstanceID, get_domain_from_id
 from synapse.util.ratelimitutils import FederationRateLimiter
 from synapse.util.versionstring import get_version_string
@@ -288,20 +293,26 @@ class BaseFederationServlet(object):
                 logger.warn("authenticate_request failed: %s", e)
                 raise
 
-            # Start an opentracing span
-            with start_active_span_from_context(
-                request.requestHeaders,
-                "incoming-federation-request",
-                tags={
-                    "request_id": request.get_request_id(),
-                    tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER,
-                    tags.HTTP_METHOD: request.get_method(),
-                    tags.HTTP_URL: request.get_redacted_uri(),
-                    tags.PEER_HOST_IPV6: request.getClientIP(),
-                    "authenticated_entity": origin,
-                    "servlet_name": request.request_metrics.name,
-                },
-            ):
+            _tags = {
+                "request_id": request.get_request_id(),
+                tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER,
+                tags.HTTP_METHOD: request.get_method(),
+                tags.HTTP_URL: request.get_redacted_uri(),
+                tags.PEER_HOST_IPV6: request.getClientIP(),
+                "authenticated_entity": origin,
+                "servlet_name": request.request_metrics.name,
+            }
+
+            # Only accept the span context if the origin is authenticated
+            # and whitelisted
+            if origin and whitelisted_homeserver(origin):
+                scope = start_active_span_from_request(
+                    request, "incoming-federation-request", tags=_tags
+                )
+            else:
+                scope = start_active_span("incoming-federation-request", tags=tags)
+
+            with scope:
                 if origin:
                     with ratelimiter.ratelimit(origin) as d:
                         await d

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -310,7 +310,9 @@ class BaseFederationServlet(object):
                     request, "incoming-federation-request", tags=request_tags
                 )
             else:
-                scope = start_active_span("incoming-federation-request", tags=request_tags)
+                scope = start_active_span(
+                    "incoming-federation-request", tags=request_tags
+                )
 
             with scope:
                 if origin:

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -300,7 +300,7 @@ class RestServlet(object):
                     http_server.register_paths(
                         method,
                         patterns,
-                        trace_servlet(servlet_classname, method_handler),
+                        trace_servlet(servlet_classname)(method_handler),
                         servlet_classname,
                     )
 

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -769,3 +769,7 @@ class _DummyTagNames(object):
 
 
 tags = _DummyTagNames
+
+
+def get_tags():
+    return tags

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -174,10 +174,48 @@ from twisted.internet import defer
 
 from synapse.config import ConfigError
 
+# Helper class
+
+
+class _DummyTagNames(object):
+    """wrapper of opentracings tags. We need to have them if we
+    want to reference them without opentracing around. Clearly they
+    should never actually show up in a trace. `set_tags` overwrites
+    these with the correct ones."""
+
+    INVALID_TAG = "invalid-tag"
+    COMPONENT = INVALID_TAG
+    DATABASE_INSTANCE = INVALID_TAG
+    DATABASE_STATEMENT = INVALID_TAG
+    DATABASE_TYPE = INVALID_TAG
+    DATABASE_USER = INVALID_TAG
+    ERROR = INVALID_TAG
+    HTTP_METHOD = INVALID_TAG
+    HTTP_STATUS_CODE = INVALID_TAG
+    HTTP_URL = INVALID_TAG
+    MESSAGE_BUS_DESTINATION = INVALID_TAG
+    PEER_ADDRESS = INVALID_TAG
+    PEER_HOSTNAME = INVALID_TAG
+    PEER_HOST_IPV4 = INVALID_TAG
+    PEER_HOST_IPV6 = INVALID_TAG
+    PEER_PORT = INVALID_TAG
+    PEER_SERVICE = INVALID_TAG
+    SAMPLING_PRIORITY = INVALID_TAG
+    SERVICE = INVALID_TAG
+    SPAN_KIND = INVALID_TAG
+    SPAN_KIND_CONSUMER = INVALID_TAG
+    SPAN_KIND_PRODUCER = INVALID_TAG
+    SPAN_KIND_RPC_CLIENT = INVALID_TAG
+    SPAN_KIND_RPC_SERVER = INVALID_TAG
+
+
 try:
     import opentracing
+
+    tags = opentracing.tags
 except ImportError:
     opentracing = None
+    tags = _DummyTagNames
 try:
     from jaeger_client import Config as JaegerConfig
     from synapse.logging.scopecontextmanager import LogContextScopeManager
@@ -251,10 +289,6 @@ def init_tracer(config):
         service_name="{} {}".format(config.server_name, name),
         scope_manager=LogContextScopeManager(config),
     ).initialize_tracer()
-
-    # Set up tags to be opentracing's tags
-    global tags
-    tags = opentracing.tags
 
 
 # Whitelisting
@@ -732,44 +766,3 @@ def trace_servlet(servlet_name, extract_context=False):
 
     return _trace_servlet_inner_1
 
-
-# Helper class
-
-
-class _DummyTagNames(object):
-    """wrapper of opentracings tags. We need to have them if we
-    want to reference them without opentracing around. Clearly they
-    should never actually show up in a trace. `set_tags` overwrites
-    these with the correct ones."""
-
-    INVALID_TAG = "invalid-tag"
-    COMPONENT = INVALID_TAG
-    DATABASE_INSTANCE = INVALID_TAG
-    DATABASE_STATEMENT = INVALID_TAG
-    DATABASE_TYPE = INVALID_TAG
-    DATABASE_USER = INVALID_TAG
-    ERROR = INVALID_TAG
-    HTTP_METHOD = INVALID_TAG
-    HTTP_STATUS_CODE = INVALID_TAG
-    HTTP_URL = INVALID_TAG
-    MESSAGE_BUS_DESTINATION = INVALID_TAG
-    PEER_ADDRESS = INVALID_TAG
-    PEER_HOSTNAME = INVALID_TAG
-    PEER_HOST_IPV4 = INVALID_TAG
-    PEER_HOST_IPV6 = INVALID_TAG
-    PEER_PORT = INVALID_TAG
-    PEER_SERVICE = INVALID_TAG
-    SAMPLING_PRIORITY = INVALID_TAG
-    SERVICE = INVALID_TAG
-    SPAN_KIND = INVALID_TAG
-    SPAN_KIND_CONSUMER = INVALID_TAG
-    SPAN_KIND_PRODUCER = INVALID_TAG
-    SPAN_KIND_RPC_CLIENT = INVALID_TAG
-    SPAN_KIND_RPC_SERVER = INVALID_TAG
-
-
-tags = _DummyTagNames
-
-
-def get_tags():
-    return tags

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -765,4 +765,3 @@ def trace_servlet(servlet_name, extract_context=False):
         return _trace_servlet_inner
 
     return _trace_servlet_inner_1
-

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -693,7 +693,14 @@ def tag_args(func):
 
 def trace_servlet(servlet_name, extract_context=False):
     """Decorator which traces a serlet. It starts a span with some servlet specific
-    tags such as the servlet_name and request information"""
+    tags such as the servlet_name and request information
+
+    Args:
+        servlet_name (str): The name to be used for the span's operation_name
+        extract_context (bool): Whether to attempt to extract the opentracing
+            context from the request the servlet is handling.
+
+    """
 
     def _trace_servlet_inner_1(func):
         if not opentracing:

--- a/synapse/replication/http/_base.py
+++ b/synapse/replication/http/_base.py
@@ -167,8 +167,8 @@ class ReplicationEndpoint(object):
                 # have a good idea that the request has either succeeded or failed on
                 # the master, and so whether we should clean up or not.
                 while True:
-                    headers = Headers()
-                    opentracing.inject_active_span_twisted_headers(
+                    headers = {}
+                    opentracing.inject_active_span_byte_dict(
                         headers, None, check_destination=False
                     )
                     try:

--- a/synapse/replication/http/_base.py
+++ b/synapse/replication/http/_base.py
@@ -21,7 +21,6 @@ from six import raise_from
 from six.moves import urllib
 
 from twisted.internet import defer
-from twisted.web.http_headers import Headers
 
 import synapse.logging.opentracing as opentracing
 from synapse.api.errors import (


### PR DESCRIPTION
When in worker mode we need to inject span contexts into the requests from master to workers and vice versa. Homeserver whitelisting would be annoying in this case so I've added some conveniences to switch it off for worker requests. The whitelists are still applied by default unless it is explicitly turned off. 