### PR TITLE
Fix room summary when rejected events are in state

### DIFF
--- a/changelog.d/5752.misc
+++ b/changelog.d/5752.misc
@@ -1,0 +1,1 @@
+Reduce database IO usage by optimising queries for current membership.

--- a/changelog.d/5774.misc
+++ b/changelog.d/5774.misc
@@ -1,0 +1,1 @@
+Reduce database IO usage by optimising queries for current membership.

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -156,9 +156,12 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             # then we can avoid a join, which is a Very Good Thing given how
             # frequently this function gets called.
             if self._current_state_events_membership_up_to_date:
+                # Note, rejected events will have a null membership field, so
+                # we we manually filter them out.
                 sql = """
                     SELECT count(*), membership FROM current_state_events
                     WHERE type = 'm.room.member' AND room_id = ?
+                        AND membership IS NOT NULL
                     GROUP BY membership
                 """
             else:
@@ -180,10 +183,13 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             # we order by membership and then fairly arbitrarily by event_id so
             # heroes are consistent
             if self._current_state_events_membership_up_to_date:
+                # Note, rejected events will have a null membership field, so
+                # we we manually filter them out.
                 sql = """
                     SELECT state_key, membership, event_id
                     FROM current_state_events
                     WHERE type = 'm.room.member' AND room_id = ?
+                        AND membership IS NOT NULL
                     ORDER BY
                         CASE membership WHEN ? THEN 1 WHEN ? THEN 2 ELSE 3 END ASC,
                         event_id ASC

--- a/synapse/storage/schema/delta/56/room_membership_idx.sql
+++ b/synapse/storage/schema/delta/56/room_membership_idx.sql
@@ -1,0 +1,25 @@
+/* Copyright 2019 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- We add membership to current state so that we don't need to join against
+-- room_memberships, which can be surprisingly costly (we do such queries
+-- very frequently).
+-- This will be null for non-membership events and the content.membership key
+-- for membership events. (Will also be null for membership events until the
+-- background update job has finished).
+
+-- Adds an index on room_memberships for fetching all forgotten rooms for a user
+INSERT INTO background_updates (update_name, progress_json) VALUES
+  ('room_membership_forgotten_idx', '{}');


### PR DESCRIPTION
Annoyingly, `current_state_events` table can include rejected events,
in which case the membership column will be null. To work around this
lets just always filter out null membership for now.

Based on #5752.

Broke in #5706.