### PR TITLE
Add ability to pass arguments to looping calls

### DIFF
--- a/changelog.d/5780.misc
+++ b/changelog.d/5780.misc
@@ -1,0 +1,1 @@
+Allow looping calls to be given arguments.

--- a/synapse/util/__init__.py
+++ b/synapse/util/__init__.py
@@ -59,7 +59,7 @@ class Clock(object):
         """Returns the current system time in miliseconds since epoch."""
         return int(self.time() * 1000)
 
-    def looping_call(self, f, msec, *args):
+    def looping_call(self, f, msec, *args, **kwargs):
         """Call a function repeatedly.
 
         Waits `msec` initially before calling `f` for the first time.
@@ -70,8 +70,10 @@ class Clock(object):
         Args:
             f(function): The function to call repeatedly.
             msec(float): How long to wait between calls in milliseconds.
+            *args: Postional arguments to pass to function.
+            **kwargs: Key arguments to pass to function.
         """
-        call = task.LoopingCall(f, *args)
+        call = task.LoopingCall(f, *args, **kwargs)
         call.clock = self._reactor
         d = call.start(msec / 1000.0, now=False)
         d.addErrback(log_failure, "Looping call died", consumeErrors=False)

--- a/synapse/util/__init__.py
+++ b/synapse/util/__init__.py
@@ -59,7 +59,7 @@ class Clock(object):
         """Returns the current system time in miliseconds since epoch."""
         return int(self.time() * 1000)
 
-    def looping_call(self, f, msec):
+    def looping_call(self, f, msec, *args):
         """Call a function repeatedly.
 
         Waits `msec` initially before calling `f` for the first time.
@@ -71,7 +71,7 @@ class Clock(object):
             f(function): The function to call repeatedly.
             msec(float): How long to wait between calls in milliseconds.
         """
-        call = task.LoopingCall(f)
+        call = task.LoopingCall(f, *args)
         call.clock = self._reactor
         d = call.start(msec / 1000.0, now=False)
         d.addErrback(log_failure, "Looping call died", consumeErrors=False)


### PR DESCRIPTION
Allow looping calls defined by the `Clock` class to be given arguments. Context is that an upcoming PR I'm working on (in which I'm starting several looping calls from the same function but with different parameters) requires it.