### PR TITLE
Fix handling of redactions of redactions

### DIFF
--- a/changelog.d/5788.bugfix
+++ b/changelog.d/5788.bugfix
@@ -1,0 +1,1 @@
+Correctly handle redactions of redactions.


### PR DESCRIPTION
When a redaction is redacted, we should strip out the content of the original redaction, including the "reason" field. Since 0f2ecb961, this has been broken. The challenge is to fix it in a way that does not reintroduce the bug which that commit fixed.

The approach taken here is to make sure we pull any redaction events we might need out of the database before we start turning any events into EventCacheEntries, so even a loop will be correctly handled.

The commits in this PR should be independently reviewable. It starts with a couple of refactors which (a) modify the interface to `_fetch_event_list` and (b) break `_enqueue_events` in half.

The third commit adds the loop which recursively fetches redactions until we have found the ends of the redaction tree, and the fourth finally fixes the problem by passing all the fetched events into `_maybe_redact_event_row`.