### PR TITLE
Fix error handling when fetching remote device keys

### DIFF
--- a/changelog.d/5789.bugfix
+++ b/changelog.d/5789.bugfix
@@ -1,0 +1,1 @@
+Fix UISIs during homeserver outage.

--- a/synapse/handlers/e2e_keys.py
+++ b/synapse/handlers/e2e_keys.py
@@ -25,6 +25,7 @@ from twisted.internet import defer
 from synapse.api.errors import CodeMessageException, SynapseError
 from synapse.logging.context import make_deferred_yieldable, run_in_background
 from synapse.types import UserID, get_domain_from_id
+from synapse.util import unwrapFirstError
 from synapse.util.retryutils import NotRetryingDestination
 
 logger = logging.getLogger(__name__)
@@ -192,7 +193,7 @@ class E2eKeysHandler(object):
                     for destination in remote_queries_not_in_cache
                 ],
                 consumeErrors=True,
-            )
+            ).addErrback(unwrapFirstError)
         )
 
         return {"device_keys": results, "failures": failures}

--- a/synapse/handlers/e2e_keys.py
+++ b/synapse/handlers/e2e_keys.py
@@ -161,9 +161,7 @@ class E2eKeysHandler(object):
                         results[user_id] = {device["device_id"]: device["keys"]}
                     user_ids_updated.append(user_id)
                 except Exception as e:
-                    failures[destination] = failures.get(destination, []).append(
-                        _exception_to_failure(e)
-                    )
+                    failures[destination] = _exception_to_failure(e)
 
             if len(destination_query) == len(user_ids_updated):
                 # We've updated all the users in the query and we do not need to


### PR DESCRIPTION
Fixes:

```
FirstError[#0, [Failure instance: Traceback: <class 'AttributeError'>: 'NoneType' object has no attribute 'append'
/home/synapse/src/synapse/handlers/e2e_keys.py:194:<listcomp>
/home/synapse/src/synapse/logging/context.py:556:run_in_background
/home/synapse/env-py37/lib/python3.7/site-packages/twisted/internet/defer.py:1613:unwindGenerator
/home/synapse/env-py37/lib/python3.7/site-packages/twisted/internet/defer.py:1529:_cancellableInlineCallbacks
--- <exception caught here> ---
/home/synapse/env-py37/lib/python3.7/site-packages/twisted/internet/defer.py:1418:_inlineCallbacks
/home/synapse/src/synapse/handlers/e2e_keys.py:164:do_remote_query
]]
```

Also unwraps errors thrown in the `gatherResults` so we get better tracebacks.

Broke in #5693