### PR TITLE
Disable codecov reports to GH comments.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,4 @@
-comment:
-  layout: "diff"
+comment: off
 
 coverage:
   status:

--- a/changelog.d/5796.misc
+++ b/changelog.d/5796.misc
@@ -1,0 +1,1 @@
+Disable codecov GitHub comments on PRs.


### PR DESCRIPTION
The double posting is really annoying, and I don't think anyone is
actually reading them. The commit statuses should give a good summary
and will link to a full report.