### PR TITLE
Return 404 instead of 403 when retrieving an event without perms

### DIFF
--- a/changelog.d/5798.bugfix
+++ b/changelog.d/5798.bugfix
@@ -1,0 +1,1 @@
+Return 404 instead of 403 when accessing /rooms/{roomId}/event/{eventId} for an event without the appropriate permissions.

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -576,7 +576,7 @@ class RoomEventServlet(RestServlet):
             # This endpoint is supposed to return a 404 when the requester does
             # not have permission to access the event
             # https://matrix.org/docs/spec/client_server/r0.5.0#get-matrix-client-r0-rooms-roomid-event-eventid
-            return (404, e.msg)
+            return (404, "Event not found.")
 
         time_now = self.clock.time_msec()
         if event:

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -569,7 +569,9 @@ class RoomEventServlet(RestServlet):
     def on_GET(self, request, room_id, event_id):
         requester = yield self.auth.get_user_by_req(request, allow_guest=True)
         try:
-            event = yield self.event_handler.get_event(requester.user, room_id, event_id)
+            event = yield self.event_handler.get_event(
+                requester.user, room_id, event_id
+            )
         except AuthError as e:
             # This endpoint is supposed to return a 404 when the requester does
             # not have permission to access the event

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -576,7 +576,7 @@ class RoomEventServlet(RestServlet):
             # This endpoint is supposed to return a 404 when the requester does
             # not have permission to access the event
             # https://matrix.org/docs/spec/client_server/r0.5.0#get-matrix-client-r0-rooms-roomid-event-eventid
-            return (404, "Event not found.")
+            return (404, "Event not found.", errcode=Codes.NOT_FOUND)
 
         time_now = self.clock.time_msec()
         if event:

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -576,7 +576,7 @@ class RoomEventServlet(RestServlet):
             # This endpoint is supposed to return a 404 when the requester does
             # not have permission to access the event
             # https://matrix.org/docs/spec/client_server/r0.5.0#get-matrix-client-r0-rooms-roomid-event-eventid
-            return (404, "Event not found.", errcode=Codes.NOT_FOUND)
+            raise SynapseError(404, "Event not found.", errcode=Codes.NOT_FOUND)
 
         time_now = self.clock.time_msec()
         if event:

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -572,7 +572,7 @@ class RoomEventServlet(RestServlet):
             event = yield self.event_handler.get_event(
                 requester.user, room_id, event_id
             )
-        except AuthError as e:
+        except AuthError:
             # This endpoint is supposed to return a 404 when the requester does
             # not have permission to access the event
             # https://matrix.org/docs/spec/client_server/r0.5.0#get-matrix-client-r0-rooms-roomid-event-eventid

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -568,7 +568,13 @@ class RoomEventServlet(RestServlet):
     @defer.inlineCallbacks
     def on_GET(self, request, room_id, event_id):
         requester = yield self.auth.get_user_by_req(request, allow_guest=True)
-        event = yield self.event_handler.get_event(requester.user, room_id, event_id)
+        try:
+            event = yield self.event_handler.get_event(requester.user, room_id, event_id)
+        except AuthError as e:
+            # This endpoint is supposed to return a 404 when the requester does
+            # not have permission to access the event
+            # https://matrix.org/docs/spec/client_server/r0.5.0#get-matrix-client-r0-rooms-roomid-event-eventid
+            return (404, e.msg)
 
         time_now = self.clock.time_msec()
         if event:

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -582,8 +582,8 @@ class RoomEventServlet(RestServlet):
         if event:
             event = yield self._event_serializer.serialize_event(event, time_now)
             return (200, event)
-        else:
-            return (404, "Event not found.")
+
+        return SynapseError(404, "Event not found.", errcode=Codes.NOT_FOUND)
 
 
 class RoomEventContextServlet(RestServlet):


### PR DESCRIPTION
Part of fixing https://github.com/matrix-org/sytest/issues/652

Sytest PR: https://github.com/matrix-org/sytest/pull/667