### PR TITLE
Deny redaction of events in a different room.

### DIFF
--- a/changelog.d/5802.misc
+++ b/changelog.d/5802.misc
@@ -1,0 +1,1 @@
+Deny redactions of events sent in a different room. 

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -795,13 +795,15 @@ class EventCreationHandler(object):
                 get_prev_content=False,
                 allow_rejected=False,
                 allow_none=True,
-                check_room_id=event.room_id,
             )
 
             # we can make some additional checks now if we have the original event.
             if original_event:
                 if original_event.type == EventTypes.Create:
                     raise AuthError(403, "Redacting create events is not permitted")
+
+                if original_event.room_id != event.room_id:
+                    raise SynapseError(400, "Cannot redact event from a different room")
 
             prev_state_ids = yield context.get_prev_state_ids(self.store)
             auth_events_ids = yield self.auth.compute_auth_events(


### PR DESCRIPTION
We already correctly filter out such redactions, but we should also deny
them over the CS API.