### PR TITLE
Account validity: allow defining HTML templates to serve the user on account renewal attempt

### DIFF
--- a/changelog.d/5807.feature
+++ b/changelog.d/5807.feature
@@ -1,0 +1,1 @@
+Allow defining HTML templates to serve the user on account renewal attempt when using the account validity feature.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -802,6 +802,16 @@ uploads_path: "DATADIR/uploads"
 #  period: 6w
 #  renew_at: 1w
 #  renew_email_subject: "Renew your %(app)s account"
+#  # Directory in which Synapse will try to find the HTML files to serve to the
+#  # user when trying to renew an account. Optional, defaults to
+#  # synapse/res/templates.
+#  template_dir: "res/templates" 
+#  # HTML to be displayed to the user after they successfully renewed their
+#  # account. Optional.
+#  account_renewed_html_path: "account_renewed.html"
+#  # HTML to be displayed when the user tries to renew an account with an invalid
+#  # renewal token. Optional.
+#  invalid_token_html_path: "invalid_token.html"
 
 # Time that a user's session remains valid for, after they log in.
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -805,7 +805,7 @@ uploads_path: "DATADIR/uploads"
 #  # Directory in which Synapse will try to find the HTML files to serve to the
 #  # user when trying to renew an account. Optional, defaults to
 #  # synapse/res/templates.
-#  template_dir: "res/templates" 
+#  template_dir: "res/templates"
 #  # HTML to be displayed to the user after they successfully renewed their
 #  # account. Optional.
 #  account_renewed_html_path: "account_renewed.html"

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 import os
-import pkg_resources
-
 from distutils.util import strtobool
+
+import pkg_resources
 
 from synapse.config._base import Config, ConfigError
 from synapse.types import RoomAlias
@@ -54,13 +54,10 @@ class AccountValidityConfig(Config):
             template_dir = pkg_resources.resource_filename("synapse", "res/templates")
 
         if "account_renewed_html_path" in config:
-            file_path = os.path.join(
-                template_dir, config["account_renewed_html_path"],
-            )
+            file_path = os.path.join(template_dir, config["account_renewed_html_path"])
 
             self.account_renewed_html_content = self.read_file(
-                file_path,
-                "account_validity.account_renewed_html_path",
+                file_path, "account_validity.account_renewed_html_path"
             )
         else:
             self.account_renewed_html_content = (
@@ -68,12 +65,10 @@ class AccountValidityConfig(Config):
             )
 
         if "invalid_token_html_path" in config:
-            file_path = os.path.join(
-                template_dir, config["invalid_token_html_path"],
-            )
+            file_path = os.path.join(template_dir, config["invalid_token_html_path"])
 
             self.invalid_token_html_content = self.read_file(
-                file_path, "account_validity.invalid_token_html_path",
+                file_path, "account_validity.invalid_token_html_path"
             )
         else:
             self.invalid_token_html_content = (
@@ -184,7 +179,7 @@ class RegistrationConfig(Config):
         #  # Directory in which Synapse will try to find the HTML files to serve to the
         #  # user when trying to renew an account. Optional, defaults to
         #  # synapse/res/templates.
-        #  template_dir: "res/templates" 
+        #  template_dir: "res/templates"
         #  # HTML to be displayed to the user after they successfully renewed their
         #  # account. Optional.
         #  account_renewed_html_path: "account_renewed.html"

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import pkg_resources
+
 from distutils.util import strtobool
 
 from synapse.config._base import Config, ConfigError
@@ -41,8 +44,41 @@ class AccountValidityConfig(Config):
 
             self.startup_job_max_delta = self.period * 10.0 / 100.0
 
-        if self.renew_by_email_enabled and "public_baseurl" not in synapse_config:
-            raise ConfigError("Can't send renewal emails without 'public_baseurl'")
+        if self.renew_by_email_enabled:
+            if "public_baseurl" not in synapse_config:
+                raise ConfigError("Can't send renewal emails without 'public_baseurl'")
+
+        template_dir = config.get("template_dir")
+
+        if not template_dir:
+            template_dir = pkg_resources.resource_filename("synapse", "res/templates")
+
+        if "account_renewed_html_path" in config:
+            file_path = os.path.join(
+                template_dir, config["account_renewed_html_path"],
+            )
+
+            self.account_renewed_html_content = self.read_file(
+                file_path,
+                "account_validity.account_renewed_html_path",
+            )
+        else:
+            self.account_renewed_html_content = (
+                "<html><body>Your account has been successfully renewed.</body><html>"
+            )
+
+        if "invalid_token_html_path" in config:
+            file_path = os.path.join(
+                template_dir, config["invalid_token_html_path"],
+            )
+
+            self.invalid_token_html_content = self.read_file(
+                file_path, "account_validity.invalid_token_html_path",
+            )
+        else:
+            self.invalid_token_html_content = (
+                "<html><body>Invalid renewal token.</body><html>"
+            )
 
 
 class RegistrationConfig(Config):
@@ -145,6 +181,16 @@ class RegistrationConfig(Config):
         #  period: 6w
         #  renew_at: 1w
         #  renew_email_subject: "Renew your %%(app)s account"
+        #  # Directory in which Synapse will try to find the HTML files to serve to the
+        #  # user when trying to renew an account. Optional, defaults to
+        #  # synapse/res/templates.
+        #  template_dir: "res/templates" 
+        #  # HTML to be displayed to the user after they successfully renewed their
+        #  # account. Optional.
+        #  account_renewed_html_path: "account_renewed.html"
+        #  # HTML to be displayed when the user tries to renew an account with an invalid
+        #  # renewal token. Optional.
+        #  invalid_token_html_path: "invalid_token.html"
 
         # Time that a user's session remains valid for, after they log in.
         #

--- a/synapse/handlers/account_validity.py
+++ b/synapse/handlers/account_validity.py
@@ -226,10 +226,18 @@ class AccountValidityHandler(object):
 
         Args:
             renewal_token (str): Token sent with the renewal request.
+        Returns:
+            bool: Whether the provided token is valid.
         """
-        user_id = yield self.store.get_user_from_renewal_token(renewal_token)
+        try:
+            user_id = yield self.store.get_user_from_renewal_token(renewal_token)
+        except StoreError:
+            defer.returnValue(False)
+
         logger.debug("Renewing an account for user %s", user_id)
         yield self.renew_account_for_user(user_id)
+
+        defer.returnValue(True)
 
     @defer.inlineCallbacks
     def renew_account_for_user(self, user_id, expiration_ts=None, email_sent=False):

--- a/synapse/res/templates/account_renewed.html
+++ b/synapse/res/templates/account_renewed.html
@@ -1,0 +1,1 @@
+<html><body>Your account has been successfully renewed.</body><html>

--- a/synapse/res/templates/invalid_token.html
+++ b/synapse/res/templates/invalid_token.html
@@ -1,0 +1,1 @@
+<html><body>Invalid renewal token.</body><html>

--- a/synapse/rest/client/v2_alpha/account_validity.py
+++ b/synapse/rest/client/v2_alpha/account_validity.py
@@ -52,7 +52,7 @@ class AccountValidityRenewServlet(RestServlet):
         renewal_token = request.args[b"token"][0]
 
         token_valid = yield self.account_activity_handler.renew_account(
-            renewal_token.decode("utf8"),
+            renewal_token.decode("utf8")
         )
 
         if token_valid:
@@ -64,9 +64,7 @@ class AccountValidityRenewServlet(RestServlet):
 
         request.setResponseCode(status_code)
         request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
-        request.setHeader(
-            b"Content-Length", b"%d" % (len(response),)
-        )
+        request.setHeader(b"Content-Length", b"%d" % (len(response),))
         request.write(response.encode("utf8"))
         finish_request(request)
         defer.returnValue(None)

--- a/synapse/rest/client/v2_alpha/account_validity.py
+++ b/synapse/rest/client/v2_alpha/account_validity.py
@@ -42,6 +42,8 @@ class AccountValidityRenewServlet(RestServlet):
         self.hs = hs
         self.account_activity_handler = hs.get_account_validity_handler()
         self.auth = hs.get_auth()
+        self.success_html = hs.config.account_validity.account_renewed_html_content
+        self.failure_html = hs.config.account_validity.invalid_token_html_content
 
     @defer.inlineCallbacks
     def on_GET(self, request):
@@ -49,16 +51,25 @@ class AccountValidityRenewServlet(RestServlet):
             raise SynapseError(400, "Missing renewal token")
         renewal_token = request.args[b"token"][0]
 
-        yield self.account_activity_handler.renew_account(renewal_token.decode("utf8"))
+        token_valid = yield self.account_activity_handler.renew_account(
+            renewal_token.decode("utf8"),
+        )
 
-        request.setResponseCode(200)
+        if token_valid:
+            status_code = 200
+            response = self.success_html
+        else:
+            status_code = 404
+            response = self.failure_html
+
+        request.setResponseCode(status_code)
         request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
         request.setHeader(
-            b"Content-Length", b"%d" % (len(AccountValidityRenewServlet.SUCCESS_HTML),)
+            b"Content-Length", b"%d" % (len(response),)
         )
-        request.write(AccountValidityRenewServlet.SUCCESS_HTML)
+        request.write(response.encode("utf8"))
         finish_request(request)
-        return None
+        defer.returnValue(None)
 
 
 class AccountValiditySendMailServlet(RestServlet):
@@ -87,7 +98,7 @@ class AccountValiditySendMailServlet(RestServlet):
         user_id = requester.user.to_string()
         yield self.account_activity_handler.send_renewal_email_to_user(user_id)
 
-        return (200, {})
+        defer.returnValue((200, {}))
 
 
 def register_servlets(hs, http_server):

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -323,6 +323,8 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
             "renew_at": 172800000,  # Time in ms for 2 days
             "renew_by_email_enabled": True,
             "renew_email_subject": "Renew your account",
+            "account_renewed_html_path": "account_renewed.html",
+            "invalid_token_html_path": "invalid_token.html",
         }
 
         # Email config.
@@ -373,6 +375,19 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         self.render(request)
         self.assertEquals(channel.result["code"], b"200", channel.result)
 
+        # Check that we're getting HTML back.
+        content_type = None
+        for header in channel.result.get("headers", []):
+            if header[0] == b"Content-Type":
+                content_type = header[1]
+        self.assertEqual(content_type, b"text/html; charset=utf-8", channel.result)
+
+        # Check that the HTML we're getting is the one we expect on a successful renewal.
+        expected_html = self.hs.config.account_validity.account_renewed_html_content
+        self.assertEqual(
+            channel.result["body"], expected_html.encode("utf8"), channel.result
+        )
+
         # Move 3 days forward. If the renewal failed, every authed request with
         # our access token should be denied from now, otherwise they should
         # succeed.
@@ -380,6 +395,28 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         request, channel = self.make_request(b"GET", "/sync", access_token=tok)
         self.render(request)
         self.assertEquals(channel.result["code"], b"200", channel.result)
+
+    def test_renewal_invalid_token(self):
+        # Hit the renewal endpoint with an invalid token and check that it behaves as
+        # expected, i.e. that it responds with 404 Not Found and the correct HTML.
+        url = "/_matrix/client/unstable/account_validity/renew?token=123"
+        request, channel = self.make_request(b"GET", url)
+        self.render(request)
+        self.assertEquals(channel.result["code"], b"404", channel.result)
+
+        # Check that we're getting HTML back.
+        content_type = None
+        for header in channel.result.get("headers", []):
+            if header[0] == b"Content-Type":
+                content_type = header[1]
+        self.assertEqual(content_type, b"text/html; charset=utf-8", channel.result)
+
+        # Check that the HTML we're getting is the one we expect when using an
+        # invalid/unknown token.
+        expected_html = self.hs.config.account_validity.invalid_token_html_content
+        self.assertEqual(
+            channel.result["body"], expected_html.encode("utf8"), channel.result
+        )
 
     def test_manual_email_send(self):
         self.email_attempts = []


### PR DESCRIPTION
Admins of servers using the account validity feature might want to be able to define the messages that users will see when attempting to renew their account.
This PR lets them define two HTML templates, which will be served to the user upon successful renewal or failure due to an unknown renewal token.