### PR TITLE
Fix bug: sometimes user can not login to server because of error of membership

### DIFF
--- a/changelog.d/5818.bugfix
+++ b/changelog.d/5818.bugfix
@@ -1,0 +1,1 @@
+Fix bug KeyError: 'membership' when client try to fetch rooms from servers.

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -172,7 +172,10 @@ class EventBase(object):
 
     @property
     def membership(self):
-        return self.content["membership"]
+        if "membership" in self.content:
+            return self.content["membership"]
+        else:
+            return None
 
     def is_state(self):
         return hasattr(self, "state_key") and self.state_key is not None


### PR DESCRIPTION
Sometimes, after updating Homeserver to new version, when user try to login, user can get error "Could not connect to the homeserver" and can not login to server. In homeserver log, we find this error:

```
  File "/usr/local/lib/python3.6/dist-packages/synapse/handlers/sync.py", line 476, in _load_filtered_recents
    always_include_ids=current_state_ids,
  File "/usr/local/lib/python3.6/dist-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/usr/local/lib/python3.6/dist-packages/synapse/visibility.py", line 211, in filter_events_for_client
    defer.returnValue(list(filtered_events))
  File "/usr/local/lib/python3.6/dist-packages/synapse/visibility.py", line 165, in allowed
    membership = membership_event.membership
  File "/usr/local/lib/python3.6/dist-packages/synapse/events/__init__.py", line 175, in membership
    return self.content["membership"]
KeyError: 'membership'
```

Signed-off-by: Nguyen Van Cuong <cuongnvbkict@gmail.com>


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
