### PR TITLE
Handle TimelineBatch being limited and empty.

### DIFF
--- a/changelog.d/5825.bugfix
+++ b/changelog.d/5825.bugfix
@@ -1,0 +1,1 @@
+Fix bug where user `/sync` stream could get wedged in rare circumstances.


### PR DESCRIPTION
This hopefully addresses #5407 by gracefully handling an empty but
limited TimelineBatch. We also add some logging to figure out how this
is happening.

This is a rare edge case, so the extra logging should not be spammy unless the case has been hit.