### PR TITLE
Smear expiry time in ExpiringCache

### DIFF
--- a/changelog.d/5838.misc
+++ b/changelog.d/5838.misc
@@ -1,0 +1,1 @@
+Smear expiry time in ExpiringCache to reduce batching up work causing spikes in CPU and DB.

--- a/tests/util/test_expiring_cache.py
+++ b/tests/util/test_expiring_cache.py
@@ -73,7 +73,7 @@ class ExpiringCacheTestCase(unittest.TestCase):
         self.assertEquals(cache.get("key"), 1)
         self.assertEquals(cache.get("key2"), 2)
 
-        clock.advance_time(0.9)
+        clock.advance_time(0.7)
         self.assertEquals(cache.get("key"), None)
         self.assertEquals(cache.get("key2"), 2)
 


### PR DESCRIPTION
This helps to ensure that we don't see cache evictions, and thus DB
work, getting batched up.

In particular, this should help avoid the 5m spikes we see fetching destination retry timings from the DB.