### PR TITLE
Fix curl command typo in purge_remote_media.sh

### DIFF
--- a/changelog.d/5839.bugfix
+++ b/changelog.d/5839.bugfix
@@ -1,0 +1,1 @@
+The purge_remote_media.sh script was fixed

--- a/changelog.d/5839.bugfix
+++ b/changelog.d/5839.bugfix
@@ -1,1 +1,1 @@
-The purge_remote_media.sh script was fixed
+The purge_remote_media.sh script was fixed.

--- a/contrib/purge_api/purge_remote_media.sh
+++ b/contrib/purge_api/purge_remote_media.sh
@@ -51,4 +51,4 @@ TOKEN=$(sql "SELECT token FROM access_tokens WHERE user_id='$ADMIN' ORDER BY id 
 # finally start pruning media:
 ###############################################################################
 set -x # for debugging the generated string
-curl --header "Authorization: Bearer $TOKEN" -v POST "$API_URL/admin/purge_media_cache/?before_ts=$UNIX_TIMESTAMP"
+curl --header "Authorization: Bearer $TOKEN" -X POST "$API_URL/admin/purge_media_cache/?before_ts=$UNIX_TIMESTAMP"


### PR DESCRIPTION
Was verbose option instead of -X, command didn't work

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
