### PR TITLE
Room Directory:  Wrap `get_local_public_room_list` call in `maybeDeferred`

### DIFF
--- a/changelog.d/5851.bugfix
+++ b/changelog.d/5851.bugfix
@@ -1,0 +1,2 @@
+Fixes 500 Internal Server Error on `publicRooms` when the public room list was
+cached.

--- a/changelog.d/5851.bugfix
+++ b/changelog.d/5851.bugfix
@@ -1,2 +1,2 @@
-Fixes 500 Internal Server Error on `publicRooms` when the public room list was
+Fix 500 Internal Server Error on `publicRooms` when the public room list was
 cached.

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -19,6 +19,8 @@ import functools
 import logging
 import re
 
+from twisted.internet.defer import maybeDeferred
+
 import synapse
 import synapse.logging.opentracing as opentracing
 from synapse.api.errors import Codes, FederationDeniedError, SynapseError
@@ -745,8 +747,12 @@ class PublicRoomList(BaseFederationServlet):
         else:
             network_tuple = ThirdPartyInstanceID(None, None)
 
-        data = await self.handler.get_local_public_room_list(
-            limit, since_token, network_tuple=network_tuple, from_federation=True
+        data = await maybeDeferred(
+            self.handler.get_local_public_room_list,
+            limit,
+            since_token,
+            network_tuple=network_tuple,
+            from_federation=True,
         )
         return 200, data
 


### PR DESCRIPTION
Fixes a `TypeError: object dict can't be used in 'await' expression` exception, whenever the result of a non-filtered public room listing was cached.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
