### PR TITLE
add the version field to the index for e2e_room_keys

### DIFF
--- a/changelog.d/5857.bugfix
+++ b/changelog.d/5857.bugfix
@@ -1,1 +1,1 @@
-Add missing version field to e2e_room_keys database index.
+Fix database index so that different backup versions can have the same sessions.

--- a/changelog.d/5857.bugfix
+++ b/changelog.d/5857.bugfix
@@ -1,0 +1,1 @@
+Add missing version field to e2e_room_keys database index.

--- a/synapse/storage/e2e_room_keys.py
+++ b/synapse/storage/e2e_room_keys.py
@@ -82,11 +82,11 @@ class EndToEndRoomKeyStore(SQLBaseStore):
             table="e2e_room_keys",
             keyvalues={
                 "user_id": user_id,
+                "version": version,
                 "room_id": room_id,
                 "session_id": session_id,
             },
             values={
-                "version": version,
                 "first_message_index": room_key["first_message_index"],
                 "forwarded_count": room_key["forwarded_count"],
                 "is_verified": room_key["is_verified"],

--- a/synapse/storage/schema/delta/56/fix_room_keys_index.sql
+++ b/synapse/storage/schema/delta/56/fix_room_keys_index.sql
@@ -1,0 +1,18 @@
+/* Copyright 2019 Matrix.org Foundation CIC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- version is supposed to be part of the room keys index
+CREATE UNIQUE INDEX e2e_room_keys_with_version_idx ON e2e_room_keys(user_id, version, room_id, session_id);
+DROP INDEX IF EXISTS e2e_room_keys_idx;


### PR DESCRIPTION
The `e2e_room_keys` index was supposed to have the `version` field included, since a key can be in multiple versions.