### PR TITLE
Add flag in /versions for whether clients should send id_server params

### DIFF
--- a/changelog.d/5868.feature
+++ b/changelog.d/5868.feature
@@ -1,0 +1,1 @@
+Add `m.require_identity_server` key to `/versions`'s `unstable_features` section.

--- a/synapse/app/client_reader.py
+++ b/synapse/app/client_reader.py
@@ -119,7 +119,7 @@ class ClientReaderServer(HomeServer):
                     KeyChangesServlet(self).register(resource)
                     VoipRestServlet(self).register(resource)
                     PushRuleRestServlet(self).register(resource)
-                    VersionsRestServlet().register(resource)
+                    VersionsRestServlet(self).register(resource)
 
                     resources.update({"/_matrix/client": resource})
 

--- a/synapse/rest/__init__.py
+++ b/synapse/rest/__init__.py
@@ -73,7 +73,7 @@ class ClientRestResource(JsonResource):
 
     @staticmethod
     def register_servlets(client_resource, hs):
-        versions.register_servlets(client_resource)
+        versions.register_servlets(hs, client_resource)
 
         # Deprecated in r0
         initial_sync.register_servlets(hs, client_resource)

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -24,6 +24,10 @@ logger = logging.getLogger(__name__)
 class VersionsRestServlet(RestServlet):
     PATTERNS = [re.compile("^/_matrix/client/versions$")]
 
+    def __init__(self, hs):
+        super(VersionsRestServlet, self).__init__()
+        self.config = hs.config
+
     def on_GET(self, request):
         return (
             200,
@@ -44,10 +48,22 @@ class VersionsRestServlet(RestServlet):
                     "r0.5.0",
                 ],
                 # as per MSC1497:
-                "unstable_features": {"m.lazy_load_members": True},
+                "unstable_features": {
+                    "m.lazy_load_members": True,
+                    # Advertise to clients whether they need not include an `id_server`
+                    # parameter during registration or password reset, as Synapse now decides
+                    # itself which identity server to use (or none at all).
+                    #
+                    # This is also used by a client when they wish to bind a 3PID to their
+                    # account, but not bind it to an identity server, the endpoint for which
+                    # also requires `id_server`. If the homeserver is handling 3PID
+                    # verification itself, there is no need to ask the user for `id_server` to
+                    # be supplied.
+                    "m.require_identity_server": self.config.account_threepid_delegate is None
+                },
             },
         )
 
 
-def register_servlets(http_server):
-    VersionsRestServlet().register(http_server)
+def register_servlets(hs, http_server):
+    VersionsRestServlet(hs).register(http_server)

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -59,8 +59,9 @@ class VersionsRestServlet(RestServlet):
                     # also requires `id_server`. If the homeserver is handling 3PID
                     # verification itself, there is no need to ask the user for `id_server` to
                     # be supplied.
-                    "m.require_identity_server": self.config.account_threepid_delegate
-                    is None,
+                    "m.require_identity_server": (
+                        self.config.account_threepid_delegate is None
+                    ),
                 },
             },
         )

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -59,7 +59,8 @@ class VersionsRestServlet(RestServlet):
                     # also requires `id_server`. If the homeserver is handling 3PID
                     # verification itself, there is no need to ask the user for `id_server` to
                     # be supplied.
-                    "m.require_identity_server": self.config.account_threepid_delegate is None
+                    "m.require_identity_server": self.config.account_threepid_delegate
+                    is None,
                 },
             },
         )


### PR DESCRIPTION
When a client is registering an account, they need to know whether they should supply an `id_server` param (the contents being the domain of an identity server) to the server in order to specify which `id_server` to send their email from.

Beginning from the branch this PR is getting merged into, the homeserver has the capability to send registration emails, as well as instead specify which identity server should send them. There's no longer any need for the client to specify an identity server here.

This flag will also be used in other cases, such as password reset and binding 3PIDs, so it's preferable to not just put it in the registration parameters.

We will remove this flag in the future when the spec drops support from needing `id_server` in `/register` and other endpoints, and Synapse drops support for older spec versions.

This PR will be based on top of https://github.com/matrix-org/synapse/pull/5876 when it lands.