### PR TITLE
Replace trust_identity_server_for_password_resets with account_threepid_delegate

### DIFF
--- a/changelog.d/5876.misc
+++ b/changelog.d/5876.misc
@@ -1,0 +1,1 @@
+Replace `trust_identity_server_for_password_resets` config option with `account_threepid_delegate`.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -894,6 +894,25 @@ uploads_path: "DATADIR/uploads"
 #  - matrix.org
 #  - vector.im
 
+# Handle threepid (email/phone etc) registration and password resets
+# through an identity server. Only change if you know what you are
+# doing
+#
+# IMPORTANT! This will give a malicious or overtaken identity server
+# the ability to reset passwords for your users and/or learn your
+# user's email/phone numbers! Make absolutely sure that you want to do
+# this! It is strongly recommended that these messages be sent by the
+# homeserver instead
+#
+# If this option is an empty string and SMTP options have not been
+# configured, registration by email and resetting user passwords via
+# email will be disabled
+#
+# Otherwise, to enable set this option to the reachable domain name, including protocol
+# definition, for an identity server (e.g "https://matrix.org")
+#
+#account_threepid_delegate: ""
+
 # Users who register on this homeserver will automatically be joined
 # to these rooms
 #
@@ -1154,19 +1173,6 @@ password_config:
 #   # the "app_name" setting is ignored
 #   #
 #   riot_base_url: "http://localhost/riot"
-#
-#   # Enable sending password reset emails via the configured, trusted
-#   # identity servers
-#   #
-#   # IMPORTANT! This will give a malicious or overtaken identity server
-#   # the ability to reset passwords for your users! Make absolutely sure
-#   # that you want to do this! It is strongly recommended that password
-#   # reset emails be sent by the homeserver instead
-#   #
-#   # If this option is set to false and SMTP options have not been
-#   # configured, resetting user passwords via email will be disabled
-#   #
-#   #trust_identity_server_for_password_resets: false
 #
 #   # Configure the time that a validation email or text message code
 #   # will expire after sending

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -895,16 +895,10 @@ uploads_path: "DATADIR/uploads"
 #  - vector.im
 
 # Handle threepid (email/phone etc) registration and password resets
-# through an identity server. Only change if you know what you are
-# doing
+# through a *trusted* identity server. Note that this allows the configured
+# identity server to reset passwords for accounts.
 #
-# IMPORTANT! This will give a malicious or overtaken identity server
-# the ability to reset passwords for your users and/or learn your
-# user's email/phone numbers! Make absolutely sure that you want to do
-# this! It is strongly recommended that these messages be sent by the
-# homeserver instead
-#
-# If this option is an empty string and SMTP options have not been
+# If this option is not defined and SMTP options have not been
 # configured, registration by email and resetting user passwords via
 # email will be disabled
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -911,7 +911,8 @@ uploads_path: "DATADIR/uploads"
 # email will be disabled
 #
 # Otherwise, to enable set this option to the reachable domain name, including protocol
-# definition, for an identity server (e.g "https://matrix.org")
+# definition, for an identity server
+# (e.g "https://matrix.org", "http://localhost:8090")
 #
 #account_threepid_delegate: ""
 

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -94,8 +94,8 @@ class EmailConfig(Config):
                     'The config option "trust_identity_server_for_password_resets" '
                     'has been replaced by "account_threepid_delegate". Attempted to use an '
                     'identity server from "trusted_third_party_id_servers" but it is empty. '
-                    'Please consult the sample config at docs/sample_config.yaml for '
-                    'details and update your config file.'
+                    "Please consult the sample config at docs/sample_config.yaml for "
+                    "details and update your config file."
                 )
 
         self.local_threepid_emails_disabled_due_to_config = False

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -16,11 +16,11 @@
 # limitations under the License.
 
 from __future__ import print_function
-from enum import Enum
 
 # This file can't be called email.py because if it is, we cannot:
 import email.utils
 import os
+from enum import Enum
 
 import pkg_resources
 
@@ -100,7 +100,10 @@ class EmailConfig(Config):
                 )
 
         self.local_threepid_emails_disabled_due_to_config = False
-        if self.email_threepid_behaviour == ThreepidBehaviour.LOCAL and email_config == {}:
+        if (
+            self.email_threepid_behaviour == ThreepidBehaviour.LOCAL
+            and email_config == {}
+        ):
             # We cannot warn the user this has happened here
             # Instead do so when a user attempts to reset their password
             self.local_threepid_emails_disabled_due_to_config = True
@@ -306,6 +309,7 @@ class ThreepidBehaviour(Enum):
     LOCAL = send tokens ourselves
     OFF = disable registration via 3pid and password resets
     """
+
     REMOTE = "remote"
     LOCAL = "local"
     OFF = "off"

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -87,7 +87,7 @@ class EmailConfig(Config):
         # identity server in the process.
         if config.get("trust_identity_server_for_password_resets", False) is True:
             # Use the first entry in self.trusted_third_party_id_servers instead
-            if len(self.trusted_third_party_id_servers):
+            if self.trusted_third_party_id_servers:
                 self.account_threepid_delegate = self.trusted_third_party_id_servers[0]
             else:
                 raise ConfigError(

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -86,17 +86,16 @@ class EmailConfig(Config):
         # use an identity server to password reset tokens on its behalf. We now warn the user
         # if they have this set and tell them to use the updated option, while using a default
         # identity server in the process.
+        self.using_identity_server_from_trusted_list = False
         if config.get("trust_identity_server_for_password_resets", False) is True:
             # Use the first entry in self.trusted_third_party_id_servers instead
             if self.trusted_third_party_id_servers:
                 self.account_threepid_delegate = self.trusted_third_party_id_servers[0]
+                self.using_identity_server_from_trusted_list = True
             else:
                 raise ConfigError(
-                    'The config option "trust_identity_server_for_password_resets" '
-                    'has been replaced by "account_threepid_delegate". Attempted to use an '
-                    'identity server from "trusted_third_party_id_servers" but it is empty. '
-                    "Please consult the sample config at docs/sample_config.yaml for "
-                    "details and update your config file."
+                    "Attempted to use an identity server from"
+                    '"trusted_third_party_id_servers" but it is empty.'
                 )
 
         self.local_threepid_emails_disabled_due_to_config = False

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -99,6 +99,7 @@ class RegistrationConfig(Config):
         self.trusted_third_party_id_servers = config.get(
             "trusted_third_party_id_servers", ["matrix.org", "vector.im"]
         )
+        self.account_threepid_delegate = config.get("account_threepid_delegate")
         self.default_identity_server = config.get("default_identity_server")
         self.allow_guest_access = config.get("allow_guest_access", False)
 
@@ -260,6 +261,25 @@ class RegistrationConfig(Config):
         #trusted_third_party_id_servers:
         #  - matrix.org
         #  - vector.im
+
+        # Handle threepid (email/phone etc) registration and password resets
+        # through an identity server. Only change if you know what you are
+        # doing
+        #
+        # IMPORTANT! This will give a malicious or overtaken identity server
+        # the ability to reset passwords for your users and/or learn your
+        # user's email/phone numbers! Make absolutely sure that you want to do
+        # this! It is strongly recommended that these messages be sent by the
+        # homeserver instead
+        #
+        # If this option is an empty string and SMTP options have not been
+        # configured, registration by email and resetting user passwords via
+        # email will be disabled
+        #
+        # Otherwise, to enable set this option to the reachable domain name, including protocol
+        # definition, for an identity server (e.g "https://matrix.org")
+        #
+        #account_threepid_delegate: ""
 
         # Users who register on this homeserver will automatically be joined
         # to these rooms

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -263,16 +263,10 @@ class RegistrationConfig(Config):
         #  - vector.im
 
         # Handle threepid (email/phone etc) registration and password resets
-        # through an identity server. Only change if you know what you are
-        # doing
+        # through a *trusted* identity server. Note that this allows the configured
+        # identity server to reset passwords for accounts.
         #
-        # IMPORTANT! This will give a malicious or overtaken identity server
-        # the ability to reset passwords for your users and/or learn your
-        # user's email/phone numbers! Make absolutely sure that you want to do
-        # this! It is strongly recommended that these messages be sent by the
-        # homeserver instead
-        #
-        # If this option is an empty string and SMTP options have not been
+        # If this option is not defined and SMTP options have not been
         # configured, registration by email and resetting user passwords via
         # email will be disabled
         #

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -279,7 +279,8 @@ class RegistrationConfig(Config):
         # email will be disabled
         #
         # Otherwise, to enable set this option to the reachable domain name, including protocol
-        # definition, for an identity server (e.g "https://matrix.org")
+        # definition, for an identity server
+        # (e.g "https://matrix.org", "http://localhost:8090")
         #
         #account_threepid_delegate: ""
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -458,12 +458,9 @@ class AuthHandler(BaseHandler):
         identity_handler = self.hs.get_handlers().identity_handler
 
         logger.info("Getting validated threepid. threepidcreds: %r", (threepid_creds,))
-        if (
-            not password_servlet
-            or self.hs.config.email_password_reset_behaviour == "remote"
-        ):
+        if not password_servlet or self.hs.config.email_threepid_behaviour == "remote":
             threepid = yield identity_handler.threepid_from_creds(threepid_creds)
-        elif self.hs.config.email_password_reset_behaviour == "local":
+        elif self.hs.config.email_threepid_behaviour == "local":
             row = yield self.store.get_threepid_validation_session(
                 medium,
                 threepid_creds["client_secret"],

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -26,7 +26,6 @@ from canonicaljson import json
 from twisted.internet import defer
 from twisted.web.client import PartialDownloadError
 
-from synapse.config.emailconfig import ThreepidBehaviour
 import synapse.util.stringutils as stringutils
 from synapse.api.constants import LoginType
 from synapse.api.errors import (
@@ -39,6 +38,7 @@ from synapse.api.errors import (
     UserDeactivatedError,
 )
 from synapse.api.ratelimiting import Ratelimiter
+from synapse.config.emailconfig import ThreepidBehaviour
 from synapse.logging.context import defer_to_thread
 from synapse.module_api import ModuleApi
 from synapse.types import UserID

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -26,6 +26,7 @@ from canonicaljson import json
 from twisted.internet import defer
 from twisted.web.client import PartialDownloadError
 
+from synapse.config.emailconfig import ThreepidBehaviour
 import synapse.util.stringutils as stringutils
 from synapse.api.constants import LoginType
 from synapse.api.errors import (
@@ -458,9 +459,12 @@ class AuthHandler(BaseHandler):
         identity_handler = self.hs.get_handlers().identity_handler
 
         logger.info("Getting validated threepid. threepidcreds: %r", (threepid_creds,))
-        if not password_servlet or self.hs.config.email_threepid_behaviour == "remote":
+        if (
+            not password_servlet
+            or self.hs.config.email_threepid_behaviour == ThreepidBehaviour.REMOTE
+        ):
             threepid = yield identity_handler.threepid_from_creds(threepid_creds)
-        elif self.hs.config.email_threepid_behaviour == "local":
+        elif self.hs.config.email_threepid_behaviour == ThreepidBehaviour.LOCAL:
             row = yield self.store.get_threepid_validation_session(
                 medium,
                 threepid_creds["client_secret"],

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -36,6 +36,7 @@ class IdentityHandler(BaseHandler):
 
         self.http_client = hs.get_simple_http_client()
         self.federation_http_client = hs.get_http_client()
+        self.hs = hs
 
     @defer.inlineCallbacks
     def threepid_from_creds(self, creds):
@@ -221,8 +222,14 @@ class IdentityHandler(BaseHandler):
         if next_link:
             params["next_link"] = next_link
 
-        if next_link:
-            params.update({"next_link": next_link})
+        if self.hs.config.using_identity_server_from_trusted_list:
+            # Warn that a deprecated config option is in use
+            logger.warn(
+                'The config option "trust_identity_server_for_password_resets" '
+                'has been replaced by "account_threepid_delegate". '
+                "Please consult the sample config at docs/sample_config.yaml for "
+                "details and update your config file."
+            )
 
         try:
             data = yield self.http_client.post_json_get_json(
@@ -266,6 +273,15 @@ class IdentityHandler(BaseHandler):
         }
         if next_link:
             params["next_link"] = next_link
+
+        if self.hs.config.using_identity_server_from_trusted_list:
+            # Warn that a deprecated config option is in use
+            logger.warn(
+                'The config option "trust_identity_server_for_password_resets" '
+                'has been replaced by "account_threepid_delegate". '
+                "Please consult the sample config at docs/sample_config.yaml for "
+                "details and update your config file."
+            )
 
         try:
             data = yield self.http_client.post_json_get_json(

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -228,7 +228,7 @@ class IdentityHandler(BaseHandler):
         if not id_server:
             if not self.hs.config.account_threepid_delegate:
                 raise SynapseError(
-                    400, "No id_server provided and none configured on the " "server"
+                    400, "No id_server provided and none configured on the server"
                 )
             id_server = self.hs.config.account_threepid_delegate
         else:

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -204,8 +204,7 @@ class IdentityHandler(BaseHandler):
         validation.
 
         Args:
-            id_server (str|None): The identity server to send this through. If None,
-                use the server specified by the account_threepid_delegate config option
+            id_server (str): The identity server to proxy to
             email (str): The email to send the message to
             client_secret (str): The unique client_secret sends by the user
             send_attempt (int): Which attempt this is
@@ -224,17 +223,6 @@ class IdentityHandler(BaseHandler):
 
         if next_link:
             params.update({"next_link": next_link})
-
-        if not id_server:
-            if not self.hs.config.account_threepid_delegate:
-                raise SynapseError(
-                    400, "No id_server provided and none configured on the server"
-                )
-            id_server = self.hs.config.account_threepid_delegate
-        else:
-            # Assume "https://" is the protocol we're using to contact the id_server
-            # provided by the client
-            id_server = "https://" + id_server
 
         try:
             data = yield self.http_client.post_json_get_json(
@@ -260,6 +248,7 @@ class IdentityHandler(BaseHandler):
         Request an external server send an SMS message on our behalf for the purposes of
         threepid validation.
         Args:
+            id_server (str): The identity server to proxy to
             country (str): The country code of the phone number
             phone_number (str): The number to send the message to
             client_secret (str): The unique client_secret sends by the user
@@ -277,17 +266,6 @@ class IdentityHandler(BaseHandler):
         }
         if next_link:
             params["next_link"] = next_link
-
-        if not id_server:
-            if not self.hs.config.account_threepid_delegate:
-                raise SynapseError(
-                    400, "No id_server provided and none configured on the " "server"
-                )
-            id_server = self.hs.config.account_threepid_delegate
-        else:
-            # Assume "https://" is the protocol we're using to contact the id_server
-            # provided by the client
-            id_server = "https://" + id_server
 
         try:
             data = yield self.http_client.post_json_get_json(

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -227,9 +227,14 @@ class IdentityHandler(BaseHandler):
 
         if not id_server:
             if not self.hs.config.account_threepid_delegate:
-                raise SynapseError(400, "No id_server provided and none configured on the "
-                                        "server")
+                raise SynapseError(
+                    400, "No id_server provided and none configured on the " "server"
+                )
             id_server = self.hs.config.account_threepid_delegate
+        else:
+            # Assume "https://" is the protocol we're using to contact the id_server
+            # provided by the client
+            id_server = "https://" + id_server
 
         try:
             data = yield self.http_client.post_json_get_json(
@@ -243,7 +248,13 @@ class IdentityHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def requestMsisdnToken(
-        self, id_server, country, phone_number, client_secret, send_attempt, next_link=None
+        self,
+        id_server,
+        country,
+        phone_number,
+        client_secret,
+        send_attempt,
+        next_link=None,
     ):
         """
         Request an external server send an SMS message on our behalf for the purposes of
@@ -269,9 +280,14 @@ class IdentityHandler(BaseHandler):
 
         if not id_server:
             if not self.hs.config.account_threepid_delegate:
-                raise SynapseError(400, "No id_server provided and none configured on the "
-                                        "server")
+                raise SynapseError(
+                    400, "No id_server provided and none configured on the " "server"
+                )
             id_server = self.hs.config.account_threepid_delegate
+        else:
+            # Assume "https://" is the protocol we're using to contact the id_server
+            # provided by the client
+            id_server = "https://" + id_server
 
         try:
             data = yield self.http_client.post_json_get_json(

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -250,7 +250,8 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
                     "this request"
                 )
                 raise SynapseError(
-                    400, "Password reset by phone number is not supported on this homeserver"
+                    400,
+                    "Password reset by phone number is not supported on this homeserver",
                 )
 
             ret = yield self.identity_handler.requestMsisdnToken(

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -109,7 +109,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
                     "this request"
                 )
                 raise SynapseError(
-                    400, "Registration by MSISDN is not supported on this homeserver"
+                    400, "Password reset by email is not supported on this homeserver"
                 )
 
             ret = yield self.identity_handler.requestEmailToken(
@@ -129,7 +129,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
             ret = {"sid": sid}
         else:
             raise SynapseError(
-                400, "Password resets via email are disabled on this homeserver"
+                400, "Password reset by email is not supported on this homeserver"
             )
 
         return (200, ret)
@@ -250,7 +250,7 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
                     "this request"
                 )
                 raise SynapseError(
-                    400, "Registration by MSISDN is not supported on this homeserver"
+                    400, "Password reset by phone number is not supported on this homeserver"
                 )
 
             ret = yield self.identity_handler.requestMsisdnToken(
@@ -264,7 +264,7 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
             return (200, ret)
 
         raise SynapseError(
-            400, "Password reset by MSISDN is not supported on this homeserver"
+            400, "Password reset by phone number is not supported on this homeserver"
         )
 
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -101,7 +101,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
         if existing_user_id is None:
             raise SynapseError(400, "Email not found", Codes.THREEPID_NOT_FOUND)
 
-        if self.config.email_threepid_behaviour == ThreepidBehaviour.REMOTE
+        if self.config.email_threepid_behaviour == ThreepidBehaviour.REMOTE:
             # Have an identity server handle the password reset flow
             ret = yield self.identity_handler.requestEmailToken(
                 None, email, client_secret, send_attempt, next_link
@@ -215,7 +215,9 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
                 Codes.THREEPID_DENIED,
             )
 
-        existing_user_id = yield self.datastore.get_user_id_by_threepid("msisdn", msisdn)
+        existing_user_id = yield self.datastore.get_user_id_by_threepid(
+            "msisdn", msisdn
+        )
 
         if existing_user_id is None:
             raise SynapseError(400, "MSISDN not found", Codes.THREEPID_NOT_FOUND)
@@ -497,7 +499,8 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
     def on_POST(self, request):
         body = parse_json_object_from_request(request)
         assert_params_in_dict(
-            body, ["id_server", "client_secret", "country", "phone_number", "send_attempt"],
+            body,
+            ["id_server", "client_secret", "country", "phone_number", "send_attempt"],
         )
 
         msisdn = phone_number_to_msisdn(body["country"], body["phone_number"])

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -68,7 +68,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
     @defer.inlineCallbacks
     def on_POST(self, request):
         if self.config.email_threepid_behaviour == "off":
-            if self.config.password_resets_were_disabled_due_to_email_config:
+            if self.config.local_threepid_emails_disabled_due_to_config:
                 logger.warn(
                     "User password resets have been disabled due to lack of email config"
                 )
@@ -127,6 +127,8 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
             email (str): The user's email address
             client_secret (str): The provided client secret
             send_attempt (int): Which send attempt this is
+            next_link (str|None): The link to redirect the user to upon success. No redirect
+                occurs if None
 
         Returns:
             The new session_id upon success
@@ -250,7 +252,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
                 400, "This medium is currently not supported for password resets"
             )
         if self.config.email_threepid_behaviour == "off":
-            if self.config.password_resets_were_disabled_due_to_email_config:
+            if self.config.local_threepid_emails_disabled_due_to_config:
                 logger.warn(
                     "User password resets have been disabled due to lack of email config"
                 )

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -106,7 +106,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
             if not self.hs.config.account_threepid_delegate:
                 logger.warn(
                     "No upstream account_threepid_delegate configured on the server to handle "
-                    "this request",
+                    "this request"
                 )
                 raise SynapseError(
                     400, "Registration by MSISDN is not supported on this homeserver"
@@ -129,8 +129,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
             ret = {"sid": sid}
         else:
             raise SynapseError(
-                400,
-                "Password resets via email are disabled on this homeserver"
+                400, "Password resets via email are disabled on this homeserver"
             )
 
         return (200, ret)
@@ -244,21 +243,14 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
         if existing_user_id is None:
             raise SynapseError(400, "MSISDN not found", Codes.THREEPID_NOT_FOUND)
 
-        if not self.hs.config.account_threepid_delegate:
-            logger.warn(
-                "No upstream account_threepid_delegate configured on the server to handle "
-                "this request",
-            )
-            raise SynapseError(
-                400, "Registration by MSISDN is not supported on this homeserver"
-            )
-
         if self.config.email_threepid_behaviour == ThreepidBehaviour.REMOTE:
             if not self.hs.config.account_threepid_delegate:
+                logger.warn(
+                    "No upstream account_threepid_delegate configured on the server to handle "
+                    "this request"
+                )
                 raise SynapseError(
-                    400,
-                    "No upstream identity server configured on the server to handle this "
-                    "request",
+                    400, "Registration by MSISDN is not supported on this homeserver"
                 )
 
             ret = yield self.identity_handler.requestMsisdnToken(

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -104,10 +104,12 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
         if self.config.email_threepid_behaviour == ThreepidBehaviour.REMOTE:
             # Have the configured identity server handle the request
             if not self.hs.config.account_threepid_delegate:
+                logger.warn(
+                    "No upstream account_threepid_delegate configured on the server to handle "
+                    "this request",
+                )
                 raise SynapseError(
-                    400,
-                    "No upstream identity server configured on the server to handle this "
-                    "request",
+                    400, "Registration by MSISDN is not supported on this homeserver"
                 )
 
             ret = yield self.identity_handler.requestEmailToken(
@@ -243,10 +245,12 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
             raise SynapseError(400, "MSISDN not found", Codes.THREEPID_NOT_FOUND)
 
         if not self.hs.config.account_threepid_delegate:
+            logger.warn(
+                "No upstream account_threepid_delegate configured on the server to handle "
+                "this request",
+            )
             raise SynapseError(
-                400,
-                "No upstream identity server configured on the server to handle this "
-                "request",
+                400, "Registration by MSISDN is not supported on this homeserver"
             )
 
         if self.config.email_threepid_behaviour == ThreepidBehaviour.REMOTE:

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -50,7 +50,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
         self.config = hs.config
         self.identity_handler = hs.get_handlers().identity_handler
 
-        if self.config.email_password_reset_behaviour == "local":
+        if self.config.email_threepid_behaviour == "local":
             from synapse.push.mailer import Mailer, load_jinja2_templates
 
             templates = load_jinja2_templates(
@@ -67,7 +67,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
 
     @defer.inlineCallbacks
     def on_POST(self, request):
-        if self.config.email_password_reset_behaviour == "off":
+        if self.config.email_threepid_behaviour == "off":
             if self.config.password_resets_were_disabled_due_to_email_config:
                 logger.warn(
                     "User password resets have been disabled due to lack of email config"
@@ -100,7 +100,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
         if existingUid is None:
             raise SynapseError(400, "Email not found", Codes.THREEPID_NOT_FOUND)
 
-        if self.config.email_password_reset_behaviour == "remote":
+        if self.config.email_threepid_behaviour == "remote":
             if "id_server" not in body:
                 raise SynapseError(400, "Missing 'id_server' param in body")
 
@@ -249,7 +249,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
             raise SynapseError(
                 400, "This medium is currently not supported for password resets"
             )
-        if self.config.email_password_reset_behaviour == "off":
+        if self.config.email_threepid_behaviour == "off":
             if self.config.password_resets_were_disabled_due_to_email_config:
                 logger.warn(
                     "User password resets have been disabled due to lack of email config"

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -24,6 +24,7 @@ from twisted.internet import defer
 
 from synapse.api.constants import LoginType
 from synapse.api.errors import Codes, SynapseError, ThreepidValidationError
+from synapse.config.emailconfig import ThreepidBehaviour
 from synapse.http.server import finish_request
 from synapse.http.servlet import (
     RestServlet,
@@ -50,7 +51,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
         self.config = hs.config
         self.identity_handler = hs.get_handlers().identity_handler
 
-        if self.config.email_threepid_behaviour == "local":
+        if self.config.email_threepid_behaviour == ThreepidBehaviour.LOCAL:
             from synapse.push.mailer import Mailer, load_jinja2_templates
 
             templates = load_jinja2_templates(
@@ -67,7 +68,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
 
     @defer.inlineCallbacks
     def on_POST(self, request):
-        if self.config.email_threepid_behaviour == "off":
+        if self.config.email_threepid_behaviour == ThreepidBehaviour.OFF:
             if self.config.local_threepid_emails_disabled_due_to_config:
                 logger.warn(
                     "User password resets have been disabled due to lack of email config"
@@ -93,20 +94,17 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
                 Codes.THREEPID_DENIED,
             )
 
-        existingUid = yield self.hs.get_datastore().get_user_id_by_threepid(
+        existing_user_id = yield self.hs.get_datastore().get_user_id_by_threepid(
             "email", email
         )
 
-        if existingUid is None:
+        if existing_user_id is None:
             raise SynapseError(400, "Email not found", Codes.THREEPID_NOT_FOUND)
 
-        if self.config.email_threepid_behaviour == "remote":
-            if "id_server" not in body:
-                raise SynapseError(400, "Missing 'id_server' param in body")
-
-            # Have the identity server handle the password reset flow
+        if self.config.email_threepid_behaviour == ThreepidBehaviour.REMOTE
+            # Have an identity server handle the password reset flow
             ret = yield self.identity_handler.requestEmailToken(
-                body["id_server"], email, client_secret, send_attempt, next_link
+                None, email, client_secret, send_attempt, next_link
             )
         else:
             # Send password reset emails from Synapse
@@ -217,9 +215,9 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
                 Codes.THREEPID_DENIED,
             )
 
-        existingUid = yield self.datastore.get_user_id_by_threepid("msisdn", msisdn)
+        existing_user_id = yield self.datastore.get_user_id_by_threepid("msisdn", msisdn)
 
-        if existingUid is None:
+        if existing_user_id is None:
             raise SynapseError(400, "MSISDN not found", Codes.THREEPID_NOT_FOUND)
 
         ret = yield self.identity_handler.requestMsisdnToken(**body)
@@ -251,7 +249,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
             raise SynapseError(
                 400, "This medium is currently not supported for password resets"
             )
-        if self.config.email_threepid_behaviour == "off":
+        if self.config.email_threepid_behaviour == ThreepidBehaviour.OFF:
             if self.config.local_threepid_emails_disabled_due_to_config:
                 logger.warn(
                     "User password resets have been disabled due to lack of email config"
@@ -459,7 +457,7 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
         self.hs = hs
         super(EmailThreepidRequestTokenRestServlet, self).__init__()
         self.identity_handler = hs.get_handlers().identity_handler
-        self.datastore = self.hs.get_datastore()
+        self.store = self.hs.get_datastore()
 
     @defer.inlineCallbacks
     def on_POST(self, request):
@@ -475,11 +473,11 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
                 Codes.THREEPID_DENIED,
             )
 
-        existingUid = yield self.datastore.get_user_id_by_threepid(
+        existing_user_id = yield self.store.get_user_id_by_threepid(
             "email", body["email"]
         )
 
-        if existingUid is not None:
+        if existing_user_id is not None:
             raise SynapseError(400, "Email is already in use", Codes.THREEPID_IN_USE)
 
         ret = yield self.identity_handler.requestEmailToken(**body)
@@ -493,14 +491,13 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
         self.hs = hs
         super(MsisdnThreepidRequestTokenRestServlet, self).__init__()
         self.identity_handler = hs.get_handlers().identity_handler
-        self.datastore = self.hs.get_datastore()
+        self.store = self.hs.get_datastore()
 
     @defer.inlineCallbacks
     def on_POST(self, request):
         body = parse_json_object_from_request(request)
         assert_params_in_dict(
-            body,
-            ["id_server", "client_secret", "country", "phone_number", "send_attempt"],
+            body, ["id_server", "client_secret", "country", "phone_number", "send_attempt"],
         )
 
         msisdn = phone_number_to_msisdn(body["country"], body["phone_number"])
@@ -512,9 +509,9 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
                 Codes.THREEPID_DENIED,
             )
 
-        existingUid = yield self.datastore.get_user_id_by_threepid("msisdn", msisdn)
+        existing_user_id = yield self.store.get_user_id_by_threepid("msisdn", msisdn)
 
-        if existingUid is not None:
+        if existing_user_id is not None:
             raise SynapseError(400, "MSISDN is already in use", Codes.THREEPID_IN_USE)
 
         ret = yield self.identity_handler.requestMsisdnToken(**body)

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -105,12 +105,17 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
             # Have the configured identity server handle the request
             if not self.hs.config.account_threepid_delegate:
                 raise SynapseError(
-                    400, "No upstream identity server configured on the server to handle this "
-                         "request"
+                    400,
+                    "No upstream identity server configured on the server to handle this "
+                    "request",
                 )
 
             ret = yield self.identity_handler.requestEmailToken(
-                self.hs.config.account_threepid_delegate, email, client_secret, send_attempt, next_link
+                self.hs.config.account_threepid_delegate,
+                email,
+                client_secret,
+                send_attempt,
+                next_link,
             )
         else:
             # Send password reset emails from Synapse
@@ -208,8 +213,7 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
         body = parse_json_object_from_request(request)
 
         assert_params_in_dict(
-            body,
-            ["client_secret", "country", "phone_number", "send_attempt"],
+            body, ["client_secret", "country", "phone_number", "send_attempt"]
         )
         client_secret = body["client_secret"]
         country = body["country"]
@@ -235,20 +239,26 @@ class MsisdnPasswordRequestTokenRestServlet(RestServlet):
 
         if not self.hs.config.account_threepid_delegate:
             raise SynapseError(
-                400, "No upstream identity server configured on the server to handle this "
-                     "request"
+                400,
+                "No upstream identity server configured on the server to handle this "
+                "request",
             )
 
         if self.config.email_threepid_behaviour == ThreepidBehaviour.REMOTE:
             if not self.hs.config.account_threepid_delegate:
                 raise SynapseError(
-                    400, "No upstream identity server configured on the server to handle this "
-                         "request"
+                    400,
+                    "No upstream identity server configured on the server to handle this "
+                    "request",
                 )
 
             ret = yield self.identity_handler.requestMsisdnToken(
-                self.config.account_threepid_delegate, country, phone_number, client_secret,
-                send_attempt, next_link
+                self.config.account_threepid_delegate,
+                country,
+                phone_number,
+                client_secret,
+                send_attempt,
+                next_link,
             )
             return (200, ret)
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -562,7 +562,7 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
         send_attempt = body["send_attempt"]
         next_link = body.get("next_link")  # Optional param
 
-        msisdn = phone_number_to_msisdn(body["country"], body["phone_number"])
+        msisdn = phone_number_to_msisdn(country, phone_number)
 
         if not check_3pid_allowed(self.hs, "msisdn", msisdn):
             raise SynapseError(

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -117,7 +117,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
                 send_attempt,
                 next_link,
             )
-        else:
+        elif self.config.email_threepid_behaviour == ThreepidBehaviour.LOCAL:
             # Send password reset emails from Synapse
             sid = yield self.send_password_reset(
                 email, client_secret, send_attempt, next_link
@@ -125,6 +125,11 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
 
             # Wrap the session id in a JSON object
             ret = {"sid": sid}
+        else:
+            raise SynapseError(
+                400,
+                "Password resets via email are disabled on this homeserver"
+            )
 
         return (200, ret)
 

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -98,8 +98,15 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
         if existing_user_id is not None:
             raise SynapseError(400, "Email is already in use", Codes.THREEPID_IN_USE)
 
+        if not self.hs.config.account_threepid_delegate:
+            raise SynapseError(
+                400, "No upstream identity server configured on the server to handle this "
+                     "request"
+            )
+
         ret = yield self.identity_handler.requestEmailToken(
-            None, email, client_secret, send_attempt, next_link
+            self.hs.config.account_threepid_delegate,
+            email, client_secret, send_attempt, next_link
         )
 
         return (200, ret)

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -102,7 +102,7 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
         if not self.hs.config.account_threepid_delegate:
             logger.warn(
                 "No upstream account_threepid_delegate configured on the server to handle "
-                "this request",
+                "this request"
             )
             raise SynapseError(
                 400, "Registration by MSISDN is not supported on this homeserver"
@@ -166,7 +166,7 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
             if not self.hs.config.account_threepid_delegate:
                 logger.warn(
                     "No upstream account_threepid_delegate configured on the server to handle "
-                    "this request",
+                    "this request"
                 )
                 raise SynapseError(
                     400, "Registration by MSISDN is not supported on this homeserver"

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -76,9 +76,7 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
     def on_POST(self, request):
         body = parse_json_object_from_request(request)
 
-        assert_params_in_dict(
-            body, ["client_secret", "email", "send_attempt"]
-        )
+        assert_params_in_dict(body, ["client_secret", "email", "send_attempt"])
 
         # Extract params from body
         client_secret = body["client_secret"]

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -100,10 +100,12 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
             raise SynapseError(400, "Email is already in use", Codes.THREEPID_IN_USE)
 
         if not self.hs.config.account_threepid_delegate:
+            logger.warn(
+                "No upstream account_threepid_delegate configured on the server to handle "
+                "this request",
+            )
             raise SynapseError(
-                400,
-                "No upstream identity server configured on the server to handle this "
-                "request",
+                400, "Registration by MSISDN is not supported on this homeserver"
             )
 
         ret = yield self.identity_handler.requestEmailToken(

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -105,7 +105,7 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
                 "this request"
             )
             raise SynapseError(
-                400, "Registration by MSISDN is not supported on this homeserver"
+                400, "Registration by email is not supported on this homeserver"
             )
 
         ret = yield self.identity_handler.requestEmailToken(
@@ -169,7 +169,7 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
                     "this request"
                 )
                 raise SynapseError(
-                    400, "Registration by MSISDN is not supported on this homeserver"
+                    400, "Registration by phone number is not supported on this homeserver"
                 )
 
             ret = yield self.identity_handler.requestMsisdnToken(
@@ -183,7 +183,7 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
             return (200, ret)
 
         raise SynapseError(
-            400, "Registration by MSISDN is not supported on this homeserver"
+            400, "Registration by phone number is not supported on this homeserver"
         )
 
 

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -162,10 +162,12 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
 
         if self.config.email_threepid_behaviour == ThreepidBehaviour.REMOTE:
             if not self.hs.config.account_threepid_delegate:
+                logger.warn(
+                    "No upstream account_threepid_delegate configured on the server to handle "
+                    "this request",
+                )
                 raise SynapseError(
-                    400,
-                    "No upstream identity server configured on the server to handle this "
-                    "request",
+                    400, "Registration by MSISDN is not supported on this homeserver"
                 )
 
             ret = yield self.identity_handler.requestMsisdnToken(

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -142,7 +142,7 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
         send_attempt = body["send_attempt"]
         next_link = body.get("next_link")  # Optional param
 
-        msisdn = phone_number_to_msisdn(body["country"], body["phone_number"])
+        msisdn = phone_number_to_msisdn(country, phone_number)
 
         if not check_3pid_allowed(self.hs, "msisdn", msisdn):
             raise SynapseError(

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -169,7 +169,8 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
                     "this request"
                 )
                 raise SynapseError(
-                    400, "Registration by phone number is not supported on this homeserver"
+                    400,
+                    "Registration by phone number is not supported on this homeserver",
                 )
 
             ret = yield self.identity_handler.requestMsisdnToken(

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -101,13 +101,17 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
 
         if not self.hs.config.account_threepid_delegate:
             raise SynapseError(
-                400, "No upstream identity server configured on the server to handle this "
-                     "request"
+                400,
+                "No upstream identity server configured on the server to handle this "
+                "request",
             )
 
         ret = yield self.identity_handler.requestEmailToken(
             self.hs.config.account_threepid_delegate,
-            email, client_secret, send_attempt, next_link
+            email,
+            client_secret,
+            send_attempt,
+            next_link,
         )
 
         return (200, ret)
@@ -130,8 +134,7 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
         body = parse_json_object_from_request(request)
 
         assert_params_in_dict(
-            body,
-            ["client_secret", "country", "phone_number", "send_attempt"],
+            body, ["client_secret", "country", "phone_number", "send_attempt"]
         )
         client_secret = body["client_secret"]
         country = body["country"]
@@ -160,13 +163,18 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
         if self.config.email_threepid_behaviour == ThreepidBehaviour.REMOTE:
             if not self.hs.config.account_threepid_delegate:
                 raise SynapseError(
-                    400, "No upstream identity server configured on the server to handle this "
-                         "request"
+                    400,
+                    "No upstream identity server configured on the server to handle this "
+                    "request",
                 )
 
             ret = yield self.identity_handler.requestMsisdnToken(
-                self.config.account_threepid_delegate, country, phone_number, client_secret,
-                send_attempt, next_link
+                self.config.account_threepid_delegate,
+                country,
+                phone_number,
+                client_secret,
+                send_attempt,
+                next_link,
             )
             return (200, ret)
 

--- a/synapse/server.pyi
+++ b/synapse/server.pyi
@@ -18,6 +18,7 @@ import synapse.server_notices.server_notices_sender
 import synapse.state
 import synapse.storage
 
+
 class HomeServer(object):
     @property
     def config(self) -> synapse.config.homeserver.HomeServerConfig:

--- a/synapse/server.pyi
+++ b/synapse/server.pyi
@@ -18,7 +18,6 @@ import synapse.server_notices.server_notices_sender
 import synapse.state
 import synapse.storage
 
-
 class HomeServer(object):
     @property
     def config(self) -> synapse.config.homeserver.HomeServerConfig:


### PR DESCRIPTION
Based on ~~https://github.com/matrix-org/synapse/pull/5875~~

Replaces the `trust_identity_server_for_password_resets` boolean option with a `account_threepid_delegate` str option that defines which identity server to use to handle password resets and registration if the homeserver does not want to or is unable to handle these tasks itself.

Having this option being something other than `null` or `""` gives the same indication as `True` for `trust_identity_server_for_password_resets`.

The domain of the identity server is actually used in https://github.com/matrix-org/synapse/pull/5835