### PR TITLE
Avoid deep recursion in appservice recovery

### DIFF
--- a/changelog.d/5885.bugfix
+++ b/changelog.d/5885.bugfix
@@ -1,0 +1,1 @@
+Fix stack overflow when recovering an appservice which had an outage.

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -252,6 +252,8 @@ class _Recoverer(object):
                 if not sent:
                     break
 
+                yield txn.complete(self.store)
+
                 # reset the backoff counter and then process the next transaction
                 self.backoff_counter = 1
 


### PR DESCRIPTION
Hopefully, this will fix a stack overflow when recovering an appservice.

The recursion here leads to a huge chain of deferred callbacks, which then overflows the stack when the chain completes. `inlineCallbacks` makes a better job of this if we use iteration instead.

Clean up the code a bit too, while we're there.