### PR TITLE
Switch to using v2 Identity Service APIs other than lookup (MSC 2140)

### DIFF
--- a/changelog.d/5892.misc
+++ b/changelog.d/5892.misc
@@ -1,0 +1,1 @@
+Compatibility with v2 Identity Service APIs.

--- a/changelog.d/5892.misc
+++ b/changelog.d/5892.misc
@@ -1,1 +1,1 @@
-Compatibility with v2 Identity Service APIs.
+Compatibility with v2 Identity Service APIs other than /lookup.

--- a/contrib/cmdclient/console.py
+++ b/contrib/cmdclient/console.py
@@ -268,6 +268,7 @@ class SynapseCmd(cmd.Cmd):
 
     @defer.inlineCallbacks
     def _do_emailrequest(self, args):
+        # TODO: Update to use v2 Identity Service API endpoint
         url = (
             self._identityServerUrl()
             + "/_matrix/identity/api/v1/validate/email/requestToken"
@@ -302,6 +303,7 @@ class SynapseCmd(cmd.Cmd):
 
     @defer.inlineCallbacks
     def _do_emailvalidate(self, args):
+        # TODO: Update to use v2 Identity Service API endpoint
         url = (
             self._identityServerUrl()
             + "/_matrix/identity/api/v1/validate/email/submitToken"
@@ -330,6 +332,7 @@ class SynapseCmd(cmd.Cmd):
 
     @defer.inlineCallbacks
     def _do_3pidbind(self, args):
+        # TODO: Update to use v2 Identity Service API endpoint
         url = self._identityServerUrl() + "/_matrix/identity/api/v1/3pid/bind"
 
         json_res = yield self.http_client.do_request(
@@ -398,6 +401,7 @@ class SynapseCmd(cmd.Cmd):
     @defer.inlineCallbacks
     def _do_invite(self, roomid, userstring):
         if not userstring.startswith("@") and self._is_on("complete_usernames"):
+            # TODO: Update to use v2 Identity Service API endpoint
             url = self._identityServerUrl() + "/_matrix/identity/api/v1/lookup"
 
             json_res = yield self.http_client.do_request(
@@ -407,6 +411,7 @@ class SynapseCmd(cmd.Cmd):
             mxid = None
 
             if "mxid" in json_res and "signatures" in json_res:
+                # TODO: Update to use v2 Identity Service API endpoint
                 url = (
                     self._identityServerUrl()
                     + "/_matrix/identity/api/v1/pubkey/ed25519"

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -146,7 +146,7 @@ class IdentityHandler(BaseHandler):
 
         # This identity server is too old to understand Identity Service API v2
         # Attempt v1 endpoint
-        logger.warn("Got 404 when POSTing JSON %s, falling back to v1 URL", url)
+        logger.info("Got 404 when POSTing JSON %s, falling back to v1 URL", url)
         return (yield self.threepid_from_creds(creds, use_v2=False))
 
     @defer.inlineCallbacks
@@ -200,7 +200,7 @@ class IdentityHandler(BaseHandler):
             data = json.loads(e.msg)  # XXX WAT?
             return data
 
-        logger.warn("Got 404 when POSTing JSON %s, falling back to v1 URL", bind_url)
+        logger.info("Got 404 when POSTing JSON %s, falling back to v1 URL", bind_url)
         return (yield self.bind_threepid(creds, mxid, use_v2=False))
 
     @defer.inlineCallbacks
@@ -300,7 +300,7 @@ class IdentityHandler(BaseHandler):
                 raise SynapseError(502, "Failed to contact identity server")
 
         if v1_fallback:
-            logger.warn("Got 404 when POSTing JSON %s, falling back to v1 URL", url)
+            logger.info("Got 404 when POSTing JSON %s, falling back to v1 URL", url)
             return (
                 yield self.try_unbind_threepid_with_id_server(
                     mxid, threepid, id_server, use_v2=False

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -248,9 +248,7 @@ class IdentityHandler(BaseHandler):
         return changed
 
     @defer.inlineCallbacks
-    def try_unbind_threepid_with_id_server(
-        self, mxid, threepid, id_server
-    ):
+    def try_unbind_threepid_with_id_server(self, mxid, threepid, id_server):
         """Removes a binding from an identity server
 
         Args:
@@ -285,7 +283,6 @@ class IdentityHandler(BaseHandler):
         )
         headers = {b"Authorization": auth_headers}
 
-        v1_fallback = False
         try:
             yield self.http_client.post_json_get_json(url, content, headers)
             changed = True

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -542,15 +542,16 @@ class ThreepidRestServlet(RestServlet):
     def on_POST(self, request):
         body = parse_json_object_from_request(request)
 
-        threePidCreds = body.get("threePidCreds")
-        threePidCreds = body.get("three_pid_creds", threePidCreds)
-        if threePidCreds is None:
-            raise SynapseError(400, "Missing param", Codes.MISSING_PARAM)
+        threepid_creds = body.get("threePidCreds") or body.get("three_pid_creds")
+        if threepid_creds is None:
+            raise SynapseError(
+                400, "Missing param three_pid_creds", Codes.MISSING_PARAM
+            )
 
         requester = yield self.auth.get_user_by_req(request)
         user_id = requester.user.to_string()
 
-        threepid = yield self.identity_handler.threepid_from_creds(threePidCreds)
+        threepid = yield self.identity_handler.threepid_from_creds(threepid_creds)
 
         if not threepid:
             raise SynapseError(400, "Failed to auth 3pid", Codes.THREEPID_AUTH_FAILED)
@@ -566,7 +567,7 @@ class ThreepidRestServlet(RestServlet):
 
         if "bind" in body and body["bind"]:
             logger.debug("Binding threepid %s to %s", threepid, user_id)
-            yield self.identity_handler.bind_threepid(threePidCreds, user_id)
+            yield self.identity_handler.bind_threepid(threepid_creds, user_id)
 
         return 200, {}
 


### PR DESCRIPTION
Fixes: https://github.com/matrix-org/synapse/issues/5786

TODO:

- [x] Switch to v2 endpoint every time we contact an identity service
- [x] Handle proxying `id_access_token` authorization tokens
- [x] Figure out 3pid invites (Done in https://github.com/matrix-org/synapse/pull/5897)