### PR TITLE
Add config option to sign remote key query responses with a separate key.

### DIFF
--- a/changelog.d/5895.feature
+++ b/changelog.d/5895.feature
@@ -1,0 +1,1 @@
+Add config option to sign remote key query responses with a separate key.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1027,6 +1027,14 @@ signing_key_path: "CONFDIR/SERVERNAME.signing.key"
 #
 #trusted_key_servers:
 #  - server_name: "matrix.org"
+#
+
+# The additional signing keys to use when acting as a trusted key server, on
+# top of the normal signing keys.
+#
+# Can contain multiple keys, one per line.
+#
+#key_server_signing_keys_path: "key_server_signing_keys.key"
 
 
 # Enable SAML2 for registration and login. Uses pysaml2.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1029,8 +1029,8 @@ signing_key_path: "CONFDIR/SERVERNAME.signing.key"
 #  - server_name: "matrix.org"
 #
 
-# The additional signing keys to use when acting as a trusted key server, on
-# top of the normal signing keys.
+# The signing keys to use when acting as a trusted key server. If not specified
+# defaults to the server signing key.
 #
 # Can contain multiple keys, one per line.
 #

--- a/synapse/config/key.py
+++ b/synapse/config/key.py
@@ -85,14 +85,13 @@ class KeyConfig(Config):
             config.get("key_refresh_interval", "1d")
         )
 
-        self.key_server_signing_keys = list(self.signing_key)
         key_server_signing_keys_path = config.get("key_server_signing_keys_path")
         if key_server_signing_keys_path:
-            self.key_server_signing_keys.extend(
-                self.read_signing_keys(
-                    key_server_signing_keys_path, "key_server_signing_keys_path"
-                )
+            self.key_server_signing_keys = self.read_signing_keys(
+                key_server_signing_keys_path, "key_server_signing_keys_path"
             )
+        else:
+            self.key_server_signing_keys = list(self.signing_key)
 
         # if neither trusted_key_servers nor perspectives are given, use the default.
         if "perspectives" not in config and "trusted_key_servers" not in config:
@@ -221,8 +220,8 @@ class KeyConfig(Config):
         #  - server_name: "matrix.org"
         #
 
-        # The additional signing keys to use when acting as a trusted key server, on
-        # top of the normal signing keys.
+        # The signing keys to use when acting as a trusted key server. If not specified
+        # defaults to the server signing key.
         #
         # Can contain multiple keys, one per line.
         #

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -30,7 +30,6 @@ from signedjson.key import (
 from signedjson.sign import (
     SignatureVerifyException,
     encode_canonical_json,
-    sign_json,
     signature_ids,
     verify_signed_json,
 )
@@ -540,15 +539,7 @@ class BaseV2KeyFetcher(object):
                     verify_key=verify_key, valid_until_ts=key_data["expired_ts"]
                 )
 
-        # re-sign the json with our own keys, so that it is ready if we are
-        # asked to give it out as a notary server
-        signed_key_json = response_json
-        for signing_key in self.config.key_server_signing_keys:
-            signed_key_json = sign_json(
-                signed_key_json, self.config.server_name, signing_key
-            )
-
-        signed_key_json_bytes = encode_canonical_json(signed_key_json)
+        signed_key_json_bytes = encode_canonical_json(response_json)
 
         yield make_deferred_yieldable(
             defer.gatherResults(

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -540,11 +540,13 @@ class BaseV2KeyFetcher(object):
                     verify_key=verify_key, valid_until_ts=key_data["expired_ts"]
                 )
 
-        # re-sign the json with our own key, so that it is ready if we are asked to
-        # give it out as a notary server
-        signed_key_json = sign_json(
-            response_json, self.config.server_name, self.config.signing_key[0]
-        )
+        # re-sign the json with our own keys, so that it is ready if we are
+        # asked to give it out as a notary server
+        signed_key_json = response_json
+        for signing_key in self.config.key_server_signing_keys:
+            signed_key_json = sign_json(
+                signed_key_json, self.config.server_name, signing_key
+            )
 
         signed_key_json_bytes = encode_canonical_json(signed_key_json)
 

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -539,7 +539,7 @@ class BaseV2KeyFetcher(object):
                     verify_key=verify_key, valid_until_ts=key_data["expired_ts"]
                 )
 
-        signed_key_json_bytes = encode_canonical_json(response_json)
+        key_json_bytes = encode_canonical_json(response_json)
 
         yield make_deferred_yieldable(
             defer.gatherResults(
@@ -551,7 +551,7 @@ class BaseV2KeyFetcher(object):
                         from_server=from_server,
                         ts_now_ms=time_added_ms,
                         ts_expires_ms=ts_valid_until_ms,
-                        key_json_bytes=signed_key_json_bytes,
+                        key_json_bytes=key_json_bytes,
                     )
                     for key_id in verify_keys
                 ],

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -14,7 +14,7 @@
 
 import logging
 
-from canonicaljson import json
+from canonicaljson import encode_canonical_json, json
 from signedjson.sign import sign_json
 
 from twisted.internet import defer
@@ -227,4 +227,4 @@ class RemoteKey(DirectServeResource):
 
             results = {"server_keys": signed_keys}
 
-            respond_with_json_bytes(request, 200, json.dumps(results).encode("utf-8"))
+            respond_with_json_bytes(request, 200, encode_canonical_json(results))


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/5351