### PR TITLE
Use the v2 lookup API for 3PID invites

### DIFF
--- a/changelog.d/5897.feature
+++ b/changelog.d/5897.feature
@@ -1,0 +1,1 @@
+Switch to the v2 lookup API for 3PID invites.

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -18,6 +18,7 @@
 """Utilities for interacting with Identity Servers"""
 
 import logging
+from enum import Enum
 
 from canonicaljson import json
 
@@ -31,7 +32,6 @@ from synapse.api.errors import (
 )
 
 from ._base import BaseHandler
-from enum import Enum
 
 logger = logging.getLogger(__name__)
 
@@ -284,6 +284,7 @@ class IdentityHandler(BaseHandler):
             logger.info("Proxied requestToken failed: %r", e)
             raise e.to_synapse_error()
 
+
 class LookupAlgorithm(Enum):
     """
     Supported hashing algorithms when performing a 3PID lookup.
@@ -292,5 +293,6 @@ class LookupAlgorithm(Enum):
         encoding
     NONE - Not performing any hashing. Simply sending an (address, medium) combo in plaintext
     """
+
     SHA256 = "sha256"
     NONE = "none"

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -18,7 +18,6 @@
 """Utilities for interacting with Identity Servers"""
 
 import logging
-from enum import Enum
 
 from canonicaljson import json
 
@@ -285,7 +284,7 @@ class IdentityHandler(BaseHandler):
             raise e.to_synapse_error()
 
 
-class LookupAlgorithm(Enum):
+class LookupAlgorithm:
     """
     Supported hashing algorithms when performing a 3PID lookup.
 

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -31,6 +31,7 @@ from synapse.api.errors import (
 )
 
 from ._base import BaseHandler
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
@@ -282,3 +283,14 @@ class IdentityHandler(BaseHandler):
         except HttpResponseException as e:
             logger.info("Proxied requestToken failed: %r", e)
             raise e.to_synapse_error()
+
+class LookupAlgorithm(Enum):
+    """
+    Supported hashing algorithms when performing a 3PID lookup.
+
+    SHA256 - Hashing an (address, medium, pepper) combo with sha256, then url-safe base64
+        encoding
+    NONE - Not performing any hashing. Simply sending an (address, medium) combo in plaintext
+    """
+    SHA256 = "sha256"
+    NONE = "none"

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -774,7 +774,7 @@ class RoomMemberHandler(object):
         lookup_pepper = hash_details["lookup_pepper"]
 
         # Check if any of the supported lookup algorithms are present
-        if str(LookupAlgorithm.SHA256) in supported_lookup_algorithms:
+        if LookupAlgorithm.SHA256 in supported_lookup_algorithms:
             # Perform a hashed lookup
             lookup_algorithm = LookupAlgorithm.SHA256
 
@@ -782,7 +782,7 @@ class RoomMemberHandler(object):
             to_hash = "%s %s %s" % (address, medium, lookup_pepper)
             lookup_value = sha256_and_url_safe_base64(to_hash)
 
-        elif str(LookupAlgorithm.NONE) in supported_lookup_algorithms:
+        elif LookupAlgorithm.NONE in supported_lookup_algorithms:
             # Perform a non-hashed lookup
             lookup_algorithm = LookupAlgorithm.NONE
 
@@ -796,7 +796,8 @@ class RoomMemberHandler(object):
                 id_server,
                 hash_details["algorithms"],
             )
-            return None
+            raise SynapseError(400, "Provided identity server does not support any v2 lookup "
+                                    "algorithms that this homeserver supports.")
 
         try:
             lookup_results = yield self.simple_http_client.post_json_get_json(

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -734,7 +734,7 @@ class RoomMemberHandler(object):
             data = yield self.simple_http_client.get_json(
                 "%s%s/_matrix/identity/api/v1/lookup" % (id_server_scheme, id_server),
                 {"medium": medium, "address": address},
-                )
+            )
 
             if "mxid" in data:
                 if "signatures" not in data:

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -790,8 +790,12 @@ class RoomMemberHandler(object):
             lookup_value = "%s %s" % (address, medium)
 
         else:
-            logger.warn("No supported lookup algorithms provided by %s%s: %s",
-                        id_server_scheme, id_server, hash_details["algorithms"])
+            logger.warn(
+                "No supported lookup algorithms provided by %s%s: %s",
+                id_server_scheme,
+                id_server,
+                hash_details["algorithms"],
+            )
             return None
 
         try:

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -796,8 +796,11 @@ class RoomMemberHandler(object):
                 id_server,
                 hash_details["algorithms"],
             )
-            raise SynapseError(400, "Provided identity server does not support any v2 lookup "
-                                    "algorithms that this homeserver supports.")
+            raise SynapseError(
+                400,
+                "Provided identity server does not support any v2 lookup "
+                "algorithms that this homeserver supports.",
+            )
 
         try:
             lookup_results = yield self.simple_http_client.post_json_get_json(

--- a/synapse/server.pyi
+++ b/synapse/server.pyi
@@ -18,6 +18,7 @@ import synapse.server_notices.server_notices_sender
 import synapse.state
 import synapse.storage
 
+
 class HomeServer(object):
     @property
     def config(self) -> synapse.config.homeserver.HomeServerConfig:

--- a/synapse/server.pyi
+++ b/synapse/server.pyi
@@ -18,7 +18,6 @@ import synapse.server_notices.server_notices_sender
 import synapse.state
 import synapse.storage
 
-
 class HomeServer(object):
     @property
     def config(self) -> synapse.config.homeserver.HomeServerConfig:

--- a/synapse/util/hash.py
+++ b/synapse/util/hash.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import hashlib
+
 import unpaddedbase64
 
 
@@ -30,4 +31,3 @@ def sha256_and_url_safe_base64(input_text):
     """
     digest = hashlib.sha256(input_text.encode()).digest()
     return unpaddedbase64.encode_base64(digest, urlsafe=True)
-

--- a/synapse/util/hash.py
+++ b/synapse/util/hash.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import unpaddedbase64
+
+
+def sha256_and_url_safe_base64(input_text):
+    """SHA256 hash an input string, encode the digest as url-safe base64, and
+    return
+
+    :param input_text: string to hash
+    :type input_text: str
+
+    :returns a sha256 hashed and url-safe base64 encoded digest
+    :rtype: str
+    """
+    digest = hashlib.sha256(input_text.encode()).digest()
+    return unpaddedbase64.encode_base64(digest, urlsafe=True)
+


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/5861

Adds support for the v2 lookup API as defined in [MSC2134](https://github.com/matrix-org/matrix-doc/pull/2134). Currently this is only used for 3PID invites.

Sytest PR: https://github.com/matrix-org/sytest/pull/679