### PR TITLE
Exempt support users from consent

### DIFF
--- a/changelog.d/5902.feature
+++ b/changelog.d/5902.feature
@@ -1,1 +1,1 @@
-Support users are no longer required to consent.
+Users with the type of "support" or "bot" are no longer required to consent.

--- a/changelog.d/5902.feature
+++ b/changelog.d/5902.feature
@@ -1,0 +1,1 @@
+Support users are no longer required to consent.

--- a/changelog.d/5903.feature
+++ b/changelog.d/5903.feature
@@ -1,1 +1,0 @@
-Add bot user type.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -24,7 +24,7 @@ from twisted.internet import defer
 from twisted.internet.defer import succeed
 
 from synapse import event_auth
-from synapse.api.constants import EventTypes, Membership, RelationTypes
+from synapse.api.constants import EventTypes, Membership, RelationTypes, UserTypes
 from synapse.api.errors import (
     AuthError,
     Codes,
@@ -469,6 +469,9 @@ class EventCreationHandler(object):
 
         u = yield self.store.get_user_by_id(user_id)
         assert u is not None
+        if u["user_type"] == UserTypes.SUPPORT:
+            # support users are not required to consent
+            return
         if u["appservice_id"] is not None:
             # users registered by an appservice are exempt
             return

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -469,8 +469,8 @@ class EventCreationHandler(object):
 
         u = yield self.store.get_user_by_id(user_id)
         assert u is not None
-        if u["user_type"] == UserTypes.SUPPORT or u["user_type"] == UserTypes.BOT:
-            # support users are not required to consent
+        if u["user_type"] in (UserTypes.SUPPORT, UserTypes.BOT):
+            # support and bot users are not required to consent
             return
         if u["appservice_id"] is not None:
             # users registered by an appservice are exempt

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -469,7 +469,7 @@ class EventCreationHandler(object):
 
         u = yield self.store.get_user_by_id(user_id)
         assert u is not None
-        if u["user_type"] == UserTypes.SUPPORT:
+        if u["user_type"] == UserTypes.SUPPORT or u["user_type"] == UserTypes.BOT:
             # support users are not required to consent
             return
         if u["appservice_id"] is not None:

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -56,6 +56,7 @@ class RegistrationWorkerStore(SQLBaseStore):
                 "consent_server_notice_sent",
                 "appservice_id",
                 "creation_ts",
+                "user_type",
             ],
             allow_none=True,
             desc="get_user_by_id",

--- a/tests/storage/test_registration.py
+++ b/tests/storage/test_registration.py
@@ -49,6 +49,7 @@ class RegistrationStoreTestCase(unittest.TestCase):
                 "consent_server_notice_sent": None,
                 "appservice_id": None,
                 "creation_ts": 1000,
+                "user_type": None,
             },
             (yield self.store.get_user_by_id(self.user_id)),
         )


### PR DESCRIPTION
This depends on #5903

This makes a change so that users with the "support" or "bot" type do not require consent to function, as spinning up bots on HHS hosts gets blocked on consent requests.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
