### PR TITLE
Let synctl use a config directory.

### DIFF
--- a/changelog.d/5904.feature
+++ b/changelog.d/5904.feature
@@ -1,0 +1,1 @@
+Let synctl accept a directory of config files.

--- a/synapse/config/__init__.py
+++ b/synapse/config/__init__.py
@@ -15,7 +15,7 @@
 
 from ._base import ConfigError, find_config_files
 
-# export ConfigError, find_config_files, read_config_files if somebody does
+# export ConfigError and find_config_files if somebody does
 # import *
 # this is largely a fudge to stop PEP8 moaning about the import
 __all__ = ["ConfigError", "find_config_files"]

--- a/synapse/config/__init__.py
+++ b/synapse/config/__init__.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._base import ConfigError, find_config_files, read_config_files
+from ._base import ConfigError, find_config_files
 
 # export ConfigError, find_config_files, read_config_files if somebody does
 # import *
 # this is largely a fudge to stop PEP8 moaning about the import
-__all__ = ["ConfigError", "find_config_files", "read_config_files"]
+__all__ = ["ConfigError", "find_config_files"]

--- a/synapse/config/__init__.py
+++ b/synapse/config/__init__.py
@@ -15,6 +15,7 @@
 
 from ._base import ConfigError, find_config_files, read_config_files
 
-# export ConfigError if somebody does import *
+# export ConfigError, find_cofig_files, read_config_files if somebody does
+# import *
 # this is largely a fudge to stop PEP8 moaning about the import
-__all__ = ["ConfigError"]
+__all__ = ["ConfigError", "find_config_files", "read_config_files"]

--- a/synapse/config/__init__.py
+++ b/synapse/config/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._base import ConfigError
+from ._base import ConfigError, find_config_files, read_config_files
 
 # export ConfigError if somebody does import *
 # this is largely a fudge to stop PEP8 moaning about the import

--- a/synapse/config/__init__.py
+++ b/synapse/config/__init__.py
@@ -15,7 +15,7 @@
 
 from ._base import ConfigError, find_config_files, read_config_files
 
-# export ConfigError, find_cofig_files, read_config_files if somebody does
+# export ConfigError, find_config_files, read_config_files if somebody does
 # import *
 # this is largely a fudge to stop PEP8 moaning about the import
 __all__ = ["ConfigError", "find_config_files", "read_config_files"]

--- a/synctl
+++ b/synctl
@@ -30,6 +30,8 @@ from six import iteritems
 
 import yaml
 
+from synapse.config import find_config_files, read_config_files
+
 SYNAPSE = [sys.executable, "-B", "-m", "synapse.app.homeserver"]
 
 GREEN = "\x1b[1;32m"
@@ -135,7 +137,8 @@ def main():
         "configfile",
         nargs="?",
         default="homeserver.yaml",
-        help="the homeserver config file, defaults to homeserver.yaml",
+        help="the homeserver config file, defaults to homeserver.yaml, may also specify"
+        " a directory with *.yaml files",
     )
     parser.add_argument(
         "-w", "--worker", metavar="WORKERCONFIG", help="start or stop a single worker"
@@ -176,8 +179,7 @@ def main():
         )
         sys.exit(1)
 
-    with open(configfile) as stream:
-        config = yaml.safe_load(stream)
+    config = read_config_files(find_config_files([configfile]))
 
     pidfile = config["pid_file"]
     cache_factor = config.get("synctl_cache_factor")

--- a/synctl
+++ b/synctl
@@ -137,7 +137,7 @@ def main():
         "configfile",
         nargs="?",
         default="homeserver.yaml",
-        help="the homeserver config file, defaults to homeserver.yaml, may also specify"
+        help="the homeserver config file. Defaults to homeserver.yaml. May also be"
         " a directory with *.yaml files",
     )
     parser.add_argument(

--- a/synctl
+++ b/synctl
@@ -30,7 +30,7 @@ from six import iteritems
 
 import yaml
 
-from synapse.config import find_config_files, read_config_files
+from synapse.config import find_config_files
 
 SYNAPSE = [sys.executable, "-B", "-m", "synapse.app.homeserver"]
 
@@ -179,7 +179,12 @@ def main():
         )
         sys.exit(1)
 
-    config = read_config_files(find_config_files([configfile]))
+    config_files = find_config_files([configfile])
+    config = {}
+    for config_file in config_files:
+        with open(config_file) as file_stream:
+            yaml_config = yaml.safe_load(file_stream)
+        config.update(yaml_config)
 
     pidfile = config["pid_file"]
     cache_factor = config.get("synctl_cache_factor")


### PR DESCRIPTION
I think it would be nicer if synctl could operate on a directory of configs just like synapse can. Unfortunately the config option between synapse and syctl differ in name: synapse uses `configpath` while syctl uses `configfile`. Can we change synctl's? I imagine synctl is burried in a number of scripts in the wild.