### PR TITLE
Fix a cache-invalidation bug for worker-based deployments

### DIFF
--- a/changelog.d/5920.bugfix
+++ b/changelog.d/5920.bugfix
@@ -1,0 +1,1 @@
+Fix a cache-invalidation bug for worker-based deployments.


### PR DESCRIPTION
Some of the caches on worker processes were not being correctly invalidated
when a room's state was changed in a way that did not affect the membership
list of the room.

We need to make sure we send out cache invalidations even when no memberships
are changing.