### PR TITLE
Separated Statistics [6/7ish]

### DIFF
--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -868,6 +868,17 @@ class RegistrationStore(
                 (user_id_obj.localpart, create_profile_with_displayname),
             )
 
+        if self.hs.config.stats_enabled:
+            # we create a new completed user statistics row
+
+            # we don't strictly need current_token since this user really can't
+            # have any state deltas before now (as it is a new user), but still,
+            # we include it for completeness.
+            current_token = self._get_max_stream_id_in_current_state_deltas_txn(txn)
+            self._update_stats_delta_txn(
+                txn, now, "user", user_id, {}, complete_with_stream_id=current_token
+            )
+
         self._invalidate_cache_and_stream(txn, self.get_user_by_id, (user_id,))
         txn.call_after(self.is_guest.invalidate, (user_id,))
 
@@ -1139,6 +1150,7 @@ class RegistrationStore(
             deferred str|None: A str representing a link to redirect the user
             to if there is one.
         """
+
         # Insert everything into a transaction in order to run atomically
         def validate_threepid_session_txn(txn):
             row = self._simple_select_one_txn(

--- a/synapse/storage/stats.py
+++ b/synapse/storage/stats.py
@@ -258,6 +258,10 @@ class StatsStore(StateDeltasStore):
                 (i.e. not deltas) of absolute fields.
                 Does not work with per-slice fields.
         """
+
+        if absolute_field_overrides is None:
+            absolute_field_overrides = {}
+
         table, id_col = TYPE_TO_TABLE[stats_type]
 
         quantised_ts = self.quantise_stats_time(int(ts))
@@ -287,9 +291,6 @@ class StatsStore(StateDeltasStore):
             for key in abs_field_names
             if key not in absolute_field_overrides
         }
-
-        if absolute_field_overrides is None:
-            absolute_field_overrides = {}
 
         if complete_with_stream_id is not None:
             absolute_field_overrides = absolute_field_overrides.copy()

--- a/synapse/storage/stats.py
+++ b/synapse/storage/stats.py
@@ -381,7 +381,7 @@ class StatsStore(StateDeltasStore):
             txn.execute(sql, qargs)
         else:
             self.database_engine.lock_table(txn, table)
-            retcols = chain(absolutes.keys(), additive_relatives.keys())
+            retcols = list(chain(absolutes.keys(), additive_relatives.keys()))
             current_row = self._simple_select_one_txn(
                 txn, table, keyvalues, retcols, allow_none=True
             )
@@ -486,7 +486,7 @@ class StatsStore(StateDeltasStore):
                 txn,
                 into_table,
                 keyvalues,
-                chain(additive_relatives.keys(), copy_columns),
+                retcols=list(chain(additive_relatives.keys(), copy_columns)),
                 allow_none=True,
             )
 


### PR DESCRIPTION
Track new users in user statistics.

This makes the rows 'completed' so that the stats regenerator need not
touch them.