### PR TITLE
Add a link to python's logging config schema

### DIFF
--- a/changelog.d/5926.misc
+++ b/changelog.d/5926.misc
@@ -1,0 +1,1 @@
+Add link in sample config to the logging config schema.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -485,7 +485,8 @@ database:
 
 ## Logging ##
 
-# A yaml python logging config file
+# A yaml python logging config file as described by
+# https://docs.python.org/3.7/library/logging.config.html#configuration-dictionary-schema
 #
 log_config: "CONFDIR/SERVERNAME.log.config"
 

--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -89,7 +89,8 @@ class LoggingConfig(Config):
             """\
         ## Logging ##
 
-        # A yaml python logging config file
+        # A yaml python logging config file as described by
+        # https://docs.python.org/3.7/library/logging.config.html#configuration-dictionary-schema
         #
         log_config: "%(log_config)s"
         """


### PR DESCRIPTION
Though the generated Template is pretty clear the origin and nuances of the config is a bit mystifying if you're unfamiliar with python's logging system.
