### PR TITLE
Add m.id_access_token flag

### DIFF
--- a/changelog.d/5930.misc
+++ b/changelog.d/5930.misc
@@ -1,0 +1,1 @@
+Add temporary flag to /versions in unstable_features to indicate this Synapse supports receiving id_access_token parameters on calls to identity server-proxying endpoints.

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -44,7 +44,12 @@ class VersionsRestServlet(RestServlet):
                     "r0.5.0",
                 ],
                 # as per MSC1497:
-                "unstable_features": {"m.lazy_load_members": True},
+                "unstable_features": {
+                    "m.lazy_load_members": True,
+                    # as per https://github.com/matrix-org/synapse/issues/5927
+                    # to be removed in r0.6.0
+                    "m.id_access_token": True,
+                },
             },
         )
 


### PR DESCRIPTION
Adds a flag to `/versions`' `unstable_features` section indicating that this Synapse understands what an `id_access_token` is, as per https://github.com/matrix-org/synapse/issues/5927#issuecomment-523566043

Fixes #5927 