### PR TITLE
Fix encoding for account validity HTML files on Python 2

### DIFF
--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -67,7 +67,7 @@ REQUIREMENTS = [
     "pymacaroons>=0.13.0",
     "msgpack>=0.5.0",
     "phonenumbers>=8.2.0",
-    "six>=1.10",
+    "six>=1.12",
     # prometheus_client 0.4.0 changed the format of counter metrics
     # (cf https://github.com/matrix-org/synapse/issues/4001)
     "prometheus_client>=0.0.18,<0.4.0",

--- a/synapse/rest/client/v2_alpha/account_validity.py
+++ b/synapse/rest/client/v2_alpha/account_validity.py
@@ -15,6 +15,8 @@
 
 import logging
 
+from six import ensure_binary
+
 from twisted.internet import defer
 
 from synapse.api.errors import AuthError, SynapseError
@@ -63,7 +65,7 @@ class AccountValidityRenewServlet(RestServlet):
         request.setResponseCode(status_code)
         request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
         request.setHeader(b"Content-Length", b"%d" % (len(response),))
-        request.write(response.encode("utf8"))
+        request.write(ensure_binary(response))
         finish_request(request)
         defer.returnValue(None)
 

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -20,6 +20,7 @@ import json
 import os
 
 from mock import Mock
+from six import ensure_binary
 
 import pkg_resources
 
@@ -437,7 +438,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         # Check that the HTML we're getting is the one we expect on a successful renewal.
         expected_html = self.hs.config.account_validity.account_renewed_html_content
         self.assertEqual(
-            channel.result["body"], expected_html.encode("utf8"), channel.result
+            channel.result["body"], ensure_binary(expected_html), channel.result
         )
 
         # Move 3 days forward. If the renewal failed, every authed request with
@@ -467,7 +468,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         # invalid/unknown token.
         expected_html = self.hs.config.account_validity.invalid_token_html_content
         self.assertEqual(
-            channel.result["body"], expected_html.encode("utf8"), channel.result
+            channel.result["body"], ensure_binary(expected_html), channel.result
         )
 
     def test_manual_email_send(self):


### PR DESCRIPTION
On Python 2, `response.encode("utf8")` wouldn't work because `response` would be of type `str` and not `unicode`, resulting in errors such as:

```
2019-08-29 16:05:49+0100 [-] 2019-08-29 16:05:49,223 - synapse.http.server - 112 - ERROR - GET-3 - Failed handle request via 'AccountValidityRenewServlet': <SynapseRequest at 0x7f97934a2fc8 method=u'GET' uri=u'/_matrix/client/unstable/account_validity/renew?token=GVpqAigVTqfdlVAGxAslbmlyIfQOuCqJ' clientproto=u'1.1' site='test'>
	Traceback (most recent call last):
	  File "/home/brendan/Documents/matrix/synapse/synapse/http/server.py", line 81, in wrapped_request_handler
	    yield h(self, request)
	  File "/home/brendan/.virtualenvs/synapse-py2/lib/python2.7/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
	    result = result.throwExceptionIntoGenerator(g)
	  File "/home/brendan/.virtualenvs/synapse-py2/lib/python2.7/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
	    return g.throw(self.type, self.value, self.tb)
	  File "/home/brendan/Documents/matrix/synapse/synapse/http/server.py", line 316, in _async_render
	    callback_return = yield callback(request, **kwargs)
	  File "/home/brendan/.virtualenvs/synapse-py2/lib/python2.7/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
	    result = g.send(result)
	  File "/home/brendan/Documents/matrix/synapse/synapse/rest/client/v2_alpha/account_validity.py", line 68, in on_GET
	    request.write(response.encode("utf8"))
	UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 536: ordinal not in range(128)
```

This PR fixes it so that it uses `six.ensure_binary` to do the conversion into bytes instead of `.encode("utf8")`.