### PR TITLE
Fix handling of UTF8 when serving content to the users

### DIFF
--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -17,6 +17,7 @@
 import logging
 import re
 
+from six import ensure_binary
 from six.moves import http_client
 
 import jinja2
@@ -295,7 +296,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
             )
             request.setResponseCode(e.code)
 
-        request.write(html.encode('utf-8'))
+        request.write(ensure_binary(html))
         finish_request(request)
         defer.returnValue(None)
 

--- a/synapse/rest/client/v2_alpha/auth.py
+++ b/synapse/rest/client/v2_alpha/auth.py
@@ -16,6 +16,7 @@
 import logging
 
 from six import ensure_binary
+
 from twisted.internet import defer
 
 from synapse.api.constants import LoginType

--- a/synapse/rest/client/v2_alpha/auth.py
+++ b/synapse/rest/client/v2_alpha/auth.py
@@ -15,6 +15,7 @@
 
 import logging
 
+from six import ensure_binary
 from twisted.internet import defer
 
 from synapse.api.constants import LoginType
@@ -144,7 +145,7 @@ class AuthRestServlet(RestServlet):
                 ),
                 'sitekey': self.hs.config.recaptcha_public_key,
             }
-            html_bytes = html.encode("utf8")
+            html_bytes = ensure_binary(html)
             request.setResponseCode(200)
             request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
             request.setHeader(b"Content-Length", b"%d" % (len(html_bytes),))
@@ -163,7 +164,7 @@ class AuthRestServlet(RestServlet):
                     CLIENT_API_PREFIX, LoginType.TERMS
                 ),
             }
-            html_bytes = html.encode("utf8")
+            html_bytes = ensure_binary(html)
             request.setResponseCode(200)
             request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
             request.setHeader(b"Content-Length", b"%d" % (len(html_bytes),))
@@ -208,7 +209,7 @@ class AuthRestServlet(RestServlet):
                     ),
                     'sitekey': self.hs.config.recaptcha_public_key,
                 }
-            html_bytes = html.encode("utf8")
+            html_bytes = ensure_binary(html)
             request.setResponseCode(200)
             request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
             request.setHeader(b"Content-Length", b"%d" % (len(html_bytes),))
@@ -244,7 +245,7 @@ class AuthRestServlet(RestServlet):
                         CLIENT_API_PREFIX, LoginType.TERMS
                     ),
                 }
-            html_bytes = html.encode("utf8")
+            html_bytes = ensure_binary(html)
             request.setResponseCode(200)
             request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
             request.setHeader(b"Content-Length", b"%d" % (len(html_bytes),))

--- a/synapse/rest/consent/consent_resource.py
+++ b/synapse/rest/consent/consent_resource.py
@@ -18,6 +18,7 @@ import logging
 from hashlib import sha256
 from os import path
 
+from six import ensure_binary
 from six.moves import http_client
 
 import jinja2
@@ -204,7 +205,7 @@ class ConsentResource(Resource):
         template_html = self._jinja_env.get_template(
             path.join(TEMPLATE_LANGUAGE, template_name)
         )
-        html_bytes = template_html.render(**template_args).encode("utf8")
+        html_bytes = ensure_binary(template_html.render(**template_args))
 
         request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
         request.setHeader(b"Content-Length", b"%i" % len(html_bytes))

--- a/synapse/rest/well_known.py
+++ b/synapse/rest/well_known.py
@@ -17,6 +17,7 @@ import json
 import logging
 
 from six import ensure_binary
+
 from twisted.web.resource import Resource
 
 from synapse.http.server import set_cors_headers

--- a/synapse/rest/well_known.py
+++ b/synapse/rest/well_known.py
@@ -16,6 +16,7 @@
 import json
 import logging
 
+from six import ensure_binary
 from twisted.web.resource import Resource
 
 from synapse.http.server import set_cors_headers
@@ -70,4 +71,4 @@ class WellKnownResource(Resource):
 
         logger.debug("returning: %s", r)
         request.setHeader(b"Content-Type", b"application/json")
-        return json.dumps(r).encode("utf-8")
+        return ensure_binary(json.dumps(r))


### PR DESCRIPTION
Same as #5932 except there was more than just account validity HTML files.