### PR TITLE
Revert "Add m.id_access_token flag"

### DIFF
--- a/changelog.d/5930.misc
+++ b/changelog.d/5930.misc
@@ -1,1 +1,0 @@
-Add temporary flag to /versions in unstable_features to indicate this Synapse supports receiving id_access_token parameters on calls to identity server-proxying endpoints.

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -44,12 +44,7 @@ class VersionsRestServlet(RestServlet):
                     "r0.5.0",
                 ],
                 # as per MSC1497:
-                "unstable_features": {
-                    "m.lazy_load_members": True,
-                    # as per https://github.com/matrix-org/synapse/issues/5927
-                    # to be removed in r0.6.0
-                    "m.id_access_token": True,
-                },
+                "unstable_features": {"m.lazy_load_members": True},
             },
         )
 


### PR DESCRIPTION
Reverts matrix-org/synapse#5930

This flag was added before the functionality it advertises landed (that being contained within https://github.com/matrix-org/synapse/pull/5892).

These PRs will be merged into a feature branch instead.