### PR TITLE
Set m.require_identity_server to always be False

### DIFF
--- a/changelog.d/5968.bugfix
+++ b/changelog.d/5968.bugfix
@@ -1,0 +1,1 @@
+Change unstable flag m.require_identity_server on /versions to always be false.

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -59,9 +59,7 @@ class VersionsRestServlet(RestServlet):
                     # also requires `id_server`. If the homeserver is handling 3PID
                     # verification itself, there is no need to ask the user for `id_server` to
                     # be supplied.
-                    "m.require_identity_server": (
-                        self.config.account_threepid_delegate is None
-                    ),
+                    "m.require_identity_server": False
                 },
             },
         )

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -59,7 +59,7 @@ class VersionsRestServlet(RestServlet):
                     # also requires `id_server`. If the homeserver is handling 3PID
                     # verification itself, there is no need to ask the user for `id_server` to
                     # be supplied.
-                    "m.require_identity_server": False
+                    "m.require_identity_server": False,
                 },
             },
         )


### PR DESCRIPTION
As [MSC2263](https://github.com/matrix-org/matrix-doc/pull/2263/files) states, `m.require_identity_server` must be set to `false` when it does not require an identity server to be provided by the client for the purposes of email registration or password reset.

We were setting this on the basis of `account_threepid_delegate` being set or not, but it should actually just always be false as `anoa/reg_email` feature branch lets the homeserver decide what upstream identity server it should use for these tasks.