### PR TITLE
Add POST /_matrix/client/r0/account/3pid/unbind (MSC2140)

### DIFF
--- a/changelog.d/5980.feature
+++ b/changelog.d/5980.feature
@@ -1,0 +1,1 @@
+Add POST /_matrix/client/r0/account/3pid/unbind endpoint from MSC2140 for unbinding a 3PID from an identity server without removing it from the homeserver user account.

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -137,7 +137,8 @@ class IdentityHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def try_unbind_threepid(self, mxid, threepid):
-        """Removes a binding from an identity server
+        """Attempt to remove a 3PID from an identity server, or if one is not provided, all
+        identity servers we're aware the binding is present on
 
         Args:
             mxid (str): Matrix user ID of binding to be removed

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -586,7 +586,7 @@ class ThreepidUnbindRestServlet(RestServlet):
         """Unbind the given 3pid from a specific identity server, or identity servers that are
         known to have this 3pid bound
         """
-        user_id = yield self.auth.get_user_by_req(request)
+        requester = yield self.auth.get_user_by_req(request)
         body = parse_json_object_from_request(request)
         assert_params_in_dict(body, ["medium", "address"])
 
@@ -597,9 +597,10 @@ class ThreepidUnbindRestServlet(RestServlet):
         # Attempt to unbind the threepid from an identity server. If id_server is None, try to
         # unbind from all identity servers this threepid has been added to in the past
         result = yield self.identity_handler.try_unbind_threepid(
-            user_id, {"address": address, "medium": medium, "id_server": id_server}
+            requester.user.to_string(),
+            {"address": address, "medium": medium, "id_server": id_server},
         )
-        return {"id_server_unbind_result": "success" if result else "no-support"}
+        return 200, {"id_server_unbind_result": "success" if result else "no-support"}
 
 
 class ThreepidDeleteRestServlet(RestServlet):


### PR DESCRIPTION
Implements `POST /_matrix/client/r0/account/3pid/unbind` from [MSC2140](https://github.com/matrix-org/matrix-doc/blob/dbkr/tos_2/proposals/2140-terms-of-service-2.md#post-_matrixclientr0account3pidunbind).

Sytests: https://github.com/matrix-org/sytest/pull/691