### PR TITLE
Add opentracing to all client servlets

### DIFF
--- a/changelog.d/5983.feature
+++ b/changelog.d/5983.feature
@@ -1,0 +1,1 @@
+Add minimum opentracing for client servlets.

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -342,7 +342,7 @@ class BaseFederationServlet(object):
                 continue
 
             server.register_paths(
-                method, (pattern,), self._wrap(code), self.__class__.__name__
+                method, (pattern,), self._wrap(code), self.__class__.__name__, trace=False
             )
 
 

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -342,7 +342,11 @@ class BaseFederationServlet(object):
                 continue
 
             server.register_paths(
-                method, (pattern,), self._wrap(code), self.__class__.__name__, trace=False
+                method,
+                (pattern,),
+                self._wrap(code),
+                self.__class__.__name__,
+                trace=False,
             )
 
 

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -20,7 +20,6 @@ import logging
 from canonicaljson import json
 
 from synapse.api.errors import Codes, SynapseError
-from synapse.logging.opentracing import trace_servlet
 
 logger = logging.getLogger(__name__)
 
@@ -298,10 +297,7 @@ class RestServlet(object):
                     servlet_classname = self.__class__.__name__
                     method_handler = getattr(self, "on_%s" % (method,))
                     http_server.register_paths(
-                        method,
-                        patterns,
-                        trace_servlet(servlet_classname)(method_handler),
-                        servlet_classname,
+                        method, patterns, method_handler, servlet_classname
                     )
 
         else:

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -319,7 +319,7 @@ def whitelisted_homeserver(destination):
     Args:
         destination (str)
         """
-    _homeserver_whitelist
+
     if _homeserver_whitelist:
         return _homeserver_whitelist.match(destination)
     return False

--- a/synapse/replication/http/_base.py
+++ b/synapse/replication/http/_base.py
@@ -28,10 +28,9 @@ from synapse.api.errors import (
     RequestSendFailed,
     SynapseError,
 )
+from synapse.logging.opentracing import inject_active_span_byte_dict, trace_servlet
 from synapse.util.caches.response_cache import ResponseCache
 from synapse.util.stringutils import random_string
-
-from synapse.logging.opentracing import trace_servlet, inject_active_span_byte_dict
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
In order to do this register_paths now automatically traces all servlets. There is a flag included to disable this.

register_paths does not extract contexts from the handled requests because we can't trust the senders of the requests.

The replication and federation servlets need to extract contexts. As a result the flag is used for them and custom tracing is implemented for both.