### PR TITLE
Give appropriate exit codes when synctl fails

### DIFF
--- a/changelog.d/5992.feature
+++ b/changelog.d/5992.feature
@@ -1,1 +1,1 @@
-Give appropriate exit codes when syctl fails.
+Give appropriate exit codes when synctl fails.

--- a/changelog.d/5992.feature
+++ b/changelog.d/5992.feature
@@ -1,0 +1,1 @@
+Give appropriate exit codes when syctl fails.

--- a/synctl
+++ b/synctl
@@ -113,7 +113,8 @@ def start_worker(app: str, configfile: str, worker_configfile: str) -> bool:
         worker_configfile: path to worker specific yaml synapse file
 
     Returns:
-        boolean stating whether synapse started successfully if daemonize is True
+        True if the process started successfully
+        False if there was an error starting the process
     """
 
     args = [sys.executable, "-B", "-m", app, "-c", configfile, "-c", worker_configfile]

--- a/synctl
+++ b/synctl
@@ -294,7 +294,7 @@ def main():
             write("All processes exited; now restarting...")
 
     if action == "start" or action == "restart":
-        error = False
+        errors = 0
         if start_stop_synapse:
             # Check if synapse is already running
             if os.path.exists(pidfile) and pid_running(int(open(pidfile).read())):
@@ -302,7 +302,7 @@ def main():
             try:
                 start(configfile, bool(options.daemonize))
             except subprocess.CalledProcessError:
-                error = True
+                errors += 1
 
         for worker in workers:
             env = os.environ.copy()
@@ -316,20 +316,19 @@ def main():
             try:
                 start_worker(worker.app, configfile, worker.configfile)
             except subprocess.CalledProcessError:
-                error = True
+                errors += 1
 
             # Reset env back to the original
             os.environ.clear()
             os.environ.update(env)
 
-        # we tried to start exactly one thing and it blew up so it's alright to have
-        # a non-zero exit code.
-        if error and (
-            (start_stop_synapse and not workers)
-            or (len(workers) == 1 and not start_stop_synapse)
-        ):
+        process_count = len(workers) + int(start_stop_synapse)
+
+        # If every process failed to start we exit with exit code 1. If a subset
+        # fails we exit with 4
+        if errors == process_count:
             exit(1)
-        elif error:
+        elif errors:
             exit(4)
 
 

--- a/synctl
+++ b/synctl
@@ -329,6 +329,8 @@ def main():
             or (len(workers) == 1 and not start_stop_synapse)
         ):
             exit(1)
+        elif error:
+            exit(4)
 
 
 if __name__ == "__main__":

--- a/synctl
+++ b/synctl
@@ -71,7 +71,7 @@ def abort(message, colour=RED, stream=sys.stderr):
     sys.exit(1)
 
 
-def start(configfile: str, daemonize=True) -> bool:
+def start(configfile: str, daemonize: bool = True) -> bool:
     """Attempts to start synapse.
     Args:
         configfile: path to a yaml synapse config file
@@ -79,9 +79,10 @@ def start(configfile: str, daemonize=True) -> bool:
             session
 
     Returns:
-        boolean stating whether synapse started successfully if daemonize is True
+        True if the process started successfully
+        False if there was an error starting the process
 
-        doesn't return unless interupted if daemonize is false.
+        If deamonize is False it will only return once synapse exits.
     """
 
     write("Starting ...")
@@ -318,12 +319,13 @@ def main():
             write("All processes exited; now restarting...")
 
     if action == "start" or action == "restart":
-        errors = 0
+        error = False
         if start_stop_synapse:
             # Check if synapse is already running
             if os.path.exists(pidfile) and pid_running(int(open(pidfile).read())):
                 abort("synapse.app.homeserver already running")
-                errors += int(start(configfile, bool(options.daemonize)))
+
+            error |= start(configfile, bool(options.daemonize))
 
         for worker in workers:
             env = os.environ.copy()
@@ -334,20 +336,14 @@ def main():
             for cache_name, factor in iteritems(worker.cache_factors):
                 os.environ["SYNAPSE_CACHE_FACTOR_" + cache_name.upper()] = str(factor)
 
-                errors += int(start_worker(worker.app, configfile, worker.configfile))
+            error |= start_worker(worker.app, configfile, worker.configfile)
 
             # Reset env back to the original
             os.environ.clear()
             os.environ.update(env)
 
-        process_count = len(workers) + int(start_stop_synapse)
-
-        # If every process failed to start we exit with exit code 1. If a subset
-        # fails we exit with 4
-        if errors == process_count:
+        if error:
             exit(1)
-        elif errors:
-            exit(4)
 
 
 if __name__ == "__main__":

--- a/synctl
+++ b/synctl
@@ -88,6 +88,7 @@ def start(configfile, daemonize=True):
             "error starting (exit code: %d); see above for logs" % e.returncode,
             colour=RED,
         )
+        raise
 
 
 def start_worker(app, configfile, worker_configfile):
@@ -102,6 +103,7 @@ def start_worker(app, configfile, worker_configfile):
             % (app, worker_configfile, e.returncode),
             colour=RED,
         )
+        raise
 
 
 def stop(pidfile, app):
@@ -292,11 +294,20 @@ def main():
             write("All processes exited; now restarting...")
 
     if action == "start" or action == "restart":
+        error = False
         if start_stop_synapse:
             # Check if synapse is already running
             if os.path.exists(pidfile) and pid_running(int(open(pidfile).read())):
                 abort("synapse.app.homeserver already running")
-            start(configfile, bool(options.daemonize))
+            try:
+                start(configfile, bool(options.daemonize))
+            except subprocess.CalledProcessError:
+                error = True
+
+        # If we're only trying to start synapse and it blew up we can safely
+        # return a non-zero exit code.
+        if not workers:
+            exit(1)
 
         for worker in workers:
             env = os.environ.copy()
@@ -307,11 +318,19 @@ def main():
             for cache_name, factor in iteritems(worker.cache_factors):
                 os.environ["SYNAPSE_CACHE_FACTOR_" + cache_name.upper()] = str(factor)
 
-            start_worker(worker.app, configfile, worker.configfile)
+            try:
+                start_worker(worker.app, configfile, worker.configfile)
+            except subprocess.CalledProcessError:
+                error = True
 
             # Reset env back to the original
             os.environ.clear()
             os.environ.update(env)
+
+        # If we only tried to start one worker and it blew up we can safely return
+        # a non-zero exit code.
+        if error and len(workers) == 1 and not start_stop_synapse:
+            exit(1)
 
 
 if __name__ == "__main__":

--- a/synctl
+++ b/synctl
@@ -325,7 +325,8 @@ def main():
             if os.path.exists(pidfile) and pid_running(int(open(pidfile).read())):
                 abort("synapse.app.homeserver already running")
 
-            error |= start(configfile, bool(options.daemonize))
+            if not start(configfile, bool(options.daemonize)):
+                error = True
 
         for worker in workers:
             env = os.environ.copy()
@@ -336,7 +337,8 @@ def main():
             for cache_name, factor in iteritems(worker.cache_factors):
                 os.environ["SYNAPSE_CACHE_FACTOR_" + cache_name.upper()] = str(factor)
 
-            error |= start_worker(worker.app, configfile, worker.configfile)
+            if not start_worker(worker.app, configfile, worker.configfile):
+                error = True
 
             # Reset env back to the original
             os.environ.clear()

--- a/synctl
+++ b/synctl
@@ -304,11 +304,6 @@ def main():
             except subprocess.CalledProcessError:
                 error = True
 
-        # If we're only trying to start synapse and it blew up we can safely
-        # return a non-zero exit code.
-        if not workers:
-            exit(1)
-
         for worker in workers:
             env = os.environ.copy()
 
@@ -327,9 +322,12 @@ def main():
             os.environ.clear()
             os.environ.update(env)
 
-        # If we only tried to start one worker and it blew up we can safely return
+        # we tried to start exactly one thing and it blew up so it's alright to have
         # a non-zero exit code.
-        if error and len(workers) == 1 and not start_stop_synapse:
+        if error and (
+            (start_stop_synapse and not workers)
+            or (len(workers) == 1 and not start_stop_synapse)
+        ):
             exit(1)
 
 

--- a/synctl
+++ b/synctl
@@ -71,7 +71,19 @@ def abort(message, colour=RED, stream=sys.stderr):
     sys.exit(1)
 
 
-def start(configfile, daemonize=True):
+def start(configfile: str, daemonize=True) -> bool:
+    """Attempts to start synapse.
+    Args:
+        configfile: path to a yaml synapse config file
+        daemonize: whether to daemonize synapse or keep it attached to the current
+            session
+
+    Returns:
+        boolean stating whether synapse started successfully if daemonize is True
+
+        doesn't return unless interupted if daemonize is false.
+    """
+
     write("Starting ...")
     args = SYNAPSE
 
@@ -83,27 +95,39 @@ def start(configfile, daemonize=True):
     try:
         subprocess.check_call(args)
         write("started synapse.app.homeserver(%r)" % (configfile,), colour=GREEN)
+        return True
     except subprocess.CalledProcessError as e:
         write(
             "error starting (exit code: %d); see above for logs" % e.returncode,
             colour=RED,
         )
-        raise
+        return False
 
 
-def start_worker(app, configfile, worker_configfile):
+def start_worker(app: str, configfile: str, worker_configfile: str) -> bool:
+    """Attempts to start a synapse worker.
+    Args:
+        app: name of the worker's appservice
+        configfile: path to a yaml synapse config file
+        worker_configfile: path to worker specific yaml synapse file
+
+    Returns:
+        boolean stating whether synapse started successfully if daemonize is True
+    """
+
     args = [sys.executable, "-B", "-m", app, "-c", configfile, "-c", worker_configfile]
 
     try:
         subprocess.check_call(args)
         write("started %s(%r)" % (app, worker_configfile), colour=GREEN)
+        return True
     except subprocess.CalledProcessError as e:
         write(
             "error starting %s(%r) (exit code: %d); see above for logs"
             % (app, worker_configfile, e.returncode),
             colour=RED,
         )
-        raise
+        return False
 
 
 def stop(pidfile, app):
@@ -299,10 +323,7 @@ def main():
             # Check if synapse is already running
             if os.path.exists(pidfile) and pid_running(int(open(pidfile).read())):
                 abort("synapse.app.homeserver already running")
-            try:
-                start(configfile, bool(options.daemonize))
-            except subprocess.CalledProcessError:
-                errors += 1
+                errors += int(start(configfile, bool(options.daemonize)))
 
         for worker in workers:
             env = os.environ.copy()
@@ -313,10 +334,7 @@ def main():
             for cache_name, factor in iteritems(worker.cache_factors):
                 os.environ["SYNAPSE_CACHE_FACTOR_" + cache_name.upper()] = str(factor)
 
-            try:
-                start_worker(worker.app, configfile, worker.configfile)
-            except subprocess.CalledProcessError:
-                errors += 1
+                errors += int(start_worker(worker.app, configfile, worker.configfile))
 
             # Reset env back to the original
             os.environ.clear()


### PR DESCRIPTION
Addresses #4640. 

Synapse doesn't return an non-zero exit code if it has an error while starting up with syctl in the event of a failure. Since synctl starts multiple things it will return two error codes. '1' for everything failed to start. '4' for a subset failed to start.