### PR TITLE
Fix destructuring assumption bug with using load_jinja2_templates

### DIFF
--- a/changelog.d/5994.feature
+++ b/changelog.d/5994.feature
@@ -1,0 +1,1 @@
+Add the ability to send registration emails from the homeserver rather than delegating to an identity server.

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -261,7 +261,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
             request.setResponseCode(e.code)
 
             # Show a failure page with a reason
-            [html_template] = load_jinja2_templates(
+            html_template, = load_jinja2_templates(
                 self.config.email_template_dir,
                 [self.config.email_password_reset_template_failure_html],
             )

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -261,7 +261,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
             request.setResponseCode(e.code)
 
             # Show a failure page with a reason
-            html_template = load_jinja2_templates(
+            [html_template] = load_jinja2_templates(
                 self.config.email_template_dir,
                 [self.config.email_password_reset_template_failure_html],
             )

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -293,7 +293,7 @@ class RegistrationSubmitTokenServlet(RestServlet):
             request.setResponseCode(e.code)
 
             # Show a failure page with a reason
-            [html_template] = load_jinja2_templates(
+            html_template, = load_jinja2_templates(
                 self.config.email_template_dir,
                 [self.config.email_registration_template_failure_html],
             )

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -293,7 +293,7 @@ class RegistrationSubmitTokenServlet(RestServlet):
             request.setResponseCode(e.code)
 
             # Show a failure page with a reason
-            html_template = load_jinja2_templates(
+            [html_template] = load_jinja2_templates(
                 self.config.email_template_dir,
                 [self.config.email_registration_template_failure_html],
             )


### PR DESCRIPTION
`load_jinja2_templates` returns a list but in some cases we were just setting it to a single variable, which became a list of a single template instead of a template.

Broken in https://github.com/matrix-org/synapse/pull/5940