### PR TITLE
Ensure a sid parameter is passed to bind_threepid

### DIFF
--- a/changelog.d/5995.bugfix
+++ b/changelog.d/5995.bugfix
@@ -1,0 +1,1 @@
+Return a M_MISSING_PARAM if `sid` is not provided to `/account/3pid`.

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -153,7 +153,9 @@ class IdentityHandler(BaseHandler):
 
         sid = creds.get("sid")
         if not sid:
-            raise SynapseError(400, "No sid in three_pid_creds", errcode=Codes.MISSING_PARAM)
+            raise SynapseError(
+                400, "No sid in three_pid_creds", errcode=Codes.MISSING_PARAM
+            )
 
         # If an id_access_token is not supplied, force usage of v1
         if id_access_token is None:

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -153,9 +153,7 @@ class IdentityHandler(BaseHandler):
 
         sid = creds.get("sid")
         if not sid:
-            raise SynapseError(
-                400, "No sid in creds", errcode=Codes.MISSING_PARAM
-            )
+            raise SynapseError(400, "No sid in creds", errcode=Codes.MISSING_PARAM)
 
         # If an id_access_token is not supplied, force usage of v1
         if id_access_token is None:

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -153,7 +153,7 @@ class IdentityHandler(BaseHandler):
 
         sid = creds.get("sid")
         if not sid:
-            raise SynapseError(400, "No sid in creds", errcode=Codes.MISSING_PARAM)
+            raise SynapseError(400, "No sid in three_pid_creds", errcode=Codes.MISSING_PARAM)
 
         # If an id_access_token is not supplied, force usage of v1
         if id_access_token is None:

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -151,12 +151,18 @@ class IdentityHandler(BaseHandler):
             creds
         )
 
+        sid = creds.get("sid")
+        if not sid:
+            raise SynapseError(
+                400, "No sid in creds", errcode=Codes.MISSING_PARAM
+            )
+
         # If an id_access_token is not supplied, force usage of v1
         if id_access_token is None:
             use_v2 = False
 
         # Decide which API endpoint URLs to use
-        bind_data = {"sid": creds["sid"], "client_secret": client_secret, "mxid": mxid}
+        bind_data = {"sid": sid, "client_secret": client_secret, "mxid": mxid}
         if use_v2:
             bind_url = "https://%s/_matrix/identity/v2/3pid/bind" % (id_server,)
             bind_data["id_access_token"] = id_access_token


### PR DESCRIPTION
`sid` is required to be part of `three_pid_creds`. We were 500'ing if it wasn't provided instead of returning `M_MISSING_PARAM`.