### PR TITLE
Add opentracing span for HTTP push

### DIFF
--- a/changelog.d/6003.misc
+++ b/changelog.d/6003.misc
@@ -1,0 +1,1 @@
+Add opentracing span over HTTP push processing.


### PR DESCRIPTION
This lets us more easily tell track what's happened with a push notification