### PR TITLE
Only count real users when checking for auto-creation of auto-join room

### DIFF
--- a/changelog.d/6004.bugfix
+++ b/changelog.d/6004.bugfix
@@ -1,0 +1,1 @@
+Only count real users when checking for auto-creation of auto-join room.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -275,16 +275,12 @@ class RegistrationHandler(BaseHandler):
         fake_requester = create_requester(user_id)
 
         # try to create the room if we're the first real user on the server. Note
-        # that an auto-generated support user is not a real user and will never be
+        # that an auto-generated support or bot user is not a real user and will never be
         # the user to create the room
         should_auto_create_rooms = False
-        is_support = yield self.store.is_support_user(user_id)
-        # There is an edge case where the first user is the support user, then
-        # the room is never created, though this seems unlikely and
-        # recoverable from given the support user being involved in the first
-        # place.
-        if self.hs.config.autocreate_auto_join_rooms and not is_support:
-            count = yield self.store.count_all_users()
+        is_real_user = yield self.store.is_real_user(user_id)
+        if self.hs.config.autocreate_auto_join_rooms and is_real_user:
+            count = yield self.store.count_real_users()
             should_auto_create_rooms = count == 1
         for r in self.hs.config.auto_join_rooms:
             logger.info("Auto-joining %s to %s", user_id, r)

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -449,9 +449,7 @@ class RegistrationWorkerStore(SQLBaseStore):
         """Counts all users without a special user_type registered on the homeserver."""
 
         def _count_users(txn):
-            txn.execute(
-                "SELECT COUNT(*) AS users FROM users where user_type is null"
-            )
+            txn.execute("SELECT COUNT(*) AS users FROM users where user_type is null")
             rows = self.cursor_to_dict(txn)
             if rows:
                 return rows[0]["users"]

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -358,7 +358,7 @@ class RegistrationWorkerStore(SQLBaseStore):
             retcol="user_type",
             allow_none=True,
         )
-        return True if res is None or res == "" else False
+        return res is None
 
     def is_support_user_txn(self, txn, user_id):
         res = self._simple_select_one_onecol_txn(

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -332,9 +332,7 @@ class RegistrationWorkerStore(SQLBaseStore):
         Returns:
             Deferred[bool]: True if user 'user_type' is null or empty string
         """
-        res = yield self.runInteraction(
-            "is_real_user", self.is_real_user_txn, user_id
-        )
+        res = yield self.runInteraction("is_real_user", self.is_real_user_txn, user_id)
         return res
 
     @cachedInlineCallbacks()
@@ -451,7 +449,9 @@ class RegistrationWorkerStore(SQLBaseStore):
         """Counts all users without a special user_type registered on the homeserver."""
 
         def _count_users(txn):
-            txn.execute("SELECT COUNT(*) AS users FROM users where user_type is null or user_type = ''")
+            txn.execute(
+                "SELECT COUNT(*) AS users FROM users where user_type is null or user_type = ''"
+            )
             rows = self.cursor_to_dict(txn)
             if rows:
                 return rows[0]["users"]

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -450,7 +450,7 @@ class RegistrationWorkerStore(SQLBaseStore):
 
         def _count_users(txn):
             txn.execute(
-                "SELECT COUNT(*) AS users FROM users where user_type is null or user_type = ''"
+                "SELECT COUNT(*) AS users FROM users where user_type is null"
             )
             rows = self.cursor_to_dict(txn)
             if rows:

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -171,17 +171,42 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
         rooms = self.get_success(self.store.get_rooms_for_user(user_id))
         self.assertEqual(len(rooms), 0)
 
-    def test_auto_create_auto_join_rooms_when_support_user_exists(self):
+    def test_auto_create_auto_join_rooms_when_user_is_not_a_real_user(self):
         room_alias_str = "#room:test"
         self.hs.config.auto_join_rooms = [room_alias_str]
 
-        self.store.is_support_user = Mock(return_value=True)
+        self.store.is_real_user = Mock(return_value=False)
         user_id = self.get_success(self.handler.register_user(localpart="support"))
         rooms = self.get_success(self.store.get_rooms_for_user(user_id))
         self.assertEqual(len(rooms), 0)
         directory_handler = self.hs.get_handlers().directory_handler
         room_alias = RoomAlias.from_string(room_alias_str)
         self.get_failure(directory_handler.get_association(room_alias), SynapseError)
+
+    def test_auto_create_auto_join_rooms_when_user_is_the_first_real_user(self):
+        room_alias_str = "#room:test"
+        self.hs.config.auto_join_rooms = [room_alias_str]
+
+        self.store.count_real_users = Mock(return_value=1)
+        self.store.is_real_user = Mock(return_value=True)
+        user_id = self.get_success(self.handler.register_user(localpart="real"))
+        rooms = self.get_success(self.store.get_rooms_for_user(user_id))
+        directory_handler = self.hs.get_handlers().directory_handler
+        room_alias = RoomAlias.from_string(room_alias_str)
+        room_id = self.get_success(directory_handler.get_association(room_alias))
+
+        self.assertTrue(room_id["room_id"] in rooms)
+        self.assertEqual(len(rooms), 1)
+
+    def test_auto_create_auto_join_rooms_when_user_is_not_the_first_real_user(self):
+        room_alias_str = "#room:test"
+        self.hs.config.auto_join_rooms = [room_alias_str]
+
+        self.store.count_real_users = Mock(return_value=2)
+        self.store.is_real_user = Mock(return_value=True)
+        user_id = self.get_success(self.handler.register_user(localpart="real"))
+        rooms = self.get_success(self.store.get_rooms_for_user(user_id))
+        self.assertEqual(len(rooms), 0)
 
     def test_auto_create_auto_join_where_no_consent(self):
         """Test to ensure that the first user is not auto-joined to a room if


### PR DESCRIPTION
Previously if the first registered user was a "support" or "bot" user,
when the first real user registers, the auto-join rooms were not
created.

Fix to exclude non-real (ie users with a special user type) users
when counting how many users there are to determine whether we should
auto-create a room.