### PR TITLE
Read localpart / displayName from attestations configured in config

### DIFF
--- a/changelog.d/6006.feature
+++ b/changelog.d/6006.feature
@@ -1,0 +1,1 @@
+SAML auth: Allow configuration of localpart and displayName attestations in server config.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1141,6 +1141,13 @@ signing_key_path: "CONFDIR/SERVERNAME.signing.key"
 #  # The default is 5 minutes.
 #  #
 #  # saml_session_lifetime: 5m
+#  #
+#  # # The ID of the attestation that will be used for the localpart of the user's Matrix ID
+#  # # Deafault: 'uid'
+#  # username_attestation: "uid"
+#  #
+#  # # The ID of the attestation that will be used for the user's display name. Default: 'displayName'
+#  # displayname_attestation: "displayName"
 
 
 

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -48,6 +48,9 @@ class SAML2Config(Config):
             saml2_config.get("saml_session_lifetime", "5m")
         )
 
+        self.saml2_username_attestation = saml2_config.get("username_attestation", "uid")
+        self.saml2_displayname_attestation = saml2_config.get("displayname_attestation", "displayName")
+
     def _default_saml_config_dict(self):
         import saml2
 
@@ -135,6 +138,13 @@ class SAML2Config(Config):
         #  # The default is 5 minutes.
         #  #
         #  # saml_session_lifetime: 5m
+        #  #
+        #  # # The ID of the attestation that will be used for the localpart of the user's Matrix ID
+        #  # # Deafault: 'uid'
+        #  # username_attestation: "uid"
+        #  #
+        #  # # The ID of the attestation that will be used for the user's display name. Default: 'displayName'
+        #  # displayname_attestation: "displayName"
         """ % {
             "config_dir_path": config_dir_path
         }

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -48,8 +48,12 @@ class SAML2Config(Config):
             saml2_config.get("saml_session_lifetime", "5m")
         )
 
-        self.saml2_username_attestation = saml2_config.get("username_attestation", "uid")
-        self.saml2_displayname_attestation = saml2_config.get("displayname_attestation", "displayName")
+        self.saml2_username_attestation = saml2_config.get(
+            "username_attestation", "uid"
+        )
+        self.saml2_displayname_attestation = saml2_config.get(
+            "displayname_attestation", "displayName"
+        )
 
     def _default_saml_config_dict(self):
         import saml2

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -94,7 +94,10 @@ class SamlHandler:
             raise SynapseError(400, "SAML2 response was not signed")
 
         if self.saml2_username_attestation not in saml2_auth.ava:
-            logger.warning("SAML2 response lacks a '%s' attestation", self.saml2_username_attestation)
+            logger.warning(
+                "SAML2 response lacks a '%s' attestation",
+                self.saml2_username_attestation,
+            )
             raise SynapseError(400, "username attestation not in SAML2 response")
 
         self._outstanding_requests_dict.pop(saml2_auth.in_response_to, None)


### PR DESCRIPTION
When using SAML, this allows synapse to use whatever attribute the server admin wants as the localpart and displayname.