### PR TITLE
Add note about extra arg to send_membership_event, remove arg in remote_reject_invite

### DIFF
--- a/changelog.d/6009.misc
+++ b/changelog.d/6009.misc
@@ -1,0 +1,1 @@
+Small refactor of function arguments and docstrings in RoomMemberHandler.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -491,8 +491,10 @@ class RoomMemberHandler(object):
                 else:
                     # send the rejection to the inviter's HS.
                     remote_room_hosts = remote_room_hosts + [inviter.domain]
+                    # Note: This is calling _remote_reject_invite on RoomMemberMasterHandler,
+                    # hence the `requester` arg
                     res = yield self._remote_reject_invite(
-                        remote_room_hosts, room_id, target
+                        requester, remote_room_hosts, room_id, target
                     )
                     return res
 

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -492,7 +492,7 @@ class RoomMemberHandler(object):
                     # send the rejection to the inviter's HS.
                     remote_room_hosts = remote_room_hosts + [inviter.domain]
                     res = yield self._remote_reject_invite(
-                        requester, remote_room_hosts, room_id, target
+                        remote_room_hosts, room_id, target
                     )
                     return res
 
@@ -510,9 +510,7 @@ class RoomMemberHandler(object):
         return res
 
     @defer.inlineCallbacks
-    def send_membership_event(
-        self, requester, event, context, remote_room_hosts=None, ratelimit=True
-    ):
+    def send_membership_event(self, requester, event, context, ratelimit=True):
         """
         Change the membership status of a user in a room.
 
@@ -522,16 +520,10 @@ class RoomMemberHandler(object):
                 act as the sender, will be skipped.
             event (SynapseEvent): The membership event.
             context: The context of the event.
-            is_guest (bool): Whether the sender is a guest.
-            room_hosts ([str]): Homeservers which are likely to already be in
-                the room, and could be danced with in order to join this
-                homeserver for the first time.
             ratelimit (bool): Whether to rate limit this request.
         Raises:
             SynapseError if there was a problem changing the membership.
         """
-        remote_room_hosts = remote_room_hosts or []
-
         target_user = UserID.from_string(event.state_key)
         room_id = event.room_id
 

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -100,7 +100,7 @@ class RoomMemberHandler(object):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def _remote_reject_invite(self, remote_room_hosts, room_id, target):
+    def _remote_reject_invite(self, requester, remote_room_hosts, room_id, target):
         """Attempt to reject an invite for a room this server is not in. If we
         fail to do so we locally mark the invite as rejected.
 
@@ -491,8 +491,6 @@ class RoomMemberHandler(object):
                 else:
                     # send the rejection to the inviter's HS.
                     remote_room_hosts = remote_room_hosts + [inviter.domain]
-                    # Note: This is calling _remote_reject_invite on RoomMemberMasterHandler,
-                    # hence the `requester` arg
                     res = yield self._remote_reject_invite(
                         requester, remote_room_hosts, room_id, target
                     )


### PR DESCRIPTION
Some small fixes to `room_member.py` found while doing other PRs.

1. Add requester to the base `_remote_reject_invite` method.
2. `send_membership_event`'s docstring was out of date and took in a `remote_room_hosts` arg that was not used and no calling function provided. 