### PR TITLE
Remove origin parameter from add_display_name_to_third_party_invite and add params to docstring

### DIFF
--- a/changelog.d/6010.misc
+++ b/changelog.d/6010.misc
@@ -1,0 +1,1 @@
+Remove unused `origin` argument on FederationHandler.add_display_name_to_third_party_invite.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -669,9 +669,9 @@ class FederationServer(FederationBase):
         return ret
 
     @defer.inlineCallbacks
-    def on_exchange_third_party_invite_request(self, origin, room_id, event_dict):
+    def on_exchange_third_party_invite_request(self, room_id, event_dict):
         ret = yield self.handler.on_exchange_third_party_invite_request(
-            origin, room_id, event_dict
+            room_id, event_dict
         )
         return ret
 

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -575,7 +575,7 @@ class FederationThirdPartyInviteExchangeServlet(BaseFederationServlet):
 
     async def on_PUT(self, origin, content, query, room_id):
         content = await self.handler.on_exchange_third_party_invite_request(
-            origin, room_id, content
+            room_id, content
         )
         return 200, content
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2530,7 +2530,7 @@ class FederationHandler(BaseHandler):
 
     @defer.inlineCallbacks
     @log_function
-    def jn_exchange_third_party_invite_request(self, room_id, event_dict):
+    def on_exchange_third_party_invite_request(self, room_id, event_dict):
         """Handle an exchange_third_party_invite request from a remote server
 
         The remote server will call this when it wants to turn a 3pid invite

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2530,11 +2530,16 @@ class FederationHandler(BaseHandler):
 
     @defer.inlineCallbacks
     @log_function
-    def on_exchange_third_party_invite_request(self, origin, room_id, event_dict):
+    def jn_exchange_third_party_invite_request(self, room_id, event_dict):
         """Handle an exchange_third_party_invite request from a remote server
 
         The remote server will call this when it wants to turn a 3pid invite
         into a normal m.room.member invite.
+
+        Args:
+            room_id (str): The ID of the room.
+
+            event_dict (dict[str, Any]): Dictionary containing the event body.
 
         Returns:
             Deferred: resolves (to None)


### PR DESCRIPTION
Another small fixup noticed during work on a larger PR. The `origin` field of `add_display_name_to_third_party_invite` is not used and likely was just carried over from the `on_PUT` method of `FederationThirdPartyInviteExchangeServlet` which, like all other servlets, provides an `origin` argument.

Since it's not used anywhere in the handler function though, we should remove it from the function arguments.