### PR TITLE
add report_stats_endpoint config option

### DIFF
--- a/changelog.d/6012.feature
+++ b/changelog.d/6012.feature
@@ -1,1 +1,1 @@
-Add report_stats_endpoint option to configure where stats are reported to, if enabled. Contributed by @Sorunome
+Add report_stats_endpoint option to configure where stats are reported to, if enabled. Contributed by @Sorunome.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -979,7 +979,10 @@ metrics_flags:
 # report_stats: true|false
 
 # The endpoint to report the anonymized homeserver usage statistics to.
-#report_stats_endpoint: https://matrix.org/report-usage-stats/push
+# Defaults to https://matrix.org/report-usage-stats/push
+#
+#report_stats_endpoint: https://example.com/report-usage-stats/push
+
 
 ## API Configuration ##
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -561,7 +561,9 @@ def run(hs):
 
         stats["database_engine"] = hs.get_datastore().database_engine_name
         stats["database_server_version"] = hs.get_datastore().get_server_version()
-        logger.info("Reporting stats to %s: %s" % (hs.config.report_stats_endpoint, stats))
+        logger.info(
+            "Reporting stats to %s: %s" % (hs.config.report_stats_endpoint, stats)
+        )
         try:
             yield hs.get_simple_http_client().put_json(
                 hs.config.report_stats_endpoint, stats

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -39,7 +39,9 @@ class MetricsConfig(Config):
     def read_config(self, config, **kwargs):
         self.enable_metrics = config.get("enable_metrics", False)
         self.report_stats = config.get("report_stats", None)
-        self.report_stats_endpoint = config.get("report_stats_endpoint", "https://matrix.org/report-usage-stats/push")
+        self.report_stats_endpoint = config.get(
+            "report_stats_endpoint", "https://matrix.org/report-usage-stats/push"
+        )
         self.metrics_port = config.get("metrics_port")
         self.metrics_bind_host = config.get("metrics_bind_host", "127.0.0.1")
 
@@ -98,8 +100,10 @@ class MetricsConfig(Config):
         else:
             res += "report_stats: %s\n" % ("true" if report_stats else "false")
 
-        res += """\
+        res += """
         # The endpoint to report the anonymized homeserver usage statistics to.
+        # Defaults to https://matrix.org/report-usage-stats/push
+        #
         #report_stats_endpoint: https://example.com/report-usage-stats/push
         """
         return res


### PR DESCRIPTION
This PR adds the optional `report_stats_endpoint` to configure where stats are reported to, if enabled.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Signed-off-by: Sorunome <sorunome@famedly.com>