### PR TITLE
Fix existing v2 identity server calls (MSC2140)

### DIFF
--- a/changelog.d/6013.bugfix
+++ b/changelog.d/6013.bugfix
@@ -1,1 +1,0 @@
-Fix v2 identity server calls using `id_access_token` instead of `access_token`, and use HTTP Authorization headers to send them instead of query parameters or JSON bodies.

--- a/changelog.d/6013.bugfix
+++ b/changelog.d/6013.bugfix
@@ -1,0 +1,1 @@
+Fix v2 identity server calls using `id_access_token` instead of `access_token`, and use HTTP Authorization headers to send them instead of query parameters or JSON bodies.

--- a/changelog.d/6013.misc
+++ b/changelog.d/6013.misc
@@ -1,0 +1,1 @@
+Compatibility with v2 Identity Service APIs other than /lookup.

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -74,6 +74,25 @@ class IdentityHandler(BaseHandler):
         id_access_token = creds.get("id_access_token")
         return client_secret, id_server, id_access_token
 
+    def create_id_access_token_header(self, id_access_token):
+        """Create an Authorization header for passing to SimpleHttpClient as the header value
+        of an HTTP request.
+
+        Args:
+            id_access_token (str): An identity server access token.
+
+        Returns:
+            list[str]: The ascii-encoded bearer token encased in a list.
+        """
+        # Prefix with Bearer
+        bearer_token = "Bearer %s" % id_access_token
+
+        # Encode headers to standard ascii
+        bearer_token.encode("ascii")
+
+        # Return as a list as that's how SimpleHttpClient takes header values
+        return [bearer_token]
+
     @defer.inlineCallbacks
     def threepid_from_creds(self, creds, use_v2=True):
         """
@@ -101,6 +120,7 @@ class IdentityHandler(BaseHandler):
             use_v2 = False
 
         query_params = {"sid": creds["sid"], "client_secret": client_secret}
+        headers = {}
 
         # Decide which API endpoint URLs and query parameters to use
         if use_v2:
@@ -108,7 +128,9 @@ class IdentityHandler(BaseHandler):
                 id_server,
                 "/_matrix/identity/v2/3pid/getValidated3pid",
             )
-            query_params["id_access_token"] = id_access_token
+            headers["Authorization"] = self.create_id_access_token_header(
+                id_access_token
+            )
         else:
             url = "https://%s%s" % (
                 id_server,
@@ -116,7 +138,7 @@ class IdentityHandler(BaseHandler):
             )
 
         try:
-            data = yield self.http_client.get_json(url, query_params)
+            data = yield self.http_client.get_json(url, query_params, headers=headers)
             return data if "medium" in data else None
         except HttpResponseException as e:
             if e.code != 404 or not use_v2:
@@ -162,15 +184,20 @@ class IdentityHandler(BaseHandler):
             use_v2 = False
 
         # Decide which API endpoint URLs to use
+        headers = {}
         bind_data = {"sid": sid, "client_secret": client_secret, "mxid": mxid}
         if use_v2:
             bind_url = "https://%s/_matrix/identity/v2/3pid/bind" % (id_server,)
-            bind_data["id_access_token"] = id_access_token
+            headers["Authorization"] = self.create_id_access_token_header(
+                id_access_token
+            )
         else:
             bind_url = "https://%s/_matrix/identity/api/v1/3pid/bind" % (id_server,)
 
         try:
-            data = yield self.http_client.post_json_get_json(bind_url, bind_data)
+            data = yield self.http_client.post_json_get_json(
+                bind_url, bind_data, headers=headers
+            )
             logger.debug("bound threepid %r to %s", creds, mxid)
 
             # Remember where we bound the threepid


### PR DESCRIPTION
Two things I missed while implementing [MSC2140](https://github.com/matrix-org/matrix-doc/pull/2140/files#diff-c03a26de5ac40fb532de19cb7fc2aaf7R80).

1. Access tokens should be provided to the identity server as `access_token`, not `id_access_token`, even though the homeserver may accept the tokens as `id_access_token`.
2. Access tokens must be sent to the identity server in a query parameter, the JSON body is not allowed.

We now send the access token as part of an `Authorization: ...` header, which fixes both things.

The breaking code was added in https://github.com/matrix-org/synapse/pull/5892

Sytest PR: https://github.com/matrix-org/sytest/pull/697