### PR TITLE
Allow use of different ratelimits for admin redactions.

### DIFF
--- a/changelog.d/6015.feature
+++ b/changelog.d/6015.feature
@@ -1,0 +1,1 @@
+Add config option to increase ratelimits for room admins redacting messages.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -518,6 +518,9 @@ log_config: "CONFDIR/SERVERNAME.log.config"
 #   - one for login that ratelimits login requests based on the account the
 #     client is attempting to log into, based on the amount of failed login
 #     attempts for this account.
+#   - one for ratelimiting redactions by room admins. If this is not explicitly
+#     set then it uses the same ratelimiting as per rc_message. This is useful
+#     to allow room admins to quickly deal with abuse quickly.
 #
 # The defaults are as shown below.
 #
@@ -539,6 +542,10 @@ log_config: "CONFDIR/SERVERNAME.log.config"
 #  failed_attempts:
 #    per_second: 0.17
 #    burst_count: 3
+#
+#rc_admin_redaction:
+#  per_second: 1
+#  burst_count: 50
 
 
 # Ratelimiting settings for incoming federation

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -520,7 +520,7 @@ log_config: "CONFDIR/SERVERNAME.log.config"
 #     attempts for this account.
 #   - one for ratelimiting redactions by room admins. If this is not explicitly
 #     set then it uses the same ratelimiting as per rc_message. This is useful
-#     to allow room admins to quickly deal with abuse quickly.
+#     to allow room admins to deal with abuse quickly.
 #
 # The defaults are as shown below.
 #

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -110,7 +110,7 @@ class RatelimitConfig(Config):
         #     attempts for this account.
         #   - one for ratelimiting redactions by room admins. If this is not explicitly
         #     set then it uses the same ratelimiting as per rc_message. This is useful
-        #     to allow room admins to quickly deal with abuse quickly.
+        #     to allow room admins to deal with abuse quickly.
         #
         # The defaults are as shown below.
         #

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -80,6 +80,12 @@ class RatelimitConfig(Config):
             "federation_rr_transactions_per_room_per_second", 50
         )
 
+        rc_admin_redaction = config.get("rc_admin_redaction")
+        if rc_admin_redaction:
+            self.rc_admin_redaction = RateLimitConfig(rc_admin_redaction)
+        else:
+            self.rc_admin_redaction = None
+
     def generate_config_section(self, **kwargs):
         return """\
         ## Ratelimiting ##
@@ -102,6 +108,9 @@ class RatelimitConfig(Config):
         #   - one for login that ratelimits login requests based on the account the
         #     client is attempting to log into, based on the amount of failed login
         #     attempts for this account.
+        #   - one for ratelimiting redactions by room admins. If this is not explicitly
+        #     set then it uses the same ratelimiting as per rc_message. This is useful
+        #     to allow room admins to quickly deal with abuse quickly.
         #
         # The defaults are as shown below.
         #
@@ -123,6 +132,10 @@ class RatelimitConfig(Config):
         #  failed_attempts:
         #    per_second: 0.17
         #    burst_count: 3
+        #
+        #rc_admin_redaction:
+        #  per_second: 1
+        #  burst_count: 50
 
 
         # Ratelimiting settings for incoming federation

--- a/synapse/handlers/_base.py
+++ b/synapse/handlers/_base.py
@@ -105,7 +105,7 @@ class BaseHandler(object):
 
         if is_admin_redaction and self.hs.config.rc_admin_redaction:
             # If we have separate config for admin redactions we use a separate
-            # ratelimiter.
+            # ratelimiter
             allowed, time_allowed = self.admin_redaction_ratelimiter.can_do_action(
                 user_id,
                 time_now,

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -731,7 +731,7 @@ class EventCreationHandler(object):
         if ratelimit:
             # We check if this is a room admin redacting an event so that we
             # can apply different ratelimiting. We do this by simply checking
-            # its not a self-redaction (to avoid having to look up whether the
+            # it's not a self-redaction (to avoid having to look up whether the
             # user is actually admin or not).
             is_admin_redaction = False
             if event.type == EventTypes.Redaction:

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -729,7 +729,13 @@ class EventCreationHandler(object):
         assert not self.config.worker_app
 
         if ratelimit:
-            yield self.base_handler.ratelimit(requester)
+            is_admin_redaction = (
+                event.type == EventTypes.Redaction
+                and event.sender != requester.user.to_string()
+            )
+            yield self.base_handler.ratelimit(
+                requester, is_admin_redaction=is_admin_redaction
+            )
 
         yield self.base_handler.maybe_kick_guest_users(event, context)
 

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -729,10 +729,24 @@ class EventCreationHandler(object):
         assert not self.config.worker_app
 
         if ratelimit:
-            is_admin_redaction = (
-                event.type == EventTypes.Redaction
-                and event.sender != requester.user.to_string()
-            )
+            # We check if this is a room admin redacting an event so that we
+            # can apply different ratelimiting. We do this by simply checking
+            # its not a self-redaction (to avoid having to look up whether the
+            # user is actually admin or not).
+            is_admin_redaction = False
+            if event.type == EventTypes.Redaction:
+                original_event = yield self.store.get_event(
+                    event.redacts,
+                    check_redacted=False,
+                    get_prev_content=False,
+                    allow_rejected=False,
+                    allow_none=True,
+                )
+
+                is_admin_redaction = (
+                    original_event and event.sender != original_event.sender
+                )
+
             yield self.base_handler.ratelimit(
                 requester, is_admin_redaction=is_admin_redaction
             )

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -221,6 +221,7 @@ class HomeServer(object):
         self.clock = Clock(reactor)
         self.distributor = Distributor()
         self.ratelimiter = Ratelimiter()
+        self.admin_redaction_ratelimiter = Ratelimiter()
         self.registration_ratelimiter = Ratelimiter()
 
         self.datastore = None
@@ -278,6 +279,9 @@ class HomeServer(object):
 
     def get_registration_ratelimiter(self):
         return self.registration_ratelimiter
+
+    def get_admin_redaction_ratelimiter(self):
+        return self.admin_redaction_ratelimiter
 
     def build_federation_client(self):
         return FederationClient(self)

--- a/tests/rest/client/test_redactions.py
+++ b/tests/rest/client/test_redactions.py
@@ -197,8 +197,8 @@ class RedactionsTestCase(HomeserverTestCase):
             message_ids.append(b["event_id"])
             self.reactor.advance(10)  # To get around ratelimits
 
-        # as the moderator, send a bunch of redactions redaction
+        # as the moderator, send a bunch of redactions
         for msg_id in message_ids:
             # These should all succeed, even though this would be denied by
-            # standard message ratelimiter
+            # the standard message ratelimiter
             self._redact_event(self.mod_access_token, self.room_id, msg_id)


### PR DESCRIPTION
This is useful to allow room admins to quickly deal with a large number
of abusive messages.

Currently by default we keep the same behaviour as today, but maybe we should enable this by default?