### PR TITLE
Fix bug in calculating the federation retry backoff period

### DIFF
--- a/changelog.d/6025.bugfix
+++ b/changelog.d/6025.bugfix
@@ -1,0 +1,1 @@
+Fix bug in calculating the federation retry backoff period.

--- a/synapse/util/retryutils.py
+++ b/synapse/util/retryutils.py
@@ -193,8 +193,9 @@ class RetryDestinationLimiter(object):
         else:
             # We couldn't connect.
             if self.retry_interval:
-                self.retry_interval *= RETRY_MULTIPLIER
-                self.retry_interval *= int(random.uniform(0.8, 1.4))
+                self.retry_interval = int(
+                    self.retry_interval * RETRY_MULTIPLIER * random.uniform(0.8, 1.4)
+                )
 
                 if self.retry_interval >= MAX_RETRY_INTERVAL:
                     self.retry_interval = MAX_RETRY_INTERVAL


### PR DESCRIPTION
This was intended to introduce an element of jitter; instead it gave you a 30/60 chance of resetting to zero.

This was introduced wayyy back in #340, and I guess could have been part of the cause of concern for #5406.

Tests are over in #6016.