### PR TITLE
Remove the cap on federation retry interval.

### DIFF
--- a/changelog.d/6026.feature
+++ b/changelog.d/6026.feature
@@ -1,0 +1,1 @@
+Stop sending federation transactions to servers which have been down for a long time.

--- a/synapse/util/retryutils.py
+++ b/synapse/util/retryutils.py
@@ -28,8 +28,8 @@ MIN_RETRY_INTERVAL = 10 * 60 * 1000
 # how much we multiply the backoff by after each subsequent fail
 RETRY_MULTIPLIER = 5
 
-# a cap on the backoff
-MAX_RETRY_INTERVAL = 24 * 60 * 60 * 1000
+# a cap on the backoff. (Essentially none)
+MAX_RETRY_INTERVAL = 2 ** 63
 
 
 class NotRetryingDestination(Exception):


### PR DESCRIPTION
Essentially the intention here is to end up blacklisting servers which never
respond to federation requests.

Fixes https://github.com/matrix-org/synapse/issues/5113.