### PR TITLE
don't push by default for group chats.

### DIFF
--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -340,10 +340,7 @@ BASE_APPEND_UNDERRIDE_RULES = [
         # we can't do this on existing servers because we need to
         # add per-user overrides to preserve their existing behaviour
         "enabled": False,
-        "actions": [
-            "notify",
-            {"set_tweak": "highlight", "value": False}
-        ],
+        "actions": ["notify", {"set_tweak": "highlight", "value": False}],
     },
     # XXX: this is going to fire for events which aren't m.room.messages
     # but are encrypted (e.g. m.call.*)...

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -335,7 +335,13 @@ BASE_APPEND_UNDERRIDE_RULES = [
                 "_id": "_message",
             }
         ],
-        "actions": ["notify", {"set_tweak": "highlight", "value": False}],
+        "actions": [
+            # default to not notifying for group chats
+            # see https://github.com/vector-im/riot-web/issues/3268
+            # we can't do this on existing servers because we need to
+            # add per-user overrides to preserve their existing behaviour
+            "dont_notify"
+        ],
     },
     # XXX: this is going to fire for events which aren't m.room.messages
     # but are encrypted (e.g. m.call.*)...

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -335,12 +335,14 @@ BASE_APPEND_UNDERRIDE_RULES = [
                 "_id": "_message",
             }
         ],
+        # default to not notifying for group chats
+        # see https://github.com/vector-im/riot-web/issues/3268
+        # we can't do this on existing servers because we need to
+        # add per-user overrides to preserve their existing behaviour
+        "enabled": False,
         "actions": [
-            # default to not notifying for group chats
-            # see https://github.com/vector-im/riot-web/issues/3268
-            # we can't do this on existing servers because we need to
-            # add per-user overrides to preserve their existing behaviour
-            "dont_notify"
+            "notify",
+            {"set_tweak": "highlight", "value": False}
         ],
     },
     # XXX: this is going to fire for events which aren't m.room.messages


### PR DESCRIPTION
see https://github.com/vector-im/riot-web/issues/3268

This only works for new servers (e.g. mozilla-test.modular.im)