### PR TITLE
Implement MSC2290

### DIFF
--- a/changelog.d/6043.feature
+++ b/changelog.d/6043.feature
@@ -1,1 +1,1 @@
-Implement [MSC2290](https://github.com/matrix-org/matrix-doc/pull/2290).
+Implement new Client Server API endpoints `/account/3pid/add` and `/account/3pid/bind` as per [MSC2290](https://github.com/matrix-org/matrix-doc/pull/2290).

--- a/changelog.d/6043.feature
+++ b/changelog.d/6043.feature
@@ -1,0 +1,1 @@
+Implement [MSC2290](https://github.com/matrix-org/matrix-doc/pull/2290).

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -373,8 +373,8 @@ class EmailConfig(Config):
         #   # Templates for success and failure pages that a user will see after attempting
         #   # to add an email or phone to their account
         #   #
-        #   #add_threepid_success_html: add_threepid_success.html
-        #   #add_threepid_failure_html: add_threepid_failure.html
+        #   #add_threepid_success_html: add_threepid.html
+        #   #add_threepid_failure_html: add_threepid.html
         """
 
 

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -373,8 +373,8 @@ class EmailConfig(Config):
         #   # Templates for success and failure pages that a user will see after attempting
         #   # to add an email or phone to their account
         #   #
-        #   #add_threepid_success_html: add_threepid.html
-        #   #add_threepid_failure_html: add_threepid.html
+        #   #add_threepid_success_html: add_threepid_success.html
+        #   #add_threepid_failure_html: add_threepid_failure.html
         """
 
 

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -73,12 +73,8 @@ class DeactivateAccountHandler(BaseHandler):
         # unbinding
         identity_server_supports_unbinding = True
 
-        # Retrieve the 3PIDs added to the user's account
-        user_threepids = yield self.store.user_get_threepids(user_id)
-
         # Retrieve the 3PIDs this user has bound to an identity server
-        bound_threepids = yield self.store.user_get_bound_threepids(user_id)
-        threepids = user_threepids + bound_threepids
+        threepids = yield self.store.user_get_bound_threepids(user_id)
 
         for threepid in threepids:
             try:

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -73,7 +73,13 @@ class DeactivateAccountHandler(BaseHandler):
         # unbinding
         identity_server_supports_unbinding = True
 
-        threepids = yield self.store.user_get_threepids(user_id)
+        # Retrieve the 3PIDs added to the user's account
+        user_threepids = yield self.store.user_get_threepids(user_id)
+
+        # Retrieve the 3PIDs this user has bound to an identity server
+        bound_threepids = yield self.store.user_get_bound_threepids(user_id)
+        threepids = user_threepids + bound_threepids
+
         for threepid in threepids:
             try:
                 result = yield self._identity_handler.try_unbind_threepid(

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -435,7 +435,7 @@ class IdentityHandler(BaseHandler):
         # and if validation fails we try msisdn
         validation_session = None
 
-        # XXX: We should need to keep wrapping and unwrapping this value
+        # XXX: We shouldn't need to keep wrapping and unwrapping this value
         threepid_creds = {"client_secret": client_secret, "sid": sid}
 
         # Try to validate as email

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -88,15 +88,15 @@ class IdentityHandler(BaseHandler):
         """Bind a 3PID to an identity server
 
         Args:
-            client_secret: A unique secret str provided by the client
+            client_secret (str): A unique secret provided by the client
 
-            sid: The ID of the validation session
+            sid (str): The ID of the validation session
 
             mxid (str): The MXID to bind the 3PID to
 
-            id_server: The domain of the identity server to query
+            id_server (str): The domain of the identity server to query
 
-            id_access_token: The access token to authenticate to the identity
+            id_access_token (str): The access token to authenticate to the identity
                 server with, if necessary. Required if use_v2 is true
 
             use_v2 (bool): Whether to use v2 Identity Service API endpoints. Defaults to True

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -44,7 +44,6 @@ class IdentityHandler(BaseHandler):
         self.http_client = hs.get_simple_http_client()
         self.federation_http_client = hs.get_http_client()
         self.hs = hs
-        self.identity_handler = hs.get_handlers().identity_handler
 
     @defer.inlineCallbacks
     def threepid_from_creds(self, id_server, creds):
@@ -441,7 +440,7 @@ class IdentityHandler(BaseHandler):
         # Try to validate as email
         if self.hs.config.threepid_behaviour_email == ThreepidBehaviour.REMOTE:
             # Ask our delegated email identity server
-            validation_session = yield self.identity_handler.threepid_from_creds(
+            validation_session = yield self.threepid_from_creds(
                 self.hs.config.account_threepid_delegate_email, threepid_creds
             )
         elif self.hs.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
@@ -456,7 +455,7 @@ class IdentityHandler(BaseHandler):
         # Try to validate as msisdn
         if self.hs.config.account_threepid_delegate_msisdn:
             # Ask our delegated msisdn identity server
-            validation_session = yield self.identity_handler.threepid_from_creds(
+            validation_session = yield self.threepid_from_creds(
                 self.hs.config.account_threepid_delegate_msisdn, threepid_creds
             )
 

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -82,7 +82,7 @@ class IdentityHandler(BaseHandler):
 
         try:
             data = yield self.http_client.get_json(url, query_params)
-          except TimeoutError:
+        except TimeoutError:
             raise SynapseError(500, "Timed out contacting identity server")
         except HttpResponseException as e:
             logger.info(

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -91,7 +91,7 @@ class IdentityHandler(BaseHandler):
             return None
 
         # Old versions of Sydent return a 200 http code even on a failed validation
-        # check. # Thus, in addition to the HttpResponseException check above (which
+        # check. Thus, in addition to the HttpResponseException check above (which
         # checks for non-200 errors), we need to make sure validation_session isn't
         # actually an error, identified by the absence of a "medium" key
         # See https://github.com/matrix-org/sydent/issues/215 for details

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -23,13 +23,13 @@ from canonicaljson import json
 
 from twisted.internet import defer
 
-from synapse.config.emailconfig import ThreepidBehaviour
 from synapse.api.errors import (
     CodeMessageException,
     Codes,
     HttpResponseException,
     SynapseError,
 )
+from synapse.config.emailconfig import ThreepidBehaviour
 from synapse.util.stringutils import random_string
 
 from ._base import BaseHandler
@@ -436,10 +436,7 @@ class IdentityHandler(BaseHandler):
         validation_session = None
 
         # XXX: We should need to keep wrapping and unwrapping this value
-        threepid_creds = {
-            "client_secret": client_secret,
-            "sid": sid,
-        }
+        threepid_creds = {"client_secret": client_secret, "sid": sid}
 
         # Try to validate as email
         if self.hs.config.threepid_behaviour_email == ThreepidBehaviour.REMOTE:

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -635,7 +635,7 @@ class ThreepidRestServlet(RestServlet):
         client_secret = threepid_creds["client_secret"]
         sid = threepid_creds["sid"]
 
-        validation_session = self.identity_handler.validate_threepid_session(
+        validation_session = yield self.identity_handler.validate_threepid_session(
             client_secret, sid
         )
         if validation_session:
@@ -672,7 +672,7 @@ class ThreepidAddRestServlet(RestServlet):
         client_secret = body["client_secret"]
         sid = body["sid"]
 
-        validation_session = self.identity_handler.validate_threepid_session(
+        validation_session = yield self.identity_handler.validate_threepid_session(
             client_secret, sid
         )
         if validation_session:

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -644,7 +644,7 @@ class ThreepidRestServlet(RestServlet):
             )
 
         if validation_session:
-            self._add_threepid_to_account(user_id, validation_session)
+            yield self._add_threepid_to_account(user_id, validation_session)
             return 200, {}
 
         # Try to validate as msisdn
@@ -655,13 +655,14 @@ class ThreepidRestServlet(RestServlet):
             )
 
             if validation_session:
-                self._add_threepid_to_account(user_id, validation_session)
+                yield self._add_threepid_to_account(user_id, validation_session)
                 return 200, {}
 
         raise SynapseError(
             400, "No validated 3pid session found", Codes.THREEPID_AUTH_FAILED
         )
 
+    @defer.inlineCallbacks
     def _add_threepid_to_account(self, user_id, validation_session):
         """Add a threepid wrapped in a validation_session dict to an account
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -193,7 +193,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
     """Handles 3PID validation token submission"""
 
     PATTERNS = client_patterns(
-        "/password_reset/(?P<medium>[^/]*)/submit_token/*$", releases=(), unstable=True
+        "/password_reset/(?P<medium>[^/]*)/submit_token$", releases=(), unstable=True
     )
 
     def __init__(self, hs):

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -748,7 +748,9 @@ class ThreepidAddRestServlet(RestServlet):
                 400, "Not validated 3pid session found", Codes.THREEPID_AUTH_FAILED
             )
 
-        address, _, medium, _, _, validated_at = validation_session
+        address = validation_session["address"]
+        medium = validation_session["medium"]
+        validated_at = validation_session["validated_at"]
 
         yield self.auth_handler.add_threepid(user_id, medium, address, validated_at)
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -745,7 +745,7 @@ class ThreepidAddRestServlet(RestServlet):
 
         if not validation_session:
             raise SynapseError(
-                400, "Not validated 3pid session found", Codes.THREEPID_AUTH_FAILED
+                400, "No validated 3pid session found", Codes.THREEPID_AUTH_FAILED
             )
 
         address = validation_session["address"]

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -818,48 +818,23 @@ class ThreepidBindRestServlet(RestServlet):
         self.hs = hs
         self.identity_handler = hs.get_handlers().identity_handler
         self.auth = hs.get_auth()
-        self.auth_handler = hs.get_auth_handler()
-        self.datastore = self.hs.get_datastore()
-
-    @defer.inlineCallbacks
-    def on_GET(self, request):
-        requester = yield self.auth.get_user_by_req(request)
-
-        threepids = yield self.datastore.user_get_threepids(requester.user.to_string())
-
-        return 200, {"threepids": threepids}
 
     @defer.inlineCallbacks
     def on_POST(self, request):
         body = parse_json_object_from_request(request)
 
-        threepid_creds = body.get("threePidCreds") or body.get("three_pid_creds")
-        if threepid_creds is None:
-            raise SynapseError(
-                400, "Missing param three_pid_creds", Codes.MISSING_PARAM
-            )
+        assert_params_in_dict(body, ["id_server", "sid", "client_secret"])
+        id_server = body["id_server"]
+        sid = body["sid"]
+        client_secret = body["client_secret"]
+        id_access_token = body.get("id_access_token")  # optional
 
         requester = yield self.auth.get_user_by_req(request)
         user_id = requester.user.to_string()
 
-        # Specify None as the identity server to retrieve it from the request body instead
-        threepid = yield self.identity_handler.threepid_from_creds(None, threepid_creds)
-
-        if not threepid:
-            raise SynapseError(400, "Failed to auth 3pid", Codes.THREEPID_AUTH_FAILED)
-
-        for reqd in ["medium", "address", "validated_at"]:
-            if reqd not in threepid:
-                logger.warn("Couldn't add 3pid: invalid response from ID server")
-                raise SynapseError(500, "Invalid response from ID Server")
-
-        yield self.auth_handler.add_threepid(
-            user_id, threepid["medium"], threepid["address"], threepid["validated_at"]
+        yield self.identity_handler.bind_threepid(
+            client_secret, sid, user_id, id_server, id_access_token
         )
-
-        if "bind" in body and body["bind"]:
-            logger.debug("Binding threepid %s to %s", threepid, user_id)
-            yield self.identity_handler.bind_threepid(threepid_creds, user_id)
 
         return 200, {}
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -862,6 +862,8 @@ def register_servlets(hs, http_server):
     MsisdnThreepidRequestTokenRestServlet(hs).register(http_server)
     AddThreepidSubmitTokenServlet(hs).register(http_server)
     ThreepidRestServlet(hs).register(http_server)
+    ThreepidAddRestServlet(hs).register(http_server)
+    ThreepidBindRestServlet(hs).register(http_server)
     ThreepidUnbindRestServlet(hs).register(http_server)
     ThreepidDeleteRestServlet(hs).register(http_server)
     WhoamiRestServlet(hs).register(http_server)

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -793,25 +793,19 @@ class ThreepidAddRestServlet(RestServlet):
         requester = yield self.auth.get_user_by_req(request)
         user_id = requester.user.to_string()
 
-        self.store.validate_threepid_session(sid, )
-
-        threepid = yield self.identity_handler.threepid_from_creds(None, threepid_creds)
-
-        if not threepid:
-            raise SynapseError(400, "Failed to auth 3pid", Codes.THREEPID_AUTH_FAILED)
-
-        for reqd in ["medium", "address", "validated_at"]:
-            if reqd not in threepid:
-                logger.warn("Couldn't add 3pid: invalid response from ID server")
-                raise SynapseError(500, "Invalid response from ID Server")
-
-        yield self.auth_handler.add_threepid(
-            user_id, threepid["medium"], threepid["address"], threepid["validated_at"]
+        # Get a validated session matching these details
+        validation_session = self.store.get_threepid_validation_session(
+            None, client_secret, sid=sid
         )
 
-        if "bind" in body and body["bind"]:
-            logger.debug("Binding threepid %s to %s", threepid, user_id)
-            yield self.identity_handler.bind_threepid(threepid_creds, user_id)
+        if not validation_session:
+            raise SynapseError(
+                400, "Not validated 3pid session found", Codes.THREEPID_AUTH_FAILED
+            )
+
+        address, _, medium, _, _, validated_at = validation_session
+
+        yield self.auth_handler.add_threepid(user_id, medium, address, validated_at)
 
         return 200, {}
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -739,7 +739,7 @@ class ThreepidAddRestServlet(RestServlet):
         user_id = requester.user.to_string()
 
         # Get a validated session matching these details
-        validation_session = self.store.get_threepid_validation_session(
+        validation_session = yield self.store.get_threepid_validation_session(
             None, client_secret, sid=sid
         )
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -627,33 +627,66 @@ class ThreepidRestServlet(RestServlet):
         client_secret = threepid_creds["client_secret"]
         sid = threepid_creds["sid"]
 
-        # Get a validated session matching these details
-        validation_session = yield self.datastore.get_threepid_validation_session(
-            None, client_secret, sid=sid, validated=True
-        )
+        # We don't actually know which medium this 3PID is. Thus we first assume it's email,
+        # and if validation fails we try msisdn
+        validation_session = None
+
+        # Try to validate as email
+        if self.hs.config.threepid_behaviour_email == ThreepidBehaviour.REMOTE:
+            # Ask our delegated email identity server
+            validation_session = yield self.identity_handler.threepid_from_creds(
+                self.hs.config.account_threepid_delegate_email, threepid_creds
+            )
+        elif self.hs.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
+            # Get a validated session matching these details
+            validation_session = yield self.datastore.get_threepid_validation_session(
+                None, client_secret, sid=sid, validated=True
+            )
+
+        if self._add_threepid_to_account(user_id, validation_session):
+            return 200, {}
+
+        # Try to validate as msisdn
+        if self.hs.config.account_threepid_delegate_msisdn:
+            # Ask our delegated msisdn identity server
+            validation_session = yield self.identity_handler.threepid_from_creds(
+                self.hs.config.account_threepid_delegate_msisdn, threepid_creds
+            )
+
+            if self._add_threepid_to_account(user_id, validation_session):
+                return 200, {}
 
         raise SynapseError(
             400, "No validated 3pid session found", Codes.THREEPID_AUTH_FAILED
         )
 
-    @defer.inlineCallbacks
     def _add_threepid_to_account(self, user_id, validation_session):
-        """Add a threepid wrapped in a validation_session dict to an account
+        """Attempt to add a threepid wrapped in a validation_session dict to an account
 
         Args:
             user_id (str): The mxid of the user to add this 3PID to
 
-            validation_session (dict): A dict containing the following:
+            validation_session (dict|None): A dict containing the following:
                 * medium       - medium of the threepid
                 * address      - address of the threepid
                 * validated_at - timestamp of when the validation occurred
+
+                If validation_session is None, this method will return False
+
+        Returns:
+            A boolean stating whether adding the threepid was successful
         """
+        if not validation_session:
+            return False
+
         yield self.auth_handler.add_threepid(
             user_id,
             validation_session["medium"],
             validation_session["address"],
             validation_session["validated_at"],
         )
+
+        return True
 
 
 class ThreepidUnbindRestServlet(RestServlet):

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -640,57 +640,10 @@ class ThreepidRestServlet(RestServlet):
         client_secret = threepid_creds["client_secret"]
         sid = threepid_creds["sid"]
 
-        # We don't actually know which medium this 3PID is. Thus we first assume it's email,
-        # and if validation fails we try msisdn
-        validation_session = None
-
-        # Try to validate as email
-        if self.hs.config.threepid_behaviour_email == ThreepidBehaviour.REMOTE:
-            # Ask our delegated email identity server
-            try:
-                validation_session = yield self.identity_handler.threepid_from_creds(
-                    self.hs.config.account_threepid_delegate_email, threepid_creds
-                )
-            except HttpResponseException:
-                logger.debug(
-                    "%s reported non-validated threepid: %s",
-                    self.hs.config.account_threepid_delegate_email,
-                    threepid_creds,
-                )
-        elif self.hs.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
-            # Get a validated session matching these details
-            validation_session = yield self.datastore.get_threepid_validation_session(
-                "email", client_secret, sid=sid, validated=True
-            )
-
-        # Old versions of Sydent return a 200 http code even on a failed validation check.
-        # Thus, in addition to the HttpResponseException check above (which checks for
-        # non-200 errors), we need to make sure validation_session isn't actually an error,
-        # identified by containing an "error" key
-        # See https://github.com/matrix-org/sydent/issues/215 for details
-        if validation_session and "error" not in validation_session:
-            yield self._add_threepid_to_account(user_id, validation_session)
-            return 200, {}
-
-        # Try to validate as msisdn
-        if self.hs.config.account_threepid_delegate_msisdn:
-            # Ask our delegated msisdn identity server
-            try:
-                validation_session = yield self.identity_handler.threepid_from_creds(
-                    self.hs.config.account_threepid_delegate_msisdn, threepid_creds
-                )
-            except HttpResponseException:
-                logger.debug(
-                    "%s reported non-validated threepid: %s",
-                    self.hs.config.account_threepid_delegate_email,
-                    threepid_creds,
-                )
-
-            # Check that validation_session isn't actually an error due to old Sydent instances
-            # See explanatory comment above
-            if validation_session and "error" not in validation_session:
-                yield self._add_threepid_to_account(user_id, validation_session)
-                return 200, {}
+        # Get a validated session matching these details
+        validation_session = yield self.datastore.get_threepid_validation_session(
+            None, client_secret, sid=sid, validated=True
+        )
 
         raise SynapseError(
             400, "No validated 3pid session found", Codes.THREEPID_AUTH_FAILED

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -646,7 +646,7 @@ class ThreepidRestServlet(RestServlet):
                 "email", client_secret, sid=sid, validated=True
             )
 
-        if validation_session:
+        if validation_session and "error" not in validation_session:
             yield self._add_threepid_to_account(user_id, validation_session)
             return 200, {}
 
@@ -660,7 +660,7 @@ class ThreepidRestServlet(RestServlet):
             except HttpResponseException:
                 pass
 
-            if validation_session:
+            if validation_session and "error" not in validation_session:
                 yield self._add_threepid_to_account(user_id, validation_session)
                 return 200, {}
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -198,7 +198,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
     """Handles 3PID validation token submission"""
 
     PATTERNS = client_patterns(
-        "/password_reset/(?P<medium>[^/]*)/submit_token$", releases=(), unstable=True
+        "/password_reset/(?P<medium>[^/]*)/submit_token/*$", releases=(), unstable=True
     )
 
     def __init__(self, hs):

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -740,7 +740,7 @@ class ThreepidAddRestServlet(RestServlet):
 
         # Get a validated session matching these details
         validation_session = yield self.store.get_threepid_validation_session(
-            None, client_secret, sid=sid
+            "email", client_secret, sid=sid
         )
 
         if not validation_session:

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -634,9 +634,12 @@ class ThreepidRestServlet(RestServlet):
         # Try to validate as email
         if self.hs.config.threepid_behaviour_email == ThreepidBehaviour.REMOTE:
             # Ask our delegated email identity server
-            validation_session = yield self.identity_handler.threepid_from_creds(
-                self.hs.config.account_threepid_delegate_email, threepid_creds
-            )
+            try:
+                validation_session = yield self.identity_handler.threepid_from_creds(
+                    self.hs.config.account_threepid_delegate_email, threepid_creds
+                )
+            except HttpResponseException:
+                pass
         elif self.hs.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
             # Get a validated session matching these details
             validation_session = yield self.datastore.get_threepid_validation_session(
@@ -650,9 +653,12 @@ class ThreepidRestServlet(RestServlet):
         # Try to validate as msisdn
         if self.hs.config.account_threepid_delegate_msisdn:
             # Ask our delegated msisdn identity server
-            validation_session = yield self.identity_handler.threepid_from_creds(
-                self.hs.config.account_threepid_delegate_msisdn, threepid_creds
-            )
+            try:
+                validation_session = yield self.identity_handler.threepid_from_creds(
+                    self.hs.config.account_threepid_delegate_msisdn, threepid_creds
+                )
+            except HttpResponseException:
+                pass
 
             if validation_session:
                 yield self._add_threepid_to_account(user_id, validation_session)

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -690,7 +690,7 @@ class ThreepidRestServlet(RestServlet):
         Args:
             user_id (str): The mxid of the user to add this 3PID to
 
-            validation_session (dict|None): A dict containing the following:
+            validation_session (dict): A dict containing the following:
                 * medium       - medium of the threepid
                 * address      - address of the threepid
                 * validated_at - timestamp of when the validation occurred

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -485,8 +485,10 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
     def on_POST(self, request):
         body = parse_json_object_from_request(request)
         assert_params_in_dict(
-            body, ["client_secret", "country", "phone_number", "send_attempt"]
+            body,
+            ["id_server", "client_secret", "country", "phone_number", "send_attempt"],
         )
+        id_server = "https://" + body["id_server"]  # Assume https
         client_secret = body["client_secret"]
         country = body["country"]
         phone_number = body["phone_number"]
@@ -507,23 +509,8 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
         if existing_user_id is not None:
             raise SynapseError(400, "MSISDN is already in use", Codes.THREEPID_IN_USE)
 
-        if not self.hs.config.account_threepid_delegate_msisdn:
-            logger.warn(
-                "No upstream msisdn account_threepid_delegate configured on the server to "
-                "handle this request"
-            )
-            raise SynapseError(
-                400,
-                "Adding phone numbers to user account is not supported by this homeserver",
-            )
-
         ret = yield self.identity_handler.requestMsisdnToken(
-            self.hs.config.email_account_threepid_delegate_msisdn,
-            country,
-            phone_number,
-            client_secret,
-            send_attempt,
-            next_link,
+            id_server, country, phone_number, client_secret, send_attempt, next_link
         )
 
         return 200, ret

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -643,7 +643,8 @@ class ThreepidRestServlet(RestServlet):
                 "email", client_secret, sid=sid, validated=True
             )
 
-        if self._add_threepid_to_account(user_id, validation_session):
+        if validation_session:
+            self._add_threepid_to_account(user_id, validation_session)
             return 200, {}
 
         # Try to validate as msisdn
@@ -653,7 +654,8 @@ class ThreepidRestServlet(RestServlet):
                 self.hs.config.account_threepid_delegate_msisdn, threepid_creds
             )
 
-            if self._add_threepid_to_account(user_id, validation_session):
+            if validation_session:
+                self._add_threepid_to_account(user_id, validation_session)
                 return 200, {}
 
         raise SynapseError(
@@ -661,7 +663,7 @@ class ThreepidRestServlet(RestServlet):
         )
 
     def _add_threepid_to_account(self, user_id, validation_session):
-        """Attempt to add a threepid wrapped in a validation_session dict to an account
+        """Add a threepid wrapped in a validation_session dict to an account
 
         Args:
             user_id (str): The mxid of the user to add this 3PID to
@@ -672,21 +674,13 @@ class ThreepidRestServlet(RestServlet):
                 * validated_at - timestamp of when the validation occurred
 
                 If validation_session is None, this method will return False
-
-        Returns:
-            A boolean stating whether adding the threepid was successful
         """
-        if not validation_session:
-            return False
-
         yield self.auth_handler.add_threepid(
             user_id,
             validation_session["medium"],
             validation_session["address"],
             validation_session["validated_at"],
         )
-
-        return True
 
 
 class ThreepidUnbindRestServlet(RestServlet):

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -717,7 +717,7 @@ class ThreepidRestServlet(RestServlet):
 
 
 class ThreepidAddRestServlet(RestServlet):
-    PATTERNS = client_patterns("/account/3pid/add$", unstable=True)
+    PATTERNS = client_patterns("/account/3pid/add$", releases=(), unstable=True)
 
     def __init__(self, hs):
         super(ThreepidAddRestServlet, self).__init__()
@@ -756,7 +756,7 @@ class ThreepidAddRestServlet(RestServlet):
 
 
 class ThreepidBindRestServlet(RestServlet):
-    PATTERNS = client_patterns("/account/3pid/bind$", unstable=True)
+    PATTERNS = client_patterns("/account/3pid/bind$", releases=(), unstable=True)
 
     def __init__(self, hs):
         super(ThreepidBindRestServlet, self).__init__()

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -514,7 +514,7 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
             )
             raise SynapseError(
                 400,
-                "Password reset by phone number is not supported on this homeserver",
+                "Adding phone numbers to user account is not supported by this homeserver",
             )
 
         ret = yield self.identity_handler.requestMsisdnToken(

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -21,12 +21,7 @@ from six.moves import http_client
 from twisted.internet import defer
 
 from synapse.api.constants import LoginType
-from synapse.api.errors import (
-    Codes,
-    HttpResponseException,
-    SynapseError,
-    ThreepidValidationError,
-)
+from synapse.api.errors import Codes, SynapseError, ThreepidValidationError
 from synapse.config.emailconfig import ThreepidBehaviour
 from synapse.http.server import finish_request
 from synapse.http.servlet import (

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -485,10 +485,8 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
     def on_POST(self, request):
         body = parse_json_object_from_request(request)
         assert_params_in_dict(
-            body,
-            ["id_server", "client_secret", "country", "phone_number", "send_attempt"],
+            body, ["client_secret", "country", "phone_number", "send_attempt"]
         )
-        id_server = "https://" + body["id_server"]  # Assume https
         client_secret = body["client_secret"]
         country = body["country"]
         phone_number = body["phone_number"]
@@ -509,8 +507,23 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
         if existing_user_id is not None:
             raise SynapseError(400, "MSISDN is already in use", Codes.THREEPID_IN_USE)
 
+        if not self.hs.config.account_threepid_delegate_msisdn:
+            logger.warn(
+                "No upstream msisdn account_threepid_delegate configured on the server to "
+                "handle this request"
+            )
+            raise SynapseError(
+                400,
+                "Password reset by phone number is not supported on this homeserver",
+            )
+
         ret = yield self.identity_handler.requestMsisdnToken(
-            id_server, country, phone_number, client_secret, send_attempt, next_link
+            self.hs.config.email_account_threepid_delegate_msisdn,
+            country,
+            phone_number,
+            client_secret,
+            send_attempt,
+            next_link,
         )
 
         return 200, ret

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -640,7 +640,7 @@ class ThreepidRestServlet(RestServlet):
         elif self.hs.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
             # Get a validated session matching these details
             validation_session = yield self.datastore.get_threepid_validation_session(
-                None, client_secret, sid=sid, validated=True
+                "email", client_secret, sid=sid, validated=True
             )
 
         if self._add_threepid_to_account(user_id, validation_session):

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -703,6 +703,105 @@ class ThreepidRestServlet(RestServlet):
         )
 
 
+class ThreepidAddRestServlet(RestServlet):
+    PATTERNS = client_patterns("/account/3pid/add$", unstable=True)
+
+    def __init__(self, hs):
+        super(ThreepidAddRestServlet, self).__init__()
+        self.hs = hs
+        self.identity_handler = hs.get_handlers().identity_handler
+        self.auth = hs.get_auth()
+        self.auth_handler = hs.get_auth_handler()
+        self.store = self.hs.get_datastore()
+
+    @defer.inlineCallbacks
+    def on_POST(self, request):
+        body = parse_json_object_from_request(request)
+
+        assert_params_in_dict(body, ["client_secret", "sid"])
+        client_secret = body["client_secret"]
+        sid = body["sid"]
+
+        requester = yield self.auth.get_user_by_req(request)
+        user_id = requester.user.to_string()
+
+        self.store.validate_threepid_session(sid, )
+
+        threepid = yield self.identity_handler.threepid_from_creds(None, threepid_creds)
+
+        if not threepid:
+            raise SynapseError(400, "Failed to auth 3pid", Codes.THREEPID_AUTH_FAILED)
+
+        for reqd in ["medium", "address", "validated_at"]:
+            if reqd not in threepid:
+                logger.warn("Couldn't add 3pid: invalid response from ID server")
+                raise SynapseError(500, "Invalid response from ID Server")
+
+        yield self.auth_handler.add_threepid(
+            user_id, threepid["medium"], threepid["address"], threepid["validated_at"]
+        )
+
+        if "bind" in body and body["bind"]:
+            logger.debug("Binding threepid %s to %s", threepid, user_id)
+            yield self.identity_handler.bind_threepid(threepid_creds, user_id)
+
+        return 200, {}
+
+
+class ThreepidBindRestServlet(RestServlet):
+    PATTERNS = client_patterns("/account/3pid/bind$", unstable=True)
+
+    def __init__(self, hs):
+        super(ThreepidBindRestServlet, self).__init__()
+        self.hs = hs
+        self.identity_handler = hs.get_handlers().identity_handler
+        self.auth = hs.get_auth()
+        self.auth_handler = hs.get_auth_handler()
+        self.datastore = self.hs.get_datastore()
+
+    @defer.inlineCallbacks
+    def on_GET(self, request):
+        requester = yield self.auth.get_user_by_req(request)
+
+        threepids = yield self.datastore.user_get_threepids(requester.user.to_string())
+
+        return 200, {"threepids": threepids}
+
+    @defer.inlineCallbacks
+    def on_POST(self, request):
+        body = parse_json_object_from_request(request)
+
+        threepid_creds = body.get("threePidCreds") or body.get("three_pid_creds")
+        if threepid_creds is None:
+            raise SynapseError(
+                400, "Missing param three_pid_creds", Codes.MISSING_PARAM
+            )
+
+        requester = yield self.auth.get_user_by_req(request)
+        user_id = requester.user.to_string()
+
+        # Specify None as the identity server to retrieve it from the request body instead
+        threepid = yield self.identity_handler.threepid_from_creds(None, threepid_creds)
+
+        if not threepid:
+            raise SynapseError(400, "Failed to auth 3pid", Codes.THREEPID_AUTH_FAILED)
+
+        for reqd in ["medium", "address", "validated_at"]:
+            if reqd not in threepid:
+                logger.warn("Couldn't add 3pid: invalid response from ID server")
+                raise SynapseError(500, "Invalid response from ID Server")
+
+        yield self.auth_handler.add_threepid(
+            user_id, threepid["medium"], threepid["address"], threepid["validated_at"]
+        )
+
+        if "bind" in body and body["bind"]:
+            logger.debug("Binding threepid %s to %s", threepid, user_id)
+            yield self.identity_handler.bind_threepid(threepid_creds, user_id)
+
+        return 200, {}
+
+
 class ThreepidUnbindRestServlet(RestServlet):
     PATTERNS = client_patterns("/account/3pid/unbind$", releases=(), unstable=True)
 

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -239,10 +239,12 @@ class RegistrationSubmitTokenServlet(RestServlet):
         self.config = hs.config
         self.clock = hs.get_clock()
         self.store = hs.get_datastore()
-        self.failure_email_template, = load_jinja2_templates(
-            self.config.email_template_dir,
-            [self.config.email_registration_template_failure_html],
-        )
+
+        if self.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
+            self.failure_email_template, = load_jinja2_templates(
+                self.config.email_template_dir,
+                [self.config.email_registration_template_failure_html],
+            )
 
         if self.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
             self.failure_email_template, = load_jinja2_templates(

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -239,6 +239,10 @@ class RegistrationSubmitTokenServlet(RestServlet):
         self.config = hs.config
         self.clock = hs.get_clock()
         self.store = hs.get_datastore()
+        self.failure_email_template, = load_jinja2_templates(
+            self.config.email_template_dir,
+            [self.config.email_registration_template_failure_html],
+        )
 
         if self.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
             self.failure_email_template, = load_jinja2_templates(

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -586,6 +586,14 @@ class RegistrationWorkerStore(SQLBaseStore):
             desc="add_user_bound_threepid",
         )
 
+    def user_get_bound_threepids(self, user_id):
+        return self._simple_select_list(
+            "user_threepid_id_server",
+            {"user_id": user_id},
+            ["medium", "address"],
+            "user_get_bound_threepids",
+        )
+
     def remove_user_bound_threepid(self, user_id, medium, address, id_server):
         """The server proxied an unbind request to the given identity server on
         behalf of the given user, so we remove the mapping of threepid to

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -587,6 +587,18 @@ class RegistrationWorkerStore(SQLBaseStore):
         )
 
     def user_get_bound_threepids(self, user_id):
+        """Get the threepids that a user has bound to an identity server through the homeserver
+        The homeserver remembers where binds to an identity server occurred. Using this
+        method can retrieve those threepids.
+
+        Args:
+            user_id (str): The ID of the user to retrieve threepids for
+
+        Returns:
+            list[dict(str, str)]: List of dictionaries containing the following:
+                medium (str): The medium of the threepid (e.g "email")
+                address (str): The address of the threepid (e.g "bob@example.com")
+        """
         return self._simple_select_list(
             table="user_threepid_id_server",
             keyvalues={"user_id": user_id},

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -588,10 +588,10 @@ class RegistrationWorkerStore(SQLBaseStore):
 
     def user_get_bound_threepids(self, user_id):
         return self._simple_select_list(
-            "user_threepid_id_server",
-            {"user_id": user_id},
-            ["medium", "address"],
-            "user_get_bound_threepids",
+            table="user_threepid_id_server",
+            keyvalues={"user_id": user_id},
+            retcols=["medium", "address"],
+            desc="user_get_bound_threepids",
         )
 
     def remove_user_bound_threepid(self, user_id, medium, address, id_server):

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -595,7 +595,7 @@ class RegistrationWorkerStore(SQLBaseStore):
             user_id (str): The ID of the user to retrieve threepids for
 
         Returns:
-            list[dict(str, str)]: List of dictionaries containing the following:
+            Deferred[list[dict]]: List of dictionaries containing the following:
                 medium (str): The medium of the threepid (e.g "email")
                 address (str): The address of the threepid (e.g "bob@example.com")
         """

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -663,7 +663,7 @@ class RegistrationWorkerStore(SQLBaseStore):
         self, medium, client_secret, address=None, sid=None, validated=True
     ):
         """Gets a session_id and last_send_attempt (if available) for a
-        client_secret/medium/(address|session_id) combo
+        combination of validation metadata
 
         Args:
             medium (str|None): The medium of the 3PID

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -29,3 +29,12 @@ Enabling an unknown default rule fails with 404
 
 # Blacklisted due to https://github.com/matrix-org/synapse/issues/1663
 New federated private chats get full presence information (SYN-115)
+
+# Blacklisted temporarily due to https://github.com/matrix-org/matrix-doc/pull/2290
+# These sytests need to be updated with new endpoints, which will come in a later PR
+# That PR will also remove this blacklist
+Can bind 3PID via home server
+Can bind and unbind 3PID via homeserver
+3PIDs are unbound after account deactivation
+Can bind and unbind 3PID via /unbind by specifying the identity server
+Can bind and unbind 3PID via /unbind without specifying the identity server

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -29,12 +29,3 @@ Enabling an unknown default rule fails with 404
 
 # Blacklisted due to https://github.com/matrix-org/synapse/issues/1663
 New federated private chats get full presence information (SYN-115)
-
-# Blacklisted temporarily due to https://github.com/matrix-org/matrix-doc/pull/2290
-# These sytests need to be updated with new endpoints, which will come in a later PR
-# That PR will also remove this blacklist
-Can bind 3PID via home server
-Can bind and unbind 3PID via homeserver
-3PIDs are unbound after account deactivation
-Can bind and unbind 3PID via /unbind by specifying the identity server
-Can bind and unbind 3PID via /unbind without specifying the identity server


### PR DESCRIPTION
Requires #6042 

Implements [MSC2290](https://github.com/matrix-org/matrix-doc/pull/2290). This PR adds two new endpoints, `/unstable/account/3pid/add` and `/unstable/account/3pid/bind`. Depending on the progress of that MSC the unstable prefix may go away.

This PR also removes the blacklist on some 3PID tests which occurs in #6042, as the corresponding Sytest PR changes them to use the new endpoints.

Finally, it also modifies the account deactivation code such that it doesn't just try to deactivate 3PIDs that were bound to the user's account, but any 3PIDs that were bound through the homeserver on that user's account.

SyTest PR: https://github.com/matrix-org/sytest/pull/703

The base branch is currently #6042, this will be changed to develop when #6042 merges.