### PR TITLE
Remove POST method from password reset submit_token endpoint

### DIFF
--- a/changelog.d/6056.bugfix
+++ b/changelog.d/6056.bugfix
@@ -1,1 +1,1 @@
-Remove POST method for all submit_token endpoints until we implement submit_url functionality.
+Remove POST method from password reset submit_token endpoint until we implement submit_url functionality.

--- a/changelog.d/6056.bugfix
+++ b/changelog.d/6056.bugfix
@@ -1,0 +1,1 @@
+Fix broken call to `validate_threepid_session` during POST requests for password reset.

--- a/changelog.d/6056.bugfix
+++ b/changelog.d/6056.bugfix
@@ -1,1 +1,1 @@
-Fix broken call to `validate_threepid_session` during POST requests for password reset.
+Remove POST method for all submit_token endpoints until we implement submit_url functionality.

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -272,28 +272,6 @@ class PasswordResetSubmitTokenServlet(RestServlet):
         request.write(html.encode("utf-8"))
         finish_request(request)
 
-    @defer.inlineCallbacks
-    def on_POST(self, request, medium):
-        if medium != "email":
-            raise SynapseError(
-                400, "This medium is currently not supported for password resets"
-            )
-
-        body = parse_json_object_from_request(request)
-        assert_params_in_dict(body, ["sid", "client_secret", "token"])
-
-        try:
-            yield self.store.validate_threepid_session(
-                body["sid"],
-                body["client_secret"],
-                body["token"],
-                self.clock.time_msec(),
-            )
-            return 200, {"success": True}
-        except ThreepidValidationError:
-            # Validation failure
-            return 400, {"success": False}
-
 
 class PasswordRestServlet(RestServlet):
     PATTERNS = client_patterns("/account/password$")

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -282,12 +282,17 @@ class PasswordResetSubmitTokenServlet(RestServlet):
         body = parse_json_object_from_request(request)
         assert_params_in_dict(body, ["sid", "client_secret", "token"])
 
-        valid, _ = yield self.store.validate_threepid_session(
-            body["sid"], body["client_secret"], body["token"], self.clock.time_msec()
-        )
-        response_code = 200 if valid else 400
-
-        return response_code, {"success": valid}
+        try:
+            yield self.store.validate_threepid_session(
+                body["sid"],
+                body["client_secret"],
+                body["token"],
+                self.clock.time_msec(),
+            )
+            return 200, {"success": True}
+        except ThreepidValidationError:
+            # Validation failure
+            return 400, {"success": False}
 
 
 class PasswordRestServlet(RestServlet):


### PR DESCRIPTION
Removes the POST method from `/password_reset/<medium>/submit_token/` as it's only used by phone number verification which Synapse does not support yet.