### PR TITLE
Fix logcontext spam on non-Linux platforms

### DIFF
--- a/changelog.d/6059.bugfix
+++ b/changelog.d/6059.bugfix
@@ -1,0 +1,1 @@
+Fix logcontext spam on non-Linux platforms.

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -43,8 +43,7 @@ try:
     # exception.
     resource.getrusage(RUSAGE_THREAD)
 
-    def is_thread_resource_usage_supported():
-        return True
+    is_thread_resource_usage_supported = True
 
     def get_thread_resource_usage():
         return resource.getrusage(RUSAGE_THREAD)
@@ -53,8 +52,7 @@ try:
 except Exception:
     # If the system doesn't support resource.getrusage(RUSAGE_THREAD) then we
     # won't track resource usage.
-    def is_thread_resource_usage_supported():
-        return False
+    is_thread_resource_usage_supported = False
 
     def get_thread_resource_usage():
         return None
@@ -367,8 +365,10 @@ class LoggingContext(object):
         # When we stop, let's record the cpu used since we started
         if not self.usage_start:
             # Log a warning on platforms that support thread usage tracking
-            if is_thread_resource_usage_supported():
-                logger.warning("Called stop on logcontext %s without calling start", self)
+            if is_thread_resource_usage_supported:
+                logger.warning(
+                    "Called stop on logcontext %s without calling start", self
+                )
             return
 
         utime_delta, stime_delta = self._get_cputime()

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -1,4 +1,5 @@
 # Copyright 2014-2016 OpenMarket Ltd
+# Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,13 +43,19 @@ try:
     # exception.
     resource.getrusage(RUSAGE_THREAD)
 
+    def is_thread_resource_usage_supported():
+        return True
+
     def get_thread_resource_usage():
         return resource.getrusage(RUSAGE_THREAD)
 
 
 except Exception:
     # If the system doesn't support resource.getrusage(RUSAGE_THREAD) then we
-    # won't track resource usage by returning None.
+    # won't track resource usage.
+    def is_thread_resource_usage_supported():
+        return False
+
     def get_thread_resource_usage():
         return None
 
@@ -359,7 +366,9 @@ class LoggingContext(object):
 
         # When we stop, let's record the cpu used since we started
         if not self.usage_start:
-            logger.warning("Called stop on logcontext %s without calling start", self)
+            # Log a warning on platforms that support thread usage tracking
+            if is_thread_resource_usage_supported():
+                logger.warning("Called stop on logcontext %s without calling start", self)
             return
 
         utime_delta, stime_delta = self._get_cputime()


### PR DESCRIPTION
This checks whether the current platform supports thread resource usage tracking
before logging a warning to avoid log spam.

Fixes https://github.com/matrix-org/synapse/issues/6055
