### PR TITLE
Use unstable prefix for 3PID unbind API

### DIFF
--- a/changelog.d/5980.feature
+++ b/changelog.d/5980.feature
@@ -1,1 +1,1 @@
-Add POST /_matrix/client/r0/account/3pid/unbind endpoint from MSC2140 for unbinding a 3PID from an identity server without removing it from the homeserver user account.
+Add POST /_matrix/client/unstable/account/3pid/unbind endpoint from MSC2140 for unbinding a 3PID from an identity server without removing it from the homeserver user account.

--- a/changelog.d/6062.bugfix
+++ b/changelog.d/6062.bugfix
@@ -1,1 +1,1 @@
-Use unstable prefix for 3PID unbind API.
+Add POST /_matrix/client/unstable/account/3pid/unbind endpoint from MSC2140 for unbinding a 3PID from an identity server without removing it from the homeserver user account.

--- a/changelog.d/6062.bugfix
+++ b/changelog.d/6062.bugfix
@@ -1,0 +1,1 @@
+Use unstable prefix for 3PID unbind API.

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -529,7 +529,7 @@ class ThreepidRestServlet(RestServlet):
 
 
 class ThreepidUnbindRestServlet(RestServlet):
-    PATTERNS = client_patterns("/account/3pid/unbind$")
+    PATTERNS = client_patterns("/account/3pid/unbind$", unstable=True)
 
     def __init__(self, hs):
         super(ThreepidUnbindRestServlet, self).__init__()

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -529,7 +529,7 @@ class ThreepidRestServlet(RestServlet):
 
 
 class ThreepidUnbindRestServlet(RestServlet):
-    PATTERNS = client_patterns("/account/3pid/unbind$", unstable=True)
+    PATTERNS = client_patterns("/account/3pid/unbind$", releases=(), unstable=True)
 
     def __init__(self, hs):
         super(ThreepidUnbindRestServlet, self).__init__()


### PR DESCRIPTION
The new 3PID APIs are not yet part of a released spec, so they should use the unstable prefix. This was missed when #5980 originally implemented MSC2140.

Depends on https://github.com/matrix-org/sytest/pull/708