### PR TITLE
Drop support for bind param on POST /account/3pid (MSC2290)

### DIFF
--- a/changelog.d/6067.feature
+++ b/changelog.d/6067.feature
@@ -1,0 +1,1 @@
+Remove `bind` parameter from Client Server POST `/account` endpoint as per [MSC2290](https://github.com/matrix-org/matrix-doc/pull/2290/).

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -521,10 +521,6 @@ class ThreepidRestServlet(RestServlet):
             user_id, threepid["medium"], threepid["address"], threepid["validated_at"]
         )
 
-        if "bind" in body and body["bind"]:
-            logger.debug("Binding threepid %s to %s", threepid, user_id)
-            yield self.identity_handler.bind_threepid(threepid_creds, user_id)
-
         return 200, {}
 
 

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -29,3 +29,12 @@ Enabling an unknown default rule fails with 404
 
 # Blacklisted due to https://github.com/matrix-org/synapse/issues/1663
 New federated private chats get full presence information (SYN-115)
+
+# Blacklisted temporarily due to https://github.com/matrix-org/matrix-doc/pull/2290
+# These sytests need to be updated with new endpoints, which will come in a later PR
+# That PR will also remove this blacklist
+Can bind 3PID via home server
+Can bind and unbind 3PID via homeserver
+3PIDs are unbound after account deactivation
+Can bind and unbind 3PID via /unbind by specifying the identity server
+Can bind and unbind 3PID via /unbind without specifying the identity server


### PR DESCRIPTION
As per [MSC2290](https://github.com/matrix-org/matrix-doc/pull/2290/files#diff-05cde9463e9209b701312b3baf2fb2ebR151), we're dropping the bind parameter from `/account/3pid`. This endpoint can now only be used for adding threepid's to the user's account on the homeserver.