### PR TITLE
Fix exception when resetting retry timings

### DIFF
--- a/changelog.d/6072.misc
+++ b/changelog.d/6072.misc
@@ -1,0 +1,1 @@
+Add a 'failure_ts' column to the 'destinations' database table.

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -165,7 +165,7 @@ class Authenticator(object):
     async def _reset_retry_timings(self, origin):
         try:
             logger.info("Marking origin %r as up", origin)
-            await self.store.set_destination_retry_timings(origin, 0, 0)
+            await self.store.set_destination_retry_timings(origin, None, 0, 0)
         except Exception:
             logger.exception("Error resetting retry timings on %s", origin)
 


### PR DESCRIPTION
Fixes:
> TypeError: set_destination_retry_timings() missing 1 required positional
argument: 'retry_interval'

Introduced in #6016.