### PR TITLE
Return timeout error to user for identity server calls

### DIFF
--- a/changelog.d/6073.feature
+++ b/changelog.d/6073.feature
@@ -1,1 +1,1 @@
-Return a 504 Timeout when timing out contacting an identity server.
+Return a clearer error message when a timeout occurs when attempting to contact an identity server.

--- a/changelog.d/6073.feature
+++ b/changelog.d/6073.feature
@@ -1,0 +1,1 @@
+Return a 504 Timeout when timing out contacting an identity server.

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -123,7 +123,7 @@ class IdentityHandler(BaseHandler):
         try:
             data = yield self.http_client.get_json(url, query_params)
         except TimeoutError:
-            raise SynapseError(504, "Timed out contacting identity server")
+            raise SynapseError(500, "Timed out contacting identity server")
         return data if "medium" in data else None
 
     @defer.inlineCallbacks
@@ -187,7 +187,7 @@ class IdentityHandler(BaseHandler):
                 logger.error("3PID bind failed with Matrix error: %r", e)
                 raise e.to_synapse_error()
         except TimeoutError:
-            raise SynapseError(504, "Timed out contacting identity server")
+            raise SynapseError(500, "Timed out contacting identity server")
         except CodeMessageException as e:
             data = json.loads(e.msg)  # XXX WAT?
             return data
@@ -278,9 +278,9 @@ class IdentityHandler(BaseHandler):
                 logger.warn("Received %d response while unbinding threepid", e.code)
             else:
                 logger.error("Failed to unbind threepid on identity server: %s", e)
-                raise SynapseError(502, "Failed to contact identity server")
+                raise SynapseError(500, "Failed to contact identity server")
         except TimeoutError:
-            raise SynapseError(504, "Timed out contacting identity server")
+            raise SynapseError(500, "Timed out contacting identity server")
 
         yield self.store.remove_user_bound_threepid(
             user_id=mxid,
@@ -414,7 +414,7 @@ class IdentityHandler(BaseHandler):
             logger.info("Proxied requestToken failed: %r", e)
             raise e.to_synapse_error()
         except TimeoutError:
-            raise SynapseError(504, "Timed out contacting identity server")
+            raise SynapseError(500, "Timed out contacting identity server")
 
     @defer.inlineCallbacks
     def requestMsisdnToken(
@@ -468,7 +468,7 @@ class IdentityHandler(BaseHandler):
             logger.info("Proxied requestToken failed: %r", e)
             raise e.to_synapse_error()
         except TimeoutError:
-            raise SynapseError(504, "Timed out contacting identity server")
+            raise SynapseError(500, "Timed out contacting identity server")
 
 
 def create_id_access_token_header(id_access_token):

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -758,7 +758,7 @@ class RoomMemberHandler(object):
                 yield self._verify_any_signature(data, id_server)
                 return data["mxid"]
         except TimeoutError:
-            raise SynapseError(504, "Timed out contacting identity server")
+            raise SynapseError(500, "Timed out contacting identity server")
         except IOError as e:
             logger.warning("Error from v1 identity server lookup: %s" % (e,))
 
@@ -785,7 +785,7 @@ class RoomMemberHandler(object):
                 {"access_token": id_access_token},
             )
         except TimeoutError:
-            raise SynapseError(504, "Timed out contacting identity server")
+            raise SynapseError(500, "Timed out contacting identity server")
 
         if not isinstance(hash_details, dict):
             logger.warning(
@@ -857,7 +857,7 @@ class RoomMemberHandler(object):
                 headers=headers,
             )
         except TimeoutError:
-            raise SynapseError(504, "Timed out contacting identity server")
+            raise SynapseError(500, "Timed out contacting identity server")
         except Exception as e:
             logger.warning("Error when performing a v2 3pid lookup: %s", e)
             raise SynapseError(
@@ -886,7 +886,7 @@ class RoomMemberHandler(object):
                     % (id_server_scheme, server_hostname, key_name)
                 )
             except TimeoutError:
-                raise SynapseError(504, "Timed out contacting identity server")
+                raise SynapseError(500, "Timed out contacting identity server")
             if "public_key" not in key_data:
                 raise AuthError(
                     401, "No public key named %s from %s" % (key_name, server_hostname)
@@ -1062,7 +1062,7 @@ class RoomMemberHandler(object):
                     {"Authorization": create_id_access_token_header(id_access_token)},
                 )
             except TimeoutError:
-                raise SynapseError(504, "Timed out contacting identity server")
+                raise SynapseError(500, "Timed out contacting identity server")
             except HttpResponseException as e:
                 if e.code != 404:
                     logger.info("Failed to POST %s with JSON: %s", url, e)
@@ -1080,7 +1080,7 @@ class RoomMemberHandler(object):
                     url, invite_config
                 )
             except TimeoutError:
-                raise SynapseError(504, "Timed out contacting identity server")
+                raise SynapseError(500, "Timed out contacting identity server")
             except HttpResponseException as e:
                 logger.warning(
                     "Error trying to call /store-invite on %s%s: %s",


### PR DESCRIPTION
Return a 504 with a nice error message when we time out contacting an identity server.