### PR TITLE
Remove trailing slash ability from password reset's submit_token endpoint

### DIFF
--- a/changelog.d/6074.feature
+++ b/changelog.d/6074.feature
@@ -1,0 +1,1 @@
+Prevent password reset's submit_token endpoint from accepting trailing slashes.

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -200,7 +200,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
     """Handles 3PID validation token submission"""
 
     PATTERNS = client_patterns(
-        "/password_reset/(?P<medium>[^/]*)/submit_token/*$", releases=(), unstable=True
+        "/password_reset/(?P<medium>[^/]*)/submit_token$", releases=(), unstable=True
     )
 
     def __init__(self, hs):


### PR DESCRIPTION
Remove trailing slash ability from the password reset submit_token endpoint. Since we provide the link in an email, and have never sent it with a trailing slash, there's no point for us to accept them on the endpoint.