### PR TITLE
Generalize email sending logging

### DIFF
--- a/changelog.d/6075.misc
+++ b/changelog.d/6075.misc
@@ -1,0 +1,1 @@
+Change mailer logging to reflect Synapse doesn't just do chat notifications by email now.

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -311,7 +311,7 @@ class Mailer(object):
         multipart_msg.attach(text_part)
         multipart_msg.attach(html_part)
 
-        logger.info("Sending email notification to %s" % email_address)
+        logger.info("Sending email to %s" % email_address)
 
         yield make_deferred_yieldable(
             self.sendmail(


### PR DESCRIPTION
In ancient times Synapse would only send emails when it was notifying a user about a message they received...

Now it can do all sorts of neat things!

Change the logging so it's not just about notifications.