### PR TITLE
Remove unused bind_threepid method

### DIFF
--- a/changelog.d/6083.misc
+++ b/changelog.d/6083.misc
@@ -1,0 +1,1 @@
+Remove IdentityHandler's bind_threepid method as it is unused.


### PR DESCRIPTION
The `bind_threepid` method is no longer used by anything, so we should remove it else it's just cruft.