### PR TITLE
Add snapcraft packaging information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.egg-info
 *.lock
 *.pyc
+*.snap
 *.tac
 _trial_temp/
 _trial_temp*/

--- a/changelog.d/6084.misc
+++ b/changelog.d/6084.misc
@@ -1,0 +1,1 @@
+Add snapcraft packaging information. Contributed by @devec0.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: matrix-synapse
+base: core18
+version: git 
+summary: Reference Matrix homeserver
+description: |
+  Synapse is the reference Matrix homeserver.
+  Matrix is a federated and decentralised instant messaging and VoIP system.
+
+grade: stable 
+confinement: strict 
+
+apps:
+  matrix-synapse: 
+    command: synctl --no-daemonize start $SNAP_COMMON/homeserver.yaml
+    stop-command: synctl -c $SNAP_COMMON stop
+    plugs: [network-bind, network]
+    daemon: simple 
+parts:
+  matrix-synapse:
+    source: .
+    plugin: python
+    python-version: python3


### PR DESCRIPTION
Signed-off-by: James Hebden <james@ec0.io>

This PR adds packaging metadata to allow snaps (https://snapcraft.io) to be built automatically and published to the snap store, where people can install Synapse by running `sudo snap install matrix-synapse`. In addition to this being merged, to enable automatic publishing (the snap can still be built locally and installed with `--devmode`) someone with access to this repository will have to enable this repo to be monitored by the snapcraft store, so that it can automatically build and publish new versions as new commits are merged into master. The version to be published to the store will be calculated based on the projects existing git tags - I have tested this with the current develop branch, which generates the version number `1.3.1`. 

I am also happy to assist in the publishing of this package to the store, and maintaining any snap-related matters in regard to any part of the Matrix ecosystem.
