### PR TITLE
Add sid to next_link for email validation

### DIFF
--- a/changelog.d/6097.bugfix
+++ b/changelog.d/6097.bugfix
@@ -1,0 +1,1 @@
+Add sid to next_link for email validation.

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -332,10 +332,10 @@ class IdentityHandler(BaseHandler):
         if next_link:
             # Manipulate the next_link to add the sid, because the caller won't get
             # it until we send a response, by which time we've sent the mail.
-            if '?' in next_link:
-                next_link += '&'
+            if "?" in next_link:
+                next_link += "&"
             else:
-                next_link += '?'
+                next_link += "?"
             next_link += "sid=" + urllib.parse.quote(session_id)
 
         # Generate a new validation token

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -18,6 +18,7 @@
 """Utilities for interacting with Identity Servers"""
 
 import logging
+import urllib
 
 from canonicaljson import json
 
@@ -327,6 +328,15 @@ class IdentityHandler(BaseHandler):
             # An non-validated session does not exist yet.
             # Generate a session id
             session_id = random_string(16)
+
+        if next_link:
+            # Manipulate the next_link to add the sid, because the caller won't get
+            # it until we send a response, by which time we've sent the mail.
+            if '?' in next_link:
+                next_link += '&'
+            else:
+                next_link += '?'
+            next_link += "sid=" + urllib.parse.quote(session_id)
 
         # Generate a new validation token
         token = random_string(32)


### PR DESCRIPTION
This appends the `sid` to the `next_link` for email validation, matching Sydent's behaviour that Riot Web expects.

Fixes https://github.com/matrix-org/synapse/issues/6096