### PR TITLE
Prune old rows in user_ips tables.

### DIFF
--- a/changelog.d/6098.feature
+++ b/changelog.d/6098.feature
@@ -1,0 +1,1 @@
+Add support for pruning old rows in `user_ips` table.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -313,6 +313,12 @@ listeners:
 #
 redaction_retention_period: 7d
 
+# How long to track users' last seen time and IPs in the database.
+#
+# Defaults to `28d`. Set to `null` to disable.
+#
+#user_ips_max_age: 14d
+
 
 ## TLS ##
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -315,7 +315,7 @@ redaction_retention_period: 7d
 
 # How long to track users' last seen time and IPs in the database.
 #
-# Defaults to `28d`. Set to `null` to disable.
+# Defaults to `28d`. Set to `null` to disable clearing out of old rows.
 #
 #user_ips_max_age: 14d
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -745,7 +745,7 @@ class ServerConfig(Config):
 
         # How long to track users' last seen time and IPs in the database.
         #
-        # Defaults to `28d`. Set to `null` to disable.
+        # Defaults to `28d`. Set to `null` to disable clearing out of old rows.
         #
         #user_ips_max_age: 14d
         """

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -172,6 +172,13 @@ class ServerConfig(Config):
         else:
             self.redaction_retention_period = None
 
+        # How long to keep entries in the `users_ips` table.
+        user_ips_max_age = config.get("user_ips_max_age", "28d")
+        if user_ips_max_age is not None:
+            self.user_ips_max_age = self.parse_duration(user_ips_max_age)
+        else:
+            self.user_ips_max_age = None
+
         # Options to disable HS
         self.hs_disabled = config.get("hs_disabled", False)
         self.hs_disabled_message = config.get("hs_disabled_message", "")
@@ -735,6 +742,12 @@ class ServerConfig(Config):
         # Defaults to `7d`. Set to `null` to disable.
         #
         redaction_retention_period: 7d
+
+        # How long to track users' last seen time and IPs in the database.
+        #
+        # Defaults to `28d`. Set to `null` to disable.
+        #
+        #user_ips_max_age: 14d
         """
             % locals()
         )

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -175,7 +175,7 @@ def run_as_background_process(desc, func, *args, **kwargs):
 
     Args:
         desc (str): a description for this background process type
-        func: a function, which may return a Deferred
+        func: a function, which may return a Deferred or a coroutine
         args: positional args for func
         kwargs: keyword args for func
 
@@ -199,11 +199,13 @@ def run_as_background_process(desc, func, *args, **kwargs):
                 _background_processes.setdefault(desc, set()).add(proc)
 
             try:
-                # We ensureDeferred here to handle coroutines
                 result = func(*args, **kwargs)
 
-                # We need this check because ensureDeferred doesn't like when
-                # func doesn't return a Deferred or coroutine.
+                # We probably don't have an ensureDeferred in our call stack to handle
+                # coroutine results, so we need to ensureDeferred here.
+                #
+                # But we need this check because ensureDeferred doesn't like being
+                # called on immediate values (as opposed to Deferreds or coroutines).
                 if iscoroutine(result):
                     result = defer.ensureDeferred(result)
 

--- a/synapse/storage/background_updates.py
+++ b/synapse/storage/background_updates.py
@@ -140,13 +140,36 @@ class BackgroundUpdateStore(SQLBaseStore):
             "background_updates",
             keyvalues=None,
             retcol="1",
-            desc="check_background_updates",
+            desc="has_completed_background_updates",
         )
         if not updates:
             self._all_done = True
             return True
 
         return False
+
+    async def has_completed_background_update(self, update_name):
+        """Check if the given background update has finished running.
+
+        Returns:
+            Deferred[bool]
+        """
+
+        if self._all_done:
+            return True
+
+        if update_name in self._background_update_queue:
+            return False
+
+        update_exists = await self._simple_select_one_onecol(
+            "background_updates",
+            keyvalues={"update_name": update_name},
+            retcol="1",
+            desc="has_completed_background_update",
+            allow_none=True,
+        )
+
+        return not update_exists
 
     @defer.inlineCallbacks
     def do_next_background_update(self, desired_duration_ms):

--- a/synapse/storage/background_updates.py
+++ b/synapse/storage/background_updates.py
@@ -148,11 +148,8 @@ class BackgroundUpdateStore(SQLBaseStore):
 
         return False
 
-    async def has_completed_background_update(self, update_name):
+    async def has_completed_background_update(self, update_name) -> bool:
         """Check if the given background update has finished running.
-
-        Returns:
-            Deferred[bool]
         """
 
         if self._all_done:

--- a/synapse/storage/client_ips.py
+++ b/synapse/storage/client_ips.py
@@ -506,7 +506,7 @@ class ClientIpStore(background_updates.BackgroundUpdateStore):
         """Removes entries in user IPs older than the configured period.
         """
 
-        if not self.user_ips_max_age:
+        if self.user_ips_max_age is None:
             # Nothing to do
             return
 


### PR DESCRIPTION
~~Based on #6089. [Diff](https://github.com/matrix-org/synapse/compare/erikj/cleanup_user_ips...erikj/cleanup_user_ips_2).~~

Commits are independently reviewable.

Note that I've added a `wrap_as_background_process` so that we don't have to have a bunch of inline functions just to wrap a function in `run_as_background_process`. If this feels icky then I'm happy to remove it.

Fixes #4352 