### PR TITLE
remove unused parameter to get_user_id_by_threepid

### DIFF
--- a/changelog.d/6099.misc
+++ b/changelog.d/6099.misc
@@ -1,0 +1,1 @@
+Remove unused parameter to get_user_id_by_threepid.

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -495,7 +495,7 @@ class RegistrationWorkerStore(SQLBaseStore):
         )
 
     @defer.inlineCallbacks
-    def get_user_id_by_threepid(self, medium, address, require_verified=False):
+    def get_user_id_by_threepid(self, medium, address):
         """Returns user id from threepid
 
         Args:


### PR DESCRIPTION
Added in #5377, apparently in error