### PR TITLE
Add User-Interactive Auth to /account/3pid/add

### DIFF
--- a/changelog.d/6119.feature
+++ b/changelog.d/6119.feature
@@ -1,0 +1,1 @@
+Require User-Interactive Authentication for `/account/3pid/add`, meaning the user's password will be required to add a third-party ID to their account.

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -642,6 +642,7 @@ class ThreepidAddRestServlet(RestServlet):
         self.auth = hs.get_auth()
         self.auth_handler = hs.get_auth_handler()
 
+    @interactive_auth_handler
     @defer.inlineCallbacks
     def on_POST(self, request):
         requester = yield self.auth.get_user_by_req(request)
@@ -651,6 +652,10 @@ class ThreepidAddRestServlet(RestServlet):
         assert_params_in_dict(body, ["client_secret", "sid"])
         client_secret = body["client_secret"]
         sid = body["sid"]
+
+        yield self.auth_handler.validate_user_via_ui_auth(
+            requester, body, self.hs.get_ip_from_request(request)
+        )
 
         validation_session = yield self.identity_handler.validate_threepid_session(
             client_secret, sid


### PR DESCRIPTION
Add User-Interactive Authentication to the `/account/3pid/add` endpoint as per [MSC2290](https://github.com/matrix-org/matrix-doc/pull/2290/files#diff-05cde9463e9209b701312b3baf2fb2ebR48).