### PR TITLE
Add domain validation when creating room with list of invitees

### DIFF
--- a/changelog.d/4088.bugfix
+++ b/changelog.d/4088.bugfix
@@ -1,0 +1,1 @@
+Added domain validation when including a list of invitees upon room creation.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -28,6 +28,7 @@ from twisted.internet import defer
 from synapse.api.constants import EventTypes, JoinRules, RoomCreationPreset
 from synapse.api.errors import AuthError, Codes, NotFoundError, StoreError, SynapseError
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
+from synapse.http.endpoint import parse_and_validate_server_name
 from synapse.storage.state import StateFilter
 from synapse.types import RoomAlias, RoomID, RoomStreamToken, StreamToken, UserID
 from synapse.util import stringutils
@@ -554,7 +555,9 @@ class RoomCreationHandler(BaseHandler):
         invite_list = config.get("invite", [])
         for i in invite_list:
             try:
-                UserID.from_string(i)
+                uid = UserID.from_string(i)
+                # TODO Maybe attempt idna encoding/decoding as well?
+                parse_and_validate_server_name(uid.domain)
             except Exception:
                 raise SynapseError(400, "Invalid user_id: %s" % (i,))
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -556,7 +556,6 @@ class RoomCreationHandler(BaseHandler):
         for i in invite_list:
             try:
                 uid = UserID.from_string(i)
-                # TODO Maybe attempt idna encoding/decoding as well?
                 parse_and_validate_server_name(uid.domain)
             except Exception:
                 raise SynapseError(400, "Invalid user_id: %s" % (i,))

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -484,11 +484,12 @@ class RoomsCreateTestCase(RoomBase):
         self.render(request)
         self.assertEquals(400, channel.code)
 
-
     def test_post_room_invitees_invalid_mxid(self):
         # POST with invalid invitee, see https://github.com/matrix-org/synapse/issues/4088
         # Note the trailing space in the MXID here!
-        request, channel = self.make_request("POST", "/createRoom", b'{"invite":["@alice:example.com "]}')
+        request, channel = self.make_request(
+            "POST", "/createRoom", b'{"invite":["@alice:example.com "]}'
+        )
         self.render(request)
         self.assertEquals(400, channel.code)
 

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -487,7 +487,7 @@ class RoomsCreateTestCase(RoomBase):
 
     def test_post_room_invitees_invalid_mxid(self):
         # POST with invalid invitee, see https://github.com/matrix-org/synapse/issues/4088
-        # Note the trailing slash in the MXID here!
+        # Note the trailing space in the MXID here!
         request, channel = self.make_request("POST", "/createRoom", b'{"invite":["@alice:example.com "]}')
         self.render(request)
         self.assertEquals(400, channel.code)

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -485,6 +485,14 @@ class RoomsCreateTestCase(RoomBase):
         self.assertEquals(400, channel.code)
 
 
+    def test_post_room_invitees_invalid_mxid(self):
+        # POST with invalid invitee, see https://github.com/matrix-org/synapse/issues/4088
+        # Note the trailing slash in the MXID here!
+        request, channel = self.make_request("POST", "/createRoom", b'{"invite":["@alice:example.com "]}')
+        self.render(request)
+        self.assertEquals(400, channel.code)
+
+
 class RoomTopicTestCase(RoomBase):
     """ Tests /rooms/$room_id/topic REST events. """
 


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

This results in a 400 bad request status instead of 500 internal server error in the case described in #4088 (trailing whitespace).

Also adds a regression test for this issue.

Question: An original (abandoned) attempt to fix this issue (see https://github.com/matrix-org/synapse/pull/4351/files) also does some trial encoding/decoding with IDNA. Should we try to do that as well? (See the TODO entry)
