### PR TITLE
Log responder we are using.

### DIFF
--- a/changelog.d/6139.misc
+++ b/changelog.d/6139.misc
@@ -1,0 +1,1 @@
+Log responder when responding to media request.

--- a/synapse/rest/media/v1/_base.py
+++ b/synapse/rest/media/v1/_base.py
@@ -195,7 +195,7 @@ def respond_with_responder(request, responder, media_type, file_size, upload_nam
         respond_404(request)
         return
 
-    logger.debug("Responding to media request with responder %s")
+    logger.debug("Responding to media request with responder %s", responder)
     add_file_headers(request, media_type, file_size, upload_name)
     try:
         with responder:


### PR DESCRIPTION
This prevents us logging "Responding to media request with responder %s".

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
