### PR TITLE
Fix yields and copy instead of move push rules on room upgrade

### DIFF
--- a/changelog.d/6144.bugfix
+++ b/changelog.d/6144.bugfix
@@ -1,0 +1,1 @@
+Prevent user push rules being deleted from a room when it is upgraded.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -217,7 +217,7 @@ class RoomMemberHandler(object):
                     predecessor["room_id"], room_id, user_id
                 )
                 # Copy over push rules
-                self.store.copy_push_rules_from_room_to_room_for_user(
+                yield self.store.copy_push_rules_from_room_to_room_for_user(
                     predecessor["room_id"], room_id, user_id
                 )
         elif event.membership == Membership.LEAVE:

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -216,8 +216,8 @@ class RoomMemberHandler(object):
                 self.copy_room_tags_and_direct_to_room(
                     predecessor["room_id"], room_id, user_id
                 )
-                # Move over old push rules
-                self.store.move_push_rules_from_room_to_room_for_user(
+                # Copy over push rules
+                self.store.copy_push_rules_from_room_to_room_for_user(
                     predecessor["room_id"], room_id, user_id
                 )
         elif event.membership == Membership.LEAVE:

--- a/synapse/storage/push_rule.py
+++ b/synapse/storage/push_rule.py
@@ -231,7 +231,7 @@ class PushRulesWorkerStore(
                 (c.get("key") == "room_id" and c.get("pattern") == old_room_id)
                 for c in conditions
             ):
-                self.copy_push_rule_from_room_to_room(new_room_id, user_id, rule)
+                yield self.copy_push_rule_from_room_to_room(new_room_id, user_id, rule)
 
     @defer.inlineCallbacks
     def bulk_get_push_rules_for_room(self, event, context):


### PR DESCRIPTION
Copy push rules during a room upgrade from the old room to the new room, instead of deleting them from the old room.

For instance, we've defined upgrading of a room multiple times to be possible, and push rules won't be transferred on the second upgrade if they're deleted during the first.

Also fix some missing yields that probably broke things quite a bit.