### PR TITLE
Fix fetching censored redactions from DB

### DIFF
--- a/changelog.d/6145.bugfix
+++ b/changelog.d/6145.bugfix
@@ -1,0 +1,1 @@
+Fix fetching censored redactions from DB, which caused APIs like initial sync to fail if it tried to include the censored redaction.


### PR DESCRIPTION
Fetching a censored redactions caused an exception due to the code
expecting redactions to have a `redact` key, which redacted redactions
don't have.

Fixes #6133