### PR TITLE
Don't 500 when trying to exchange a revoked 3PID invite

### DIFF
--- a/changelog.d/6147.bugfix
+++ b/changelog.d/6147.bugfix
@@ -1,0 +1,1 @@
+Don't 500 when trying to exchange a revoked 3PID invite.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2600,20 +2600,14 @@ class FederationHandler(BaseHandler):
             )
         if original_invite:
             # If the m.room.third_party_invite event's content is empty, it means the
-            # invite has been revoked.
-            if original_invite.content:
-                display_name = original_invite.content["display_name"]
-                event_dict["content"]["third_party_invite"][
-                    "display_name"
-                ] = display_name
-            else:
-                # Don't discard or raise an error here because that's not the right place
-                # to do auth checks. The auth check will fail on this invite because we
-                # won't be able to fetch public keys from the m.room.third_party_invite
-                # event's content (because it's empty).
-                logger.info(
-                    "Found invite event for third_party_invite but it has been revoked"
-                )
+            # invite has been revoked. In this case, we don't have to raise an error here
+            # because the auth check will fail on the invite (because it's not able to
+            # fetch public keys from the m.room.third_party_invite event's content, which
+            # is empty.
+            display_name = original_invite.content.get("display_name")
+            event_dict["content"]["third_party_invite"][
+                "display_name"
+            ] = display_name
         else:
             logger.info(
                 "Could not find invite event for third_party_invite: %r", event_dict

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2570,7 +2570,7 @@ class FederationHandler(BaseHandler):
         )
 
         try:
-            self.auth.check_from_context(room_version, event, context)
+            yield self.auth.check_from_context(room_version, event, context)
         except AuthError as e:
             logger.warn("Denying third party invite %r because %s", event, e)
             raise e

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2603,7 +2603,7 @@ class FederationHandler(BaseHandler):
             # invite has been revoked. In this case, we don't have to raise an error here
             # because the auth check will fail on the invite (because it's not able to
             # fetch public keys from the m.room.third_party_invite event's content, which
-            # is empty.
+            # is empty).
             display_name = original_invite.content.get("display_name")
             event_dict["content"]["third_party_invite"]["display_name"] = display_name
         else:

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2603,7 +2603,9 @@ class FederationHandler(BaseHandler):
             # invite has been revoked.
             if original_invite.content:
                 display_name = original_invite.content["display_name"]
-                event_dict["content"]["third_party_invite"]["display_name"] = display_name
+                event_dict["content"]["third_party_invite"][
+                    "display_name"
+                ] = display_name
             else:
                 # Don't discard or raise an error here because that's not the right place
                 # to do auth checks. The auth check will fail on this invite because we

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2605,9 +2605,7 @@ class FederationHandler(BaseHandler):
             # fetch public keys from the m.room.third_party_invite event's content, which
             # is empty.
             display_name = original_invite.content.get("display_name")
-            event_dict["content"]["third_party_invite"][
-                "display_name"
-            ] = display_name
+            event_dict["content"]["third_party_invite"]["display_name"] = display_name
         else:
             logger.info(
                 "Could not find invite event for third_party_invite: %r", event_dict

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -37,9 +37,7 @@ class FederationTestCase(unittest.HomeserverTestCase):
         user_id = self.register_user("kermit", "test")
         tok = self.login("kermit", "test")
 
-        room_id = self.helper.create_room_as(
-            room_creator=user_id, tok=tok
-        )
+        room_id = self.helper.create_room_as(room_creator=user_id, tok=tok)
 
         # Send a 3PID invite event with an empty body so it's considered as a revoked one.
         invite_token = "sometoken"

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from synapse.api.constants import EventTypes
+from synapse.api.errors import AuthError, Codes
+from synapse.rest import admin
+from synapse.rest.client.v1 import login, room
+
+from tests import unittest
+
+
+class FederationTestCase(unittest.HomeserverTestCase):
+    servlets = [
+        admin.register_servlets,
+        login.register_servlets,
+        room.register_servlets,
+    ]
+
+    def make_homeserver(self, reactor, clock):
+        hs = self.setup_test_homeserver(http_client=None)
+        self.handler = hs.get_handlers().federation_handler
+        self.store = hs.get_datastore()
+        return hs
+
+    def test_exchange_revoked_invite(self):
+        user_id = self.register_user("kermit", "test")
+        tok = self.login("kermit", "test")
+
+        room_id = self.helper.create_room_as(
+            room_creator=user_id, tok=tok
+        )
+
+        # Send a 3PID invite event with an empty body so it's considered as a revoked one.
+        invite_token = "sometoken"
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.ThirdPartyInvite,
+            state_key=invite_token,
+            body={},
+            tok=tok,
+        )
+
+        d = self.handler.on_exchange_third_party_invite_request(
+            room_id=room_id,
+            event_dict={
+                "type": EventTypes.Member,
+                "room_id": room_id,
+                "sender": user_id,
+                "state_key": "@someone:example.org",
+                "content": {
+                    "membership": "invite",
+                    "third_party_invite": {
+                        "display_name": "alice",
+                        "signed": {
+                            "mxid": "@alice:localhost",
+                            "token": invite_token,
+                            "signatures": {
+                                "magic.forest": {
+                                    "ed25519:3": "fQpGIW1Snz+pwLZu6sTy2aHy/DYWWTspTJRPyNp0PKkymfIsNffysMl6ObMMFdIJhk6g6pwlIqZ54rxo8SLmAg"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+        failure = self.get_failure(d, AuthError).value
+
+        self.assertEqual(failure.code, 403, failure)
+        self.assertEqual(failure.errcode, Codes.FORBIDDEN, failure)
+        self.assertEqual(failure.msg, "You are not invited to this room.")

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -69,11 +69,11 @@ class FederationTestCase(unittest.HomeserverTestCase):
                                 "magic.forest": {
                                     "ed25519:3": "fQpGIW1Snz+pwLZu6sTy2aHy/DYWWTspTJRPyNp0PKkymfIsNffysMl6ObMMFdIJhk6g6pwlIqZ54rxo8SLmAg"
                                 }
-                            }
-                        }
-                    }
-                }
-            }
+                            },
+                        },
+                    },
+                },
+            },
         )
 
         failure = self.get_failure(d, AuthError).value


### PR DESCRIPTION
While this is not documented in the spec (but should be), Riot (and other clients) revoke 3PID invites by sending a `m.room.third_party_invite` event with an empty (`{}`) content to the room's state.
When the invited 3PID gets associated with a MXID, the identity server (which doesn't know about revocations) sends down to the MXID's homeserver all of the undelivered invites it has for this 3PID. The receiving homeserver then tries to talk to the inviting homeserver in order to exchange these invite for `m.room.member` events.

When one of the invites is revoked, the inviting homeserver responds with a 500 error because it tries to extract a `display_name` property from the content, which is empty. This might cause the invited server to consider that the server is down and not try to exchange other, valid invites (or at least delay it).

This fix handles the case of revoked invites by avoiding trying to fetch a `display_name` from the original invite's content, and letting the `m.room.member` event fail the auth rules (because, since the original invite's content is empty, it doesn't have public keys), which results in sending a 403 with the correct error message to the invited server.