### PR TITLE
Bound find_next_generated_user_id DB query.

### DIFF
--- a/changelog.d/6148.misc
+++ b/changelog.d/6148.misc
@@ -1,0 +1,1 @@
+Improve performance of `find_next_generated_user_id` DB query.

--- a/synapse/storage/registration.py
+++ b/synapse/storage/registration.py
@@ -493,7 +493,9 @@ class RegistrationWorkerStore(SQLBaseStore):
         """
 
         def _find_next_generated_user_id(txn):
-            txn.execute("SELECT name FROM users")
+            # We bound between '@1' and '@a' to avoid pulling the entire table
+            # out.
+            txn.execute("SELECT name FROM users WHERE '@1' <= name AND name < '@a'")
 
             regex = re.compile(r"^@(\d+):")
 


### PR DESCRIPTION
We can easily bound the set of user IDs we pull out of the DB, so lets
do that.