### PR TITLE
Fix not showing non-federatable rooms to remote room list queries

### DIFF
--- a/changelog.d/6153.misc
+++ b/changelog.d/6153.misc
@@ -1,0 +1,1 @@
+Improve performance of the public room list directory.

--- a/synapse/storage/room.py
+++ b/synapse/storage/room.py
@@ -174,6 +174,9 @@ class RoomWorkerStore(SQLBaseStore):
 
             query_args += [last_joined_members, last_joined_members, last_room_id]
 
+        if ignore_non_federatable:
+            where_clauses.append("is_federatable")
+
         if search_filter and search_filter.get("generic_search_term", None):
             search_term = "%" + search_filter["generic_search_term"] + "%"
 


### PR DESCRIPTION
This was broken when we changed the room list query.

~~Based on #6152~~. Broke in #6019.