### PR TITLE
Fix appservice room list pagination

### DIFF
--- a/changelog.d/6154.misc
+++ b/changelog.d/6154.misc
@@ -1,0 +1,1 @@
+Improve performance of the public room list directory.

--- a/synapse/storage/room.py
+++ b/synapse/storage/room.py
@@ -150,6 +150,24 @@ class RoomWorkerStore(SQLBaseStore):
         where_clauses = []
         query_args = []
 
+        if network_tuple:
+            if network_tuple.appservice_id:
+                published_sql = """
+                    SELECT room_id from appservice_room_list
+                    WHERE appservice_id = ? AND network_id = ?
+                """
+                query_args.append(network_tuple.appservice_id)
+                query_args.append(network_tuple.network_id)
+            else:
+                published_sql = """
+                    SELECT room_id FROM rooms WHERE is_public
+                """
+        else:
+            published_sql = """
+                SELECT room_id FROM rooms WHERE is_public
+                UNION SELECT room_id from appservice_room_list
+            """
+
         # Work out the bounds if we're given them, these bounds look slightly
         # odd, but are designed to help query planner use indices by pulling
         # out a common bound.
@@ -187,24 +205,6 @@ class RoomWorkerStore(SQLBaseStore):
                 """
             )
             query_args += [search_term, search_term, search_term]
-
-        if network_tuple:
-            if network_tuple.appservice_id:
-                published_sql = """
-                    SELECT room_id from appservice_room_list
-                    WHERE appservice_id = ? AND network_id = ?
-                """
-                query_args.append(network_tuple.appservice_id)
-                query_args.append(network_tuple.network_id)
-            else:
-                published_sql = """
-                    SELECT room_id FROM rooms WHERE is_public
-                """
-        else:
-            published_sql = """
-                SELECT room_id FROM rooms WHERE is_public
-                UNION SELECT room_id from appservice_room_list
-            """
 
         where_clause = ""
         if where_clauses:


### PR DESCRIPTION
We need to add to `query_args` in the same order as the various clauses appear in the SQL.