### PR TITLE
Cache room membership lookups in _get_joined_users_from_context

### DIFF
--- a/changelog.d/6159.misc
+++ b/changelog.d/6159.misc
@@ -1,0 +1,1 @@
+Add more caching to `_get_joined_users_from_context` DB query.

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -584,7 +584,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
 
     @cached(max_entries=10000)
     def _get_joined_profile_from_event_id(self, event_id):
-        raise NotADirectoryError()
+        raise NotImplementedError()
 
     @cachedList(
         cached_method_name="_get_joined_profile_from_event_id",

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -568,7 +568,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
                 missing_member_event_ids.append(event_id)
 
         if missing_member_event_ids:
-            event_to_memberships = yield self._get_membership_from_event_ids(
+            event_to_memberships = yield self._get_joined_profiles_from_event_ids(
                 missing_member_event_ids
             )
             users_in_room.update((row for row in event_to_memberships.values() if row))
@@ -584,23 +584,24 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         return users_in_room
 
     @cached(max_entries=10000)
-    def _get_membership_from_event_id(self, event_id):
+    def _get_joined_profile_from_event_id(self, event_id):
         raise NotADirectoryError()
 
     @cachedList(
-        cached_method_name="_get_membership_from_event_id",
+        cached_method_name="_get_joined_profile_from_event_id",
         list_name="event_ids",
         inlineCallbacks=True,
     )
-    def _get_membership_from_event_ids(self, event_ids):
-        """Lookup profile info for set of member event IDs.
+    def _get_joined_profiles_from_event_ids(self, event_ids):
+        """For given set of member event_ids check if they point to a join
+        event and if so return the associated user and profile info.
 
         Args:
             event_ids (Iterable[str]): The member event IDs to lookup
 
         Returns:
             Deferred[dict[str, Tuple[str, ProfileInfo]|None]]: Map from event ID
-            to `user_id` and ProfileInfo (or None if couldn't find event).
+            to `user_id` and ProfileInfo (or None if not join event).
         """
 
         rows = yield self._simple_select_many_batch(

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -592,11 +592,11 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         list_name="event_ids",
         inlineCallbacks=True,
     )
-    def _get_membership_from_event_ids(self, event_ids: Iterable[str]):
+    def _get_membership_from_event_ids(self, event_ids):
         """Lookup profile info for set of member event IDs.
 
         Args:
-            event_ids: The member event IDs to lookup
+            event_ids (Iterable[str]): The member event IDs to lookup
 
         Returns:
             Deferred[dict[str, Tuple[str, ProfileInfo]|None]]: Map from event ID

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -16,7 +16,6 @@
 
 import logging
 from collections import namedtuple
-from typing import Iterable
 
 from six import iteritems, itervalues
 

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -612,7 +612,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             table="room_memberships",
             column="event_id",
             iterable=event_ids,
-            retcols=("user_id", "display_name", "avatar_url"),
+            retcols=("user_id", "display_name", "avatar_url", "event_id"),
             keyvalues={"membership": Membership.JOIN},
             batch_size=500,
             desc="_get_membership_from_event_ids",


### PR DESCRIPTION
Hopefully this will allow us to do less DB work when the `_get_joined_users_from_context` working set is too large.