### PR TITLE
Don't regenerate numeric user ID if registration fails.

### DIFF
--- a/changelog.d/6161.bugfix
+++ b/changelog.d/6161.bugfix
@@ -1,0 +1,1 @@
+Fix bug where guest account registration can wedge after restart.

--- a/changelog.d/6161.misc
+++ b/changelog.d/6161.misc
@@ -1,0 +1,1 @@
+Don't regenerate numeric user ID if registration fails.

--- a/changelog.d/6161.misc
+++ b/changelog.d/6161.misc
@@ -1,1 +1,0 @@
-Don't regenerate numeric user ID if registration fails.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -217,7 +217,6 @@ class RegistrationHandler(BaseHandler):
 
         else:
             # autogen a sequential user ID
-            attempts = 0
             user = None
             while not user:
                 localpart = yield self._generate_user_id()
@@ -238,7 +237,6 @@ class RegistrationHandler(BaseHandler):
                     # if user id is taken, just generate another
                     user = None
                     user_id = None
-                    attempts += 1
 
         if not self.hs.config.user_consent_at_registration:
             yield self._auto_join_rooms(user_id)

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -220,7 +220,7 @@ class RegistrationHandler(BaseHandler):
             attempts = 0
             user = None
             while not user:
-                localpart = yield self._generate_user_id(attempts > 0)
+                localpart = yield self._generate_user_id()
                 user = UserID(localpart, self.hs.hostname)
                 user_id = user.to_string()
                 yield self.check_user_id_not_appservice_exclusive(user_id)
@@ -379,10 +379,10 @@ class RegistrationHandler(BaseHandler):
                 )
 
     @defer.inlineCallbacks
-    def _generate_user_id(self, reseed=False):
-        if reseed or self._next_generated_user_id is None:
+    def _generate_user_id(self):
+        if self._next_generated_user_id is None:
             with (yield self._generate_user_id_linearizer.queue(())):
-                if reseed or self._next_generated_user_id is None:
+                if self._next_generated_user_id is None:
                     self._next_generated_user_id = (
                         yield self.store.find_next_generated_user_id_localpart()
                     )


### PR DESCRIPTION
This causes huge amounts of DB IO if registrations start to fail e.g. because the DB is struggling with IO.