### PR TITLE
Add contributer docs for using the provided linters script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,4 @@
 * [ ] Pull request is based on the develop branch
 * [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
 * [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
+* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#code-style))

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,7 +64,7 @@ makes it horribly hard to review otherwise.
 
 Before doing a commit, ensure the changes you've made don't produce
 linting errors. You can do this by running the linters as follows. Ensure to
-commit any files that were auto-corrected.
+commit any files that were corrected.
 
 ::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -67,7 +67,10 @@ linting errors. You can do this by running the linters as follows. Ensure to
 commit any files that were corrected.
 
 ::
-
+    # Install the dependencies
+    pip install -U black flake8 isort
+    
+    # Run the linter script
     ./scripts-dev/lint.sh
 
 Changelog

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -62,6 +62,14 @@ Please ensure your changes match the cosmetic style of the existing project,
 and **never** mix cosmetic and functional changes in the same commit, as it
 makes it horribly hard to review otherwise.
 
+Before doing a commit, ensure the changes you've made don't produce
+linting errors. You can do this by running the linters as follows. Ensure to
+commit any files that were auto-corrected.
+
+::
+
+    ./scripts-dev/lint.sh
+
 Changelog
 ~~~~~~~~~
 

--- a/changelog.d/6164.doc
+++ b/changelog.d/6164.doc
@@ -1,0 +1,1 @@
+Contributor documentation now mentions script to run linters.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -97,7 +97,6 @@ CONDITIONAL_REQUIREMENTS = {
     "sentry": ["sentry-sdk>=0.7.2"],
     "opentracing": ["jaeger-client>=4.0.0", "opentracing>=2.2.0"],
     "jwt": ["pyjwt>=1.6.4"],
-    "lint": ["black", "flake8", "isort"],
 }
 
 ALL_OPTIONAL_REQUIREMENTS = set()  # type: Set[str]

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -97,6 +97,7 @@ CONDITIONAL_REQUIREMENTS = {
     "sentry": ["sentry-sdk>=0.7.2"],
     "opentracing": ["jaeger-client>=4.0.0", "opentracing>=2.2.0"],
     "jwt": ["pyjwt>=1.6.4"],
+    "lint": ["black", "flake8", "isort"],
 }
 
 ALL_OPTIONAL_REQUIREMENTS = set()  # type: Set[str]


### PR DESCRIPTION
Add also to the pull request template to avoid build failures due
to people not knowing that linters need running.

Add lint dependencies black, flake8 and isort. 
These are required when running the `lint.sh` dev scripts.