### PR TITLE
[WIP/Need Help] Redirect stdio to a file with synctl --daemonize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ _trial_temp*/
 /*.log
 /*.log.config
 /*.pid
+/*.out
 /.python-version
 /*.signing.key
 /env/

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -132,7 +132,6 @@ def start_reactor(
                 app=appname,
                 pid=pid_file,
                 action=run,
-                auto_close_fds=False,
                 verbose=True,
                 logger=logger,
                 outfile=outfile

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -128,7 +128,7 @@ def start_reactor(
             if print_pidfile:
                 print(pid_file)
 
-            daemon = _daemonize.Daemonize2(
+            daemon = _daemonize.Daemonize(
                 app=appname,
                 pid=pid_file,
                 action=run,

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -21,7 +21,7 @@ import socket
 import sys
 import traceback
 
-from daemonize import Daemonize
+from synapse.app import _daemonize 
 
 from twisted.internet import defer, error, reactor
 from twisted.protocols.tls import TLSMemoryBIOFactory
@@ -71,6 +71,7 @@ def start_worker_reactor(appname, config, run_command=reactor.run):
         soft_file_limit=config.soft_file_limit,
         gc_thresholds=config.gc_thresholds,
         pid_file=config.worker_pid_file,
+        outfile=config.out_file,
         daemonize=config.worker_daemonize,
         print_pidfile=config.print_pidfile,
         logger=logger,
@@ -83,6 +84,7 @@ def start_reactor(
     soft_file_limit,
     gc_thresholds,
     pid_file,
+    outfile,
     daemonize,
     print_pidfile,
     logger,
@@ -126,13 +128,14 @@ def start_reactor(
             if print_pidfile:
                 print(pid_file)
 
-            daemon = Daemonize(
+            daemon = _daemonize.Daemonize2(
                 app=appname,
                 pid=pid_file,
                 action=run,
                 auto_close_fds=False,
                 verbose=True,
                 logger=logger,
+                outfile=outfile
             )
             daemon.start()
         else:

--- a/synapse/app/_daemonize.py
+++ b/synapse/app/_daemonize.py
@@ -29,18 +29,8 @@ class Daemonize2(object):
     :param app: contains the application name which will be sent to syslog.
     :param pid: path to the pidfile.
     :param action: your custom function which will be executed after daemonization.
-    :param keep_fds: optional list of fds which should not be closed.
-    :param auto_close_fds: optional parameter to not close opened fds.
-    :param privileged_action: action that will be executed before drop privileges if user or
-                              group parameter is provided.
-                              If you want to transfer anything from privileged_action to action, such as
-                              opened privileged file descriptor, you should return it from
-                              privileged_action function and catch it inside action function.
-    :param user: drop privileges to this user if provided.
-    :param group: drop privileges to this group if provided.
     :param verbose: send debug messages to logger if provided.
     :param logger: use this logger object instead of creating new one, if provided.
-    :param foreground: stay in foreground; do not fork (for debugging)
     :param chdir: change working directory if provided or /
     """
     def __init__(self, app, pid, action,

--- a/synapse/app/_daemonize.py
+++ b/synapse/app/_daemonize.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*
+# HEAVILY "inspired" by https://github.com/thesharp/daemonize/blob/master/daemonize.py
+# TODO: License header
+# app, pid, action, autoclose, verbose, logger, 
+
+
+import fcntl
+import os
+import pwd
+import grp
+import sys
+import signal
+import resource
+import logging
+import atexit
+from logging import handlers
+import traceback
+
+
+__version__ = "2.5.0"
+
+
+class Daemonize2(object):
+    """
+    Daemonize object.
+
+    Object constructor expects three arguments.
+
+    :param app: contains the application name which will be sent to syslog.
+    :param pid: path to the pidfile.
+    :param action: your custom function which will be executed after daemonization.
+    :param keep_fds: optional list of fds which should not be closed.
+    :param auto_close_fds: optional parameter to not close opened fds.
+    :param privileged_action: action that will be executed before drop privileges if user or
+                              group parameter is provided.
+                              If you want to transfer anything from privileged_action to action, such as
+                              opened privileged file descriptor, you should return it from
+                              privileged_action function and catch it inside action function.
+    :param user: drop privileges to this user if provided.
+    :param group: drop privileges to this group if provided.
+    :param verbose: send debug messages to logger if provided.
+    :param logger: use this logger object instead of creating new one, if provided.
+    :param foreground: stay in foreground; do not fork (for debugging)
+    :param chdir: change working directory if provided or /
+    """
+    def __init__(self, app, pid, action,
+                 keep_fds=None, auto_close_fds=True, privileged_action=None,
+                 user=None, group=None, verbose=False, logger=None,
+                 foreground=False, chdir="/", outfile="homeserver.out"):
+        self.app = app
+        self.pid = os.path.abspath(pid)
+        self.outfile = os.path.abspath(outfile)
+        self.action = action
+        self.logger = logger
+        self.verbose = verbose
+        self.chdir = chdir
+
+    def sigterm(self, signum, frame):
+        """
+        These actions will be done after SIGTERM.
+        """
+        self.logger.warning("Caught signal %s. Stopping daemon." % signum)
+        sys.exit(0)
+
+    def exit(self):
+        """
+        Cleanup pid file at exit.
+        """
+        self.logger.warning("Stopping daemon.")
+        os.remove(self.pid)
+        sys.exit(0)
+
+    def start(self):
+        """
+        Start daemonization process.
+        """
+        # If pidfile already exists, we should read pid from there; to overwrite it, if locking
+        # will fail, because locking attempt somehow purges the file contents.
+        if os.path.isfile(self.pid):
+            with open(self.pid, "r") as old_pidfile:
+                old_pid = old_pidfile.read()
+        # Create a lockfile so that only one instance of this daemon is running at any time.
+        try:
+            lockfile = open(self.pid, "w")
+        except IOError:
+            print("Unable to create the pidfile.")
+            sys.exit(1)
+        try:
+            # Try to get an exclusive lock on the file. This will fail if another process has the file
+            # locked.
+            fcntl.flock(lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except IOError:
+            print("Unable to lock on the pidfile.")
+            # We need to overwrite the pidfile if we got here.
+            with open(self.pid, "w") as pidfile:
+                pidfile.write(old_pid)
+            sys.exit(1)
+
+        # Fork, creating a new process for the child.
+        try:
+            process_id = os.fork()
+        except OSError as e:
+            self.logger.error("Unable to fork, errno: {0}".format(e.errno))
+            sys.exit(1)
+        if process_id != 0:
+            sys.exit(0)
+
+        # This is the child process. Continue.
+
+        # Stop listening for signals that the parent process receives.
+        # This is done by getting a new process id.
+        # setpgrp() is an alternative to setsid().
+        # setsid puts the process in a new parent group and detaches its controlling terminal.
+        process_id = os.setsid()
+        if process_id == -1:
+            # Uh oh, there was a problem.
+            sys.exit(1)
+
+        with open(self.outfile, 'w+') as f:
+            os.dup2(f.fileno(), 2)
+            os.dup2(f.fileno(), 1)
+
+
+
+        # Set umask to default to safe file permissions when running as a root daemon. 027 is an
+        # octal number which we are typing as 0o27 for Python3 compatibility.
+        os.umask(0o27)
+
+        # Change to a known directory. If this isn't done, starting a daemon in a subdirectory that
+        # needs to be deleted results in "directory busy" errors.
+        os.chdir(self.chdir)
+
+        try:
+            lockfile.write("%s" % (os.getpid()))
+            lockfile.flush()
+        except IOError:
+            self.logger.error("Unable to write pid to the pidfile.")
+            print("Unable to write pid to the pidfile.")
+            sys.exit(1)
+
+        # Set custom action on SIGTERM.
+        signal.signal(signal.SIGTERM, self.sigterm)
+        atexit.register(self.exit)
+
+        self.logger.warning("Starting daemon.")
+
+        print("################## PRINTED TO STDERR FROM _daemonize!!!!!!!!!", file=sys.stderr)
+
+        try:
+            self.action()
+        except Exception:
+            for line in traceback.format_exc().split("\n"):
+                self.logger.error(line)

--- a/synapse/app/_daemonize.py
+++ b/synapse/app/_daemonize.py
@@ -20,7 +20,7 @@ import traceback
 __version__ = "2.5.0"
 
 
-class Daemonize2(object):
+class Daemonize(object):
     """
     Daemonize object.
 
@@ -107,6 +107,7 @@ class Daemonize2(object):
             sys.exit(1)
 
         with open(self.outfile, 'w+') as f:
+            f.write("***STARTED STDIO REDIRECT FILE")
             os.dup2(f.fileno(), 2)
             os.dup2(f.fileno(), 1)
 
@@ -134,7 +135,6 @@ class Daemonize2(object):
 
         self.logger.warning("Starting daemon.")
 
-        print("################## PRINTED TO STDERR FROM _daemonize!!!!!!!!!", file=sys.stderr)
 
         try:
             self.action()

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -644,6 +644,7 @@ def run(hs):
         daemonize=hs.config.daemonize,
         print_pidfile=hs.config.print_pidfile,
         logger=logger,
+        outfile=hs.config.out_file
     )
 
 

--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -114,7 +114,7 @@ class LoggingConfig(Config):
             "--no-redirect-stdio",
             action="store_true",
             default=None,
-            help="Do not redirect stdout/stderr to the log",
+            help="[DEFUNCT] Do not redirect stdout/stderr to the log",
         )
 
     def generate_files(self, config, config_dir_path):
@@ -170,9 +170,10 @@ def _setup_stdlib_logging(config, log_config, logBeginner: LogBeginner):
 
         return observer(event)
 
-    logBeginner.beginLoggingTo([_log], redirectStandardIO=not config.no_redirect_stdio)
-    if not config.no_redirect_stdio:
-        print("Redirected stdout/stderr to logs")
+    # logBeginner.beginLoggingTo([_log], redirectStandardIO=not config.no_redirect_stdio)
+    logBeginner.beginLoggingTo([_log], redirectStandardIO=False)
+    # if not config.no_redirect_stdio:
+    #     print("Redirected stdout/stderr to logs")
 
     return observer
 
@@ -236,5 +237,8 @@ def setup_logging(
     logging.warn("***** STARTING SERVER *****")
     logging.warn("Server %s version %s", sys.argv[0], get_version_string(synapse))
     logging.info("Server hostname: %s", config.server_name)
+
+    if (self.no_redirect_stdio):
+        logging.warn("--no-redirect-stdio is ignored. STDOUT/ERR is redirected to out_file defined in the server config")
 
     return logger

--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -238,7 +238,6 @@ def setup_logging(
     logging.warn("Server %s version %s", sys.argv[0], get_version_string(synapse))
     logging.info("Server hostname: %s", config.server_name)
 
-    if (self.no_redirect_stdio):
-        logging.warn("--no-redirect-stdio is ignored. STDOUT/ERR is redirected to out_file defined in the server config")
+    logging.warn("--no-redirect-stdio is ignored. STDOUT/ERR is redirected to out_file defined in the server config")
 
     return logger

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -68,6 +68,7 @@ class ServerConfig(Config):
             raise ConfigError(str(e))
 
         self.pid_file = self.abspath(config.get("pid_file"))
+        self.out_file = self.abspath(config.get("out_file"))
         self.web_client_location = config.get("web_client_location", None)
         self.soft_file_limit = config.get("soft_file_limit", 0)
         self.daemonize = config.get("daemonize")
@@ -384,6 +385,7 @@ class ServerConfig(Config):
             unsecure_port = 8008
 
         pid_file = os.path.join(data_dir_path, "homeserver.pid")
+        out_file = os.path.join(data_dir_path, "homeserver.out")
 
         # Bring DEFAULT_ROOM_VERSION into the local-scope for use in the
         # default config string
@@ -466,6 +468,11 @@ class ServerConfig(Config):
         # When running as a daemon, the file to store the pid in
         #
         pid_file: %(pid_file)s
+
+
+        # When running as a daemon, the file to redirect stdout and stderr to
+        #
+        out_file: %(out_file)%
 
         # The path to the web client which will be served at /_matrix/client/
         # if 'webclient' is configured under the 'listeners' configuration.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -472,7 +472,7 @@ class ServerConfig(Config):
 
         # When running as a daemon, the file to redirect stdout and stderr to
         #
-        out_file: %(out_file)%
+        out_file: %(out_file)s
 
         # The path to the web client which will be served at /_matrix/client/
         # if 'webclient' is configured under the 'listeners' configuration.


### PR DESCRIPTION
Attempt to fix https://github.com/matrix-org/synapse/issues/1539

### Changes
- Added `synapse/app/_daemonize.py` inspired by [daemonize](https://github.com/thesharp/daemonize/blob/master/daemonize.py) but stripped down.
- Used the file above to redirect stdio/stderr to a file (default "homserver.out")
- Added config option for "homeserver.out"
- Ignored `--no-redirect-stdio`

### Need Help!
- Still need to properly separate the two files by changing twisted's log config. This looks like a pretty huge task, especially cause I'm not familiar with twisted (I'm in the process of learning twisted)
- Need to find a better/more elegant way of warning `--no-redirect-stdio` is ignored, ie the warning should be printed only if the option is used etc
- Need to finish the license header for `_daemonize.py`. The file is very similar to the original, I don't know how to copyright/license it.
- Need to know what else is needed to be done to finish this

#### Disclaimer
I'm pretty unfamiliar with the codebase and twisted. Hence, there's a good chance this PR is a bugfest. I'd love to learn and make changes though :smiley: 


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
