### PR TITLE
Fix unique_user_filter_index schema update

### DIFF
--- a/changelog.d/6175.bugfix
+++ b/changelog.d/6175.bugfix
@@ -1,0 +1,1 @@
+Fix syntax error in unique_user_filter_index schema update.

--- a/synapse/storage/schema/delta/56/unique_user_filter_index.py
+++ b/synapse/storage/schema/delta/56/unique_user_filter_index.py
@@ -24,8 +24,8 @@ def run_upgrade(cur, database_engine, *args, **kwargs):
             DROP INDEX user_filters_by_user_id_filter_id;
             DELETE FROM user_filters;
             ALTER TABLE user_filters
-               ALTER COLUMN user_id SET NOT NULL
-               ALTER COLUMN filter_id SET NOT NULL
+               ALTER COLUMN user_id SET NOT NULL,
+               ALTER COLUMN filter_id SET NOT NULL,
                ALTER COLUMN filter_json SET NOT NULL;
             INSERT INTO user_filters(user_id, filter_id, filter_json)
                 SELECT * FROM user_filters_migration;


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/matrix-org/synapse/pull/1172

Fixes a syntax error in the `ALTER TABLE` statement (each `ALTER COLUMN` line must end with a comma, see https://www.postgresql.org/docs/9.6/sql-altertable.html).