### PR TITLE
fix: add is_admin flag to /whois return object

### DIFF
--- a/changelog.d/6180.feature
+++ b/changelog.d/6180.feature
@@ -1,0 +1,1 @@
+Add is_admin flag to the response of /whois. Fixes issue #6130.

--- a/synapse/handlers/admin.py
+++ b/synapse/handlers/admin.py
@@ -32,9 +32,10 @@ class AdminHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def get_whois(self, user):
-        connections = []
-
+        is_admin = yield self.store.is_server_admin(user)
         sessions = yield self.store.get_user_ip_and_agents(user)
+
+        connections = []
         for session in sessions:
             connections.append(
                 {
@@ -44,8 +45,10 @@ class AdminHandler(BaseHandler):
                 }
             )
 
+
         ret = {
             "user_id": user.to_string(),
+            "is_admin": is_admin,
             "devices": {"": {"sessions": [{"connections": connections}]}},
         }
 


### PR DESCRIPTION
Add is_admin flag to the response of /whois.

Fixes #6130

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
