### PR TITLE
Clarify environment variable usage when running in Docker

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -217,8 +217,9 @@ def main(args, environ):
         # backwards-compatibility generate-a-config-on-the-fly mode
         if "SYNAPSE_CONFIG_PATH" in environ:
             error(
-                "SYNAPSE_SERVER_NAME and SYNAPSE_CONFIG_PATH are mutually exclusive "
-                "except in `generate` or `migrate_config` mode."
+                "SYNAPSE_SERVER_NAME can only be combined with SYNAPSE_CONFIG_PATH "
+                "in `generate` or `migrate_config` mode. To start synapse using a "
+                "config file, unset the SYNAPSE_SERVER_NAME environment variable."
             )
 
         config_path = "/compiled/homeserver.yaml"


### PR DESCRIPTION
This error message was quite confusing when setting up a Synapse server for the first time:

> SYNAPSE_SERVER_NAME and SYNAPSE_CONFIG_PATH are mutually exclusive except in `generate` or `migrate_config` mode.

As someone who has had not used Synapse before, I wasn't sure how to resolve the error, and I ended up unsetting `SYNAPSE_CONFIG_PATH`. I figured this was safe because my config file was in the default location.

The server started working, but it was not until much later that I realized the config was not being used at all.

I've reworked the message to the following:

> SYNAPSE_SERVER_NAME can only be combined with SYNAPSE_CONFIG_PATH in `generate` or `migrate_config` mode. To start synapse using a config file, unset the SYNAPSE_SERVER_NAME environment variable.

This should make it more clear as to which variable is the preferred method of configuration.