### PR TITLE
Fix races in room stats (and other) updates.

### DIFF
--- a/changelog.d/6187.bugfix
+++ b/changelog.d/6187.bugfix
@@ -1,0 +1,1 @@
+Fix occasional missed updates in the room and user directories.

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -138,9 +138,16 @@ class UserDirectoryHandler(StateDeltasHandler):
         # Loop round handling deltas until we're up to date
         while True:
             with Measure(self.clock, "user_dir_delta"):
-                max_pos, deltas = yield self.store.get_current_state_deltas(self.pos)
-                if not deltas:
+                room_max_stream_ordering = self.store.get_room_max_stream_ordering()
+                if self.pos == room_max_stream_ordering:
                     return
+
+                logger.debug(
+                    "Processing user stats %s->%s", self.pos, room_max_stream_ordering
+                )
+                max_pos, deltas = yield self.store.get_current_state_deltas(
+                    self.pos, room_max_stream_ordering
+                )
 
                 logger.info("Handling %d state deltas", len(deltas))
                 yield self._handle_deltas(deltas)

--- a/synapse/storage/state_deltas.py
+++ b/synapse/storage/state_deltas.py
@@ -15,8 +15,6 @@
 import abc
 import logging
 
-from twisted.internet import defer
-
 from synapse.storage._base import SQLBaseStore
 
 logger = logging.getLogger(__name__)

--- a/synapse/storage/state_deltas.py
+++ b/synapse/storage/state_deltas.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import logging
 
 from synapse.storage._base import SQLBaseStore
@@ -44,7 +45,6 @@ class StateDeltasStore(SQLBaseStore):
                - list of current_state_delta_stream rows. If it is empty, we are
                  up to date.
         """
-
         prev_stream_id = int(prev_stream_id)
 
         # check we're not going backwards
@@ -59,7 +59,7 @@ class StateDeltasStore(SQLBaseStore):
             return max_stream_id, []
 
         def get_current_state_deltas_txn(txn):
-            # First we calculate a max stream id that will give us less than
+            # First we calculate the max stream id that will give us less than
             # N results.
             # We arbitarily limit to 100 stream_id entries to ensure we don't
             # select toooo many.

--- a/synapse/storage/state_deltas.py
+++ b/synapse/storage/state_deltas.py
@@ -12,8 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import abc
 import logging
+
+from twisted.internet import defer
 
 from synapse.storage._base import SQLBaseStore
 
@@ -21,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 class StateDeltasStore(SQLBaseStore):
+    __metaclass__ = abc.ABCMeta
+
     def get_current_state_deltas(self, prev_stream_id):
         """Fetch a list of room state changes since the given stream id
 
@@ -38,31 +42,50 @@ class StateDeltasStore(SQLBaseStore):
             prev_stream_id (int): point to get changes since (exclusive)
 
         Returns:
-            Deferred[list[dict]]: results
+            Deferred[tuple[int, list[dict]]: A tuple consisting of:
+               - the stream id which these results go up to, or the latest (persisted)
+                 room stream ordering
+               - list of current_state_delta_stream rows. If it is empty, we are
+                 up to date.
         """
+
         prev_stream_id = int(prev_stream_id)
+
+        # rows are not necessarily persisted to the CSDS table in order. make
+        # sure that we only consider stream_ids which have been fully persisted.
+        room_max_stream_ordering = self.get_room_max_stream_ordering()
+
+        # check we're not going backwards
+        assert prev_stream_id <= room_max_stream_ordering
+
         if not self._curr_state_delta_stream_cache.has_any_entity_changed(
             prev_stream_id
         ):
-            return []
+            # if the CSDs haven't changed between prev_stream_id and now, we
+            # know for certain that they haven't changed between prev_stream_id and
+            # room_max_stream_ordering.
+            return room_max_stream_ordering, []
 
         def get_current_state_deltas_txn(txn):
-            # First we calculate the max stream id that will give us less than
+            # First we calculate a max stream id that will give us less than
             # N results.
             # We arbitarily limit to 100 stream_id entries to ensure we don't
             # select toooo many.
             sql = """
                 SELECT stream_id, count(*)
                 FROM current_state_delta_stream
-                WHERE stream_id > ?
+                WHERE stream_id > ? AND stream_id <= ?
                 GROUP BY stream_id
                 ORDER BY stream_id ASC
                 LIMIT 100
             """
-            txn.execute(sql, (prev_stream_id,))
+            txn.execute(sql, (prev_stream_id, room_max_stream_ordering))
 
             total = 0
-            max_stream_id = prev_stream_id
+
+            # if there are no entries, we may as well go up to the current max stream id
+            max_stream_id = room_max_stream_ordering
+
             for max_stream_id, count in txn:
                 total += count
                 if total > 100:
@@ -78,7 +101,7 @@ class StateDeltasStore(SQLBaseStore):
                 ORDER BY stream_id ASC
             """
             txn.execute(sql, (prev_stream_id, max_stream_id))
-            return self.cursor_to_dict(txn)
+            return max_stream_id, self.cursor_to_dict(txn)
 
         return self.runInteraction(
             "get_current_state_deltas", get_current_state_deltas_txn
@@ -97,3 +120,9 @@ class StateDeltasStore(SQLBaseStore):
             "get_max_stream_id_in_current_state_deltas",
             self._get_max_stream_id_in_current_state_deltas_txn,
         )
+
+    @abc.abstractmethod
+    def get_room_max_stream_ordering(self):
+        # we expect this to be implemented one way or the other by other classes
+        # in the hierarchy
+        raise NotImplementedError()

--- a/synapse/storage/state_deltas.py
+++ b/synapse/storage/state_deltas.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import abc
 import logging
 
 from synapse.storage._base import SQLBaseStore
@@ -21,9 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class StateDeltasStore(SQLBaseStore):
-    __metaclass__ = abc.ABCMeta
-
-    def get_current_state_deltas(self, prev_stream_id):
+    def get_current_state_deltas(self, prev_stream_id: int, max_stream_id: int):
         """Fetch a list of room state changes since the given stream id
 
         Each entry in the result contains the following fields:
@@ -38,31 +35,28 @@ class StateDeltasStore(SQLBaseStore):
 
         Args:
             prev_stream_id (int): point to get changes since (exclusive)
+            max_stream_id (int): the point that we know has been correctly persisted
+               - ie, an upper limit to return changes from.
 
         Returns:
             Deferred[tuple[int, list[dict]]: A tuple consisting of:
-               - the stream id which these results go up to, or the latest (persisted)
-                 room stream ordering
+               - the stream id which these results go up to
                - list of current_state_delta_stream rows. If it is empty, we are
                  up to date.
         """
 
         prev_stream_id = int(prev_stream_id)
 
-        # rows are not necessarily persisted to the CSDS table in order. make
-        # sure that we only consider stream_ids which have been fully persisted.
-        room_max_stream_ordering = self.get_room_max_stream_ordering()
-
         # check we're not going backwards
-        assert prev_stream_id <= room_max_stream_ordering
+        assert prev_stream_id <= max_stream_id
 
         if not self._curr_state_delta_stream_cache.has_any_entity_changed(
             prev_stream_id
         ):
             # if the CSDs haven't changed between prev_stream_id and now, we
             # know for certain that they haven't changed between prev_stream_id and
-            # room_max_stream_ordering.
-            return room_max_stream_ordering, []
+            # max_stream_id.
+            return max_stream_id, []
 
         def get_current_state_deltas_txn(txn):
             # First we calculate a max stream id that will give us less than
@@ -77,19 +71,24 @@ class StateDeltasStore(SQLBaseStore):
                 ORDER BY stream_id ASC
                 LIMIT 100
             """
-            txn.execute(sql, (prev_stream_id, room_max_stream_ordering))
+            txn.execute(sql, (prev_stream_id, max_stream_id))
 
             total = 0
 
-            # if there are no entries, we may as well go up to the current max stream id
-            max_stream_id = room_max_stream_ordering
-
-            for max_stream_id, count in txn:
+            for stream_id, count in txn:
                 total += count
                 if total > 100:
                     # We arbitarily limit to 100 entries to ensure we don't
                     # select toooo many.
+                    logger.debug(
+                        "Clipping current_state_delta_stream rows to stream_id %i",
+                        stream_id,
+                    )
+                    clipped_stream_id = stream_id
                     break
+            else:
+                # if there's no problem, we may as well go right up to the max_stream_id
+                clipped_stream_id = max_stream_id
 
             # Now actually get the deltas
             sql = """
@@ -98,8 +97,8 @@ class StateDeltasStore(SQLBaseStore):
                 WHERE ? < stream_id AND stream_id <= ?
                 ORDER BY stream_id ASC
             """
-            txn.execute(sql, (prev_stream_id, max_stream_id))
-            return max_stream_id, self.cursor_to_dict(txn)
+            txn.execute(sql, (prev_stream_id, clipped_stream_id))
+            return clipped_stream_id, self.cursor_to_dict(txn)
 
         return self.runInteraction(
             "get_current_state_deltas", get_current_state_deltas_txn
@@ -118,9 +117,3 @@ class StateDeltasStore(SQLBaseStore):
             "get_max_stream_id_in_current_state_deltas",
             self._get_max_stream_id_in_current_state_deltas_txn,
         )
-
-    @abc.abstractmethod
-    def get_room_max_stream_ordering(self):
-        # we expect this to be implemented one way or the other by other classes
-        # in the hierarchy
-        raise NotImplementedError()

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -139,7 +139,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
             defer.succeed(1)
         )
 
-        self.datastore.get_current_state_deltas.return_value = None
+        self.datastore.get_current_state_deltas.return_value = (0, None)
 
         self.datastore.get_to_device_stream_token = lambda: 0
         self.datastore.get_new_device_msgs_for_remote = lambda *args, **kargs: ([], 0)

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -62,7 +62,7 @@ class UserRegisterTestCase(unittest.HomeserverTestCase):
         self.device_handler.check_device_registered = Mock(return_value="FAKE")
 
         self.datastore = Mock(return_value=Mock())
-        self.datastore.get_current_state_deltas = Mock(return_value=[])
+        self.datastore.get_current_state_deltas = Mock(return_value=(0, []))
 
         self.secrets = Mock()
 


### PR DESCRIPTION
Hopefully this will fix the occasional failures we were seeing in the room directory.

The problem was that events are not necessarily persisted (and `current_state_delta_stream` updated) in the same order as their stream_id. So for instance current_state_delta 9 might be persisted *before* current_state_delta 8. Then, when the room stats saw stream_id 9, it assumed it had done everything up to 9, and never came back to do stream_id 8.

We can solve this easily by only processing up to the stream_id where we know all events have been persisted.