### PR TITLE
make version optional in body of e2e backup version update

### DIFF
--- a/changelog.d/6189.misc
+++ b/changelog.d/6189.misc
@@ -1,0 +1,1 @@
+Make `version` optional in body of `PUT /room_keys/version/{version}`, since it's redundant.

--- a/synapse/handlers/e2e_room_keys.py
+++ b/synapse/handlers/e2e_room_keys.py
@@ -352,8 +352,8 @@ class E2eRoomKeysHandler(object):
             A deferred of an empty dict.
         """
         if "version" not in version_info:
-            raise SynapseError(400, "Missing version in body", Codes.MISSING_PARAM)
-        if version_info["version"] != version:
+            version_info["version"] = version
+        elif version_info["version"] != version:
             raise SynapseError(
                 400, "Version in body does not match", Codes.INVALID_PARAM
             )

--- a/synapse/rest/client/v2_alpha/room_keys.py
+++ b/synapse/rest/client/v2_alpha/room_keys.py
@@ -375,7 +375,7 @@ class RoomKeysVersionServlet(RestServlet):
                     "ed25519:something": "hijklmnop"
                 }
             },
-            "version": "42"
+            "version": "12345"
         }
 
         HTTP/1.1 200 OK

--- a/tests/handlers/test_e2e_room_keys.py
+++ b/tests/handlers/test_e2e_room_keys.py
@@ -187,7 +187,7 @@ class E2eRoomKeysHandlerTestCase(unittest.TestCase):
         self.assertEqual(res, 404)
 
     @defer.inlineCallbacks
-    def test_update_missing_version(self):
+    def test_update_omitted_version(self):
         """Check that the update succeeds if the version is missing from the body
         """
         version = yield self.handler.create_version(


### PR DESCRIPTION
to agree with latest version of the MSC (https://github.com/matrix-org/matrix-doc/pull/1538#discussion_r330389684)
