### PR TITLE
Fix presence timeouts when synchrotron restarts.

### DIFF
--- a/changelog.d/6212.bugfix
+++ b/changelog.d/6212.bugfix
@@ -1,0 +1,1 @@
+Fix bug where presence would not get timed out correctly if a synchrotron worker is used and restarted.

--- a/tox.ini
+++ b/tox.ini
@@ -161,7 +161,7 @@ basepython = python3.7
 skip_install = True
 deps =
     {[base]deps}
-    mypy
+    mypy==0.730
     mypy-zope
 env =
     MYPYPATH = stubs/


### PR DESCRIPTION
Handling timeouts would fail if there was an external process that had
timed out, e.g. a synchrotron restarting. This was due to a couple of
variable name typoes.

Fixes #3715.
