### PR TITLE
Add missing BOOLEAN_COLUMNs to synapse_port_db

### DIFF
--- a/changelog.d/6216.bugfix
+++ b/changelog.d/6216.bugfix
@@ -1,0 +1,1 @@
+synapse_port_db: Add 2 additional BOOLEAN_COLUMNS to be able to convert from database schema v56.

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -55,6 +55,8 @@ BOOLEAN_COLUMNS = {
     "local_group_membership": ["is_publicised", "is_admin"],
     "e2e_room_keys": ["is_verified"],
     "account_validity": ["email_sent"],
+    "redactions": ["have_censored"],
+    "room_stats_state": ["is_federatable"],
 }
 
 


### PR DESCRIPTION
Small fix to synapse_port_db to be able to convert from database schema v56.

Signed-off-by: Bart Noordervliet <bart@noordervliet.net>
