### PR TITLE
Replace deprecated --force dpkg option

### DIFF
--- a/debian/matrix-synapse-py3.postinst
+++ b/debian/matrix-synapse-py3.postinst
@@ -44,7 +44,7 @@ EOF
 
     for DIR in /var/lib/matrix-synapse /var/log/matrix-synapse /etc/matrix-synapse; do
       if ! dpkg-statoverride --list --quiet $DIR >/dev/null; then
-        dpkg-statoverride --force --quiet --update --add $USER nogroup 0755 $DIR
+        dpkg-statoverride --force-all --quiet --update --add $USER nogroup 0755 $DIR
       fi
     done
 


### PR DESCRIPTION
While watching @Half-Shot install his new Synapse dpkg popped out an error that `--force` was deprecated.

This was on Ubuntu 19.04. Not sure if the `--force-all` option is supported by older distributions that we support

Requesting review to see if this is a good idea, I know CI will fail until a newspaper file is added.