### PR TITLE
Added the room_stats_state and redactions to the booleans_column for …

### DIFF
--- a/changelog.d/6227.bugfix
+++ b/changelog.d/6227.bugfix
@@ -1,0 +1,1 @@
+Add "room_stats_state" and "redactions" to the list of boolean columns in synapse_port_db

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -57,6 +57,8 @@ BOOLEAN_COLUMNS = {
     "account_validity": ["email_sent"],
     "redactions": ["have_censored"],
     "room_stats_state": ["is_federatable"],
+    "room_stats_state": ["is_federatable"],
+    "redactions": ["have_censored"],
 }
 
 


### PR DESCRIPTION
…the db port script

I noticed while trying to port my SQLite database to postgres that I ran into a few issues with failures to insert two different new features that matrix-synapse has, those being "rooms_stats_state" and "redactions". I found #5306 and was able to resolve this and thought I'd send my changes that got the script working back. 

I'm not sure how I'm supposed to add the Changelog file without knowing what # my PR will be... I'm creating a draft in hopes that I'll be able to add the changelog file then.

Signed-off-by: James Eversole <james@eversole.co>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
