### PR TITLE
Implement MSC2316

### DIFF
--- a/changelog.d/6176.feature
+++ b/changelog.d/6176.feature
@@ -1,0 +1,1 @@
+Implement the v2/state Federation API as drafted in MSC2314.

--- a/changelog.d/6230.feature
+++ b/changelog.d/6230.feature
@@ -1,0 +1,1 @@
+Implement MSC2316.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -339,7 +339,7 @@ class FederationServer(FederationBase):
     @defer.inlineCallbacks
     def on_query_request(self, query_type, args):
         received_queries_counter.labels(query_type).inc()
-        resp = yield self.registry.on_query(query_type, args)
+        resp = yield defer.ensureDeferred(self.registry.on_query(query_type, args))
         return 200, resp
 
     @defer.inlineCallbacks

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015, 2016 OpenMarket Ltd
 # Copyright 2018 New Vector Ltd
+# Copyright 2019 Matrix.org Federation C.I.C
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,6 +75,7 @@ class FederationServer(FederationBase):
 
         self.auth = hs.get_auth()
         self.handler = hs.get_handlers().federation_handler
+        self.state = hs.get_state_handler()
 
         self._server_linearizer = Linearizer("fed_server")
         self._transaction_linearizer = Linearizer("fed_txn_handler")
@@ -300,6 +302,35 @@ class FederationServer(FederationBase):
         return 200, resp
 
     @defer.inlineCallbacks
+    @log_function
+    def on_context_state_request_v2(self, origin, room_id, event_id):
+        origin_host, _ = parse_server_name(origin)
+        yield self.check_server_matches_acl(origin_host, room_id)
+
+        in_room = yield self.auth.check_host_in_room(room_id, origin)
+        if not in_room:
+            raise AuthError(403, "Host not in room.")
+
+        # we grab the linearizer to protect ourselves from servers which hammer
+        # us. In theory we might already have the response to this query
+        # in the cache so we could return it without waiting for the linearizer
+        # - but that's non-trivial to get right, and anyway somewhat defeats
+        # the point of the linearizer.
+        with (yield self._server_linearizer.queue((origin, room_id))):
+            resp = yield self._state_resp_cache.wrap(
+                (room_id, event_id),
+                self._on_context_state_request_compute,
+                room_id,
+                event_id,
+            )
+
+        room_version = yield self.store.get_room_version(room_id)
+        resp = dict(resp)
+        resp["room_version"] = room_version
+
+        return 200, resp
+
+    @defer.inlineCallbacks
     def on_state_ids_request(self, origin, room_id, event_id):
         if not event_id:
             raise NotImplementedError("Specify an event")
@@ -318,7 +349,11 @@ class FederationServer(FederationBase):
 
     @defer.inlineCallbacks
     def _on_context_state_request_compute(self, room_id, event_id):
-        pdus = yield self.handler.get_state_for_pdu(room_id, event_id)
+        if event_id:
+            pdus = yield self.handler.get_state_for_pdu(room_id, event_id)
+        else:
+            pdus = (yield self.state.get_current_state(room_id)).values()
+
         auth_chain = yield self.store.get_auth_chain([pdu.event_id for pdu in pdus])
 
         return {

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -474,6 +474,7 @@ class FederationQueryServlet(BaseFederationServlet):
     # This is when we receive a server-server Query
     async def on_GET(self, origin, content, query, query_type):
         return await self.handler.on_query_request(
+            origin,
             query_type,
             {k.decode("utf8"): v[0].decode("utf-8") for k, v in query.items()},
         )

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -419,7 +419,7 @@ class FederationEventServlet(BaseFederationServlet):
         return await self.handler.on_pdu_request(origin, event_id)
 
 
-class FederationStateServlet(BaseFederationServlet):
+class FederationStateV1Servlet(BaseFederationServlet):
     PATH = "/state/(?P<context>[^/]*)/?"
 
     # This is when someone asks for all data for a given context.
@@ -428,6 +428,19 @@ class FederationStateServlet(BaseFederationServlet):
             origin,
             context,
             parse_string_from_args(query, "event_id", None, required=True),
+        )
+
+
+class FederationStateV2Servlet(BaseFederationServlet):
+    PATH = "/state/(?P<context>[^/]*)/?"
+
+    PREFIX = FEDERATION_V2_PREFIX
+
+    async def on_GET(self, origin, content, query, context):
+        return await self.handler.on_context_state_request_v2(
+            origin,
+            context,
+            parse_string_from_args(query, "event_id", None, required=False),
         )
 
 
@@ -1358,7 +1371,8 @@ class RoomComplexityServlet(BaseFederationServlet):
 FEDERATION_SERVLET_CLASSES = (
     FederationSendServlet,
     FederationEventServlet,
-    FederationStateServlet,
+    FederationStateV1Servlet,
+    FederationStateV2Servlet,
     FederationStateIdsServlet,
     FederationBackfillServlet,
     FederationQueryServlet,

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -456,7 +456,7 @@ class DeviceHandler(DeviceWorkerHandler):
         self.notifier.on_new_event("device_list_key", position, users=[from_user_id])
 
     @defer.inlineCallbacks
-    def on_federation_query_user_devices(self, user_id):
+    def on_federation_query_user_devices(self, origin, user_id):
         stream_id, devices = yield self.store.get_devices_with_keys_by_user(user_id)
         return {"user_id": user_id, "stream_id": stream_id, "devices": devices}
 

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -280,7 +280,7 @@ class DirectoryHandler(BaseHandler):
         return {"room_id": room_id, "servers": servers}
 
     @defer.inlineCallbacks
-    def on_directory_query(self, args):
+    def on_directory_query(self, origin, args):
         room_alias = RoomAlias.from_string(args["room_alias"])
         if not self.hs.is_mine(room_alias):
             raise SynapseError(400, "Room Alias is not hosted on this Home Server")

--- a/synapse/handlers/e2e_keys.py
+++ b/synapse/handlers/e2e_keys.py
@@ -335,7 +335,7 @@ class E2eKeysHandler(object):
         return result_dict
 
     @defer.inlineCallbacks
-    def on_federation_query_client_keys(self, query_body):
+    def on_federation_query_client_keys(self, origin, query_body):
         """ Handle a device key query from a federated server
         """
         device_keys_query = query_body.get("device_keys", {})

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -228,7 +228,7 @@ class BaseProfileHandler(BaseHandler):
         yield self._update_join_states(requester, target_user)
 
     @defer.inlineCallbacks
-    def on_profile_query(self, args):
+    def on_profile_query(self, origin, args):
         user = UserID.from_string(args["user_id"])
         if not self.hs.is_mine(user):
             raise SynapseError(400, "User is not hosted on this Home Server")

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -77,8 +77,10 @@ class RoomMemberHandler(object):
         self.base_handler = BaseHandler(hs)
 
         federation_registry = hs.get_federation_registry()
+
+        # UNSTABLE/PREFIXED query type
         federation_registry.register_query_handler(
-            "members", self.on_federation_query_members
+            "net.maunium.members", self.on_federation_query_members
         )
 
     @abc.abstractmethod

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -75,7 +75,6 @@ class RoomMemberHandler(object):
         # it doesn't store state.
         self.base_handler = BaseHandler(hs)
 
-
         federation_registry = hs.get_federation_registry()
         federation_registry.register_query_handler(
             "members", self.on_federation_query_members
@@ -987,9 +986,18 @@ class RoomMemberMasterHandler(RoomMemberHandler):
         if membership:
             yield self.store.forget(user_id, room_id)
 
+    async def on_federation_query_members(self, origin, args):
 
-    async def on_federation_query_members(self, args):
+        if args.get("limit_per_room"):
+            limit_per_room = int(args["limit_per_room"])
+        else:
+            limit_per_room = 0
 
-        return args
+        if args.get("pdu_ids"):
+            pdu_ids = True
+        else:
+            pdu_ids = False
 
-        pass
+        return await self.store.member_events_for_remote(
+            origin, limit_per_room, pdu_ids
+        )

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -17,6 +17,7 @@
 
 import abc
 import logging
+from typing import List, Union
 
 from six.moves import http_client
 
@@ -986,8 +987,12 @@ class RoomMemberMasterHandler(RoomMemberHandler):
         if membership:
             yield self.store.forget(user_id, room_id)
 
-    async def on_federation_query_members(self, origin, args):
-
+    async def on_federation_query_members(
+        self, origin: str, args: List[str]
+    ) -> Union[List[dict], List[str]]:
+        """
+        Return the member events that belong to users of a given origin.
+        """
         if args.get("limit_per_room"):
             limit_per_room = int(args["limit_per_room"])
         else:

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -75,6 +75,12 @@ class RoomMemberHandler(object):
         # it doesn't store state.
         self.base_handler = BaseHandler(hs)
 
+
+        federation_registry = hs.get_federation_registry()
+        federation_registry.register_query_handler(
+            "members", self.on_federation_query_members
+        )
+
     @abc.abstractmethod
     def _remote_join(self, requester, remote_room_hosts, room_id, user, content):
         """Try and join a room that this server is not in
@@ -980,3 +986,10 @@ class RoomMemberMasterHandler(RoomMemberHandler):
 
         if membership:
             yield self.store.forget(user_id, room_id)
+
+
+    async def on_federation_query_members(self, args):
+
+        return args
+
+        pass

--- a/synapse/storage/roommember.py
+++ b/synapse/storage/roommember.py
@@ -16,6 +16,7 @@
 
 import logging
 from collections import namedtuple
+from typing import List, Union
 
 from six import iteritems, itervalues
 
@@ -708,8 +709,16 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         return True
 
     async def member_events_for_remote(
-        self, remote, limit_per_room: int, pdu_ids: bool
-    ):
+        self, remote: str, limit_per_room: int, pdu_ids: bool
+    ) -> Union[List[dict], List[str]]:
+        """
+        Fetch the member events that belong to a given remote.
+
+        Args:
+            remote: The remote server to fetch events for.
+            limit_per_room: How many events to limit fetching to.
+            pdu_ids: If True, just returns the PDU IDs, not full events.
+        """
 
         if "%" in remote or "_" in remote:
             raise Exception("Invalid host name")

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -19,7 +19,7 @@ from twisted.internet import defer
 
 from synapse.types import ReadReceipt
 
-from tests.unittest import HomeserverTestCase
+from tests.unittest import HomeserverTestCase, override_config
 
 
 class FederationSenderTestCases(HomeserverTestCase):
@@ -29,6 +29,7 @@ class FederationSenderTestCases(HomeserverTestCase):
             federation_transport_client=Mock(spec=["send_transaction"]),
         )
 
+    @override_config({"send_federation": True})
     def test_send_receipts(self):
         mock_state_handler = self.hs.get_state_handler()
         mock_state_handler.get_current_hosts_in_room.return_value = ["test", "host2"]
@@ -69,6 +70,7 @@ class FederationSenderTestCases(HomeserverTestCase):
             ],
         )
 
+    @override_config({"send_federation": True})
     def test_send_receipts_with_backoff(self):
         """Send two receipts in quick succession; the second should be flushed, but
         only after 20ms"""

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 New Vector Ltd
+# Copyright 2019 Matrix.org Federation C.I.C
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +17,8 @@ import logging
 
 from synapse.events import FrozenEvent
 from synapse.federation.federation_server import server_matches_acl_event
+from synapse.rest import admin
+from synapse.rest.client.v1 import login, room
 
 from tests import unittest
 
@@ -39,6 +42,66 @@ class ServerACLsTestCase(unittest.TestCase):
         self.assertTrue(server_matches_acl_event("1a.2.3.4", e))
         self.assertFalse(server_matches_acl_event("[1:2::]", e))
         self.assertTrue(server_matches_acl_event("1:2:3:4", e))
+
+
+class StateQueryTests(unittest.FederatingHomeserverTestCase):
+
+    servlets = [
+        admin.register_servlets,
+        room.register_servlets,
+        login.register_servlets,
+    ]
+
+    def test_without_event_id(self):
+        """
+        Querying v2/state/<room_id> without an event ID will return the current
+        known state.
+        """
+        u1 = self.register_user("u1", "pass")
+        u1_token = self.login("u1", "pass")
+
+        room_1 = self.helper.create_room_as(u1, tok=u1_token)
+        self.inject_room_member(room_1, "@user:other.example.com", "join")
+
+        request, channel = self.make_request(
+            "GET", "/_matrix/federation/v2/state/%s" % (room_1,)
+        )
+        self.render(request)
+        self.assertEquals(200, channel.code, channel.result)
+
+        self.assertEqual(
+            channel.json_body["room_version"],
+            self.hs.config.default_room_version.identifier,
+        )
+
+        members = set(
+            map(
+                lambda x: x["state_key"],
+                filter(
+                    lambda x: x["type"] == "m.room.member", channel.json_body["pdus"]
+                ),
+            )
+        )
+
+        self.assertEqual(members, set(["@user:other.example.com", u1]))
+        self.assertEqual(len(channel.json_body["pdus"]), 6)
+
+    def test_needs_to_be_in_room(self):
+        """
+        Querying v2/state/<room_id> requires the server be in the room to
+        provide data.
+        """
+        u1 = self.register_user("u1", "pass")
+        u1_token = self.login("u1", "pass")
+
+        room_1 = self.helper.create_room_as(u1, tok=u1_token)
+
+        request, channel = self.make_request(
+            "GET", "/_matrix/federation/v2/state/%s" % (room_1,)
+        )
+        self.render(request)
+        self.assertEquals(403, channel.code, channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_FORBIDDEN")
 
 
 def _create_acl_event(content):

--- a/tests/federation/test_query.py
+++ b/tests/federation/test_query.py
@@ -37,7 +37,7 @@ class RoomMemberQueryTestCase(FederatingHomeserverTestCase):
     def test_none(self):
 
         request, channel = self.make_request(
-            "GET", "/_matrix/federation/v1/query/members"
+            "GET", "/_matrix/federation/v1/query/net.maunium.members"
         )
         self.render(request)
         self.assertEquals(200, channel.code, channel.result)
@@ -48,7 +48,7 @@ class RoomMemberQueryTestCase(FederatingHomeserverTestCase):
         injected = self.inject_room_member(room_1, "@user:other.example.com", "join")
 
         request, channel = self.make_request(
-            "GET", "/_matrix/federation/v1/query/members?pdu_ids=1"
+            "GET", "/_matrix/federation/v1/query/net.maunium.members?pdu_ids=1"
         )
         self.render(request)
         self.assertEquals(200, channel.code, channel.result)
@@ -59,7 +59,7 @@ class RoomMemberQueryTestCase(FederatingHomeserverTestCase):
         injected = self.inject_room_member(room_1, "@user:other.example.com", "join")
 
         request, channel = self.make_request(
-            "GET", "/_matrix/federation/v1/query/members"
+            "GET", "/_matrix/federation/v1/query/net.maunium.members"
         )
         self.render(request)
         self.assertEquals(200, channel.code, channel.result)
@@ -71,7 +71,7 @@ class RoomMemberQueryTestCase(FederatingHomeserverTestCase):
         injected_1 = self.inject_room_member(room_1, "@user2:other.example.com", "join")
 
         request, channel = self.make_request(
-            "GET", "/_matrix/federation/v1/query/members?limit_per_room=1"
+            "GET", "/_matrix/federation/v1/query/net.maunium.members?limit_per_room=1"
         )
         self.render(request)
         self.assertEquals(200, channel.code, channel.result)

--- a/tests/federation/test_query.py
+++ b/tests/federation/test_query.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from synapse.rest import admin
+from synapse.rest.client.v1 import login, room
+
+from tests.unittest import FederatingHomeserverTestCase
+
+
+class RoomMemberQueryTestCase(FederatingHomeserverTestCase):
+
+    servlets = [
+        admin.register_servlets,
+        room.register_servlets,
+        login.register_servlets,
+    ]
+
+    def prepare(self, reactor, clock, hs):
+
+        self.u1 = self.register_user("u1", "pass")
+        self.u1_token = self.login("u1", "pass")
+
+        super().prepare(reactor, clock, hs)
+
+    def test_none(self):
+
+        request, channel = self.make_request(
+            "GET", "/_matrix/federation/v1/query/members"
+        )
+        self.render(request)
+        self.assertEquals(200, channel.code, channel.result)
+        self.assertEquals(channel.json_body, [])
+
+    def test_in_room_pdus(self):
+        room_1 = self.helper.create_room_as(self.u1, tok=self.u1_token)
+        injected = self.inject_room_member(room_1, "@user:other.example.com", "join")
+
+        request, channel = self.make_request(
+            "GET", "/_matrix/federation/v1/query/members?pdu_ids=1"
+        )
+        self.render(request)
+        self.assertEquals(200, channel.code, channel.result)
+        self.assertEquals(channel.json_body, [injected.event_id])
+
+    def test_in_room_full(self):
+        room_1 = self.helper.create_room_as(self.u1, tok=self.u1_token)
+        injected = self.inject_room_member(room_1, "@user:other.example.com", "join")
+
+        request, channel = self.make_request(
+            "GET", "/_matrix/federation/v1/query/members"
+        )
+        self.render(request)
+        self.assertEquals(200, channel.code, channel.result)
+        self.assertEquals(channel.json_body, [injected.get_pdu_json()])
+
+    def test_in_room_many(self):
+        room_1 = self.helper.create_room_as(self.u1, tok=self.u1_token)
+        injected_2 = self.inject_room_member(room_1, "@user:other.example.com", "join")
+        injected_1 = self.inject_room_member(room_1, "@user2:other.example.com", "join")
+
+        request, channel = self.make_request(
+            "GET", "/_matrix/federation/v1/query/members?limit_per_room=1"
+        )
+        self.render(request)
+        self.assertEquals(200, channel.code, channel.result)
+        self.assertEquals(len(channel.json_body), 1)
+        self.assertIn(
+            channel.json_body[0], [injected_1.get_pdu_json(), injected_2.get_pdu_json()]
+        )

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -24,6 +24,7 @@ from synapse.api.errors import AuthError
 from synapse.types import UserID
 
 from tests import unittest
+from tests.unittest import override_config
 from tests.utils import register_federation_servlets
 
 # Some local users to test with
@@ -171,6 +172,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
             ],
         )
 
+    @override_config({"send_federation": True})
     def test_started_typing_remote_send(self):
         self.room_members = [U_APPLE, U_ONION]
 
@@ -234,6 +236,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
             ],
         )
 
+    @override_config({"send_federation": True})
     def test_stopped_typing(self):
         self.room_members = [U_APPLE, U_BANANA, U_ONION]
 

--- a/tests/replication/slave/storage/_base.py
+++ b/tests/replication/slave/storage/_base.py
@@ -47,7 +47,10 @@ class BaseSlavedStoreTestCase(unittest.HomeserverTestCase):
         server_factory = ReplicationStreamProtocolFactory(self.hs)
         self.streamer = server_factory.streamer
 
+        handler_factory = Mock()
         self.replication_handler = ReplicationClientHandler(self.slaved_store)
+        self.replication_handler.factory = handler_factory
+
         client_factory = ReplicationClientFactory(
             self.hs, "client_name", self.replication_handler
         )

--- a/tests/replication/tcp/streams/_base.py
+++ b/tests/replication/tcp/streams/_base.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mock import Mock
+
 from synapse.replication.tcp.commands import ReplicateCommand
 from synapse.replication.tcp.protocol import ClientReplicationStreamProtocol
 from synapse.replication.tcp.resource import ReplicationStreamProtocolFactory
@@ -30,7 +32,9 @@ class BaseStreamTestCase(unittest.HomeserverTestCase):
         server = server_factory.buildProtocol(None)
 
         # build a replication client, with a dummy handler
+        handler_factory = Mock()
         self.test_handler = TestReplicationClientHandler()
+        self.test_handler.factory = handler_factory
         self.client = ClientReplicationStreamProtocol(
             "client", "test", clock, self.test_handler
         )

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -16,8 +16,7 @@
 
 from unittest.mock import Mock
 
-from synapse.api.constants import EventTypes, Membership
-from synapse.api.room_versions import RoomVersions
+from synapse.api.constants import Membership
 from synapse.rest.admin import register_servlets_for_client_rest_resource
 from synapse.rest.client.v1 import login, room
 from synapse.types import Requester, UserID
@@ -44,8 +43,6 @@ class RoomMemberStoreTestCase(unittest.HomeserverTestCase):
         # We can't test the RoomMemberStore on its own without the other event
         # storage logic
         self.store = hs.get_datastore()
-        self.event_builder_factory = hs.get_event_builder_factory()
-        self.event_creation_handler = hs.get_event_creation_handler()
 
         self.u_alice = self.register_user("alice", "pass")
         self.t_alice = self.login("alice", "pass")
@@ -53,26 +50,6 @@ class RoomMemberStoreTestCase(unittest.HomeserverTestCase):
 
         # User elsewhere on another host
         self.u_charlie = UserID.from_string("@charlie:elsewhere")
-
-    def inject_room_member(self, room, user, membership, replaces_state=None):
-        builder = self.event_builder_factory.for_room_version(
-            RoomVersions.V1,
-            {
-                "type": EventTypes.Member,
-                "sender": user,
-                "state_key": user,
-                "room_id": room,
-                "content": {"membership": membership},
-            },
-        )
-
-        event, context = self.get_success(
-            self.event_creation_handler.create_new_client_event(builder)
-        )
-
-        self.get_success(self.store.persist_event(event, context))
-
-        return event
 
     def test_one_member(self):
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -589,6 +589,8 @@ class HomeserverTestCase(TestCase):
 
         self.get_success(self.hs.get_datastore().persist_event(event, context))
 
+        return event
+
 
 class FederatingHomeserverTestCase(HomeserverTestCase):
     """

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014-2016 OpenMarket Ltd
 # Copyright 2018 New Vector
+# Copyright 2019 Matrix.org Federation C.I.C
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import gc
 import hashlib
 import hmac
@@ -28,12 +30,16 @@ from twisted.python.threadpool import ThreadPool
 from twisted.trial import unittest
 
 from synapse.api.constants import EventTypes
+from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
 from synapse.config.homeserver import HomeServerConfig
+from synapse.config.ratelimiting import FederationRateLimitConfig
+from synapse.federation.transport import server as federation_server
 from synapse.http.server import JsonResource
 from synapse.http.site import SynapseRequest
 from synapse.logging.context import LoggingContext
 from synapse.server import HomeServer
 from synapse.types import Requester, UserID, create_requester
+from synapse.util.ratelimitutils import FederationRateLimiter
 
 from tests.server import get_clock, make_request, render, setup_test_homeserver
 from tests.test_utils.logging_setup import setup_logging
@@ -558,6 +564,57 @@ class HomeserverTestCase(TestCase):
         )
         self.render(request)
         self.assertEqual(channel.code, 403, channel.result)
+
+    def inject_room_member(self, room, user, membership, replaces_state=None):
+
+        event_builder_factory = self.hs.get_event_builder_factory()
+        event_creation_handler = self.hs.get_event_creation_handler()
+
+        room_version = self.get_success(self.hs.get_datastore().get_room_version(room))
+
+        builder = event_builder_factory.for_room_version(
+            KNOWN_ROOM_VERSIONS[room_version],
+            {
+                "type": EventTypes.Member,
+                "sender": user,
+                "state_key": user,
+                "room_id": room,
+                "content": {"membership": membership},
+            },
+        )
+
+        event, context = self.get_success(
+            event_creation_handler.create_new_client_event(builder)
+        )
+
+        self.get_success(self.hs.get_datastore().persist_event(event, context))
+
+
+class FederatingHomeserverTestCase(HomeserverTestCase):
+    """
+    A federating homeserver that authenticates incoming requests as `other.example.com`.
+    """
+
+    def prepare(self, reactor, clock, homeserver):
+        class Authenticator(object):
+            def authenticate_request(self, request, content):
+                return succeed("other.example.com")
+
+        ratelimiter = FederationRateLimiter(
+            clock,
+            FederationRateLimitConfig(
+                window_size=1,
+                sleep_limit=1,
+                sleep_msec=1,
+                reject_limit=1000,
+                concurrent_requests=1000,
+            ),
+        )
+        federation_server.register_servlets(
+            homeserver, self.resource, Authenticator(), ratelimiter
+        )
+
+        return super().prepare(reactor, clock, homeserver)
 
 
 def override_config(extra_config):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -117,6 +117,7 @@ def default_config(name, parse=False):
     """
     config_dict = {
         "server_name": name,
+        "send_federation": False,
         "media_store_path": "media",
         "uploads_path": "uploads",
         # the test signing key is just an arbitrary ed25519 key to keep the config


### PR DESCRIPTION
https://github.com/tulir/matrix-doc/blob/federation_data_loss_queries/proposals/2316-federation-data-loss-queries.md

This has the query type `net.maunium.members` in an attempt to comply with https://github.com/matrix-org/matrix-doc/blob/travis/msc/shipit/proposals/2324-when-to-ship.md