### PR TITLE
Depublish a room from the public rooms list when it is upgraded

### DIFF
--- a/changelog.d/6232.bugfix
+++ b/changelog.d/6232.bugfix
@@ -1,0 +1,1 @@
+Remove a room from a server's public rooms list on room upgrade.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -553,7 +553,7 @@ class FederationClient(FederationBase):
         Note that this does not append any events to any graphs.
 
         Args:
-            destinations (Iterable[unicode]): Candidate homeservers which are probably
+            destinations (Iterable[str]): Candidate homeservers which are probably
                 participating in the room.
             room_id (str): The room in which the event will happen.
             user_id (str): The user whose membership is being evented.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -553,7 +553,7 @@ class FederationClient(FederationBase):
         Note that this does not append any events to any graphs.
 
         Args:
-            destinations (str): Candidate homeservers which are probably
+            destinations (Iterable[unicode]): Candidate homeservers which are probably
                 participating in the room.
             room_id (str): The room in which the event will happen.
             user_id (str): The user whose membership is being evented.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1112,7 +1112,7 @@ class FederationHandler(BaseHandler):
         have finished processing the join.
 
         Args:
-            target_hosts (Iterable[unicode]): List of servers to attempt to join the room with.
+            target_hosts (Iterable[str]): List of servers to attempt to join the room with.
 
             room_id (str): The ID of the room to join.
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1180,9 +1180,19 @@ class FederationHandler(BaseHandler):
 
             # Check whether this room is the result of an upgrade of a room we already know
             # about. If so, migrate over user information
+            predecessor = yield self.store.get_room_predecessor(room_id)
+            if not predecessor:
+                return
+            old_room_id = predecessor["room_id"]
+            logger.debug(
+                "Found predecessor for %s during remote join: %s", room_id, old_room_id
+            )
+
             # We retrieve the room member handler here as to not cause a cyclic dependency
             member_handler = self.hs.get_room_member_handler()
-            yield member_handler.transfer_room_state_if_room_upgrade(room_id)
+            yield member_handler.transfer_room_state_on_room_upgrade(
+                old_room_id, room_id
+            )
 
             logger.debug("Finished joining %s to %s", joinee, room_id)
         finally:

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -129,6 +129,7 @@ class RoomCreationHandler(BaseHandler):
             old_room_id,
             new_version,  # args for _upgrade_room
         )
+
         return ret
 
     @defer.inlineCallbacks
@@ -188,7 +189,11 @@ class RoomCreationHandler(BaseHandler):
             requester, old_room_id, new_room_id, old_room_state
         )
 
-        # and finally, shut down the PLs in the old room, and update them in the new
+        # Copy over user push rules, tags and depublish the old room from the room directory
+        # if necessary
+        yield self.room_member_handler.transfer_room_state_if_room_upgrade(new_room_id)
+
+        # finally, shut down the PLs in the old room, and update them in the new
         # room.
         yield self._update_upgraded_room_pls(
             requester, old_room_id, new_room_id, old_room_state

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -189,9 +189,10 @@ class RoomCreationHandler(BaseHandler):
             requester, old_room_id, new_room_id, old_room_state
         )
 
-        # Copy over user push rules, tags and depublish the old room from the room directory
-        # if necessary
-        yield self.room_member_handler.transfer_room_state_if_room_upgrade(new_room_id)
+        # Copy over user push rules, tags and migrate room directory state
+        yield self.room_member_handler.transfer_room_state_on_room_upgrade(
+            old_room_id, new_room_id
+        )
 
         # finally, shut down the PLs in the old room, and update them in the new
         # room.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -546,7 +546,11 @@ class RoomMemberHandler(object):
             Deferred
         """
 
-        logger.debug("Copying over room tags and push rules")
+        logger.debug(
+            "Copying over room tags and push rules from %s to %s",
+            old_room_id,
+            new_room_id,
+        )
 
         # It is an upgraded room. Copy over old tags
         yield self.copy_room_tags_and_direct_to_room(old_room_id, new_room_id, user_id)

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -505,6 +505,10 @@ class RoomMemberHandler(object):
         room upgrade. At this point, the server can transfer over information from the previous
         room.
 
+        Checks if the given room is the result of a room upgrade. If so, copies user state
+        (tags/push rules) from the old room, as well as depublishing it from the room
+        directory if it was in there.
+
         Args:
             room_id (str): The ID of the room the user is joining
 

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -547,7 +547,7 @@ class RoomMemberHandler(object):
                     old_room_id, new_room_id, user_id
                 )
             except Exception:
-                logger.warning(
+                logger.exception(
                     "Error copying tags and/or push rules from rooms %s to %s for user %s. "
                     "Skipping...",
                     old_room_id,

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -512,7 +512,7 @@ class RoomMemberHandler(object):
         logger.debug("Found predecessor for %s: %s", room_id, old_room_id)
 
         # Find all local users that were in the old room and copy over each user's state
-        users = self.store.get_users_in_room(old_room_id)
+        users = yield self.store.get_users_in_room(old_room_id)
         yield self.copy_user_state_on_room_upgrade(old_room_id, room_id, users)
 
         # Depublish the old room from the room directory if it was published
@@ -535,9 +535,10 @@ class RoomMemberHandler(object):
         """
 
         logger.debug(
-            "Copying over room tags and push rules from %s to %s",
+            "Copying over room tags and push rules from %s to %s for users %s",
             old_room_id,
             new_room_id,
+            user_ids,
         )
 
         for user_id in user_ids:

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -547,6 +547,13 @@ class RoomMemberHandler(object):
                     old_room_id, new_room_id, user_id
                 )
             except Exception:
+                logger.warning(
+                    "Error copying tags and/or push rules from rooms %s to %s for user %s. "
+                    "Skipping...",
+                    old_room_id,
+                    new_room_id,
+                    user_id,
+                )
                 continue
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/4948

Remove a room from the public rooms list on a server when a user from that server joins the upgraded room, and when that user has permission to remove the listing in the old room.

Also fix an incorrect docstring.

TODO:
- [x] Remove the need for the user to have permission; we are the server so we should have power to do this
- [x] Consolidate duplicated code