### PR TITLE
Transfer rooms on groups on room upgrade

### DIFF
--- a/changelog.d/6235.bugfix
+++ b/changelog.d/6235.bugfix
@@ -1,0 +1,1 @@
+Remove a room from a server's public rooms list on room upgrade.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -514,7 +514,7 @@ class RoomMemberHandler(object):
         if old_room and old_room["is_public"]:
             yield self.store.set_room_is_public(old_room_id, False)
             yield self.store.set_room_is_public(room_id, True)
-            
+
         # Check if any groups we own contain the predecessor room
         local_group_ids = yield self.store.get_local_groups_for_room(old_room_id)
         for group_id in local_group_ids:

--- a/synapse/storage/data_stores/main/group_server.py
+++ b/synapse/storage/data_stores/main/group_server.py
@@ -552,7 +552,7 @@ class GroupServerStore(SQLBaseStore):
             keyvalues={"group_id": group_id, "role_id": role_id, "user_id": user_id},
             desc="remove_user_from_summary",
         )
-    
+
     def get_local_groups_for_room(self, room_id):
         """Get all of the local group that contain a given room
         Args:

--- a/synapse/storage/data_stores/main/group_server.py
+++ b/synapse/storage/data_stores/main/group_server.py
@@ -552,6 +552,21 @@ class GroupServerStore(SQLBaseStore):
             keyvalues={"group_id": group_id, "role_id": role_id, "user_id": user_id},
             desc="remove_user_from_summary",
         )
+    
+    def get_local_groups_for_room(self, room_id):
+        """Get all of the local group that contain a given room
+        Args:
+            room_id (str): The ID of a room
+        Returns:
+            Deferred[list[str]]: A twisted.Deferred containing a list of group ids
+                containing this room
+        """
+        return self._simple_select_onecol(
+            table="group_rooms",
+            keyvalues={"room_id": room_id},
+            retcol="group_id",
+            desc="get_local_groups_for_room",
+        )
 
     def get_users_for_summary_by_role(self, group_id, include_private=False):
         """Get the users and roles that should be included in a summary request

--- a/synapse/storage/data_stores/main/state.py
+++ b/synapse/storage/data_stores/main/state.py
@@ -285,7 +285,11 @@ class StateGroupWorkerStore(
             room_id (str)
 
         Returns:
-            Deferred[unicode|None]: predecessor room id
+            Deferred[dict|None]: A dictionary containing the structure of the predecessor
+                field from the room's create event. The structure is subject to other servers,
+                but it is expected to be:
+                    * room_id (str): The room ID of the predecessor room
+                    * event_id (str): The ID of the tombstone event in the predecessor room
 
         Raises:
             NotFoundError if the room is unknown


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/4897
~~Includes commits from https://github.com/matrix-org/synapse/pull/6232~~

~~When a user joins a room that's been upgraded, have the server check if that room is present on any local groups. If so, add its successor to the group, then remove the upgraded room.~~

When a server sees a room for the first time, or when a server upgrades a room itself, it will check if any groups it has contains that room, and if so removes it from the group and adds the upgraded room instead.

Sytest: https://github.com/matrix-org/sytest/pull/737