### PR TITLE
Add new boolean column to synapse_port_db

### DIFF
--- a/changelog.d/6247.bugfix
+++ b/changelog.d/6247.bugfix
@@ -1,0 +1,1 @@
+Update list of boolean columns in `synapse_port_db`.

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -66,6 +66,7 @@ BOOLEAN_COLUMNS = {
     "presence_list": ["accepted"],
     "presence_stream": ["currently_active"],
     "public_room_list_stream": ["visibility"],
+    "devices": ["hidden"],
     "device_lists_outbound_pokes": ["sent"],
     "users_who_share_rooms": ["share_private"],
     "groups": ["is_public"],


### PR DESCRIPTION
Add the newly-added `hidden` column of the `devices` table to the list of boolean columns in `synapse_port_db`.