### PR TITLE
Update CI to run isort on scripts and scripts-dev

### DIFF
--- a/changelog.d/6270.misc
+++ b/changelog.d/6270.misc
@@ -1,0 +1,1 @@
+Update CI to run `isort` over the `scripts` and `scripts-dev` directories.

--- a/scripts-dev/update_database
+++ b/scripts-dev/update_database
@@ -25,8 +25,8 @@ from twisted.internet import defer, reactor
 from synapse.config.homeserver import HomeServerConfig
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.server import HomeServer
-from synapse.storage.engines import create_engine
 from synapse.storage import DataStore
+from synapse.storage.engines import create_engine
 from synapse.storage.prepare_database import prepare_database
 
 logger = logging.getLogger("update_database")
@@ -122,4 +122,3 @@ if __name__ == "__main__":
     ))
 
     reactor.run()
-

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ commands =
 [testenv:check_isort]
 skip_install = True
 deps = isort
-commands = /bin/sh -c "isort -c -df -sp setup.cfg -rc synapse tests"
+commands = /bin/sh -c "isort -c -df -sp setup.cfg -rc synapse tests scripts-dev scripts"
 
 [testenv:check-newsfragment]
 skip_install = True


### PR DESCRIPTION
We already run `black` and `flake8` over the `scripts` and `scripts-dev` folders in CI:

https://github.com/matrix-org/synapse/blob/fa7cf8778eccee209b8ffadb71bbe33d12fa0f97/tox.ini#L119-L120

Do the same with `isort`.