### PR TITLE
Update email section of INSTALL.md about account_threepid_delegates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -413,16 +413,18 @@ For a more detailed guide to configuring your server for federation, see
 
 ## Email
 
-It is desirable for Synapse to have the capability to send email. For example,
-this is required to support the 'password reset' feature.
+It is desirable for Synapse to have the capability to send email. This allows
+Synapse to send password reset emails, send verifications when an email address
+is added to a user's account, and send email notifications to users when they
+receive new messages.
 
 To configure an SMTP server for Synapse, modify the configuration section
-headed ``email``, and be sure to have at least the ``smtp_host``, ``smtp_port``
-and ``notif_from`` fields filled out. You may also need to set ``smtp_user``,
-``smtp_pass``, and ``require_transport_security``.
+headed `email`, and be sure to have at least the `smtp_host`, `smtp_port`
+and `notif_from` fields filled out.  You may also need to set `smtp_user`,
+`smtp_pass`, and `require_transport_security`.
 
-If Synapse is not configured with an SMTP server, password reset via email will
- be disabled by default.
+If email is not configured password reset, registration and notifications via
+email will be disabled.
 
 ## Registering a user
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -423,7 +423,7 @@ headed `email`, and be sure to have at least the `smtp_host`, `smtp_port`
 and `notif_from` fields filled out.  You may also need to set `smtp_user`,
 `smtp_pass`, and `require_transport_security`.
 
-If email is not configured password reset, registration and notifications via
+If email is not configured, password reset, registration and notifications via
 email will be disabled.
 
 ## Registering a user

--- a/changelog.d/6272.doc
+++ b/changelog.d/6272.doc
@@ -1,0 +1,1 @@
+Update `INSTALL.md` Email section to talk about `account_threepid_delegates`.


### PR DESCRIPTION
Update the email section of `INSTALL.md` to reflect the changes made to Synapse's email setup, namely that it now handles email registration by itself, and that it will need to be configured in some sense in order for those features to be enabled.