### PR TITLE
Fix typo in domain name in account_threepid_delegates config option

### DIFF
--- a/changelog.d/6273.doc
+++ b/changelog.d/6273.doc
@@ -1,0 +1,1 @@
+Fix a small typo in `account_threepid_delegates` configuration option.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -955,7 +955,7 @@ uploads_path: "DATADIR/uploads"
 # If a delegate is specified, the config option public_baseurl must also be filled out.
 #
 account_threepid_delegates:
-    #email: https://example.com     # Delegate email sending to example.org
+    #email: https://example.com     # Delegate email sending to example.com
     #msisdn: http://localhost:8090  # Delegate SMS sending to this local process
 
 # Users who register on this homeserver will automatically be joined

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -300,7 +300,7 @@ class RegistrationConfig(Config):
         # If a delegate is specified, the config option public_baseurl must also be filled out.
         #
         account_threepid_delegates:
-            #email: https://example.com     # Delegate email sending to example.org
+            #email: https://example.com     # Delegate email sending to example.com
             #msisdn: http://localhost:8090  # Delegate SMS sending to this local process
 
         # Users who register on this homeserver will automatically be joined


### PR DESCRIPTION
Another very small typo.