### PR TITLE
Remove redundant arguments to CI's flake8

### DIFF
--- a/changelog.d/6277.misc
+++ b/changelog.d/6277.misc
@@ -1,0 +1,1 @@
+Remove redundant CLI parameters on CI's `flake8` step.

--- a/tox.ini
+++ b/tox.ini
@@ -117,7 +117,7 @@ deps =
     black==19.3b0  # We pin so that our tests don't start failing on new releases of black.
 commands =
     python -m black --check --diff .
-    /bin/sh -c "flake8 synapse tests scripts scripts-dev scripts/hash_password scripts/register_new_matrix_user scripts/synapse_port_db synctl {env:PEP8SUFFIX:}"
+    /bin/sh -c "flake8 synapse tests scripts scripts-dev synctl {env:PEP8SUFFIX:}"
     {toxinidir}/scripts-dev/config-lint.sh
 
 [testenv:check_isort]


### PR DESCRIPTION
`flake8` is already scanning the `scripts` directory, so there's no need to include specific files in the `scripts` directory.