### PR TITLE
Handle FileNotFound error in checking git repository version

### DIFF
--- a/changelog.d/6284.bugfix
+++ b/changelog.d/6284.bugfix
@@ -1,0 +1,1 @@
+Prevent errors from appearing on Synapse startup if `git` is not installed.

--- a/synapse/util/versionstring.py
+++ b/synapse/util/versionstring.py
@@ -42,6 +42,7 @@ def get_version_string(module):
     try:
         null = open(os.devnull, "w")
         cwd = os.path.dirname(os.path.abspath(module.__file__))
+
         try:
             git_branch = (
                 subprocess.check_output(
@@ -51,7 +52,8 @@ def get_version_string(module):
                 .decode("ascii")
             )
             git_branch = "b=" + git_branch
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            # FileNotFoundError can arise when git is not installed
             git_branch = ""
 
         try:
@@ -63,7 +65,7 @@ def get_version_string(module):
                 .decode("ascii")
             )
             git_tag = "t=" + git_tag
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             git_tag = ""
 
         try:
@@ -74,7 +76,7 @@ def get_version_string(module):
                 .strip()
                 .decode("ascii")
             )
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             git_commit = ""
 
         try:
@@ -89,7 +91,7 @@ def get_version_string(module):
             )
 
             git_dirty = "dirty" if is_dirty else ""
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             git_dirty = ""
 
         if git_branch or git_tag or git_commit or git_dirty:


### PR DESCRIPTION
A user hit an interesting edge case where they'd get an error if `git` was not installed: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=240498#c3

```
2019-09-11 14:43:53,745 - synapse.util.versionstring - 85 - INFO - None - Failed to check for git repository: [Errno 2] No such file or directory: 'git': 'git'
```

Just assume no git branch (does the same as if we weren't in a git directory) on `FileNotFoundError`, which not having git installed will produce:

```
✗ python3                                                                   
Python 3.6.8 (default, Jun 20 2019, 17:11:57) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import subprocess
>>> subprocess.check_output(["git", "diff"])
b'diff --git a/scripts-dev/update_database b/scripts-dev/update_database\nindex 10166583e..27a1ad1e7 100755\n--- a/scripts-dev/update_database\n+++ b/scripts-dev/update_database\n@@ -25,8 +25,8 @@ from twisted.internet import defer, reactor\n from synapse.config.homeserver import HomeServerConfig\n from synapse.metrics.background_process_metrics import run_as_background_process\n from synapse.server import HomeServer\n-from synapse.storage.engines import create_engine\n from synapse.storage import DataStore\n+from synapse.storage.engines import create_engine\n from synapse.storage.prepare_database import prepare_database\n \n logger = logging.getLogger("update_database")\n@@ -122,4 +122,3 @@ if __name__ == "__main__":\n     ))\n \n     reactor.run()\n-\n'
>>> subprocess.check_output(["gitx", "diff"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/.pyenv/versions/3.6.8/lib/python3.6/subprocess.py", line 356, in check_output
    **kwargs).stdout
  File "/home/user/.pyenv/versions/3.6.8/lib/python3.6/subprocess.py", line 423, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/home/user/.pyenv/versions/3.6.8/lib/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/home/user/.pyenv/versions/3.6.8/lib/python3.6/subprocess.py", line 1364, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'gitx': 'gitx'
>>> 
```