### PR TITLE
rstrip slashes from url on appservice

### DIFF
--- a/changelog.d/6306.bugfix
+++ b/changelog.d/6306.bugfix
@@ -1,0 +1,1 @@
+Appservice requests will no longer contain a double slash prefix when the appservice url provided ends in a slash.

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -94,7 +94,9 @@ class ApplicationService(object):
         ip_range_whitelist=None,
     ):
         self.token = token
-        self.url = None if url is None else url.rstrip("/")  # url must not end with a slash
+        self.url = (
+            None if url is None else url.rstrip("/")
+        )  # url must not end with a slash
         self.hs_token = hs_token
         self.sender = sender
         self.server_name = hostname

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -94,7 +94,7 @@ class ApplicationService(object):
         ip_range_whitelist=None,
     ):
         self.token = token
-        self.url = url.rstrip("/") # url must not end with a slash
+        self.url = url.rstrip("/")  # url must not end with a slash
         self.hs_token = hs_token
         self.sender = sender
         self.server_name = hostname

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -94,7 +94,7 @@ class ApplicationService(object):
         ip_range_whitelist=None,
     ):
         self.token = token
-        self.url = url
+        self.url = url.rstrip("/") # url must not end with a slash
         self.hs_token = hs_token
         self.sender = sender
         self.server_name = hostname

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -94,7 +94,7 @@ class ApplicationService(object):
         ip_range_whitelist=None,
     ):
         self.token = token
-        self.url = url.rstrip("/")  # url must not end with a slash
+        self.url = None if url is None else url.rstrip("/")  # url must not end with a slash
         self.hs_token = hs_token
         self.sender = sender
         self.server_name = hostname

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -95,7 +95,7 @@ class ApplicationService(object):
     ):
         self.token = token
         self.url = (
-            None if url is None else url.rstrip("/")
+            url.rstrip("/") if isinstance(url, str) else None
         )  # url must not end with a slash
         self.hs_token = hs_token
         self.sender = sender


### PR DESCRIPTION
On many occasions users have written registration files that contain an ending slash. Synapse already prefixes every request with a slash and this tends to trip up users more often than not. It seems wise here to just remove any trailing slashes on initiation.

And joy of joys, this fixes https://github.com/matrix-org/synapse/issues/3523