### PR TITLE
MSC2326: Add background update to take previous events into account

### DIFF
--- a/changelog.d/6310.feature
+++ b/changelog.d/6310.feature
@@ -1,1 +1,1 @@
-Implement label-based filtering.
+Implement label-based filtering on `/sync` and `/messages` ([MSC2326](https://github.com/matrix-org/matrix-doc/pull/2326)).

--- a/changelog.d/6310.feature
+++ b/changelog.d/6310.feature
@@ -1,0 +1,1 @@
+Implement label-based filtering.

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -522,7 +522,7 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
                 WHERE event_id > ? AND label IS NULL
                 LIMIT ?
                 """,
-                (last_event_id, batch_size)
+                (last_event_id, batch_size),
             )
 
             rows = self.cursor_to_dict(txn)
@@ -537,12 +537,9 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
                     txn=txn,
                     table="event_labels",
                     values=[
-                        {
-                            "event_id": event_id,
-                            "label": label,
-                        }
+                        {"event_id": event_id, "label": label}
                         for label in event_json["content"].get(LabelsField, [])
-                    ]
+                    ],
                 )
 
             self._background_update_progress_txn(

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -525,9 +525,11 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
                 (last_event_id, batch_size),
             )
 
+            results = list(txn)
+
             nbrows = 0
             last_row_event_id = ""
-            for (event_id, event_json_raw) in txn:
+            for (event_id, event_json_raw) in results:
                 event_json = json.loads(event_json_raw)
 
                 self._simple_insert_many_txn(

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -518,7 +518,8 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
             txn.execute(
                 """
                 SELECT event_id, json FROM event_json
-                WHERE event_id > ?
+                LEFT JOIN event_labels USING (event_id)
+                WHERE event_id > ? AND label IS NULL
                 LIMIT ?
                 """,
                 (last_event_id, batch_size)

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -527,7 +527,7 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
 
             rows = self.cursor_to_dict(txn)
             if not rows:
-                return True
+                return True, 0
 
             for row in rows:
                 event_id = row["event_id"]
@@ -550,13 +550,13 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
 
             # We want to return true (to end the background update) only when
             # the query returned with less rows than we asked for.
-            return len(rows) != batch_size
+            return len(rows) != batch_size, len(rows)
 
-        end = yield self.runInteraction(
+        end, num_rows = yield self.runInteraction(
             desc="event_store_labels", func=_event_store_labels_txn
         )
 
         if end:
             yield self._end_background_update("event_store_labels")
 
-        return batch_size
+        return num_rows

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -548,6 +548,8 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
 
             # We want to return true (to end the background update) only when
             # the query returned with less rows than we asked for.
+            # TODO: this currently doesn't work, i.e. it only runs once whereas
+            #       its opposite does the whole thing, investigate.
             return len(rows) != batch_size
 
         end = yield self.runInteraction(

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -524,7 +524,7 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
                 (last_event_id, batch_size)
             )
 
-            rows = txn.fetchall()
+            rows = self.cursor_to_dict(txn)
             if not rows:
                 return True
 

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -511,7 +511,7 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
 
     @defer.inlineCallbacks
     def _event_store_labels(self, progress, batch_size):
-        """Stores labels for events."""
+        """Background update handler which will store labels for existing events."""
         last_event_id = progress.get("last_event_id", "")
 
         def _event_store_labels_txn(txn):

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -546,7 +546,9 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
                 txn, "event_store_labels", {"last_event_id": event_id}
             )
 
-            return len(rows) == batch_size
+            # We want to return true (to end the background update) only when
+            # the query returned with less rows than we asked for.
+            return len(rows) != batch_size
 
         end = yield self.runInteraction(
             desc="event_store_labels", func=_event_store_labels_txn

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -540,7 +540,7 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
                             "event_id": event_id,
                             "label": label,
                         }
-                        for label in event_json["content"].get(LabelsField)
+                        for label in event_json["content"].get(LabelsField, [])
                     ]
                 )
 

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -544,7 +544,7 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
                             "topological_ordering": event_json["depth"],
                         }
                         for label in event_json["content"].get(
-                            EventContentFields.Labels, []
+                            EventContentFields.LABELS, []
                         )
                     ],
                 )

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -545,7 +545,7 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
                         for label in event_json["content"].get(
                             EventContentFields.LABELS, []
                         )
-                        if label is not None and isinstance(label, str)
+                        if isinstance(label, str)
                     ],
                 )
 

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -537,7 +537,12 @@ class EventsBackgroundUpdatesStore(BackgroundUpdateStore):
                     txn=txn,
                     table="event_labels",
                     values=[
-                        {"event_id": event_id, "label": label}
+                        {
+                            "event_id": event_id,
+                            "label": label,
+                            "room_id": event_json["room_id"],
+                            "topological_ordering": event_json["depth"],
+                        }
                         for label in event_json["content"].get(
                             EventContentFields.Labels, []
                         )

--- a/synapse/storage/data_stores/main/schema/delta/56/event_labels_background_update.sql
+++ b/synapse/storage/data_stores/main/schema/delta/56/event_labels_background_update.sql
@@ -1,0 +1,17 @@
+/* Copyright 2019 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+INSERT INTO background_updates (update_name, progress_json) VALUES
+  ('event_store_labels', '{}');


### PR DESCRIPTION
Built on top of #6301 

Add a background update that goes through all of the events in the server's database and, for each event that has at least one label, saves those labels to the `event_labels` table, so that events sent prior to upgrading Synapse can be filtered by labels (like the ones sent after the upgrade).

Fixes #6288 