### PR TITLE
Document lint.sh & allow application to specified files only

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -62,7 +62,9 @@ To facilitate meeting these criteria you can run ``scripts-dev/lint.sh``
 locally. Since this runs the tools listed in the above document, you'll need
 python 3.6 and to install each tool. **Note that the script does not just
 test/check, but also reformats code, so you may wish to ensure any new code is
-committed first**.
+committed first**. By default this script checks all files and can take some
+time; if you alter only certain files, you might wish to specify paths as
+arguments to reduce the run-time.
 
 Please ensure your changes match the cosmetic style of the existing project,
 and **never** mix cosmetic and functional changes in the same commit, as it

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -58,6 +58,12 @@ All Matrix projects have a well-defined code-style - and sometimes we've even
 got as far as documenting it... For instance, synapse's code style doc lives
 at https://github.com/matrix-org/synapse/tree/master/docs/code_style.md.
 
+To facilitate meeting these criteria you can run ``scripts-dev/lint.sh``
+locally. Since this runs the tools listed in the above document, you'll need
+python 3.6 and to install each tool. **Note that the script does not just
+test/check, but also reformats code, so you may wish to ensure any new code is
+committed first**.
+
 Please ensure your changes match the cosmetic style of the existing project,
 and **never** mix cosmetic and functional changes in the same commit, as it
 makes it horribly hard to review otherwise.

--- a/changelog.d/6312.misc
+++ b/changelog.d/6312.misc
@@ -1,0 +1,1 @@
+Document the use of `lint.sh` for code style enforcement & extend it to run on specified paths only.

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -7,7 +7,15 @@
 
 set -e
 
-isort -y -rc synapse tests scripts-dev scripts
-flake8 synapse tests
-python3 -m black synapse tests scripts-dev scripts
+if [ $# -ge 1 ]
+then
+  files=$*
+else
+  files="synapse tests scripts-dev scripts"
+fi
+
+echo "Linting these locations: $files"
+isort -y -rc $files
+flake8 $files
+python3 -m black $files
 ./scripts-dev/config-lint.sh


### PR DESCRIPTION
Thanks to @anoadragon453 for pointing me towards `lint.sh` :+1: 

So others can find it, this PR adds a note about it in the Code Style section of `CONTRIBUTING`.

Since the tool can take a while to run, I've amended it slightly to enable running it on specified files (if any arguments are provided), and adjusted the documentation added in the first commit accordingly. Now I can just run it on specific updated files, rather than it taking 4-5m here :)