### PR TITLE
fix hidden field in devices table for older sqlite

### DIFF
--- a/changelog.d/6313.bugfix
+++ b/changelog.d/6313.bugfix
@@ -1,0 +1,1 @@
+Fix the `hidden` field in the `devices` table for SQLite versions prior to 3.23.0.

--- a/synapse/storage/data_stores/main/schema/delta/56/hidden_devices_fix.sql.sqlite
+++ b/synapse/storage/data_stores/main/schema/delta/56/hidden_devices_fix.sql.sqlite
@@ -1,0 +1,42 @@
+/* Copyright 2019 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Change the hidden column from a default value of FALSE to a default value of
+ * 0, because sqlite3 prior to 3.23.0 caused the hidden column to contain the
+ * string 'FALSE', which is truthy.
+ *
+ * Since sqlite doesn't allow us to just change the default value, we have to
+ * recreate the table, copy the data, fix the rows that have incorrect data, and
+ * replace the old table with the new table.
+ */
+
+CREATE TABLE IF NOT EXISTS devices2 (
+    user_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    display_name TEXT,
+    last_seen BIGINT,
+    ip TEXT,
+    user_agent TEXT,
+    hidden BOOLEAN DEFAULT 0,
+    CONSTRAINT device_uniqueness UNIQUE (user_id, device_id)
+);
+
+INSERT INTO devices2 SELECT * FROM devices;
+
+UPDATE devices2 SET hidden = 0 WHERE hidden = 'FALSE';
+
+DROP TABLE devices;
+
+ALTER TABLE devices2 RENAME TO devices;


### PR DESCRIPTION
fixes https://github.com/matrix-org/synapse/issues/6302

I've tested sqlite 3.27.2 (Debian buster) and sqlite 3.16.2 (Debian stretch), both doing upgrades of v1.4.1 -> v1.5.0 -> this branch, as well as v1.4.1 -> this branch.  All the tests resulted in the correct behaviour of the `hidden` field set to 0 instead of `'FALSE'`.

I was unable to figure out a way to avoid doing the db upgrade step from `56/hidden_devices.sql` when going v1.4.1 -> this branch.  Anything that I thought of would break something in sqlite and/or postgresql.  So we're stuck with doing `56/hidden_devices.sql` followed immediately by `56/hidden_devices_fix.sql.sqlite` for sqlite database, which has to copy the whole `devices` table.