### PR TITLE
Expose common commands via snap run interface to allow easier invocation

### DIFF
--- a/changelog.d/6315.feature
+++ b/changelog.d/6315.feature
@@ -1,0 +1,1 @@
+Exposed synctl, hash_password and generate_config via the snap run interface.

--- a/changelog.d/6315.feature
+++ b/changelog.d/6315.feature
@@ -1,1 +1,1 @@
-Exposed synctl, hash_password and generate_config via the snap run interface.
+Expose the `synctl`, `hash_password` and `generate_config` commands in the snapcraft package. Contributed by @devec0.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,20 +1,31 @@
 name: matrix-synapse
 base: core18
-version: git 
+version: git
 summary: Reference Matrix homeserver
 description: |
   Synapse is the reference Matrix homeserver.
   Matrix is a federated and decentralised instant messaging and VoIP system.
 
-grade: stable 
-confinement: strict 
+grade: stable
+confinement: strict
 
 apps:
-  matrix-synapse: 
+  matrix-synapse:
     command: synctl --no-daemonize start $SNAP_COMMON/homeserver.yaml
     stop-command: synctl -c $SNAP_COMMON stop
     plugs: [network-bind, network]
-    daemon: simple 
+    daemon: simple
+  hash-password:
+    command: hash_password
+  generate-config:
+    command: generate_config
+  generate-signing-key:
+    command: generate_signing_key.py
+  register-new-matrix-user:
+    command: register_new_matrix_user
+    plugs: [network]
+  synctl:
+    command: synctl
 parts:
   matrix-synapse:
     source: .


### PR DESCRIPTION
### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

This PR exposed three binaries via the snap run interface, to make it easier to run them without entering the snap with `snap run --shell`.
 * synctl
 * hash_password
 * generate_config
 * generate_signing_key.py
 * register_new_matrix_user

The underscores in the name have been replaced with dashes when exposed via snap as the underscore is invalid schema for snapcraft commands. The binaries themselves remain unmodified and use their original names.

Signed-off-by: James Hebden <james@ec0.io>