### PR TITLE
Add optional python dependencies to snap packaging

### DIFF
--- a/changelog.d/6317.misc
+++ b/changelog.d/6317.misc
@@ -1,0 +1,1 @@
+Add optional python dependencies and dependant binary libraries to snapcraft packaging.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,3 +20,23 @@ parts:
     source: .
     plugin: python
     python-version: python3
+    python-packages:
+      - '.[all]'
+    build-packages:
+      - libffi-dev
+      - libturbojpeg0-dev
+      - libssl-dev
+      - libxslt1-dev
+      - libpq-dev
+      - zlib1g-dev
+    stage-packages:
+      - libasn1-8-heimdal
+      - libgssapi3-heimdal
+      - libhcrypto4-heimdal
+      - libheimbase1-heimdal
+      - libheimntlm0-heimdal
+      - libhx509-5-heimdal
+      - libkrb5-26-heimdal
+      - libldap-2.4-2
+      - libpq5
+      - libsasl2-2


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

This PR adds the optional dependencies to snapcraft packaging, including required build and stage libraries to enable features such as PostgreSQL support.

NOTE: This is currently done by adding the '.[all]' requirement to the python-packages section of the snapcraft file, to avoid having to keep the snapcraft file up to date as dependencies change, and also to work around al imitation in snapcraft, noted in [LP#1786939](https://bugs.launchpad.net/snapcraft/+bug/1786939). Once this bug is fixed, then the method could be changed to use a supported snapcraft option to pull in additional dependencies based on the `extras_require` section of setup.py directly.

The additional stage and build packages are just used to ensure the required binary libraries which are needed by the optional dependencies are included in the resulting snap.

I have built and tested t his snap and am able to run a synapse instance using PostgreSQL as backing database based on these changes.

Signed-off-by: James Hebden <james@ec0.io>