### PR TITLE
Prevent account_data content from being sent over TCP replication

### DIFF
--- a/changelog.d/6333.bugfix
+++ b/changelog.d/6333.bugfix
@@ -1,0 +1,1 @@
+Prevent account data syncs getting lost across TCP replication.

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -89,7 +89,7 @@ TagAccountDataStreamRow = namedtuple(
 )
 AccountDataStreamRow = namedtuple(
     "AccountDataStream",
-    ("user_id", "room_id", "data_type", "data"),  # str  # str  # str  # dict
+    ("user_id", "room_id", "data_type"),  # str  # str  # str
 )
 GroupsStreamRow = namedtuple(
     "GroupsStreamRow",
@@ -421,8 +421,8 @@ class AccountDataStream(Stream):
 
         results = list(room_results)
         results.extend(
-            (stream_id, user_id, None, account_data_type, content)
-            for stream_id, user_id, account_data_type, content in global_results
+            (stream_id, user_id, None, account_data_type)
+            for stream_id, user_id, account_data_type in global_results
         )
 
         return results

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -88,8 +88,7 @@ TagAccountDataStreamRow = namedtuple(
     "TagAccountDataStreamRow", ("user_id", "room_id", "data")  # str  # str  # dict
 )
 AccountDataStreamRow = namedtuple(
-    "AccountDataStream",
-    ("user_id", "room_id", "data_type"),  # str  # str  # str
+    "AccountDataStream", ("user_id", "room_id", "data_type")  # str  # str  # str
 )
 GroupsStreamRow = namedtuple(
     "GroupsStreamRow",

--- a/synapse/storage/data_stores/main/account_data.py
+++ b/synapse/storage/data_stores/main/account_data.py
@@ -184,14 +184,14 @@ class AccountDataWorkerStore(SQLBaseStore):
             current_id(int): The position to fetch up to.
         Returns:
             A deferred pair of lists of tuples of stream_id int, user_id string,
-            room_id string, type string, and content string.
+            room_id string, and type string.
         """
         if last_room_id == current_id and last_global_id == current_id:
             return defer.succeed(([], []))
 
         def get_updated_account_data_txn(txn):
             sql = (
-                "SELECT stream_id, user_id, account_data_type, content"
+                "SELECT stream_id, user_id, account_data_type"
                 " FROM account_data WHERE ? < stream_id AND stream_id <= ?"
                 " ORDER BY stream_id ASC LIMIT ?"
             )
@@ -199,7 +199,7 @@ class AccountDataWorkerStore(SQLBaseStore):
             global_results = txn.fetchall()
 
             sql = (
-                "SELECT stream_id, user_id, room_id, account_data_type, content"
+                "SELECT stream_id, user_id, room_id, account_data_type"
                 " FROM room_account_data WHERE ? < stream_id AND stream_id <= ?"
                 " ORDER BY stream_id ASC LIMIT ?"
             )


### PR DESCRIPTION
There was an issue with changes to `account_data` not being reflected upon a `/sync` request from a client, specifically changes to `m.direct`. The client would send a `PUT /.../m.direct`, but never receive the new version down `/sync`.

This seemed to only happen on servers running in worker mode for large user accounts. It turns out that `m.direct` for large user accounts is *huge*, literally a dictionary for every user_id and room_id for a direct chat that your account has.

When a change is made on the master process, the updated account_data entry is replicated over to synchrotron workers, to tell them that they need to send down a new copy to clients when they ask for it. Unfortunately, the content of this replication was so large that twisted would deny it and drop the request:

```
Traceback (most recent call last):
  File "/home/ops/.synapse3/env3/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
StopIteration: ([(505374, ('@andrewm:amorgan.xyz', None, 'm.direct', '{"@xxx:matrix.org": ["!WUAgSOAjsAMjDlDkhf:amorgan.xyz", "!uLpJrldJgpBjerWFJD:matrix.org", "!aSlnrTeGrTkKwziiij:matrix.org"], "@yyy:matrix.org": ["!yZHTGeDKZUeKaqeTeU:matrix.org"], <truncated>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ops/.synapse3/env3/lib/python3.5/site-packages/synapse/replication/tcp/resource.py", line 225, in _run_notifier_loop
    conn.stream_update(stream.NAME, token, row)
  File "/home/ops/.synapse3/env3/lib/python3.5/site-packages/synapse/replication/tcp/protocol.py", line 544, in stream_update
    self.send_command(RdataCommand(stream_name, token, data))
  File "/home/ops/.synapse3/env3/lib/python3.5/site-packages/synapse/replication/tcp/protocol.py", line 293, in send_command
    % (cmd.NAME, len(encoded_string), self.MAX_LENGTH)
Exception: Failed to send command RDATA as too long (21544 > 16384)
```

This means the synchrotron would never get the update, and never know to send the updated account_data entry to clients.

Instead, since the account_data cache on the synchrotron is already invalidated through replication, we can simply stop sending the content of account_data.m.direct over instead. Replications will, the synchrotron will know to pull m.direct data out of the database a fresh, and everything works again.