### PR TITLE
Make numeric user_id checker start at @0, and don't ratelimit on checking

### DIFF
--- a/changelog.d/6338.bugfix
+++ b/changelog.d/6338.bugfix
@@ -1,0 +1,1 @@
+Prevent the server taking a long time to start up when guest registration is enabled.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -168,7 +168,7 @@ class RegistrationHandler(BaseHandler):
         Raises:
             RegistrationError if there was a problem registering.
         """
-        yield self._check_registration_ratelimit(address)
+        yield self.check_registration_ratelimit(address)
 
         yield self.auth.check_auth_blocking(threepid=threepid)
         password_hash = None
@@ -415,7 +415,7 @@ class RegistrationHandler(BaseHandler):
             ratelimit=False,
         )
 
-    def _check_registration_ratelimit(self, address):
+    def check_registration_ratelimit(self, address):
         """A simple helper method to check whether the registration rate limit has been hit
         for a given IP address
 

--- a/synapse/replication/http/register.py
+++ b/synapse/replication/http/register.py
@@ -75,7 +75,7 @@ class ReplicationRegisterServlet(ReplicationEndpoint):
     async def _handle_request(self, request, user_id):
         content = parse_json_object_from_request(request)
 
-        await self.registration_handler.check_registration_ratelimit(content["address"])
+        self.registration_handler.check_registration_ratelimit(content["address"])
 
         await self.registration_handler.register_with_store(
             user_id=user_id,

--- a/synapse/replication/http/register.py
+++ b/synapse/replication/http/register.py
@@ -75,6 +75,8 @@ class ReplicationRegisterServlet(ReplicationEndpoint):
     async def _handle_request(self, request, user_id):
         content = parse_json_object_from_request(request)
 
+        await self.registration_handler.check_registration_ratelimit(content["address"])
+
         await self.registration_handler.register_with_store(
             user_id=user_id,
             password_hash=content["password_hash"],

--- a/synapse/storage/data_stores/main/registration.py
+++ b/synapse/storage/data_stores/main/registration.py
@@ -488,14 +488,14 @@ class RegistrationWorkerStore(SQLBaseStore):
         we can. Unfortunately, it's possible some of them are already taken by
         existing users, and there may be gaps in the already taken range. This
         function returns the start of the first allocatable gap. This is to
-        avoid the case of ID 10000000 being pre-allocated, so us wasting the
-        first (and shortest) many generated user IDs.
+        avoid the case of ID 1000 being pre-allocated and starting at 1001 while
+        0-999 are available.
         """
 
         def _find_next_generated_user_id(txn):
-            # We bound between '@1' and '@a' to avoid pulling the entire table
+            # We bound between '@0' and '@a' to avoid pulling the entire table
             # out.
-            txn.execute("SELECT name FROM users WHERE '@1' <= name AND name < '@a'")
+            txn.execute("SELECT name FROM users WHERE '@0' <= name AND name < '@a'")
 
             regex = re.compile(r"^@(\d+):")
 


### PR DESCRIPTION
Fixes #5225 

This PR:

* Changes [`find_next_generated_user_id_localpart`](https://github.com/matrix-org/synapse/blob/master/synapse/storage/data_stores/main/registration.py#L483) to start at `@0` instead of `@1`, so we don't tell people it's ok to register `@0` and then they proceed to try every number up the entire table
* I've removed the rate limiting check from `register_with_store` and moved it up and out, also eliminating the need to have an explicit check for application service registration.