### PR TITLE
Fix the SQL SELECT query in _paginate_room_events_txn

### DIFF
--- a/changelog.d/6340.feature
+++ b/changelog.d/6340.feature
@@ -1,0 +1,1 @@
+Implement label-based filtering on `/sync` and `/messages` ([MSC2326](https://github.com/matrix-org/matrix-doc/pull/2326)).

--- a/synapse/storage/data_stores/main/stream.py
+++ b/synapse/storage/data_stores/main/stream.py
@@ -877,10 +877,10 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
             # If we're not filtering on a label, then joining on event_labels will
             # return as many row for a single event as the number of labels it has. To
             # avoid this, only join if we're filtering on at least one label.
-            join_clause = (
-                "LEFT JOIN event_labels"
-                " USING (event_id, room_id, topological_ordering)"
-            )
+            join_clause = """
+                LEFT JOIN event_labels
+                USING (event_id, room_id, topological_ordering)
+            """
             if len(event_filter.labels) > 1:
                 # Using DISTINCT in this SELECT query is quite expensive, because it
                 # requires the engine to sort on the entire (not limited) result set,
@@ -890,14 +890,14 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
                 # the results.
                 select_keywords += "DISTINCT"
 
-        sql = (
-            "%(select_keywords)s event_id, topological_ordering, stream_ordering"
-            " FROM events"
-            " %(join_clause)s"
-            " WHERE outlier = ? AND room_id = ? AND %(bounds)s"
-            " ORDER BY topological_ordering %(order)s,"
-            " stream_ordering %(order)s LIMIT ?"
-        ) % {
+        sql = """
+            %(select_keywords)s event_id, topological_ordering, stream_ordering
+            FROM events
+            %(join_clause)s
+            WHERE outlier = ? AND room_id = ? AND %(bounds)s
+            ORDER BY topological_ordering %(order)s,
+            stream_ordering %(order)s LIMIT ?
+        """ % {
             "select_keywords": select_keywords,
             "join_clause": join_clause,
             "bounds": bounds,

--- a/synapse/storage/data_stores/main/stream.py
+++ b/synapse/storage/data_stores/main/stream.py
@@ -876,11 +876,9 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
         # table. We only need to use it when we're filtering on more than two labels,
         # because that's the only scenario in which we can possibly to get multiple times
         # the same event ID in the results.
-        if event_filter.labels and len(event_filter.labels) > 1:
-            select_keywords = "SELECT DISTINCT"
-
-        else:
-            select_keywords = "SELECT"
+        select_keywords = "SELECT"
+        if event_filter and event_filter.labels and len(event_filter.labels) > 1:
+            select_keywords += "DISTINCT"
 
         sql = (
             "%(select_keywords)s event_id, topological_ordering, stream_ordering"

--- a/synapse/storage/data_stores/main/stream.py
+++ b/synapse/storage/data_stores/main/stream.py
@@ -871,23 +871,38 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
 
         args.append(int(limit))
 
-        # Using DISTINCT in this SELECT query is quite expensive, because it requires the
-        # engine to sort on the entire (not limited) result set, i.e. the entire events
-        # table. We only need to use it when we're filtering on more than two labels,
-        # because that's the only scenario in which we can possibly to get multiple times
-        # the same event ID in the results.
         select_keywords = "SELECT"
-        if event_filter and event_filter.labels and len(event_filter.labels) > 1:
-            select_keywords += "DISTINCT"
+        join_clause = ""
+        if event_filter and event_filter.labels:
+            # If we're not filtering on a label, then joining on event_labels will
+            # return as many row for a single event as the number of labels it has. To
+            # avoid this, only join if we're filtering on at least one label. 
+            join_clause = (
+                "LEFT JOIN event_labels"
+                " USING (event_id, room_id, topological_ordering)"
+            )
+            if len(event_filter.labels) > 1:
+                # Using DISTINCT in this SELECT query is quite expensive, because it
+                # requires the engine to sort on the entire (not limited) result set,
+                # i.e. the entire events table. We only need to use it when we're
+                # filtering on more than two labels, because that's the only scenario
+                # in which we can possibly to get multiple times the same event ID in
+                # the results.
+                select_keywords += "DISTINCT"
 
         sql = (
             "%(select_keywords)s event_id, topological_ordering, stream_ordering"
             " FROM events"
-            " LEFT JOIN event_labels USING (event_id, room_id, topological_ordering)"
+            " %(join_clause)s"
             " WHERE outlier = ? AND room_id = ? AND %(bounds)s"
             " ORDER BY topological_ordering %(order)s,"
             " stream_ordering %(order)s LIMIT ?"
-        ) % {"select_keywords": select_keywords, "bounds": bounds, "order": order}
+        ) % {
+            "select_keywords": select_keywords,
+            "join_clause": join_clause,
+            "bounds": bounds,
+            "order": order
+        }
 
         txn.execute(sql, args)
 

--- a/synapse/storage/data_stores/main/stream.py
+++ b/synapse/storage/data_stores/main/stream.py
@@ -876,7 +876,7 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
         if event_filter and event_filter.labels:
             # If we're not filtering on a label, then joining on event_labels will
             # return as many row for a single event as the number of labels it has. To
-            # avoid this, only join if we're filtering on at least one label. 
+            # avoid this, only join if we're filtering on at least one label.
             join_clause = (
                 "LEFT JOIN event_labels"
                 " USING (event_id, room_id, topological_ordering)"
@@ -901,7 +901,7 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
             "select_keywords": select_keywords,
             "join_clause": join_clause,
             "bounds": bounds,
-            "order": order
+            "order": order,
         }
 
         txn.execute(sql, args)


### PR DESCRIPTION
Doing a SELECT DISTINCT when paginating is quite expensive, because it requires the engine to do sorting on the entire events table. However, we only need to run it if we're filtering on 2+ labels, so this PR is changing the request so that DISTINCT is only used then.

Fixes #6337