### PR TITLE
Fix guest -> real account upgrade with account validity enabled

### DIFF
--- a/changelog.d/6359.bugfix
+++ b/changelog.d/6359.bugfix
@@ -1,0 +1,1 @@
+Fix bug where upgrading a guest account to a full user would fail when account validity is enabled.

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -361,14 +361,11 @@ class SQLBaseStore(object):
                 expiration_ts,
             )
 
-        self._simple_insert_txn(
+        self._simple_upsert_txn(
             txn,
             "account_validity",
-            values={
-                "user_id": user_id,
-                "expiration_ts_ms": expiration_ts,
-                "email_sent": False,
-            },
+            keyvalues={"user_id": user_id,},
+            values={"expiration_ts_ms": expiration_ts, "email_sent": False,},
         )
 
     def start_profiling(self):

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -364,8 +364,8 @@ class SQLBaseStore(object):
         self._simple_upsert_txn(
             txn,
             "account_validity",
-            keyvalues={"user_id": user_id, },
-            values={"expiration_ts_ms": expiration_ts, "email_sent": False, },
+            keyvalues={"user_id": user_id},
+            values={"expiration_ts_ms": expiration_ts, "email_sent": False},
         )
 
     def start_profiling(self):

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -364,8 +364,8 @@ class SQLBaseStore(object):
         self._simple_upsert_txn(
             txn,
             "account_validity",
-            keyvalues={"user_id": user_id,},
-            values={"expiration_ts_ms": expiration_ts, "email_sent": False,},
+            keyvalues={"user_id": user_id, },
+            values={"expiration_ts_ms": expiration_ts, "email_sent": False, },
         )
 
     def start_profiling(self):


### PR DESCRIPTION
When [enabling account validity on sytest](https://github.com/matrix-org/sytest/pull/743), I noticed the test "Guest user can upgrade to fully featured user" broke. This was due to this user being registered once as a guest, then again as a real user. This failed when account validity was enabled however, as inserting into the `account_validity` table sets `user_id` as a unique column, and we were trying to insert the same thing into two rows.

I've changed the insert to an upsert, which still makes sense and doesn't crash in this edge case.