### PR TITLE
WIP: Oauth: support

### DIFF
--- a/synapse/app/client_reader.py
+++ b/synapse/app/client_reader.py
@@ -47,6 +47,7 @@ from synapse.replication.slave.storage.room import RoomStore
 from synapse.replication.slave.storage.transactions import SlavedTransactionStore
 from synapse.replication.tcp.client import ReplicationClientHandler
 from synapse.rest.client.v1.login import LoginRestServlet
+from synapse.rest.client.v1.login import OauthRestServlet
 from synapse.rest.client.v1.push_rule import PushRuleRestServlet
 from synapse.rest.client.v1.room import (
     JoinedRoomMemberListRestServlet,
@@ -114,6 +115,7 @@ class ClientReaderServer(HomeServer):
                     RoomMessageListRestServlet(self).register(resource)
                     RegisterRestServlet(self).register(resource)
                     LoginRestServlet(self).register(resource)
+                    OauthRestServlet(self).register(resource)
                     ThreepidRestServlet(self).register(resource)
                     KeyQueryServlet(self).register(resource)
                     KeyChangesServlet(self).register(resource)

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -325,6 +325,18 @@ class LoginRestServlet(RestServlet):
         return result
 
 
+class OauthRestServlet(RestServlet):
+    PATTERNS = client_patterns("/oauth$", v1=True)
+
+    def __init__(self, hs):
+        super(OauthRestServlet, self).__init__()
+        self.hs = hs
+
+    def on_GET(self, request):
+        providers = [{"type": "m.oauth.mediawiki"}]
+        return 200, {"providers": providers}
+
+
 class BaseSSORedirectServlet(RestServlet):
     """Common base class for /login/sso/redirect impls"""
 
@@ -543,6 +555,7 @@ class SSOAuthHandler(object):
 
 def register_servlets(hs, http_server):
     LoginRestServlet(hs).register(http_server)
+    OauthRestServlet(hs).register(http_server)
     if hs.config.cas_enabled:
         CasRedirectServlet(hs).register(http_server)
         CasTicketServlet(hs).register(http_server)


### PR DESCRIPTION
Issue: https://github.com/matrix-org/synapse/issues/2376

Currently this only adds a endpoint that can return the supported providers to the client. I am probably going to work on the configuration next.

I could use some help which Oauth library to use. I was thinking of https://github.com/python-social-auth/social-core because it has a lot of supported providers.

Part of these pull requests:
- matrix-react-sdk: https://github.com/matrix-org/matrix-react-sdk/pull/3623
- matrix-js-sdk: https://github.com/matrix-org/matrix-js-sdk/pull/1073
- riot-web: https://github.com/vector-im/riot-web/pull/11401

Signed-off-by: Tobias Schönberg <tobias47n9e@gmail.com>
