### PR TITLE
Remove assertion and provide a clear warning on startup for missing public_baseurl

### DIFF
--- a/changelog.d/6379.misc
+++ b/changelog.d/6379.misc
@@ -1,0 +1,1 @@
+Complain on startup instead of 500'ing during runtime when `public_baseurl` isn't set when necessary.

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -240,14 +240,6 @@ class EmailConfig(Config):
             self.email_add_threepid_template_success_html_content = self.read_file(
                 filepath, "email.add_threepid_template_success_html"
             )
-        elif self.account_threepid_delegate_msisdn:
-            if not self.public_baseurl:
-                raise ConfigError(
-                    "The configuration option `public_baseurl` is required if "
-                    "`account_threepid_delegate.msisdn` is set, such that "
-                    "clients know where to submit validation tokens to. Please "
-                    "configure `public_baseurl`."
-                )
 
         if self.email_enable_notifs:
             required = [

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -146,6 +146,8 @@ class EmailConfig(Config):
                 if k not in email_config:
                     missing.append("email." + k)
 
+            # public_baseurl is required to build password reset and validation links that
+            # will be emailed to users
             if config.get("public_baseurl") is None:
                 missing.append("public_baseurl")
 
@@ -238,6 +240,14 @@ class EmailConfig(Config):
             self.email_add_threepid_template_success_html_content = self.read_file(
                 filepath, "email.add_threepid_template_success_html"
             )
+        elif self.account_threepid_delegate_msisdn:
+            if not self.public_baseurl:
+                raise ConfigError(
+                    "The configuration option `public_baseurl` is required if "
+                    "`account_threepid_delegate.msisdn` is set, such that "
+                    "clients know where to submit validation tokens to. Please "
+                    "configure `public_baseurl`."
+                )
 
         if self.email_enable_notifs:
             required = [

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -106,6 +106,13 @@ class RegistrationConfig(Config):
         account_threepid_delegates = config.get("account_threepid_delegates") or {}
         self.account_threepid_delegate_email = account_threepid_delegates.get("email")
         self.account_threepid_delegate_msisdn = account_threepid_delegates.get("msisdn")
+        if self.account_threepid_delegate_msisdn and not self.public_baseurl:
+            raise ConfigError(
+                "The configuration option `public_baseurl` is required if "
+                "`account_threepid_delegate.msisdn` is set, such that "
+                "clients know where to submit validation tokens to. Please "
+                "configure `public_baseurl`."
+            )
 
         self.default_identity_server = config.get("default_identity_server")
         self.allow_guest_access = config.get("allow_guest_access", False)

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -475,8 +475,6 @@ class IdentityHandler(BaseHandler):
         except TimeoutError:
             raise SynapseError(500, "Timed out contacting identity server")
 
-        assert self.hs.config.public_baseurl
-
         # we need to tell the client to send the token back to us, since it doesn't
         # otherwise know where to send it, so add submit_url response parameter
         # (see also MSC2078)

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -475,6 +475,8 @@ class IdentityHandler(BaseHandler):
         except TimeoutError:
             raise SynapseError(500, "Timed out contacting identity server")
 
+        assert self.hs.config.public_baseurl
+
         # we need to tell the client to send the token back to us, since it doesn't
         # otherwise know where to send it, so add submit_url response parameter
         # (see also MSC2078)

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -203,6 +203,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
 
     @unittest.override_config(
         {
+            "public_baseurl": "https://test_server",
             "enable_registration_captcha": True,
             "user_consent": {
                 "version": "1",


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/6376

Remove assertion and raise a `ConfigError` on startup instead so admins aren't caught off-guard.