### PR TITLE
Test if a purge can make /messages return 500 responses

### DIFF
--- a/changelog.d/6392.misc
+++ b/changelog.d/6392.misc
@@ -1,0 +1,1 @@
+Add a test scenario to make sure room history purges don't break `/messages` in the future.

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -25,7 +25,9 @@ from twisted.internet import defer
 
 import synapse.rest.admin
 from synapse.api.constants import EventContentFields, EventTypes, Membership
+from synapse.handlers.pagination import PurgeStatus
 from synapse.rest.client.v1 import login, profile, room
+from synapse.util.stringutils import random_string
 
 from tests import unittest
 
@@ -909,6 +911,76 @@ class RoomMessageListTestCase(RoomBase):
         self.render(request)
 
         return channel.json_body["chunk"]
+
+    def test_room_messages_purge(self):
+        store = self.hs.get_datastore()
+        pagination_handler = self.hs.get_pagination_handler()
+
+        # Send a first message in the room, which will be removed by the purge.
+        first_event_id = self.helper.send(self.room_id, "message 1")["event_id"]
+        first_token = self.get_success(
+            store.get_topological_token_for_event(first_event_id)
+        )
+
+        # Send a second message in the room, which won't be removed, and which we'll
+        # use as the marker to purge events before.
+        second_event_id = self.helper.send(self.room_id, "message 2")["event_id"]
+        second_token = self.get_success(
+            store.get_topological_token_for_event(second_event_id)
+        )
+
+        # Send a third event in the room to ensure we don't fall under any edge case
+        # due to our marker being the latest forward extremity in the room.
+        self.helper.send(self.room_id, "message 3")
+
+        # Check that we get the first and second message when querying /messages.
+        request, channel = self.make_request(
+            "GET",
+            "/rooms/%s/messages?access_token=x&from=%s&dir=b&filter=%s"
+            % (self.room_id, second_token, json.dumps({"types": [EventTypes.Message]})),
+        )
+        self.render(request)
+        self.assertEqual(channel.code, 200, channel.json_body)
+
+        chunk = channel.json_body["chunk"]
+        self.assertEqual(len(chunk), 2, [event["content"] for event in chunk])
+
+        # Purge every event before the second event.
+        purge_id = random_string(16)
+        pagination_handler._purges_by_id[purge_id] = PurgeStatus()
+        self.get_success(pagination_handler._purge_history(
+            purge_id=purge_id,
+            room_id=self.room_id,
+            token=second_token,
+            delete_local_events=True,
+        ))
+
+        # Check that we only get the second message through /message now that the first
+        # has been purged.
+        request, channel = self.make_request(
+            "GET",
+            "/rooms/%s/messages?access_token=x&from=%s&dir=b&filter=%s"
+            % (self.room_id, second_token, json.dumps({"types": [EventTypes.Message]})),
+        )
+        self.render(request)
+        self.assertEqual(channel.code, 200, channel.json_body)
+
+        chunk = channel.json_body["chunk"]
+        self.assertEqual(len(chunk), 1, [event["content"] for event in chunk])
+
+        # Check that we get no event, but also no error, when querying /messages with
+        # the token that was pointing at the first event, because we don't have it
+        # anymore.
+        request, channel = self.make_request(
+            "GET",
+            "/rooms/%s/messages?access_token=x&from=%s&dir=b&filter=%s"
+            % (self.room_id, first_token, json.dumps({"types": [EventTypes.Message]})),
+        )
+        self.render(request)
+        self.assertEqual(channel.code, 200, channel.json_body)
+
+        chunk = channel.json_body["chunk"]
+        self.assertEqual(len(chunk), 0, [event["content"] for event in chunk])
 
 
 class RoomSearchTestCase(unittest.HomeserverTestCase):

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -948,12 +948,14 @@ class RoomMessageListTestCase(RoomBase):
         # Purge every event before the second event.
         purge_id = random_string(16)
         pagination_handler._purges_by_id[purge_id] = PurgeStatus()
-        self.get_success(pagination_handler._purge_history(
-            purge_id=purge_id,
-            room_id=self.room_id,
-            token=second_token,
-            delete_local_events=True,
-        ))
+        self.get_success(
+            pagination_handler._purge_history(
+                purge_id=purge_id,
+                room_id=self.room_id,
+                token=second_token,
+                delete_local_events=True,
+            )
+        )
 
         # Check that we only get the second message through /message now that the first
         # has been purged.


### PR DESCRIPTION
Test to make sure https://github.com/matrix-org/synapse/issues/1623 doesn't happen again.

The test follows this scenario:

1. Send message 1 in room
2. Send message 2 in room
3. Send message 3 in room
4. Query `/messages` with message 2's topological token to make sure we get both message 1 and message 2
5. Purge everything before message 2
6. Query `/messages` with message 2's topological token (same request as in step 4) to check that we're only getting message 2 now, and no error
7. Query `/messages` with message 1's topological token to check that we're not getting any event, and no error

(step 3 only exists so that we're sure nothing happens as an edge case of the message which token we're purging with being a forward extremity, but it also passes without it)