### PR TITLE
Fix exceptions from background database update for event labels.

### DIFF
--- a/changelog.d/6407.bugfix
+++ b/changelog.d/6407.bugfix
@@ -1,0 +1,1 @@
+Fix a bug which could cause the background database update hander for event labels to get stuck in a loop raising exceptions.


### PR DESCRIPTION
Add some exception handling here so that events whose json cannot be parsed are
ignored rather than getting us stuck in a loop.

Fixes #6404.