### PR TITLE
Make sure that we close cursors before returning from a query

### DIFF
--- a/changelog.d/6408.bugfix
+++ b/changelog.d/6408.bugfix
@@ -1,0 +1,1 @@
+Fix an intermittent exception when handling read-receipts.

--- a/synapse/storage/data_stores/main/receipts.py
+++ b/synapse/storage/data_stores/main/receipts.py
@@ -280,7 +280,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
                 args.append(limit)
             txn.execute(sql, args)
 
-            return (r[0:5] + (json.loads(r[5]),) for r in txn)
+            return [r[0:5] + (json.loads(r[5]),) for r in txn]
 
         return self.runInteraction(
             "get_all_updated_receipts", get_all_updated_receipts_txn

--- a/synapse/storage/data_stores/main/receipts.py
+++ b/synapse/storage/data_stores/main/receipts.py
@@ -280,7 +280,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
                 args.append(limit)
             txn.execute(sql, args)
 
-            return [r[0:5] + (json.loads(r[5]),) for r in txn]
+            return list(r[0:5] + (json.loads(r[5]),) for r in txn)
 
         return self.runInteraction(
             "get_all_updated_receipts", get_all_updated_receipts_txn


### PR DESCRIPTION
There are lots of words in the comment as to why this is a good idea.

Fixes #6403.