### PR TITLE
Fix guest registration 

### DIFF
--- a/changelog.d/6420.bugfix
+++ b/changelog.d/6420.bugfix
@@ -1,0 +1,1 @@
+Fix broken guest registration when there are existing blocks of numeric user IDs.

--- a/synapse/storage/data_stores/main/registration.py
+++ b/synapse/storage/data_stores/main/registration.py
@@ -492,17 +492,14 @@ class RegistrationWorkerStore(SQLBaseStore):
 
             regex = re.compile(r"^@(\d+):")
 
-            found = set()
+            max_found = 0
 
             for (user_id,) in txn:
                 match = regex.search(user_id)
                 if match:
-                    found.add(int(match.group(1)))
+                    max_found = max(int(match.group(1)), max_found)
 
-            if not found:
-                return 1
-
-            return max(found) + 1
+            return max_found + 1
 
         return (
             (

--- a/synapse/storage/data_stores/main/registration.py
+++ b/synapse/storage/data_stores/main/registration.py
@@ -19,7 +19,6 @@ import logging
 import re
 
 from six import iterkeys
-from six.moves import range
 
 from twisted.internet import defer
 from twisted.internet.defer import Deferred
@@ -482,12 +481,8 @@ class RegistrationWorkerStore(SQLBaseStore):
         """
         Gets the localpart of the next generated user ID.
 
-        Generated user IDs are integers, and we aim for them to be as small as
-        we can. Unfortunately, it's possible some of them are already taken by
-        existing users, and there may be gaps in the already taken range. This
-        function returns the start of the first allocatable gap. This is to
-        avoid the case of ID 1000 being pre-allocated and starting at 1001 while
-        0-999 are available.
+        Generated user IDs are integers, so we find the largest integer user ID
+        already taken and return that plus one.
         """
 
         def _find_next_generated_user_id(txn):
@@ -503,9 +498,11 @@ class RegistrationWorkerStore(SQLBaseStore):
                 match = regex.search(user_id)
                 if match:
                     found.add(int(match.group(1)))
-            for i in range(len(found) + 1):
-                if i not in found:
-                    return i
+
+            if not found:
+                return 1
+
+            return max(found) + 1
 
         return (
             (


### PR DESCRIPTION
For whatever reason the current code tries to find the minimum unused guest ID. This runs into problems if the next ten IDs after that are not free, as in that case we 500.

Instead, lets just always use the max integer ID and increment from there.