### PR TITLE
Remove local threepids on account deactivation

### DIFF
--- a/changelog.d/6426.bugfix
+++ b/changelog.d/6426.bugfix
@@ -1,0 +1,1 @@
+Clean up local threepids from user on account deactivation.

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -95,13 +95,8 @@ class DeactivateAccountHandler(BaseHandler):
                 user_id, threepid["medium"], threepid["address"]
             )
 
-        # Retrieve the 3PIDs this user has bound to the homeserver
-        local_threepids = yield self.store.user_get_threepids(user_id)
-        for threepid in local_threepids:
-            # Delete this threepid locally
-            yield self.store.user_delete_threepid(
-                user_id, threepid["medium"], threepid["address"]
-            )
+        # Remove all 3PIDs this user has bound to the homeserver
+        yield self.store.user_delete_threepids(user_id)
 
         # delete any devices belonging to the user, which will also
         # delete corresponding access tokens.

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -76,6 +76,10 @@ class DeactivateAccountHandler(BaseHandler):
         # Retrieve the 3PIDs this user has bound to an identity server
         threepids = yield self.store.user_get_bound_threepids(user_id)
 
+        # Retrieve the 3PIDs this user has bound to the homeserver
+        local_threepids = yield self.store.user_get_threepids(user_id)
+        threepids.extend(local_threepids)
+
         for threepid in threepids:
             try:
                 result = yield self._identity_handler.try_unbind_threepid(

--- a/synapse/storage/data_stores/main/registration.py
+++ b/synapse/storage/data_stores/main/registration.py
@@ -569,6 +569,14 @@ class RegistrationWorkerStore(SQLBaseStore):
         return self._simple_delete(
             "user_threepids",
             keyvalues={"user_id": user_id, "medium": medium, "address": address},
+            desc="user_delete_threepid",
+        )
+
+    def user_delete_threepids(self, user_id):
+        """Delete all threepid this user has bound"""
+        return self._simple_delete(
+            "user_threepids",
+            keyvalues={"user_id": user_id},
             desc="user_delete_threepids",
         )
 

--- a/synapse/storage/data_stores/main/registration.py
+++ b/synapse/storage/data_stores/main/registration.py
@@ -572,8 +572,13 @@ class RegistrationWorkerStore(SQLBaseStore):
             desc="user_delete_threepid",
         )
 
-    def user_delete_threepids(self, user_id):
-        """Delete all threepid this user has bound"""
+    def user_delete_threepids(self, user_id: str):
+        """Delete all threepid this user has bound
+
+        Args:
+             user_id: The user id to delete all threepids of
+
+        """
         return self._simple_delete(
             "user_threepids",
             keyvalues={"user_id": user_id},


### PR DESCRIPTION
Threepids bound to identity servers were being removed from a user's account on deactivation, but not local threepids. Probably best to clean these up.