### PR TITLE
Fix error when using synapse_port_db on a vanilla synapse db

### DIFF
--- a/changelog.d/6449.bugfix
+++ b/changelog.d/6449.bugfix
@@ -1,1 +1,1 @@
-Fix assumed missing state_groups index in synapse_port_db.
+Fix error when using synapse_port_db on a vanilla synapse db.

--- a/changelog.d/6449.bugfix
+++ b/changelog.d/6449.bugfix
@@ -1,0 +1,1 @@
+Fix assumed missing state_groups index in synapse_port_db.

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -782,7 +782,10 @@ class Porter(object):
     def _setup_state_group_id_seq(self):
         def r(txn):
             txn.execute("SELECT MAX(id) FROM state_groups")
-            next_id = txn.fetchone()[0] + 1
+            curr_id = txn.fetchone()[0]
+            if not curr_id:
+                return
+            next_id = curr_id + 1
             txn.execute("ALTER SEQUENCE state_group_id_seq RESTART WITH %s", (next_id,))
 
         return self.postgres_store.runInteraction("setup_state_group_id_seq", r)


### PR DESCRIPTION
Broken off from https://github.com/matrix-org/synapse/pull/6394

When trying to run `synapse_port_db` on a DB that's just been generated by running all the schema delta files/background jobs, I get the following error:

```
2019-12-02 18:38:25,407 - synapse_port_db - 632 - ERROR - 
Traceback (most recent call last):
  File "scripts/synapse_port_db", line 626, in run
    yield self._setup_state_group_id_seq()
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "scripts/synapse_port_db", line 171, in runInteraction
    return (yield self.db_pool.runWithConnection(r))
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/threadpool.py", line 250, in inContext
    result = inContext.theWork()
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/threadpool.py", line 266, in <lambda>
    inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/context.py", line 122, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/context.py", line 85, in callWithContext
    return func(*args,**kw)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/enterprise/adbapi.py", line 306, in _runWithConnection
    compat.reraise(excValue, excTraceback)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/enterprise/adbapi.py", line 297, in _runWithConnection
    result = func(conn, *args, **kw)
  File "scripts/synapse_port_db", line 156, in r
    **kwargs
  File "scripts/synapse_port_db", line 785, in r
    next_id = txn.fetchone()[0] + 1
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
Traceback (most recent call last):
  File "scripts/synapse_port_db", line 626, in run
    yield self._setup_state_group_id_seq()
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "scripts/synapse_port_db", line 171, in runInteraction
    return (yield self.db_pool.runWithConnection(r))
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/threadpool.py", line 250, in inContext
    result = inContext.theWork()
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/threadpool.py", line 266, in <lambda>
    inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/context.py", line 122, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/context.py", line 85, in callWithContext
    return func(*args,**kw)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/enterprise/adbapi.py", line 306, in _runWithConnection
    compat.reraise(excValue, excTraceback)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/user/code/synapse/env/lib/python3.6/site-packages/twisted/enterprise/adbapi.py", line 297, in _runWithConnection
    result = func(conn, *args, **kw)
  File "scripts/synapse_port_db", line 156, in r
    **kwargs
  File "scripts/synapse_port_db", line 785, in r
    next_id = txn.fetchone()[0] + 1
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

Here is a fix. (Though maybe the fix is to have an id in `state_groups` generated?) Here is a test DB if you want to have a play around with it:

[homeserver.db.zip](https://github.com/matrix-org/synapse/files/3912793/homeserver.db.zip)
