### PR TITLE
Use v1 endpoints for appservices

### DIFF
--- a/changelog.d/6460.bugfix
+++ b/changelog.d/6460.bugfix
@@ -1,0 +1,1 @@
+Use `/_matrix/app/v1` endpoint prefix for appservices.

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -46,10 +46,7 @@ sent_events_counter = Counter(
 )
 
 HOUR_IN_MS = 60 * 60 * 1000
-
-
-APP_SERVICE_PREFIX = "/_matrix/app/unstable"
-
+APP_SERVICE_PREFIX = "/_matrix/app/v1"
 
 def _is_valid_3pe_metadata(info):
     if "instances" not in info:

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -81,7 +81,7 @@ def _is_valid_3pe_result(r, field):
 
 
 def _build_as_uri(service, endpoint_name, key):
-    key = urllib.parse.quote(user_id)
+    key = urllib.parse.quote(key)
     return os.path.join(service.url, APP_SERVICE_PREFIX, endpoint_name, key)
 
 

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import logging
 import os.path
+import urllib.parse
 
 from six.moves import urllib
 
@@ -47,7 +48,7 @@ sent_events_counter = Counter(
 )
 
 HOUR_IN_MS = 60 * 60 * 1000
-APP_SERVICE_PREFIX = "/_matrix/app/v1"
+APP_SERVICE_PREFIX = "_matrix/app/v1"
 
 
 def _is_valid_3pe_metadata(info):


### PR DESCRIPTION
Fixes #3780 

This PR updates the prefix of all appservice endpoints to v1 to be inline with the AS spec. This change however is **extremely breaking** as currently all matrix-org bridges rely on the old behaviour. Comments welcome on how we could support both (not as simple as checking for 404s, as that's a valid response for some of these endpoints).