### PR TITLE
Make synapse_port_db exit with a non-0 code if something failed

### DIFF
--- a/changelog.d/6470.bugfix
+++ b/changelog.d/6470.bugfix
@@ -1,0 +1,1 @@
+Fix `synapse_port_db` not exiting with a 0 code if something went wrong during the port process.

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -47,6 +47,7 @@ from synapse.storage.data_stores.main.media_repository import (
 from synapse.storage.data_stores.main.registration import (
     RegistrationBackgroundUpdateStore,
 )
+from synapse.storage.data_stores.main.room import RoomBackgroundUpdateStore
 from synapse.storage.data_stores.main.roommember import RoomMemberBackgroundUpdateStore
 from synapse.storage.data_stores.main.search import SearchBackgroundUpdateStore
 from synapse.storage.data_stores.main.state import StateBackgroundUpdateStore
@@ -131,6 +132,7 @@ class Store(
     EventsBackgroundUpdatesStore,
     MediaRepositoryBackgroundUpdateStore,
     RegistrationBackgroundUpdateStore,
+    RoomBackgroundUpdateStore,
     RoomMemberBackgroundUpdateStore,
     SearchBackgroundUpdateStore,
     StateBackgroundUpdateStore,

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -1055,3 +1055,4 @@ if __name__ == "__main__":
     if end_error_exec_info:
         exc_type, exc_value, exc_traceback = end_error_exec_info
         traceback.print_exception(exc_type, exc_value, exc_traceback)
+        sys.exit(5)


### PR DESCRIPTION
If something go wrong while porting the DB, `synapse_port_db` exits with a 0 code, causing the CI to succeed when it should fail.