### PR TITLE
Better errors regarding changing avatar_url

### DIFF
--- a/changelog.d/6497.bugfix
+++ b/changelog.d/6497.bugfix
@@ -1,0 +1,1 @@
+Fix error message when setting your profile's avatar URL mentioning displaynames, and prevent NoneType avatar_urls.

--- a/synapse/rest/client/v1/profile.py
+++ b/synapse/rest/client/v1/profile.py
@@ -103,11 +103,16 @@ class ProfileAvatarURLRestServlet(RestServlet):
 
         content = parse_json_object_from_request(request)
         try:
-            new_name = content["avatar_url"]
+            new_avatar_url = content.get("avatar_url")
         except Exception:
-            return 400, "Unable to parse name"
+            return 400, "Unable to parse avatar_url"
 
-        await self.profile_handler.set_avatar_url(user, requester, new_name, is_admin)
+        if new_avatar_url is None:
+            return 400, "Missing required key: avatar_url"
+
+        await self.profile_handler.set_avatar_url(
+            user, requester, new_avatar_url, is_admin
+        )
 
         return 200, {}
 


### PR DESCRIPTION
Fixes some copy/paste errors with setting an avatar_url on your profile. Also prevents `None` avatar_urls, which I found in testing is possible.