### PR TITLE
Fix support for SQLite 3.7.

### DIFF
--- a/changelog.d/6499.bugfix
+++ b/changelog.d/6499.bugfix
@@ -1,0 +1,1 @@
+Fix support for SQLite 3.7.

--- a/synapse/storage/data_stores/main/events.py
+++ b/synapse/storage/data_stores/main/events.py
@@ -1039,22 +1039,20 @@ class EventsStore(
             },
         )
 
-    @defer.inlineCallbacks
-    def _censor_redactions(self):
+    async def _censor_redactions(self):
         """Censors all redactions older than the configured period that haven't
         been censored yet.
 
         By censor we mean update the event_json table with the redacted event.
-
-        Returns:
-            Deferred
         """
 
         if self.hs.config.redaction_retention_period is None:
             return
 
-        if self.db.updates.has_completed_background_update(
-            "redactions_have_censored_ts_idx"
+        if not (
+            await self.db.updates.has_completed_background_update(
+                "redactions_have_censored_ts_idx"
+            )
         ):
             # We don't want to run this until the appropriate index has been
             # created.
@@ -1081,15 +1079,15 @@ class EventsStore(
             LIMIT ?
         """
 
-        rows = yield self.db.execute(
+        rows = await self.db.execute(
             "_censor_redactions_fetch", None, sql, before_ts, 100
         )
 
         updates = []
 
         for redaction_id, event_id in rows:
-            redaction_event = yield self.get_event(redaction_id, allow_none=True)
-            original_event = yield self.get_event(
+            redaction_event = await self.get_event(redaction_id, allow_none=True)
+            original_event = await self.get_event(
                 event_id, allow_rejected=True, allow_none=True
             )
 
@@ -1122,7 +1120,7 @@ class EventsStore(
                     updatevalues={"have_censored": True},
                 )
 
-        yield self.db.runInteraction("_update_censor_txn", _update_censor_txn)
+        await self.db.runInteraction("_update_censor_txn", _update_censor_txn)
 
     def _censor_event_txn(self, txn, event_id, pruned_json):
         """Censor an event by replacing its JSON in the event_json table with the

--- a/synapse/storage/data_stores/main/events.py
+++ b/synapse/storage/data_stores/main/events.py
@@ -1053,6 +1053,13 @@ class EventsStore(
         if self.hs.config.redaction_retention_period is None:
             return
 
+        if self.db.updates.has_completed_background_update(
+            "redactions_have_censored_ts_idx"
+        ):
+            # We don't want to run this until the appropriate index has been
+            # created.
+            return
+
         before_ts = self._clock.time_msec() - self.hs.config.redaction_retention_period
 
         # We fetch all redactions that:

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -91,14 +91,6 @@ class EventsBackgroundUpdatesStore(SQLBaseStore):
         )
 
         self.db.updates.register_background_index_update(
-            "redactions_have_censored_idx",
-            index_name="redactions_have_censored",
-            table="redactions",
-            columns=["event_id"],
-            where_clause="NOT have_censored",
-        )
-
-        self.db.updates.register_background_index_update(
             "redactions_have_censored_ts_idx",
             index_name="redactions_have_censored_ts",
             table="redactions",

--- a/synapse/storage/data_stores/main/events_bg_updates.py
+++ b/synapse/storage/data_stores/main/events_bg_updates.py
@@ -90,6 +90,22 @@ class EventsBackgroundUpdatesStore(SQLBaseStore):
             "event_store_labels", self._event_store_labels
         )
 
+        self.db.updates.register_background_index_update(
+            "redactions_have_censored_idx",
+            index_name="redactions_have_censored",
+            table="redactions",
+            columns=["event_id"],
+            where_clause="NOT have_censored",
+        )
+
+        self.db.updates.register_background_index_update(
+            "redactions_have_censored_ts_idx",
+            index_name="redactions_have_censored_ts",
+            table="redactions",
+            columns=["received_ts"],
+            where_clause="NOT have_censored",
+        )
+
     @defer.inlineCallbacks
     def _background_reindex_fields_sender(self, progress, batch_size):
         target_min_stream_id = progress["target_min_stream_id_inclusive"]

--- a/synapse/storage/data_stores/main/schema/delta/56/redaction_censor.sql
+++ b/synapse/storage/data_stores/main/schema/delta/56/redaction_censor.sql
@@ -14,4 +14,6 @@
  */
 
 ALTER TABLE redactions ADD COLUMN have_censored BOOL NOT NULL DEFAULT false;
-CREATE INDEX redactions_have_censored ON redactions(event_id) WHERE not have_censored;
+
+INSERT INTO background_updates (update_name, progress_json) VALUES
+  ('redactions_have_censored_idx', '{}');

--- a/synapse/storage/data_stores/main/schema/delta/56/redaction_censor.sql
+++ b/synapse/storage/data_stores/main/schema/delta/56/redaction_censor.sql
@@ -14,6 +14,3 @@
  */
 
 ALTER TABLE redactions ADD COLUMN have_censored BOOL NOT NULL DEFAULT false;
-
-INSERT INTO background_updates (update_name, progress_json) VALUES
-  ('redactions_have_censored_idx', '{}');

--- a/synapse/storage/data_stores/main/schema/delta/56/redaction_censor2.sql
+++ b/synapse/storage/data_stores/main/schema/delta/56/redaction_censor2.sql
@@ -14,7 +14,9 @@
  */
 
 ALTER TABLE redactions ADD COLUMN received_ts BIGINT;
-CREATE INDEX redactions_have_censored_ts ON redactions(received_ts) WHERE not have_censored;
 
 INSERT INTO background_updates (update_name, progress_json) VALUES
   ('redactions_received_ts', '{}');
+
+INSERT INTO background_updates (update_name, progress_json) VALUES
+  ('redactions_have_censored_ts_idx', '{}');

--- a/synapse/storage/data_stores/main/schema/delta/56/redaction_censor2.sql
+++ b/synapse/storage/data_stores/main/schema/delta/56/redaction_censor2.sql
@@ -18,5 +18,5 @@ ALTER TABLE redactions ADD COLUMN received_ts BIGINT;
 INSERT INTO background_updates (update_name, progress_json) VALUES
   ('redactions_received_ts', '{}');
 
-INSERT INTO background_updates (update_name, progress_json) VALUES
-  ('redactions_have_censored_ts_idx', '{}');
+INSERT INTO background_updates (update_name, progress_json, depends_on) VALUES
+  ('redactions_have_censored_ts_idx', '{}', 'redactions_have_censored_idx');

--- a/synapse/storage/data_stores/main/schema/delta/56/redaction_censor4.sql
+++ b/synapse/storage/data_stores/main/schema/delta/56/redaction_censor4.sql
@@ -13,10 +13,4 @@
  * limitations under the License.
  */
 
-ALTER TABLE redactions ADD COLUMN received_ts BIGINT;
-
-INSERT INTO background_updates (update_name, progress_json) VALUES
-  ('redactions_received_ts', '{}');
-
-INSERT INTO background_updates (update_name, progress_json) VALUES
-  ('redactions_have_censored_ts_idx', '{}');
+DROP INDEX IF EXISTS redactions_have_censored;


### PR DESCRIPTION
Partial indices support was added in 3.8.0, so we need to use the background updates that handles this correctly.

Fixes #6246. Broke in #5934.
