### PR TITLE
Silence mypy errors for files outside those specified

### DIFF
--- a/changelog.d/6512.misc
+++ b/changelog.d/6512.misc
@@ -1,0 +1,1 @@
+Silence mypy errors for files outside those specified.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 namespace_packages = True
 plugins = mypy_zope:plugin
-follow_imports = normal
+follow_imports = silent
 check_untyped_defs = True
 show_error_codes = True
 show_traceback = True


### PR DESCRIPTION
This is required for the database config splitting up PR, as a file in `config/` needs to import a class in `storage/`, which  then leads to lots and lots of errors.