### PR TITLE
Add `include_event_in_state` to _get_state_for_room

### DIFF
--- a/changelog.d/6521.misc
+++ b/changelog.d/6521.misc
@@ -1,0 +1,1 @@
+Refactor some code in the event authentication path for clarity.


### PR DESCRIPTION
Make it return the state *after* the requested event, rather than the one 
before it. This is a bit easier and requires fewer calls to 
get_events_from_store_or_dest.

based on #6517