### PR TITLE
Fix redacted events being returned in search results ordered by "recent"

### DIFF
--- a/changelog.d/6522.bugfix
+++ b/changelog.d/6522.bugfix
@@ -1,0 +1,1 @@
+Prevent redacted events from being returned during message search.

--- a/synapse/storage/data_stores/main/search.py
+++ b/synapse/storage/data_stores/main/search.py
@@ -385,7 +385,7 @@ class SearchStore(SearchBackgroundUpdateStore):
         """
         clauses = []
 
-        search_query = search_query = _parse_query(self.database_engine, search_term)
+        search_query = _parse_query(self.database_engine, search_term)
 
         args = []
 
@@ -501,7 +501,7 @@ class SearchStore(SearchBackgroundUpdateStore):
         """
         clauses = []
 
-        search_query = search_query = _parse_query(self.database_engine, search_term)
+        search_query = _parse_query(self.database_engine, search_term)
 
         args = []
 
@@ -606,7 +606,12 @@ class SearchStore(SearchBackgroundUpdateStore):
 
         results = list(filter(lambda row: row["room_id"] in room_ids, results))
 
-        events = yield self.get_events_as_list([r["event_id"] for r in results])
+        # We set redact_behaviour to BLOCK here to prevent redacted events being returned in
+        # search results (which is a data leak)
+        events = yield self.get_events_as_list(
+            [r["event_id"] for r in results],
+            redact_behaviour=EventRedactBehaviour.BLOCK,
+        )
 
         event_map = {ev.event_id: ev for ev in events}
 


### PR DESCRIPTION
An amendment to https://github.com/matrix-org/synapse/pull/6377 and an additional fix to #1454.

https://github.com/matrix-org/synapse/pull/6377 only removed redacted search events from search results ordered by "rank". This PR also removes them for searches ordered by "recent".

I've updated https://github.com/matrix-org/sytest/pull/747 to test both cases appropriately.