### PR TITLE
Add option to allow profile queries without sharing a room

### DIFF
--- a/changelog.d/6523.feature
+++ b/changelog.d/6523.feature
@@ -1,1 +1,1 @@
-Add option `limit_profile_requests_to_users_who_share_rooms` to prevent requirement of a user sharing a room with another user to query their profile information.
+Add option `limit_profile_requests_to_users_who_share_rooms` to prevent requirement of a local user sharing a room with another user to query their profile information.

--- a/changelog.d/6523.feature
+++ b/changelog.d/6523.feature
@@ -1,0 +1,1 @@
+Add option `limit_profile_requests_to_users_who_share_rooms` to prevent requirement of a user sharing a room with another user to query their profile information.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -54,13 +54,12 @@ pid_file: DATADIR/homeserver.pid
 #
 #require_auth_for_profile_requests: true
 
-
 # Whether to require a user to share a room with another user in order
 # to retrieve their profile information. Only checked on Client-Server
 # requests. Profile requests from other servers should be checked by the
 # requesting server. Defaults to 'false'.
 #
-# limit_profile_requests_to_users_who_share_rooms: true
+#limit_profile_requests_to_known_users: false
 
 # If set to 'true', removes the need for authentication to access the server's
 # public rooms directory through the client API, meaning that anyone can

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -54,12 +54,12 @@ pid_file: DATADIR/homeserver.pid
 #
 #require_auth_for_profile_requests: true
 
-# Whether to require a user to share a room with another user in order
+# Uncomment to require a user to share a room with another user in order
 # to retrieve their profile information. Only checked on Client-Server
 # requests. Profile requests from other servers should be checked by the
 # requesting server. Defaults to 'false'.
 #
-#limit_profile_requests_to_users_who_share_rooms: false
+#limit_profile_requests_to_users_who_share_rooms: true
 
 # If set to 'true', removes the need for authentication to access the server's
 # public rooms directory through the client API, meaning that anyone can

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -59,7 +59,7 @@ pid_file: DATADIR/homeserver.pid
 # requests. Profile requests from other servers should be checked by the
 # requesting server. Defaults to 'false'.
 #
-#limit_profile_requests_to_known_users: false
+#limit_profile_requests_to_users_who_share_rooms: false
 
 # If set to 'true', removes the need for authentication to access the server's
 # public rooms directory through the client API, meaning that anyone can

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -54,6 +54,14 @@ pid_file: DATADIR/homeserver.pid
 #
 #require_auth_for_profile_requests: true
 
+
+# Whether to require a user to share a room with another user in order
+# to retrieve their profile information. Only checked on Client-Server
+# requests. Profile requests from other servers should be checked by the
+# requesting server. Defaults to 'false'.
+#
+# limit_profile_requests_to_users_who_share_rooms: true
+
 # If set to 'true', removes the need for authentication to access the server's
 # public rooms directory through the client API, meaning that anyone can
 # query the room directory. Defaults to 'false'.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -102,6 +102,12 @@ class ServerConfig(Config):
             "require_auth_for_profile_requests", False
         )
 
+        # Whether to require sharing a room with a user to retrieve their
+        # profile data
+        self.limit_profile_requests_to_known_users = config.get(
+            "limit_profile_requests_to_users_who_share_rooms", False,
+        )
+
         if "restrict_public_rooms_to_local_users" in config and (
             "allow_public_rooms_without_auth" in config
             or "allow_public_rooms_over_federation" in config
@@ -620,6 +626,13 @@ class ServerConfig(Config):
         # the server.
         #
         #require_auth_for_profile_requests: true
+
+        # Whether to require a user to share a room with another user in order
+        # to retrieve their profile information. Only checked on Client-Server
+        # requests. Profile requests from other servers should be checked by the
+        # requesting server. Defaults to 'false'.
+        #
+        #limit_profile_requests_to_known_users: false
 
         # If set to 'true', removes the need for authentication to access the server's
         # public rooms directory through the client API, meaning that anyone can

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -104,7 +104,7 @@ class ServerConfig(Config):
 
         # Whether to require sharing a room with a user to retrieve their
         # profile data
-        self.limit_profile_requests_to_known_users = config.get(
+        self.limit_profile_requests_to_users_who_share_rooms = config.get(
             "limit_profile_requests_to_users_who_share_rooms", False,
         )
 
@@ -632,7 +632,7 @@ class ServerConfig(Config):
         # requests. Profile requests from other servers should be checked by the
         # requesting server. Defaults to 'false'.
         #
-        #limit_profile_requests_to_known_users: false
+        #limit_profile_requests_to_users_who_share_rooms: false
 
         # If set to 'true', removes the need for authentication to access the server's
         # public rooms directory through the client API, meaning that anyone can

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -627,12 +627,12 @@ class ServerConfig(Config):
         #
         #require_auth_for_profile_requests: true
 
-        # Whether to require a user to share a room with another user in order
+        # Uncomment to require a user to share a room with another user in order
         # to retrieve their profile information. Only checked on Client-Server
         # requests. Profile requests from other servers should be checked by the
         # requesting server. Defaults to 'false'.
         #
-        #limit_profile_requests_to_users_who_share_rooms: false
+        #limit_profile_requests_to_users_who_share_rooms: true
 
         # If set to 'true', removes the need for authentication to access the server's
         # public rooms directory through the client API, meaning that anyone can

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -300,7 +300,7 @@ class BaseProfileHandler(BaseHandler):
         # be None when this function is called outside of a profile query, e.g.
         # when building a membership event. In this case, we must allow the
         # lookup.
-        if not self.hs.config.require_auth_for_profile_requests or not requester:
+        if not self.hs.config.limit_profile_requests_to_users_who_share_rooms or not requester:
             return
 
         # Always allow the user to query their own profile.

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -295,12 +295,16 @@ class BaseProfileHandler(BaseHandler):
                 be found to be in any room the server is in, and therefore the query
                 is denied.
         """
+
         # Implementation of MSC1301: don't allow looking up profiles if the
         # requester isn't in the same room as the target. We expect requester to
         # be None when this function is called outside of a profile query, e.g.
         # when building a membership event. In this case, we must allow the
         # lookup.
-        if not self.hs.config.limit_profile_requests_to_users_who_share_rooms or not requester:
+        if (
+            not self.hs.config.limit_profile_requests_to_users_who_share_rooms
+            or not requester
+        ):
             return
 
         # Always allow the user to query their own profile.

--- a/tests/rest/client/v1/test_profile.py
+++ b/tests/rest/client/v1/test_profile.py
@@ -237,7 +237,7 @@ class ProfilesRestrictedTestCase(unittest.HomeserverTestCase):
 
         config = self.default_config()
         config["require_auth_for_profile_requests"] = True
-        config["limit_profile_requests_to_known_users"] = True
+        config["limit_profile_requests_to_users_who_share_rooms"] = True
         self.hs = self.setup_test_homeserver(config=config)
 
         return self.hs
@@ -310,7 +310,7 @@ class OwnProfileUnrestrictedTestCase(unittest.HomeserverTestCase):
     def make_homeserver(self, reactor, clock):
         config = self.default_config()
         config["require_auth_for_profile_requests"] = True
-        config["limit_profile_requests_to_known_users"] = True
+        config["limit_profile_requests_to_users_who_share_rooms"] = True
         self.hs = self.setup_test_homeserver(config=config)
 
         return self.hs

--- a/tests/rest/client/v1/test_profile.py
+++ b/tests/rest/client/v1/test_profile.py
@@ -237,6 +237,7 @@ class ProfilesRestrictedTestCase(unittest.HomeserverTestCase):
 
         config = self.default_config()
         config["require_auth_for_profile_requests"] = True
+        config["limit_profile_requests_to_known_users"] = True
         self.hs = self.setup_test_homeserver(config=config)
 
         return self.hs
@@ -309,6 +310,7 @@ class OwnProfileUnrestrictedTestCase(unittest.HomeserverTestCase):
     def make_homeserver(self, reactor, clock):
         config = self.default_config()
         config["require_auth_for_profile_requests"] = True
+        config["limit_profile_requests_to_known_users"] = True
         self.hs = self.setup_test_homeserver(config=config)
 
         return self.hs


### PR DESCRIPTION
This is a port of https://github.com/matrix-org/synapse-dinsic/pull/18 to mainline, with an adjustment to make the config key spell out with it does.