### PR TITLE
Persist auth/state events at backwards extremities when we fetch them

### DIFF
--- a/changelog.d/6526.bugfix
+++ b/changelog.d/6526.bugfix
@@ -1,0 +1,1 @@
+Fix a bug which could cause the federation server to incorrectly return errors when handling certain obscure event graphs.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -65,7 +65,6 @@ from synapse.replication.http.membership import ReplicationUserJoinedLeftRoomRes
 from synapse.state import StateResolutionStore, resolve_events_with_store
 from synapse.storage.data_stores.main.events_worker import EventRedactBehaviour
 from synapse.types import UserID, get_domain_from_id
-from synapse.util import batch_iter
 from synapse.util.async_helpers import Linearizer, concurrently_execute
 from synapse.util.distributor import user_joined_room
 from synapse.util.retryutils import NotRetryingDestination

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -140,8 +140,8 @@ def concurrently_execute(func, args, limit):
 
     Args:
         func (func): Function to execute, should return a deferred or coroutine.
-        args (list): List of arguments to pass to func, each invocation of func
-            gets a signle argument.
+        args (Iterable): List of arguments to pass to func, each invocation of func
+            gets a single argument.
         limit (int): Maximum number of conccurent executions.
 
     Returns:


### PR DESCRIPTION
The main point here is to make sure that the state returned by `_get_state_in_room` has been authed before we try to use it as state in the room.

The diff is a bit gnarly but I've tried to order it into distinct commits.

~~Based on #6524.~~