### PR TITLE
Exclude rejected state events when calculating state at backwards extrems

### DIFF
--- a/changelog.d/6527.bugfix
+++ b/changelog.d/6527.bugfix
@@ -1,0 +1,1 @@
+Fix a bug which could cause the federation server to incorrectly return errors when handling certain obscure event graphs.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -605,7 +605,7 @@ class FederationHandler(BaseHandler):
             remote_event = event_map.get(event_id)
             if not remote_event:
                 raise Exception("Unable to get missing prev_event %s" % (event_id,))
-            if remote_event.is_state():
+            if remote_event.is_state() and remote_event.rejected_reason is None:
                 remote_state.append(remote_event)
 
         auth_chain = [event_map[e_id] for e_id in auth_event_ids if e_id in event_map]


### PR DESCRIPTION
This fixes a weird bug where, if you were determined enough, you could end up with a rejected event forming part of the state at a backwards-extremity. Authing that backwards extrem would then lead to us trying to pull the rejected event from the db (with `allow_rejected=False`), which would fail with a 404.

~~Based on #6526.~~