### PR TITLE
Include more folders in mypy

### DIFF
--- a/changelog.d/6534.misc
+++ b/changelog.d/6534.misc
@@ -1,0 +1,1 @@
+Test more folders against mypy.

--- a/tox.ini
+++ b/tox.ini
@@ -177,5 +177,17 @@ env =
     MYPYPATH = stubs/
 extras = all
 commands = mypy \
+            synapse/config/ \
+            synapse/handlers/ui_auth \
             synapse/logging/ \
-            synapse/config/
+            synapse/module_api \
+            synapse/rest/consent \
+            synapse/rest/media/v0 \
+            synapse/rest/saml2 \
+            synapse/spam_checker_api \
+            synapse/storage/engines \
+            synapse/streams
+
+# To find all folders that pass mypy you run:
+#
+#   find synapse/* -type d -not -name __pycache__ -exec bash -c "mypy '{}' > /dev/null"  \; -print


### PR DESCRIPTION
There are actually a bunch of directories that already pass `mypy`, so lets add them to CI to stop regressions