### PR TITLE
Configure structured logging

### DIFF
--- a/synapse/logging/_terse_json.py
+++ b/synapse/logging/_terse_json.py
@@ -76,9 +76,9 @@ def flatten_event(event: dict, metadata: dict, include_time: bool = False):
     # context only given in the log format (e.g. what is being logged) is
     # available.
     if "log_text" in event:
-        new_event["log"] = event["log_text"]
+        new_event["message"] = event["log_text"]
     else:
-        new_event["log"] = event["log_format"]
+        new_event["message"] = event["log_format"]
 
     # We want to include the timestamp when forwarding over the network, but
     # exclude it when we are writing to stdout. This is because the log ingester


### PR DESCRIPTION
Making this PR to illustrate a change that I'd like to see; however I imagine that changing the name of a json body without backwards compatibility is somewhat incorrect.

How would be best to do this in the right python/synapse-config way that we can default to the old "log" and allow configuration to set this to "message" for those situations it's required? Or is it acceptable to move wholesale as we don't have many users of the structured logging?

The need to change this is for when synapse, run in a docker style environment, where json structured logging lines on stdout are automatically scraped into a kibana instance, and expect specific named keys, specifically, they cannot handle the key named "log".
