### PR TITLE
Add delta file to fix missing default table data

### DIFF
--- a/changelog.d/6555.bugfix
+++ b/changelog.d/6555.bugfix
@@ -1,0 +1,1 @@
+Fix missing row in device_max_stream_id that could cause unable to decrypt errors after server restart.

--- a/synapse/storage/data_stores/main/deviceinbox.py
+++ b/synapse/storage/data_stores/main/deviceinbox.py
@@ -358,21 +358,8 @@ class DeviceInboxStore(DeviceInboxWorkerStore, DeviceInboxBackgroundUpdateStore)
     def _add_messages_to_local_device_inbox_txn(
         self, txn, stream_id, messages_by_user_then_device
     ):
-        # Compatible method of performing an upsert
-        sql = "SELECT stream_id FROM device_max_stream_id"
-
-        txn.execute(sql)
-        rows = txn.fetchone()
-        if rows:
-            db_stream_id = rows[0]
-            if db_stream_id < stream_id:
-                # Insert the new stream_id
-                sql = "UPDATE device_max_stream_id SET stream_id = ?"
-        else:
-            # No rows, perform an insert
-            sql = "INSERT INTO device_max_stream_id (stream_id) VALUES (?)"
-
-        txn.execute(sql, (stream_id,))
+        sql = "UPDATE device_max_stream_id" " SET stream_id = ?" " WHERE stream_id < ?"
+        txn.execute(sql, (stream_id, stream_id))
 
         local_by_user_then_device = {}
         for user_id, messages_by_device in messages_by_user_then_device.items():

--- a/synapse/storage/data_stores/main/schema/delta/56/device_stream_id_insert.sql
+++ b/synapse/storage/data_stores/main/schema/delta/56/device_stream_id_insert.sql
@@ -12,6 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+-- This line already existed in deltas/35/device_stream_id but was not included in the
+-- 54 full schema SQL. Add some SQL here to insert the missing row if it does not exist
 INSERT INTO device_max_stream_id (stream_id) SELECT 0 WHERE NOT EXISTS (
     SELECT * from device_max_stream_id
 );

--- a/synapse/storage/data_stores/main/schema/delta/56/device_stream_id_insert.sql
+++ b/synapse/storage/data_stores/main/schema/delta/56/device_stream_id_insert.sql
@@ -1,0 +1,17 @@
+/* Copyright 2019 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+INSERT INTO device_max_stream_id (stream_id) SELECT 0 WHERE NOT EXISTS (
+    SELECT * from device_max_stream_id
+);

--- a/synapse/storage/data_stores/main/schema/full_schemas/54/stream_positions.sql
+++ b/synapse/storage/data_stores/main/schema/full_schemas/54/stream_positions.sql
@@ -5,3 +5,4 @@ INSERT INTO federation_stream_position (type, stream_id) SELECT 'events', coales
 INSERT INTO user_directory_stream_pos (stream_id) VALUES (0);
 INSERT INTO stats_stream_pos (stream_id) VALUES (0);
 INSERT INTO event_push_summary_stream_ordering (stream_ordering) VALUES (0);
+-- device_max_stream_id is handled separately in 56/device_stream_id_insert.sql


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/6311

The above issue came about because we missed an INSERT statement when making the 56 full schema. Synapse expected that row to exist, and had an UPDATE statement for it. When we missed the INSERT, the UPDATE just failed silently.

#6363 fixed it by doing some INSERT/UPDATE stuff in python, but it's not efficient and is prone to race conditions. This PR reverts that commit, and instead just adds another delta file, which is a cleaner fix.  

Reverts https://github.com/matrix-org/synapse/pull/6363 