### PR TITLE
Fix bug where we added duplicate event IDs as auth_events

### DIFF
--- a/changelog.d/6560.bugfix
+++ b/changelog.d/6560.bugfix
@@ -1,0 +1,1 @@
+Fix a cause of state resets in room versions 2 onwards.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -649,13 +649,11 @@ def auth_types_for_event(event) -> Set[Tuple[str]]:
     if event.type == EventTypes.Create:
         return set()
 
-    auth_types = set(
-        (
-            (EventTypes.PowerLevels, ""),
-            (EventTypes.Member, event.sender),
-            (EventTypes.Create, ""),
-        )
-    )
+    auth_types = {
+        (EventTypes.PowerLevels, ""),
+        (EventTypes.Member, event.sender),
+        (EventTypes.Create, ""),
+    }
 
     if event.type == EventTypes.Member:
         membership = event.content["membership"]


### PR DESCRIPTION
All other call sites iterated through the list and (eventually) created dicts, which is why this isn't a problem elsewhere.

Broke in #6556.