### PR TITLE
Explode on duplicate delta file names.

### DIFF
--- a/changelog.d/6565.misc
+++ b/changelog.d/6565.misc
@@ -1,0 +1,1 @@
+Add assertion that schema delta file names are unique.


### PR DESCRIPTION
Delta files must have unique names across data stores, so lets assert that.