### PR TITLE
Improve diagnostics on database upgrade failure

### DIFF
--- a/changelog.d/6570.misc
+++ b/changelog.d/6570.misc
@@ -1,0 +1,1 @@
+Improve diagnostics on database upgrade failure.

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -342,13 +342,8 @@ def setup(config_options):
         hs.setup()
     except IncorrectDatabaseSetup as e:
         quit_with_error(str(e))
-    except UpgradeDatabaseException:
-        sys.stderr.write(
-            "\nFailed to upgrade database.\n"
-            "Have you checked for version specific instructions in"
-            " UPGRADES.rst?\n"
-        )
-        sys.exit(1)
+    except UpgradeDatabaseException as e:
+        quit_with_error("Failed to upgrade database: %s" % (e,))
 
     hs.setup_master()
 

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -69,7 +69,10 @@ def prepare_database(db_conn, database_engine, config, data_stores=["main"]):
                 if user_version != SCHEMA_VERSION:
                     # If we don't pass in a config file then we are expecting to
                     # have already upgraded the DB.
-                    raise UpgradeDatabaseException("Database needs to be upgraded")
+                    raise UpgradeDatabaseException(
+                        "Expected database schema version %i but got %i"
+                        % (SCHEMA_VERSION, user_version)
+                    )
             else:
                 _upgrade_existing_database(
                     cur,


### PR DESCRIPTION
`Failed to upgrade database` is not helpful, and it's unlikely that UPGRADE.rst has anything useful.

Related: #6569