### PR TITLE
Backport fixes to sqlite upgrade from develop

### DIFF
--- a/changelog.d/6578.bugfix
+++ b/changelog.d/6578.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.7.0 which caused an error on startup when upgrading from versions before 1.3.0.


### PR DESCRIPTION
Only run prepare_database on connection for in-memory databases.

Fixes #6569.