### PR TITLE
Hacks to work around #6605

### DIFF
--- a/changelog.d/6608.bugfix
+++ b/changelog.d/6608.bugfix
@@ -1,0 +1,1 @@
+Fix exceptions caused by state resolution choking on malformed events.


### PR DESCRIPTION
When we have an event which refers to non-existent auth_events, ignore said events rather than exploding in a ball of fire.

Fixes #6605 .