### PR TITLE
Reduce the reconnect time when replication fails.

### DIFF
--- a/changelog.d/6617.misc
+++ b/changelog.d/6617.misc
@@ -1,0 +1,1 @@
+Reduce the reconnect time when worker replication fails, to make it easier to catch up.

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -46,7 +46,8 @@ class ReplicationClientFactory(ReconnectingClientFactory):
     is required.
     """
 
-    maxDelay = 30  # Try at least once every N seconds
+    initialDelay = 0.1
+    maxDelay = 1  # Try at least once every N seconds
 
     def __init__(self, hs, client_name, handler: AbstractReplicationClientHandler):
         self.client_name = client_name


### PR DESCRIPTION
The thinking here is that, if we wait a full 30 seconds, there's a good chance that there will be a huge volume of data waiting for us, so we'll get booted straight off again, and never successfully reconnect. OTOH even if we end up tight-looping on a reconnection, one connection every second isn't so bad.

This is all something of a sticking-plaster, of course: ideally there would be a separate "catching up mode" in which we wouldn't get booted straight off again.

Helps to mitigate #6602.