### PR TITLE
federation client: Don't put remote certificate errors into the log

### DIFF
--- a/changelog.d/6622.misc
+++ b/changelog.d/6622.misc
@@ -1,0 +1,1 @@
+federation client: Don't put remote certificate errors into the log

--- a/changelog.d/6622.misc
+++ b/changelog.d/6622.misc
@@ -1,1 +1,1 @@
-federation client: Don't put remote certificate errors into the log
+federation client: Don't put remote certificate errors into the log.

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -762,9 +762,10 @@ class ServerKeyFetcher(BaseV2KeyFetcher):
                 keys = yield self.get_server_verify_key_v2_direct(server_name, key_ids)
                 results[server_name] = keys
             except KeyLookupError as e:
-                logger.warning(
-                    "Error looking up keys %s from %s: %s", key_ids, server_name, e
-                )
+                if str(e) != "Failed to connect to remote server":
+                    logger.warning(
+                        "Error looking up keys %s from %s: %s", key_ids, server_name, e
+                    )
             except Exception:
                 logger.exception("Error getting keys %s from %s", key_ids, server_name)
 

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -292,7 +292,8 @@ class BaseFederationServlet(object):
                     )
                     raise
             except Exception as e:
-                logger.warning("authenticate_request failed: %s", e)
+                if not (isinstance(e, SynapseError) and e.errcode == Codes.UNAUTHORIZED):
+                    logger.warning("authenticate_request failed: %s", e)
                 raise
 
             request_tags = {

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -292,7 +292,9 @@ class BaseFederationServlet(object):
                     )
                     raise
             except Exception as e:
-                if not (isinstance(e, SynapseError) and e.errcode == Codes.UNAUTHORIZED):
+                if not (
+                    isinstance(e, SynapseError) and e.errcode == Codes.UNAUTHORIZED
+                ):
                     logger.warning("authenticate_request failed: %s", e)
                 raise
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -478,14 +478,16 @@ class MatrixFederationHttpClient(object):
 
                     break
                 except RequestSendFailed as e:
-                    logger.warning(
-                        "{%s} [%s] Request failed: %s %s: %s",
-                        request.txn_id,
-                        request.destination,
-                        request.method,
-                        url_str,
-                        _flatten_response_never_received(e.inner_exception),
-                    )
+                    in_ex_txt = _flatten_response_never_received(e.inner_exception)
+                    if in_ex_txt != "ResponseNeverReceived:[Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')])]":
+                        logger.warning(
+                            "{%s} [%s] Request failed: %s %s: %s",
+                            request.txn_id,
+                            request.destination,
+                            request.method,
+                            url_str,
+                            in_ex_txt,
+                        )
 
                     if not e.can_retry:
                         raise

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -479,7 +479,10 @@ class MatrixFederationHttpClient(object):
                     break
                 except RequestSendFailed as e:
                     in_ex_txt = _flatten_response_never_received(e.inner_exception)
-                    if in_ex_txt != "ResponseNeverReceived:[Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')])]":
+                    if (
+                        in_ex_txt
+                        != "ResponseNeverReceived:[Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')])]"
+                    ):
                         logger.warning(
                             "{%s} [%s] Request failed: %s %s: %s",
                             request.txn_id,


### PR DESCRIPTION
There's nothing an admin can do about invalid certificates on remote site.
Hence, it's not needed to send these messages as warnings to the log.

```
2019-07-14 18:21:12,202 - synapse.http.matrixfederationclient - 482 - WARNING - PUT-63776- {GET-O-1479} [bruder.space] Request failed: GET matrix://bruder.space/_matrix/key/v2/server/ed25519%3Aa_fAer: ResponseNeverReceived:[Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')])]
2019-07-14 18:21:12,203 - synapse.crypto.keyring - 792 - WARNING - PUT-63776- Error looking up keys {'ed25519:a_fAer': 1563121271468} from bruder.space: Failed to connect to remote server
2019-07-14 18:21:12,203 - synapse.federation.transport.server - 286 - WARNING - PUT-63776- authenticate_request failed: 401: No key for bruder.space with ids in ['ed25519:a_fAer'] (min_validity 1563121271468)
```

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
