### PR TITLE
Fix exception when fetching notary server's old keys

### DIFF
--- a/changelog.d/6625.bugfix
+++ b/changelog.d/6625.bugfix
@@ -1,0 +1,1 @@
+Fix exception when fetching the `matrix.org:ed25519:auto` key.


### PR DESCRIPTION
Lift the restriction that *all* the keys used for signing v2 key responses be
present in verify_keys.

Fixes #6596.