### PR TITLE
Remove a bunch of unused code from event creation

### DIFF
--- a/changelog.d/6629.misc
+++ b/changelog.d/6629.misc
@@ -1,0 +1,1 @@
+Simplify event creation code by removing redundant queries on the event_reference_hashes table.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -740,7 +740,7 @@ class EventCreationHandler(object):
                 % (len(prev_events_and_hashes),)
             )
         else:
-            prev_events_and_hashes = yield self.store.get_prev_events_for_room(
+            prev_events_and_hashes = yield self.store.get_prev_events_and_hashes_for_room(
                 builder.room_id
             )
 
@@ -1042,7 +1042,9 @@ class EventCreationHandler(object):
             # For each room we need to find a joined member we can use to send
             # the dummy event with.
 
-            prev_events_and_hashes = yield self.store.get_prev_events_for_room(room_id)
+            prev_events_and_hashes = yield self.store.get_prev_events_and_hashes_for_room(
+                room_id
+            )
 
             latest_event_ids = (event_id for (event_id, _, _) in prev_events_and_hashes)
 

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -739,17 +739,11 @@ class EventCreationHandler(object):
                 "Attempting to create an event with %i prev_events"
                 % (len(prev_events_and_hashes),)
             )
+            prev_event_ids = [event_id for event_id, _, _ in prev_events_and_hashes]
         else:
-            prev_events_and_hashes = yield self.store.get_prev_events_and_hashes_for_room(
-                builder.room_id
-            )
+            prev_event_ids = yield self.store.get_prev_events_for_room(builder.room_id)
 
-        prev_events = [
-            (event_id, prev_hashes)
-            for event_id, prev_hashes, _ in prev_events_and_hashes
-        ]
-
-        event = yield builder.build(prev_event_ids=[p for p, _ in prev_events])
+        event = yield builder.build(prev_event_ids=prev_event_ids)
         context = yield self.state.compute_event_context(event)
         if requester:
             context.app_service = requester.app_service

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -370,7 +370,9 @@ class RoomMemberHandler(object):
             if block_invite:
                 raise SynapseError(403, "Invites have been disabled on this server")
 
-        prev_events_and_hashes = yield self.store.get_prev_events_for_room(room_id)
+        prev_events_and_hashes = yield self.store.get_prev_events_and_hashes_for_room(
+            room_id
+        )
         latest_event_ids = (event_id for (event_id, _, _) in prev_events_and_hashes)
 
         current_state_ids = yield self.state_handler.get_current_state_ids(

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -164,6 +164,12 @@ class RoomMemberHandler(object):
         if requester.is_guest:
             content["kind"] = "guest"
 
+        prev_event_ids = (
+            None
+            if prev_events_and_hashes is None
+            else [event_id for event_id, _, _ in prev_events_and_hashes]
+        )
+
         event, context = yield self.event_creation_handler.create_event(
             requester,
             {
@@ -177,7 +183,7 @@ class RoomMemberHandler(object):
             },
             token_id=requester.access_token_id,
             txn_id=txn_id,
-            prev_events_and_hashes=prev_events_and_hashes,
+            prev_event_ids=prev_event_ids,
             require_consent=require_consent,
         )
 

--- a/synapse/storage/data_stores/main/event_federation.py
+++ b/synapse/storage/data_stores/main/event_federation.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import itertools
 import logging
-import random
 
 from six.moves import range
 from six.moves.queue import Empty, PriorityQueue
@@ -147,35 +146,6 @@ class EventFederationWorkerStore(EventsWorkerStore, SignatureWorkerStore, SQLBas
             keyvalues={"room_id": room_id},
             retcol="event_id",
         )
-
-    @defer.inlineCallbacks
-    def get_prev_events_and_hashes_for_room(self, room_id):
-        """
-        Gets a subset of the current forward extremities in the given room,
-        along with their depths and hashes.
-
-        Limits the result to 10 extremities, so that we can avoid creating
-        events which refer to hundreds of prev_events.
-
-        Args:
-            room_id (str): room_id
-
-        Returns:
-            Deferred[list[(str, dict[str, str], int)]]
-                for each event, a tuple of (event_id, hashes, depth)
-                where *hashes* is a map from algorithm to hash.
-        """
-        res = yield self.get_latest_event_ids_and_hashes_in_room(room_id)
-        if len(res) > 10:
-            # Sort by reverse depth, so we point to the most recent.
-            res.sort(key=lambda a: -a[2])
-
-            # we use half of the limit for the actual most recent events, and
-            # the other half to randomly point to some of the older events, to
-            # make sure that we don't completely ignore the older events.
-            res = res[0:5] + random.sample(res[5:], 5)
-
-        return res
 
     def get_prev_events_for_room(self, room_id: str):
         """

--- a/synapse/storage/data_stores/main/event_federation.py
+++ b/synapse/storage/data_stores/main/event_federation.py
@@ -149,9 +149,10 @@ class EventFederationWorkerStore(EventsWorkerStore, SignatureWorkerStore, SQLBas
         )
 
     @defer.inlineCallbacks
-    def get_prev_events_for_room(self, room_id):
+    def get_prev_events_and_hashes_for_room(self, room_id):
         """
-        Gets a subset of the current forward extremities in the given room.
+        Gets a subset of the current forward extremities in the given room,
+        along with their depths and hashes.
 
         Limits the result to 10 extremities, so that we can avoid creating
         events which refer to hundreds of prev_events.

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 import re
 import string
+import sys
 from collections import namedtuple
 
 import attr
@@ -22,6 +23,17 @@ from signedjson.key import decode_verify_key_bytes
 from unpaddedbase64 import decode_base64
 
 from synapse.api.errors import SynapseError
+
+# define a version of typing.Collection that works on python 3.5
+if sys.version_info[:3] >= (3, 6, 0):
+    from typing import Collection
+else:
+    from typing import Sized, Iterable, Container, TypeVar
+
+    T_co = TypeVar("T_co", covariant=True)
+
+    class Collection(Iterable[T_co], Container[T_co], Sized):
+        __slots__ = ()
 
 
 class Requester(

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -26,7 +26,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.TestCase):
         self.store = hs.get_datastore()
 
     @defer.inlineCallbacks
-    def test_get_prev_events_for_room(self):
+    def test_get_prev_events_and_hashes_for_room(self):
         room_id = "@ROOM:local"
 
         # add a bunch of events and hashes to act as forward extremities
@@ -64,7 +64,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.TestCase):
             yield self.store.db.runInteraction("insert", insert_event, i)
 
         # this should get the last five and five others
-        r = yield self.store.get_prev_events_for_room(room_id)
+        r = yield self.store.get_prev_events_and_hashes_for_room(room_id)
         self.assertEqual(10, len(r))
         for i in range(0, 5):
             el = r[i]

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -26,7 +26,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.TestCase):
         self.store = hs.get_datastore()
 
     @defer.inlineCallbacks
-    def test_get_prev_events_and_hashes_for_room(self):
+    def test_get_prev_events_for_room(self):
         room_id = "@ROOM:local"
 
         # add a bunch of events and hashes to act as forward extremities
@@ -60,21 +60,14 @@ class EventFederationWorkerStoreTestCase(tests.unittest.TestCase):
                 (event_id, bytearray(b"ffff")),
             )
 
-        for i in range(0, 11):
+        for i in range(0, 20):
             yield self.store.db.runInteraction("insert", insert_event, i)
 
-        # this should get the last five and five others
-        r = yield self.store.get_prev_events_and_hashes_for_room(room_id)
+        # this should get the last ten
+        r = yield self.store.get_prev_events_for_room(room_id)
         self.assertEqual(10, len(r))
-        for i in range(0, 5):
-            el = r[i]
-            depth = el[2]
-            self.assertEqual(10 - i, depth)
-
-        for i in range(5, 5):
-            el = r[i]
-            depth = el[2]
-            self.assertLessEqual(5, depth)
+        for i in range(0, 10):
+            self.assertEqual("$event_%i:local" % (19 - i), r[i])
 
     @defer.inlineCallbacks
     def test_get_rooms_with_many_extremities(self):

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -522,10 +522,6 @@ class HomeserverTestCase(TestCase):
         secrets = self.hs.get_secrets()
         requester = Requester(user, None, False, None, None)
 
-        prev_events_and_hashes = None
-        if prev_event_ids:
-            prev_events_and_hashes = [[p, {}, 0] for p in prev_event_ids]
-
         event, context = self.get_success(
             event_creator.create_event(
                 requester,
@@ -535,7 +531,7 @@ class HomeserverTestCase(TestCase):
                     "sender": user.to_string(),
                     "content": {"body": secrets.token_hex(), "msgtype": "m.text"},
                 },
-                prev_events_and_hashes=prev_events_and_hashes,
+                prev_event_ids=prev_event_ids,
             )
         )
 


### PR DESCRIPTION
As per #6574, we were carefully pulling the event hashes out of `event_reference_hashes` and then throwing them away. We can simplify this. Sadly we can't kill off event_reference_hashes altogether because it turns out to be used elsewhere after all.

This PR is a series of commits each of which stands alone.