### PR TITLE
Fix power levels being incorrectly set in old and new rooms after a room upgrade

### DIFF
--- a/changelog.d/6633.bugfix
+++ b/changelog.d/6633.bugfix
@@ -1,0 +1,1 @@
+Fix bug where a moderator upgraded a room and became an admin in the new room.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -370,12 +370,12 @@ class RoomCreationHandler(BaseHandler):
         if current_power_level < needed_power_level:
             # Perform a deepcopy of the dict in order to not modify initial_state, as its
             # contents are preserved as the state for the old room later on
-            initial_state = copy.deepcopy(initial_state)
+            existing_power_levels = initial_state[(EventTypes.PowerLevels, "")]
+            new_power_levels = copy.deepcopy(existing_power_levels)
+            initial_state[(EventTypes.PowerLevels, "")] = new_power_levels
 
             # Assign this power level to the requester
-            initial_state[(EventTypes.PowerLevels, "")]["users"][
-                requester.user.to_string()
-            ] = needed_power_level
+            new_power_levels["users"][requester.user.to_string()] = needed_power_level
 
         yield self._send_events_for_new_room(
             requester,

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -366,16 +366,15 @@ class RoomCreationHandler(BaseHandler):
         needed_power_level = max(state_default, ban, max(event_power_levels.values()))
 
         # Raise the requester's power level in the new room if necessary
-        current_power_level = power_levels["users"][requester.user.to_string()]
+        current_power_level = power_levels["users"][user_id]
         if current_power_level < needed_power_level:
             # Perform a deepcopy in order to not modify the original power levels in a
             # room, as its contents are preserved as the state for the old room later on
-            existing_power_levels = initial_state[(EventTypes.PowerLevels, "")]
-            new_power_levels = copy.deepcopy(existing_power_levels)
+            new_power_levels = copy.deepcopy(power_levels)
             initial_state[(EventTypes.PowerLevels, "")] = new_power_levels
 
             # Assign this power level to the requester
-            new_power_levels["users"][requester.user.to_string()] = needed_power_level
+            new_power_levels["users"][user_id] = needed_power_level
 
         yield self._send_events_for_new_room(
             requester,

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -368,8 +368,8 @@ class RoomCreationHandler(BaseHandler):
         # Raise the requester's power level in the new room if necessary
         current_power_level = power_levels["users"][requester.user.to_string()]
         if current_power_level < needed_power_level:
-            # Perform a deepcopy of the dict in order to not modify initial_state, as its
-            # contents are preserved as the state for the old room later on
+            # Perform a deepcopy in order to not modify the original power levels in a
+            # room, as its contents are preserved as the state for the old room later on
             existing_power_levels = initial_state[(EventTypes.PowerLevels, "")]
             new_power_levels = copy.deepcopy(existing_power_levels)
             initial_state[(EventTypes.PowerLevels, "")] = new_power_levels


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/6632

Sytests: https://github.com/matrix-org/sytest/pull/777

Fixes a bug introduced in https://github.com/matrix-org/synapse/pull/6237 where in which a moderator in a room upgrades the room, the following oddities occur:

* The Mod in the old room gets upgraded to an Admin (but only from the perspective of the server upgrading the room).
* The Mod in the new room isn't being downgraded back to a Mod again, but is left as an Admin. (They need to be an Admin initially to send required room state, but should be downgraded back to their original power level immediately afterwards).

Turns out the problem was due to modifying `initial_state`, which was a dictionary representing the state of the old room. This modified object continues to persist however, and later on in `_update_upgraded_room_pls`, when we attempt to send a power level event to mute users in the old room, we end up grabbing `initial_state` again, which contains the Mod as an Admin instead. At this point, the Mod is set to an Admin in the old room.

Additionally, the way we downgrade the Mod back from an Admin to a Mod in the new room, is by simply applying the old room's power levels once again. But, since we're using the modified power levels object, which had the Mod as an Admin, the Mod remains an Admin in the new room.

Performing a deepcopy instead solves both of these problems.