### PR TITLE
Fix CAS redirect url

### DIFF
--- a/changelog.d/6634.bugfix
+++ b/changelog.d/6634.bugfix
@@ -1,1 +1,1 @@
-Build the same service URL when requesting the CAS ticket and when calling the proxyValidate URL.
+Fix single-sign on with CAS systems: pass the same service URL when requesting the CAS ticket and when calling the `proxyValidate` URL. Contributed by @Naugrimm.

--- a/changelog.d/6634.bugfix
+++ b/changelog.d/6634.bugfix
@@ -1,0 +1,1 @@
+Build the same service URL when requesting the CAS ticket and when calling the proxyValidate URL.

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -448,7 +448,10 @@ class CasTicketServlet(RestServlet):
     def __init__(self, hs):
         super(CasTicketServlet, self).__init__()
         self.cas_server_url = hs.config.cas_server_url
-        self.cas_service_url = hs.config.cas_service_url.encode("ascii") + b"/_matrix/client/r0/login/cas/ticket?redirectUrl="
+        self.cas_service_url = (
+            hs.config.cas_service_url.encode("ascii")
+            + b"/_matrix/client/r0/login/cas/ticket?redirectUrl="
+        )
         self.cas_displayname_attribute = hs.config.cas_displayname_attribute
         self.cas_required_attributes = hs.config.cas_required_attributes
         self._sso_auth_handler = SSOAuthHandler(hs)
@@ -457,7 +460,9 @@ class CasTicketServlet(RestServlet):
     async def on_GET(self, request):
         client_redirect_url = parse_string(request, "redirectUrl", required=True)
         uri = self.cas_server_url + "/proxyValidate"
-        service_url = self.cas_service_url + urllib.parse.quote(client_redirect_url, safe='').encode("ascii")
+        service_url = self.cas_service_url + urllib.parse.quote(
+            client_redirect_url, safe=""
+        ).encode("ascii")
         args = {
             "ticket": parse_string(request, "ticket", required=True),
             "service": service_url,

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -448,7 +448,7 @@ class CasTicketServlet(RestServlet):
     def __init__(self, hs):
         super(CasTicketServlet, self).__init__()
         self.cas_server_url = hs.config.cas_server_url
-        self.cas_service_url = hs.config.cas_service_url
+        self.cas_service_url = hs.config.cas_service_url.encode("ascii") + b"/_matrix/client/r0/login/cas/ticket?redirectUrl="
         self.cas_displayname_attribute = hs.config.cas_displayname_attribute
         self.cas_required_attributes = hs.config.cas_required_attributes
         self._sso_auth_handler = SSOAuthHandler(hs)
@@ -457,9 +457,10 @@ class CasTicketServlet(RestServlet):
     async def on_GET(self, request):
         client_redirect_url = parse_string(request, "redirectUrl", required=True)
         uri = self.cas_server_url + "/proxyValidate"
+        service_url = self.cas_service_url + urllib.parse.quote(client_redirect_url, safe='').encode("ascii")
         args = {
             "ticket": parse_string(request, "ticket", required=True),
-            "service": self.cas_service_url,
+            "service": service_url,
         }
         try:
             body = await self._http_client.get_raw(uri, args)


### PR DESCRIPTION
Build the same service URL when requesting the CAS ticket and when calling the proxyValidate URL.

<strike>This now of course breaks the CAS-related tests.</strike>
The fixed tests are in https://github.com/matrix-org/sytest/pull/829

Fixes #2639 

Signed-off-by: Erik <erik.gto@googlemail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
