### PR TITLE
Fix an error which was thrown by the PresenceHandler _on_shutdown handler.

### DIFF
--- a/changelog.d/6640.bugfix
+++ b/changelog.d/6640.bugfix
@@ -1,0 +1,1 @@
+Fix an error which was thrown by the PresenceHandler _on_shutdown handler.

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -95,12 +95,7 @@ assert LAST_ACTIVE_GRANULARITY < IDLE_TIMER
 
 
 class PresenceHandler(object):
-    def __init__(self, hs):
-        """
-
-        Args:
-            hs (synapse.server.HomeServer):
-        """
+    def __init__(self, hs: "synapse.server.HomeServer"):
         self.hs = hs
         self.is_mine = hs.is_mine
         self.is_mine_id = hs.is_mine_id
@@ -230,7 +225,7 @@ class PresenceHandler(object):
         is some spurious presence changes that will self-correct.
         """
         # If the DB pool has already terminated, don't try updating
-        if not self.store.database.is_running():
+        if not self.store.db.is_running():
             return
 
         logger.info(


### PR DESCRIPTION
The exception looked like:

```
2020-01-06 10:05:01,649 - synapse.metrics.background_process_metrics - 214 - ERROR - presence.on_shutdown-0 - Background process 'presence.on_shutdown' threw an exception
Traceback (most recent call last):
  File "/venv/lib/python3.5/site-packages/synapse/metrics/background_process_metrics.py", line 212, in run
    return (yield result)
  File "/venv/lib/python3.5/site-packages/synapse/util/patch_inline_callbacks.py", line 190, in check_yield_points_inner
    result = yield d
AttributeError: 'DataStore' object has no attribute 'database'
```

Introduced (I think) by #6513