### PR TITLE
Quarantine media by ID or user ID

### DIFF
--- a/changelog.d/6681.feature
+++ b/changelog.d/6681.feature
@@ -1,0 +1,1 @@
+Extend the quarantine_media admin API to quarantine media by ID or all media by a specific user.

--- a/docs/admin_api/media_admin_api.md
+++ b/docs/admin_api/media_admin_api.md
@@ -33,6 +33,8 @@ The media file itself (and any thumbnails) is not deleted from the server.
 
 This API quarantines a single piece of local or remote media.
 
+Request:
+
 ```
 POST /_synapse/admin/v1/quarantine_media_by_id/<server_name>/<media_id>
 
@@ -42,19 +44,33 @@ POST /_synapse/admin/v1/quarantine_media_by_id/<server_name>/<media_id>
 Where `server_name` is in the form of `example.org`, and `media_id` is in the
 form of `abcdefg12345...`.
 
+Response:
+
+```
+{}
+```
+
 ## Quarantining media in a room
 
 This API quarantines all local and remote media in a room.
 
+Request:
+
 ```
 POST /_synapse/admin/v1/quarantine_media_by_room/<room_id>
 
+{}
+```
+
+Where `room_id` is in the form of `!roomid12345:example.org`.
+
+Response:
+
+```
 {
   "num_quarantined": 10  # The number of media items successfully quarantined
 }
 ```
-
-Where `room_id` is in the form of `!roomid12345:example.org`.
 
 Note that there is a legacy endpoint, `POST
 /_synapse/admin/v1/quarantine_media/<room_id >`, that operates the same.
@@ -66,11 +82,21 @@ This API quarantines all *local* media that a *local* user has uploaded. That is
 you would like to quarantine media uploaded by a user on a remote homeserver, you should
 instead use one of the other APIs.
 
+Request:
+
 ```
 POST /_synapse/admin/v1/quarantine_media_by_user/<user_id>
+
+{}
+```
+
+Where `user_id` is in the form of `@bob:example.org`.
+
+Response:
+
+```
 {
   "num_quarantined": 10  # The number of media items successfully quarantined
 }
 ```
 
-Where `user_id` is in the form of `@bob:example.org`.

--- a/docs/admin_api/media_admin_api.md
+++ b/docs/admin_api/media_admin_api.md
@@ -22,19 +22,50 @@ It returns a JSON body like the following:
 }
 ```
 
-# Quarantine media in a room
-
-This API 'quarantines' all the media in a room.
-
-The API is:
-
-```
-POST /_synapse/admin/v1/quarantine_media/<room_id>
-
-{}
-```
+# Quarantine media
 
 Quarantining media means that it is marked as inaccessible by users. It applies
 to any local media, and any locally-cached copies of remote media.
 
 The media file itself (and any thumbnails) is not deleted from the server.
+
+## Quarantining media by ID
+
+This API quarantines a single piece of local or remote media.
+
+```
+POST /_synapse/admin/v1/quarantine_media/<media_id>
+
+{}
+```
+
+Where `media_id` is in the form of `example.org/abcdefg12345...`.
+
+## Quarantining media in a room
+
+This API quarantines all local and remote media in a room.
+
+```
+POST /_synapse/admin/v1/quarantine_media/<room_id>
+
+{
+  "num_quarantined": 10  # The number of media items successfully quarantined
+}
+```
+
+Where `room_id` is in the form of `!roomid12345:example.org`.
+
+## Quarantining all media of a user
+
+This API quarantines all *local* media that a *local* user has uploaded. That is to say, if
+you would like to quarantine media uploaded by a user on a remote homeserver, you should
+instead use one of the other APIs.
+
+```
+POST /_synapse/admin/v1/quarantine_media/<user_id>
+{
+  "num_quarantined": 10  # The number of media items successfully quarantined
+}
+```
+
+Where `user_id` is in the form of `@bob:example.org`.

--- a/docs/admin_api/media_admin_api.md
+++ b/docs/admin_api/media_admin_api.md
@@ -34,19 +34,20 @@ The media file itself (and any thumbnails) is not deleted from the server.
 This API quarantines a single piece of local or remote media.
 
 ```
-POST /_synapse/admin/v1/quarantine_media/<media_id>
+POST /_synapse/admin/v1/quarantine_media_by_id/<server_name>/<media_id>
 
 {}
 ```
 
-Where `media_id` is in the form of `example.org/abcdefg12345...`.
+Where `server_name` is in the form of `example.org`, and `media_id` is in the
+form of `abcdefg12345...`.
 
 ## Quarantining media in a room
 
 This API quarantines all local and remote media in a room.
 
 ```
-POST /_synapse/admin/v1/quarantine_media/<room_id>
+POST /_synapse/admin/v1/quarantine_media_by_room/<room_id>
 
 {
   "num_quarantined": 10  # The number of media items successfully quarantined
@@ -55,6 +56,10 @@ POST /_synapse/admin/v1/quarantine_media/<room_id>
 
 Where `room_id` is in the form of `!roomid12345:example.org`.
 
+Note that there is a legacy endpoint, `POST
+/_synapse/admin/v1/quarantine_media/<room_id >`, that operates the same.
+However, it is deprecated and may be removed in a future release.
+
 ## Quarantining all media of a user
 
 This API quarantines all *local* media that a *local* user has uploaded. That is to say, if
@@ -62,7 +67,7 @@ you would like to quarantine media uploaded by a user on a remote homeserver, yo
 instead use one of the other APIs.
 
 ```
-POST /_synapse/admin/v1/quarantine_media/<user_id>
+POST /_synapse/admin/v1/quarantine_media_by_user/<user_id>
 {
   "num_quarantined": 10  # The number of media items successfully quarantined
 }

--- a/docs/admin_api/media_admin_api.md
+++ b/docs/admin_api/media_admin_api.md
@@ -36,7 +36,7 @@ This API quarantines a single piece of local or remote media.
 Request:
 
 ```
-POST /_synapse/admin/v1/quarantine_media_by_id/<server_name>/<media_id>
+POST /_synapse/admin/v1/media/quarantine/<server_name>/<media_id>
 
 {}
 ```
@@ -57,7 +57,7 @@ This API quarantines all local and remote media in a room.
 Request:
 
 ```
-POST /_synapse/admin/v1/quarantine_media_by_room/<room_id>
+POST /_synapse/admin/v1/room/<room_id>/media/quarantine
 
 {}
 ```
@@ -85,7 +85,7 @@ instead use one of the other APIs.
 Request:
 
 ```
-POST /_synapse/admin/v1/quarantine_media_by_user/<user_id>
+POST /_synapse/admin/v1/user/<user_id>/media/quarantine
 
 {}
 ```

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -199,7 +199,9 @@ Handles the media repository. It can handle all endpoints starting with:
 ... and the following regular expressions matching media-specific administration APIs:
 
     ^/_synapse/admin/v1/purge_media_cache$
-    ^/_synapse/admin/v1/room/.*/media$
+    ^/_synapse/admin/v1/room/.*/media.*$
+    ^/_synapse/admin/v1/user/.*/media.*$
+    ^/_synapse/admin/v1/media/.*$
     ^/_synapse/admin/v1/quarantine_media/.*$
 
 You should also set `enable_media_repo: False` in the shared configuration

--- a/synapse/rest/admin/media.py
+++ b/synapse/rest/admin/media.py
@@ -33,7 +33,7 @@ class QuarantineMediaInRoom(RestServlet):
     """
 
     PATTERNS = (
-        historical_admin_path_patterns("/quarantine_media_by_room/(?P<room_id>[^/]+)")
+        historical_admin_path_patterns("/room/(?P<room_id>[^/]+)/media/quarantine")
         +
         # This path kept around for legacy reasons
         historical_admin_path_patterns("/quarantine_media/(?P<room_id>![^/]+)")
@@ -63,7 +63,7 @@ class QuarantineMediaByUser(RestServlet):
     """
 
     PATTERNS = historical_admin_path_patterns(
-        "/quarantine_media_by_user/(?P<user_id>[^/]+)"
+        "/user/(?P<user_id>[^/]+)/media/quarantine"
     )
 
     def __init__(self, hs):
@@ -90,7 +90,7 @@ class QuarantineMediaByID(RestServlet):
     """
 
     PATTERNS = historical_admin_path_patterns(
-        "/quarantine_media_by_id/(?P<server_name>[^/]+)/(?P<media_id>[^/]+)"
+        "/media/quarantine/(?P<server_name>[^/]+)/(?P<media_id>[^/]+)"
     )
 
     def __init__(self, hs):

--- a/synapse/storage/data_stores/main/room.py
+++ b/synapse/storage/data_stores/main/room.py
@@ -399,6 +399,8 @@ class RoomWorkerStore(SQLBaseStore):
         the associated media
         """
 
+        logger.info("Quarantining media in room: %s", room_id)
+
         def _quarantine_media_in_room_txn(txn):
             local_mxcs, remote_mxcs = self._get_media_mxcs_in_room_txn(txn, room_id)
             total_media_quarantined = 0
@@ -493,6 +495,118 @@ class RoomWorkerStore(SQLBaseStore):
             )
 
         return local_media_mxcs, remote_media_mxcs
+
+    def quarantine_media_by_id(
+        self, server_name: str, media_id: str, quarantined_by: str,
+    ):
+        """quarantines a single local or remote media id
+
+        Args:
+            server_name: The name of the server that holds this media
+            media_id: The ID of the media to be quarantined
+            quarantined_by: The user ID that initiated the quarantine request
+        """
+        logger.info("Quarantining media: %s/%s", server_name, media_id)
+        is_local = server_name == self.config.server_name
+
+        def _quarantine_media_by_id_txn(txn):
+            local_mxcs = [media_id] if is_local else []
+            remote_mxcs = [(server_name, media_id)] if not is_local else []
+
+            return self._quarantine_media_txn(
+                txn, local_mxcs, remote_mxcs, quarantined_by
+            )
+
+        return self.db.runInteraction(
+            "quarantine_media_by_user", _quarantine_media_by_id_txn
+        )
+
+    def quarantine_media_ids_by_user(self, user_id: str, quarantined_by: str):
+        """quarantines all local media associated with a single user
+
+        Args:
+            user_id: The ID of the user to quarantine media of
+            quarantined_by: The ID of the user who made the quarantine request
+        """
+
+        def _quarantine_media_by_user_txn(txn):
+            local_media_ids = self._get_media_ids_by_user_txn(txn, user_id)
+            return self._quarantine_media_txn(txn, local_media_ids, [], quarantined_by)
+
+        return self.db.runInteraction(
+            "quarantine_media_by_user", _quarantine_media_by_user_txn
+        )
+
+    def _get_media_ids_by_user_txn(self, txn, user_id: str, filter_quarantined=True):
+        """Retrieves local media IDs by a given user
+
+        Args:
+            txn (cursor)
+            user_id: The ID of the user to retrieve media IDs of
+
+        Returns:
+            The local and remote media as a lists of tuples where the key is
+            the hostname and the value is the media ID.
+        """
+        # Local media
+        sql = """
+            SELECT media_id
+            FROM local_media_repository
+            WHERE user_id = ?
+            """
+        if filter_quarantined:
+            sql += "AND quarantined_by IS NULL"
+        txn.execute(sql, (user_id,))
+
+        local_media_ids = [row[0] for row in txn]
+
+        # TODO: Figure out all remote media a user has referenced in a message
+
+        return local_media_ids
+
+    def _quarantine_media_txn(
+        self,
+        txn,
+        local_mxcs: List[str],
+        remote_mxcs: List[Tuple[str, str]],
+        quarantined_by: str,
+    ) -> int:
+        """Quarantine local and remote media items
+
+        Args:
+            txn (cursor)
+            local_mxcs: A list of local mxc URLs
+            remote_mxcs: A list of (remote server, media id) tuples representing
+                remote mxc URLs
+            quarantined_by: The ID of the user who initiated the quarantine request
+        Returns:
+            The total number of media items quarantined
+        """
+        total_media_quarantined = 0
+
+        # Update all the tables to set the quarantined_by flag
+        txn.executemany(
+            """
+            UPDATE local_media_repository
+            SET quarantined_by = ?
+            WHERE media_id = ?
+        """,
+            ((quarantined_by, media_id) for media_id in local_mxcs),
+        )
+
+        txn.executemany(
+            """
+                UPDATE remote_media_cache
+                SET quarantined_by = ?
+                WHERE media_origin = ? AND media_id = ?
+            """,
+            ((quarantined_by, origin, media_id) for origin, media_id in remote_mxcs),
+        )
+
+        total_media_quarantined += len(local_mxcs)
+        total_media_quarantined += len(remote_mxcs)
+
+        return total_media_quarantined
 
 
 class RoomBackgroundUpdateStore(SQLBaseStore):
@@ -965,190 +1079,6 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore, SearchStore):
         return self.db.runInteraction(
             "get_media_ids_in_room", _get_media_mxcs_in_room_txn
         )
-
-    def quarantine_media_ids_in_room(self, room_id, quarantined_by):
-        """For a room loops through all events with media and quarantines
-        the associated media
-        """
-
-        def _quarantine_media_in_room_txn(txn):
-            local_mxcs, remote_mxcs = self._get_media_mxcs_in_room_txn(txn, room_id)
-            return self._quarantine_media_txn(
-                txn, local_mxcs, remote_mxcs, quarantined_by,
-            )
-
-        return self.db.runInteraction(
-            "quarantine_media_in_room", _quarantine_media_in_room_txn
-        )
-
-    def _get_media_mxcs_in_room_txn(
-        self, txn, room_id,
-    ) -> Tuple[List[str], List[Tuple[str, str]]]:
-        """Retrieves all the local and remote media MXC URIs in a given room
-
-        Args:
-            txn (cursor)
-            room_id (str)
-
-        Returns:
-            The local and remote media as a lists of tuples where the key is
-            the hostname and the value is the media ID.
-        """
-        mxc_re = re.compile("^mxc://([^/]+)/([^/#?]+)")
-
-        next_token = self.get_current_events_token() + 1
-        local_media_mxcs = []
-        remote_media_mxcs = []
-
-        while next_token:
-            sql = """
-                SELECT stream_ordering, json FROM events
-                JOIN event_json USING (room_id, event_id)
-                WHERE room_id = ?
-                    AND stream_ordering < ?
-                    AND contains_url = ? AND outlier = ?
-                ORDER BY stream_ordering DESC
-                LIMIT ?
-            """
-            txn.execute(sql, (room_id, next_token, True, False, 100))
-
-            next_token = None
-            for stream_ordering, content_json in txn:
-                next_token = stream_ordering
-                event_json = json.loads(content_json)
-                content = event_json["content"]
-                content_url = content.get("url")
-                thumbnail_url = content.get("info", {}).get("thumbnail_url")
-
-                for url in (content_url, thumbnail_url):
-                    if not url:
-                        continue
-                    matches = mxc_re.match(url)
-                    if matches:
-                        hostname = matches.group(1)
-                        media_id = matches.group(2)
-                        if hostname == self.hs.hostname:
-                            local_media_mxcs.append(media_id)
-                        else:
-                            remote_media_mxcs.append((hostname, media_id))
-
-        return local_media_mxcs, remote_media_mxcs
-
-    def quarantine_media_by_id(
-        self, server_name: str, media_id: str, quarantined_by: str,
-    ):
-        """quarantines a single local or remote media id
-
-        Args:
-            server_name: The name of the server that holds this media
-            media_id: The ID of the media to be quarantined
-            quarantined_by: The user ID that initiated the quarantine request
-        """
-        logger.info("Quarantining media: %s/%s", server_name, media_id)
-        is_local = server_name == self.config.server_name
-
-        def _quarantine_media_by_id_txn(txn):
-            local_mxcs = [media_id] if is_local else []
-            remote_mxcs = [(server_name, media_id)] if not is_local else []
-
-            return self._quarantine_media_txn(
-                txn, local_mxcs, remote_mxcs, quarantined_by
-            )
-
-        return self.db.runInteraction(
-            "quarantine_media_by_user", _quarantine_media_by_id_txn
-        )
-
-    def quarantine_media_ids_by_user(self, user_id: str, quarantined_by: str):
-        """quarantines all local media associated with a single user
-
-        Args:
-            user_id: The ID of the user to quarantine media of
-            quarantined_by: The ID of the user who made the quarantine request
-        """
-
-        def _quarantine_media_by_user_txn(txn):
-            local_media_ids = self._get_media_ids_by_user_txn(txn, user_id)
-            return self._quarantine_media_txn(txn, local_media_ids, [], quarantined_by)
-
-        return self.db.runInteraction(
-            "quarantine_media_by_user", _quarantine_media_by_user_txn
-        )
-
-    def _get_media_ids_by_user_txn(self, txn, user_id: str, filter_quarantined=True):
-        """Retrieves local media IDs by a given user
-
-        Args:
-            txn (cursor)
-            user_id: The ID of the user to retrieve media IDs of
-
-        Returns:
-            The local and remote media as a lists of tuples where the key is
-            the hostname and the value is the media ID.
-        """
-        # Local media
-        sql = """
-            SELECT media_id
-            FROM local_media_repository
-            WHERE user_id = ?
-            """
-        if filter_quarantined:
-            sql += "AND quarantined_by IS NULL"
-        txn.execute(sql, (user_id,))
-
-        rows = txn.fetchall()
-        if rows:
-            local_media_ids = [row[0] for row in rows]
-        else:
-            local_media_ids = []
-
-        # TODO: Figure out all remote media a user has referenced in a message
-
-        return local_media_ids
-
-    def _quarantine_media_txn(
-        self,
-        txn,
-        local_mxcs: List[str],
-        remote_mxcs: List[Tuple[str, str]],
-        quarantined_by: str,
-    ) -> int:
-        """Quarantine local and remote media items
-
-        Args:
-            txn (cursor)
-            local_mxcs: A list of local mxc URLs
-            remote_mxcs: A list of (remote server, media id) tuples representing
-                remote mxc URLs
-            quarantined_by: The ID of the user who initiated the quarantine request
-        Returns:
-            The total number of media items quarantined
-        """
-        total_media_quarantined = 0
-
-        # Update all the tables to set the quarantined_by flag
-        txn.executemany(
-            """
-            UPDATE local_media_repository
-            SET quarantined_by = ?
-            WHERE media_id = ?
-        """,
-            ((quarantined_by, media_id) for media_id in local_mxcs),
-        )
-
-        txn.executemany(
-            """
-                UPDATE remote_media_cache
-                SET quarantined_by = ?
-                WHERE media_origin = ? AND media_id = ?
-            """,
-            ((quarantined_by, origin, media_id) for origin, media_id in remote_mxcs),
-        )
-
-        total_media_quarantined += len(local_mxcs)
-        total_media_quarantined += len(remote_mxcs)
-
-        return total_media_quarantined
 
     @defer.inlineCallbacks
     def get_rooms_for_retention_period_in_range(

--- a/synapse/storage/data_stores/main/room.py
+++ b/synapse/storage/data_stores/main/room.py
@@ -1052,34 +1052,6 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore, SearchStore):
             (room_id,),
         )
 
-    def get_media_mxcs_in_room(self, room_id):
-        """Retrieves all the local and remote media MXC URIs in a given room
-
-        Args:
-            room_id (str)
-
-        Returns:
-            The local and remote media as a lists of tuples where the key is
-            the hostname and the value is the media ID.
-        """
-
-        def _get_media_mxcs_in_room_txn(txn):
-            local_mxcs, remote_mxcs = self._get_media_mxcs_in_room_txn(txn, room_id)
-            local_media_mxcs = []
-            remote_media_mxcs = []
-
-            # Convert the IDs to MXC URIs
-            for media_id in local_mxcs:
-                local_media_mxcs.append("mxc://%s/%s" % (self.hs.hostname, media_id))
-            for hostname, media_id in remote_mxcs:
-                remote_media_mxcs.append("mxc://%s/%s" % (hostname, media_id))
-
-            return local_media_mxcs, remote_media_mxcs
-
-        return self.db.runInteraction(
-            "get_media_ids_in_room", _get_media_mxcs_in_room_txn
-        )
-
     @defer.inlineCallbacks
     def get_rooms_for_retention_period_in_range(
         self, min_ms, max_ms, include_null=False

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -567,7 +567,7 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         self.pump(1.0)
         self.assertEqual(200, int(channel.code), msg=channel.result["body"])
         self.assertEqual(
-            json.loads(channel.result["body"]),
+            json.loads(channel.result["body"].decode("utf-8")),
             {"num_quarantined": 2},
             "Expected 2 quarantined items",
         )
@@ -646,7 +646,7 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         self.pump(1.0)
         self.assertEqual(200, int(channel.result["code"]), msg=channel.result["body"])
         self.assertEqual(
-            json.loads(channel.result["body"]),
+            json.loads(channel.result["body"].decode("utf-8")),
             {"num_quarantined": 2},
             "Expected 2 quarantined items",
         )

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -430,7 +430,7 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         non_admin_user_tok = self.login("nonadmin", "pass")
 
         # Attempt quarantine media APIs as non-admin
-        url = "/_synapse/admin/v1/quarantine_media_by_id/example.org/abcde12345"
+        url = "/_synapse/admin/v1/media/quarantine/example.org/abcde12345"
         request, channel = self.make_request(
             "POST", url.encode("ascii"), access_token=non_admin_user_tok,
         )
@@ -444,7 +444,7 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         )
 
         # And the roomID/userID endpoint
-        url = "/_synapse/admin/v1/quarantine_media_by_room/!room%3Aexample.com"
+        url = "/_synapse/admin/v1/room/!room%3Aexample.com/media/quarantine"
         request, channel = self.make_request(
             "POST", url.encode("ascii"), access_token=non_admin_user_tok,
         )
@@ -490,7 +490,7 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         self.assertEqual(200, int(channel.code), msg=channel.result["body"])
 
         # Quarantine the media
-        url = "/_synapse/admin/v1/quarantine_media_by_id/%s/%s" % (
+        url = "/_synapse/admin/v1/media/quarantine/%s/%s" % (
             urllib.parse.quote(server_name),
             urllib.parse.quote(media_id),
         )
@@ -559,7 +559,7 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         )
 
         # Quarantine all media in the room
-        url = "/_synapse/admin/v1/quarantine_media_by_room/" + urllib.parse.quote(
+        url = "/_synapse/admin/v1/room/%s/media/quarantine" % urllib.parse.quote(
             room_id
         )
         request, channel = self.make_request("POST", url, access_token=admin_user_tok,)
@@ -636,7 +636,7 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         server_and_media_id_2 = response_2["content_uri"][6:]
 
         # Quarantine all media by this user
-        url = "/_synapse/admin/v1/quarantine_media_by_user/" + urllib.parse.quote(
+        url = "/_synapse/admin/v1/user/%s/media/quarantine" % urllib.parse.quote(
             non_admin_user
         )
         request, channel = self.make_request(

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -457,7 +457,6 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
             msg="Expected forbidden on quarantining media as a non-admin",
         )
 
-    @unittest.DEBUG
     def test_quarantine_media_by_id(self):
         self.register_user("id_admin", "pass", admin=True)
         admin_user_tok = self.login("id_admin", "pass")
@@ -519,7 +518,6 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
             ),
         )
 
-    @unittest.DEBUG
     def test_quarantine_all_media_in_room(self):
         self.register_user("room_admin", "pass", admin=True)
         admin_user_tok = self.login("room_admin", "pass")
@@ -615,7 +613,6 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
             ),
         )
 
-    @unittest.DEBUG
     def test_quarantine_all_media_by_user(self):
         self.register_user("user_admin", "pass", admin=True)
         admin_user_tok = self.login("user_admin", "pass")

--- a/tests/rest/client/v1/utils.py
+++ b/tests/rest/client/v1/utils.py
@@ -177,7 +177,6 @@ class RestHelper(object):
             filename: The filename of the media to be uploaded
             expect_code: The return code to expect from attempting to upload the media
         """
-        # small png
         image_length = len(image_data)
         path = "/_matrix/media/r0/upload?filename=%s" % (filename,)
         request, channel = make_request(

--- a/tests/rest/client/v1/utils.py
+++ b/tests/rest/client/v1/utils.py
@@ -22,6 +22,7 @@ import time
 import attr
 
 from twisted.web.resource import Resource
+
 from synapse.api.constants import Membership
 
 from tests.server import make_request, render

--- a/tests/rest/client/v1/utils.py
+++ b/tests/rest/client/v1/utils.py
@@ -21,6 +21,7 @@ import time
 
 import attr
 
+from twisted.web.resource import Resource
 from synapse.api.constants import Membership
 
 from tests.server import make_request, render
@@ -163,7 +164,7 @@ class RestHelper(object):
 
     def upload_media(
         self,
-        resource,
+        resource: Resource,
         image_data: bytes,
         tok: str,
         filename: str = "test.png",
@@ -171,7 +172,7 @@ class RestHelper(object):
     ) -> dict:
         """Upload a piece of test media to the media repo
         Args:
-            resource:
+            resource: The resource that will handle the upload request
             image_data: The image data to upload
             tok: The user token to use during the upload
             filename: The filename of the media to be uploaded


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/5956

This PR adds some admin APIs to:

* Quarantine media by ID
* Quarantine all local media that a local user has uploaded

Most of the code here is test-related.