### PR TITLE
Allow additional_resources to implement Resource directly

### DIFF
--- a/changelog.d/6686.misc
+++ b/changelog.d/6686.misc
@@ -1,0 +1,1 @@
+Allow additional_resources to implement IResource directly.


### PR DESCRIPTION
AdditionalResource really doesn't add any value, and it gets in the way for
resources which want to support child resources or the like. So, if the
resource object already implements the IResource interface, don't bother
wrapping it.