### PR TITLE
Cleanups and additions to the module API

### DIFF
--- a/changelog.d/6688.misc
+++ b/changelog.d/6688.misc
@@ -1,0 +1,1 @@
+Updates and extensions to the module API.

--- a/synapse/module_api/errors.py
+++ b/synapse/module_api/errors.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exception types which are exposed as part of the stable module API"""
+
+from synapse.api.errors import RedirectException, SynapseError  # noqa: F401

--- a/synapse/util/module_loader.py
+++ b/synapse/util/module_loader.py
@@ -34,7 +34,7 @@ def load_module(provider):
     provider_class = getattr(module, clz)
 
     try:
-        provider_config = provider_class.parse_config(provider["config"])
+        provider_config = provider_class.parse_config(provider.get("config"))
     except Exception as e:
         raise ConfigError("Failed to parse config for %r: %r" % (provider["module"], e))
 


### PR DESCRIPTION
Add some useful things, such as error types and logcontext handling, to the API.

Make `hs` a private member to dissuade people from using it (hopefully they aren't already).

Add a couple of new methods (`record_user_external_id` and `generate_short_term_login_token`).

Make `config` optional in the configuration file when loading a module.