### PR TITLE
Don't assign numeric IDs for empty usernames

### DIFF
--- a/changelog.d/6690.bugfix
+++ b/changelog.d/6690.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where we would assign a numeric userid if somebody tried registering with an empty username.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -174,7 +174,7 @@ class RegistrationHandler(BaseHandler):
         if password:
             password_hash = yield self._auth_handler.hash(password)
 
-        if localpart:
+        if localpart is not None:
             yield self.check_username(localpart, guest_access_token=guest_access_token)
 
             was_guest = guest_access_token is not None


### PR DESCRIPTION
Fix a bug where we would assign a numeric userid if somebody tried registering
with an empty username