### PR TITLE
Process EDUs in parallel with PDUs.

### DIFF
--- a/changelog.d/6697.misc
+++ b/changelog.d/6697.misc
@@ -1,0 +1,1 @@
+Don't block processing of incoming EDUs behind processing PDUs in the same transaction.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -168,7 +168,7 @@ class FederationServer(FederationBase):
 
         # We process PDUs and EDUs in parallel. This is important as we don't
         # want to block things like to device messages from reaching clients
-        # behind the pontentially expensive handling of PDUs.
+        # behind the potentially expensive handling of PDUs.
         pdu_results, _ = await make_deferred_yieldable(
             defer.gatherResults(
                 [
@@ -200,7 +200,7 @@ class FederationServer(FederationBase):
 
         Returns:
             A map from event ID of a processed PDU to any errors we should
-            report back to sending server.
+            report back to the sending server.
         """
 
         received_pdus_counter.inc(len(transaction.pdus))


### PR DESCRIPTION
This means that things like to device messages don't get blocked behind processing PDUs, which can potentially take *ages* if e.g. the server has been down for a while and has a lot to catch up on.