### PR TITLE
Wake up transaction queue when remote server comes back online

### DIFF
--- a/changelog.d/6706.misc
+++ b/changelog.d/6706.misc
@@ -1,0 +1,1 @@
+Attempt to retry sending a transaction when we detect a remote server has come back online, rather than waiting for a transaction to be triggered by new data.

--- a/docs/tcp_replication.md
+++ b/docs/tcp_replication.md
@@ -236,7 +236,7 @@ in which case the `<token>` must be set to `NOW`.
 
 ### REMOTE_SERVER_UP (S, C)
 
-    Inform other processes that a remote server may have come back online.
+   Inform other processes that a remote server may have come back online.
 
 See `synapse/replication/tcp/commands.py` for a detailed description and
 the format of each command.

--- a/docs/tcp_replication.md
+++ b/docs/tcp_replication.md
@@ -209,7 +209,7 @@ Where `<token>` may be either:
  * a numeric stream_id to stream updates since (exclusive)
  * `NOW` to stream all subsequent updates.
 
-The `<stream_name>` is the name of a replication stream to subscribe 
+The `<stream_name>` is the name of a replication stream to subscribe
 to (see [here](../synapse/replication/tcp/streams/_base.py) for a list
 of streams). It can also be `ALL` to subscribe to all known streams,
 in which case the `<token>` must be set to `NOW`.
@@ -233,6 +233,10 @@ in which case the `<token>` must be set to `NOW`.
 #### SYNC (S, C)
 
    Used exclusively in tests
+
+### REMOTE_SERVER_UP (S, C)
+
+    Inform other processes that a remote server may have come back online.
 
 See `synapse/replication/tcp/commands.py` for a detailed description and
 the format of each command.

--- a/synapse/app/federation_sender.py
+++ b/synapse/app/federation_sender.py
@@ -159,6 +159,13 @@ class FederationSenderReplicationHandler(ReplicationClientHandler):
         args.update(self.send_handler.stream_positions())
         return args
 
+    def on_remote_server_up(self, server: str):
+        """Called when get a new REMOTE_SERVER_UP command."""
+
+        # Let's wake up the transaction queue for the server in case we have
+        # pending stuff to send to it.
+        self.send_handler.wake_destination(server)
+
 
 def start(config_options):
     try:
@@ -206,7 +213,7 @@ class FederationSenderHandler(object):
     to the federation sender.
     """
 
-    def __init__(self, hs, replication_client):
+    def __init__(self, hs: FederationSenderServer, replication_client):
         self.store = hs.get_datastore()
         self._is_mine_id = hs.is_mine_id
         self.federation_sender = hs.get_federation_sender()
@@ -226,6 +233,9 @@ class FederationSenderHandler(object):
         self.federation_sender.notify_new_events(
             self.store.get_room_max_stream_ordering()
         )
+
+    def wake_destination(self, server: str):
+        self.federation_sender.wake_destination(server)
 
     def stream_positions(self):
         return {"federation": self.federation_position}

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -483,7 +483,7 @@ class FederationSender(object):
 
     def send_device_messages(self, destination):
         if destination == self.server_name:
-            logger.info("Not sending device update to ourselves")
+            logger.warning("Not sending device update to ourselves")
             return
 
         self._get_per_destination_queue(destination).attempt_new_transaction()
@@ -492,11 +492,11 @@ class FederationSender(object):
         """Called when we want to retry sending transactions to a remote.
 
         This is mainly useful if the remote server has been down and we think it
-        migtht have come back.
+        might have come back.
         """
 
         if destination == self.server_name:
-            logger.info("Not waking up ourselves")
+            logger.warning("Not waking up ourselves")
             return
 
         self._get_per_destination_queue(destination).attempt_new_transaction()

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -487,5 +487,18 @@ class FederationSender(object):
 
         self._get_per_destination_queue(destination).attempt_new_transaction()
 
+    def wake_destination(self, destination: str):
+        """Called when we want to retry sending transactions to a remote.
+
+        This is mainly useful if the remote server has been down and we think it
+        migtht have come back.
+        """
+
+        if destination == self.server_name:
+            logger.info("Not waking up ourselves")
+            return
+
+        self._get_per_destination_queue(destination).attempt_new_transaction()
+
     def get_current_token(self):
         return 0

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -21,6 +21,7 @@ from prometheus_client import Counter
 
 from twisted.internet import defer
 
+import synapse
 import synapse.metrics
 from synapse.federation.sender.per_destination_queue import PerDestinationQueue
 from synapse.federation.sender.transaction_manager import TransactionManager
@@ -54,7 +55,7 @@ sent_pdus_destination_dist_total = Counter(
 
 
 class FederationSender(object):
-    def __init__(self, hs):
+    def __init__(self, hs: "synapse.server.HomeServer"):
         self.hs = hs
         self.server_name = hs.hostname
 

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -44,6 +44,7 @@ from synapse.logging.opentracing import (
     tags,
     whitelisted_homeserver,
 )
+from synapse.server import HomeServer
 from synapse.types import ThirdPartyInstanceID, get_domain_from_id
 from synapse.util.ratelimitutils import FederationRateLimiter
 from synapse.util.versionstring import get_version_string
@@ -101,12 +102,17 @@ class NoAuthenticationError(AuthenticationError):
 
 
 class Authenticator(object):
-    def __init__(self, hs):
+    def __init__(self, hs: HomeServer):
         self._clock = hs.get_clock()
         self.keyring = hs.get_keyring()
         self.server_name = hs.hostname
         self.store = hs.get_datastore()
         self.federation_domain_whitelist = hs.config.federation_domain_whitelist
+        self.notifer = hs.get_notifier()
+
+        self.replication_client = None
+        if hs.config.worker.worker_app:
+            self.replication_client = hs.get_tcp_replication()
 
     # A method just so we can pass 'self' as the authenticator to the Servlets
     async def authenticate_request(self, request, content):
@@ -166,6 +172,17 @@ class Authenticator(object):
         try:
             logger.info("Marking origin %r as up", origin)
             await self.store.set_destination_retry_timings(origin, None, 0, 0)
+
+            # Inform the relevant places that the remote server is back up.
+            self.notifer.notify_remote_server_up(origin)
+            if self.replication_client:
+                # If we're on a worker we try and inform master about this. The
+                # replication client doesn't hook into the notifier to avoid
+                # infinite loops where we send a `REMOTE_SERVER_UP` command to
+                # master, which then echoes it back to us which in turn pokes
+                # the notifier.
+                self.replication_client.send_remote_server_up(origin)
+
         except Exception:
             logger.exception("Error resetting retry timings on %s", origin)
 

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -146,6 +146,9 @@ class ReplicationClientHandler(AbstractReplicationClientHandler):
         if d:
             d.callback(data)
 
+    def on_remote_server_up(self, server: str):
+        """Called when get a new REMOTE_SERVER_UP command."""
+
     def get_streams_to_replicate(self) -> Dict[str, int]:
         """Called when a new connection has been established and we need to
         subscribe to streams.

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -395,10 +395,10 @@ class RemoteServerUpCommand(Command):
 
     Format::
 
-        REMOTE_SEREVER_UP <server>
+        REMOTE_SERVER_UP <server>
     """
 
-    NAME = "REMOTE_SEREVER_UP"
+    NAME = "REMOTE_SERVER_UP"
 
 
 _COMMANDS = (

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -387,6 +387,20 @@ class UserIpCommand(Command):
         )
 
 
+class RemoteServerUpCommand(Command):
+    """Sent when a worker has detected that a remote server is no longer
+    "down" and retry timings should be reset.
+
+    If sent from a client the server will relay to all other workers.
+
+    Format::
+
+        REMOTE_SEREVER_UP <server>
+    """
+
+    NAME = "REMOTE_SEREVER_UP"
+
+
 _COMMANDS = (
     ServerCommand,
     RdataCommand,
@@ -401,6 +415,7 @@ _COMMANDS = (
     RemovePusherCommand,
     InvalidateCacheCommand,
     UserIpCommand,
+    RemoteServerUpCommand,
 )  # type: Tuple[Type[Command], ...]
 
 # Map of command name to command type.
@@ -414,6 +429,7 @@ VALID_SERVER_COMMANDS = (
     ErrorCommand.NAME,
     PingCommand.NAME,
     SyncCommand.NAME,
+    RemoteServerUpCommand.NAME,
 )
 
 # The commands the client is allowed to send
@@ -427,4 +443,5 @@ VALID_CLIENT_COMMANDS = (
     InvalidateCacheCommand.NAME,
     UserIpCommand.NAME,
     ErrorCommand.NAME,
+    RemoteServerUpCommand.NAME,
 )

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -294,6 +294,11 @@ class ReplicationStreamer(object):
     @measure_func("repl.on_remote_server_up")
     @defer.inlineCallbacks
     def on_remote_server_up(self, server: str):
+        # If we're responsible for sending outbound federation traffic, lets
+        # wake up the transaction queue for that destination.
+        if self.federation_sender:
+            self.federation_sender.wake_destination(server)
+
         for conn in self.connections:
             conn.send_remote_server_up(server)
 

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -290,7 +290,6 @@ class ReplicationStreamer(object):
         await self._server_notices_sender.on_user_ip(user_id)
 
     @measure_func("repl.on_remote_server_up")
-    @defer.inlineCallbacks
     def on_remote_server_up(self, server: str):
         self.notifier.notify_remote_server_up(server)
 

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -121,6 +121,7 @@ class ReplicationStreamer(object):
             self.federation_sender = hs.get_federation_sender()
 
         self.notifier.add_replication_callback(self.on_notifier_poke)
+        self.notifier.add_remote_server_up_callback(self.send_remote_server_up)
 
         # Keeps track of whether we are currently checking for updates
         self.is_looping = False
@@ -294,11 +295,9 @@ class ReplicationStreamer(object):
     @measure_func("repl.on_remote_server_up")
     @defer.inlineCallbacks
     def on_remote_server_up(self, server: str):
-        # If we're responsible for sending outbound federation traffic, lets
-        # wake up the transaction queue for that destination.
-        if self.federation_sender:
-            self.federation_sender.wake_destination(server)
+        self.notifier.notify_remote_server_up(server)
 
+    def send_remote_server_up(self, server: str):
         for conn in self.connections:
             conn.send_remote_server_up(server)
 

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -291,6 +291,12 @@ class ReplicationStreamer(object):
         )
         yield self._server_notices_sender.on_user_ip(user_id)
 
+    @measure_func("repl.on_remote_server_up")
+    @defer.inlineCallbacks
+    def on_remote_server_up(self, server: str):
+        for conn in self.connections:
+            conn.send_remote_server_up(server)
+
     def send_sync_to_all_connections(self, data):
         """Sends a SYNC command to all clients.
 

--- a/synapse/server.pyi
+++ b/synapse/server.pyi
@@ -1,3 +1,5 @@
+import twisted.internet
+
 import synapse.api.auth
 import synapse.config.homeserver
 import synapse.federation.sender
@@ -9,10 +11,12 @@ import synapse.handlers.deactivate_account
 import synapse.handlers.device
 import synapse.handlers.e2e_keys
 import synapse.handlers.message
+import synapse.handlers.presence
 import synapse.handlers.room
 import synapse.handlers.room_member
 import synapse.handlers.set_password
 import synapse.http.client
+import synapse.notifier
 import synapse.rest.media.v1.media_repository
 import synapse.server_notices.server_notices_manager
 import synapse.server_notices.server_notices_sender
@@ -84,4 +88,12 @@ class HomeServer(object):
     def get_server_notices_sender(
         self,
     ) -> synapse.server_notices.server_notices_sender.ServerNoticesSender:
+        pass
+    def get_notifier(self) -> synapse.notifier.Notifier:
+        pass
+    def get_presence_handler(self) -> synapse.handlers.presence.PresenceHandler:
+        pass
+    def get_clock(self) -> synapse.util.Clock:
+        pass
+    def get_reactor(self) -> twisted.internet.base.ReactorBase:
         pass


### PR DESCRIPTION
This is a bit fiddly to do as we might only notice a remote is back up on a worker, and the federation sending may or may not be happening on another worker.

Basically:
1. We poke the notifier when we see a remote is back up, which pokes the transaction queue if on the same process.
2.
   1. If on master then the replication resource also gets poked by the notifier, triggering it to broadcast a `REMOTE_SERVER_UP` replication command to workers.
   2. If on a worker then we use the replication client to send a `REMOTE_SERVER_UP` to master, which then triggers the notifier to be called on master too (and in turn causes it to send the command to the the workers)

(*Note*: this means that the original worker will get a `REMOTE_SERVER_UP` echoed back to it, but that is not actually problematic so long as we don't then trigger another `REMOTE_SERVER_UP`. This is why the notifier doesn't poke replication clients on workers)