### PR TITLE
Delegate remote_user_id mapping to the saml mapping provider

### DIFF
--- a/changelog.d/6723.misc
+++ b/changelog.d/6723.misc
@@ -1,0 +1,1 @@
+Updates to the SAML mapping provider API.

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -121,6 +121,7 @@ class SAML2Config(Config):
         required_methods = [
             "get_saml_attributes",
             "saml_response_to_user_attributes",
+            "get_remote_user_id",
         ]
         missing_methods = [
             method

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -141,6 +141,9 @@ class SamlHandler:
             saml2_auth, client_redirect_url
         )
 
+        if not remote_user_id:
+            raise Exception("Failed to extract remote user id from SAML response")
+
         with (await self._mapping_lock.queue(self._auth_provider_id)):
             # first of all, check if we already have a mapping for this user
             logger.info(


### PR DESCRIPTION
Turns out that figuring out a remote user id for the SAML user isn't quite as obvious as it seems. Factor it out to the SamlMappingProvider so that it's easy to control.