### PR TITLE
Add EXTRA_PYPI_DEPS argument to the docker build process

### DIFF
--- a/changelog.d/6744.docker
+++ b/changelog.d/6744.docker
@@ -1,0 +1,1 @@
+Add the EXTRA_PYPI_DEPS build arg to the Docker image to allow for adding extra Python packages from PyPI at build time.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,9 @@
 #
 #    docker build -f docker/Dockerfile --build-arg PYTHON_VERSION=3.6 .
 #
+# There is also the EXTRA_PYPI_DEPS build argument which allows for the
+# installation of additional Python dependencies from PyPI during build.
+#
 
 ARG PYTHON_VERSION=3.7
 
@@ -17,6 +20,8 @@ ARG PYTHON_VERSION=3.7
 ### Stage 0: builder
 ###
 FROM docker.io/python:${PYTHON_VERSION}-alpine3.10 as builder
+
+ARG EXTRA_PYPI_DEPS=
 
 # install the OS build deps
 
@@ -36,7 +41,7 @@ RUN apk add \
 # (we really just care about caching a wheel here, as the "pip install" below
 # will install them again.)
 
-RUN pip install --prefix="/install" --no-warn-script-location \
+RUN pip install --prefix="/install" --no-warn-script-location --no-cache-dir \
         cryptography \
         msgpack-python \
         pillow \
@@ -48,8 +53,8 @@ COPY synapse /synapse/synapse/
 COPY scripts /synapse/scripts/
 COPY MANIFEST.in README.rst setup.py synctl /synapse/
 
-RUN pip install --prefix="/install" --no-warn-script-location \
-        /synapse[all]
+RUN pip install --prefix="/install" --no-warn-script-location --no-cache-dir \
+        /synapse[all] $EXTRA_PYPI_DEPS
 
 ###
 ### Stage 1: runtime


### PR DESCRIPTION
This lets us add extra deps without a whole sub-image thing.