### PR TITLE
Fix empty account_validity config block

### DIFF
--- a/changelog.d/6747.bugfix
+++ b/changelog.d/6747.bugfix
@@ -1,0 +1,1 @@
+Fix infinite recursion and dictionary access bug when setting `account_validity` to an empty block in the homeserver config. Thanks to @Sorunome for reporting.

--- a/changelog.d/6747.bugfix
+++ b/changelog.d/6747.bugfix
@@ -1,1 +1,1 @@
-Fix infinite recursion and dictionary access bug when setting `account_validity` to an empty block in the homeserver config. Thanks to @Sorunome for reporting.
+Fix bug when setting `account_validity` to an empty block in the config. Thanks to @Sorunome for reporting.

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -29,6 +29,7 @@ class AccountValidityConfig(Config):
     def __init__(self, config, synapse_config):
         if config is None:
             return
+        super(AccountValidityConfig, self).__init__()
         self.enabled = config.get("enabled", False)
         self.renew_by_email_enabled = "renew_at" in config
 
@@ -93,7 +94,7 @@ class RegistrationConfig(Config):
             )
 
         self.account_validity = AccountValidityConfig(
-            config.get("account_validity", {}), config
+            config.get("account_validity") or {}, config
         )
 
         self.registrations_require_3pid = config.get("registrations_require_3pid", [])


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/6740

Having `account_validity` as an empty config block has been broken since it was introduced. We just didn't notice it until now when `account_validity` with an empty config block became part of the default sample config. This is fixed by the usual `config.get("account_validity") or {}` change.

However, we were also hitting a confusing recursion bug mentioned in #6740. This was due to a call in `Config`'s `__getattr__` method querying `self.root`. Now, `self.root` shouldn't call `__getattr__` because `root` is defined in `Config`s `__init__` method.

However, `AccountValidityConfig` which is a child of `Config` overloads `__init__` without calling `__init__` from its superclass, thus `self.root` is never defined and `__getattr__` *is* called when accessed, leading to `__getattr__` calling itself and thus infinite recursion.

`AccountValidityConfig` now calls its superclass's `__init__` method, which prevents this bug.