### PR TITLE
Avoid attribute error when `password_config` present but empty

### DIFF
--- a/changelog.d/6753.bugfix
+++ b/changelog.d/6753.bugfix
@@ -1,1 +1,1 @@
-Fix `AttributeError: 'NoneType' object has no attribute 'get'` in `hash_password` when configuration has an empty `password_config`.
+Fix `AttributeError: 'NoneType' object has no attribute 'get'` in `hash_password` when configuration has an empty `password_config`. Contributed by @ivilata.

--- a/changelog.d/6753.bugfix
+++ b/changelog.d/6753.bugfix
@@ -1,0 +1,1 @@
+Fix `AttributeError: 'NoneType' object has no attribute 'get'` in `hash_password` when configuration has an empty `password_config`.

--- a/scripts/hash_password
+++ b/scripts/hash_password
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     if "config" in args and args.config:
         config = yaml.safe_load(args.config)
         bcrypt_rounds = config.get("bcrypt_rounds", bcrypt_rounds)
-        password_config = config.get("password_config", {})
+        password_config = config.get("password_config", None) or {}
         password_pepper = password_config.get("pepper", password_pepper)
     password = args.password
 


### PR DESCRIPTION
The old statement returned `None` for such a `password_config` (like the one
created on first run), thus retrieval of the `pepper` key failed with
`AttributeError`.

Fixes #5315

Signed-off-by: Ivan Vilata i Balaguer <ivan@selidor.net>