### PR TITLE
Minor fixes to user admin api

### DIFF
--- a/changelog.d/6761.bugfix
+++ b/changelog.d/6761.bugfix
@@ -1,0 +1,1 @@
+Minor fixes to `PUT /_synapse/admin/v2/users` admin api.


### PR DESCRIPTION
* don't insist on a password (this is valid if you have an SSO login)
* fix reference to undefined `requester`