### PR TITLE
Clarifications to the workers documentation

### DIFF
--- a/changelog.d/6775.doc
+++ b/changelog.d/6775.doc
@@ -1,1 +1,1 @@
-Clarify documentation related to user_dir and federation_reader workers.
+Clarify documentation related to `user_dir` and `federation_reader` workers.

--- a/changelog.d/6775.doc
+++ b/changelog.d/6775.doc
@@ -1,0 +1,1 @@
+Clarify documentation related to user_dir and federation_reader workers.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -185,8 +185,18 @@ reverse-proxy configuration.
 The `^/_matrix/federation/v1/send/` endpoint must only be handled by a single
 instance.
 
-Note that the `worker_listeners.resources.name` needs to be set to `federation`
-for this worker.
+Note that `federation` must be added to the listener resources in the worker config:
+
+```yaml
+worker_app: synapse.app.federation_reader
+...
+worker_listeners:
+ - type: http
+   port: <port>
+   resources:
+     - names:
+       - federation
+```
 
 ### `synapse.app.federation_sender`
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -185,6 +185,9 @@ reverse-proxy configuration.
 The `^/_matrix/federation/v1/send/` endpoint must only be handled by a single
 instance.
 
+Note that the `worker_listeners.resources.name` needs to be set to `federation`
+for this worker.
+
 ### `synapse.app.federation_sender`
 
 Handles sending federation traffic to other servers. Doesn't handle any
@@ -264,6 +267,10 @@ Handles searches in the user directory. It can handle REST endpoints matching
 the following regular expressions:
 
     ^/_matrix/client/(api/v1|r0|unstable)/user_directory/search$
+
+When using this worker you must also set `update_user_directory: False` in the 
+shared configuration file to stop the main synapse running background 
+jobs related to updating the user directory.
 
 ### `synapse.app.frontend_proxy`
 


### PR DESCRIPTION
* Add note that user_dir requires disabling user dir
  updates from the main synapse process.
* Add note that federation_reader should have
  the federation listener resource.

Signed-off-by: Jason Robinson <jasonr@matrix.org>