### PR TITLE
Fix setting `mau_limit_reserved_threepids` config

### DIFF
--- a/changelog.d/6793.bugfix
+++ b/changelog.d/6793.bugfix
@@ -1,0 +1,1 @@
+Fix bug where setting `mau_limit_reserved_threepids` config would cause Synapse to refuse to start.

--- a/synapse/storage/data_stores/main/monthly_active_users.py
+++ b/synapse/storage/data_stores/main/monthly_active_users.py
@@ -121,7 +121,13 @@ class MonthlyActiveUsersStore(MonthlyActiveUsersWorkerStore):
             if user_id:
                 is_support = self.is_support_user_txn(txn, user_id)
                 if not is_support:
-                    self.upsert_monthly_active_user_txn(txn, user_id)
+                    # We do this manually here to avoid hitting #6791
+                    self.db.simple_upsert_txn(
+                        txn,
+                        table="monthly_active_users",
+                        keyvalues={"user_id": user_id},
+                        values={"timestamp": int(self._clock.time_msec())},
+                    )
             else:
                 logger.warning("mau limit reserved threepid %s not found in db" % tp)
 


### PR DESCRIPTION
Calling the invalidation function during initialisation of the data
stores introduces a circular dependency, causing Synapse to fail to
start.

Fixes #6791