### PR TITLE
Fix bug when querying remote user keys that require a resync.

### DIFF
--- a/changelog.d/6796.bugfix
+++ b/changelog.d/6796.bugfix
@@ -1,0 +1,1 @@
+Fix bug where querying a remote user's device keys that weren't cached resulted in only returning a single device.

--- a/synapse/handlers/e2e_keys.py
+++ b/synapse/handlers/e2e_keys.py
@@ -208,8 +208,9 @@ class E2eKeysHandler(object):
                         )
 
                     user_devices = user_devices["devices"]
+                    user_results = results.setdefault(user_id, {})
                     for device in user_devices:
-                        results[user_id] = {device["device_id"]: device["keys"]}
+                        user_results[device["device_id"]] = device["keys"]
                     user_ids_updated.append(user_id)
                 except Exception as e:
                     failures[destination] = _exception_to_failure(e)


### PR DESCRIPTION
We ended up only returning a single device, rather than all of them.

This only happens when the local server thinks it should be tracking the keys of a remote user, but hasn't yet fetched them, when a local user requests those keys. The results get correctly cached so subsequent calls were fine.
