### PR TITLE
When a client asks for remote keys check if should resync.

### DIFF
--- a/changelog.d/6797.misc
+++ b/changelog.d/6797.misc
@@ -1,0 +1,1 @@
+When a client asks for a remote user's device keys check if the local cache for that user has been marked as potentially stale.


### PR DESCRIPTION
If we have detected that the remote users' keys may have changed then we should attempt to resync against the remote server rather than using the (potentially) stale local cache.
