### PR TITLE
When server leaves room check for stale device lists.

### DIFF
--- a/changelog.d/6801.bugfix
+++ b/changelog.d/6801.bugfix
@@ -1,0 +1,1 @@
+Fix bug where Synapse didn't invalidate cache of remote users' devices when Synapse left a room.

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -785,4 +785,4 @@ class EventsPersistenceStorage(object):
         left_users = user_ids - joined_users
 
         for user_id in left_users:
-            await self.main_store.mark_remote_user_device_cache_as_stale(user_id)
+            await self.main_store.mark_remote_user_device_list_as_unsubscribed(user_id)

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -711,8 +711,8 @@ class EventsPersistenceStorage(object):
                 and what the new current state will be.
             current_state: The new current state if it already been calculated,
                 otherwise None.
-            potentially_left_users: If the server has left the room then joined
-                remote users will be added to the set to indicate that the
+            potentially_left_users: If the server has left the room, then joined
+                remote users will be added to this set to indicate that the
                 server may no longer be sharing a room with them.
         """
 


### PR DESCRIPTION
When a server leaves a room it may stop sharing a room with remote
users, and thus not get any updates to their device lists. So we need to
check for this case and mark those device lists and stale.

We don't need to do this if we stop sharing a room because the remote
user leaves the room, because we track that case via looking at
membership changes.

---

The alternative to marking the device lists as stale is to delete the users from the cache? This would mean that if the remote server is down we won't get stale events.

This, coupled with #6797, should help fix #6399.