### PR TITLE
Fix room_version in `_persist_auth_tree`

### DIFF
--- a/changelog.d/6818.misc
+++ b/changelog.d/6818.misc
@@ -1,0 +1,1 @@
+Record room versions in the `rooms` table.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1929,7 +1929,11 @@ class FederationHandler(BaseHandler):
 
         for e_id in missing_auth_events:
             m_ev = yield self.federation_client.get_pdu(
-                [origin], e_id, room_version=room_version, outlier=True, timeout=10000
+                [origin],
+                e_id,
+                room_version=room_version.identifier,
+                outlier=True,
+                timeout=10000,
             )
             if m_ev and m_ev.event_id == e_id:
                 event_map[e_id] = m_ev


### PR DESCRIPTION
Fixes a confusion about whether room_version is a string or an object.

This was introduced in #6729 and half-fixed in #6788.

It's a bit worrying that this codepath clearly isn't tested. I'll look into fixing that.