### PR TITLE
Fix deleting of stale marker for device lists

### DIFF
--- a/changelog.d/6819.misc
+++ b/changelog.d/6819.misc
@@ -1,0 +1,1 @@
+Detect unknown remote devices and mark cache as stale.

--- a/synapse/storage/data_stores/main/devices.py
+++ b/synapse/storage/data_stores/main/devices.py
@@ -940,13 +940,6 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
             lock=False,
         )
 
-        # If we're replacing the remote user's device list cache presumably
-        # we've done a full resync, so we remove the entry that says we need
-        # to resync
-        self.db.simple_delete_txn(
-            txn, table="device_lists_remote_resync", keyvalues={"user_id": user_id},
-        )
-
     def update_remote_device_list_cache(self, user_id, devices, stream_id):
         """Replace the entire cache of the remote user's devices.
 
@@ -1001,6 +994,13 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
             # we don't need to lock, because we can assume we are the only thread
             # updating this user's extremity.
             lock=False,
+        )
+
+        # If we're replacing the remote user's device list cache presumably
+        # we've done a full resync, so we remove the entry that says we need
+        # to resync
+        self.db.simple_delete_txn(
+            txn, table="device_lists_remote_resync", keyvalues={"user_id": user_id},
         )
 
     @defer.inlineCallbacks


### PR DESCRIPTION
We were in fact only deleting stale marker when we got an incremental update, rather than when we did a full resync.

Fixes up PR #6776 