### PR TITLE
pass room versions around

### DIFF
--- a/changelog.d/6823.misc
+++ b/changelog.d/6823.misc
@@ -1,0 +1,1 @@
+Refactoring work in preparation for changing the event redaction algorithm.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -230,7 +230,7 @@ class FederationClient(FederationBase):
         self,
         destinations: Iterable[str],
         event_id: str,
-        room_version: str,
+        room_version: RoomVersion,
         outlier: bool = False,
         timeout: Optional[int] = None,
     ) -> Optional[EventBase]:
@@ -262,7 +262,7 @@ class FederationClient(FederationBase):
 
         pdu_attempts = self.pdu_destination_tried.setdefault(event_id, {})
 
-        format_ver = room_version_to_event_format(room_version)
+        format_ver = room_version.event_format
 
         signed_pdu = None
         for destination in destinations:
@@ -292,7 +292,9 @@ class FederationClient(FederationBase):
                     pdu = pdu_list[0]
 
                     # Check signatures are correct.
-                    signed_pdu = await self._check_sigs_and_hash(room_version, pdu)
+                    signed_pdu = await self._check_sigs_and_hash(
+                        room_version.identifier, pdu
+                    )
 
                     break
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1110,7 +1110,7 @@ class FederationHandler(BaseHandler):
         Logs a warning if we can't find the given event.
         """
 
-        room_version = await self.store.get_room_version_id(room_id)
+        room_version = await self.store.get_room_version(room_id)
 
         event_infos = []
 
@@ -1916,11 +1916,7 @@ class FederationHandler(BaseHandler):
 
         for e_id in missing_auth_events:
             m_ev = await self.federation_client.get_pdu(
-                [origin],
-                e_id,
-                room_version=room_version.identifier,
-                outlier=True,
-                timeout=10000,
+                [origin], e_id, room_version=room_version, outlier=True, timeout=10000,
             )
             if m_ev and m_ev.event_id == e_id:
                 event_map[e_id] = m_ev


### PR DESCRIPTION
This is a couple of commits which adds some `room_version` plumbing to bits of the code.