### PR TITLE
Fix `room_version` in `on_invite_request` flow

### DIFF
--- a/changelog.d/6827.misc
+++ b/changelog.d/6827.misc
@@ -1,0 +1,1 @@
+Refactoring work in preparation for changing the event redaction algorithm.

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -579,7 +579,7 @@ class FederationV1InviteServlet(BaseFederationServlet):
         # state resolution algorithm, and we don't use that for processing
         # invites
         content = await self.handler.on_invite_request(
-            origin, content, room_version=RoomVersions.V1.identifier
+            origin, content, room_version_id=RoomVersions.V1.identifier
         )
 
         # V1 federation API is defined to return a content of `[200, {...}]`
@@ -606,7 +606,7 @@ class FederationV2InviteServlet(BaseFederationServlet):
         event.setdefault("unsigned", {})["invite_room_state"] = invite_room_state
 
         content = await self.handler.on_invite_request(
-            origin, event, room_version=room_version
+            origin, event, room_version_id=room_version
         )
         return 200, content
 


### PR DESCRIPTION
I messed this up a bit in #6805, but fortunately we weren't actually doing
anything with the room_version so it didn't matter that it was a str not a RoomVersion.