### PR TITLE
Reduce performance logging to DEBUG

### DIFF
--- a/changelog.d/6833.misc
+++ b/changelog.d/6833.misc
@@ -1,0 +1,1 @@
+Reducing log level to DEBUG for synapse.storage.TIME.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -343,7 +343,7 @@ class Database(object):
 
             top_three_counters = self._txn_perf_counters.interval(duration, limit=3)
 
-            perf_logger.info(
+            perf_logger.debug(
                 "Total database time: %.3f%% {%s}", ratio * 100, top_three_counters
             )
 


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [X] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [X] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

This PR reduces the default logging level of verbose performance monitoring counters from INFO to DEBUG.

Leo even wrote along side this code:
```
        # TODO(paul): These can eventually be removed once the metrics code
        #   is running in mainline, and we have some nice monitoring frontends
        #   to watch it
```
So there's definitely a case to rip this out entirely - reducing to DEBUG seems safe.

These metrics are available more generally in the prometheus metrics (eg `synapse_background_process_db_txn_duration_seconds`) which when looking at performance changes over time is probably a better way to access this data.

This change originated in feedback that these messages are confusing to server administrators, especially at the INFO level.