### PR TITLE
async/await and simplify is_server_admin

### DIFF
--- a/changelog.d/6835.misc
+++ b/changelog.d/6835.misc
@@ -1,0 +1,1 @@
+Convert `is_server_admin` from deferreds to async/await.

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -499,7 +499,7 @@ class Auth(object):
         request.authenticated_entity = service.sender
         return defer.succeed(service)
 
-    def is_server_admin(self, user):
+    async def is_server_admin(self, user):
         """ Check if the given user is a local server admin.
 
         Args:
@@ -508,7 +508,7 @@ class Auth(object):
         Returns:
             bool: True if the user is an admin
         """
-        return self.store.is_server_admin(user)
+        return await self.store.is_server_admin(user)
 
     def compute_auth_events(
         self, event, current_state_ids: StateMap[str], for_verification: bool = False,

--- a/synapse/storage/data_stores/main/registration.py
+++ b/synapse/storage/data_stores/main/registration.py
@@ -273,8 +273,7 @@ class RegistrationWorkerStore(SQLBaseStore):
             desc="delete_account_validity_for_user",
         )
 
-    @defer.inlineCallbacks
-    def is_server_admin(self, user):
+    async def is_server_admin(self, user):
         """Determines if a user is an admin of this homeserver.
 
         Args:
@@ -283,7 +282,7 @@ class RegistrationWorkerStore(SQLBaseStore):
         Returns (bool):
             true iff the user is a server admin, false otherwise.
         """
-        res = yield self.db.simple_select_one_onecol(
+        res = await self.db.simple_select_one_onecol(
             table="users",
             keyvalues={"name": user.to_string()},
             retcol="admin",
@@ -291,7 +290,7 @@ class RegistrationWorkerStore(SQLBaseStore):
             desc="is_server_admin",
         )
 
-        return bool(res) if res else False
+        return bool(res)
 
     def set_server_admin(self, user, admin):
         """Sets whether a user is an admin of this homeserver.


### PR DESCRIPTION
Convert `is_server_admin` stack to async/await and remove useless ternary operator expression.