### PR TITLE
Fix stacktraces when using ObservableDeferred and async/await

### DIFF
--- a/changelog.d/6836.misc
+++ b/changelog.d/6836.misc
@@ -1,0 +1,1 @@
+Fix stacktraces when using `ObservableDeferred` and async/await.

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -73,6 +73,10 @@ class ObservableDeferred(object):
         def errback(f):
             object.__setattr__(self, "_result", (False, f))
             while self._observers:
+                # This is a little bit of magic to correctly propagate stack
+                # traces when we `await` on one of the observer deferreds.
+                f.value.__failure__ = f
+
                 try:
                     # TODO: Handle errors here.
                     self._observers.pop().errback(f)


### PR DESCRIPTION
So `__failure__` is a magic (undocumented) thing that twisted will look for when raising exception during an `await`: https://github.com/twisted/twisted/blob/twisted-19.10.0/src/twisted/internet/defer.py#L748.

Empirically this seems to Do The Right Thing, but it somewhat feels like we're working against Twisted here. Ideally there would be some sort of `ObservableDeferred` in Twisted that handled this stuff properly, but there doesn't seem to be.
