### PR TITLE
Check sender_key matches on inbound encrypted events.

### DIFF
--- a/changelog.d/6850.misc
+++ b/changelog.d/6850.misc
@@ -1,0 +1,1 @@
+Detect unexpected sender keys on inbound encrypted events and resync device lists.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -598,7 +598,13 @@ class DeviceListUpdater(object):
             # happens if we've missed updates.
             resync = yield self._need_to_do_resync(user_id, pending_updates)
 
-            logger.debug("Need to re-sync devices for %r? %r", user_id, resync)
+            if logger.isEnabledFor(logging.INFO):
+                logger.info(
+                    "Received device list update for %s, requiring resync: %s. Devices: %s",
+                    user_id,
+                    resync,
+                    ", ".join(u[0] for u in pending_updates),
+                )
 
             if resync:
                 yield self.user_device_resync(user_id)


### PR DESCRIPTION
If it doesn't then the device lists are probably out of sync so we should resync.

Also add info logging when we receive device updates to help debug missing device lists. Hopefully this shouldn't be tooooo spammy.