### PR TITLE
Add quotes around the pip install target to avoid my shell complaining

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -272,7 +272,7 @@ to install using pip and a virtualenv::
 
     virtualenv -p python3 env
     source env/bin/activate
-    python -m pip install --no-use-pep517 -e .[all]
+    python -m pip install --no-use-pep517 -e ".[all]"
 
 This will run a process of downloading and installing all the needed
 dependencies into a virtual env.

--- a/changelog.d/6855.misc
+++ b/changelog.d/6855.misc
@@ -1,0 +1,1 @@
+Update pip install directiosn in readme to avoid error when using zsh.


### PR DESCRIPTION
Without this change my shell complains with:

```
$ python -m pip install --no-use-pep517 -e .[all]
zsh: no matches found: .[all]
```

