### PR TITLE
Limit the number of events that can be requested when backfilling events

### DIFF
--- a/changelog.d/6864.misc
+++ b/changelog.d/6864.misc
@@ -1,2 +1,1 @@
 Limit the number of events that can be requested by the backfill federation API to 100.
-

--- a/changelog.d/6864.misc
+++ b/changelog.d/6864.misc
@@ -1,0 +1,2 @@
+Limit the number of events that can be requested by the backfill federation API to 100.
+

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1789,6 +1789,9 @@ class FederationHandler(BaseHandler):
         if not in_room:
             raise AuthError(403, "Host not in room.")
 
+        # Synapse asks for 100 events per backfill request. Do not allow more.
+        limit = min(limit, 100)
+
         events = yield self.store.get_backfill_events(room_id, pdu_list, limit)
 
         events = yield filter_events_for_server(self.storage, origin, events)
@@ -2169,6 +2172,7 @@ class FederationHandler(BaseHandler):
         if not in_room:
             raise AuthError(403, "Host not in room.")
 
+        # Only allow up to 20 events to be retrieved per request.
         limit = min(limit, 20)
 
         missing_events = await self.store.get_missing_events(


### PR DESCRIPTION
Limits the maximum number of events that can be requested from the backfill events federation API.

The maximum limit was suggested by @erikjohnston to match what Synapse requests when calling this API as a client (see https://github.com/matrix-org/synapse/blob/v1.9.0/synapse/handlers/federation.py#L978-L980).