### PR TITLE
Store room_versions in EventBase objects

### DIFF
--- a/changelog.d/6875.misc
+++ b/changelog.d/6875.misc
@@ -1,0 +1,1 @@
+Refactoring work in preparation for changing the event redaction algorithm.

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -470,7 +470,7 @@ class FrozenEventV3(FrozenEventV2):
         return self._event_id
 
 
-def event_type_from_format_version(format_version: int) -> Type[EventBase]:
+def _event_type_from_format_version(format_version: int) -> Type[EventBase]:
     """Returns the python type to use to construct an Event object for the
     given event format version.
 
@@ -499,5 +499,5 @@ def make_event_from_dict(
     rejected_reason: Optional[str] = None,
 ) -> EventBase:
     """Construct an EventBase from the given event dict"""
-    event_type = event_type_from_format_version(room_version.event_format)
+    event_type = _event_type_from_format_version(room_version.event_format)
     return event_type(event_dict, room_version, internal_metadata_dict, rejected_reason)

--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -35,26 +35,20 @@ from . import EventBase
 SPLIT_FIELD_REGEX = re.compile(r"(?<!\\)\.")
 
 
-def prune_event(event):
+def prune_event(event: EventBase) -> EventBase:
     """ Returns a pruned version of the given event, which removes all keys we
     don't know about or think could potentially be dodgy.
 
     This is used when we "redact" an event. We want to remove all fields that
     the user has specified, but we do want to keep necessary information like
     type, state_key etc.
-
-    Args:
-        event (FrozenEvent)
-
-    Returns:
-        FrozenEvent
     """
     pruned_event_dict = prune_event_dict(event.get_dict())
 
-    from . import event_type_from_format_version
+    from . import make_event_from_dict
 
-    pruned_event = event_type_from_format_version(event.format_version)(
-        pruned_event_dict, event.internal_metadata.get_dict()
+    pruned_event = make_event_from_dict(
+        pruned_event_dict, event.room_version, event.internal_metadata.get_dict()
     )
 
     # Mark the event as redacted

--- a/synapse/replication/http/send_event.py
+++ b/synapse/replication/http/send_event.py
@@ -98,7 +98,7 @@ class ReplicationSendEventRestServlet(ReplicationEndpoint):
             content = parse_json_object_from_request(request)
 
             event_dict = content["event"]
-            room_ver = KNOWN_ROOM_VERSIONS[content["room_ver"]]
+            room_ver = KNOWN_ROOM_VERSIONS[content["room_version"]]
             internal_metadata = content["internal_metadata"]
             rejected_reason = content["rejected_reason"]
 


### PR DESCRIPTION
This is a bit fiddly because it all has to be done on one fell swoop:
 * Wherever we create a new event, pass in the room version (and check it matches the format version)
 * When we prune an event, use the room version of the unpruned event to create the pruned version.
 * When we pass an event over the replication protocol, pass the room version over alongside it, and use it when deserialising the event again.

~~Based on #6874~~