### PR TITLE
filter out m.room.aliases from the CS API until a better solution is specced

### DIFF
--- a/changelog.d/6878.feature
+++ b/changelog.d/6878.feature
@@ -1,1 +1,1 @@
-Filter out m.room.aliases from the CS API until we can redact them properly.
+Filter out m.room.aliases from the CS API to mitigate abuse while a better solution is specced

--- a/changelog.d/6878.feature
+++ b/changelog.d/6878.feature
@@ -1,1 +1,1 @@
-Filter out m.room.aliases from the CS API to mitigate abuse while a better solution is specced
+Filter out m.room.aliases from the CS API to mitigate abuse while a better solution is specced.

--- a/changelog.d/6878.feature
+++ b/changelog.d/6878.feature
@@ -1,0 +1,1 @@
+Filter out m.room.aliases from the CS API until we can redact them properly.

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -122,6 +122,12 @@ def filter_events_for_client(
         if not event.is_state() and event.sender in ignore_list:
             return None
 
+        # Until MSC2261 has landed we can't redact malicious aliases, so for
+        # now we temporarily filter out m.room.aliases entirely, until we bump
+        # to a room version which lets us manage them properly.
+        if event.type == EventTypes.Aliases:
+            return None
+
         # Don't try to apply the room's retention policy if the event is a state event, as
         # MSC1763 states that retention is only considered for non-state events.
         if apply_retention_policies and not event.is_state():

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -122,9 +122,10 @@ def filter_events_for_client(
         if not event.is_state() and event.sender in ignore_list:
             return None
 
-        # Until MSC2261 has landed we can't redact malicious aliases, so for
-        # now we temporarily filter out m.room.aliases entirely, until we bump
-        # to a room version which lets us manage them properly.
+        # Until MSC2261 has landed we can't redact malicious alias events, so for
+        # now we temporarily filter out m.room.aliases entirely to mitigate
+        # abuse, while we spec a better solution to advertising aliases
+        # on rooms.
         if event.type == EventTypes.Aliases:
             return None
 


### PR DESCRIPTION
We're in the middle of properly mitigating spam caused by malicious aliases being added to a room. However, until this work fully lands, we temporarily filter out all `m.room.aliases` events from /sync and /messages on the CS API, to remove abusive aliases.  This is considered acceptable as `m.room.aliases` events were never a reliable record of the given alias->id mapping and were purely informational, and in their current state do more harm than good.