### PR TITLE
Update setuptools for python 3.5 tests

### DIFF
--- a/.buildkite/scripts/test_old_deps.sh
+++ b/.buildkite/scripts/test_old_deps.sh
@@ -9,7 +9,7 @@ apt-get update
 apt-get install -y python3.5 python3.5-dev python3-pip libxml2-dev libxslt-dev zlib1g-dev
 
 # workaround for https://github.com/jaraco/zipp/issues/40
-python3.5 -m pip install setuptools
+python3.5 -m pip install 'setuptools>=34.4.0'
 
 python3.5 -m pip install tox
 

--- a/.buildkite/scripts/test_old_deps.sh
+++ b/.buildkite/scripts/test_old_deps.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# this script is run by buildkite in a plain `xenial` container; it installs the
+# minimal requirements for tox and hands over to the py35-old tox environment.
+
+set -ex
+
+apt-get update
+apt-get install -y python3.5 python3.5-dev python3-pip libxml2-dev libxslt-dev zlib1g-dev
+
+# workaround for https://github.com/jaraco/zipp/issues/40
+python3.5 -m pip install setuptools
+
+python3.5 -m pip install tox
+
+exec tox -e py35-old,combine

--- a/.buildkite/scripts/test_old_deps.sh
+++ b/.buildkite/scripts/test_old_deps.sh
@@ -13,4 +13,6 @@ python3.5 -m pip install setuptools
 
 python3.5 -m pip install tox
 
+export LANG="C.UTF-8"
+
 exec tox -e py35-old,combine

--- a/changelog.d/6880.misc
+++ b/changelog.d/6880.misc
@@ -1,0 +1,1 @@
+Fix continuous integration failures with old versions of `pip`, which were introduced by a release of the `zipp` library.

--- a/tox.ini
+++ b/tox.ini
@@ -90,10 +90,6 @@ deps =
     coverage
     coverage-enable-subprocess
 
-    # workaround for https://github.com/jaraco/zipp/issues/40
-    # I'm not sure if this is the best solution, but it will do for now.
-    setuptools == 34.4.0
-
 commands =
     /usr/bin/find "{toxinidir}" -name '*.pyc' -delete
     # Make all greater-thans equals so we test the oldest version of our direct

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,10 @@ deps =
     coverage
     coverage-enable-subprocess
 
+    # workaround for https://github.com/jaraco/zipp/issues/40
+    # I'm not sure if this is the best solution, but it will do for now.
+    setuptools == 34.4.0
+
 commands =
     /usr/bin/find "{toxinidir}" -name '*.pyc' -delete
     # Make all greater-thans equals so we test the oldest version of our direct


### PR DESCRIPTION
Workaround for https://github.com/jaraco/zipp/issues/40