### PR TITLE
Add a flaky test to the SyTest worker blacklist

### DIFF
--- a/.buildkite/worker-blacklist
+++ b/.buildkite/worker-blacklist
@@ -39,3 +39,5 @@ Server correctly handles incoming m.device_list_update
 
 # this fails reliably with a torture level of 100 due to https://github.com/matrix-org/synapse/issues/6536
 Outbound federation requests missing prev_events and then asks for /state_ids and resolves the state
+
+Can get rooms/{roomId}/members at a given point

--- a/changelog.d/6883.misc
+++ b/changelog.d/6883.misc
@@ -1,0 +1,1 @@
+Add an additional entry to the SyTest blacklist for worker mode.


### PR DESCRIPTION
This adds the "Can get rooms/{roomId}/members at a given point" to the SyTest worker mode blacklist.