### PR TITLE
filter out m.room.aliases from /sync state blocks

### DIFF
--- a/changelog.d/6884.feature
+++ b/changelog.d/6884.feature
@@ -1,1 +1,1 @@
-Filter out m.room.aliases from /sync state blocks until a full fix lands
+Filter out m.room.aliases from /sync state blocks until a full fix lands.

--- a/changelog.d/6884.feature
+++ b/changelog.d/6884.feature
@@ -1,0 +1,1 @@
+Filter out m.room.aliases from /sync state blocks until a full fix lands

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -882,7 +882,7 @@ class SyncHandler(object):
             (e.type, e.state_key): e
             for e in sync_config.filter_collection.filter_room_state(
                 list(state.values())
-            )
+            ) if e.type != EventTypes.Aliases  # until MSC2261
         }
 
     async def unread_notifs_for_room_id(self, room_id, sync_config):

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -882,7 +882,7 @@ class SyncHandler(object):
             (e.type, e.state_key): e
             for e in sync_config.filter_collection.filter_room_state(
                 list(state.values())
-            ) 
+            )
             if e.type != EventTypes.Aliases  # until MSC2261 or alternative solution
         }
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -882,7 +882,8 @@ class SyncHandler(object):
             (e.type, e.state_key): e
             for e in sync_config.filter_collection.filter_room_state(
                 list(state.values())
-            ) if e.type != EventTypes.Aliases  # until MSC2261
+            ) 
+            if e.type != EventTypes.Aliases  # until MSC2261 or alternative solution
         }
 
     async def unread_notifs_for_room_id(self, room_id, sync_config):


### PR DESCRIPTION
I forgot to filter out aliases from /sync state blocks as well as the timeline.