### PR TITLE
Use BSD-compatible in-place editing for sed.

### DIFF
--- a/changelog.d/6887.misc
+++ b/changelog.d/6887.misc
@@ -1,0 +1,1 @@
+Fix the use of sed in the linting scripts when using BSD sed.

--- a/scripts-dev/config-lint.sh
+++ b/scripts-dev/config-lint.sh
@@ -3,7 +3,8 @@
 # Exits with 0 if there are no problems, or another code otherwise.
 
 # Fix non-lowercase true/false values
-sed -i -E "s/: +True/: true/g; s/: +False/: false/g;" docs/sample_config.yaml
+sed -i.bak -E "s/: +True/: true/g; s/: +False/: false/g;" docs/sample_config.yaml
+rm docs/sample_config.yaml.bak
 
 # Check if anything changed
 git diff --exit-code docs/sample_config.yaml


### PR DESCRIPTION
In the linting scripts the use of sed is not compatible with BSD's sed (which is what macOS uses unless a different version is installed).

This [StackOverflow](https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux) has a good explanation of the differences.

Without this change I end up with a `docs/sample_config.yaml-E` file in my directory each time I run the linting script.

I have not tested this with GNU sed, but I'm fairly certain it will work! You can check which version you have via the man pages (`man sed`). (Weirdly my version doesn't seem to have a `--version` flag...)