### PR TITLE
Filter the results of user directory searching via the spam checker

### DIFF
--- a/changelog.d/6888.feature
+++ b/changelog.d/6888.feature
@@ -1,0 +1,1 @@
+The result of a user directory search can now be filtered via the spam checker.

--- a/docs/spam_checker.md
+++ b/docs/spam_checker.md
@@ -54,6 +54,9 @@ class ExampleSpamChecker:
 
     def user_may_publish_room(self, userid, room_id):
         return True  # allow publishing of all rooms
+
+    def check_username_for_spam(self, user_profile):
+        return False  # allow all usernames
 ```
 
 ## Configuration

--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -125,3 +125,25 @@ class SpamChecker(object):
             return True
 
         return self.spam_checker.user_may_publish_room(userid, room_id)
+
+    def check_for_banned_user(self, userid, display_name):
+        """Checks if a user ID and display name are considered banned by this server.
+
+        If the server considers a user banned, then it will not be included in
+        user directory results.
+
+        Args:
+            userid (string): The ID of the user to check
+            display_name (string): The display name of the user to check
+
+        Returns:
+            bool: True if the user is banned.
+        """
+        if self.spam_checker is None:
+            return False
+
+        # For backwards compatibility, if the method does not exist on the spam checker fallback to not interfering.
+        if not hasattr(self.spam_checker, "check_for_banned_user"):
+            return False
+
+        return self.spam_checker.check_for_banned_user(userid, display_name)

--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -126,24 +126,24 @@ class SpamChecker(object):
 
         return self.spam_checker.user_may_publish_room(userid, room_id)
 
-    def check_for_banned_user(self, userid, display_name):
-        """Checks if a user ID and display name are considered banned by this server.
+    def check_username_for_spam(self, userid: str, display_name: str) -> bool:
+        """Checks if a user ID or display name are considered "spammy" by this server.
 
-        If the server considers a user banned, then it will not be included in
+        If the server considers a username spammy, then it will not be included in
         user directory results.
 
         Args:
-            userid (string): The ID of the user to check
-            display_name (string): The display name of the user to check
+            userid: The ID of the user to check
+            display_name: The display name of the user to check
 
         Returns:
-            bool: True if the user is banned.
+            True if the user is banned.
         """
         if self.spam_checker is None:
             return False
 
         # For backwards compatibility, if the method does not exist on the spam checker, fallback to not interfering.
-        if not hasattr(self.spam_checker, "check_for_banned_user"):
+        if not hasattr(self.spam_checker, "check_username_for_spam"):
             return False
 
-        return self.spam_checker.check_for_banned_user(userid, display_name)
+        return self.spam_checker.check_username_for_spam(userid, display_name)

--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -142,7 +142,7 @@ class SpamChecker(object):
         if self.spam_checker is None:
             return False
 
-        # For backwards compatibility, if the method does not exist on the spam checker fallback to not interfering.
+        # For backwards compatibility, if the method does not exist on the spam checker, fallback to not interfering.
         if not hasattr(self.spam_checker, "check_for_banned_user"):
             return False
 

--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -143,7 +143,7 @@ class SpamChecker(object):
             return False
 
         # For backwards compatibility, if the method does not exist on the spam checker, fallback to not interfering.
-        if not hasattr(self.spam_checker, "check_username_for_spam"):
+        checker = getattr(self.spam_checker, "check_username_for_spam", None)
+        if not checker:
             return False
-
-        return self.spam_checker.check_username_for_spam(userid, display_name)
+        return checker(userid, display_name)

--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import inspect
+from typing import Dict
 
 from synapse.spam_checker_api import SpamCheckerApi
 
@@ -126,18 +127,20 @@ class SpamChecker(object):
 
         return self.spam_checker.user_may_publish_room(userid, room_id)
 
-    def check_username_for_spam(self, userid: str, display_name: str) -> bool:
+    def check_username_for_spam(self, user_profile: Dict[str, str]) -> bool:
         """Checks if a user ID or display name are considered "spammy" by this server.
 
         If the server considers a username spammy, then it will not be included in
         user directory results.
 
         Args:
-            userid: The ID of the user to check
-            display_name: The display name of the user to check
+            user_profile: The user information to check, it contains the keys:
+                * user_id
+                * display_name
+                * avatar_url
 
         Returns:
-            True if the user is banned.
+            True if the user is spammy.
         """
         if self.spam_checker is None:
             return False
@@ -146,4 +149,6 @@ class SpamChecker(object):
         checker = getattr(self.spam_checker, "check_username_for_spam", None)
         if not checker:
             return False
-        return checker(userid, display_name)
+        # Make a copy of the user profile object to ensure the spam checker
+        # cannot modify it.
+        return checker(user_profile.copy())

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -87,7 +87,8 @@ class UserDirectoryHandler(StateDeltasHandler):
 
         # Remove any spammy users from the results.
         results["results"] = [
-            user for user in results["results"]
+            user
+            for user in results["results"]
             if not self.spam_checker.check_username_for_spam(
                 user["user_id"], user["display_name"]
             )

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -85,14 +85,13 @@ class UserDirectoryHandler(StateDeltasHandler):
         """
         results = await self.store.search_user_dir(user_id, search_term, limit)
 
-        if self.spam_checker:
-            # Remove any banned users from the results.
-            results["results"] = [
-                user for user in results["results"]
-                if not self.spam_checker.check_username_for_spam(
-                    user["user_id"], user["display_name"]
-                )
-            ]
+        # Remove any spammy users from the results.
+        results["results"] = [
+            user for user in results["results"]
+            if not self.spam_checker.check_username_for_spam(
+                user["user_id"], user["display_name"]
+            )
+        ]
 
         return results
 

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -87,14 +87,12 @@ class UserDirectoryHandler(StateDeltasHandler):
 
         if self.spam_checker:
             # Remove any banned users from the results.
-            results["results"] = list(
-                filter(
-                    lambda user_info: not self.spam_checker.check_for_banned_user(
-                        user_info["user_id"], user_info["display_name"]
-                    ),
-                    results["results"],
+            results["results"] = [
+                user for user in results["results"]
+                if not self.spam_checker.check_username_for_spam(
+                    user["user_id"], user["display_name"]
                 )
-            )
+            ]
 
         return results
 

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -89,9 +89,7 @@ class UserDirectoryHandler(StateDeltasHandler):
         results["results"] = [
             user
             for user in results["results"]
-            if not self.spam_checker.check_username_for_spam(
-                user["user_id"], user["display_name"]
-            )
+            if not self.spam_checker.check_username_for_spam(user)
         ]
 
         return results

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -147,6 +147,50 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         s = self.get_success(self.handler.search_users(u1, "user3", 10))
         self.assertEqual(len(s["results"]), 0)
 
+    def test_banned_user(self):
+        """
+        A banned user will not appear in search results.
+        """
+        u1 = self.register_user("user1", "pass")
+        u1_token = self.login(u1, "pass")
+        u2 = self.register_user("user2", "pass")
+        u2_token = self.login(u2, "pass")
+
+        # We do not add users to the directory until they join a room.
+        s = self.get_success(self.handler.search_users(u1, "user2", 10))
+        self.assertEqual(len(s["results"]), 0)
+
+        room = self.helper.create_room_as(u1, is_public=False, tok=u1_token)
+        self.helper.invite(room, src=u1, targ=u2, tok=u1_token)
+        self.helper.join(room, user=u2, tok=u2_token)
+
+        # Check we have populated the database correctly.
+        shares_private = self.get_users_who_share_private_rooms()
+        public_users = self.get_users_in_public_rooms()
+
+        self.assertEqual(
+            self._compress_shared(shares_private), set([(u1, u2, room), (u2, u1, room)])
+        )
+        self.assertEqual(public_users, [])
+
+        # We get one search result when searching for user2 by user1.
+        s = self.get_success(self.handler.search_users(u1, "user2", 10))
+        self.assertEqual(len(s["results"]), 1)
+
+        # Configure a user ban. This is implemented by a separate module.
+        spam_checker = self.hs.get_spam_checker()
+
+        class SpamChecker(object):
+            def check_for_banned_user(self, userid, display_name):
+                # Ban all users.
+                return True
+
+        spam_checker.spam_checker = SpamChecker()
+
+        # User1 now gets no search results for any of the other users.
+        s = self.get_success(self.handler.search_users(u1, "user2", 10))
+        self.assertEqual(len(s["results"]), 0)
+
     def _compress_shared(self, shared):
         """
         Compress a list of users who share rooms dicts to a list of tuples.

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -147,9 +147,9 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         s = self.get_success(self.handler.search_users(u1, "user3", 10))
         self.assertEqual(len(s["results"]), 0)
 
-    def test_banned_user(self):
+    def test_spam_checker(self):
         """
-        A banned user will not appear in search results.
+        A user which fails to the spam checks will not appear in search results.
         """
         u1 = self.register_user("user1", "pass")
         u1_token = self.login(u1, "pass")
@@ -177,19 +177,67 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         s = self.get_success(self.handler.search_users(u1, "user2", 10))
         self.assertEqual(len(s["results"]), 1)
 
-        # Configure a user ban. This is implemented by a separate module.
+        # Configure a spam checker that does not filter any users.
         spam_checker = self.hs.get_spam_checker()
 
-        class SpamChecker(object):
-            def check_for_banned_user(self, userid, display_name):
+        class AllowAll(object):
+            def check_for_banned_user(self, user_id, display_name):
+                # Allow all users.
+                return False
+
+        spam_checker.spam_checker = AllowAll()
+
+        # The results do not change:
+        # We get one search result when searching for user2 by user1.
+        s = self.get_success(self.handler.search_users(u1, "user2", 10))
+        self.assertEqual(len(s["results"]), 1)
+
+        # Configure a spam checker that filters all users.
+        class BlockAll(object):
+            def check_for_banned_user(self, user_id, display_name):
                 # Ban all users.
                 return True
 
-        spam_checker.spam_checker = SpamChecker()
+        spam_checker.spam_checker = BlockAll()
 
         # User1 now gets no search results for any of the other users.
         s = self.get_success(self.handler.search_users(u1, "user2", 10))
         self.assertEqual(len(s["results"]), 0)
+
+    def test_legacy_spam_checker(self):
+        """
+        A spam checker without the expected method should be ignored.
+        """
+        u1 = self.register_user("user1", "pass")
+        u1_token = self.login(u1, "pass")
+        u2 = self.register_user("user2", "pass")
+        u2_token = self.login(u2, "pass")
+
+        # We do not add users to the directory until they join a room.
+        s = self.get_success(self.handler.search_users(u1, "user2", 10))
+        self.assertEqual(len(s["results"]), 0)
+
+        room = self.helper.create_room_as(u1, is_public=False, tok=u1_token)
+        self.helper.invite(room, src=u1, targ=u2, tok=u1_token)
+        self.helper.join(room, user=u2, tok=u2_token)
+
+        # Check we have populated the database correctly.
+        shares_private = self.get_users_who_share_private_rooms()
+        public_users = self.get_users_in_public_rooms()
+
+        self.assertEqual(
+            self._compress_shared(shares_private), set([(u1, u2, room), (u2, u1, room)])
+        )
+        self.assertEqual(public_users, [])
+
+        # Configure a user ban. This is implemented by a separate module.
+        spam_checker = self.hs.get_spam_checker()
+        # The spam checker doesn't need any methods, so create a bare object.
+        spam_checker.spam_checker = object()
+
+        # We get one search result when searching for user2 by user1.
+        s = self.get_success(self.handler.search_users(u1, "user2", 10))
+        self.assertEqual(len(s["results"]), 1)
 
     def _compress_shared(self, shared):
         """

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -181,7 +181,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         spam_checker = self.hs.get_spam_checker()
 
         class AllowAll(object):
-            def check_username_for_spam(self, user_id, display_name):
+            def check_username_for_spam(self, user_profile):
                 # Allow all users.
                 return False
 
@@ -194,7 +194,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
 
         # Configure a spam checker that filters all users.
         class BlockAll(object):
-            def check_username_for_spam(self, user_id, display_name):
+            def check_username_for_spam(self, user_profile):
                 # All users are spammy.
                 return True
 

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -181,7 +181,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         spam_checker = self.hs.get_spam_checker()
 
         class AllowAll(object):
-            def check_for_banned_user(self, user_id, display_name):
+            def check_username_for_spam(self, user_id, display_name):
                 # Allow all users.
                 return False
 
@@ -194,8 +194,8 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
 
         # Configure a spam checker that filters all users.
         class BlockAll(object):
-            def check_for_banned_user(self, user_id, display_name):
-                # Ban all users.
+            def check_username_for_spam(self, user_id, display_name):
+                # All users are spammy.
                 return True
 
         spam_checker.spam_checker = BlockAll()
@@ -230,7 +230,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(public_users, [])
 
-        # Configure a user ban. This is implemented by a separate module.
+        # Configure a spam checker.
         spam_checker = self.hs.get_spam_checker()
         # The spam checker doesn't need any methods, so create a bare object.
         spam_checker.spam_checker = object()


### PR DESCRIPTION
* Adds a method to the spam checker with a user ID & display name and expects whether to display that user or not.
* For backwards compatibility, if the method on the spam checker doesn't exist it is ignored.
* Uses the above method in the user directory search to filter the responses.

Fixes #5648