### PR TITLE
Spell out that the last event sent to a room won't be deleted by a purge

### DIFF
--- a/changelog.d/6891.doc
+++ b/changelog.d/6891.doc
@@ -1,1 +1,1 @@
-Spell out that the last event sent to a room won't be deleted by the purge jobs for the message retention policies support.
+Spell out that the last event sent to a room won't be deleted by a purge. 

--- a/changelog.d/6891.doc
+++ b/changelog.d/6891.doc
@@ -1,0 +1,1 @@
+Spell out that the last event sent to a room won't be deleted by the purge jobs for the message retention policies support.

--- a/docs/admin_api/purge_history_api.rst
+++ b/docs/admin_api/purge_history_api.rst
@@ -8,6 +8,9 @@ Depending on the amount of history being purged a call to the API may take
 several minutes or longer. During this period users will not be able to
 paginate further back in the room from the point being purged from.
 
+Note that, in order to not break the room, this API won't delete the last
+message sent to it.
+
 The API is:
 
 ``POST /_synapse/admin/v1/purge_history/<room_id>[/<event_id>]``

--- a/docs/admin_api/purge_history_api.rst
+++ b/docs/admin_api/purge_history_api.rst
@@ -8,8 +8,8 @@ Depending on the amount of history being purged a call to the API may take
 several minutes or longer. During this period users will not be able to
 paginate further back in the room from the point being purged from.
 
-Note that, in order to not break the room, this API won't delete the last
-message sent to it.
+Note that Synapse requires at least one message in each room, so it will never
+delete the last message in a room.
 
 The API is:
 

--- a/docs/message_retention_policies.md
+++ b/docs/message_retention_policies.md
@@ -42,6 +42,10 @@ purged according to its room's policy, then the receiving server will
 process and store that event until it's picked up by the next purge job,
 though it will always hide it from clients.
 
+With the current implementation of this feature, in order not to break
+rooms, Synapse will never delete the last message sent to a room, and
+will only hide it from clients.
+
 
 ## Server configuration
 

--- a/docs/message_retention_policies.md
+++ b/docs/message_retention_policies.md
@@ -42,9 +42,9 @@ purged according to its room's policy, then the receiving server will
 process and store that event until it's picked up by the next purge job,
 though it will always hide it from clients.
 
-With the current implementation of this feature, in order not to break
-rooms, Synapse will never delete the last message sent to a room, and
-will only hide it from clients.
+Synapse requires at least one message in each room, so it will never
+delete the last message in a room. It will, however, hide it from
+clients.
 
 
 ## Server configuration


### PR DESCRIPTION
Because people can (rightfully) get confused by that, e.g. https://github.com/matrix-org/synapse/issues/3148