### PR TITLE
Return a 404 for admin api user lookup if user not found

### DIFF
--- a/changelog.d/6901.misc
+++ b/changelog.d/6901.misc
@@ -1,0 +1,1 @@
+Return a 404 instead of 200 for querying information of a non-existant user through the admin API.

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -21,7 +21,7 @@ from six import text_type
 from six.moves import http_client
 
 from synapse.api.constants import UserTypes
-from synapse.api.errors import Codes, SynapseError
+from synapse.api.errors import Codes, SynapseError, NotFoundError
 from synapse.http.servlet import (
     RestServlet,
     assert_params_in_dict,
@@ -153,7 +153,7 @@ class UserRestServletV2(RestServlet):
         ret = await self.admin_handler.get_user(target_user)
 
         if not ret:
-            raise SynapseError(404, "User not found", errcode=Codes.NOT_FOUND)
+            raise NotFoundError("User not found")
 
         return 200, ret
 

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -21,7 +21,7 @@ from six import text_type
 from six.moves import http_client
 
 from synapse.api.constants import UserTypes
-from synapse.api.errors import Codes, SynapseError, NotFoundError
+from synapse.api.errors import Codes, NotFoundError, SynapseError
 from synapse.http.servlet import (
     RestServlet,
     assert_params_in_dict,

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -152,6 +152,9 @@ class UserRestServletV2(RestServlet):
 
         ret = await self.admin_handler.get_user(target_user)
 
+        if not ret:
+            raise SynapseError(404, "User not found", errcode=Codes.NOT_FOUND)
+
         return 200, ret
 
     async def on_PUT(self, request, user_id):

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -401,6 +401,22 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual(403, int(channel.result["code"]), msg=channel.result["body"])
         self.assertEqual("You are not a server admin", channel.json_body["error"])
 
+    def test_user_does_not_exist(self):
+        """
+        Tests that a lookup for a user that does not exist returns a 404
+        """
+        self.hs.config.registration_shared_secret = None
+
+        request, channel = self.make_request(
+            "GET",
+            "/_synapse/admin/v2/users/@unknown_person:test",
+            access_token=self.admin_user_tok,
+        )
+        self.render(request)
+
+        self.assertEqual(404, channel.code, msg=channel.json_body)
+        self.assertEqual("M_NOT_FOUND", channel.json_body["errcode"])
+
     def test_requester_is_admin(self):
         """
         If the user is a server admin, a new user is created.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/6900