### PR TITLE
Add mention and warning about ACME v1 deprecation to the TLS config

### DIFF
--- a/changelog.d/6907.doc
+++ b/changelog.d/6907.doc
@@ -1,0 +1,1 @@
+Update Synapse's documentation to warn about the deprecation of ACME v1.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -466,6 +466,11 @@ retention:
 # ACME support: This will configure Synapse to request a valid TLS certificate
 # for your configured `server_name` via Let's Encrypt.
 #
+# Note that ACME v1 is now deprecated, and Synapse currently doesn't support
+# ACME v2. This means that this feature currently won't work with installs set
+# up after November 2019. For more info, and alternative solutions, see
+# https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1
+#
 # Note that provisioning a certificate in this way requires port 80 to be
 # routed to Synapse so that it can complete the http-01 ACME challenge.
 # By default, if you enable ACME support, Synapse will attempt to listen on

--- a/synapse/config/tls.py
+++ b/synapse/config/tls.py
@@ -40,7 +40,7 @@ November 2019, and that it may stop working on June 2020 for installs set up
 before that date.
 
 For more info and alternative solutions, see
-https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1 
+https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1
 --------------------------------------------------------------------------------"""
 
 

--- a/synapse/config/tls.py
+++ b/synapse/config/tls.py
@@ -41,7 +41,7 @@ before that date.
 
 For more info and alternative solutions, see
 https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1 
-"""
+--------------------------------------------------------------------------------"""
 
 
 class TlsConfig(Config):

--- a/synapse/config/tls.py
+++ b/synapse/config/tls.py
@@ -32,6 +32,17 @@ from synapse.util import glob_to_regex
 
 logger = logging.getLogger(__name__)
 
+ACME_SUPPORT_ENABLED_WARN = """\
+This server uses Synapse's built-in ACME support. Note that ACME v1 has been
+deprecated by Let's Encrypt, and that Synapse doesn't currently support ACME v2,
+which means that this feature will not work with Synapse installs set up after
+November 2019, and that it may stop working on June 2020 for installs set up
+before that date.
+
+For more info and alternative solutions, see
+https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1 
+"""
+
 
 class TlsConfig(Config):
     section = "tls"
@@ -43,6 +54,9 @@ class TlsConfig(Config):
             acme_config = {}
 
         self.acme_enabled = acme_config.get("enabled", False)
+
+        if self.acme_enabled:
+            logger.warning(ACME_SUPPORT_ENABLED_WARN)
 
         # hyperlink complains on py2 if this is not a Unicode
         self.acme_url = six.text_type(
@@ -361,6 +375,11 @@ class TlsConfig(Config):
 
         # ACME support: This will configure Synapse to request a valid TLS certificate
         # for your configured `server_name` via Let's Encrypt.
+        #
+        # Note that ACME v1 is now deprecated, and Synapse currently doesn't support
+        # ACME v2. This means that this feature currently won't work with installs set
+        # up after November 2019. For more info, and alternative solutions, see
+        # https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1
         #
         # Note that provisioning a certificate in this way requires port 80 to be
         # routed to Synapse so that it can complete the http-01 ACME challenge.

--- a/synapse/handlers/acme.py
+++ b/synapse/handlers/acme.py
@@ -26,12 +26,13 @@ from synapse.app import check_bind_error
 logger = logging.getLogger(__name__)
 
 ACME_REGISTER_FAIL_ERROR = """
+--------------------------------------------------------------------------------
 Failed to register with the ACME provider. This is likely happening because the install
 is new, and ACME v1 has been deprecated by Let's Encrypt and is disabled for installs set
 up after November 2019.
 At the moment, Synapse doesn't support ACME v2. For more info and alternative solution,
 check out https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1
-------------------------------------------------------"""
+--------------------------------------------------------------------------------"""
 
 
 class AcmeHandler(object):

--- a/synapse/handlers/acme.py
+++ b/synapse/handlers/acme.py
@@ -76,12 +76,13 @@ class AcmeHandler(object):
         try:
             yield self._issuer._ensure_registered()
         except Exception:
-            raise ConfigError("Failed to register with the ACME provider. This is likely"
-                " happening because the install is new, and ACME v1 has been deprecated"
-                " by Let's Encrypt and is disabled for installs set up after November"
-                " 2019. At the moment, Synapse doesn't support ACME v2. For more info"
-                " and alternative solution, check out https://github.com/matrix-org"
-                "/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1"
+            raise ConfigError(
+                "Failed to register with the ACME provider. This is likely happening"
+                " because the install is new, and ACME v1 has been deprecated by Let's"
+                " Encrypt and is disabled for installs set up after November 2019. At the"
+                " moment, Synapse doesn't support ACME v2. For more info and alternative"
+                " solution, check out https://github.com/matrix-org/synapse/blob/master"
+                "/docs/ACME.md#deprecation-of-acme-v1"
             )
 
     @defer.inlineCallbacks

--- a/synapse/handlers/acme.py
+++ b/synapse/handlers/acme.py
@@ -77,13 +77,12 @@ class AcmeHandler(object):
             yield self._issuer._ensure_registered()
         except Exception:
             raise ConfigError("Failed to register with the ACME provider. This is likely"
-                              " happening because the install is new, and ACME v1 has"
-                              " been deprecated by Let's Encrypt and is disabled for"
-                              " installs set up after November 2019. At the moment,"
-                              " Synapse doesn't support ACME v2. For more info and"
-                              " alternative solution, check out"
-                              " https://github.com/matrix-org/synapse/blob/master/docs/"
-                              "ACME.md#deprecation-of-acme-v1")
+                " happening because the install is new, and ACME v1 has been deprecated"
+                " by Let's Encrypt and is disabled for installs set up after November"
+                " 2019. At the moment, Synapse doesn't support ACME v2. For more info"
+                " and alternative solution, check out https://github.com/matrix-org"
+                "/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1"
+            )
 
     @defer.inlineCallbacks
     def provision_certificate(self):

--- a/synapse/handlers/acme.py
+++ b/synapse/handlers/acme.py
@@ -22,9 +22,16 @@ from twisted.web import server, static
 from twisted.web.resource import Resource
 
 from synapse.app import check_bind_error
-from synapse.config import ConfigError
 
 logger = logging.getLogger(__name__)
+
+ACME_REGISTER_FAIL_ERROR = """
+Failed to register with the ACME provider. This is likely happening because the install
+is new, and ACME v1 has been deprecated by Let's Encrypt and is disabled for installs set
+up after November 2019.
+At the moment, Synapse doesn't support ACME v2. For more info and alternative solution,
+check out https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1
+------------------------------------------------------"""
 
 
 class AcmeHandler(object):
@@ -76,14 +83,8 @@ class AcmeHandler(object):
         try:
             yield self._issuer._ensure_registered()
         except Exception:
-            raise ConfigError(
-                "Failed to register with the ACME provider. This is likely happening"
-                " because the install is new, and ACME v1 has been deprecated by Let's"
-                " Encrypt and is disabled for installs set up after November 2019. At the"
-                " moment, Synapse doesn't support ACME v2. For more info and alternative"
-                " solution, check out https://github.com/matrix-org/synapse/blob/master"
-                "/docs/ACME.md#deprecation-of-acme-v1"
-            )
+            logger.error(ACME_REGISTER_FAIL_ERROR)
+            raise
 
     @defer.inlineCallbacks
     def provision_certificate(self):


### PR DESCRIPTION
Also raises a more understandable error when failing to register against the ACME provider at startup (raising a `ConfigError`, not sure if that's the best error type to use?).