### PR TITLE
Convert the directory handler tests to use HomeserverTestCase

### DIFF
--- a/changelog.d/6919.misc
+++ b/changelog.d/6919.misc
@@ -1,0 +1,1 @@
+Convert the directory handler tests to use HomeserverTestCase.

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -27,11 +27,6 @@ from tests import unittest
 from tests.utils import setup_test_homeserver
 
 
-class DirectoryHandlers(object):
-    def __init__(self, hs):
-        self.directory_handler = DirectoryHandler(hs)
-
-
 class DirectoryTestCase(unittest.HomeserverTestCase):
     """ Tests the directory service. """
 
@@ -52,7 +47,6 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
             federation_client=self.mock_federation,
             federation_registry=self.mock_registry,
         )
-        hs.handlers = DirectoryHandlers(hs)
 
         self.handler = hs.get_handlers().directory_handler
 

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -19,12 +19,10 @@ from mock import Mock
 from twisted.internet import defer
 
 from synapse.config.room_directory import RoomDirectoryConfig
-from synapse.handlers.directory import DirectoryHandler
 from synapse.rest.client.v1 import directory, room
 from synapse.types import RoomAlias
 
 from tests import unittest
-from tests.utils import setup_test_homeserver
 
 
 class DirectoryTestCase(unittest.HomeserverTestCase):
@@ -59,9 +57,11 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
         return hs
 
     def test_get_local_association(self):
-        self.get_success(self.store.create_room_alias_association(
-            self.my_room, "!8765qwer:test", ["test"]
-        ))
+        self.get_success(
+            self.store.create_room_alias_association(
+                self.my_room, "!8765qwer:test", ["test"]
+            )
+        )
 
         result = self.get_success(self.handler.get_association(self.my_room))
 
@@ -86,13 +86,15 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
         )
 
     def test_incoming_fed_query(self):
-        self.get_success(self.store.create_room_alias_association(
-            self.your_room, "!8765asdf:test", ["test"]
-        ))
+        self.get_success(
+            self.store.create_room_alias_association(
+                self.your_room, "!8765asdf:test", ["test"]
+            )
+        )
 
-        response = self.get_success(self.handler.on_directory_query(
-            {"room_alias": "#your-room:test"}
-        ))
+        response = self.get_success(
+            self.handler.on_directory_query({"room_alias": "#your-room:test"})
+        )
 
         self.assertEquals({"room_id": "!8765asdf:test", "servers": ["test"]}, response)
 


### PR DESCRIPTION
This is a test only change, so if the code looks sane and unit tests pass this should be fine!

As requested in https://github.com/matrix-org/synapse/pull/6904/files#r379126831