### PR TITLE
contrib/docker: Ensure correct encoding and locale settings on DB creation

### DIFF
--- a/changelog.d/6921.docker
+++ b/changelog.d/6921.docker
@@ -1,0 +1,1 @@
+Databases created using the compose file in contrib/docker will now always have correct encoding and locale settings. Contributed by Fridtjof Mund.

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -56,6 +56,9 @@ services:
     environment:
       - POSTGRES_USER=synapse
       - POSTGRES_PASSWORD=changeme
+      # ensure the database gets created correctly
+      # https://github.com/matrix-org/synapse/blob/master/docs/postgres.md#set-up-database
+      - POSTGRES_INITDB_ARGS="--encoding=UTF-8 --lc-collate=C --lc-ctype=C"
     volumes:
       # You may store the database tables in a local folder..
       - ./schemas:/var/lib/postgresql/data


### PR DESCRIPTION
According to [the docs](https://github.com/matrix-org/synapse/blob/master/docs/postgres.md#set-up-database), these should be explicitly set. In my case, after setting up a homeserver with this compose file as a reference, I ended up with this:

```
synapse=# SELECT datcollate,datctype FROM pg_database WHERE datname = current_database();
 datcollate |  datctype  
------------+------------
 en_US.utf8 | en_US.utf8
```

Signed-off-by: Fridtjof Mund <fridtjof@das-labor.org>

