### PR TITLE
Increase DB/CPU perf of `_is_server_still_joined` check.

### DIFF
--- a/changelog.d/6936.misc
+++ b/changelog.d/6936.misc
@@ -1,0 +1,1 @@
+Increase DB/CPU perf of `_is_server_still_joined` check.

--- a/synapse/storage/data_stores/main/roommember.py
+++ b/synapse/storage/data_stores/main/roommember.py
@@ -871,8 +871,8 @@ class RoomMemberWorkerStore(EventsWorkerStore):
     async def is_local_host_in_room_ignoring_users(
         self, room_id: str, ignore_users: Collection[str]
     ) -> bool:
-        """Checks if the local server is in the room, ignoring membership of
-        the given users.
+        """Check if there are any local users, excluding those in the given
+        list, in the room.
         """
 
         clause, args = make_in_list_sql_clause(

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -748,7 +748,8 @@ class EventsPersistenceStorage(object):
 
         # None of the changes to state are joins, so we fall back to checking
         # the current state of the room to see if any of our users are joined
-        # (ingnoring users that have changed state.)
+        # None of the new state events are joins, so now we check the current
+        # room state to see if there are any other users in the room.
         users_to_ignore = [
             state_key
             for _, state_key in itertools.chain(delta.to_insert, delta.to_delete)

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -727,6 +727,7 @@ class EventsPersistenceStorage(object):
 
         # Check if any of the given events are a local join that appear in the
         # current state
+        events_to_check = []  # Event IDs that aren't an event we're persisting
         for (typ, state_key), event_id in delta.to_insert.items():
             if typ != EventTypes.Member or not self.is_mine_id(state_key):
                 continue
@@ -735,9 +736,32 @@ class EventsPersistenceStorage(object):
                 if event_id == event.event_id:
                     if event.membership == Membership.JOIN:
                         return True
+                else:
+                    events_to_check.append(event_id)
 
-        # There's been a change of membership but we don't have a local join
-        # event in the new events, so we need to check the full state.
+        # Check if any of the changes that we don't have events for are joins.
+        if events_to_check:
+            rows = await self.main_store.get_membership_from_event_ids(events_to_check)
+            is_still_joined = any(row["membership"] == Membership.JOIN for row in rows)
+            if is_still_joined:
+                return True
+
+        # None of the changes to state are joins, so we fall back to checking
+        # the current state of the room to see if any of our users are joined
+        # (ingnoring users that have changed state.)
+        users_to_ignore = [
+            state_key
+            for _, state_key in itertools.chain(delta.to_insert, delta.to_delete)
+            if self.is_mine_id(state_key)
+        ]
+
+        if await self.main_store.is_local_host_in_room_ignoring_users(
+            room_id, users_to_ignore
+        ):
+            return True
+
+        # The server will leave the room, so we go and find out which remote
+        # users will still be joined when we leave.
         if current_state is None:
             current_state = await self.main_store.get_current_state_ids(room_id)
             current_state = dict(current_state)
@@ -746,19 +770,6 @@ class EventsPersistenceStorage(object):
 
             current_state.update(delta.to_insert)
 
-        event_ids = [
-            event_id
-            for (typ, state_key,), event_id in current_state.items()
-            if typ == EventTypes.Member and self.is_mine_id(state_key)
-        ]
-
-        rows = await self.main_store.get_membership_from_event_ids(event_ids)
-        is_still_joined = any(row["membership"] == Membership.JOIN for row in rows)
-        if is_still_joined:
-            return True
-
-        # The server will leave the room, so we go and find out which remote
-        # users will still be joined when we leave.
         remote_event_ids = [
             event_id
             for (typ, state_key,), event_id in current_state.items()

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -735,11 +735,11 @@ class EventsPersistenceStorage(object):
             for event, _ in ev_ctx_rm:
                 if event_id == event.event_id:
                     if event.membership == Membership.JOIN:
-                        return True
-            else:
-                # The event is not in `ev_ctx_rm`, so we need to pull it out of
-                # the DB.
-                events_to_check.append(event_id)
+                        return
+
+            # The event is not in `ev_ctx_rm`, so we need to pull it out of
+            # the DB.
+            events_to_check.append(event_id)
 
         # Check if any of the changes that we don't have events for are joins.
         if events_to_check:
@@ -748,10 +748,9 @@ class EventsPersistenceStorage(object):
             if is_still_joined:
                 return True
 
-        # None of the changes to state are joins, so we fall back to checking
-        # the current state of the room to see if any of our users are joined
-        # None of the new state events are joins, so now we check the current
-        # room state to see if there are any other users in the room.
+        # None of the new state events are local joins, so we check the database
+        # to see if there are any other local users in the room. We ignore users
+        # whose state has changed as we've already their new state above.
         users_to_ignore = [
             state_key
             for _, state_key in itertools.chain(delta.to_insert, delta.to_delete)

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -735,7 +735,7 @@ class EventsPersistenceStorage(object):
             for event, _ in ev_ctx_rm:
                 if event_id == event.event_id:
                     if event.membership == Membership.JOIN:
-                        return
+                        return True
 
             # The event is not in `ev_ctx_rm`, so we need to pull it out of
             # the DB.

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -736,8 +736,10 @@ class EventsPersistenceStorage(object):
                 if event_id == event.event_id:
                     if event.membership == Membership.JOIN:
                         return True
-                else:
-                    events_to_check.append(event_id)
+            else:
+                # The event is not in `ev_ctx_rm`, so we need to pull it out of
+                # the DB.
+                events_to_check.append(event_id)
 
         # Check if any of the changes that we don't have events for are joins.
         if events_to_check:


### PR DESCRIPTION
For rooms with large amount of state a single user leaving could cause us to go and load a lot of membership events and then pull out membership state in a large number of batches.