### PR TITLE
Do not send alias events when creating / upgrading a room

### DIFF
--- a/changelog.d/6941.removal
+++ b/changelog.d/6941.removal
@@ -1,0 +1,1 @@
+Stop sending m.room.aliases events during room creation and upgrade.

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -283,22 +283,6 @@ class DirectoryHandler(BaseHandler):
             )
 
     @defer.inlineCallbacks
-    def send_room_alias_update_event(self, requester, room_id):
-        aliases = yield self.store.get_aliases_for_room(room_id)
-
-        yield self.event_creation_handler.create_and_send_nonmember_event(
-            requester,
-            {
-                "type": EventTypes.Aliases,
-                "state_key": self.hs.hostname,
-                "room_id": room_id,
-                "sender": requester.user.to_string(),
-                "content": {"aliases": aliases},
-            },
-            ratelimit=False,
-        )
-
-    @defer.inlineCallbacks
     def _update_canonical_alias(self, requester, user_id, room_id, room_alias):
         """
         Send an updated canonical alias event if the removed alias was set as

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -310,7 +310,7 @@ class DirectoryHandler(BaseHandler):
         alt_aliases = content.pop("alt_aliases", None)
         # If the aliases are not a list (or not found) do not attempt to modify
         # the list.
-        if isinstance(alt_aliases, list):
+        if isinstance(alt_aliases, (list, tuple)):
             send_update = True
             alt_aliases = [alias for alias in alt_aliases if alias != alias_str]
             if alt_aliases:

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import collections
 import logging
 import string
 from typing import List
@@ -310,7 +311,7 @@ class DirectoryHandler(BaseHandler):
         alt_aliases = content.pop("alt_aliases", None)
         # If the aliases are not a list (or not found) do not attempt to modify
         # the list.
-        if isinstance(alt_aliases, (list, tuple)):
+        if isinstance(alt_aliases, collections.Sequence):
             send_update = True
             alt_aliases = [alias for alias in alt_aliases if alias != alias_str]
             if alt_aliases:

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -839,7 +839,6 @@ class RoomCreationHandler(BaseHandler):
         if room_alias and (EventTypes.CanonicalAlias, "") not in initial_state:
             yield send(
                 etype=EventTypes.CanonicalAlias,
-                # TODO Alt alias?
                 content={"alias": room_alias.to_string()},
             )
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -149,7 +149,9 @@ class RoomCreationHandler(BaseHandler):
         return ret
 
     @defer.inlineCallbacks
-    def _upgrade_room(self, requester, old_room_id, new_version):
+    def _upgrade_room(
+        self, requester: Requester, old_room_id: str, new_version: RoomVersion
+    ):
         user_id = requester.user.to_string()
 
         # start by allocating a new room id
@@ -448,7 +450,11 @@ class RoomCreationHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def _move_aliases_to_new_room(
-        self, requester, old_room_id, new_room_id, old_room_state
+        self,
+        requester: Requester,
+        old_room_id: str,
+        new_room_id: str,
+        old_room_state: StateMap[str],
     ):
         directory_handler = self.hs.get_handlers().directory_handler
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -456,6 +456,7 @@ class RoomCreationHandler(BaseHandler):
 
         # check to see if we have a canonical alias.
         canonical_alias = None
+        canonical_alt_aliases = []
         canonical_alias_event_id = old_room_state.get((EventTypes.CanonicalAlias, ""))
         if canonical_alias_event_id:
             canonical_alias_event = yield self.store.get_event(canonical_alias_event_id)
@@ -466,7 +467,7 @@ class RoomCreationHandler(BaseHandler):
                 )
                 # If alt_aliases is not a list, overwrite it as whatever is there
                 # cannot be handled.
-                if not isinstance(canonical_alt_aliases, list):
+                if not isinstance(canonical_alt_aliases, (list, tuple)):
                     canonical_alt_aliases = []
 
         # first we try to remove the aliases from the old room (we suppress sending


### PR DESCRIPTION
This is the second part of #6898:

> Update POST /_matrix/client/r0/rooms/{roomId}/upgrade API to stop copying room aliases (and thus to stop m.room.aliases events). Update POST /_matrix/client/r0/createRoom to stop sending m.room.aliases events.

~~Additionally it also propagates the "alt_aliases" from the old room to the new room during room upgrade.~~

Additionally it propagates the content of the canonical alias event from the old room to the new room during a room upgrade.