### PR TITLE
Small grammar fixes to the ACME v1 deprecation notice

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -420,11 +420,10 @@ so, you will need to edit `homeserver.yaml`, as follows:
   Note that, as pointed out in that document, this feature will not
   work with installs set up after November 2020. 
   
-  If you are using your
-  own certificate, be sure to use a `.pem` file that includes the full
-  certificate chain including any intermediate certificates (for
-  instance, if using certbot, use `fullchain.pem` as your certificate,
-  not `cert.pem`).
+  If you are using your own certificate, be sure to use a `.pem` file that
+  includes the full certificate chain including any intermediate certificates
+  (for instance, if using certbot, use `fullchain.pem` as your certificate, not
+  `cert.pem`).
 
 For a more detailed guide to configuring your server for federation, see
 [federate.md](docs/federate.md)

--- a/changelog.d/6944.doc
+++ b/changelog.d/6944.doc
@@ -1,0 +1,1 @@
+Small grammatical fixes to the ACME v1 deprecation notice.

--- a/synapse/handlers/acme.py
+++ b/synapse/handlers/acme.py
@@ -27,11 +27,11 @@ logger = logging.getLogger(__name__)
 
 ACME_REGISTER_FAIL_ERROR = """
 --------------------------------------------------------------------------------
-Failed to register with the ACME provider. This is likely happening because the install
-is new, and ACME v1 has been deprecated by Let's Encrypt and is disabled for installs set
-up after November 2019.
-At the moment, Synapse doesn't support ACME v2. For more info and alternative solution,
-check out https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1
+Failed to register with the ACME provider. This is likely happening because the installation
+is new, and ACME v1 has been deprecated by Let's Encrypt and disabled for
+new installations after November 2019.
+At the moment, Synapse doesn't support ACME v2. For more information and an alternative
+solution, please read https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1
 --------------------------------------------------------------------------------"""
 
 

--- a/synapse/handlers/acme.py
+++ b/synapse/handlers/acme.py
@@ -30,8 +30,8 @@ ACME_REGISTER_FAIL_ERROR = """
 Failed to register with the ACME provider. This is likely happening because the installation
 is new, and ACME v1 has been deprecated by Let's Encrypt and disabled for
 new installations after November 2019.
-At the moment, Synapse doesn't support ACME v2. For more information and an alternative
-solution, please read https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1
+At the moment, Synapse doesn't support ACME v2. For more information and alternative
+solutions, please read https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1
 --------------------------------------------------------------------------------"""
 
 

--- a/synapse/handlers/acme.py
+++ b/synapse/handlers/acme.py
@@ -29,7 +29,7 @@ ACME_REGISTER_FAIL_ERROR = """
 --------------------------------------------------------------------------------
 Failed to register with the ACME provider. This is likely happening because the installation
 is new, and ACME v1 has been deprecated by Let's Encrypt and disabled for
-new installations after November 2019.
+new installations since November 2019.
 At the moment, Synapse doesn't support ACME v2. For more information and alternative
 solutions, please read https://github.com/matrix-org/synapse/blob/master/docs/ACME.md#deprecation-of-acme-v1
 --------------------------------------------------------------------------------"""


### PR DESCRIPTION
Some small fixes to the copy in https://github.com/matrix-org/synapse/pull/6907.