### PR TITLE
Tiny optimisation for _get_handler_for_request

### DIFF
--- a/changelog.d/6950.misc
+++ b/changelog.d/6950.misc
@@ -1,0 +1,1 @@
+Tiny optimisation for incoming HTTP request dispatch.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -353,10 +353,12 @@ class JsonResource(HttpServer, resource.Resource):
         if request.method == b"OPTIONS":
             return _options_handler, "options_request_handler", {}
 
+        request_path = request.path.decode("ascii")
+
         # Loop through all the registered callbacks to check if the method
         # and path regex match
         for path_entry in self.path_regexs.get(request.method, []):
-            m = path_entry.pattern.match(request.path.decode("ascii"))
+            m = path_entry.pattern.match(request_path)
             if m:
                 # We found a match!
                 return path_entry.callback, path_entry.servlet_classname, m.groupdict()


### PR DESCRIPTION
we have hundreds of path_regexes (see #5118), so let's not convert the same
bytes to str for each of them.