### PR TITLE
Freeze allocated objects on startup.

### DIFF
--- a/changelog.d/6953.misc
+++ b/changelog.d/6953.misc
@@ -1,0 +1,1 @@
+Reduce time spent doing GC by freezing objects on startup.

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -282,9 +282,12 @@ def start(hs, listeners=None):
 
         # We now freeze all allocated objects in the hopes that (almost)
         # everything currently allocated are things that will be used for the
-        # rest of time. Doing so means less work each GC (hopefully)
-        gc.collect()
-        gc.freeze()
+        # rest of time. Doing so means less work each GC (hopefully).
+        #
+        # This only works on Python 3.7
+        if sys.version_info >= (3, 7):
+            gc.collect()
+            gc.freeze()
     except Exception:
         traceback.print_exc(file=sys.stderr)
         reactor = hs.get_reactor()

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -279,6 +279,12 @@ def start(hs, listeners=None):
 
         setup_sentry(hs)
         setup_sdnotify(hs)
+
+        # We now freeze all allocated objects in the hopes that (almost)
+        # everything currently allocated are things that will be used for the
+        # rest of time. Doing so means less work each GC (hopefully)
+        gc.collect()
+        gc.freeze()
     except Exception:
         traceback.print_exc(file=sys.stderr)
         reactor = hs.get_reactor()


### PR DESCRIPTION
This may make gc go a bit faster as the gc will know things like caches/data stores etc. are frozen without having to check.

I'm not actually sure this will work.