### PR TITLE
don't insert into the device table for remote cross-signing keys

### DIFF
--- a/changelog.d/6956.misc
+++ b/changelog.d/6956.misc
@@ -1,0 +1,1 @@
+Don't record remote cross-signing keys in the `devices` table.


### PR DESCRIPTION
device table should only be for local users.  This may also fix an issue when receiving multiple key updates from another server.