### PR TITLE
Increase MAX_EVENTS_BEHIND for replication clients

### DIFF
--- a/changelog.d/6967.bugfix
+++ b/changelog.d/6967.bugfix
@@ -1,0 +1,1 @@
+Fix an issue affecting worker-based deployments where replication would stop working, necessitating a full restart, after joining a large room.

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -24,7 +24,7 @@ import attr
 logger = logging.getLogger(__name__)
 
 
-MAX_EVENTS_BEHIND = 10000
+MAX_EVENTS_BEHIND = 500000
 
 BackfillStreamRow = namedtuple(
     "BackfillStreamRow",


### PR DESCRIPTION
This is intended to fix, or at least work around, #2738.

The problem is essentially that when we join a room with more than 10000 state events (ie, a room that has ever had more than 10000 different mxids in it), this creates an entry in the replication stream which consists of 10000 rows. The master then thinks that the worker has got behind and drops the connection. The worker reconnects, but immediately the same problem recurs.

There's some debate about whether it's useful to have a cap at all: it's not like booting the worker off actually fixes anything, so it's more a red flag to indicate that there's a problem (and helps stop the master ending up with massive queues of replication data when the workers get behind).

Still, it's likely that we'll be reworking things in this department soon as part of #6677, so for now let's just make the limit huge and move on.