### PR TITLE
Do not return aliases as part of the public room list

### DIFF
--- a/changelog.d/6970.removal
+++ b/changelog.d/6970.removal
@@ -1,0 +1,1 @@
+The room list endpoint no longer returns a list of aliases.

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -216,15 +216,6 @@ class RoomListHandler(BaseHandler):
                         direction_is_forward=False,
                     ).to_token()
 
-        for room in results:
-            # populate search result entries with additional fields, namely
-            # 'aliases'
-            room_id = room["room_id"]
-
-            aliases = yield self.store.get_aliases_for_room(room_id)
-            if aliases:
-                room["aliases"] = aliases
-
         response["chunk"] = results
 
         response["total_room_count_estimate"] = yield self.store.count_public_rooms(


### PR DESCRIPTION
Part of #6898:

>  Update /_matrix/client/r0/publicRooms to stop sending a list of aliases.
