### PR TITLE
Remove redundant store_room call

### DIFF
--- a/changelog.d/6979.misc
+++ b/changelog.d/6979.misc
@@ -1,1 +1,1 @@
-Remove redundant store_room call from `FederationHandler._process_received_pdu`.
+Remove redundant `store_room` call from `FederationHandler._process_received_pdu`.

--- a/changelog.d/6979.misc
+++ b/changelog.d/6979.misc
@@ -1,0 +1,1 @@
+Remove redundant store_room call from `FederationHandler._process_received_pdu`.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -707,28 +707,6 @@ class FederationHandler(BaseHandler):
         except AuthError as e:
             raise FederationError("ERROR", e.code, e.msg, affected=event.event_id)
 
-        room = await self.store.get_room(room_id)
-
-        if not room:
-            try:
-                prev_state_ids = await context.get_prev_state_ids()
-                create_event = await self.store.get_event(
-                    prev_state_ids[(EventTypes.Create, "")]
-                )
-
-                room_version_id = create_event.content.get(
-                    "room_version", RoomVersions.V1.identifier
-                )
-
-                await self.store.store_room(
-                    room_id=room_id,
-                    room_creator_user_id="",
-                    is_public=False,
-                    room_version=KNOWN_ROOM_VERSIONS[room_version_id],
-                )
-            except StoreError:
-                logger.exception("Failed to store room.")
-
         if event.type == EventTypes.Member:
             if event.membership == Membership.JOIN:
                 # Only fire user_joined_room if the user has acutally

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -41,7 +41,6 @@ from synapse.api.errors import (
     FederationDeniedError,
     FederationError,
     RequestSendFailed,
-    StoreError,
     SynapseError,
 )
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersion, RoomVersions


### PR DESCRIPTION
`_process_received_pdu` is only called by `on_receive_pdu`, which ignores any
events for unknown rooms, so this is redundant.