### PR TITLE
contrib/docker: remove quotes for POSTGRES_INITDB_ARGS

### DIFF
--- a/changelog.d/6984.docker
+++ b/changelog.d/6984.docker
@@ -1,1 +1,1 @@
-The docker-compose file in contrib/docker would not start correctly after PR #6921.
+Fix `POSTGRES_INITDB_ARGS` in the `contrib/docker/docker-compose.yml` example docker-compose configuration.

--- a/changelog.d/6984.docker
+++ b/changelog.d/6984.docker
@@ -1,0 +1,1 @@
+The docker-compose file in contrib/docker would not start correctly after PR #6921.

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - POSTGRES_PASSWORD=changeme
       # ensure the database gets created correctly
       # https://github.com/matrix-org/synapse/blob/master/docs/postgres.md#set-up-database
-      - POSTGRES_INITDB_ARGS="--encoding=UTF-8 --lc-collate=C --lc-ctype=C"
+      - POSTGRES_INITDB_ARGS=--encoding=UTF-8 --lc-collate=C --lc-ctype=C
     volumes:
       # You may store the database tables in a local folder..
       - ./schemas:/var/lib/postgresql/data


### PR DESCRIPTION
I made a mistake in https://github.com/matrix-org/synapse/pull/6921 - the quotes break the postgres container's startup script (or docker-compose), which makes initdb fail: https://github.com/matrix-org/synapse/pull/6921#issuecomment-590657154

Signed-off-by: Fridtjof Mund <fridtjof@das-labor.org>