### PR TITLE
Cast a coroutine into a Deferred in the federation base

### DIFF
--- a/changelog.d/6996.bugfix
+++ b/changelog.d/6996.bugfix
@@ -1,0 +1,1 @@
+Properly handle the result of FederationClient.get_pdu as a coroutine.

--- a/changelog.d/6996.bugfix
+++ b/changelog.d/6996.bugfix
@@ -1,1 +1,1 @@
-Properly handle the result of FederationClient.get_pdu as a coroutine.
+Fix bug which caused an error when joining a room, with `'coroutine' object has no attribute 'event_id'`.

--- a/synapse/federation/federation_base.py
+++ b/synapse/federation/federation_base.py
@@ -96,13 +96,15 @@ class FederationBase(object):
 
             if not res and pdu.origin != origin:
                 try:
-                    res = yield defer.ensureDeferred(self.get_pdu(
-                        destinations=[pdu.origin],
-                        event_id=pdu.event_id,
-                        room_version=room_version,
-                        outlier=outlier,
-                        timeout=10000,
-                    ))
+                    res = yield defer.ensureDeferred(
+                        self.get_pdu(
+                            destinations=[pdu.origin],
+                            event_id=pdu.event_id,
+                            room_version=room_version,
+                            outlier=outlier,
+                            timeout=10000,
+                        )
+                    )
                 except SynapseError:
                     pass
 

--- a/synapse/federation/federation_base.py
+++ b/synapse/federation/federation_base.py
@@ -96,13 +96,13 @@ class FederationBase(object):
 
             if not res and pdu.origin != origin:
                 try:
-                    res = yield self.get_pdu(
+                    res = yield defer.ensureDeferred(self.get_pdu(
                         destinations=[pdu.origin],
                         event_id=pdu.event_id,
                         room_version=room_version,
                         outlier=outlier,
                         timeout=10000,
-                    )
+                    ))
                 except SynapseError:
                     pass
 


### PR DESCRIPTION
`FederationClient.get_pdu` was made async/await in #6840 (released in 1.110rc1), but a caller of it was not converted. I'm guessing this was missed because `FederationBase._check_sigs_and_hash_and_fetch` has an inner function which calls back into `FederationBase.get_pdu` (see the mypy errors in #6995).

Note that `FederationBase._check_sigs_and_hash_and_fetch` is also used by `FederationServer`, so I believe there's potential for another bug here.

Part of #6978.