### PR TITLE
Fix py35-old CI by using native tox.

### DIFF
--- a/.buildkite/scripts/test_old_deps.sh
+++ b/.buildkite/scripts/test_old_deps.sh
@@ -6,12 +6,7 @@
 set -ex
 
 apt-get update
-apt-get install -y python3.5 python3.5-dev python3-pip libxml2-dev libxslt-dev zlib1g-dev
-
-# workaround for https://github.com/jaraco/zipp/issues/40
-python3.5 -m pip install 'setuptools>=34.4.0'
-
-python3.5 -m pip install tox
+apt-get install -y python3.5 python3.5-dev python3-pip libxml2-dev libxslt-dev zlib1g-dev tox
 
 export LANG="C.UTF-8"
 

--- a/changelog.d/7018.bugfix
+++ b/changelog.d/7018.bugfix
@@ -1,0 +1,1 @@
+Fix py35-old CI by using native tox package.


### PR DESCRIPTION
I'm not really sure how this was going wrong, but this seems like the
right approach anyway.