### PR TITLE
Hide extremities dummy events from clients

### DIFF
--- a/changelog.d/7035.bugfix
+++ b/changelog.d/7035.bugfix
@@ -1,0 +1,1 @@
+Fix a bug causing `org.matrix.dummy_event` to be included in responses from `/sync`.

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -119,6 +119,9 @@ def filter_events_for_client(
 
                the original event if they can see it as normal.
         """
+        if event.type == "org.matrix.dummy_event":
+            return None
+
         if not event.is_state() and event.sender in ignore_list:
             return None
 


### PR DESCRIPTION
Fix https://github.com/matrix-org/synapse/issues/6174