### PR TITLE
Make sure that is_verified is a boolean when processing room keys

### DIFF
--- a/changelog.d/7045.misc
+++ b/changelog.d/7045.misc
@@ -1,0 +1,1 @@
+Add a type check to `is_verified` when processing room keys.

--- a/synapse/handlers/e2e_room_keys.py
+++ b/synapse/handlers/e2e_room_keys.py
@@ -207,6 +207,12 @@ class E2eRoomKeysHandler(object):
             changed = False  # if anything has changed, we need to update the etag
             for room_id, room in iteritems(room_keys["rooms"]):
                 for session_id, room_key in iteritems(room["sessions"]):
+                    if not isinstance(room_key["is_verified"], bool):
+                        msg = (
+                            "is_verified must be a boolean in keys for room %s" % room_id
+                        )
+                        raise SynapseError(400, msg, Codes.INVALID_PARAM)
+
                     log_kv(
                         {
                             "message": "Trying to upload room key",

--- a/synapse/handlers/e2e_room_keys.py
+++ b/synapse/handlers/e2e_room_keys.py
@@ -209,7 +209,8 @@ class E2eRoomKeysHandler(object):
                 for session_id, room_key in iteritems(room["sessions"]):
                     if not isinstance(room_key["is_verified"], bool):
                         msg = (
-                            "is_verified must be a boolean in keys for room %s" % room_id
+                            "is_verified must be a boolean in keys for room %s"
+                            % room_id
                         )
                         raise SynapseError(400, msg, Codes.INVALID_PARAM)
 

--- a/synapse/handlers/e2e_room_keys.py
+++ b/synapse/handlers/e2e_room_keys.py
@@ -210,8 +210,7 @@ class E2eRoomKeysHandler(object):
                     if not isinstance(room_key["is_verified"], bool):
                         msg = (
                             "is_verified must be a boolean in keys for session %s in"
-                            "room %s"
-                            % (session_id, room_id)
+                            "room %s" % (session_id, room_id)
                         )
                         raise SynapseError(400, msg, Codes.INVALID_PARAM)
 

--- a/synapse/handlers/e2e_room_keys.py
+++ b/synapse/handlers/e2e_room_keys.py
@@ -209,8 +209,9 @@ class E2eRoomKeysHandler(object):
                 for session_id, room_key in iteritems(room["sessions"]):
                     if not isinstance(room_key["is_verified"], bool):
                         msg = (
-                            "is_verified must be a boolean in keys for room %s"
-                            % room_id
+                            "is_verified must be a boolean in keys for session %s in"
+                            "room %s"
+                            % (session_id, room_id)
                         )
                         raise SynapseError(400, msg, Codes.INVALID_PARAM)
 


### PR DESCRIPTION
Fixes #7036, or at least the confusion around it, by adding a check on the type to return a more understandable error message.