### PR TITLE
Document that fallback auth must be routed to the same worker node as register

### DIFF
--- a/changelog.d/7048.doc
+++ b/changelog.d/7048.doc
@@ -1,0 +1,1 @@
+Document that the fallback auth endpoints must be routed to the same worker node as the register endpoints.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -273,6 +273,7 @@ Additionally, the following REST endpoints can be handled, but all requests must
 be routed to the same instance:
 
     ^/_matrix/client/(r0|unstable)/register$
+    ^/_matrix/client/(r0|unstable)/auth/.*/fallback/web$
 
 Pagination requests can also be handled, but all requests with the same path
 room must be routed to the same instance. Additionally, care must be taken to


### PR DESCRIPTION
Per the description in #6705, this updates the documentation to state that fallback auth and register must be routed to the same worker node, this is because there is memory state shared between these endpoints (in the `session` `dict`).

Fixes #6705.