### PR TITLE
Move get_time_of_last_push_action_before to the EventPushActionsWorkerStore

### DIFF
--- a/changelog.d/7055.misc
+++ b/changelog.d/7055.misc
@@ -1,0 +1,1 @@
+Merge worker apps together.

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -555,10 +555,12 @@ class Mailer(object):
             else:
                 # If the reason room doesn't have a name, say who the messages
                 # are from explicitly to avoid, "messages in the Bob room"
+                room_id = reason["room_id"]
+
                 sender_ids = list(
                     {
                         notif_events[n["event_id"]].sender
-                        for n in notifs_by_room[reason["room_id"]]
+                        for n in notifs_by_room[room_id]
                     }
                 )
 


### PR DESCRIPTION
Fixes #7054

I also had a look at the rest of the functions in
`EventPushActionsStore` and in the push notifications send code and it
looks to me like there shouldn't be any other method with this issue in
this part of the codebase.