### PR TITLE
Skip the correct visibility checks when checking the visibility of the state at a given event

### DIFF
--- a/changelog.d/7066.bugfix
+++ b/changelog.d/7066.bugfix
@@ -1,0 +1,1 @@
+Fix a bug that would cause Synapse to respond with an error about event visibility if a client tried to request the state of a room at a given token.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -160,7 +160,7 @@ class MessageHandler(object):
                 raise NotFoundError("Can't find event for token %s" % (at_token,))
 
             visible_events = yield filter_events_for_client(
-                self.storage, user_id, last_events, apply_retention_policies=False
+                self.storage, user_id, last_events, filter_send_to_client=False
             )
 
             event = last_events[0]

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -121,7 +121,7 @@ def filter_events_for_client(
         if event.type == "org.matrix.dummy_event" and filter_send_to_client:
             return None
 
-        if not event.is_state() and event.sender in ignore_list:
+        if not event.is_state() and event.sender in ignore_list and filter_send_to_client:
             return None
 
         # Until MSC2261 has landed we can't redact malicious alias events, so for

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -95,7 +95,7 @@ def filter_events_for_client(
 
     erased_senders = yield storage.main.are_users_erased((e.sender for e in events))
 
-    if not filter_send_to_client:
+    if filter_send_to_client:
         room_ids = {e.room_id for e in events}
         retention_policies = {}
 

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -118,34 +118,36 @@ def filter_events_for_client(
 
                the original event if they can see it as normal.
         """
-        if event.type == "org.matrix.dummy_event" and filter_send_to_client:
-            return None
+        # Only run some checks if these events aren't about to be sent to clients. This is
+        # because, if this is not the case, we're probably only checking if the users can
+        # see events in the room at that point in the DAG, and that shouldn't be decided
+        # on those checks.
+        if filter_send_to_client:
+            if event.type == "org.matrix.dummy_event":
+                return None
 
-        if (
-            not event.is_state()
-            and event.sender in ignore_list
-            and filter_send_to_client
-        ):
-            return None
+            if not event.is_state() and event.sender in ignore_list:
+                return None
 
-        # Until MSC2261 has landed we can't redact malicious alias events, so for
-        # now we temporarily filter out m.room.aliases entirely to mitigate
-        # abuse, while we spec a better solution to advertising aliases
-        # on rooms.
-        if event.type == EventTypes.Aliases and filter_send_to_client:
-            return None
+            # Until MSC2261 has landed we can't redact malicious alias events, so for
+            # now we temporarily filter out m.room.aliases entirely to mitigate
+            # abuse, while we spec a better solution to advertising aliases
+            # on rooms.
+            if event.type == EventTypes.Aliases:
+                return None
 
-        # Don't try to apply the room's retention policy if the event is a state event, as
-        # MSC1763 states that retention is only considered for non-state events.
-        if filter_send_to_client and not event.is_state():
-            retention_policy = retention_policies[event.room_id]
-            max_lifetime = retention_policy.get("max_lifetime")
+            # Don't try to apply the room's retention policy if the event is a state
+            # event, as MSC1763 states that retention is only considered for non-state
+            # events.
+            if not event.is_state():
+                retention_policy = retention_policies[event.room_id]
+                max_lifetime = retention_policy.get("max_lifetime")
 
-            if max_lifetime is not None:
-                oldest_allowed_ts = storage.main.clock.time_msec() - max_lifetime
+                if max_lifetime is not None:
+                    oldest_allowed_ts = storage.main.clock.time_msec() - max_lifetime
 
-                if event.origin_server_ts < oldest_allowed_ts:
-                    return None
+                    if event.origin_server_ts < oldest_allowed_ts:
+                        return None
 
         if event.event_id in always_include_ids:
             return event

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -121,7 +121,11 @@ def filter_events_for_client(
         if event.type == "org.matrix.dummy_event" and filter_send_to_client:
             return None
 
-        if not event.is_state() and event.sender in ignore_list and filter_send_to_client:
+        if (
+            not event.is_state()
+            and event.sender in ignore_list
+            and filter_send_to_client
+        ):
             return None
 
         # Until MSC2261 has landed we can't redact malicious alias events, so for

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -132,7 +132,7 @@ def filter_events_for_client(
         # now we temporarily filter out m.room.aliases entirely to mitigate
         # abuse, while we spec a better solution to advertising aliases
         # on rooms.
-        if event.type == EventTypes.Aliases:
+        if event.type == EventTypes.Aliases and filter_send_to_client:
             return None
 
         # Don't try to apply the room's retention policy if the event is a state event, as


### PR DESCRIPTION
Otherwise the requesting user will get told `User @alice:example.com not allowed to view events in room !someroom:example.com at token StreamToken(...)`.

Technical explanation on why this causes Riot to show that error every time we render a room (as copy-pasted from internal room):

> Basically Riot will ask the server for the list of members in a room each time you render that room in Riot, using the latest sync token it knows about or something like that. Synapse then proceeds to check if the user is allowed to see the latest event before this token based on the state at that event, which happens to be the same function call as when wondering if Synapse should send an event to the client, which is a similar question but not exactly the same. For example, we don't want to send dummy events to clients, but we also don't want that to mean "users don't have the perms to see any event in the room with the state at that point in the dag". So we've introduced a flag that allows this function to make the difference between these two use cases, and that flag causes a few tests to be skipped when we're in the "checking visibility" one. Except that we weren't applying it on messages sent by a user that had been ignored.
>
> So if that semi-random event happened to be from a user I'm ignoring, Synapse is going to tell me that I can't see the state of the room at that event with this "not allowed to view events in room" error.