### PR TITLE
Move the default SAML2 error HTML to a dedicated file

### DIFF
--- a/changelog.d/7067.feature
+++ b/changelog.d/7067.feature
@@ -1,0 +1,1 @@
+Render a configurable and comprehensible error page if something goes wrong during the SAML2 authentication process.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1365,6 +1365,9 @@ saml2_config:
   # If no file is provided, this defaults to some minimalistic HTML telling the
   # user that something went wrong and they should try authenticating again.
   #
+  # See https://github.com/matrix-org/synapse/blob/master/synapse/res/templates/saml_error.html
+  # for an example.
+  #
   #error_html_path: /path/to/static/content/saml_error.html
 
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1360,15 +1360,24 @@ saml2_config:
   #
   #grandfathered_mxid_source_attribute: upn
 
-  # Path to a file containing HTML content to serve in case an error happens
-  # when the user gets redirected from the SAML IdP back to Synapse.
-  # If no file is provided, this defaults to some minimalistic HTML telling the
-  # user that something went wrong and they should try authenticating again.
+  # Directory in which Synapse will try to find the template files below.
+  # If not set, default templates from within the Synapse package will be used.
   #
-  # See https://github.com/matrix-org/synapse/blob/master/synapse/res/templates/saml_error.html
-  # for an example.
+  # DO NOT UNCOMMENT THIS SETTING unless you want to customise the templates.
+  # If you *do* uncomment it, you will need to make sure that all the templates
+  # below are in the directory.
   #
-  #error_html_path: /path/to/static/content/saml_error.html
+  # Synapse will look for the following templates in this directory:
+  #
+  # * HTML page to display to users if something goes wrong during the
+  #   authentication process: 'saml_error.html'.
+  #
+  #   This template doesn't currently need any variable to render.
+  #
+  # You can see the default templates at:
+  # https://github.com/matrix-org/synapse/tree/master/synapse/res/templates
+  #
+  #template_dir: "res/templates"
 
 
 

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -343,6 +343,9 @@ class SAML2Config(Config):
           # If no file is provided, this defaults to some minimalistic HTML telling the
           # user that something went wrong and they should try authenticating again.
           #
+          # See https://github.com/matrix-org/synapse/blob/master/synapse/res/templates/saml_error.html
+          # for an example.
+          #
           #error_html_path: /path/to/static/content/saml_error.html
         """ % {
             "config_dir_path": config_dir_path

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -15,6 +15,9 @@
 # limitations under the License.
 
 import logging
+import os
+
+import pkg_resources
 
 from synapse.python_dependencies import DependencyException, check_requirements
 from synapse.util.module_loader import load_module, load_python_module
@@ -26,18 +29,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_USER_MAPPING_PROVIDER = (
     "synapse.handlers.saml_handler.DefaultSamlMappingProvider"
 )
-
-SAML2_ERROR_DEFAULT_HTML = """
-<html>
-    <body>
-        <p>Oops! Something went wrong</p>
-        <p>
-            Try logging in again from your Matrix client and if the problem persists
-            please contact the server's administrator.
-        </p>
-    </body>
-</html>
-"""
 
 
 def _dict_merge(merge_dict, into_dict):
@@ -172,12 +163,14 @@ class SAML2Config(Config):
             saml2_config.get("saml_session_lifetime", "5m")
         )
 
-        if "error_html_path" in config:
-            self.saml2_error_html_content = self.read_file(
-                config["error_html_path"], "saml2_config.error_html_path",
-            )
-        else:
-            self.saml2_error_html_content = SAML2_ERROR_DEFAULT_HTML
+        error_html_path = config.get("error_html_path")
+        if not error_html_path:
+            template_dir = pkg_resources.resource_filename("synapse", "res/templates")
+            error_html_path = os.path.join(template_dir, "saml_error.html")
+
+        self.saml2_error_html_content = self.read_file(
+            error_html_path, "saml2_config.error_html_path",
+        )
 
     def _default_saml_config_dict(
         self, required_attributes: set, optional_attributes: set

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -163,13 +163,13 @@ class SAML2Config(Config):
             saml2_config.get("saml_session_lifetime", "5m")
         )
 
-        error_html_path = config.get("error_html_path")
-        if not error_html_path:
-            template_dir = pkg_resources.resource_filename("synapse", "res/templates")
-            error_html_path = os.path.join(template_dir, "saml_error.html")
+        template_dir = saml2_config.get("template_dir")
+        if not template_dir:
+            template_dir = pkg_resources.resource_filename("synapse", "res/templates",)
 
         self.saml2_error_html_content = self.read_file(
-            error_html_path, "saml2_config.error_html_path",
+            os.path.join(template_dir, "saml_error.html"),
+            "saml2_config.saml_error",
         )
 
     def _default_saml_config_dict(
@@ -338,15 +338,24 @@ class SAML2Config(Config):
           #
           #grandfathered_mxid_source_attribute: upn
 
-          # Path to a file containing HTML content to serve in case an error happens
-          # when the user gets redirected from the SAML IdP back to Synapse.
-          # If no file is provided, this defaults to some minimalistic HTML telling the
-          # user that something went wrong and they should try authenticating again.
+          # Directory in which Synapse will try to find the template files below.
+          # If not set, default templates from within the Synapse package will be used.
           #
-          # See https://github.com/matrix-org/synapse/blob/master/synapse/res/templates/saml_error.html
-          # for an example.
+          # DO NOT UNCOMMENT THIS SETTING unless you want to customise the templates.
+          # If you *do* uncomment it, you will need to make sure that all the templates
+          # below are in the directory.
           #
-          #error_html_path: /path/to/static/content/saml_error.html
+          # Synapse will look for the following templates in this directory:
+          #
+          # * HTML page to display to users if something goes wrong during the
+          #   authentication process: 'saml_error.html'.
+          #
+          #   This template doesn't currently need any variable to render.
+          #
+          # You can see the default templates at:
+          # https://github.com/matrix-org/synapse/tree/master/synapse/res/templates
+          #
+          #template_dir: "res/templates"
         """ % {
             "config_dir_path": config_dir_path
         }

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -168,8 +168,7 @@ class SAML2Config(Config):
             template_dir = pkg_resources.resource_filename("synapse", "res/templates",)
 
         self.saml2_error_html_content = self.read_file(
-            os.path.join(template_dir, "saml_error.html"),
-            "saml2_config.saml_error",
+            os.path.join(template_dir, "saml_error.html"), "saml2_config.saml_error",
         )
 
     def _default_saml_config_dict(

--- a/synapse/res/templates/saml_error.html
+++ b/synapse/res/templates/saml_error.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SSO error</title>
+</head>
+<body>
+    <p>Oops! Something went wrong during authentication<span id="errormsg"></span>.</p>
+    <p>
+        If you are seeing this page after clicking a link sent to you via email, make
+        sure you only click the confirmation link once, and that you open the
+        validation link in the same client you're logging in from.
+    </p>
+    <p>
+        Try logging in again from your Matrix client and if the problem persists
+        please contact the server's administrator.
+    </p>
+
+    <script type="text/javascript">
+        // Error handling to support Auth0 errors that we might get through a GET request
+        // to the validation endpoint. If an error is provided, it's either going to be
+        // located in the query string or in a query string-like URI fragment.
+        // We try to locate the error from any of these two locations, but if we can't
+        // we just don't print anything specific.
+        let searchStr = "";
+        if (window.location.search) {
+            // For some reason window.location.searchParams isn't always defined when
+            // window.location.search is, so we can't just use it right away.
+            searchStr = window.location.search;
+        } else if (window.location.hash) {
+            // Replace the # with a ? so that URLSearchParams does the right thing and
+            // doesn't parse the first parameter incorrectly.
+            searchStr = window.location.hash.replace("#", "?");
+        }
+
+        // We might end up with no error in the URL, so we need to check if we have one
+        // to print one.
+        let errorDesc = new URLSearchParams(searchStr).get("error_description")
+        if (errorDesc) {
+            document.getElementById("errormsg").innerHTML = ` ("${errorDesc}")`;
+        }
+    </script>
+</body>
+</html>

--- a/synapse/res/templates/saml_error.html
+++ b/synapse/res/templates/saml_error.html
@@ -37,7 +37,8 @@
         // to print one.
         let errorDesc = new URLSearchParams(searchStr).get("error_description")
         if (errorDesc) {
-            document.getElementById("errormsg").innerHTML = ` ("${errorDesc}")`;
+
+            document.getElementById("errormsg").innerText = ` ("${errorDesc}")`;
         }
     </script>
 </body>

--- a/synapse/res/templates/saml_error.html
+++ b/synapse/res/templates/saml_error.html
@@ -24,8 +24,8 @@
         // we just don't print anything specific.
         let searchStr = "";
         if (window.location.search) {
-            // For some reason window.location.searchParams isn't always defined when
-            // window.location.search is, so we can't just use it right away.
+            // window.location.searchParams isn't always defined when
+            // window.location.search is, so it's more reliable to parse the latter.
             searchStr = window.location.search;
         } else if (window.location.hash) {
             // Replace the # with a ? so that URLSearchParams does the right thing and


### PR DESCRIPTION
Also add some JS to it to process any error we might have in the URI
(see #6893).