### PR TITLE
Validate that a UI-Auth session is not being reused

### DIFF
--- a/changelog.d/7068.bugfix
+++ b/changelog.d/7068.bugfix
@@ -1,0 +1,1 @@
+Ensure that a user inteactive authentication session is tied to a single request.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -347,6 +347,10 @@ class AuthHandler(BaseHandler):
                     creds,
                     list(clientdict),
                 )
+
+                # Blow away the session so it can not be re-used.
+                self._invalidate_session(session["id"])
+
                 return creds, clientdict, session["id"]
 
         ret = self._auth_dict_for_flows(flows, session)
@@ -518,6 +522,17 @@ class AuthHandler(BaseHandler):
             self.sessions[session_id] = {"id": session_id}
 
         return self.sessions[session_id]
+
+    def _invalidate_session(self, session_id) -> None:
+        """Invalidate session information for session ID"""
+        session = self.sessions.get(session_id, None)
+        if session and "ui_auth" in session:
+            # Set the items in the ui_auth session to sentinel values that can
+            # never be equaled.
+            session["ui_auth"] = {
+                "action_type": object(),
+                "action_id": object(),
+            }
 
     @defer.inlineCallbacks
     def get_access_token_for_user_id(

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -351,9 +351,9 @@ class AuthHandler(BaseHandler):
                     list(clientdict),
                 )
 
-                # If the authentication flow is complete and this is the
-                # subsequent request, mark this session as invalid, so it cannot
-                # be re-used.
+                # Once the authentication flow has completed and the final
+                # operation is requested, the session should be removed so it
+                # cannot be re-used.
                 if "type" not in authdict:
                     self._remove_session(session["id"])
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -351,12 +351,6 @@ class AuthHandler(BaseHandler):
                     list(clientdict),
                 )
 
-                # Once the authentication flow has completed and the final
-                # operation is requested, the session should be removed so it
-                # cannot be re-used.
-                if "type" not in authdict:
-                    self._remove_session(session["id"])
-
                 return creds, clientdict, session["id"]
 
         ret = self._auth_dict_for_flows(flows, session)
@@ -528,10 +522,6 @@ class AuthHandler(BaseHandler):
             self.sessions[session_id] = {"id": session_id}
 
         return self.sessions[session_id]
-
-    def _remove_session(self, session_id) -> None:
-        """Remove a session (if it exists)."""
-        self.sessions.pop(session_id, None)
 
     @defer.inlineCallbacks
     def get_access_token_for_user_id(

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -237,8 +237,7 @@ class PasswordRestServlet(RestServlet):
                 requester,
                 body,
                 self.hs.get_ip_from_request(request),
-                "modify_password",
-                "",  # TODO
+                {"operation": "modify_password", "user": requester.user.to_string()},
             )
             user_id = requester.user.to_string()
         else:
@@ -247,8 +246,7 @@ class PasswordRestServlet(RestServlet):
                 [[LoginType.EMAIL_IDENTITY]],
                 body,
                 self.hs.get_ip_from_request(request),
-                "modify_password",
-                "",  # TODO
+                {"operation": "modify_password"},  # TODO
             )
 
             if LoginType.EMAIL_IDENTITY in result:
@@ -319,8 +317,7 @@ class DeactivateAccountRestServlet(RestServlet):
             requester,
             body,
             self.hs.get_ip_from_request(request),
-            "deactivate",
-            requester.user.to_string(),
+            {"operation": "deactivate", "user": requester.user.to_string()},
         )
         result = await self._deactivate_account_handler.deactivate_account(
             requester.user.to_string(), erase, id_server=body.get("id_server")
@@ -668,7 +665,10 @@ class ThreepidAddRestServlet(RestServlet):
         assert_valid_client_secret(client_secret)
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, body, self.hs.get_ip_from_request(request), "add_3pid", user_id
+            requester,
+            body,
+            self.hs.get_ip_from_request(request),
+            {"operation": "add_3pid", "user": user_id},
         )
 
         validation_session = await self.identity_handler.validate_threepid_session(

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -234,13 +234,21 @@ class PasswordRestServlet(RestServlet):
         if self.auth.has_access_token(request):
             requester = await self.auth.get_user_by_req(request)
             params = await self.auth_handler.validate_user_via_ui_auth(
-                requester, body, self.hs.get_ip_from_request(request)
+                requester,
+                body,
+                self.hs.get_ip_from_request(request),
+                "modify_password",
+                "",  # TODO
             )
             user_id = requester.user.to_string()
         else:
             requester = None
             result, params, _ = await self.auth_handler.check_auth(
-                [[LoginType.EMAIL_IDENTITY]], body, self.hs.get_ip_from_request(request)
+                [[LoginType.EMAIL_IDENTITY]],
+                body,
+                self.hs.get_ip_from_request(request),
+                "modify_password",
+                "",  # TODO
             )
 
             if LoginType.EMAIL_IDENTITY in result:
@@ -308,7 +316,11 @@ class DeactivateAccountRestServlet(RestServlet):
             return 200, {}
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, body, self.hs.get_ip_from_request(request)
+            requester,
+            body,
+            self.hs.get_ip_from_request(request),
+            "deactivate",
+            requester.user.to_string(),
         )
         result = await self._deactivate_account_handler.deactivate_account(
             requester.user.to_string(), erase, id_server=body.get("id_server")
@@ -656,7 +668,7 @@ class ThreepidAddRestServlet(RestServlet):
         assert_valid_client_secret(client_secret)
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, body, self.hs.get_ip_from_request(request)
+            requester, body, self.hs.get_ip_from_request(request), "add_3pid", user_id
         )
 
         validation_session = await self.identity_handler.validate_threepid_session(

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -234,19 +234,16 @@ class PasswordRestServlet(RestServlet):
         if self.auth.has_access_token(request):
             requester = await self.auth.get_user_by_req(request)
             params = await self.auth_handler.validate_user_via_ui_auth(
-                requester,
-                body,
-                self.hs.get_ip_from_request(request),
-                {"operation": "modify_password", "user": requester.user.to_string()},
+                requester, request, body, self.hs.get_ip_from_request(request),
             )
             user_id = requester.user.to_string()
         else:
             requester = None
             result, params, _ = await self.auth_handler.check_auth(
                 [[LoginType.EMAIL_IDENTITY]],
+                request,
                 body,
                 self.hs.get_ip_from_request(request),
-                {"operation": "modify_password"},  # TODO
             )
 
             if LoginType.EMAIL_IDENTITY in result:
@@ -314,10 +311,7 @@ class DeactivateAccountRestServlet(RestServlet):
             return 200, {}
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester,
-            body,
-            self.hs.get_ip_from_request(request),
-            {"operation": "deactivate", "user": requester.user.to_string()},
+            requester, request, body, self.hs.get_ip_from_request(request),
         )
         result = await self._deactivate_account_handler.deactivate_account(
             requester.user.to_string(), erase, id_server=body.get("id_server")
@@ -665,10 +659,7 @@ class ThreepidAddRestServlet(RestServlet):
         assert_valid_client_secret(client_secret)
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester,
-            body,
-            self.hs.get_ip_from_request(request),
-            {"operation": "add_3pid", "user": user_id},
+            requester, request, body, self.hs.get_ip_from_request(request),
         )
 
         validation_session = await self.identity_handler.validate_threepid_session(

--- a/synapse/rest/client/v2_alpha/devices.py
+++ b/synapse/rest/client/v2_alpha/devices.py
@@ -81,7 +81,11 @@ class DeleteDevicesRestServlet(RestServlet):
         assert_params_in_dict(body, ["devices"])
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, body, self.hs.get_ip_from_request(request)
+            requester,
+            body,
+            self.hs.get_ip_from_request(request),
+            "delete_devices",
+            "",  # TODO
         )
 
         await self.device_handler.delete_devices(
@@ -127,7 +131,11 @@ class DeviceRestServlet(RestServlet):
                 raise
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, body, self.hs.get_ip_from_request(request)
+            requester,
+            body,
+            self.hs.get_ip_from_request(request),
+            "delete_device",
+            device_id,
         )
 
         await self.device_handler.delete_device(requester.user.to_string(), device_id)

--- a/synapse/rest/client/v2_alpha/devices.py
+++ b/synapse/rest/client/v2_alpha/devices.py
@@ -84,8 +84,7 @@ class DeleteDevicesRestServlet(RestServlet):
             requester,
             body,
             self.hs.get_ip_from_request(request),
-            "delete_devices",
-            "",  # TODO
+            {"operation": "delete_devices", "devices": body["devices"]},
         )
 
         await self.device_handler.delete_devices(
@@ -134,8 +133,7 @@ class DeviceRestServlet(RestServlet):
             requester,
             body,
             self.hs.get_ip_from_request(request),
-            "delete_device",
-            device_id,
+            {"operation": "delete_device", "device": device_id},
         )
 
         await self.device_handler.delete_device(requester.user.to_string(), device_id)

--- a/synapse/rest/client/v2_alpha/devices.py
+++ b/synapse/rest/client/v2_alpha/devices.py
@@ -81,10 +81,7 @@ class DeleteDevicesRestServlet(RestServlet):
         assert_params_in_dict(body, ["devices"])
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester,
-            body,
-            self.hs.get_ip_from_request(request),
-            {"operation": "delete_devices", "devices": body["devices"]},
+            requester, request, body, self.hs.get_ip_from_request(request),
         )
 
         await self.device_handler.delete_devices(
@@ -130,10 +127,7 @@ class DeviceRestServlet(RestServlet):
                 raise
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester,
-            body,
-            self.hs.get_ip_from_request(request),
-            {"operation": "delete_device", "device": device_id},
+            requester, request, body, self.hs.get_ip_from_request(request),
         )
 
         await self.device_handler.delete_device(requester.user.to_string(), device_id)

--- a/synapse/rest/client/v2_alpha/keys.py
+++ b/synapse/rest/client/v2_alpha/keys.py
@@ -263,7 +263,7 @@ class SigningKeyUploadServlet(RestServlet):
         body = parse_json_object_from_request(request)
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, body, self.hs.get_ip_from_request(request)
+            requester, body, self.hs.get_ip_from_request(request), "add_keys", user_id
         )
 
         result = await self.e2e_keys_handler.upload_signing_keys_for_user(user_id, body)

--- a/synapse/rest/client/v2_alpha/keys.py
+++ b/synapse/rest/client/v2_alpha/keys.py
@@ -263,10 +263,7 @@ class SigningKeyUploadServlet(RestServlet):
         body = parse_json_object_from_request(request)
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester,
-            body,
-            self.hs.get_ip_from_request(request),
-            {"operation": "add_keys", "user": user_id},
+            requester, request, body, self.hs.get_ip_from_request(request),
         )
 
         result = await self.e2e_keys_handler.upload_signing_keys_for_user(user_id, body)

--- a/synapse/rest/client/v2_alpha/keys.py
+++ b/synapse/rest/client/v2_alpha/keys.py
@@ -263,7 +263,10 @@ class SigningKeyUploadServlet(RestServlet):
         body = parse_json_object_from_request(request)
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, body, self.hs.get_ip_from_request(request), "add_keys", user_id
+            requester,
+            body,
+            self.hs.get_ip_from_request(request),
+            {"operation": "add_keys", "user": user_id},
         )
 
         result = await self.e2e_keys_handler.upload_signing_keys_for_user(user_id, body)

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -499,7 +499,11 @@ class RegisterRestServlet(RestServlet):
             )
 
         auth_result, params, session_id = await self.auth_handler.check_auth(
-            self._registration_flows, body, self.hs.get_ip_from_request(request)
+            self._registration_flows,
+            body,
+            self.hs.get_ip_from_request(request),
+            "register",
+            "",  # TODO
         )
 
         # Check that we're not trying to register a denied 3pid.

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -502,8 +502,7 @@ class RegisterRestServlet(RestServlet):
             self._registration_flows,
             body,
             self.hs.get_ip_from_request(request),
-            "register",
-            "",  # TODO
+            {"operation": "register"},
         )
 
         # Check that we're not trying to register a denied 3pid.

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -500,9 +500,9 @@ class RegisterRestServlet(RestServlet):
 
         auth_result, params, session_id = await self.auth_handler.check_auth(
             self._registration_flows,
+            request,
             body,
             self.hs.get_ip_from_request(request),
-            {"operation": "register"},
         )
 
         # Check that we're not trying to register a denied 3pid.

--- a/tests/rest/client/v2_alpha/test_auth.py
+++ b/tests/rest/client/v2_alpha/test_auth.py
@@ -104,7 +104,7 @@ class FallbackAuthTests(unittest.HomeserverTestCase):
         )
         self.render(request)
 
-        # Now we should have fufilled a complete auth flow, including
+        # Now we should have fulfilled a complete auth flow, including
         # the recaptcha fallback step, we can then send a
         # request to the register API with the session in the authdict.
         request, channel = self.make_request(

--- a/tests/rest/client/v2_alpha/test_auth.py
+++ b/tests/rest/client/v2_alpha/test_auth.py
@@ -115,3 +115,69 @@ class FallbackAuthTests(unittest.HomeserverTestCase):
 
         # We're given a registered user.
         self.assertEqual(channel.json_body["user_id"], "@user:test")
+
+    def test_cannot_change_operation(self):
+        """
+        The initial requested operation cannot be modified during the user interactive authentication session.
+        """
+
+        # Make the initial request to register. (Later on a different password
+        # will be used.)
+        request, channel = self.make_request(
+            "POST",
+            "register",
+            {"username": "user", "type": "m.login.password", "password": "bar"},
+        )
+        self.render(request)
+
+        # Returns a 401 as per the spec
+        self.assertEqual(request.code, 401)
+        # Grab the session
+        session = channel.json_body["session"]
+        # Assert our configured public key is being given
+        self.assertEqual(
+            channel.json_body["params"]["m.login.recaptcha"]["public_key"], "brokencake"
+        )
+
+        request, channel = self.make_request(
+            "GET", "auth/m.login.recaptcha/fallback/web?session=" + session
+        )
+        self.render(request)
+        self.assertEqual(request.code, 200)
+
+        request, channel = self.make_request(
+            "POST",
+            "auth/m.login.recaptcha/fallback/web?session="
+            + session
+            + "&g-recaptcha-response=a",
+        )
+        self.render(request)
+        self.assertEqual(request.code, 200)
+
+        # The recaptcha handler is called with the response given
+        attempts = self.recaptcha_checker.recaptcha_attempts
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(attempts[0][0]["response"], "a")
+
+        # also complete the dummy auth
+        request, channel = self.make_request(
+            "POST", "register", {"auth": {"session": session, "type": "m.login.dummy"}}
+        )
+        self.render(request)
+
+        # Now we should have fulfilled a complete auth flow, including
+        # the recaptcha fallback step. Make the initial request again, but
+        # with a different password. This causes the request to fail since the
+        # operaiton was modified during the ui auth session.
+        request, channel = self.make_request(
+            "POST",
+            "register",
+            {
+                "username": "user",
+                "type": "m.login.password",
+                "password": "foo",  # Note this doesn't match the original request.
+                "auth": {"session": session},
+            },
+        )
+        self.render(request)
+        self.assertEqual(channel.code, 403)

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -53,7 +53,8 @@ class TermsTestCase(unittest.HomeserverTestCase):
 
     def test_ui_auth(self):
         # Do a UI auth request
-        request, channel = self.make_request(b"POST", self.url, b"{}")
+        request_data = json.dumps({"username": "kermit", "password": "monkey"})
+        request, channel = self.make_request(b"POST", self.url, request_data)
         self.render(request)
 
         self.assertEquals(channel.result["code"], b"401", channel.result)


### PR DESCRIPTION
This is my attempt to fix:

>  make sure that UI-Auth sessions are tied to a single request (ie, the client can't change its mind about what it's asking for in the middle of a session)

The general idea is to store some additional information in the session about what is being authenticated (namely the URI, the method, and the data associated with whatever operation is being performed). So at each stage in when we check the status of the user interactive authentication session we ensure that the event being authenticated for has not been modified.

~~This isn't fully finished, but I wanted to put this up and get some feedback.~~

Part of #5667 

## TODO

* [x] Finalize design.
* [x] Fix unit tests.

~~Currently based on #7063.~~