### PR TITLE
Fix buggy condition in account validity handler

### DIFF
--- a/changelog.d/7074.bugfix
+++ b/changelog.d/7074.bugfix
@@ -1,0 +1,1 @@
+Fix a bug causing account validity renewal emails to be sent even if the feature is turned off in some cases.

--- a/synapse/handlers/account_validity.py
+++ b/synapse/handlers/account_validity.py
@@ -44,7 +44,11 @@ class AccountValidityHandler(object):
 
         self._account_validity = self.hs.config.account_validity
 
-        if self._account_validity.renew_by_email_enabled and load_jinja2_templates:
+        if (
+            self._account_validity.enabled
+            and self._account_validity.renew_by_email_enabled
+            and load_jinja2_templates
+        ):
             # Don't do email-specific configuration if renewal by email is disabled.
             try:
                 app_name = self.hs.config.email_app_name


### PR DESCRIPTION
Otherwise renewal emails would be sent even if enabled is set to false in the account validity config.