### PR TITLE
Fix a typing issue in the federation client code found with mypy

### DIFF
--- a/changelog.d/7089.bugfix
+++ b/changelog.d/7089.bugfix
@@ -1,0 +1,1 @@
+Fix typing issue in federation client found with mypy.

--- a/changelog.d/7089.bugfix
+++ b/changelog.d/7089.bugfix
@@ -1,1 +1,1 @@
-Fix typing issue in federation client found with mypy.
+Fix a bug in the federation API which could cause occasional "Failed to get PDU" errors.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -409,7 +409,7 @@ class FederationServer(FederationBase):
         pdu = event_from_pdu_json(content, room_version)
         origin_host, _ = parse_server_name(origin)
         await self.check_server_matches_acl(origin_host, pdu.room_id)
-        pdu = await self._check_sigs_and_hash(room_version.identifier, pdu)
+        pdu = await self._check_sigs_and_hash(room_version, pdu)
         ret_pdu = await self.handler.on_invite_request(origin, pdu, room_version)
         time_now = self._clock.time_msec()
         return {"event": ret_pdu.get_pdu_json(time_now)}
@@ -425,7 +425,7 @@ class FederationServer(FederationBase):
 
         logger.debug("on_send_join_request: pdu sigs: %s", pdu.signatures)
 
-        pdu = await self._check_sigs_and_hash(room_version.identifier, pdu)
+        pdu = await self._check_sigs_and_hash(room_version, pdu)
 
         res_pdus = await self.handler.on_send_join_request(origin, pdu)
         time_now = self._clock.time_msec()
@@ -455,7 +455,7 @@ class FederationServer(FederationBase):
 
         logger.debug("on_send_leave_request: pdu sigs: %s", pdu.signatures)
 
-        pdu = await self._check_sigs_and_hash(room_version.identifier, pdu)
+        pdu = await self._check_sigs_and_hash(room_version, pdu)
 
         await self.handler.on_send_leave_request(origin, pdu)
         return {}
@@ -611,7 +611,7 @@ class FederationServer(FederationBase):
                 logger.info("Accepting join PDU %s from %s", pdu.event_id, origin)
 
         # We've already checked that we know the room version by this point
-        room_version = await self.store.get_room_version_id(pdu.room_id)
+        room_version = await self.store.get_room_version(pdu.room_id)
 
         # Check signature.
         try:


### PR DESCRIPTION
Per the conversation at https://github.com/matrix-org/synapse/pull/7026#discussion_r388975243, this fixes the typing issue found with mypy that was introduced in f84700fba8cd9345d7a1a025462c7f8650f27386.

The `room_version` variable is now consistently a `RoomVersion` instead of sometimes a `RoomVersion` and sometimes a `str`.