### PR TITLE
Improve get auth chain difference algorithm.

### DIFF
--- a/changelog.d/7095.misc
+++ b/changelog.d/7095.misc
@@ -1,0 +1,1 @@
+Attempt to improve performance of state res v2 algorithm.

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -671,7 +671,7 @@ class StateResolutionStore(object):
         chain.
 
         Returns:
-            Deferred[Set[str]]
+            Deferred[Set[str]]: Set of event IDs.
         """
 
         return self.store.get_auth_chain_difference(state_sets)

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -662,28 +662,16 @@ class StateResolutionStore(object):
             allow_rejected=allow_rejected,
         )
 
-    def get_auth_chain(self, event_ids: List[str], ignore_events: Set[str]):
-        """Gets the full auth chain for a set of events (including rejected
-        events).
+    def get_auth_chain_difference(self, state_sets: List[Set[str]]):
+        """Given sets of state events figure out the auth chain difference (as
+        per state res v2 algorithm).
 
-        Includes the given event IDs in the result.
-
-        Note that:
-            1. All events must be state events.
-            2. For v1 rooms this may not have the full auth chain in the
-               presence of rejected events
-
-        Args:
-            event_ids: The event IDs of the events to fetch the auth chain for.
-                Must be state events.
-            ignore_events: Set of events to exclude from the returned auth
-                chain.
-
+        This equivalent to fetching the full auth chain for each set of state
+        and returning the events that don't appear in each and every auth
+        chain.
 
         Returns:
-            Deferred[list[str]]: List of event IDs of the auth chain.
+            Deferred[Set[str]]
         """
 
-        return self.store.get_auth_chain_ids(
-            event_ids, include_given=True, ignore_events=ignore_events,
-        )
+        return self.store.get_auth_chain_difference(state_sets)

--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -227,36 +227,27 @@ def _get_auth_chain_difference(state_sets, event_map, state_res_store):
     Returns:
         Deferred[set[str]]: Set of event IDs
     """
-    common = set(itervalues(state_sets[0])).intersection(
-        *(itervalues(s) for s in state_sets[1:])
-    )
-
     auth_sets = []
     for state_set in state_sets:
-        auth_ids = {
-            eid
-            for key, eid in iteritems(state_set)
-            if (
-                key[0] in (EventTypes.Member, EventTypes.ThirdPartyInvite)
-                or key
-                in (
-                    (EventTypes.PowerLevels, ""),
-                    (EventTypes.Create, ""),
-                    (EventTypes.JoinRules, ""),
+        auth_sets.append(
+            {
+                eid
+                for key, eid in iteritems(state_set)
+                if (
+                    key[0] in (EventTypes.Member, EventTypes.ThirdPartyInvite)
+                    or key
+                    in (
+                        (EventTypes.PowerLevels, ""),
+                        (EventTypes.Create, ""),
+                        (EventTypes.JoinRules, ""),
+                    )
                 )
-            )
-            and eid not in common
-        }
+            }
+        )
 
-        auth_chain = yield state_res_store.get_auth_chain(auth_ids, common)
-        auth_ids.update(auth_chain)
+    difference = yield state_res_store.get_auth_chain_difference(auth_sets)
 
-        auth_sets.append(auth_ids)
-
-    intersection = set(auth_sets[0]).intersection(*auth_sets[1:])
-    union = set().union(*auth_sets)
-
-    return union - intersection
+    return difference
 
 
 def _seperate(state_sets):

--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -227,25 +227,10 @@ def _get_auth_chain_difference(state_sets, event_map, state_res_store):
     Returns:
         Deferred[set[str]]: Set of event IDs
     """
-    auth_sets = []
-    for state_set in state_sets:
-        auth_sets.append(
-            {
-                eid
-                for key, eid in iteritems(state_set)
-                if (
-                    key[0] in (EventTypes.Member, EventTypes.ThirdPartyInvite)
-                    or key
-                    in (
-                        (EventTypes.PowerLevels, ""),
-                        (EventTypes.Create, ""),
-                        (EventTypes.JoinRules, ""),
-                    )
-                )
-            }
-        )
 
-    difference = yield state_res_store.get_auth_chain_difference(auth_sets)
+    difference = yield state_res_store.get_auth_chain_difference(
+        [set(state_set.values()) for state_set in state_sets]
+    )
 
     return difference
 

--- a/synapse/storage/data_stores/main/event_federation.py
+++ b/synapse/storage/data_stores/main/event_federation.py
@@ -185,7 +185,7 @@ class EventFederationWorkerStore(EventsWorkerStore, SignatureWorkerStore, SQLBas
         txn.execute(sql % (clause,), args)
 
         # The sorted list of events whose auth chains we should walk.
-        search = txn.fetchall()
+        search = txn.fetchall()   # type: List[Tuple[int, str]]
 
         # Map from event to its auth events
         event_to_auth_events = {}  # type: Dict[str, Set[str]]
@@ -222,9 +222,7 @@ class EventFederationWorkerStore(EventsWorkerStore, SignatureWorkerStore, SQLBas
 
                     # Assume that this event is unreachable from any of the
                     # state sets until proven otherwise
-                    sets = event_to_missing_sets.setdefault(
-                        auth_event_id, set(range(len(state_sets)))
-                    )
+                    sets = event_to_missing_sets[auth_event_id] = set(range(len(state_sets)))
                 else:
                     # We've previously seen this event, so look up its auth
                     # events and recursively mark all ancestors as reachable

--- a/synapse/storage/data_stores/main/event_federation.py
+++ b/synapse/storage/data_stores/main/event_federation.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import itertools
 import logging
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 from six.moves.queue import Empty, PriorityQueue
 
@@ -185,7 +185,7 @@ class EventFederationWorkerStore(EventsWorkerStore, SignatureWorkerStore, SQLBas
         txn.execute(sql % (clause,), args)
 
         # The sorted list of events whose auth chains we should walk.
-        search = txn.fetchall()   # type: List[Tuple[int, str]]
+        search = txn.fetchall()  # type: List[Tuple[int, str]]
 
         # Map from event to its auth events
         event_to_auth_events = {}  # type: Dict[str, Set[str]]
@@ -222,7 +222,9 @@ class EventFederationWorkerStore(EventsWorkerStore, SignatureWorkerStore, SQLBas
 
                     # Assume that this event is unreachable from any of the
                     # state sets until proven otherwise
-                    sets = event_to_missing_sets[auth_event_id] = set(range(len(state_sets)))
+                    sets = event_to_missing_sets[auth_event_id] = set(
+                        range(len(state_sets))
+                    )
                 else:
                     # We've previously seen this event, so look up its auth
                     # events and recursively mark all ancestors as reachable

--- a/synapse/storage/data_stores/main/event_federation.py
+++ b/synapse/storage/data_stores/main/event_federation.py
@@ -148,7 +148,7 @@ class EventFederationWorkerStore(EventsWorkerStore, SignatureWorkerStore, SQLBas
         #       B -´---------´
         #
         # and state sets {A} and {B} then walking the auth chains of A and B
-        # would immediatley show that C is reachable by both. However, if we
+        # would immediately show that C is reachable by both. However, if we
         # stopped at C then we'd only reach E via the auth chain of B and so E
         # would errornously get included in the returned difference.
         #
@@ -159,7 +159,7 @@ class EventFederationWorkerStore(EventsWorkerStore, SignatureWorkerStore, SQLBas
         # lower depth are likely reachable by those with higher depths.
         #
         # We could use any ordering that we believe would give a rough
-        # toplogical ordfering, e.g. origin server timestamp. If the ordering
+        # topological ordering, e.g. origin server timestamp. If the ordering
         # chosen is not topological then the algorithm still produces the right
         # result, but perhaps a bit more inefficiently. This is why it is safe
         # to use "depth" here.

--- a/tests/state/test_v2.py
+++ b/tests/state/test_v2.py
@@ -603,7 +603,7 @@ class TestStateResolutionStore(object):
 
         return {eid: self.event_map[eid] for eid in event_ids if eid in self.event_map}
 
-    def get_auth_chain(self, event_ids, ignore_events):
+    def _get_auth_chain(self, event_ids):
         """Gets the full auth chain for a set of events (including rejected
         events).
 
@@ -617,9 +617,6 @@ class TestStateResolutionStore(object):
         Args:
             event_ids (list): The event IDs of the events to fetch the auth
                 chain for. Must be state events.
-            ignore_events: Set of events to exclude from the returned auth
-                chain.
-
         Returns:
             Deferred[list[str]]: List of event IDs of the auth chain.
         """
@@ -629,7 +626,7 @@ class TestStateResolutionStore(object):
         stack = list(event_ids)
         while stack:
             event_id = stack.pop()
-            if event_id in result or event_id in ignore_events:
+            if event_id in result:
                 continue
 
             result.add(event_id)
@@ -639,3 +636,9 @@ class TestStateResolutionStore(object):
                 stack.append(aid)
 
         return list(result)
+
+    def get_auth_chain_difference(self, auth_sets):
+        chains = [frozenset(self._get_auth_chain(a)) for a in auth_sets]
+
+        common = set(chains[0]).intersection(*chains[1:])
+        return set(chains[0]).union(*chains[1:]) - common

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -175,6 +175,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
                     "type": "m.test",
                     "processed": True,
                     "outlier": False,
+                    "stream_ordering": depth,
                 },
             )
 

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -114,7 +114,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
     def test_auth_difference(self):
         room_id = "@ROOM:local"
 
-        # The silly auth graph we use to test th eauth difference algorithm,
+        # The silly auth graph we use to test the auth difference algorithm,
         # where the top are the most recent events.
         #
         #   A   B

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -160,7 +160,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         # We rudely fiddle with the appropriate tables directly, as that's much
         # easier than constructing events properly.
 
-        def insert_event(txn, event_id):
+        def insert_event(txn, event_id, stream_ordering):
 
             depth = depth_map[event_id]
 
@@ -175,7 +175,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
                     "type": "m.test",
                     "processed": True,
                     "outlier": False,
-                    "stream_ordering": depth,
+                    "stream_ordering": stream_ordering,
                 },
             )
 
@@ -188,9 +188,13 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
                 ],
             )
 
+        next_stream_ordering = 0
         for event_id in auth_graph:
+            next_stream_ordering += 1
             self.get_success(
-                self.store.db.runInteraction("insert", insert_event, event_id)
+                self.store.db.runInteraction(
+                    "insert", insert_event, event_id, next_stream_ordering
+                )
             )
 
         # Now actually test that various combinations give the right result:


### PR DESCRIPTION
It was originally implemented by pulling the full auth chain of all
state sets out of the database and doing set comparison. However, that
can take a lot work if the state and auth chains are large.

Instead, lets try and fetch the auth chains at the same time and
calcualte the difference on the fly, allowing us to bail early if all
the auth chains converge. Assuming that the auth chains do converge more
often than not, this should improve performance. Hopefully.


Relates to: #6943