### PR TITLE
Support SAML in the user interactive authentication workflow.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+Next version
+============
+
+* A new template (`sso_auth_confirm.html`) was added to Synapse. If your Synapse
+  is configured to use SSO and a custom `sso_redirect_confirm_template_dir`
+  configuration then this template will need to be duplicated into that
+  directory.
+
 Synapse 1.12.0 (2020-03-23)
 ===========================
 

--- a/changelog.d/7102.feature
+++ b/changelog.d/7102.feature
@@ -1,0 +1,1 @@
+Support SSO in the user interactive authentication workflow.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -61,6 +61,7 @@ class LoginType(object):
     MSISDN = "m.login.msisdn"
     RECAPTCHA = "m.login.recaptcha"
     TERMS = "m.login.terms"
+    SSO = "org.matrix.login.sso"
     DUMMY = "m.login.dummy"
 
     # Only for C/S API v1

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -53,6 +53,31 @@ from ._base import BaseHandler
 logger = logging.getLogger(__name__)
 
 
+SUCCESS_TEMPLATE = """
+<html>
+<head>
+<title>Success!</title>
+<meta name='viewport' content='width=device-width, initial-scale=1,
+    user-scalable=no, minimum-scale=1.0, maximum-scale=1.0'>
+<link rel="stylesheet" href="/_matrix/static/client/register/style.css">
+<script>
+if (window.onAuthDone) {
+    window.onAuthDone();
+} else if (window.opener && window.opener.postMessage) {
+     window.opener.postMessage("authDone", "*");
+}
+</script>
+</head>
+<body>
+    <div>
+        <p>Thank you</p>
+        <p>You may now close this window and return to the application</p>
+    </div>
+</body>
+</html>
+"""
+
+
 class AuthHandler(BaseHandler):
     SESSION_EXPIRE_MS = 48 * 60 * 60 * 1000
 
@@ -1042,9 +1067,6 @@ class AuthHandler(BaseHandler):
 
         creds[LoginType.SSO] = True
         self._save_session(sess)
-
-        # TODO Import this seems wrong.
-        from synapse.rest.client.v2_alpha.auth import SUCCESS_TEMPLATE
 
         # Render the HTML and return.
         html_bytes = SUCCESS_TEMPLATE.encode("utf8")

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1045,11 +1045,7 @@ class AuthHandler(BaseHandler):
         return self._sso_auth_confirm_template.render(redirect_url=redirect_url,)
 
     def complete_sso_ui_auth(
-        self,
-        registered_user_id: str,
-        session_id: str,
-        request: SynapseRequest,
-        requester: Requester,
+        self, registered_user_id: str, session_id: str, request: SynapseRequest,
     ):
         """Having figured out a mxid for this user, complete the HTTP request
 
@@ -1059,18 +1055,15 @@ class AuthHandler(BaseHandler):
             client_redirect_url: The URL to which to redirect the user at the end of the
                 process.
         """
-        # If the user ID of the SAML session does not match the user from the
-        # request, something went wrong.
-        if registered_user_id != requester.user.to_string():
-            raise SynapseError(403, "SAML user does not match requester.")
-
         # Mark the stage of the authentication as successful.
         sess = self._get_session_info(session_id)
         if "creds" not in sess:
             sess["creds"] = {}
         creds = sess["creds"]
 
-        creds[LoginType.SSO] = True
+        # Save the user who authenticated with SSO, this will be used to ensure
+        # that the account be modified is also the person who logged in.
+        creds[LoginType.SSO] = registered_user_id
         self._save_session(sess)
 
         # Render the HTML and return.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1039,8 +1039,11 @@ class AuthHandler(BaseHandler):
         """
         Get the HTML for the SSO redirect confirmation page.
 
-        :param redirect_url: The URL to redirect to the SSO provider.
-        :return: The HTML to render.
+        Args:
+            redirect_url: The URL to redirect to the SSO provider.
+
+        Returns:
+            The HTML to render.
         """
         return self._sso_auth_confirm_template.render(redirect_url=redirect_url,)
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -148,10 +148,10 @@ class AuthHandler(BaseHandler):
 
         # Load the SSO HTML templates.
 
-        # The following template is shown to the user before redirecting them to
-        # the SSO login page. It notifies the user they are about to be
-        # redirected and that the Synapse server will be gaining access to their
-        # SSO account.
+        # The following template is shown to the user during a client login via SSO,
+        # after the SSO completes and before redirecting them back to their client.
+        # It notifies the user they are about to give access to their matrix account
+        # to the client.
         self._sso_redirect_confirm_template = load_jinja2_templates(
             hs.config.sso_redirect_confirm_template_dir, ["sso_redirect_confirm.html"],
         )[0]

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import logging
 import re
-from typing import Tuple
+from typing import Optional, Tuple
 
 import attr
 import saml2
@@ -44,11 +44,15 @@ class Saml2SessionData:
 
     # time the session was created, in milliseconds
     creation_time = attr.ib()
+    # The user interactive authentication session ID associated with this SAML
+    # session (or None if this SAML session is for an initial login).
+    ui_auth_session_id = attr.ib(type=Optional[str], default=None)
 
 
 class SamlHandler:
     def __init__(self, hs):
         self._saml_client = Saml2Client(hs.config.saml2_sp_config)
+        self._auth = hs.get_auth()
         self._auth_handler = hs.get_auth_handler()
         self._registration_handler = hs.get_registration_handler()
 
@@ -77,12 +81,14 @@ class SamlHandler:
 
         self._error_html_content = hs.config.saml2_error_html_content
 
-    def handle_redirect_request(self, client_redirect_url):
+    def handle_redirect_request(self, client_redirect_url, ui_auth_session_id=None):
         """Handle an incoming request to /login/sso/redirect
 
         Args:
             client_redirect_url (bytes): the URL that we should redirect the
                 client to when everything is done
+            ui_auth_session_id (Optional[str]): The session ID of the ongoing UI Auth (or
+                None if this is a login).
 
         Returns:
             bytes: URL to redirect to
@@ -92,7 +98,9 @@ class SamlHandler:
         )
 
         now = self._clock.time_msec()
-        self._outstanding_requests_dict[reqid] = Saml2SessionData(creation_time=now)
+        self._outstanding_requests_dict[reqid] = Saml2SessionData(
+            creation_time=now, ui_auth_session_id=ui_auth_session_id,
+        )
 
         for key, value in info["headers"]:
             if key == "Location":
@@ -119,7 +127,9 @@ class SamlHandler:
         self.expire_sessions()
 
         try:
-            user_id = await self._map_saml_response_to_user(resp_bytes, relay_state)
+            user_id, current_session = await self._map_saml_response_to_user(
+                resp_bytes, relay_state
+            )
         except RedirectException:
             # Raise the exception as per the wishes of the SAML module response
             raise
@@ -137,9 +147,29 @@ class SamlHandler:
             finish_request(request)
             return
 
-        self._auth_handler.complete_sso_login(user_id, request, relay_state)
+        # Complete the interactive auth session or the login.
+        if current_session and current_session.ui_auth_session_id:
+            requester = await self._auth.get_user_by_req(request)
+            self._auth_handler.complete_sso_ui_auth(
+                user_id, current_session.ui_auth_session_id, request, requester
+            )
 
-    async def _map_saml_response_to_user(self, resp_bytes, client_redirect_url):
+        else:
+            self._auth_handler.complete_sso_login(user_id, request, relay_state)
+
+    async def _map_saml_response_to_user(
+        self, resp_bytes: str, client_redirect_url: str
+    ) -> Tuple[str, Optional[Saml2SessionData]]:
+        """
+        Given a sample response, retrieve the cached session and user for it.
+
+        Args:
+            resp_bytes: The SAML response.
+            client_redirect_url: The redirect URL passed in by the client.
+
+        Returns:
+             Tuple of the user ID and SAML session associated with this response.
+        """
         try:
             saml2_auth = self._saml_client.parse_authn_request_response(
                 resp_bytes,
@@ -167,7 +197,9 @@ class SamlHandler:
 
         logger.info("SAML2 mapped attributes: %s", saml2_auth.ava)
 
-        self._outstanding_requests_dict.pop(saml2_auth.in_response_to, None)
+        current_session = self._outstanding_requests_dict.pop(
+            saml2_auth.in_response_to, None
+        )
 
         remote_user_id = self._user_mapping_provider.get_remote_user_id(
             saml2_auth, client_redirect_url
@@ -188,7 +220,7 @@ class SamlHandler:
             )
             if registered_user_id is not None:
                 logger.info("Found existing mapping %s", registered_user_id)
-                return registered_user_id
+                return registered_user_id, current_session
 
             # backwards-compatibility hack: see if there is an existing user with a
             # suitable mapping from the uid
@@ -213,7 +245,7 @@ class SamlHandler:
                     await self._datastore.record_user_external_id(
                         self._auth_provider_id, remote_user_id, registered_user_id
                     )
-                    return registered_user_id
+                    return registered_user_id, current_session
 
             # Map saml response to user attributes using the configured mapping provider
             for i in range(1000):
@@ -260,7 +292,7 @@ class SamlHandler:
             await self._datastore.record_user_external_id(
                 self._auth_provider_id, remote_user_id, registered_user_id
             )
-            return registered_user_id
+            return registered_user_id, current_session
 
     def expire_sessions(self):
         expire_before = self._clock.time_msec() - self._saml2_session_lifetime

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -149,9 +149,8 @@ class SamlHandler:
 
         # Complete the interactive auth session or the login.
         if current_session and current_session.ui_auth_session_id:
-            requester = await self._auth.get_user_by_req(request)
             self._auth_handler.complete_sso_ui_auth(
-                user_id, current_session.ui_auth_session_id, request, requester
+                user_id, current_session.ui_auth_session_id, request
             )
 
         else:

--- a/synapse/res/templates/sso_auth_confirm.html
+++ b/synapse/res/templates/sso_auth_confirm.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+    <title>Authentication</title>
+</head>
+    <body>
+        <div>
+            <p>
+                A client is trying to remove a device/add an email address/take over
+                your account. To confirm this action,
+                <a href="{{ redirect_url | e }}">re-authenticate with single sign-on</a>.
+                If you did not expect this, your account may be compromised!
+            </p>
+        </div>
+    </body>
+</html>

--- a/synapse/res/templates/sso_auth_confirm.html
+++ b/synapse/res/templates/sso_auth_confirm.html
@@ -5,8 +5,7 @@
     <body>
         <div>
             <p>
-                A client is trying to remove a device/add an email address/take over
-                your account. To confirm this action,
+                A client is trying to {{ description | e }}. To confirm this action,
                 <a href="{{ redirect_url | e }}">re-authenticate with single sign-on</a>.
                 If you did not expect this, your account may be compromised!
             </p>

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -234,7 +234,11 @@ class PasswordRestServlet(RestServlet):
         if self.auth.has_access_token(request):
             requester = await self.auth.get_user_by_req(request)
             params = await self.auth_handler.validate_user_via_ui_auth(
-                requester, request, body, self.hs.get_ip_from_request(request),
+                requester,
+                request,
+                body,
+                self.hs.get_ip_from_request(request),
+                "modify your account password",
             )
             user_id = requester.user.to_string()
         else:
@@ -244,6 +248,7 @@ class PasswordRestServlet(RestServlet):
                 request,
                 body,
                 self.hs.get_ip_from_request(request),
+                "modify your account password",
             )
 
             if LoginType.EMAIL_IDENTITY in result:
@@ -311,7 +316,11 @@ class DeactivateAccountRestServlet(RestServlet):
             return 200, {}
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, request, body, self.hs.get_ip_from_request(request),
+            requester,
+            request,
+            body,
+            self.hs.get_ip_from_request(request),
+            "deactivate your account",
         )
         result = await self._deactivate_account_handler.deactivate_account(
             requester.user.to_string(), erase, id_server=body.get("id_server")
@@ -669,7 +678,11 @@ class ThreepidAddRestServlet(RestServlet):
         assert_valid_client_secret(client_secret)
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, request, body, self.hs.get_ip_from_request(request),
+            requester,
+            request,
+            body,
+            self.hs.get_ip_from_request(request),
+            "add a third-party identifier to your account",
         )
 
         validation_session = await self.identity_handler.validate_threepid_session(

--- a/synapse/rest/client/v2_alpha/auth.py
+++ b/synapse/rest/client/v2_alpha/auth.py
@@ -18,6 +18,7 @@ import logging
 from synapse.api.constants import LoginType
 from synapse.api.errors import SynapseError
 from synapse.api.urls import CLIENT_API_PREFIX
+from synapse.handlers.auth import SUCCESS_TEMPLATE
 from synapse.http.server import finish_request
 from synapse.http.servlet import RestServlet, parse_string
 
@@ -85,30 +86,6 @@ TERMS_TEMPLATE = """
         <input type="submit" value="Agree" />
     </div>
 </form>
-</body>
-</html>
-"""
-
-SUCCESS_TEMPLATE = """
-<html>
-<head>
-<title>Success!</title>
-<meta name='viewport' content='width=device-width, initial-scale=1,
-    user-scalable=no, minimum-scale=1.0, maximum-scale=1.0'>
-<link rel="stylesheet" href="/_matrix/static/client/register/style.css">
-<script>
-if (window.onAuthDone) {
-    window.onAuthDone();
-} else if (window.opener && window.opener.postMessage) {
-     window.opener.postMessage("authDone", "*");
-}
-</script>
-</head>
-<body>
-    <div>
-        <p>Thank you</p>
-        <p>You may now close this window and return to the application</p>
-    </div>
 </body>
 </html>
 """

--- a/synapse/rest/client/v2_alpha/auth.py
+++ b/synapse/rest/client/v2_alpha/auth.py
@@ -113,24 +113,6 @@ if (window.onAuthDone) {
 </html>
 """
 
-SAML2_TEMPLATE = """
-<html>
-<head>
-<title>Authentication</title>
-</head>
-<body>
-<div>
-    <p>
-    A client is trying to remove a device/add an email address/take over
-    your account. To confirm this action,
-    <a href="%(myurl)s">re-authenticate with single sign-on</a>.
-    If you did not expect this, your account may be compromised!
-    </p>
-</div>
-</body>
-</html>
-"""
-
 
 class AuthRestServlet(RestServlet):
     """
@@ -178,12 +160,10 @@ class AuthRestServlet(RestServlet):
             # Display a confirmation page which prompts the user to
             # re-authenticate with their SSO provider.
             client_redirect_url = ""
-            value = self._saml_handler.handle_redirect_request(
+            sso_redirect_url = self._saml_handler.handle_redirect_request(
                 client_redirect_url, session
             )
-            html = SAML2_TEMPLATE % {
-                "myurl": value,
-            }
+            html = self.auth_handler.start_sso_ui_auth(sso_redirect_url)
         else:
             raise SynapseError(404, "Unknown auth stage type")
 

--- a/synapse/rest/client/v2_alpha/auth.py
+++ b/synapse/rest/client/v2_alpha/auth.py
@@ -140,7 +140,7 @@ class AuthRestServlet(RestServlet):
             sso_redirect_url = self._saml_handler.handle_redirect_request(
                 client_redirect_url, session
             )
-            html = self.auth_handler.start_sso_ui_auth(sso_redirect_url)
+            html = self.auth_handler.start_sso_ui_auth(sso_redirect_url, session)
         else:
             raise SynapseError(404, "Unknown auth stage type")
 

--- a/synapse/rest/client/v2_alpha/devices.py
+++ b/synapse/rest/client/v2_alpha/devices.py
@@ -81,7 +81,11 @@ class DeleteDevicesRestServlet(RestServlet):
         assert_params_in_dict(body, ["devices"])
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, request, body, self.hs.get_ip_from_request(request),
+            requester,
+            request,
+            body,
+            self.hs.get_ip_from_request(request),
+            "remove device(s) from your account",
         )
 
         await self.device_handler.delete_devices(
@@ -127,7 +131,11 @@ class DeviceRestServlet(RestServlet):
                 raise
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, request, body, self.hs.get_ip_from_request(request),
+            requester,
+            request,
+            body,
+            self.hs.get_ip_from_request(request),
+            "remove a device from your account",
         )
 
         await self.device_handler.delete_device(requester.user.to_string(), device_id)

--- a/synapse/rest/client/v2_alpha/keys.py
+++ b/synapse/rest/client/v2_alpha/keys.py
@@ -263,7 +263,11 @@ class SigningKeyUploadServlet(RestServlet):
         body = parse_json_object_from_request(request)
 
         await self.auth_handler.validate_user_via_ui_auth(
-            requester, request, body, self.hs.get_ip_from_request(request),
+            requester,
+            request,
+            body,
+            self.hs.get_ip_from_request(request),
+            "add a device signing key to your account",
         )
 
         result = await self.e2e_keys_handler.upload_signing_keys_for_user(user_id, body)

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -505,6 +505,7 @@ class RegisterRestServlet(RestServlet):
             request,
             body,
             self.hs.get_ip_from_request(request),
+            "log into your account",
         )
 
         # Check that we're not trying to register a denied 3pid.

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -505,7 +505,7 @@ class RegisterRestServlet(RestServlet):
             request,
             body,
             self.hs.get_ip_from_request(request),
-            "log into your account",
+            "register a new account",
         )
 
         # Check that we're not trying to register a denied 3pid.


### PR DESCRIPTION
This aims to accomplish a portion of #5667:
* Update `validate_user_via_ui_auth` to return `m.login.sso` for homeservers which use sso login
* Implement a handler for `/_matrix/client/r0/auth/m.login.sso/fallback/web` which shows a confirmation page, and redirects to the SAML server.
* Update the SAML return page handlers to behave differently for a UI auth flow, and:
  * Update the UI Auth session
  * Return the fallback completion page

## TODO

* [x] Remove any debug statements.
* [x] Handle any other TODO comments.
* [x] Add validation of session + user information.
* [x] Think about redirect URLs.
* [x] Use a Jinja template for the confirmation page.
* [x] Fix unit tests.
* [x] SyTests? See matrix-org/sytest#845

~~This is currently based on #7115.~~

## Testing

### SAML

I was testing SAML by first generally following the directions at [docs/dev/saml.md](https://github.com/matrix-org/synapse/blob/master/docs/dev/saml.md) to create a user. Note that I also had to set the following in the config:

```yaml
public_baseurl: http://localhost:8080/
```

Then to test the UI Auth workflow:

1. Add a debug line so you can see what UI-Auth sessions are getting created in Synapse:

```diff
diff --git a/synapse/handlers/auth.py b/synapse/handlers/auth.py
--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -494,6 +494,7 @@ class AuthHandler(BaseHandler):
             while session_id is None or session_id in self.sessions:
                 session_id = stringutils.random_string(24)
             self.sessions[session_id] = {"id": session_id}
+            print("Created new session: %s" % session_id)
 
         return self.sessions[session_id]
 
```

2. Restart Synapse to pick up the change.
3. Go to the "User Details" page on https://capriza.github.io/samling/samling.html and click "Logout" (weirdly this doesn't show anything, refresh the page to ensure you're logged out).
4. Perform an operation that dumps you into the UI Auth workflow (e.g. deleting a device).
5. Check out the logs to get the session ID.
6. Browse to http://localhost:8080/_matrix/client/r0/auth/org.matrix.login.sso/fallback/web?session=<the session ID from above>
7. Read this, go through the SSO workflow.
8. You should end up at a success page telling you to close the window.

Unfortunately at this point you're stuck since the client doesn't know the auth has completed.