### PR TITLE
Move pusherpool startup into _base.setup

### DIFF
--- a/changelog.d/7104.misc
+++ b/changelog.d/7104.misc
@@ -1,0 +1,1 @@
+Merge worker apps together.

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -276,6 +276,7 @@ def start(hs, listeners=None):
         # It is now safe to start your Synapse.
         hs.start_listening(listeners)
         hs.get_datastore().db.start_profiling()
+        hs.get_pusherpool().start()
 
         setup_sentry(hs)
         setup_sdnotify(hs)

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -408,7 +408,6 @@ def setup(config_options):
 
             _base.start(hs, config.listeners)
 
-            hs.get_pusherpool().start()
             hs.get_datastore().db.updates.start_doing_background_updates()
         except Exception:
             # Print the exception and bail out.


### PR DESCRIPTION
This should be safe to do on all workers/masters because it is guarded by
a config option which will ensure it is only actually done on the worker
assigned as a pusher.

Hopefully fixes #7075.