### PR TITLE
Fix concurrent modification errors in pusher metrics

### DIFF
--- a/changelog.d/7106.feature
+++ b/changelog.d/7106.feature
@@ -1,0 +1,1 @@
+Add prometheus metrics for the number of active pushers.


### PR DESCRIPTION
add a lock to try to make this metric actually work