### PR TITLE
Add default values for notif_template_html and notif_template_text

### DIFF
--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1487,8 +1487,8 @@ email:
   
   # Edit these values to choose a custom notification template
   #
-  notif_template_html: notif_mail.html
-  notif_template_text: notif_mail.txt
+  email.notif_template_html: notif_mail.html
+  email.notif_template_text: notif_mail.txt
 
   # Custom URL for client links within the email notifications. By default
   # links will be based on "https://matrix.to".

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1484,11 +1484,7 @@ email:
   # notifications for new users. Enabled by default.
   #
   #notif_for_new_users: false
-  
-  # Edit these values to choose a custom notification template
-  #
-  email.notif_template_html: notif_mail.html
-  email.notif_template_text: notif_mail.txt
+ 
 
   # Custom URL for client links within the email notifications. By default
   # links will be based on "https://matrix.to".
@@ -1544,6 +1540,10 @@ email:
   # https://github.com/matrix-org/synapse/tree/master/synapse/res/templates
   #
   #template_dir: "res/templates"
+  # Edit these values to choose a custom notification template
+  #
+  notif_template_html: notif_mail.html
+  notif_template_text: notif_mail.txt
 
 
 #password_providers:

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1484,6 +1484,11 @@ email:
   # notifications for new users. Enabled by default.
   #
   #notif_for_new_users: false
+  
+  # Edit these values to choose a custom notification template
+  #
+  notif_template_html: notif_mail.html
+  notif_template_text: notif_mail.txt
 
   # Custom URL for client links within the email notifications. By default
   # links will be based on "https://matrix.to".


### PR DESCRIPTION
Ref #6551 

When setting up synapse I found the lack of default values for these fields confusing. I encountered #6551 and decided to add the fields to sample config. Is it where defaults are taken from? If not, please correct me

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
