### PR TITLE
Bump Twisted version to 20.3.0

### DIFF
--- a/changelog.d/7131.bugfix
+++ b/changelog.d/7131.bugfix
@@ -1,0 +1,1 @@
+Bump Twisted version to 20.3.0 to fix vulnerabilities when using Synapse behind a reverse-proxy. Contributed by @DylanVanAssche.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -52,7 +52,8 @@ REQUIREMENTS = [
     "service_identity>=18.1.0",
     # Twisted 18.9 introduces some logger improvements that the structured
     # logger utilises
-    "Twisted>=18.9.0",
+    # Twisted 20.3 fixes vulnerabilties when using a reverse-proxy
+    "Twisted>=20.3.0",
     "treq>=15.1",
     # Twisted has required pyopenssl 16.0 since about Twisted 16.6.
     "pyopenssl>=16.0.0",


### PR DESCRIPTION
With the release of Synapse V1.0.12 it is advised to upgrade Twisted to 20.3.0 to avoid vulnerabilities when using Synapse behind a reverse-proxy. This PR upgrades the minimum dependency version of Synapse which install the right Twisted version automatically when running `pip install --upgrade .` when upgrading.

Signed-off-by: Dylan Van Assche <dylan.van.assche@protonmail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
