### PR TITLE
Fix starting workers when federation sending not split out.

### DIFF
--- a/changelog.d/7133.bugfix
+++ b/changelog.d/7133.bugfix
@@ -1,0 +1,1 @@
+Fix starting workers when federation sending not split out.

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -860,6 +860,9 @@ def start(config_options):
 
         # Force the appservice to start since they will be disabled in the main config
         config.notify_appservices = True
+    else:
+        # For other worker types we force this to off.
+        config.notify_appservices = False
 
     if config.worker_app == "synapse.app.pusher":
         if config.start_pushers:
@@ -873,6 +876,9 @@ def start(config_options):
 
         # Force the pushers to start since they will be disabled in the main config
         config.start_pushers = True
+    else:
+        # For other worker types we force this to off.
+        config.start_pushers = False
 
     if config.worker_app == "synapse.app.user_dir":
         if config.update_user_directory:
@@ -886,6 +892,9 @@ def start(config_options):
 
         # Force the pushers to start since they will be disabled in the main config
         config.update_user_directory = True
+    else:
+        # For other worker types we force this to off.
+        config.update_user_directory = False
 
     if config.worker_app == "synapse.app.federation_sender":
         if config.send_federation:
@@ -899,6 +908,9 @@ def start(config_options):
 
         # Force the pushers to start since they will be disabled in the main config
         config.send_federation = True
+    else:
+        # For other worker types we force this to off.
+        config.send_federation = False
 
     synapse.events.USE_FROZEN_DICTS = config.use_frozen_dicts
 


### PR DESCRIPTION
This is a bit of a hacky fix, but will do for now. Branch is based off of master, so we can do a hotfix if we want to.

Fixes #7130.