### PR TITLE
Only import sqlite3 by default if running mypy checks

### DIFF
--- a/changelog.d/7143.bugfix
+++ b/changelog.d/7143.bugfix
@@ -1,0 +1,1 @@
+Prevent `sqlite3` module from being imported even when using the postgres backend.

--- a/synapse/storage/engines/__init__.py
+++ b/synapse/storage/engines/__init__.py
@@ -17,21 +17,18 @@ import platform
 from ._base import BaseDatabaseEngine, IncorrectDatabaseSetup
 
 MYPY = False
-if MYPY:
-    from .sqlite import Sqlite3Engine
-    from .postgres import PostgresEngine
 
 
 def create_engine(database_config) -> BaseDatabaseEngine:
     name = database_config["name"]
 
-    if name == "sqlite3":
+    if name == "sqlite3" or MYPY:
         import sqlite3
         from .sqlite import Sqlite3Engine
 
         return Sqlite3Engine(sqlite3, database_config)
 
-    if name == "psycopg2":
+    if name == "psycopg2" or MYPY:
         # pypy requires psycopg2cffi rather than psycopg2
         if platform.python_implementation() == "PyPy":
             import psycopg2cffi as psycopg2  # type: ignore

--- a/synapse/storage/engines/__init__.py
+++ b/synapse/storage/engines/__init__.py
@@ -16,6 +16,11 @@ import platform
 
 from ._base import BaseDatabaseEngine, IncorrectDatabaseSetup
 
+MYPY = False
+if MYPY:
+    from .sqlite import Sqlite3Engine
+    from .postgres import PostgresEngine
+
 
 def create_engine(database_config) -> BaseDatabaseEngine:
     name = database_config["name"]

--- a/synapse/storage/engines/__init__.py
+++ b/synapse/storage/engines/__init__.py
@@ -15,8 +15,6 @@
 import platform
 
 from ._base import BaseDatabaseEngine, IncorrectDatabaseSetup
-from .postgres import PostgresEngine
-from .sqlite import Sqlite3Engine
 
 
 def create_engine(database_config) -> BaseDatabaseEngine:
@@ -24,6 +22,7 @@ def create_engine(database_config) -> BaseDatabaseEngine:
 
     if name == "sqlite3":
         import sqlite3
+        from .sqlite import Sqlite3Engine
 
         return Sqlite3Engine(sqlite3, database_config)
 
@@ -33,6 +32,8 @@ def create_engine(database_config) -> BaseDatabaseEngine:
             import psycopg2cffi as psycopg2  # type: ignore
         else:
             import psycopg2  # type: ignore
+
+        from .postgres import PostgresEngine
 
         return PostgresEngine(psycopg2, database_config)
 

--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -12,16 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-
 import struct
 import threading
 
-from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-
 from synapse.storage.engines import BaseDatabaseEngine
 
-if MYPY_CHECK_RUNNING:
+MYPY = False
+if MYPY:
     import sqlite3
 
 

--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 import struct
 import threading
 

--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -12,11 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sqlite3
 import struct
 import threading
 
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
 from synapse.storage.engines import BaseDatabaseEngine
+
+if MYPY_CHECK_RUNNING:
+    import sqlite3
 
 
 class Sqlite3Engine(BaseDatabaseEngine[sqlite3.Connection]):


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/7127

Only import `sqlite3` for mypy checks, not by default, else python binaries built without sqlite3 will fail to start Synapse, even if they're using postgres.