### PR TITLE
Add an optional config flag to skip the SSO confirmation step

### DIFF
--- a/changelog.d/7145.feature
+++ b/changelog.d/7145.feature
@@ -1,0 +1,1 @@
+Add a configuration flag to disable the extra confirmation step after a successful SSO authentication. Server admins should make sure their SSO backend allows sensible authentication options before using this flag.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1382,6 +1382,17 @@ saml2_config:
 # Additional settings to use with single-sign on systems such as SAML2 and CAS.
 #
 sso:
+    # Uncomment the following to disable the extra confirmation step before
+    # redirecting to the client after a successful authentication. This step is
+    # enabled by default.
+    #
+    # Make sure the SSO backend is sufficiently locked down and allows sensible
+    # authentication options (e.g. no "passwordless" authentication) before
+    # disabling this step, otherwise users could be vulnerable to phishing
+    # attacks.
+    #
+    #enable_redirect_confirm: false
+
     # A list of client URLs which are whitelisted so that the user does not
     # have to confirm giving access to their account to the URL. Any client
     # whose URL starts with an entry in the following list will not be subject

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1386,9 +1386,10 @@ sso:
     # redirecting to the client after a successful authentication. This step is
     # enabled by default.
     #
-    # Make sure the SSO backend allows sensible authentication options (e.g. no
-    # "passwordless" authentication) before disabling this step, otherwise users
-    # could be vulnerable to phishing attacks.
+    # Authentication methods that involve sending an authentication link to an
+    # email which includes a redirect URL (e.g. "passwordless" login) are
+    # vulnerable to "open redirect" phishing attacks, and in such cases it is
+    # highly recommended to keep this option enabled.
     #
     #enable_redirect_confirm: false
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1386,10 +1386,9 @@ sso:
     # redirecting to the client after a successful authentication. This step is
     # enabled by default.
     #
-    # Make sure the SSO backend is sufficiently locked down and allows sensible
-    # authentication options (e.g. no "passwordless" authentication) before
-    # disabling this step, otherwise users could be vulnerable to phishing
-    # attacks.
+    # Make sure the SSO backend allows sensible authentication options (e.g. no
+    # "passwordless" authentication) before disabling this step, otherwise users
+    # could be vulnerable to phishing attacks.
     #
     #enable_redirect_confirm: false
 

--- a/synapse/config/sso.py
+++ b/synapse/config/sso.py
@@ -52,9 +52,10 @@ class SSOConfig(Config):
             # redirecting to the client after a successful authentication. This step is
             # enabled by default.
             #
-            # Make sure the SSO backend allows sensible authentication options (e.g. no
-            # "passwordless" authentication) before disabling this step, otherwise users
-            # could be vulnerable to phishing attacks.
+            # Authentication methods that involve sending an authentication link to an
+            # email which includes a redirect URL (e.g. "passwordless" login) are
+            # vulnerable to "open redirect" phishing attacks, and in such cases it is
+            # highly recommended to keep this option enabled.
             #
             #enable_redirect_confirm: false
 

--- a/synapse/config/sso.py
+++ b/synapse/config/sso.py
@@ -52,6 +52,11 @@ class SSOConfig(Config):
             # redirecting to the client after a successful authentication. This step is
             # enabled by default.
             #
+            # Make sure the SSO backend is sufficiently locked down and allows sensible
+            # authentication options (e.g. no "passwordless" authentication) before
+            # disabling this step, otherwise users could be vulnerable to phishing
+            # attacks.
+            #
             #enable_redirect_confirm: false
 
             # A list of client URLs which are whitelisted so that the user does not

--- a/synapse/config/sso.py
+++ b/synapse/config/sso.py
@@ -52,10 +52,9 @@ class SSOConfig(Config):
             # redirecting to the client after a successful authentication. This step is
             # enabled by default.
             #
-            # Make sure the SSO backend is sufficiently locked down and allows sensible
-            # authentication options (e.g. no "passwordless" authentication) before
-            # disabling this step, otherwise users could be vulnerable to phishing
-            # attacks.
+            # Make sure the SSO backend allows sensible authentication options (e.g. no
+            # "passwordless" authentication) before disabling this step, otherwise users
+            # could be vulnerable to phishing attacks.
             #
             #enable_redirect_confirm: false
 

--- a/synapse/config/sso.py
+++ b/synapse/config/sso.py
@@ -28,6 +28,10 @@ class SSOConfig(Config):
     def read_config(self, config, **kwargs):
         sso_config = config.get("sso") or {}  # type: Dict[str, Any]
 
+        self.sso_enable_redirect_confirm = sso_config.get(
+            "enable_redirect_confirm", True,
+        )
+
         # Pick a template directory in order of:
         # * The sso-specific template_dir
         # * /path/to/synapse/install/res/templates
@@ -44,6 +48,12 @@ class SSOConfig(Config):
         # Additional settings to use with single-sign on systems such as SAML2 and CAS.
         #
         sso:
+            # Uncomment the following to disable the extra confirmation step before
+            # redirecting to the client after a successful authentication. This step is
+            # enabled by default.
+            #
+            #enable_redirect_confirm: false
+
             # A list of client URLs which are whitelisted so that the user does not
             # have to confirm giving access to their account to the URL. Any client
             # whose URL starts with an entry in the following list will not be subject

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -990,11 +990,12 @@ class AuthHandler(BaseHandler):
             client_redirect_url, "loginToken", login_token
         )
 
-        # Skip the confirmation step and redirect to the client if it is whitelisted or
-        # if the server's configuration explicitly disables that step.
+        # Skip the confirmation step and redirect to the client if that step is
+        # explicitly disabled in the server's configuration, or if the client is
+        # whitelisted.
         if (
-            client_redirect_url.startswith(self._whitelisted_sso_clients)
-            or not self._sso_enable_redirect_confirm
+            not self._sso_enable_redirect_confirm
+            or client_redirect_url.startswith(self._whitelisted_sso_clients)
         ):
             request.redirect(redirect_url)
             finish_request(request)

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -113,6 +113,8 @@ class AuthHandler(BaseHandler):
 
         self._clock = self.hs.get_clock()
 
+        self._sso_enable_redirect_confirm = hs.config.sso_enable_redirect_confirm
+
         # Load the SSO redirect confirmation page HTML template
         self._sso_redirect_confirm_template = load_jinja2_templates(
             hs.config.sso_redirect_confirm_template_dir, ["sso_redirect_confirm.html"],
@@ -988,8 +990,12 @@ class AuthHandler(BaseHandler):
             client_redirect_url, "loginToken", login_token
         )
 
-        # if the client is whitelisted, we can redirect straight to it
-        if client_redirect_url.startswith(self._whitelisted_sso_clients):
+        # Skip the confirmation step and redirect to the client if it is whitelisted or
+        # if the server's configuration explicitly disables that step.
+        if (
+            client_redirect_url.startswith(self._whitelisted_sso_clients)
+            or not self._sso_enable_redirect_confirm
+        ):
             request.redirect(redirect_url)
             finish_request(request)
             return

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -993,9 +993,8 @@ class AuthHandler(BaseHandler):
         # Skip the confirmation step and redirect to the client if that step is
         # explicitly disabled in the server's configuration, or if the client is
         # whitelisted.
-        if (
-            not self._sso_enable_redirect_confirm
-            or client_redirect_url.startswith(self._whitelisted_sso_clients)
+        if not self._sso_enable_redirect_confirm or client_redirect_url.startswith(
+            self._whitelisted_sso_clients
         ):
             request.redirect(redirect_url)
             finish_request(request)

--- a/tests/rest/client/v1/test_login.py
+++ b/tests/rest/client/v1/test_login.py
@@ -352,13 +352,7 @@ class CASRedirectConfirmTestCase(unittest.HomeserverTestCase):
         """
         self._test_no_confirmation_step()
 
-    @override_config(
-        {
-            "sso": {
-                "enable_redirect_confirm": False,
-            }
-        }
-    )
+    @override_config({"sso": {"enable_redirect_confirm": False}})
     def test_cas_redirect_confirm_disabled(self):
         """Tests that the SSO login flow serves a redirect if the confirmation step is
         explicitly disabled in the server's configuration.

--- a/tests/rest/client/v1/test_login.py
+++ b/tests/rest/client/v1/test_login.py
@@ -350,6 +350,25 @@ class CASRedirectConfirmTestCase(unittest.HomeserverTestCase):
     def test_cas_redirect_whitelisted(self):
         """Tests that the SSO login flow serves a redirect to a whitelisted url
         """
+        self._test_no_confirmation_step()
+
+    @override_config(
+        {
+            "sso": {
+                "enable_redirect_confirm": False,
+            }
+        }
+    )
+    def test_cas_redirect_confirm_disabled(self):
+        """Tests that the SSO login flow serves a redirect if the confirmation step is
+        explicitly disabled in the server's configuration.
+        """
+        self._test_no_confirmation_step()
+
+    def _test_no_confirmation_step(self):
+        """Tests that the SSO login flows serves a redirect with the current test's
+        configuration.
+        """
         redirect_url = "https://legit-site.com/"
         cas_ticket_url = (
             "/_matrix/client/r0/login/cas/ticket?redirectUrl=%s&ticket=ticket"


### PR DESCRIPTION
In the case of an instance which SSO backend is quite restrictive, or doesn't allow e.g. "passwordless" email login, it makes the SSO login flow feel a bit clunky to have a confirmation step after a successful authentication.