### PR TITLE
Ensure is_verified on /_matrix/client/r0/room_keys/keys is a boolean

### DIFF
--- a/changelog.d/7150.bugfix
+++ b/changelog.d/7150.bugfix
@@ -1,0 +1,1 @@
+Ensure `is_verified` is a boolean in responses to `GET /_matrix/client/r0/room_keys/keys`. Also warn the user if they forgot the `version` query param.

--- a/synapse/rest/client/v2_alpha/room_keys.py
+++ b/synapse/rest/client/v2_alpha/room_keys.py
@@ -190,6 +190,9 @@ class RoomKeysServlet(RestServlet):
         user_id = requester.user.to_string()
         version = parse_string(request, "version")
 
+        if not version:
+            raise SynapseError(400, "Missing version query parameter", errcode=Codes.MISSING_PARAM)
+
         room_keys = await self.e2e_room_keys_handler.get_room_keys(
             user_id, version, room_id, session_id
         )

--- a/synapse/rest/client/v2_alpha/room_keys.py
+++ b/synapse/rest/client/v2_alpha/room_keys.py
@@ -188,12 +188,7 @@ class RoomKeysServlet(RestServlet):
         """
         requester = await self.auth.get_user_by_req(request, allow_guest=False)
         user_id = requester.user.to_string()
-        version = parse_string(request, "version")
-
-        if not version:
-            raise SynapseError(
-                400, "Missing version query parameter", errcode=Codes.MISSING_PARAM
-            )
+        version = parse_string(request, "version", required=True)
 
         room_keys = await self.e2e_room_keys_handler.get_room_keys(
             user_id, version, room_id, session_id

--- a/synapse/rest/client/v2_alpha/room_keys.py
+++ b/synapse/rest/client/v2_alpha/room_keys.py
@@ -191,7 +191,9 @@ class RoomKeysServlet(RestServlet):
         version = parse_string(request, "version")
 
         if not version:
-            raise SynapseError(400, "Missing version query parameter", errcode=Codes.MISSING_PARAM)
+            raise SynapseError(
+                400, "Missing version query parameter", errcode=Codes.MISSING_PARAM
+            )
 
         room_keys = await self.e2e_room_keys_handler.get_room_keys(
             user_id, version, room_id, session_id

--- a/synapse/storage/data_stores/main/e2e_room_keys.py
+++ b/synapse/storage/data_stores/main/e2e_room_keys.py
@@ -146,7 +146,8 @@ class EndToEndRoomKeyStore(SQLBaseStore):
             room_entry["sessions"][row["session_id"]] = {
                 "first_message_index": row["first_message_index"],
                 "forwarded_count": row["forwarded_count"],
-                "is_verified": row["is_verified"],
+                # is_verified must be returned to the client as a boolean
+                "is_verified": bool(row["is_verified"]),
                 "session_data": json.loads(row["session_data"]),
             }
 


### PR DESCRIPTION
Fixes: https://github.com/matrix-org/synapse/issues/6977

Also tells the user whether they're missing the `version` query parameter instead of 500'ing (this confused me for a bit while testing).

I'm not sure how [this sytest](https://github.com/matrix-org/sytest/blob/aee12f9414e5b36cba569e3ca0220e8e2f995329/tests/41end-to-end-keys/07-backup.pl#L225) didn't catch this initially though.