### PR TITLE
Improve the UX of the login fallback when using SSO

### DIFF
--- a/changelog.d/7152.feature
+++ b/changelog.d/7152.feature
@@ -1,0 +1,1 @@
+Improve the support for SSO authentication on the login fallback page.

--- a/synapse/static/client/login/index.html
+++ b/synapse/static/client/login/index.html
@@ -9,7 +9,7 @@
 <body onload="matrixLogin.onLoad()">
     <center>
         <br/>
-        <h1>Log in with one of the following methods</h1>
+        <h1 id="title"></h1>
 
         <span id="feedback" style="color: #f00"></span>
 

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -33,6 +33,8 @@ var submitToken = function(loginToken) {
 };
 
 var errorFunc = function(err) {
+    // We want to show the error to the user rather than redirecting immediately to the
+    // SSO portal (if SSO is the only login option), so we inhibit the redirect.
     show_login(true);
 
     if (err.responseJSON && err.responseJSON.error) {
@@ -63,8 +65,6 @@ var show_login = function(inhibit_redirect) {
         $("#sso_form").show();
     }
 
-    set_title(title_pre_auth);
-
     if (matrixLogin.serverAcceptsPassword) {
         $("#password_flow").show();
     }
@@ -72,6 +72,8 @@ var show_login = function(inhibit_redirect) {
     if (!matrixLogin.serverAcceptsPassword && !matrixLogin.serverAcceptsSso) {
         $("#no_login_types").show();
     }
+
+    set_title(title_pre_auth);
 
     $("#loading").hide();
 };

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -5,10 +5,12 @@ window.matrixLogin = {
     serverAcceptsSso: false,
 };
 
-var title_pre_auth = "Log in with one of the following methods"
+var title_pre_auth = "Log in with one of the following methods";
+var title_post_auth = "Logging in...";
 
 var submitPassword = function(user, pwd) {
     console.log("Logging in with password...");
+    set_title(title_post_auth);
     var data = {
         type: "m.login.password",
         user: user,
@@ -21,6 +23,7 @@ var submitPassword = function(user, pwd) {
 
 var submitToken = function(loginToken) {
     console.log("Logging in with login token...");
+    set_title(title_post_auth);
     var data = {
         type: "m.login.token",
         token: loginToken
@@ -92,7 +95,7 @@ var show_spinner = function() {
 };
 
 var set_title = function(title) {
-    $("#title").innerText = title;
+    $("#title").text(title);
 };
 
 var fetch_info = function(cb) {

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -52,23 +52,19 @@ var show_login = function() {
     var this_page = window.location.origin + window.location.pathname;
     $("#sso_redirect_url").val(this_page);
 
-    if (matrixLogin.serverAcceptsCas) {
-        $("#sso_form").attr("action", "/_matrix/client/r0/login/cas/redirect");
-    }
-
-    if ((matrixLogin.serverAcceptsSso || matrixLogin.serverAcceptsCas)) {
-        if (try_token()) {
-            // Only show the SSO form if there's a login token in the query. That's
-            // because, if there is a token, and this function is run, it means an error
-            // happened, and in this case it's nicer to show the form with an error
-            // rather than redirect immediately to the SSO portal.
+    if (matrixLogin.serverAcceptsSso) {
+        if (try_token() || matrixLogin.serverAcceptsPassword) {
+            // Show the SSO form if there's a login token in the query. That's because,
+            // if there is a token, and this function is run, it means an error happened,
+            // and in this case it's nicer to show the form with an error rather than
+            // redirect immediately to the SSO portal.
+            // Also show the form if the server is accepting password login as well.
             $("#sso_form").show();
         } else {
             // Submit the SSO form instead of displaying it. The reason behind this
             // behaviour is that the user will likely arrive here after clicking on a
-            // button, in the client, with a label such as "Continue with SSO". And even
-            // if that's not the case, it kind of makes sense to direct the user directly
-            // to the SSO portal and skip the password login form.
+            // button, in the client, with a label such as "Continue with SSO", so
+            // clicking on another button with the same semantics is a bit pointless.
             $("#sso_form").submit();
             return;
         }

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -61,7 +61,7 @@ var show_login = function(inhibit_redirect) {
             return;
         }
 
-        // Otherwise, show the SSO form the form
+        // Otherwise, show the SSO form
         $("#sso_form").show();
     }
 

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -1,7 +1,6 @@
 window.matrixLogin = {
     endpoint: location.origin + "/_matrix/client/r0/login",
     serverAcceptsPassword: false,
-    serverAcceptsCas: false,
     serverAcceptsSso: false,
 };
 
@@ -78,7 +77,7 @@ var show_login = function() {
         $("#password_flow").show();
     }
 
-    if (!matrixLogin.serverAcceptsPassword && !matrixLogin.serverAcceptsCas && !matrixLogin.serverAcceptsSso) {
+    if (!matrixLogin.serverAcceptsPassword && !matrixLogin.serverAcceptsSso) {
         $("#no_login_types").show();
     }
 };
@@ -97,13 +96,8 @@ var set_title = function(title) {
 var fetch_info = function(cb) {
     $.get(matrixLogin.endpoint, function(response) {
         var serverAcceptsPassword = false;
-        var serverAcceptsCas = false;
         for (var i=0; i<response.flows.length; i++) {
             var flow = response.flows[i];
-            if ("m.login.cas" === flow.type) {
-                matrixLogin.serverAcceptsCas = true;
-                console.log("Server accepts CAS");
-            }
             if ("m.login.sso" === flow.type) {
                 matrixLogin.serverAcceptsSso = true;
                 console.log("Server accepts SSO");


### PR DESCRIPTION
* Don't show the login forms if we're currently logging in with a
  password or a token.
* Submit directly the SSO login form, showing only a spinner to the
  user, in order to eliminate from the clunkiness of SSO through this
  fallback.