### PR TITLE
Always whitelist the login fallback for SSO

### DIFF
--- a/changelog.d/7153.feature
+++ b/changelog.d/7153.feature
@@ -1,0 +1,1 @@
+Always whitelist the login fallback in the SSO configuration if `public_baseurl` is set.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1392,7 +1392,11 @@ sso:
     # phishing attacks from evil.site. To avoid this, include a slash after the
     # hostname: "https://my.client/".
     #
-    # By default, this list is empty.
+    # If public_baseurl is set, then the login fallback page (used by clients
+    # that don't have full support for SSO) is always included in this list.
+    #
+    # By default, this list is empty, except if public_baseurl is set (in which
+    # case the login fallback page is the only element in the list).
     #
     #client_whitelist:
     #  - https://riot.im/develop

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1393,10 +1393,10 @@ sso:
     # hostname: "https://my.client/".
     #
     # If public_baseurl is set, then the login fallback page (used by clients
-    # that don't have full support for SSO) is always included in this list.
+    # that don't natively support the required login flows) is whitelisted in
+    # addition to any URLs in this list.
     #
-    # By default, this list is empty, except if public_baseurl is set (in which
-    # case the login fallback page is the only element in the list).
+    # By default, this list is empty.
     #
     #client_whitelist:
     #  - https://riot.im/develop

--- a/synapse/config/sso.py
+++ b/synapse/config/sso.py
@@ -66,10 +66,10 @@ class SSOConfig(Config):
             # hostname: "https://my.client/".
             #
             # If public_baseurl is set, then the login fallback page (used by clients
-            # that don't have full support for SSO) is always included in this list.
+            # that don't natively support the required login flows) is whitelisted in
+            # addition to any URLs in this list.
             #
-            # By default, this list is empty, except if public_baseurl is set (in which
-            # case the login fallback page is the only element in the list).
+            # By default, this list is empty.
             #
             #client_whitelist:
             #  - https://riot.im/develop

--- a/synapse/config/sso.py
+++ b/synapse/config/sso.py
@@ -39,6 +39,17 @@ class SSOConfig(Config):
 
         self.sso_client_whitelist = sso_config.get("client_whitelist") or []
 
+        # Attempt to also whitelist the server's login fallback, since that fallback sets
+        # the redirect URL to itself (so it can process the login token then return
+        # gracefully to the client). This would make it pointless to ask the user for
+        # confirmation, since the URL the confirmation page would be showing wouldn't be
+        # the client's.
+        # public_baseurl is an optional setting, so we only add the fallback's URL to the
+        # list if it's provided (because we can't figure out what that URL is otherwise).
+        if self.public_baseurl:
+            login_fallback_url = self.public_baseurl + "_matrix/static/client/login"
+            self.sso_client_whitelist.append(login_fallback_url)
+
     def generate_config_section(self, **kwargs):
         return """\
         # Additional settings to use with single-sign on systems such as SAML2 and CAS.
@@ -54,7 +65,11 @@ class SSOConfig(Config):
             # phishing attacks from evil.site. To avoid this, include a slash after the
             # hostname: "https://my.client/".
             #
-            # By default, this list is empty.
+            # If public_baseurl is set, then the login fallback page (used by clients
+            # that don't have full support for SSO) is always included in this list.
+            #
+            # By default, this list is empty, except if public_baseurl is set (in which
+            # case the login fallback page is the only element in the list).
             #
             #client_whitelist:
             #  - https://riot.im/develop

--- a/tests/rest/client/v1/test_login.py
+++ b/tests/rest/client/v1/test_login.py
@@ -352,11 +352,7 @@ class CASRedirectConfirmTestCase(unittest.HomeserverTestCase):
         """
         self._test_redirect("https://legit-site.com/")
 
-    @override_config(
-        {
-            "public_baseurl": "https://example.com"
-        }
-    )
+    @override_config({"public_baseurl": "https://example.com"})
     def test_cas_redirect_login_fallback(self):
         self._test_redirect("https://example.com/_matrix/static/client/login")
 

--- a/tests/rest/client/v1/test_login.py
+++ b/tests/rest/client/v1/test_login.py
@@ -350,7 +350,18 @@ class CASRedirectConfirmTestCase(unittest.HomeserverTestCase):
     def test_cas_redirect_whitelisted(self):
         """Tests that the SSO login flow serves a redirect to a whitelisted url
         """
-        redirect_url = "https://legit-site.com/"
+        self._test_redirect("https://legit-site.com/")
+
+    @override_config(
+        {
+            "public_baseurl": "https://example.com"
+        }
+    )
+    def test_cas_redirect_login_fallback(self):
+        self._test_redirect("https://example.com/_matrix/static/client/login")
+
+    def _test_redirect(self, redirect_url):
+        """Tests that the SSO login flow serves a redirect for the given redirect URL."""
         cas_ticket_url = (
             "/_matrix/client/r0/login/cas/ticket?redirectUrl=%s&ticket=ticket"
             % (urllib.parse.quote(redirect_url))


### PR DESCRIPTION
That fallback sets the redirect URL to itself (so it can process the login token then return gracefully to the client). This would make it pointless to ask the user for confirmation, since the URL the confirmation page would be showing wouldn't be the client's.