### PR TITLE
Always send the user updates to their own device list

### DIFF
--- a/changelog.d/7160.feature
+++ b/changelog.d/7160.feature
@@ -1,0 +1,1 @@
+Always send users their own device updates.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -122,7 +122,9 @@ class DeviceWorkerHandler(BaseHandler):
 
         # First we check if any devices have changed for users that we share
         # rooms with.
-        tracked_users = yield self.store.get_users_who_share_room_with_user(user_id)
+        users_who_share_room = yield self.store.get_users_who_share_room_with_user(user_id)
+
+        tracked_users = set(users_who_share_room)
         # always tell the user about their own devices
         tracked_users.add(user_id)
 
@@ -217,8 +219,8 @@ class DeviceWorkerHandler(BaseHandler):
         if possibly_changed or possibly_left:
             # Take the intersection of the users whose devices may have changed
             # and those that actually still share a room with the user
-            possibly_joined = possibly_changed & tracked_users
-            possibly_left = (possibly_changed | possibly_left) - tracked_users
+            possibly_joined = possibly_changed & users_who_share_room
+            possibly_left = (possibly_changed | possibly_left) - users_who_share_room
         else:
             possibly_joined = []
             possibly_left = []

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -126,16 +126,8 @@ class DeviceWorkerHandler(BaseHandler):
         # always tell the user about their own devices
         tracked_users.add(user_id)
 
-        logger.info(
-            "tracked users ids: %r", tracked_users,
-        )
-
         changed = yield self.store.get_users_whose_devices_changed(
             from_token.device_list_key, tracked_users
-        )
-
-        logger.info(
-            "changed users IDs: %r", changed,
         )
 
         # Then work out if any users have since joined
@@ -225,8 +217,8 @@ class DeviceWorkerHandler(BaseHandler):
         if possibly_changed or possibly_left:
             # Take the intersection of the users whose devices may have changed
             # and those that actually still share a room with the user
-            possibly_joined = possibly_changed & users_who_share_room
-            possibly_left = (possibly_changed | possibly_left) - users_who_share_room
+            possibly_joined = possibly_changed & tracked_users
+            possibly_left = (possibly_changed | possibly_left) - tracked_users
         else:
             possibly_joined = []
             possibly_left = []

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -122,7 +122,9 @@ class DeviceWorkerHandler(BaseHandler):
 
         # First we check if any devices have changed for users that we share
         # rooms with.
-        users_who_share_room = yield self.store.get_users_who_share_room_with_user(user_id)
+        users_who_share_room = yield self.store.get_users_who_share_room_with_user(
+            user_id
+        )
 
         tracked_users = set(users_who_share_room)
         # always tell the user about their own devices

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -127,7 +127,8 @@ class DeviceWorkerHandler(BaseHandler):
         )
 
         tracked_users = set(users_who_share_room)
-        # always tell the user about their own devices
+
+        # Always tell the user about their own devices
         tracked_users.add(user_id)
 
         changed = yield self.store.get_users_whose_devices_changed(

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -122,9 +122,7 @@ class DeviceWorkerHandler(BaseHandler):
 
         # First we check if any devices have changed for users that we share
         # rooms with.
-        tracked_users = yield self.store.get_users_who_share_room_with_user(
-            user_id
-        )
+        tracked_users = yield self.store.get_users_who_share_room_with_user(user_id)
         # always tell the user about their own devices
         tracked_users.add(user_id)
 
@@ -469,7 +467,9 @@ class DeviceHandler(DeviceWorkerHandler):
 
         # specify the user ID too since the user should always get their own device list
         # updates, even if they aren't in any rooms.
-        yield self.notifier.on_new_event("device_list_key", position, users=[user_id], rooms=room_ids)
+        yield self.notifier.on_new_event(
+            "device_list_key", position, users=[user_id], rooms=room_ids
+        )
 
         if hosts:
             logger.info(

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1144,6 +1144,8 @@ class SyncHandler(object):
             )
 
             tracked_users = set(users_who_share_room)
+
+            # Always tell the user about their own devices
             tracked_users.add(user_id)
 
             # Step 1a, check for changes in devices of users we share a room with

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1139,13 +1139,14 @@ class SyncHandler(object):
             # room with by looking at all users that have left a room plus users
             # that were in a room we've left.
 
-            users_who_share_room = await self.store.get_users_who_share_room_with_user(
+            users_we_track = await self.store.get_users_who_share_room_with_user(
                 user_id
             )
+            users_we_track.add(user_id)
 
             # Step 1a, check for changes in devices of users we share a room with
             users_that_have_changed = await self.store.get_users_whose_devices_changed(
-                since_token.device_list_key, users_who_share_room
+                since_token.device_list_key, users_we_track
             )
 
             # Step 1b, check for newly joined rooms
@@ -1168,7 +1169,7 @@ class SyncHandler(object):
                 newly_left_users.update(left_users)
 
             # Remove any users that we still share a room with.
-            newly_left_users -= users_who_share_room
+            newly_left_users -= users_we_track
 
             return DeviceLists(changed=users_that_have_changed, left=newly_left_users)
         else:

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1139,14 +1139,16 @@ class SyncHandler(object):
             # room with by looking at all users that have left a room plus users
             # that were in a room we've left.
 
-            users_we_track = await self.store.get_users_who_share_room_with_user(
+            users_who_share_room = await self.store.get_users_who_share_room_with_user(
                 user_id
             )
-            users_we_track.add(user_id)
+
+            tracked_users = set(users_who_share_room)
+            tracked_users.add(user_id)
 
             # Step 1a, check for changes in devices of users we share a room with
             users_that_have_changed = await self.store.get_users_whose_devices_changed(
-                since_token.device_list_key, users_we_track
+                since_token.device_list_key, tracked_users
             )
 
             # Step 1b, check for newly joined rooms
@@ -1169,7 +1171,7 @@ class SyncHandler(object):
                 newly_left_users.update(left_users)
 
             # Remove any users that we still share a room with.
-            newly_left_users -= users_we_track
+            newly_left_users -= users_who_share_room
 
             return DeviceLists(changed=users_that_have_changed, left=newly_left_users)
         else:


### PR DESCRIPTION
This will allow clients to notify users about new devices even if
the user isn't in any rooms (yet).