### PR TITLE
Fix a small typo in the `metrics_flags` config option.

### DIFF
--- a/changelog.d/7171.doc
+++ b/changelog.d/7171.doc
@@ -1,0 +1,1 @@
+Fix a small typo in the `metrics_flags` config option.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1144,7 +1144,7 @@ account_threepid_delegates:
 # enabled by default, either for performance reasons or limited use.
 #
 metrics_flags:
-    # Publish synapse_federation_known_servers, a g auge of the number of
+    # Publish synapse_federation_known_servers, a gauge of the number of
     # servers this homeserver knows about, including itself. May cause
     # performance problems on large homeservers.
     #

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -86,7 +86,7 @@ class MetricsConfig(Config):
         # enabled by default, either for performance reasons or limited use.
         #
         metrics_flags:
-            # Publish synapse_federation_known_servers, a g auge of the number of
+            # Publish synapse_federation_known_servers, a gauge of the number of
             # servers this homeserver knows about, including itself. May cause
             # performance problems on large homeservers.
             #


### PR DESCRIPTION
`g auge` -> `gauge`