### PR TITLE
Only setdefault for signatures if device has key_json

### DIFF
--- a/changelog.d/7177.bugfix
+++ b/changelog.d/7177.bugfix
@@ -1,0 +1,1 @@
+Mitigation for a bug in `_get_e2e_device_keys_txn` which broke federation for some servers.

--- a/changelog.d/7177.bugfix
+++ b/changelog.d/7177.bugfix
@@ -1,1 +1,1 @@
-Mitigation for a bug in `_get_e2e_device_keys_txn` which broke federation for some servers.
+Fix a bug which could cause outbound federation traffic to stop working if a client uploaded an incorrect e2e device signature.

--- a/synapse/storage/data_stores/main/devices.py
+++ b/synapse/storage/data_stores/main/devices.py
@@ -495,14 +495,16 @@ class DeviceWorkerStore(SQLBaseStore):
                 key_json = device.get("key_json", None)
                 if key_json:
                     result["keys"] = db_to_json(key_json)
+
+                    if "signatures" in device:
+                        for sig_user_id, sigs in device["signatures"].items():
+                            result["keys"].setdefault("signatures", {}).setdefault(
+                                sig_user_id, {}
+                            ).update(sigs)
+
                 device_display_name = device.get("device_display_name", None)
                 if device_display_name:
                     result["device_display_name"] = device_display_name
-                if "signatures" in device:
-                    for sig_user_id, sigs in device["signatures"].items():
-                        result["keys"].setdefault("signatures", {}).setdefault(
-                            sig_user_id, {}
-                        ).update(sigs)
 
                 results.append(result)
 

--- a/synapse/storage/data_stores/main/devices.py
+++ b/synapse/storage/data_stores/main/devices.py
@@ -285,14 +285,16 @@ class DeviceWorkerStore(SQLBaseStore):
                     key_json = device.get("key_json", None)
                     if key_json:
                         result["keys"] = db_to_json(key_json)
+
+                        if "signatures" in device:
+                            for sig_user_id, sigs in device["signatures"].items():
+                                result["keys"].setdefault("signatures", {}).setdefault(
+                                    sig_user_id, {}
+                                ).update(sigs)
+
                     device_display_name = device.get("device_display_name", None)
                     if device_display_name:
                         result["device_display_name"] = device_display_name
-                    if "signatures" in device:
-                        for sig_user_id, sigs in device["signatures"].items():
-                            result["keys"].setdefault("signatures", {}).setdefault(
-                                sig_user_id, {}
-                            ).update(sigs)
                 else:
                     result["deleted"] = True
 


### PR DESCRIPTION
A possible fix for https://github.com/matrix-org/synapse/issues/7163

I'm not entirely sure what this code is doing, but I know it's incorrect that we're trying to pull a key out of a dictionary all the time, when we're only setting that key sometimes (when `key_json` is truthy).

~~Stopped the exception on Cadair's server (which is expected), however I'm not convinced that this isn't just fixing a symptom of another issue.~~ (@uhoreg seems to think this does the right thing). Considering this code was introduced in 1.11.0 with https://github.com/matrix-org/synapse/pull/6844, but has only been reported with 1.12.0.