### PR TITLE
Fix a bug which could cause incorrect 'cyclic dependency' error.

### DIFF
--- a/changelog.d/7178.bugfix
+++ b/changelog.d/7178.bugfix
@@ -1,0 +1,1 @@
+Fix a bug which could cause incorrect 'cyclic dependency' error.


### PR DESCRIPTION
If there was an exception setting up one of the attributes of the Homeserver
god object, then future attempts to fetch that attribute would raise a
confusing "Cyclic dependency" error. Let's make sure that we clear the
`building` flag so that we just get the original exception.

Ref: #7169