### PR TITLE
Do not try to await None, which can be returned by delete_url_cache.

### DIFF
--- a/changelog.d/7184.misc
+++ b/changelog.d/7184.misc
@@ -1,0 +1,1 @@
+Convert some of synapse.rest.media to async/await.

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -427,7 +427,7 @@ class PreviewUrlResource(DirectServeResource):
             except Exception:
                 pass
 
-        await defer.ensureDeferred(self.store.delete_url_cache(removed_media))
+        await self.store.delete_url_cache(removed_media)
 
         if removed_media:
             logger.info("Deleted %d entries from url cache", len(removed_media))

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -427,7 +427,7 @@ class PreviewUrlResource(DirectServeResource):
             except Exception:
                 pass
 
-        await self.store.delete_url_cache(removed_media)
+        await defer.ensureDeferred(self.store.delete_url_cache(removed_media))
 
         if removed_media:
             logger.info("Deleted %d entries from url cache", len(removed_media))

--- a/synapse/storage/data_stores/main/media_repository.py
+++ b/synapse/storage/data_stores/main/media_repository.py
@@ -340,7 +340,7 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
             "get_expired_url_cache", _get_expired_url_cache_txn
         )
 
-    def delete_url_cache(self, media_ids):
+    async def delete_url_cache(self, media_ids):
         if len(media_ids) == 0:
             return
 
@@ -349,7 +349,7 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
         def _delete_url_cache_txn(txn):
             txn.executemany(sql, [(media_id,) for media_id in media_ids])
 
-        return self.db.runInteraction("delete_url_cache", _delete_url_cache_txn)
+        return await self.db.runInteraction("delete_url_cache", _delete_url_cache_txn)
 
     def get_url_cache_media_before(self, before_ts):
         sql = (


### PR DESCRIPTION
Fixes #7182

In the case were `removed_media` is an empty list then `delete_url_cache` returns `None`.

Wrapping this in `defer.ensureDeferred` should fix the error, but it does seem silly to call into a method which we know will just return `None` and then wrap that in a `Deferred`, etc. I did consider just moving the modified line down into the `if removed_media` block.