### PR TITLE
Convert http.HTTPStatus objects to their int equivalent

### DIFF
--- a/changelog.d/7188.misc
+++ b/changelog.d/7188.misc
@@ -1,1 +1,1 @@
-Fix consistency of HTTP status codes reported in log lines. Instances of `HTTPStatus.*` are replaced with their integer equivalent.
+Fix consistency of HTTP status codes reported in log lines.

--- a/changelog.d/7188.misc
+++ b/changelog.d/7188.misc
@@ -1,0 +1,1 @@
+Fix consistency of HTTP status codes reported in log lines. Instances of `HTTPStatus.*` are replaced with their integer equivalent.

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -80,7 +80,7 @@ class CodeMessageException(RuntimeError):
     """An exception with integer code and message string attributes.
 
     Attributes:
-        code (int): HTTP error code.
+        code (int): HTTP error code
         msg (str): string describing the error
     """
 

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -17,6 +17,7 @@
 """Contains exceptions and error codes."""
 
 import logging
+from http import HTTPStatus
 from typing import Dict, List
 
 from six import iteritems
@@ -86,6 +87,11 @@ class CodeMessageException(RuntimeError):
 
     def __init__(self, code, msg):
         super(CodeMessageException, self).__init__("%d: %s" % (code, msg))
+
+        # Convert http.HTTPStatus objects to their int status code equivalents
+        if isinstance(code, HTTPStatus):
+            code = code.value
+
         self.code = code
         self.msg = msg
 

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -93,7 +93,6 @@ class CodeMessageException(RuntimeError):
         # This causes inconsistency in our log lines.
         #
         # To eliminate this behaviour, we convert them to their integer equivalents here.
-        # TODO: Clean up all calls to this method such that this type cast isn't needed
         self.code = int(code)
         self.msg = msg
 

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -87,7 +87,7 @@ class CodeMessageException(RuntimeError):
     def __init__(self, code, msg):
         super(CodeMessageException, self).__init__("%d: %s" % (code, msg))
 
-        # Some caller to this method pass instances of http.HTTPStatus for `code`.
+        # Some calls to this method pass instances of http.HTTPStatus for `code`.
         # While HTTPStatus is a subclass of int, it has magic __str__ methods
         # which emit `HTTPStatus.FORBIDDEN` when converted to a str, instead of `403`.
         # This causes inconsistency in our log lines.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/7017

This PR fixes a bug where `http.HTTPStatus` objects were printed (whose representation is a str) into logs, showing something like `HTTPStatus.FORBIDDEN` instead of `403`.

This was inconsistent with other log lines and thus made writing log parsers a bit more painful than necessary.

This PR changes any `CodeMessageException` given an `http.HTTPStatus` object will convert it to its integer equivalent when it's instantiated.