### PR TITLE
Allow admins to create aliases when they are not in the room

### DIFF
--- a/changelog.d/7191.feature
+++ b/changelog.d/7191.feature
@@ -1,0 +1,1 @@
+Admin users are no longer required to be in a room to create an alias for it.

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -127,7 +127,11 @@ class DirectoryHandler(BaseHandler):
                     errcode=Codes.EXCLUSIVE,
                 )
         else:
-            if self.require_membership and check_membership:
+            # Server admins are not subject to the same constraints as normal
+            # users when creating an alias (e.g. being in the room).
+            is_admin = yield self.auth.is_server_admin(requester.user)
+
+            if (self.require_membership and check_membership) and not is_admin:
                 rooms_for_user = yield self.store.get_rooms_for_user(user_id)
                 if room_id not in rooms_for_user:
                     raise AuthError(


### PR DESCRIPTION
This fixes #7052 by allowing server admins to create aliases even when not in the room.