### PR TITLE
Remove some `run_in_background` calls in replication code

### DIFF
--- a/changelog.d/7203.bugfix
+++ b/changelog.d/7203.bugfix
@@ -1,0 +1,1 @@
+Fix some worker-mode replication handling not being correctly recorded in CPU usage stats.


### PR DESCRIPTION
By running this stuff with `run_in_background`, it won't be correctly reported
against the relevant CPU usage stats.

Fixes #7202