### PR TITLE
Remove stream before/after debug log lines

### DIFF
--- a/changelog.d/7207.misc
+++ b/changelog.d/7207.misc
@@ -1,0 +1,1 @@
+Remove some extraneous debugging log lines.

--- a/synapse/storage/data_stores/main/stream.py
+++ b/synapse/storage/data_stores/main/stream.py
@@ -481,11 +481,9 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
             room_id, limit, end_token
         )
 
-        logger.debug("stream before")
         events = yield self.get_events_as_list(
             [r.event_id for r in rows], get_prev_content=True
         )
-        logger.debug("stream after")
 
         self._set_before_and_after(events, rows)
 


### PR DESCRIPTION
I noticed these debug log lines. They were added in 2016 and seemed a bit useless, but let me know if anyone actually uses them for debugging.