### PR TITLE
Optional dependencies specifically for building the debs

### DIFF
--- a/debian/build_virtualenv
+++ b/debian/build_virtualenv
@@ -34,7 +34,7 @@ esac
 # than the 2/3 compatible `virtualenv`.
 
 dh_virtualenv \
-    --install-suffix "matrix-synapse" \
+    --install-suffix "matrix-synapse[debian]" \
     --builtin-venv \
     --setuptools \
     --python "$SNAKE" \

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -61,9 +61,7 @@ REQUIREMENTS = [
     "pyasn1-modules>=0.0.7",
     "daemonize>=2.3.1",
     "bcrypt>=3.1.0",
-    # Pillow 7.1.0 causes the following issue on debian buster:
-    # https://github.com/python-pillow/Pillow/issues/2377
-    "pillow>=4.3.0,<7.1.0",
+    "pillow>=4.3.0",
     "sortedcontainers>=1.4.4",
     "pymacaroons>=0.13.0",
     "msgpack>=0.5.2",
@@ -100,6 +98,9 @@ CONDITIONAL_REQUIREMENTS = {
     "sentry": ["sentry-sdk>=0.7.2"],
     "opentracing": ["jaeger-client>=4.0.0", "opentracing>=2.2.0"],
     "jwt": ["pyjwt>=1.6.4"],
+    # Pillow 7.1.0 causes the following issue on debian buster:
+    # https://github.com/python-pillow/Pillow/issues/2377
+    "debian": ["pillow>=4.3.0,<7.1.0"],
 }
 
 ALL_OPTIONAL_REQUIREMENTS = set()  # type: Set[str]


### PR DESCRIPTION
Only applies the workaround for #7208 to building debian packages, not regular Synapse users.

Prevents people with Pillow v7.1.0 from receiving an error trying to start Synapse. They could downgrade, but it'd be a massive faff.