### PR TITLE
Add explicit python build tools to snapcraft

### DIFF
--- a/changelog.d/7213.misc
+++ b/changelog.d/7213.misc
@@ -1,0 +1,1 @@
+Add explicit Python build tooling as dependencies for the snapcraft build.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,10 @@ parts:
     python-version: python3
     python-packages:
       - '.[all]'
+      - pip
+      - setuptools
+      - setuptools-scm
+      - wheel
     build-packages:
       - libffi-dev
       - libturbojpeg0-dev


### PR DESCRIPTION
A small change to explicitly add required Python build tools to the snapcraft metadata.
This resolves an issue where setuptools-scm and wheel were not being installed during building of the Snap due to recent changes.

Adding pip, setuptools, setuptools-scm and wheel ensures these required tools are available now and in the future regardless of changes to Python requirements or the snapcraft tooling.
