### PR TITLE
Unblacklist /upgrade creates a new room

### DIFF
--- a/.buildkite/worker-blacklist
+++ b/.buildkite/worker-blacklist
@@ -5,8 +5,6 @@ Message history can be paginated
 
 Can re-join room if re-invited
 
-/upgrade creates a new room
-
 The only membership state included in an initial sync is for all the senders in the timeline
 
 Local device key changes get to remote servers

--- a/changelog.d/7228.misc
+++ b/changelog.d/7228.misc
@@ -1,0 +1,1 @@
+Unblacklist '/upgrade creates a new room' sytest for workers.


### PR DESCRIPTION
Tests in `tests/30rooms/60version_upgrade.pl` for worker mode doesn't seem to be flaky locally.

Let's try unblacklisting it.