### PR TITLE
Fix typo in the login fallback javascript

### DIFF
--- a/changelog.d/7235.bugfix
+++ b/changelog.d/7235.bugfix
@@ -1,0 +1,1 @@
+Fix a bug causing the login fallback to not display the SSO login form.

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -62,7 +62,7 @@ var show_login = function(inhibit_redirect) {
         }
 
         // Otherwise, show the SSO form
-        $("#sso_form").show();
+        $("#sso_flow").show();
     }
 
     if (matrixLogin.serverAcceptsPassword) {


### PR DESCRIPTION
This would cause the SSO login form to not show up, making it impossible to auth via SSO through the login fallback if SSO isn't the only authentication option the HS offers.