### PR TITLE
Make it clearer to the user that they haven't overridden onLogin/Register

### DIFF
--- a/changelog.d/7237.misc
+++ b/changelog.d/7237.misc
@@ -1,0 +1,1 @@
+Change log line that told user to implement onLogin/onRegister fallback js functions to a warning, instead of an info, so it's more visible.

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -129,7 +129,6 @@ matrixLogin.password_login = function() {
 matrixLogin.onLogin = function(response) {
     // clobber this function
     console.warn("onLogin - This function should be replaced to proceed.");
-    console.log(response);
 };
 
 var parseQsFromUrl = function(query) {

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -128,7 +128,7 @@ matrixLogin.password_login = function() {
 
 matrixLogin.onLogin = function(response) {
     // clobber this function
-    console.log("onLogin - This function should be replaced to proceed.");
+    console.warn("onLogin - This function should be replaced to proceed.");
     console.log(response);
 };
 

--- a/synapse/static/client/register/js/register.js
+++ b/synapse/static/client/register/js/register.js
@@ -113,5 +113,5 @@ matrixRegistration.signUp = function() {
 
 matrixRegistration.onRegistered = function(hs_url, user_id, access_token) {
     // clobber this function
-    console.log("onRegistered - This function should be replaced to proceed.");
+    console.warn("onRegistered - This function should be replaced to proceed.");
 };


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1342360/78687274-e69e4080-78eb-11ea-822f-899dbecdab27.png)


Perform a `console.warn` instead of `console.log` when informing the user they need to replace the stub.

Just makes things jump out a bit more.