### PR TITLE
Add documentation to password_providers config option

### DIFF
--- a/changelog.d/7238.doc
+++ b/changelog.d/7238.doc
@@ -1,0 +1,1 @@
+Add documentation to the `password_providers` config option. Add known password provider implementations to docs.

--- a/docs/password_auth_providers.md
+++ b/docs/password_auth_providers.md
@@ -9,7 +9,10 @@ into Synapse, and provides a number of methods by which it can integrate
 with the authentication system.
 
 This document serves as a reference for those looking to implement their
-own password auth providers.
+own password auth providers. Additionally, here is a list of known
+password auth provider module implementations:
+
+* [matrix-synapse-ldap3](https://github.com/matrix-org/matrix-synapse-ldap3/)
 
 ## Required methods
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1667,7 +1667,8 @@ email:
 # Note: instances wishing to use SAML or CAS authentication should
 # use the `saml2_config` option instead.
 #
-#password_providers:
+password_providers:
+#    # Example config for an LDAP auth provider
 #    - module: "ldap_auth_provider.LdapAuthProvider"
 #      config:
 #        enabled: true

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1657,6 +1657,16 @@ email:
   #template_dir: "res/templates"
 
 
+# Password providers allow homeserver administrators to integrate
+# their Synapse installation with existing authentication methods
+# ex. LDAP, external tokens, etc.
+#
+# For more information and known implementations, please see
+# https://github.com/matrix-org/synapse/blob/master/docs/password_auth_providers.md
+#
+# Note: instances wishing to use SAML or CAS authentication should
+# use the `saml2_config` option instead.
+#
 #password_providers:
 #    - module: "ldap_auth_provider.LdapAuthProvider"
 #      config:

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1665,7 +1665,8 @@ email:
 # https://github.com/matrix-org/synapse/blob/master/docs/password_auth_providers.md
 #
 # Note: instances wishing to use SAML or CAS authentication should
-# use the `saml2_config` option instead.
+# instead use the `saml2_config` or `cas_config` options,
+# respectively.
 #
 password_providers:
 #    # Example config for an LDAP auth provider

--- a/synapse/config/password_auth_providers.py
+++ b/synapse/config/password_auth_providers.py
@@ -35,7 +35,7 @@ class PasswordAuthProviderConfig(Config):
         if ldap_config.get("enabled", False):
             providers.append({"module": LDAP_PROVIDER, "config": ldap_config})
 
-        providers.extend(config.get("password_providers", []))
+        providers.extend(config.get("password_providers") or [])
         for provider in providers:
             mod_name = provider["module"]
 
@@ -62,7 +62,8 @@ class PasswordAuthProviderConfig(Config):
         # Note: instances wishing to use SAML or CAS authentication should
         # use the `saml2_config` option instead.
         #
-        #password_providers:
+        password_providers:
+        #    # Example config for an LDAP auth provider
         #    - module: "ldap_auth_provider.LdapAuthProvider"
         #      config:
         #        enabled: true

--- a/synapse/config/password_auth_providers.py
+++ b/synapse/config/password_auth_providers.py
@@ -52,6 +52,16 @@ class PasswordAuthProviderConfig(Config):
 
     def generate_config_section(self, **kwargs):
         return """\
+        # Password providers allow homeserver administrators to integrate
+        # their Synapse installation with existing authentication methods
+        # ex. LDAP, external tokens, etc.
+        #
+        # For more information and known implementations, please see
+        # https://github.com/matrix-org/synapse/blob/master/docs/password_auth_providers.md
+        #
+        # Note: instances wishing to use SAML or CAS authentication should
+        # use the `saml2_config` option instead.
+        #
         #password_providers:
         #    - module: "ldap_auth_provider.LdapAuthProvider"
         #      config:

--- a/synapse/config/password_auth_providers.py
+++ b/synapse/config/password_auth_providers.py
@@ -76,5 +76,5 @@ class PasswordAuthProviderConfig(Config):
         #           name: "givenName"
         #        #bind_dn:
         #        #bind_password:
-        #        #filter: "(objectClass=posixAccount)"
+        #        #filter: "(objectClass=posixAccount)"\
         """

--- a/synapse/config/password_auth_providers.py
+++ b/synapse/config/password_auth_providers.py
@@ -60,7 +60,8 @@ class PasswordAuthProviderConfig(Config):
         # https://github.com/matrix-org/synapse/blob/master/docs/password_auth_providers.md
         #
         # Note: instances wishing to use SAML or CAS authentication should
-        # use the `saml2_config` option instead.
+        # instead use the `saml2_config` or `cas_config` options,
+        # respectively.
         #
         password_providers:
         #    # Example config for an LDAP auth provider
@@ -76,5 +77,5 @@ class PasswordAuthProviderConfig(Config):
         #           name: "givenName"
         #        #bind_dn:
         #        #bind_password:
-        #        #filter: "(objectClass=posixAccount)"\
+        #        #filter: "(objectClass=posixAccount)"
         """


### PR DESCRIPTION
Sooo... I just watched someone trying to set up Synapse's LDAP support but getting stuck with not knowing that they needed to install [matrix-synapse-ldap3](https://github.com/matrix-org/matrix-synapse-ldap3) to actually get things working.

During so I also realized that the `password_providers` config option has zero documentation in the sample config.

So in an attempt to solve both of these problems I added some docs to the option and pointed people to the password provider auth module docs, which now have to link to known implementations in there, which includes a link to the LDAP3 module.

If there are other known implementations we can add, please suggest them.

This PR also changes `password_providers` such that it's uncommented by default, in accordance with our doc writing... docs: https://github.com/matrix-org/synapse/blob/master/docs/code_style.md#configuration-file-format