### PR TITLE
Do not allow a deactivated user to login via SSO.

### DIFF
--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1126,6 +1126,19 @@ class AuthHandler(BaseHandler):
             finish_request(request)
             return
 
+        self._complete_sso_login(registered_user_id, request, client_redirect_url)
+
+    def _complete_sso_login(
+        self,
+        registered_user_id: str,
+        request: SynapseRequest,
+        client_redirect_url: str,
+    ):
+        """
+        The synchronous portion of complete_sso_login.
+
+        This exists purely for backwards compatibility of synapse.module_api.ModuleApi.
+        """
         # Create a login token
         login_token = self.macaroon_gen.generate_short_term_login_token(
             registered_user_id

--- a/synapse/handlers/cas_handler.py
+++ b/synapse/handlers/cas_handler.py
@@ -216,6 +216,6 @@ class CasHandler:
                     localpart=localpart, default_display_name=user_display_name
                 )
 
-            self._auth_handler.complete_sso_login(
+            await self._auth_handler.complete_sso_login(
                 registered_user_id, request, client_redirect_url
             )

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -154,7 +154,7 @@ class SamlHandler:
             )
 
         else:
-            self._auth_handler.complete_sso_login(user_id, request, relay_state)
+            await self._auth_handler.complete_sso_login(user_id, request, relay_state)
 
     async def _map_saml_response_to_user(
         self, resp_bytes: str, client_redirect_url: str

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -213,7 +213,27 @@ class ModuleApi(object):
         """
         return self._store.db.runInteraction(desc, func, *args, **kwargs)
 
-    async def complete_sso_login(
+    def complete_sso_login(
+        self, registered_user_id: str, request: SynapseRequest, client_redirect_url: str
+    ):
+        """Complete a SSO login by redirecting the user to a page to confirm whether they
+        want their access token sent to `client_redirect_url`, or redirect them to that
+        URL with a token directly if the URL matches with one of the whitelisted clients.
+
+        This is deprecated in favor of complete_sso_login_async.
+
+        Args:
+            registered_user_id: The MXID that has been registered as a previous step of
+                of this SSO login.
+            request: The request to respond to.
+            client_redirect_url: The URL to which to offer to redirect the user (or to
+                redirect them directly if whitelisted).
+        """
+        self._auth_handler._complete_sso_login(
+            registered_user_id, request, client_redirect_url,
+        )
+
+    async def complete_sso_login_async(
         self, registered_user_id: str, request: SynapseRequest, client_redirect_url: str
     ):
         """Complete a SSO login by redirecting the user to a page to confirm whether they

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -213,7 +213,7 @@ class ModuleApi(object):
         """
         return self._store.db.runInteraction(desc, func, *args, **kwargs)
 
-    def complete_sso_login(
+    async def complete_sso_login(
         self, registered_user_id: str, request: SynapseRequest, client_redirect_url: str
     ):
         """Complete a SSO login by redirecting the user to a page to confirm whether they
@@ -227,6 +227,6 @@ class ModuleApi(object):
             client_redirect_url: The URL to which to offer to redirect the user (or to
                 redirect them directly if whitelisted).
         """
-        self._auth_handler.complete_sso_login(
+        await self._auth_handler.complete_sso_login(
             registered_user_id, request, client_redirect_url,
         )

--- a/synapse/res/templates/sso_account_deactivated.html
+++ b/synapse/res/templates/sso_account_deactivated.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SSO account deactivated</title>
+</head>
+    <body>
+        <p>This account has been deactivated.</p>
+    </body>
+</html>


### PR DESCRIPTION
This checks the deactivated status of a user during login for SSO.

If a user is deactivated, they are shown an HTML page explaining what happened.

As part of this it makes the `complete_sso_login` on the auth handler async, unfortunately to keep API compatibility in `ModuleApi` this PR adds a separate `complete_sso_login_async` and deprecates `complete_sso_login`. The sync version will not do the deactivation check.