### PR TITLE
Add matrix-synapse-shared-secret-auth as an example password provider

### DIFF
--- a/changelog.d/7248.doc
+++ b/changelog.d/7248.doc
@@ -1,0 +1,1 @@
+Add documentation to the `password_providers` config option. Add known password provider implementations to docs.

--- a/docs/password_auth_providers.md
+++ b/docs/password_auth_providers.md
@@ -13,6 +13,7 @@ own password auth providers. Additionally, here is a list of known
 password auth provider module implementations:
 
 * [matrix-synapse-ldap3](https://github.com/matrix-org/matrix-synapse-ldap3/)
+* [matrix-synapse-shared-secret-auth](https://github.com/devture/matrix-synapse-shared-secret-auth)
 
 ## Required methods
 


### PR DESCRIPTION
I found another one!

Updates #7238 to add another example of a password provider auth module: https://github.com/devture/matrix-synapse-shared-secret-auth/