### PR TITLE
Fix --help commandline argument

### DIFF
--- a/changelog.d/7249.bugfix
+++ b/changelog.d/7249.bugfix
@@ -1,0 +1,1 @@
+Fix --help commandline argument.

--- a/changelog.d/7249.bugfix
+++ b/changelog.d/7249.bugfix
@@ -1,1 +1,1 @@
-Fix --help commandline argument.
+Fix --help command-line argument.


### PR DESCRIPTION
I don't really remember why this was so complicated; I think it dates
back to the time when we had to instantiate the Config classes before
we could call `add_arguments` - ie before #5597. In any case, I don't
think there's a good reason for it any more, and the impact of it
being complicated is that `--help` doesn't work correctly.