### PR TITLE
Add setting to nginx configuration to allow larger file uploads

### DIFF
--- a/changelog.d/7251.doc
+++ b/changelog.d/7251.doc
@@ -1,1 +1,1 @@
-Add setting to nginx reverse proxy configuration to allow larger file uploads.
+Modify suggested nginx reverse proxy configuration to match Synapse's default file upload size. Contributed by @ProCycleDev.

--- a/changelog.d/7251.doc
+++ b/changelog.d/7251.doc
@@ -1,0 +1,1 @@
+Add setting to nginx reverse proxy configuration to allow larger file uploads.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -42,6 +42,9 @@ the reverse proxy and the homeserver.
             location /_matrix {
                 proxy_pass http://localhost:8008;
                 proxy_set_header X-Forwarded-For $remote_addr;
+                # Nginx by default only allows file uploads up to 1M in size
+                # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
+                client_max_body_size 10M;
             }
         }
 


### PR DESCRIPTION
Nginx defaults to only allow file uploads up to 1MB while synapse allows up to 10MB by default. Added a line to the nginx configuration to increase the limit with a note about how to use the setting and having a default value to match synapse's default.

Signed-off-by: Ryan Hovland <ryan@procycle.us>