### PR TITLE
Explicitly create UI Auth sessions

### DIFF
--- a/changelog.d/7268.bugfix
+++ b/changelog.d/7268.bugfix
@@ -1,0 +1,1 @@
+Reject unknown session IDs during user interactive authentication instead of silently creating a new session.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -609,7 +609,10 @@ class AuthHandler(BaseHandler):
         The session can be used to track data across multiple requests, e.g. for
         interactive authentication.
         """
-        return self.sessions[session_id]
+        try:
+            return self.sessions[session_id]
+        except KeyError:
+            raise SynapseError(400, "Unknown session ID: %s" % session_id)
 
     async def get_access_token_for_user_id(
         self, user_id: str, device_id: Optional[str], valid_until_ms: Optional[int]

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -277,10 +277,6 @@ class AuthHandler(BaseHandler):
         Takes a dictionary sent by the client in the login / registration
         protocol and handles the User-Interactive Auth flow.
 
-        As a side effect, this function fills in the 'creds' key on the user's
-        session with a map, which maps each auth-type (str) to the relevant
-        identity authenticated by that auth-type (mostly str, but for captcha, bool).
-
         If no auth flows have been completed successfully, raises an
         InteractiveAuthIncompleteError. To handle this, you can use
         synapse.rest.client.v2_alpha._base.interactive_auth_handler as a
@@ -569,6 +565,27 @@ class AuthHandler(BaseHandler):
 
         The session can be used to track data across multiple requests, e.g. for
         interactive authentication.
+
+        Each session has the following keys:
+
+            id:
+                A unique identifier for this session. Passed back to the client
+                and returned for each stage.
+            clientdict:
+                The dictionary from the client root level, not the 'auth' key.
+            ui_auth:
+                A tuple which is checked at each stage of the authentication to
+                ensure that the asked for operation has not changed.
+            creds:
+                A map, which maps each auth-type (str) to the relevant identity
+                authenticated by that auth-type (mostly str, but for captcha, bool).
+            serverdict:
+                A map of data that is stored server-side and cannot be modified
+                by the client.
+            description:
+                A string description of the operation that the current
+                authentication is authorizing.
+
         """
         session_id = None
         while session_id is None or session_id in self.sessions:

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -584,12 +584,13 @@ class AuthHandler(BaseHandler):
                 by the client.
             description:
                 A string description of the operation that the current
-                authentication is authorizing.
+                authentication is authorising.
 
         """
         session_id = None
         while session_id is None or session_id in self.sessions:
             session_id = stringutils.random_string(24)
+
         self.sessions[session_id] = {
             "id": session_id,
             "clientdict": clientdict,

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -557,7 +557,7 @@ class AuthHandler(BaseHandler):
     def _create_session(
         self,
         clientdict: Dict[str, Any],
-        ui_auth: Tuple[str, str, Dict[str, Any]],
+        ui_auth: Tuple[bytes, bytes, Dict[str, Any]],
         description: str,
     ) -> dict:
         """
@@ -585,7 +585,8 @@ class AuthHandler(BaseHandler):
             description:
                 A string description of the operation that the current
                 authentication is authorising.
-
+    Returns:
+        The newly created session.
         """
         session_id = None
         while session_id is None or session_id in self.sessions:
@@ -612,7 +613,7 @@ class AuthHandler(BaseHandler):
         try:
             return self.sessions[session_id]
         except KeyError:
-            raise SynapseError(400, "Unknown session ID: %s" % session_id)
+            raise SynapseError(400, "Unknown session ID: %s" % (session_id,))
 
     async def get_access_token_for_user_id(
         self, user_id: str, device_id: Optional[str], valid_until_ms: Optional[int]


### PR DESCRIPTION
This makes a tweak to the way that UI Auth sessions get created that I think will be necessary to persist UI Auth sessions (for #6705). UI auth sessions are now created explicitly when no session ID is provided (i.e. at the beginning of a UI auth negotiation).

This does have a change of behavior that clients might notice, but I think being stricter here avoids an abuse channel. Instead of lazily creating sessions if the UI Auth session is unknown (e.g. if the session ID is not found) this will now error with an unknown session.

As far as I can tell the [result is unspecced when an unknown session ID](https://matrix.org/docs/spec/client_server/r0.6.0#user-interactive-authentication-api) is provided, so the previous behavior was being generous, but does not need to be supported.