### PR TITLE
Use a template for the SSO success page to allow for customization.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,11 @@
 Next version
 ============
 
-* Two new templates (`sso_auth_confirm.html` and `sso_account_deactivated.html`)
-  were added to Synapse. If your Synapse is configured to use SSO and a custom 
-  `sso_redirect_confirm_template_dir` configuration then these templates will
-  need to be duplicated into that directory.
+* New templates (`sso_auth_confirm.html`, `sso_auth_success.html`, and
+ `sso_account_deactivated.html`) were added to Synapse. If your Synapse is
+ configured to use SSO and a custom  `sso_redirect_confirm_template_dir`
+ configuration then these templates will need to be duplicated into that
+ directory.
 
 * Plugins using the `complete_sso_login` method of `synapse.module_api.ModuleApi`
   should update to using the async/await version `complete_sso_login_async` which

--- a/changelog.d/7279.feature
+++ b/changelog.d/7279.feature
@@ -1,0 +1,1 @@
+ Support SSO in the user interactive authentication workflow.

--- a/synapse/config/sso.py
+++ b/synapse/config/sso.py
@@ -43,6 +43,12 @@ class SSOConfig(Config):
             ),
             "sso_account_deactivated_template",
         )
+        self.sso_auth_success_template = self.read_file(
+            os.path.join(
+                self.sso_redirect_confirm_template_dir, "sso_auth_success.html"
+            ),
+            "sso_auth_success_template",
+        )
 
         self.sso_client_whitelist = sso_config.get("client_whitelist") or []
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1071,12 +1071,12 @@ class AuthHandler(BaseHandler):
         self._save_session(sess)
 
         # Render the HTML and return.
-        html = self._sso_auth_success_template.encode("utf-8")
+        html_bytes = self._sso_auth_success_template.encode("utf-8")
         request.setResponseCode(200)
         request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
-        request.setHeader(b"Content-Length", b"%d" % (len(html),))
+        request.setHeader(b"Content-Length", b"%d" % (len(html_bytes),))
 
-        request.write(html)
+        request.write(html_bytes)
         finish_request(request)
 
     async def complete_sso_login(
@@ -1097,12 +1097,12 @@ class AuthHandler(BaseHandler):
         # flow.
         deactivated = await self.store.get_user_deactivated_status(registered_user_id)
         if deactivated:
-            html = self._sso_account_deactivated_template.encode("utf-8")
+            html_bytes = self._sso_account_deactivated_template.encode("utf-8")
 
             request.setResponseCode(403)
             request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
-            request.setHeader(b"Content-Length", b"%d" % (len(html),))
-            request.write(html)
+            request.setHeader(b"Content-Length", b"%d" % (len(html_bytes),))
+            request.write(html_bytes)
             finish_request(request)
             return
 
@@ -1144,7 +1144,7 @@ class AuthHandler(BaseHandler):
         # URL we redirect users to.
         redirect_url_no_params = client_redirect_url.split("?")[0]
 
-        html = self._sso_redirect_confirm_template.render(
+        html_bytes = self._sso_redirect_confirm_template.render(
             display_url=redirect_url_no_params,
             redirect_url=redirect_url,
             server_name=self._server_name,
@@ -1152,8 +1152,8 @@ class AuthHandler(BaseHandler):
 
         request.setResponseCode(200)
         request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
-        request.setHeader(b"Content-Length", b"%d" % (len(html),))
-        request.write(html)
+        request.setHeader(b"Content-Length", b"%d" % (len(html_bytes),))
+        request.write(html_bytes)
         finish_request(request)
 
     @staticmethod

--- a/synapse/res/templates/sso_auth_success.html
+++ b/synapse/res/templates/sso_auth_success.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+    <title>Authentication</title>
+</head>
+    <body>
+        <div>
+            <p>Thank you</p>
+            <p>You may now close this window and return to the application</p>
+        </div>
+    </body>
+</html>

--- a/synapse/res/templates/sso_auth_success.html
+++ b/synapse/res/templates/sso_auth_success.html
@@ -1,6 +1,13 @@
 <html>
 <head>
-    <title>Authentication</title>
+    <title>Authentication Successful</title>
+    <script>
+    if (window.onAuthDone) {
+        window.onAuthDone();
+    } else if (window.opener && window.opener.postMessage) {
+        window.opener.postMessage("authDone", "*");
+    }
+    </script>
 </head>
     <body>
         <div>

--- a/synapse/rest/client/v2_alpha/auth.py
+++ b/synapse/rest/client/v2_alpha/auth.py
@@ -18,7 +18,6 @@ import logging
 from synapse.api.constants import LoginType
 from synapse.api.errors import SynapseError
 from synapse.api.urls import CLIENT_API_PREFIX
-from synapse.handlers.auth import SUCCESS_TEMPLATE
 from synapse.http.server import finish_request
 from synapse.http.servlet import RestServlet, parse_string
 
@@ -86,6 +85,30 @@ TERMS_TEMPLATE = """
         <input type="submit" value="Agree" />
     </div>
 </form>
+</body>
+</html>
+"""
+
+SUCCESS_TEMPLATE = """
+<html>
+<head>
+<title>Success!</title>
+<meta name='viewport' content='width=device-width, initial-scale=1,
+    user-scalable=no, minimum-scale=1.0, maximum-scale=1.0'>
+<link rel="stylesheet" href="/_matrix/static/client/register/style.css">
+<script>
+if (window.onAuthDone) {
+    window.onAuthDone();
+} else if (window.opener && window.opener.postMessage) {
+     window.opener.postMessage("authDone", "*");
+}
+</script>
+</head>
+<body>
+    <div>
+        <p>Thank you</p>
+        <p>You may now close this window and return to the application</p>
+    </div>
 </body>
 </html>
 """


### PR DESCRIPTION
This fixes a bug from #7102 -- the steps in the SSO authentication flow have customizable templates, except the success template, which was re-used from the fallback authentication flow.

This breaks that dependency and adds a new template for a successful SSO authentication. As part of this I moved the `SUCCESS_TEMPLATE` back to where it used to belong.

I filed #7280 about treating templates better.