### PR TITLE
Improve example TURN configuration

### DIFF
--- a/docs/turn-howto.md
+++ b/docs/turn-howto.md
@@ -113,7 +113,7 @@ Your home server configuration file needs the following extra keys:
 As an example, here is the relevant section of the config file for matrix.org:
 
     turn_uris: [ "turn:turn.matrix.org:3478?transport=udp", "turn:turn.matrix.org:3478?transport=tcp" ]
-    turn_shared_secret: n0t4ctuAllymatr1Xd0TorgSshar3d5ecret4obvIousreAsons
+    turn_shared_secret: "n0t4ctuAllymatr1Xd0TorgSshar3d5ecret4obvIousreAsons"
     turn_user_lifetime: 86400000
     turn_allow_guests: True
 


### PR DESCRIPTION
Should use quotes for turn_shared_secret value, or it will not work

Me and my firends met same problem on this spot. When  you are not familiar with software it is difficult to find why it does not work, when there are no quotes there...