### PR TITLE
On catchup, process each row with its own stream id

### DIFF
--- a/changelog.d/7286.misc
+++ b/changelog.d/7286.misc
@@ -1,0 +1,1 @@
+Move catchup of replication streams logic to worker.

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -15,7 +15,18 @@
 # limitations under the License.
 
 import logging
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+)
 
 from prometheus_client import Counter
 
@@ -268,9 +279,14 @@ class ReplicationCommandHandler:
                     missing_updates,
                 ) = await stream.get_updates_since(current_token, cmd.token)
 
-                for token, row in updates:
+                # TODO: add some tests for this
+
+                # Some streams return multiple rows with the same stream IDs,
+                # which need to be processed in batches.
+
+                for token, rows in _batch_updates(updates):
                     await self.on_rdata(
-                        cmd.stream_name, token, [stream.parse_row(row)],
+                        cmd.stream_name, token, [stream.parse_row(row) for row in rows],
                     )
 
             # We've now caught up to position sent to us, notify handler.
@@ -402,3 +418,49 @@ class ReplicationCommandHandler:
         We need to check if the client is interested in the stream or not
         """
         self.send_command(RdataCommand(stream_name, token, data))
+
+
+UpdateToken = TypeVar("UpdateToken")
+UpdateRow = TypeVar("UpdateRow")
+
+
+def _batch_updates(
+    updates: Iterable[Tuple[UpdateToken, UpdateRow]]
+) -> Iterator[Tuple[UpdateToken, List[UpdateRow]]]:
+    """Collect stream updates with the same token together
+
+    Given a series of updates returned by Stream.get_updates_since(), collects
+    the updates which share the same stream_id together.
+
+    For example:
+
+        [(1, a), (1, b), (2, c), (3, d), (3, e)]
+
+    becomes:
+
+        [
+            (1, [a, b]),
+            (2, [c]),
+            (3, [d, e]),
+        ]
+    """
+
+    update_iter = iter(updates)
+    token, row = next(update_iter)
+
+    current_batch_token = token
+    current_batch = [row]
+
+    for token, row in update_iter:
+        if token != current_batch_token:
+            # different token to the previous row: flush the previous
+            # batch and start anew
+            yield current_batch_token, current_batch
+            current_batch_token = token
+            current_batch = []
+
+        current_batch.append(row)
+
+    # flush the final batch
+    if current_batch_token is not None:
+        yield current_batch_token, current_batch

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -268,11 +268,9 @@ class ReplicationCommandHandler:
                     missing_updates,
                 ) = await stream.get_updates_since(current_token, cmd.token)
 
-                if updates:
+                for token, row in updates:
                     await self.on_rdata(
-                        cmd.stream_name,
-                        current_token,
-                        [stream.parse_row(update[1]) for update in updates],
+                        cmd.stream_name, token, [stream.parse_row(row)],
                     )
 
             # We've now caught up to position sent to us, notify handler.

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -446,10 +446,14 @@ def _batch_updates(
     """
 
     update_iter = iter(updates)
-    token, row = next(update_iter)
 
-    current_batch_token = token
-    current_batch = [row]
+    first_update = next(update_iter, None)
+    if first_update is None:
+        # empty input
+        return
+
+    current_batch_token = first_update[0]
+    current_batch = [first_update[1]]
 
     for token, row in update_iter:
         if token != current_batch_token:
@@ -462,5 +466,4 @@ def _batch_updates(
         current_batch.append(row)
 
     # flush the final batch
-    if current_batch_token is not None:
-        yield current_batch_token, current_batch
+    yield current_batch_token, current_batch

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -126,6 +126,11 @@ class StreamChangeCache(object):
         """
         assert type(stream_pos) is int
 
+        if stream_pos in self._cache:
+            raise NotImplementedError(
+                "more than one entity changing at a stream position"
+            )
+
         if stream_pos > self._earliest_known_stream_pos:
             old_pos = self._entity_to_key.get(entity, None)
             if old_pos is not None:

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -126,14 +126,8 @@ class StreamChangeCache(object):
         """
         assert type(stream_pos) is int
 
-        # sanity-check that we are not going to overwrite existing data.
-        current = self._cache.get(stream_pos)
-        if current is not None:
-            if current != entity:
-                raise NotImplementedError(
-                    "more than one entity changing at a stream position"
-                )
-            return
+        # FIXME: add a sanity check here that we are not overwriting existing
+        # data in self._cache
 
         if stream_pos > self._earliest_known_stream_pos:
             old_pos = self._entity_to_key.get(entity, None)

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -126,10 +126,14 @@ class StreamChangeCache(object):
         """
         assert type(stream_pos) is int
 
-        if stream_pos in self._cache:
-            raise NotImplementedError(
-                "more than one entity changing at a stream position"
-            )
+        # sanity-check that we are not going to overwrite existing data.
+        current = self._cache.get(stream_pos)
+        if current is not None:
+            if current != entity:
+                raise NotImplementedError(
+                    "more than one entity changing at a stream position"
+                )
+            return
 
         if stream_pos > self._earliest_known_stream_pos:
             old_pos = self._entity_to_key.get(entity, None)


### PR DESCRIPTION
Other parts of the code (such as the StreamChangeCache) assume that there will
not be multiple changes with the same stream id.

This code was introduced in #7024, and I hope this fixes #7206.