### PR TITLE
Fix 'generator object is not subscriptable' error

### DIFF
--- a/changelog.d/7290.misc
+++ b/changelog.d/7290.misc
@@ -1,0 +1,1 @@
+Move catchup of replication streams logic to worker.

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -148,8 +148,9 @@ def db_query_to_update_function(
         updates = [(row[0], row[1:]) for row in rows]
         limited = False
         if len(updates) == limit:
-            upto_token = rows[-1][0]
+            upto_token = updates[-1][0]
             limited = True
+        assert len(updates) <= limit
 
         return updates, upto_token, limited
 


### PR DESCRIPTION
Some of the query functions return generators rather than lists, so we can't
index into the result. Happily we already have a copy of the results.

(think this was introduced in #7024)