### PR TITLE
Improve type checking in `replication.tcp.Stream`

### DIFF
--- a/changelog.d/7291.misc
+++ b/changelog.d/7291.misc
@@ -1,0 +1,1 @@
+Improve typing annotations in `synapse.replication.tcp.streams.Stream`.

--- a/synapse/replication/tcp/streams/__init__.py
+++ b/synapse/replication/tcp/streams/__init__.py
@@ -25,8 +25,6 @@ Each stream is defined by the following information:
     update_function:    The function that returns a list of updates between two tokens
 """
 
-from typing import Dict, Type
-
 from synapse.replication.tcp.streams._base import (
     AccountDataStream,
     BackfillStream,
@@ -67,8 +65,7 @@ STREAMS_MAP = {
         GroupServerStream,
         UserSignatureStream,
     )
-}  # type: Dict[str, Type[Stream]]
-
+}
 
 __all__ = [
     "STREAMS_MAP",

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -16,7 +16,7 @@
 
 import logging
 from collections import namedtuple
-from typing import Any, Awaitable, Callable, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Iterable, List, Optional, Tuple
 
 import attr
 
@@ -137,7 +137,7 @@ class Stream(object):
 
 
 def db_query_to_update_function(
-    query_function: Callable[[Token, Token, int], Awaitable[List[tuple]]]
+    query_function: Callable[[Token, Token, int], Awaitable[Iterable[tuple]]]
 ) -> Callable[[Token, Token, int], Awaitable[Tuple[List[StreamRow], Token, bool]]]:
     """Wraps a db query function which returns a list of rows to make it
     suitable for use as an `update_function` for the Stream class

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -21,7 +21,6 @@ from typing import Any, Awaitable, Callable, Iterable, List, Optional, Tuple
 import attr
 
 from synapse.replication.http.streams import ReplicationGetStreamUpdates
-from synapse.types import JsonDict
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +77,7 @@ class Stream(object):
         """
         self.last_token = self.current_token()
 
-    async def get_updates(self) -> Tuple[List[Tuple[Token, JsonDict]], Token, bool]:
+    async def get_updates(self) -> Tuple[List[Tuple[Token, StreamRow]], Token, bool]:
         """Gets all updates since the last time this function was called (or
         since the stream was constructed if it hadn't been called before).
 
@@ -98,7 +97,7 @@ class Stream(object):
 
     async def get_updates_since(
         self, from_token: Token, upto_token: Token, limit: int = 100
-    ) -> Tuple[List[Tuple[Token, JsonDict]], Token, bool]:
+    ) -> Tuple[List[Tuple[Token, StreamRow]], Token, bool]:
         """Like get_updates except allows specifying from when we should
         stream updates
 
@@ -165,7 +164,7 @@ def db_query_to_update_function(
 def make_http_update_function(
     hs, stream_name: str
 ) -> Callable[
-    [Token, Token, Token], Awaitable[Tuple[List[Tuple[Token, StreamRow]], Token, bool]]
+    [Token, Token, int], Awaitable[Tuple[List[Tuple[Token, StreamRow]], Token, bool]]
 ]:
     """Makes a suitable function for use as an `update_function` that queries
     the master process for updates.

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -94,21 +94,19 @@ class Stream(object):
     ):
         """Instantiate a Stream
 
-        current_token_function and update_function are callback which should be
+        current_token_function and update_function are callbacks which should be
         implemented by subclasses.
 
-        currrent_token_function is called to get the current token of
-        the underlying stream.
+        current_token_function is called to get the current token of the underlying
+        stream.
 
         update_function is called to get updates for this stream between a pair of
-        stream tokens. See the UpdateFunction type definition for more info
+        stream tokens. See the UpdateFunction type definition for more info.
 
         Args:
             current_token_function: callback to get the current token, as above
             update_function: callback go get stream updates, as above
-
         """
-
         self.current_token = current_token_function
         self.update_function = update_function
 


### PR DESCRIPTION
The general idea here is to get rid of the `type: ignore` annotations on all of the `current_token` and `update_function` assignments, which would have caught #7290.

After a bit of experimentation, it seems like the least-awful way to do this is to pass the offending functions in as parameters to the `Stream` constructor. Unfortunately that means that the concrete implementations no longer have the same constructor signature as `Stream` itself, which means that it gets hard to correctly annotate `STREAMS_MAP`.

I've also introduced a couple of new types, to take out some duplication.