### PR TITLE
Reduce verbosity of URL cache cleanup.

### DIFF
--- a/changelog.d/7295.misc
+++ b/changelog.d/7295.misc
@@ -1,0 +1,1 @@
+Reduce log verbosity of url cache cleanup tasks.

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -488,6 +488,7 @@ class PreviewUrlResource(DirectServeResource):
         else:
             logger.debug("No media removed from url cache")
 
+
 def decode_and_calc_og(body, media_uri, request_encoding=None):
     from lxml import etree
 

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -402,7 +402,7 @@ class PreviewUrlResource(DirectServeResource):
 
         now = self.clock.time_msec()
 
-        logger.info("Running url preview cache expiry")
+        logger.debug("Running url preview cache expiry")
 
         if not (await self.store.db.updates.has_completed_background_updates()):
             logger.info("Still running DB updates; skipping expiry")
@@ -435,6 +435,8 @@ class PreviewUrlResource(DirectServeResource):
 
         if removed_media:
             logger.info("Deleted %d entries from url cache", len(removed_media))
+        else:
+            logger.debug("No entries removed from url cache")
 
         # Now we delete old images associated with the url cache.
         # These may be cached for a bit on the client (i.e., they
@@ -481,8 +483,10 @@ class PreviewUrlResource(DirectServeResource):
 
         await self.store.delete_url_cache_media(removed_media)
 
-        logger.info("Deleted %d media from url cache", len(removed_media))
-
+        if removed_media:
+            logger.info("Deleted %d media from url cache", len(removed_media))
+        else:
+            logger.debug("No media removed from url cache")
 
 def decode_and_calc_og(body, media_uri, request_encoding=None):
     from lxml import etree


### PR DESCRIPTION
This task runs every 10s, so log at info only if media/urls removed, as low-volume homeservers will be very verbose for little benefit otherwise.

We already skip the "deleted X entries" line if it's zero length.

While setting log level to 'WARN' for this class could also be done, that simply silences the entire process, providing no mix of visibility between no-op actions and actions that did something.
