### PR TITLE
Fix fallback value for account_threepid_delegates.email

### DIFF
--- a/changelog.d/7316.bugfix
+++ b/changelog.d/7316.bugfix
@@ -1,0 +1,1 @@
+Fixed backwards compatibility logic of the first value of `trusted_third_party_id_servers` being used for `account_threepid_delegates.email`, which occurs when the former, deprecated option is set and the latter is not.

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -114,7 +114,7 @@ class EmailConfig(Config):
                 # account_threepid_delegate_email is expected to. Presume https
                 self.account_threepid_delegate_email = (
                     "https://" + first_trusted_identity_server
-                )
+                )  # type: str
                 self.using_identity_server_from_trusted_list = True
             else:
                 raise ConfigError(

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -108,9 +108,12 @@ class EmailConfig(Config):
             if self.trusted_third_party_id_servers:
                 # XXX: It's a little confusing that account_threepid_delegate_email is modified
                 # both in RegistrationConfig and here. We should factor this bit out
-                self.account_threepid_delegate_email = self.trusted_third_party_id_servers[
-                    0
-                ]  # type: Optional[str]
+
+                first_trusted_identity_server = self.trusted_third_party_id_servers[0]
+
+                # This config option does not contain a scheme whereas
+                # account_threepid_delegate_email is expected to. Presume https
+                self.account_threepid_delegate_email = "https://" + first_trusted_identity_server
                 self.using_identity_server_from_trusted_list = True
             else:
                 raise ConfigError(

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import email.utils
 import os
 from enum import Enum
+from typing import Optional
 
 import pkg_resources
 
@@ -110,11 +111,11 @@ class EmailConfig(Config):
 
                 first_trusted_identity_server = self.trusted_third_party_id_servers[0]
 
-                # This config option does not contain a scheme whereas
+                # trusted_third_party_id_servers does not contain a scheme whereas
                 # account_threepid_delegate_email is expected to. Presume https
                 self.account_threepid_delegate_email = (
                     "https://" + first_trusted_identity_server
-                )  # type: str
+                )  # type: Optional[str]
                 self.using_identity_server_from_trusted_list = True
             else:
                 raise ConfigError(

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 import email.utils
 import os
 from enum import Enum
-from typing import Optional
 
 import pkg_resources
 
@@ -113,7 +112,9 @@ class EmailConfig(Config):
 
                 # This config option does not contain a scheme whereas
                 # account_threepid_delegate_email is expected to. Presume https
-                self.account_threepid_delegate_email = "https://" + first_trusted_identity_server
+                self.account_threepid_delegate_email = (
+                    "https://" + first_trusted_identity_server
+                )
                 self.using_identity_server_from_trusted_list = True
             else:
                 raise ConfigError(

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -104,8 +104,8 @@ class RegistrationConfig(Config):
 
         self.bcrypt_rounds = config.get("bcrypt_rounds", 12)
         self.trusted_third_party_id_servers = config.get(
-            "trusted_third_party_id_servers", ["matrix.org", "vector.im"]
-        )
+            "trusted_third_party_id_servers"
+        ) or ["matrix.org", "vector.im"]
         account_threepid_delegates = config.get("account_threepid_delegates") or {}
         self.account_threepid_delegate_email = account_threepid_delegates.get("email")
         self.account_threepid_delegate_msisdn = account_threepid_delegates.get("msisdn")

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -104,8 +104,8 @@ class RegistrationConfig(Config):
 
         self.bcrypt_rounds = config.get("bcrypt_rounds", 12)
         self.trusted_third_party_id_servers = config.get(
-            "trusted_third_party_id_servers"
-        ) or ["matrix.org", "vector.im"]
+            "trusted_third_party_id_servers", ["matrix.org", "vector.im"]
+        )
         account_threepid_delegates = config.get("account_threepid_delegates") or {}
         self.account_threepid_delegate_email = account_threepid_delegates.get("email")
         self.account_threepid_delegate_msisdn = account_threepid_delegates.get("msisdn")


### PR DESCRIPTION
Config option `account_threepid_delegates.email` is expected to be a URL to a identity server, *including* the protocol scheme (https://).

In part of deprecating `trusted_third_party_id_servers`, we state that if `account_threepid_delegates` has not been set, and `trusted_third_party_id_servers` is, then we use the first value from that list as the value for `account_threepid_delegates.email`.

Unfortunately, values from `trusted_third_party_id_servers` do not have a protocol scheme (ex. `example.com`), where `account_threepid_delegates.email` is expected to have a protocol scheme( ex. `https://example.com`).

So this fallback wouldn't have worked. This patch fixes things to presume `https://` for the URL.