### PR TITLE
Stop the master relaying USER_SYNC for other workers

### DIFF
--- a/changelog.d/7318.misc
+++ b/changelog.d/7318.misc
@@ -1,0 +1,1 @@
+Move catchup of replication streams logic to worker.

--- a/docs/tcp_replication.md
+++ b/docs/tcp_replication.md
@@ -196,7 +196,7 @@ Asks the server for the current position of all streams.
 
 #### USER_SYNC (C)
 
-   A user has started or stopped syncing
+   A user has started or stopped syncing on this process.
 
 #### CLEAR_USER_SYNC (C)
 
@@ -215,10 +215,6 @@ Asks the server for the current position of all streams.
 #### INVALIDATE_CACHE (C)
 
    Inform the server a cache should be invalidated
-
-#### SYNC (S, C)
-
-   Used exclusively in tests
 
 ### REMOTE_SERVER_UP (S, C)
 

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -97,6 +97,8 @@ class EventTypes(object):
 
     Retention = "m.room.retention"
 
+    Presence = "m.presence"
+
 
 class RejectedReason(object):
     AUTH_ERROR = "auth_error"

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -386,12 +386,12 @@ class GenericWorkerPresence(BasePresenceHandler):
         stream_id = token
         yield self.notify_from_replication(states, stream_id)
 
-    def get_currently_syncing_users(self) -> Set[str]:
-        return {
+    def get_currently_syncing_users_for_replication(self) -> Iterable[str]:
+        return [
             user_id
             for user_id, count in self._user_to_num_current_syncs.items()
             if count > 0
-        }
+        ]
 
 
 class GenericWorkerTyping(object):

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -38,7 +38,11 @@ from synapse.config.homeserver import HomeServerConfig
 from synapse.config.logger import setup_logging
 from synapse.federation import send_queue
 from synapse.federation.transport.server import TransportLayerServer
-from synapse.handlers.presence import PresenceHandler, get_interested_parties
+from synapse.handlers.presence import (
+    AbstractPresenceHandler,
+    PresenceHandler,
+    get_interested_parties,
+)
 from synapse.http.server import JsonResource
 from synapse.http.servlet import RestServlet, parse_json_object_from_request
 from synapse.http.site import SynapseSite
@@ -224,7 +228,7 @@ class KeyUploadServlet(RestServlet):
 UPDATE_SYNCING_USERS_MS = 10 * 1000
 
 
-class GenericWorkerPresence(object):
+class GenericWorkerPresence(AbstractPresenceHandler):
     def __init__(self, hs):
         self.hs = hs
         self.is_mine_id = hs.is_mine_id

--- a/synapse/handlers/initial_sync.py
+++ b/synapse/handlers/initial_sync.py
@@ -381,10 +381,16 @@ class InitialSyncHandler(BaseHandler):
                 return []
 
             states = await presence_handler.get_states(
-                [m.user_id for m in room_members], as_event=True
+                [m.user_id for m in room_members]
             )
 
-            return states
+            return [
+                {
+                    "type": EventTypes.Presence,
+                    "content": format_user_presence_state(s, time_now),
+                }
+                for s in states
+            ]
 
         async def get_receipts():
             receipts = await self.store.get_linearized_receipts_for_room(

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -122,8 +122,8 @@ class BasePresenceHandler(abc.ABC):
         when users disconnect/reconnect.
 
         Args:
-            user_id (str)
-            affect_presence (bool): If false this function will be a no-op.
+            user_id: the user that is starting a sync
+            affect_presence: If false this function will be a no-op.
                 Useful for streams that are not associated with an actual
                 client that is being used by a user.
         """

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -130,14 +130,14 @@ class BasePresenceHandler(abc.ABC):
 
     @abc.abstractmethod
     def get_currently_syncing_users_for_replication(self) -> Iterable[str]:
-        """Get the set of syncing users on this worker, to send to the presence handler
+        """Get an iterable of syncing users on this worker, to send to the presence handler
 
         This is called when a replication connection is established. It should return
         a list of user ids, which are then sent as USER_SYNC commands to inform the
         process handling presence about those users.
 
         Returns:
-            A set of user_id strings.
+            An iterable of user_id strings.
         """
 
     async def get_state(self, target_user: UserID) -> UserPresenceState:

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -210,7 +210,10 @@ class ReplicateCommand(Command):
 
 class UserSyncCommand(Command):
     """Sent by the client to inform the server that a user has started or
-    stopped syncing. Used to calculate presence on the master.
+    stopped syncing on this process.
+
+    This is used by the process handling presence (typically the master) to
+    calculate who is online and who is not.
 
     Includes a timestamp of when the last user sync was.
 
@@ -218,7 +221,7 @@ class UserSyncCommand(Command):
 
         USER_SYNC <instance_id> <user_id> <state> <last_sync_ms>
 
-    Where <state> is either "start" or "stop"
+    Where <state> is either "start" or "end"
     """
 
     NAME = "USER_SYNC"

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -301,13 +301,6 @@ class ReplicationCommandHandler:
         if self._is_master:
             self._notifier.notify_remote_server_up(cmd.data)
 
-    def get_currently_syncing_users(self):
-        """Get the list of currently syncing users (if any). This is called
-        when a connection has been established and we need to send the
-        currently syncing users.
-        """
-        return self._presence_handler.get_currently_syncing_users()
-
     def new_connection(self, connection: AbstractConnection):
         """Called when we have a new connection.
         """
@@ -325,9 +318,11 @@ class ReplicationCommandHandler:
         if self._factory:
             self._factory.resetDelay()
 
-        # Tell the server if we have any users currently syncing (should only
-        # happen on synchrotrons)
-        currently_syncing = self.get_currently_syncing_users()
+        # Tell the other end if we have any users currently syncing.
+        currently_syncing = (
+            self._presence_handler.get_currently_syncing_users_for_replication()
+        )
+
         now = self._clock.time_msec()
         for user_id in currently_syncing:
             connection.send_command(

--- a/synapse/server.pyi
+++ b/synapse/server.pyi
@@ -97,9 +97,7 @@ class HomeServer(object):
         pass
     def get_notifier(self) -> synapse.notifier.Notifier:
         pass
-    def get_presence_handler(
-        self,
-    ) -> synapse.handlers.presence.AbstractPresenceHandler:
+    def get_presence_handler(self) -> synapse.handlers.presence.BasePresenceHandler:
         pass
     def get_clock(self) -> synapse.util.Clock:
         pass

--- a/synapse/server.pyi
+++ b/synapse/server.pyi
@@ -97,7 +97,9 @@ class HomeServer(object):
         pass
     def get_notifier(self) -> synapse.notifier.Notifier:
         pass
-    def get_presence_handler(self) -> synapse.handlers.presence.PresenceHandler:
+    def get_presence_handler(
+        self,
+    ) -> synapse.handlers.presence.AbstractPresenceHandler:
         pass
     def get_clock(self) -> synapse.util.Clock:
         pass


### PR DESCRIPTION
Long story short: if we're handling presence on the current worker, we shouldn't be sending USER_SYNC commands over replication.

In an attempt to figure out what is going on here, I ended up refactoring some bits of the presencehandler code, so the first 4 commits here are non-functional refactors to move this code slightly closer to sanity. (There's still plenty to do here :/). Suggest reviewing individual commits.

Fixes (I hope) #7257.