### PR TITLE
Reduce federation logging on success

### DIFF
--- a/changelog.d/7321.misc
+++ b/changelog.d/7321.misc
@@ -1,0 +1,1 @@
+Reduce logging verbosity for successful federation requests.

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -434,7 +434,6 @@ class MatrixFederationHttpClient(object):
                         logger.info("Failed to send request: %s", e)
                         raise_from(RequestSendFailed(e, can_retry=True), e)
 
-
                     incoming_responses_counter.labels(method_bytes, response.code).inc()
 
                     set_tag(tags.HTTP_STATUS_CODE, response.code)

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -434,21 +434,28 @@ class MatrixFederationHttpClient(object):
                         logger.info("Failed to send request: %s", e)
                         raise_from(RequestSendFailed(e, can_retry=True), e)
 
-                    logger.info(
-                        "{%s} [%s] Got response headers: %d %s",
-                        request.txn_id,
-                        request.destination,
-                        response.code,
-                        response.phrase.decode("ascii", errors="replace"),
-                    )
 
                     incoming_responses_counter.labels(method_bytes, response.code).inc()
 
                     set_tag(tags.HTTP_STATUS_CODE, response.code)
 
                     if 200 <= response.code < 300:
+                        logger.debug(
+                            "{%s} [%s] Got response headers: %d %s",
+                            request.txn_id,
+                            request.destination,
+                            response.code,
+                            response.phrase.decode("ascii", errors="replace"),
+                        )
                         pass
                     else:
+                        logger.info(
+                            "{%s} [%s] Got response headers: %d %s",
+                            request.txn_id,
+                            request.destination,
+                            response.code,
+                            response.phrase.decode("ascii", errors="replace"),
+                        )
                         # :'(
                         # Update transactions table?
                         d = treq.content(response)


### PR DESCRIPTION
When we successfully transmit over federation we log the following lines:
```
2020-04-21 00:00:25,111 - synapse.http.matrixfederationclient - 442 - INFO - federation_transaction_transmission_loop-15561448 - {PUT-O-13904925} [matrix.hostname] Got response headers: 200 OK
2020-04-21 00:00:25,111 - synapse.http.matrixfederationclient - 164 - INFO - federation_transaction_transmission_loop-15561448 - {PUT-O-13904925} [matrix.hostname] Completed: 200 OK
2020-04-21 00:00:25,112 - synapse.federation.sender.transaction_manager - 150 - INFO - federation_transaction_transmission_loop-15561448 - TX [matrix.hostname] {1587140000000} got 200 response
```

Looking at this, we are logging the same data three different ways, during the successful flow. Only about 0.5% of these log lines do not contain "200 OK". Moving just one of these lines to debug allows them to be filtered out, and with the matrix.org logs, this would save about 15% of the log lines written to this file each day, while still retaining the failures and retries if needed.
