### PR TITLE
reCaptcha docs: add note about vector-domain

### DIFF
--- a/docs/CAPTCHA_SETUP.md
+++ b/docs/CAPTCHA_SETUP.md
@@ -10,6 +10,8 @@ Requires a site/secret key pair from:
 
 Must be a reCAPTCHA v2 key using the "I'm not a robot" Checkbox option
 
+**NOTE**: If you're planning on allowing registration from within the Riot Desktop client and you want to leave "Verify the origin of reCAPTCHA solutions" checked, you need to add `vector` to your domains, i.e. Domains: `matrix.mydomain.com` and `vector` (yes, without the `.im`).
+
 ## Setting ReCaptcha Keys
 
 The keys are a config option on the home server config. If they are not


### PR DESCRIPTION
I'm not sure this place in the docs is correct because I get that there are other matrix clients and this is a very specific clients need.
But a) most people are probably using Riot as of now and b) from Riots perspective there is no documentation on Captcha because it's not really their scope either.

PS: I didnt work through the codying style etc checkboxes because this only concerns docs. Hope that's okay?

PPS: https://github.com/vector-im/riot-web/issues/13307 here's a ticket about this