### PR TITLE
Add information about client delegation

### DIFF
--- a/changelog.d/7332.doc
+++ b/changelog.d/7332.doc
@@ -1,0 +1,1 @@
+Add information about setting up client-side well-known files.

--- a/docs/delegate.md
+++ b/docs/delegate.md
@@ -41,7 +41,8 @@ to 8448.
 With .well-known delegation, federating servers will check for a valid TLS
 certificate for the delegated hostname (in our example: `synapse.example.com`).
 
-The URL `https://<server_name>/.well-known/matrix/client` is used by clients to lookup your homeserver
+The URL `https://<server_name>/.well-known/matrix/client` is used by clients to
+find the web location of where Client-Server endpoints are available.
 
 In our example, this would mean that URL `https://example.com/.well-known/matrix/client`
 should return:
@@ -53,9 +54,10 @@ should return:
     }
 }
 ```
-This url is accesed from a Browser and you need to allow cross site access via HTTP header
- `Access-Control-Allow-Origin: *`
- 
+
+As users may access this file from from a web-based matrix client on a different domain,
+you must allow cross site access by configuring your web server to return the HTTP header
+`Access-Control-Allow-Origin: *`.
 
 ## SRV DNS record delegation
 

--- a/docs/delegate.md
+++ b/docs/delegate.md
@@ -41,6 +41,22 @@ to 8448.
 With .well-known delegation, federating servers will check for a valid TLS
 certificate for the delegated hostname (in our example: `synapse.example.com`).
 
+The URL `https://<server_name>/.well-known/matrix/client` is used by clients to lookup your homeserver
+
+In our example, this would mean that URL `https://example.com/.well-known/matrix/client`
+should return:
+
+```json
+{
+    "m.homeserver": {
+        "base_url": "https://synapse.example.com"
+    }
+}
+```
+This url is accesed from a Browser and you need to allow cross site access via HTTP header
+ `Access-Control-Allow-Origin: *`
+ 
+
 ## SRV DNS record delegation
 
 It is also possible to do delegation using a SRV DNS record. However, that is


### PR DESCRIPTION
Delegation also requires .well-known/matrix/client for clients to find the homeserver
