### PR TITLE
Remove bind_email parameter from register_user

### DIFF
--- a/changelog.d/7336.misc
+++ b/changelog.d/7336.misc
@@ -1,0 +1,1 @@
+Remove code that became unused in #5964.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -140,7 +140,6 @@ class RegistrationHandler(BaseHandler):
         user_type=None,
         default_display_name=None,
         address=None,
-        bind_emails=[],
     ):
         """Registers a new client on the server.
 
@@ -250,19 +249,6 @@ class RegistrationHandler(BaseHandler):
                 "Skipping auto-join for %s because consent is required at registration",
                 user_id,
             )
-
-        # Bind any specified emails to this account
-        current_time = self.hs.get_clock().time_msec()
-        for email in bind_emails:
-            # generate threepid dict
-            threepid_dict = {
-                "medium": "email",
-                "address": email,
-                "validated_at": current_time,
-            }
-
-            # Bind email to new account
-            yield self._register_email_threepid(user_id, threepid_dict, None)
 
         return user_id
 

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -89,7 +89,7 @@ class ModuleApi(object):
         return defer.ensureDeferred(self._auth_handler.check_user_exists(user_id))
 
     @defer.inlineCallbacks
-    def register(self, localpart, displayname=None, emails=[]):
+    def register(self, localpart, displayname=None):
         """Registers a new user with given localpart and optional displayname, emails.
 
         Also returns an access token for the new user.
@@ -101,7 +101,6 @@ class ModuleApi(object):
         Args:
             localpart (str): The localpart of the new user.
             displayname (str|None): The displayname of the new user.
-            emails (List[str]): Emails to bind to the new user.
 
         Returns:
             Deferred[tuple[str, str]]: a 2-tuple of (user_id, access_token)
@@ -109,11 +108,11 @@ class ModuleApi(object):
         logger.warning(
             "Using deprecated ModuleApi.register which creates a dummy user device."
         )
-        user_id = yield self.register_user(localpart, displayname, emails)
+        user_id = yield self.register_user(localpart, displayname)
         _, access_token = yield self.register_device(user_id)
         return user_id, access_token
 
-    def register_user(self, localpart, displayname=None, emails=[]):
+    def register_user(self, localpart, displayname=None):
         """Registers a new user with given localpart and optional displayname, emails.
 
         Args:
@@ -129,7 +128,7 @@ class ModuleApi(object):
             Deferred[str]: user_id
         """
         return self._hs.get_registration_handler().register_user(
-            localpart=localpart, default_display_name=displayname, bind_emails=emails
+            localpart=localpart, default_display_name=displayname
         )
 
     def register_device(self, user_id, device_id=None, initial_display_name=None):


### PR DESCRIPTION
As far as I can tell, this was only used by the `bind_email` parameter which was removed in https://github.com/matrix-org/synapse/pull/5964.

Emails added during registration still happen in `post_registration_actions`:

https://github.com/matrix-org/synapse/blob/2d6d4fa8aff7187b33fa00147703a802c1c80c95/synapse/handlers/register.py#L556-L565