### PR TITLE
Validate that integers are in the proper range while decoding JSON.

### DIFF
--- a/changelog.d/7356.bugfix
+++ b/changelog.d/7356.bugfix
@@ -1,0 +1,1 @@
+Validate that integers are in the proper range while decoding JSON.

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -22,9 +22,9 @@ from typing import Dict, List
 from six import iteritems
 from six.moves import http_client
 
-from canonicaljson import json
-
 from twisted.web import http
+
+from synapse.util.json import safe_loads
 
 logger = logging.getLogger(__name__)
 
@@ -575,7 +575,7 @@ class HttpResponseException(CodeMessageException):
         # try to parse the body as json, to get better errcode/msg, but
         # default to M_UNKNOWN with the HTTP status as the error text
         try:
-            j = json.loads(self.response)
+            j = safe_loads(self.response)
         except ValueError:
             j = {}
 

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -20,7 +20,6 @@
 import logging
 import urllib.parse
 
-from canonicaljson import json
 from signedjson.key import decode_verify_key_bytes
 from signedjson.sign import verify_signed_json
 from unpaddedbase64 import decode_base64
@@ -38,6 +37,7 @@ from synapse.api.errors import (
 from synapse.config.emailconfig import ThreepidBehaviour
 from synapse.http.client import SimpleHttpClient
 from synapse.util.hash import sha256_and_url_safe_base64
+from synapse.util.json import safe_loads
 from synapse.util.stringutils import assert_valid_client_secret, random_string
 
 from ._base import BaseHandler
@@ -181,7 +181,7 @@ class IdentityHandler(BaseHandler):
         except TimeoutError:
             raise SynapseError(500, "Timed out contacting identity server")
         except CodeMessageException as e:
-            data = json.loads(e.msg)  # XXX WAT?
+            data = safe_loads(e.msg)  # XXX WAT?
             return data
 
         logger.info("Got 404 when POSTing JSON %s, falling back to v1 URL", bind_url)

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 from six import iteritems, itervalues, string_types
 
-from canonicaljson import encode_canonical_json, json
+from canonicaljson import encode_canonical_json
 
 from twisted.internet import defer
 from twisted.internet.defer import succeed
@@ -51,6 +51,7 @@ from synapse.storage.state import StateFilter
 from synapse.types import Collection, RoomAlias, UserID, create_requester
 from synapse.util.async_helpers import Linearizer
 from synapse.util.frozenutils import frozendict_json_encoder
+from synapse.util.json import safe_loads
 from synapse.util.metrics import measure_func
 from synapse.visibility import filter_events_for_client
 
@@ -813,7 +814,7 @@ class EventCreationHandler(object):
         # Ensure that we can round trip before trying to persist in db
         try:
             dump = frozendict_json_encoder.encode(event.content)
-            json.loads(dump)
+            safe_loads(dump)
         except Exception:
             logger.exception("Failed to encode content: %r", event.content)
             raise

--- a/synapse/handlers/ui_auth/checkers.py
+++ b/synapse/handlers/ui_auth/checkers.py
@@ -14,14 +14,13 @@
 # limitations under the License.
 import logging
 
-from canonicaljson import json
-
 from twisted.internet import defer
 from twisted.web.client import PartialDownloadError
 
 from synapse.api.constants import LoginType
 from synapse.api.errors import Codes, LoginError, SynapseError
 from synapse.config.emailconfig import ThreepidBehaviour
+from synapse.util.json import safe_loads
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +116,7 @@ class RecaptchaAuthChecker(UserInteractiveAuthChecker):
         except PartialDownloadError as pde:
             # Twisted is silly
             data = pde.response
-            resp_body = json.loads(data)
+            resp_body = safe_loads(data)
 
         if "success" in resp_body:
             # Note that we do NOT check the hostname here: we explicitly

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -21,7 +21,7 @@ from six import raise_from, text_type
 from six.moves import urllib
 
 import treq
-from canonicaljson import encode_canonical_json, json
+from canonicaljson import encode_canonical_json
 from netaddr import IPAddress
 from prometheus_client import Counter
 from zope.interface import implementer, provider
@@ -50,6 +50,7 @@ from synapse.logging.context import make_deferred_yieldable
 from synapse.logging.opentracing import set_tag, start_active_span, tags
 from synapse.util.async_helpers import timeout_deferred
 from synapse.util.caches import CACHE_SIZE_FACTOR
+from synapse.util.json import safe_loads
 
 logger = logging.getLogger(__name__)
 
@@ -370,7 +371,7 @@ class SimpleHttpClient(object):
         body = yield make_deferred_yieldable(readBody(response))
 
         if 200 <= response.code < 300:
-            return json.loads(body)
+            return safe_loads(body)
         else:
             raise HttpResponseException(response.code, response.phrase, body)
 
@@ -410,7 +411,7 @@ class SimpleHttpClient(object):
         body = yield make_deferred_yieldable(readBody(response))
 
         if 200 <= response.code < 300:
-            return json.loads(body)
+            return safe_loads(body)
         else:
             raise HttpResponseException(response.code, response.phrase, body)
 
@@ -435,7 +436,7 @@ class SimpleHttpClient(object):
             ValueError: if the response was not JSON
         """
         body = yield self.get_raw(uri, args, headers=headers)
-        return json.loads(body)
+        return safe_loads(body)
 
     @defer.inlineCallbacks
     def put_json(self, uri, json_body, args={}, headers=None):
@@ -478,7 +479,7 @@ class SimpleHttpClient(object):
         body = yield make_deferred_yieldable(readBody(response))
 
         if 200 <= response.code < 300:
-            return json.loads(body)
+            return safe_loads(body)
         else:
             raise HttpResponseException(response.code, response.phrase, body)
 

--- a/synapse/http/federation/well_known_resolver.py
+++ b/synapse/http/federation/well_known_resolver.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 import random
 import time
@@ -27,6 +26,7 @@ from twisted.web.http import stringToDatetime
 from synapse.logging.context import make_deferred_yieldable
 from synapse.util import Clock
 from synapse.util.caches.ttlcache import TTLCache
+from synapse.util.json import safe_loads
 from synapse.util.metrics import Measure
 
 # period to cache .well-known results for by default
@@ -174,7 +174,7 @@ class WellKnownResolver(object):
             if response.code != 200:
                 raise Exception("Non-200 response %s" % (response.code,))
 
-            parsed_body = json.loads(body.decode("utf-8"))
+            parsed_body = safe_loads(body.decode("utf-8"))
             logger.info("Response from .well-known: %s", parsed_body)
 
             result = parsed_body["m.server"].encode("ascii")

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -17,9 +17,8 @@
 
 import logging
 
-from canonicaljson import json
-
 from synapse.api.errors import Codes, SynapseError
+from synapse.util.json import safe_loads
 
 logger = logging.getLogger(__name__)
 
@@ -214,16 +213,8 @@ def parse_json_value_from_request(request, allow_empty_body=False):
     if not content_bytes and allow_empty_body:
         return None
 
-    # Decode to Unicode so that simplejson will return Unicode strings on
-    # Python 2
     try:
-        content_unicode = content_bytes.decode("utf8")
-    except UnicodeDecodeError:
-        logger.warning("Unable to decode UTF-8")
-        raise SynapseError(400, "Content not JSON.", errcode=Codes.NOT_JSON)
-
-    try:
-        content = json.loads(content_unicode)
+        content = safe_loads(content_bytes)
     except Exception as e:
         logger.warning("Unable to parse JSON: %s", e)
         raise SynapseError(400, "Content not JSON.", errcode=Codes.NOT_JSON)

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -21,8 +21,6 @@ from typing import List, Optional
 
 from six.moves.urllib import parse as urlparse
 
-from canonicaljson import json
-
 from synapse.api.constants import EventTypes, Membership
 from synapse.api.errors import (
     AuthError,
@@ -46,6 +44,7 @@ from synapse.rest.client.v2_alpha._base import client_patterns
 from synapse.storage.state import StateFilter
 from synapse.streams.config import PaginationConfig
 from synapse.types import RoomAlias, RoomID, StreamToken, ThirdPartyInstanceID, UserID
+from synapse.util.json import safe_loads
 
 MYPY = False
 if MYPY:
@@ -517,7 +516,7 @@ class RoomMessageListRestServlet(RestServlet):
         filter_bytes = parse_string(request, b"filter", encoding=None)
         if filter_bytes:
             filter_json = urlparse.unquote(filter_bytes.decode("UTF-8"))
-            event_filter = Filter(json.loads(filter_json))  # type: Optional[Filter]
+            event_filter = Filter(safe_loads(filter_json))  # type: Optional[Filter]
             if (
                 event_filter
                 and event_filter.filter_json.get("event_format", "client")
@@ -629,7 +628,7 @@ class RoomEventContextServlet(RestServlet):
         filter_bytes = parse_string(request, "filter")
         if filter_bytes:
             filter_json = urlparse.unquote(filter_bytes)
-            event_filter = Filter(json.loads(filter_json))  # type: Optional[Filter]
+            event_filter = Filter(safe_loads(filter_json))  # type: Optional[Filter]
         else:
             event_filter = None
 

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -16,8 +16,6 @@
 import itertools
 import logging
 
-from canonicaljson import json
-
 from synapse.api.constants import PresenceState
 from synapse.api.errors import Codes, StoreError, SynapseError
 from synapse.api.filtering import DEFAULT_FILTER_COLLECTION, FilterCollection
@@ -29,6 +27,7 @@ from synapse.handlers.presence import format_user_presence_state
 from synapse.handlers.sync import SyncConfig
 from synapse.http.servlet import RestServlet, parse_boolean, parse_integer, parse_string
 from synapse.types import StreamToken
+from synapse.util.json import safe_loads
 
 from ._base import client_patterns, set_timeline_upper_limit
 
@@ -125,7 +124,7 @@ class SyncRestServlet(RestServlet):
             filter_collection = DEFAULT_FILTER_COLLECTION
         elif filter_id.startswith("{"):
             try:
-                filter_object = json.loads(filter_id)
+                filter_object = safe_loads(filter_id)
                 set_timeline_upper_limit(
                     filter_object, self.hs.config.filter_timeline_limit
                 )

--- a/synapse/util/json.py
+++ b/synapse/util/json.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shorthand to use simplejson if it is available.
+from canonicaljson import json
+
+
+def _safe_int(s: str) -> int:
+    """
+    Parse an integer from a string, but reject integers outside the valid JSON range.
+
+    THe range of valid integers for JSON is defined as [-2 ^ 53 + 1, 2 ^ 53 -1],
+    per RFC 7159.
+    """
+    res = int(s)
+    if -2 ** 53 < res < 2 ** 53:
+        return res
+    raise ValueError("Invalid int literal: %s" % s)
+
+
+_decoder = json.JSONDecoder(parse_int=_safe_int)
+
+
+def safe_loads(content_bytes):
+    """
+    Load a JSON document while abiding by the RFC limitations.
+
+    This should be used for any external JSON parsed by Synapse.
+    """
+    return _decoder.decode(content_bytes)

--- a/synapse/util/json.py
+++ b/synapse/util/json.py
@@ -25,7 +25,7 @@ def _safe_int(s: str) -> int:
     per RFC 7159.
     """
     res = int(s)
-    if -2 ** 53 < res < 2 ** 53:
+    if -(2 ** 53) < res < 2 ** 53:
         return res
     raise ValueError("Invalid int literal: %s" % s)
 


### PR DESCRIPTION
Per [the Matrix specification](https://matrix.org/docs/spec/appendices#canonical-json), canonical JSON needs to limit integers in JSON to the range of [-2 ^ 53 + 1, 2 ^ 53 + 1] to match [RFC 7159](https://tools.ietf.org/html/rfc7159).

This PR enforces this restriction in Synapse for all "incoming" JSON data that is deserialized by Synapse, including:
* The client-server API.
* The server-server API.
* The identity server API.
* The push gateway API.

This is mostly done via modifying the core areas that parse JSON from HTTP queries and HTTP responses.

This does **NOT** make any changes to:
* The replication API (which uses JSON internally within Synapse workers).
* Data that is sent via Synapse.
* Loading of JSON data from the database.

My hope is that this will mean nothing in Synapse will break if a database already has bad data in it.

Note that I do not believe this is really part of the "canonicaljson" package since the APIs should not be using these invalid values anyway. After this change, anytime we generate a canonicaljson value it should be *after* the JSON has been validated, so it should already abide by these rules.