### PR TITLE
Fix collation for postgres for unit tests

### DIFF
--- a/changelog.d/7359.misc
+++ b/changelog.d/7359.misc
@@ -1,0 +1,1 @@
+Fix collation for postgres for unit tests.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -74,7 +74,10 @@ def setupdb():
         db_conn.autocommit = True
         cur = db_conn.cursor()
         cur.execute("DROP DATABASE IF EXISTS %s;" % (POSTGRES_BASE_DB,))
-        cur.execute("CREATE DATABASE %s;" % (POSTGRES_BASE_DB,))
+        cur.execute(
+            "CREATE DATABASE %s ENCODING 'UTF8' LC_COLLATE='C' LC_CTYPE='C' "
+            "template=template0;" % (POSTGRES_BASE_DB,)
+        )
         cur.close()
         db_conn.close()
 


### PR DESCRIPTION
When running the UTs against a postgres database, we need to set the collation
correctly.