### PR TITLE
Apply federation check for /publicRooms with filter list

### DIFF
--- a/changelog.d/7367.bugfix
+++ b/changelog.d/7367.bugfix
@@ -1,1 +1,1 @@
-Prevent non-federating rooms from appearing in responses to `POST /publicRoom` when a filter was included.
+Prevent non-federating rooms from appearing in responses to federated `POST /publicRoom` requests when a filter was included.

--- a/changelog.d/7367.bugfix
+++ b/changelog.d/7367.bugfix
@@ -1,0 +1,1 @@
+Prevent non-federating rooms from appearing in responses to `POST /publicRoom` when a filter was included.

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -90,7 +90,11 @@ class RoomListHandler(BaseHandler):
             logger.info("Bypassing cache as search request.")
 
             return self._get_public_room_list(
-                limit, since_token, search_filter, network_tuple=network_tuple
+                limit,
+                since_token,
+                search_filter,
+                network_tuple=network_tuple,
+                from_federation=from_federation,
             )
 
         key = (limit, since_token, network_tuple)


### PR DESCRIPTION
Fixes: https://github.com/matrix-org/synapse/issues/7366

The `from_federation` parameter determines whether to mutate the `/publicRooms` response based on whether the request is coming from another homeserver or a local client.

Currently this is only used for determining whether to show rooms that are set to not federate. This missing parameter meant that these rooms would be shown to other servers if they providing a filter with their `/publicRooms` query.

Missed in #4736: https://github.com/matrix-org/synapse/pull/4736/files#diff-a78cb67d0a36ffde4ccd3d5c78c25a13R85