### PR TITLE
Further improvements to requesting the public rooms list on a homeserver which has it set to private

### DIFF
--- a/changelog.d/7368.bugfix
+++ b/changelog.d/7368.bugfix
@@ -1,0 +1,1 @@
+Improve error responses when accessing remote public room lists.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -889,7 +889,7 @@ class FederationClient(FederationBase):
         search_filter: Optional[Dict] = None,
         include_all_networks: bool = False,
         third_party_instance_id: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Dict[str, Any]:
         """Get the list of public rooms from a remote homeserver
 
         Args:
@@ -912,9 +912,6 @@ class FederationClient(FederationBase):
                 requests over federation
 
         """
-        if remote_server == self.server_name:
-            return
-
         return self.transport_layer.get_public_rooms(
             remote_server,
             limit,

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -889,7 +889,7 @@ class FederationClient(FederationBase):
         search_filter: Optional[Dict] = None,
         include_all_networks: bool = False,
         third_party_instance_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ):
         """Get the list of public rooms from a remote homeserver
 
         Args:
@@ -903,8 +903,8 @@ class FederationClient(FederationBase):
                 party instance
 
         Returns:
-            The response from the remote server, or None if `remote_server` is the same as the
-            local server_name
+            Deferred[Dict[str, Any]]: The response from the remote server, or None if
+            `remote_server` is the same as the local server_name
 
         Raises:
             HttpResponseException: There was an exception returned from the remote server

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -883,18 +883,40 @@ class FederationClient(FederationBase):
 
     def get_public_rooms(
         self,
-        destination,
-        limit=None,
-        since_token=None,
-        search_filter=None,
-        include_all_networks=False,
-        third_party_instance_id=None,
-    ):
-        if destination == self.server_name:
+        remote_server: str,
+        limit: Optional[int] = None,
+        since_token: Optional[str] = None,
+        search_filter: Optional[Dict] = None,
+        include_all_networks: bool = False,
+        third_party_instance_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Get the list of public rooms from a remote homeserver
+
+        Args:
+            remote_server: The name of the remote server
+            limit: Maximum amount of rooms to return
+            since_token: Used for result pagination
+            search_filter: A filter dictionary to send the remote homeserver
+                and filter the result set
+            include_all_networks: Whether to include results from all third party instances
+            third_party_instance_id: Whether to only include results from a specific third
+                party instance
+
+        Returns:
+            The response from the remote server, or None if `remote_server` is the same as the
+            local server_name
+
+        Raises:
+            HttpResponseException: There was an exception returned from the remote server
+            SynapseException: M_FORBIDDEN when the remote server has disallowed publicRoom
+                requests over federation
+
+        """
+        if remote_server == self.server_name:
             return
 
         return self.transport_layer.get_public_rooms(
-            destination,
+            remote_server,
             limit,
             since_token,
             search_filter,

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from six.moves import urllib
 
@@ -327,13 +327,18 @@ class TransportLayerClient(object):
     @log_function
     def get_public_rooms(
         self,
-        remote_server,
-        limit,
-        since_token,
-        search_filter=None,
-        include_all_networks=False,
-        third_party_instance_id=None,
-    ):
+        remote_server: str,
+        limit: Optional[int] = None,
+        since_token: Optional[str] = None,
+        search_filter: Optional[Dict] = None,
+        include_all_networks: bool = False,
+        third_party_instance_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get the list of public rooms from a remote homeserver
+
+        See synapse.federation.federation_client.FederationClient.get_public_rooms for
+        more information.
+        """
         if search_filter:
             # this uses MSC2197 (Search Filtering over Federation)
             path = _create_v1_path("/publicRooms")

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -22,13 +22,13 @@ from six.moves import urllib
 from twisted.internet import defer
 
 from synapse.api.constants import Membership
+from synapse.api.errors import Codes, HttpResponseException, SynapseError
 from synapse.api.urls import (
     FEDERATION_UNSTABLE_PREFIX,
     FEDERATION_V1_PREFIX,
     FEDERATION_V2_PREFIX,
 )
 from synapse.logging.utils import log_function
-from synapse.api.errors import Codes, HttpResponseException, SynapseError
 
 logger = logging.getLogger(__name__)
 
@@ -333,7 +333,7 @@ class TransportLayerClient(object):
         search_filter: Optional[Dict] = None,
         include_all_networks: bool = False,
         third_party_instance_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ):
         """Get the list of public rooms from a remote homeserver
 
         See synapse.federation.federation_client.FederationClient.get_public_rooms for
@@ -361,7 +361,8 @@ class TransportLayerClient(object):
                 if e.code == 403:
                     raise SynapseError(
                         403,
-                        "You are not allowed to view the public rooms list of %s" % (remote_server,),
+                        "You are not allowed to view the public rooms list of %s"
+                        % (remote_server,),
                         errcode=Codes.FORBIDDEN,
                     )
                 raise
@@ -386,7 +387,8 @@ class TransportLayerClient(object):
                 if e.code == 403:
                     raise SynapseError(
                         403,
-                        "You are not allowed to view the public rooms list of %s" % (remote_server,),
+                        "You are not allowed to view the public rooms list of %s"
+                        % (remote_server,),
                         errcode=Codes.FORBIDDEN,
                     )
                 raise

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -343,7 +343,9 @@ class TransportLayerClient(object):
             # this uses MSC2197 (Search Filtering over Federation)
             path = _create_v1_path("/publicRooms")
 
-            data = {"include_all_networks": "true" if include_all_networks else "false"}
+            data = {
+                "include_all_networks": "true" if include_all_networks else "false"
+            }  # type: Dict[str, Any]
             if third_party_instance_id:
                 data["third_party_instance_id"] = third_party_instance_id
             if limit:

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -361,7 +361,7 @@ class TransportLayerClient(object):
                 if e.code == 403:
                     raise SynapseError(
                         403,
-                        "The public room list of %s is private" % (remote_server,),
+                        "You are not allowed to view the public rooms list of %s" % (remote_server,),
                         errcode=Codes.FORBIDDEN,
                     )
                 raise
@@ -386,9 +386,9 @@ class TransportLayerClient(object):
                 if e.code == 403:
                     raise SynapseError(
                         403,
-                        "The public room list of %s is private" % (remote_server,),
+                        "You are not allowed to view the public rooms list of %s" % (remote_server,),
                         errcode=Codes.FORBIDDEN,
-                        )
+                    )
                 raise
 
         return response


### PR DESCRIPTION
Improves upon https://github.com/matrix-org/synapse/pull/6899

This PR:

* Adds nice docstrings
* Removes an unnecessary check
* Returns a more descriptive error when we request a private publicRooms list from a remote homeserver.

Why you ask? Well, I noticed the problem on my homeserver and went to fix it, and once done realized I had already fixed this in that other PR, and it still hasn't hit master. Still, the changes here should be useful.

Using the same changelog as the previous PR.