### PR TITLE
Workaround for assertion errors from db_query_to_update_function

### DIFF
--- a/changelog.d/7378.misc
+++ b/changelog.d/7378.misc
@@ -1,0 +1,1 @@
+Move catchup of replication streams logic to worker.

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -176,10 +176,9 @@ def db_query_to_update_function(
         rows = await query_function(from_token, upto_token, limit)
         updates = [(row[0], row[1:]) for row in rows]
         limited = False
-        if len(updates) == limit:
+        if len(updates) >= limit:
             upto_token = updates[-1][0]
             limited = True
-        assert len(updates) <= limit
 
         return updates, upto_token, limited
 


### PR DESCRIPTION
Hopefully this is no worse than what we have on master...

This is a mitigation to the assertionerrors in #7340, but I'm still deeply suspicious that we're not doing the right thing here.