### PR TITLE
Make it clearer that #synapse:matrix.org is our support channel

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+**If you're looking for support** please ask in **#synapse:matrix.org**
+(using a matrix.org account if necessary). We do not use GitHub issues for
+support.
+
+**If you want to report a security issue** please see https://matrix.org/security-disclosure-policy/

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-**If you're looking for support** please ask in **#synapse:matrix.org**
+**If you are looking for support** please ask in **#synapse:matrix.org**
 (using a matrix.org account if necessary). We do not use GitHub issues for
 support.
 

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -10,6 +10,8 @@ please ask in **#synapse:matrix.org** (using a matrix.org account if necessary)
 
 <!--
 
+If you want to report a security issue, please see https://matrix.org/security-disclosure-policy/
+
 This is a bug report template. By following the instructions below and
 filling out the sections with your information, you will help the us to get all
 the necessary data to fix your issue.

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -4,11 +4,11 @@ about: Create a report to help us improve
 
 ---
 
+**THIS IS NOT A SUPPORT CHANNEL!**
+**IF YOU HAVE SUPPORT QUESTIONS ABOUT RUNNING OR CONFIGURING YOUR OWN HOME SERVER**,
+please ask in **#synapse:matrix.org** (using a matrix.org account if necessary)
+
 <!--
-
-**IF YOU HAVE SUPPORT QUESTIONS ABOUT RUNNING OR CONFIGURING YOUR OWN HOME SERVER**:
-You will likely get better support more quickly if you ask in ** #synapse:matrix.org ** ;)
-
 
 This is a bug report template. By following the instructions below and
 filling out the sections with your information, you will help the us to get all

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,11 @@
+================
+Synapse |shield|
+================
+
+.. |shield| image:: https://img.shields.io/matrix/synapse:matrix.org?label=support&logo=matrix
+  :alt: (get support on #synapse:matrix.org)
+  :target: https://matrix.to/#/#synapse:matrix.org
+
 .. contents::
 
 Introduction

--- a/changelog.d/7377.doc
+++ b/changelog.d/7377.doc
@@ -1,0 +1,1 @@
+Spell it in an even more obvious way that the support channel for Synapse is `#synapse:matrix.org`.


### PR DESCRIPTION
This PR moves the "support is in #synapse:matrix.org" in the bug report template outside of the comment as some people seem to ignore what's in the comments, and phrase it a bit more like the support request template. It also adds a default issue template that says the same thing. It's also adding a notice about the security disclosure to both the default template and the bug report one.

It also adds a badge to the top of the README that looks like this:

![Screenshot from 2020-04-30 11-10-12](https://user-images.githubusercontent.com/5547783/80737183-72824180-8b13-11ea-9b59-32ece2131e25.png)

With an alt text saying about the same message if the badge doesn't load (e.g. if matrix.org is slow):

![Screenshot from 2020-04-30 18-51-15](https://user-images.githubusercontent.com/5547783/80737650-2257af00-8b14-11ea-952c-a8f951beea11.png)

I've opened this PR against master on purpose (for once) because I believe it's a good thing to have this out on master soon.

Fixes #6826 