### PR TITLE
Add a section about support to the top of the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,15 @@ Thanks for using Matrix!
 [1] End-to-end encryption is currently in beta: `blog post <https://matrix.org/blog/2016/11/21/matrixs-olm-end-to-end-encryption-security-assessment-released-and-implemented-cross-platform-on-riot-at-last>`_.
 
 
+Support
+=======
+
+If you need support installing or managing Synapse, please join
+[`#synapse:matrix.org`](https://matrix.to/#/#synapse:matrix.org) (from a matrix.org
+account if necessary) and ask your questions there. We do not use GitHub issues for
+support requests, only for bug reports and feature requests.
+
+
 Synapse Installation
 ====================
 

--- a/changelog.d/7392.doc
+++ b/changelog.d/7392.doc
@@ -1,0 +1,1 @@
+Spell it in an even more obvious way that the support channel for Synapse is `#synapse:matrix.org`.


### PR DESCRIPTION
Continuation of https://github.com/matrix-org/synapse/pull/7379

Adds a section in the README telling people to go to #synapse:matrix.org instead of using github issues. I'm not entirely sure about placing it above the install section but then people are likely to first seek support when installing (if something goes boom), and it's probably better to have it as high as possible anyway so people actually see it.