### PR TITLE
Convert synapse.server_notices to async/await.

### DIFF
--- a/changelog.d/7394.misc
+++ b/changelog.d/7394.misc
@@ -1,0 +1,1 @@
+Convert synapse.server_notices to async/await.

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -67,7 +67,7 @@ class TestResourceLimitsServerNotices(unittest.HomeserverTestCase):
             return_value=defer.succeed("!something:localhost")
         )
         self._rlsn._store.add_tag_to_room = Mock(return_value=defer.succeed(None))
-        self._rlsn._store.get_tags_for_room = Mock(return_value={})
+        self._rlsn._store.get_tags_for_room = Mock(return_value=defer.succeed({}))
         self.hs.config.admin_contact = "mailto:user@test.com"
 
     def test_maybe_send_server_notice_to_user_flag_off(self):


### PR DESCRIPTION
I noticed while reviewing #7363 that there was only a couple more usages of `inlineCallbacks` in `synapse.server_notices`. I figured it made sense to just finish it up while being somewhat familar with the code.