### PR TITLE
Docker image: Multi arch support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,38 @@
 version: 2
 jobs:
   dockerhubuploadrelease:
-    machine: true
+    docker:
+    - image: docker:git
     steps:
       - checkout
-      - run: docker build -f docker/Dockerfile --label gitsha1=${CIRCLE_SHA1} -t matrixdotorg/synapse:${CIRCLE_TAG} -t matrixdotorg/synapse:${CIRCLE_TAG}-py3 .
-      - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
-      - run: docker push matrixdotorg/synapse:${CIRCLE_TAG}
-      - run: docker push matrixdotorg/synapse:${CIRCLE_TAG}-py3
+      - setup_remote_docker:
+           version: 18.09.3
+       - run: apk add --no-cache curl
+       - run: mkdir -vp ~/.docker/cli-plugins/ ~/dockercache
+       - run: curl --silent -L "https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
+       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+       - run: docker context create old-style
+       - run: docker buildx create old-style --use
+       - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
+       - run: docker buildx build  -f docker/Dockerfile --push --platform linux/arm64/v8,linux/amd64 --label gitsha1=${CIRCLE_SHA1} -t matrixdotorg/synapse:${CIRCLE_TAG} -t matrixdotorg/synapse:${CIRCLE_TAG}-py3 .
+
   dockerhubuploadlatest:
-    machine: true
+    docker:
+    - image: docker:git
     steps:
       - checkout
-      - run: docker build -f docker/Dockerfile --label gitsha1=${CIRCLE_SHA1} -t matrixdotorg/synapse:latest -t matrixdotorg/synapse:latest-py3 .
-      - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
-      - run: docker push matrixdotorg/synapse:latest
-      - run: docker push matrixdotorg/synapse:latest-py3
+      - setup_remote_docker:
+           version: 18.09.3
+       - run: apk add --no-cache curl
+       - run: mkdir -vp ~/.docker/cli-plugins/ ~/dockercache
+       - run: curl --silent -L "https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
+       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+       - run: docker context create old-style
+       - run: docker buildx create old-style --use
+       - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
+       - run: docker buildx build  -f docker/Dockerfile --push --platform linux/arm64/v8,linux/amd64 --label gitsha1=${CIRCLE_SHA1} -t matrixdotorg/synapse:latest -t matrixdotorg/synapse:latest-py3 .
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,41 +1,30 @@
-version: 2
+version: 2.1
 jobs:
   dockerhubuploadrelease:
     docker:
-    - image: docker:git
+      - image: docker:git
     steps:
       - checkout
       - setup_remote_docker:
-           version: 18.09.3
-       - run: apk add --no-cache curl
-       - run: mkdir -vp ~/.docker/cli-plugins/ ~/dockercache
-       - run: curl --silent -L "https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
-       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
-       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-       - run: docker context create old-style
-       - run: docker buildx create old-style --use
-       - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
-       - run: docker buildx build  -f docker/Dockerfile --push --platform linux/arm64/v8,linux/amd64 --label gitsha1=${CIRCLE_SHA1} -t matrixdotorg/synapse:${CIRCLE_TAG} -t matrixdotorg/synapse:${CIRCLE_TAG}-py3 .
+          version: 18.09.3
+      - docker_prepare
+      - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
+      - docker_build:
+          parameters: --label gitsha1=${CIRCLE_SHA1} -t matrixdotorg/synapse:${CIRCLE_TAG} -t matrixdotorg/synapse:${CIRCLE_TAG}-py3
 
   dockerhubuploadlatest:
     docker:
-    - image: docker:git
+      - image: docker:git
     steps:
       - checkout
       - setup_remote_docker:
-           version: 18.09.3
-       - run: apk add --no-cache curl
-       - run: mkdir -vp ~/.docker/cli-plugins/ ~/dockercache
-       - run: curl --silent -L "https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
-       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
-       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-       - run: docker context create old-style
-       - run: docker buildx create old-style --use
-       - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
-       - run: docker buildx build  -f docker/Dockerfile --push --platform linux/arm64/v8,linux/amd64 --label gitsha1=${CIRCLE_SHA1} -t matrixdotorg/synapse:latest -t matrixdotorg/synapse:latest-py3 .
+          version: 18.09.3
+      - docker_prepare
+      - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
+      - docker_build:
+          parameters: --label gitsha1=${CIRCLE_SHA1} -t matrixdotorg/synapse:latest -t matrixdotorg/synapse:latest-py3
 
 workflows:
-  version: 2
   build:
     jobs:
       - dockerhubuploadrelease:
@@ -48,3 +37,40 @@ workflows:
           filters:
             branches:
               only: master
+
+commands:
+  docker_prepare:
+    description: Downloads the buildx cli plugin and enables multiarch execution
+    parameters:
+      buildx_version:
+        type: string
+        default: "v0.4.1"
+    steps:
+      - run: apk add --no-cache curl
+      - run: mkdir -vp ~/.docker/cli-plugins/ ~/dockercache
+      - run: curl --silent -L "https://github.com/docker/buildx/releases/download/<< parameters.buildx_version >>/buildx-<< parameters.buildx_version >>.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+      - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
+      - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - run: docker context create old-style
+      - run: docker buildx create old-style --use
+
+  docker_build:
+    description: Builds and pushed images to dockerhub using buildx
+    parameters:
+      dockerfile:
+        type: string
+        default: docker/Dockerfile
+      push:
+        type: boolean
+        default: true
+      platforms:
+        type: string
+        default: linux/arm64/v8,linux/amd64
+      context:
+        type: string
+        default: .
+      parameters:
+        type: string
+        default: --label gitsha1=${CIRCLE_SHA1}
+    steps:
+      - run: docker buildx build -f << parameters.dockerfile >><<# parameters.push >> --push<</ parameters.push >> --platform << parameters.platforms >> << parameters.parameters >> << parameters.context >>

--- a/changelog.d/7397.docker
+++ b/changelog.d/7397.docker
@@ -1,0 +1,1 @@
+Build multi-arch docker images. Contributed by @Starbix.


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

This PR updates the CircleCI configuration to use `docker buildx` to build the docker image. This way multi-arch images can be built on amd64. Currently only amd64 and arm64v8 are enabled. But other architectures such as arm/v7 or even s390x can be easily added.

Building for amd64 and arm64v8 took around 1h 30m on a Docker Medium instance on CircleCI.

Closes #4599

In case you want to test it, the multiarch image created by CircleCI is available under `starbix/synapse:latest` (master branch).

Signed-off-by: Cédric Laubacher <cedric@laubacher.io>