### PR TITLE
Fix MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -35,18 +35,19 @@ exclude .dockerignore
 exclude test_postgresql.sh
 exclude .editorconfig
 exclude sytest-blacklist
+exclude mypy.ini
+exclude .codecov.yml
+exclude .coveragerc
 
 include pyproject.toml
 recursive-include changelog.d *
 
 prune .buildkite
 prune .circleci
-prune .codecov.yml
-prune .coveragerc
 prune .github
 prune debian
 prune demo/etc
 prune docker
-prune mypy.ini
 prune snap
 prune stubs
+prune contrib

--- a/changelog.d/7404.misc
+++ b/changelog.d/7404.misc
@@ -1,0 +1,1 @@
+Fix issues with the Python package manifest.


### PR DESCRIPTION
An update of check-manifest shone some light on some issues with `MANIFEST.in`, specifically that we didn't exclude/prune the contrib directory, and that we were using `prune` instead of `exclude` for files. This fixes both issues.

Fixes #7403

---

This broke in `check-manifest` v0.42 ~anoa