### PR TITLE
Add backwards compatibility codepath to LoggingContext.

### DIFF
--- a/changelog.d/7408.misc
+++ b/changelog.d/7408.misc
@@ -1,0 +1,1 @@
+Clean up some LoggingContext code.

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -27,8 +27,8 @@ import inspect
 import logging
 import threading
 import types
-from typing import TYPE_CHECKING, Optional, Tuple, TypeVar, Union
 import warnings
+from typing import TYPE_CHECKING, Optional, Tuple, TypeVar, Union
 
 from typing_extensions import Literal
 
@@ -299,9 +299,10 @@ class LoggingContext(object):
             LoggingContext: the current logging context
         """
         warnings.warn(
-            'synapse.logging.context.LoggingContext.current_context() is deprecated '
-            'in favor of synapse.logging.context.current_context().',
-            PendingDeprecationWarning, stacklevel=2,
+            "synapse.logging.context.LoggingContext.current_context() is deprecated "
+            "in favor of synapse.logging.context.current_context().",
+            PendingDeprecationWarning,
+            stacklevel=2,
         )
         return current_context()
 
@@ -320,9 +321,10 @@ class LoggingContext(object):
             The context that was previously active
         """
         warnings.warn(
-            'synapse.logging.context.LoggingContext.set_current_context() is deprecated '
-            'in favor of synapse.logging.context.set_current_context().',
-            PendingDeprecationWarning, stacklevel=2,
+            "synapse.logging.context.LoggingContext.set_current_context() is deprecated "
+            "in favor of synapse.logging.context.set_current_context().",
+            PendingDeprecationWarning,
+            stacklevel=2,
         )
         return set_current_context(context)
 

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -299,6 +299,22 @@ class LoggingContext(object):
         """
         return current_context()
 
+    @classmethod
+    def set_current_context(
+        cls, context: LoggingContextOrSentinel
+    ) -> LoggingContextOrSentinel:
+        """Set the current logging context in thread local storage
+
+        This exists for backwards compatibility. ``set_current_context()`` should be
+        called directly.
+
+        Args:
+            context(LoggingContext): The context to activate.
+        Returns:
+            The context that was previously active
+        """
+        return set_current_context(context)
+
     def __enter__(self) -> "LoggingContext":
         """Enters this logging context into thread local storage"""
         old_context = set_current_context(self)

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -28,6 +28,7 @@ import logging
 import threading
 import types
 from typing import TYPE_CHECKING, Optional, Tuple, TypeVar, Union
+import warnings
 
 from typing_extensions import Literal
 
@@ -297,6 +298,11 @@ class LoggingContext(object):
         Returns:
             LoggingContext: the current logging context
         """
+        warnings.warn(
+            'synapse.logging.context.LoggingContext.current_context() is deprecated '
+            'in favor of synapse.logging.context.current_context().',
+            PendingDeprecationWarning, stacklevel=2,
+        )
         return current_context()
 
     @classmethod
@@ -313,6 +319,11 @@ class LoggingContext(object):
         Returns:
             The context that was previously active
         """
+        warnings.warn(
+            'synapse.logging.context.LoggingContext.set_current_context() is deprecated '
+            'in favor of synapse.logging.context.set_current_context().',
+            PendingDeprecationWarning, stacklevel=2,
+        )
         return set_current_context(context)
 
     def __enter__(self) -> "LoggingContext":

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -287,6 +287,18 @@ class LoggingContext(object):
             return str(self.request)
         return "%s@%x" % (self.name, id(self))
 
+    @classmethod
+    def current_context(cls) -> LoggingContextOrSentinel:
+        """Get the current logging context from thread local storage
+
+        This exists for backwards compatibility. ``current_context()`` should be
+        called directly.
+
+        Returns:
+            LoggingContext: the current logging context
+        """
+        return current_context()
+
     def __enter__(self) -> "LoggingContext":
         """Enters this logging context into thread local storage"""
         old_context = set_current_context(self)

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -301,7 +301,7 @@ class LoggingContext(object):
         warnings.warn(
             "synapse.logging.context.LoggingContext.current_context() is deprecated "
             "in favor of synapse.logging.context.current_context().",
-            PendingDeprecationWarning,
+            DeprecationWarning,
             stacklevel=2,
         )
         return current_context()
@@ -323,7 +323,7 @@ class LoggingContext(object):
         warnings.warn(
             "synapse.logging.context.LoggingContext.set_current_context() is deprecated "
             "in favor of synapse.logging.context.set_current_context().",
-            PendingDeprecationWarning,
+            DeprecationWarning,
             stacklevel=2,
         )
         return set_current_context(context)


### PR DESCRIPTION
The [synapse-s3-storage-provider](https://github.com/matrix-org/synapse-s3-storage-provider) depends on `LoggingContext.current_context` which was removed in #7120. We add this back (as a pass through to `current_context`). I'll make a separate PR for ss3sp to update the reference there too.

Note this PR is made against the release branch so it will go out with #7120.

Should we mention any changes to `LoggingContext` in the changelog?

Fixes #7400