### PR TITLE
Stop Auth methods from polling the config on every req.

### DIFF
--- a/changelog.d/7420.misc
+++ b/changelog.d/7420.misc
@@ -1,0 +1,1 @@
+Prevent methods in `synapse.handlers.auth` from polling the homeserver config every request.

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -15,7 +15,6 @@
 
 import logging
 from typing import Optional
-from synapse.api.auth_blocking import AuthBlocking
 
 from six import itervalues
 
@@ -27,16 +26,15 @@ from twisted.internet import defer
 import synapse.logging.opentracing as opentracing
 import synapse.types
 from synapse import event_auth
-from synapse.api.constants import EventTypes, LimitBlockingTypes, Membership, UserTypes
+from synapse.api.auth_blocking import AuthBlocking
+from synapse.api.constants import EventTypes, Membership
 from synapse.api.errors import (
     AuthError,
     Codes,
     InvalidClientTokenError,
     MissingClientTokenError,
-    ResourceLimitError,
 )
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
-from synapse.config.server import is_threepid_reserved
 from synapse.events import EventBase
 from synapse.types import StateMap, UserID
 from synapse.util.caches import CACHE_SIZE_FACTOR, register_cache

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -76,11 +76,11 @@ class Auth(object):
         self.token_cache = LruCache(CACHE_SIZE_FACTOR * 10000)
         register_cache("cache", "token_cache", self.token_cache)
 
-        self._auth_blocking = AuthBlocking(hs)
+        self._auth_blocking = AuthBlocking(self.hs)
 
         self._account_validity = hs.config.account_validity
-        self._track_appservice_user_ips = self.hs.config.track_appservice_user_ips
-        self._macaroon_secret_key = self.hs.config.macaroon_secret_key
+        self._track_appservice_user_ips = hs.config.track_appservice_user_ips
+        self._macaroon_secret_key = hs.config.macaroon_secret_key
 
     @defer.inlineCallbacks
     def check_from_context(self, room_version: str, event, context, do_sig_check=True):

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -86,7 +86,9 @@ class Auth(object):
         self._hs_disabled_message = self.hs.config.hs_disabled_message
         self._admin_contact = self.hs.config.admin_contact
         self._limit_usage_by_mau = self.hs.config.limit_usage_by_mau
-        self._mau_limits_reserved_threepids = self.hs.config.mau_limits_reserved_threepids
+        self._mau_limits_reserved_threepids = (
+            self.hs.config.mau_limits_reserved_threepids
+        )
         self._max_mau_value = self.hs.config.max_mau_value
 
     @defer.inlineCallbacks
@@ -723,9 +725,7 @@ class Auth(object):
             elif threepid:
                 # If the user does not exist yet, but is signing up with a
                 # reserved threepid then pass auth check
-                if is_threepid_reserved(
-                    self._mau_limits_reserved_threepids, threepid
-                ):
+                if is_threepid_reserved(self._mau_limits_reserved_threepids, threepid):
                     return
             elif user_type == UserTypes.SUPPORT:
                 # If the user does not exist yet and is of type "support",

--- a/synapse/api/auth_blocking.py
+++ b/synapse/api/auth_blocking.py
@@ -30,10 +30,10 @@ class AuthBlocking(object):
 
         self._server_notices_mxid = hs.config.server_notices_mxid
         self._hs_disabled = hs.config.hs_disabled
-        self._limit_usage_by_mau = hs.config.limit_usage_by_mau
         self._hs_disabled_message = hs.config.hs_disabled_message
         self._admin_contact = hs.config.admin_contact
         self._max_mau_value = hs.config.max_mau_value
+        self._limit_usage_by_mau = hs.config.limit_usage_by_mau
         self._mau_limits_reserved_threepids = hs.config.mau_limits_reserved_threepids
 
     @defer.inlineCallbacks

--- a/synapse/api/auth_blocking.py
+++ b/synapse/api/auth_blocking.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 The Matrix.org Foundation C.I.C.
+# Copyright 2020 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,13 +18,8 @@ import logging
 from twisted.internet import defer
 
 from synapse.api.constants import LimitBlockingTypes, UserTypes
-from synapse.api.errors import (
-    Codes,
-    ResourceLimitError,
-)
+from synapse.api.errors import Codes, ResourceLimitError
 from synapse.config.server import is_threepid_reserved
-from synapse.util.caches import CACHE_SIZE_FACTOR, register_cache
-from synapse.util.caches.lrucache import LruCache
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/api/auth_blocking.py
+++ b/synapse/api/auth_blocking.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from twisted.internet import defer
+
+from synapse.api.constants import LimitBlockingTypes, UserTypes
+from synapse.api.errors import (
+    Codes,
+    ResourceLimitError,
+)
+from synapse.config.server import is_threepid_reserved
+from synapse.util.caches import CACHE_SIZE_FACTOR, register_cache
+from synapse.util.caches.lrucache import LruCache
+
+logger = logging.getLogger(__name__)
+
+
+class AuthBlocking(object):
+    def __init__(self, hs):
+        self.store = hs.get_datastore()
+
+        self._server_notices_mxid = hs.config.server_notices_mxid
+        self._hs_disabled = hs.config.hs_disabled
+        self._limit_usage_by_mau = hs.config.limit_usage_by_mau
+        self._hs_disabled_message = hs.config.hs_disabled_message
+        self._admin_contact = hs.config.admin_contact
+        self._max_mau_value = hs.config.max_mau_value
+        self._mau_limits_reserved_threepids = hs.config.mau_limits_reserved_threepids
+
+    @defer.inlineCallbacks
+    def check_auth_blocking(self, user_id=None, threepid=None, user_type=None):
+        """Checks if the user should be rejected for some external reason,
+        such as monthly active user limiting or global disable flag
+
+        Args:
+            user_id(str|None): If present, checks for presence against existing
+                MAU cohort
+
+            threepid(dict|None): If present, checks for presence against configured
+                reserved threepid. Used in cases where the user is trying register
+                with a MAU blocked server, normally they would be rejected but their
+                threepid is on the reserved list. user_id and
+                threepid should never be set at the same time.
+
+            user_type(str|None): If present, is used to decide whether to check against
+                certain blocking reasons like MAU.
+        """
+
+        # Never fail an auth check for the server notices users or support user
+        # This can be a problem where event creation is prohibited due to blocking
+        if user_id is not None:
+            if user_id == self._server_notices_mxid:
+                return
+            if (yield self.store.is_support_user(user_id)):
+                return
+
+        if self._hs_disabled:
+            raise ResourceLimitError(
+                403,
+                self._hs_disabled_message,
+                errcode=Codes.RESOURCE_LIMIT_EXCEEDED,
+                admin_contact=self._admin_contact,
+                limit_type=LimitBlockingTypes.HS_DISABLED,
+            )
+        if self._limit_usage_by_mau is True:
+            assert not (user_id and threepid)
+
+            # If the user is already part of the MAU cohort or a trial user
+            if user_id:
+                timestamp = yield self.store.user_last_seen_monthly_active(user_id)
+                if timestamp:
+                    return
+
+                is_trial = yield self.store.is_trial_user(user_id)
+                if is_trial:
+                    return
+            elif threepid:
+                # If the user does not exist yet, but is signing up with a
+                # reserved threepid then pass auth check
+                if is_threepid_reserved(self._mau_limits_reserved_threepids, threepid):
+                    return
+            elif user_type == UserTypes.SUPPORT:
+                # If the user does not exist yet and is of type "support",
+                # allow registration. Support users are excluded from MAU checks.
+                return
+            # Else if there is no room in the MAU bucket, bail
+            current_mau = yield self.store.get_monthly_active_count()
+            if current_mau >= self._max_mau_value:
+                raise ResourceLimitError(
+                    403,
+                    "Monthly Active User Limit Exceeded",
+                    admin_contact=self._admin_contact,
+                    errcode=Codes.RESOURCE_LIMIT_EXCEEDED,
+                    limit_type=LimitBlockingTypes.MONTHLY_ACTIVE_USER,
+                )


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/7419

Polls all the config options on server setup instead of every req. `check_auth_blocking`, which used the majority of the config options, was moved to a separate class to keep `Auth` clean.

Merging to the release branch to help get this out on matrix.org.

Edit: Lots of tests needed to be updated as they modified the hs' config after the hs had been initialized, which means `check_auth_blocking`, which pulls options on hs intiialization, would be using stale values. These tests were changed such that they modify values in the new `AuthBlocking` class instead of the hs' config.