### PR TITLE
Add a configuration setting for the dummy event threshold

### DIFF
--- a/changelog.d/7422.feature
+++ b/changelog.d/7422.feature
@@ -1,0 +1,1 @@
+Add a configuration setting to tweak the threshold for dummy events.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -424,8 +424,8 @@ retention:
 #
 #request_token_inhibit_3pid_errors: true
 
-# Number of forward extremities in a room at which Synapse will start sending
-# dummy events.
+# Number of forward extremities in a room at which Synapse will send a dummy
+# events.
 # This is to prevent forward extremities from building up in the room, which
 # could lead to poor performance.
 # The default value is 10.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -253,6 +253,18 @@ listeners:
   #  bind_addresses: ['::1', '127.0.0.1']
   #  type: manhole
 
+# Forward extremities can build up in a room due to networking delays between
+# homeservers. Once this happens in a large room, calculation of the state of
+# that room can become quite expensive. To mitigate this, once the number of
+# forward extremities reaches a given threshold, Synapse will send an
+# org.matrix.dummy_event event, which will reduce the forward extremities
+# in the room.
+#
+# This setting defines the threshold (i.e. number of forward extremities in the
+# room) at which dummy events are sent. The default value is 10.
+#
+#dummy_event_threshold: 5
+
 
 ## Homeserver blocking ##
 
@@ -423,14 +435,6 @@ retention:
 # act as if no error happened and return a fake session ID ('sid') to clients.
 #
 #request_token_inhibit_3pid_errors: true
-
-# Number of forward extremities in a room at which Synapse will send a dummy
-# events.
-# This is to prevent forward extremities from building up in the room, which
-# could lead to poor performance.
-# The default value is 10.
-#
-#dummy_event_threshold: 5
 
 
 ## TLS ##

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -424,6 +424,14 @@ retention:
 #
 #request_token_inhibit_3pid_errors: true
 
+# Number of forward extremities in a room at which Synapse will start sending
+# dummy events.
+# This is to prevent forward extremities from building up in the room, which
+# could lead to poor performance.
+# The default value is 10.
+#
+#dummy_event_threshold: 5
+
 
 ## TLS ##
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -263,7 +263,7 @@ listeners:
 # This setting defines the threshold (i.e. number of forward extremities in the
 # room) at which dummy events are sent. The default value is 10.
 #
-#dummy_event_threshold: 5
+#dummy_events_threshold: 5
 
 
 ## Homeserver blocking ##

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -996,6 +996,14 @@ class ServerConfig(Config):
         # act as if no error happened and return a fake session ID ('sid') to clients.
         #
         #request_token_inhibit_3pid_errors: true
+        
+        # Number of forward extremities in a room at which Synapse will start sending
+        # dummy events.
+        # This is to prevent forward extremities from building up in the room, which
+        # could lead to poor performance.
+        # The default value is 10.
+        #
+        #dummy_event_threshold: 5
         """
             % locals()
         )

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -506,7 +506,7 @@ class ServerConfig(Config):
         )
 
         # The number of forward extremities in a room needed to send a dummy event.
-        self.dummy_event_threshold = config.get("dummy_event_threshold", 10)
+        self.dummy_events_threshold = config.get("dummy_events_threshold", 10)
 
         self.enable_ephemeral_messages = config.get("enable_ephemeral_messages", False)
 
@@ -836,7 +836,7 @@ class ServerConfig(Config):
         # This setting defines the threshold (i.e. number of forward extremities in the
         # room) at which dummy events are sent. The default value is 10.
         #
-        #dummy_event_threshold: 5
+        #dummy_events_threshold: 5
 
 
         ## Homeserver blocking ##

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -505,6 +505,11 @@ class ServerConfig(Config):
             "cleanup_extremities_with_dummy_events", True
         )
 
+        # The number of forward extremities in a room needed to send a dummy event.
+        self.dummy_event_threshold = config.get(
+            "dummy_event_threshold", 10,
+        )
+
         self.enable_ephemeral_messages = config.get("enable_ephemeral_messages", False)
 
         # Inhibits the /requestToken endpoints from returning an error that might leak

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -506,9 +506,7 @@ class ServerConfig(Config):
         )
 
         # The number of forward extremities in a room needed to send a dummy event.
-        self.dummy_event_threshold = config.get(
-            "dummy_event_threshold", 10,
-        )
+        self.dummy_event_threshold = config.get("dummy_event_threshold", 10)
 
         self.enable_ephemeral_messages = config.get("enable_ephemeral_messages", False)
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -997,8 +997,8 @@ class ServerConfig(Config):
         #
         #request_token_inhibit_3pid_errors: true
         
-        # Number of forward extremities in a room at which Synapse will start sending
-        # dummy events.
+        # Number of forward extremities in a room at which Synapse will send a dummy
+        # events.
         # This is to prevent forward extremities from building up in the room, which
         # could lead to poor performance.
         # The default value is 10.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -826,6 +826,18 @@ class ServerConfig(Config):
           #  bind_addresses: ['::1', '127.0.0.1']
           #  type: manhole
 
+        # Forward extremities can build up in a room due to networking delays between
+        # homeservers. Once this happens in a large room, calculation of the state of
+        # that room can become quite expensive. To mitigate this, once the number of
+        # forward extremities reaches a given threshold, Synapse will send an
+        # org.matrix.dummy_event event, which will reduce the forward extremities
+        # in the room.
+        #
+        # This setting defines the threshold (i.e. number of forward extremities in the
+        # room) at which dummy events are sent. The default value is 10.
+        #
+        #dummy_event_threshold: 5
+
 
         ## Homeserver blocking ##
 
@@ -996,14 +1008,6 @@ class ServerConfig(Config):
         # act as if no error happened and return a fake session ID ('sid') to clients.
         #
         #request_token_inhibit_3pid_errors: true
-
-        # Number of forward extremities in a room at which Synapse will send a dummy
-        # events.
-        # This is to prevent forward extremities from building up in the room, which
-        # could lead to poor performance.
-        # The default value is 10.
-        #
-        #dummy_event_threshold: 5
         """
             % locals()
         )

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -996,7 +996,7 @@ class ServerConfig(Config):
         # act as if no error happened and return a fake session ID ('sid') to clients.
         #
         #request_token_inhibit_3pid_errors: true
-        
+
         # Number of forward extremities in a room at which Synapse will send a dummy
         # events.
         # This is to prevent forward extremities from building up in the room, which

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -419,6 +419,8 @@ class EventCreationHandler(object):
 
         self._ephemeral_events_enabled = hs.config.enable_ephemeral_messages
 
+        self._dummy_events_threshold = hs.config.dummy_event_threshold
+
     @defer.inlineCallbacks
     def create_event(
         self,
@@ -1085,7 +1087,7 @@ class EventCreationHandler(object):
         """
         self._expire_rooms_to_exclude_from_dummy_event_insertion()
         room_ids = await self.store.get_rooms_with_many_extremities(
-            min_count=10,
+            min_count=self._dummy_events_threshold,
             limit=5,
             room_id_filter=self._rooms_to_exclude_from_dummy_event_insertion.keys(),
         )

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -419,7 +419,7 @@ class EventCreationHandler(object):
 
         self._ephemeral_events_enabled = hs.config.enable_ephemeral_messages
 
-        self._dummy_events_threshold = hs.config.dummy_event_threshold
+        self._dummy_events_threshold = hs.config.dummy_events_threshold
 
     @defer.inlineCallbacks
     def create_event(


### PR DESCRIPTION
Add `dummy_events_threshold` which allows configuring the number of forward extremities a room needs for Synapse to send forward extremities in it.

~I decided not to expose it in the sample config as the flag to enable/disable that feature is also hidden from there.~

Fixes https://github.com/matrix-org/synapse/issues/7413