### PR TITLE
Improve per-block CPU and DB usage metrics

### DIFF
--- a/changelog.d/7426.misc
+++ b/changelog.d/7426.misc
@@ -1,0 +1,1 @@
+Clean up some LoggingContext code.


### PR DESCRIPTION
This reworks the code to incrementally report the resource usage of a context to a context's parent, but avoids resetting the resource usage.

Fixes #7370