### PR TITLE
Make get_e2e_cross_signing_key delegate to get_e2e_cross_signing_keys_bulk

### DIFF
--- a/changelog.d/7428.misc
+++ b/changelog.d/7428.misc
@@ -1,0 +1,1 @@
+Improve performance of `get_e2e_cross_signing_key`.


### PR DESCRIPTION
... mostly because the latter has a cache.

Also (in a separate commit), some fixes for the batching in the bulk lookup methods.