### PR TITLE
Make redis go faster with hiredis

### DIFF
--- a/changelog.d/7439.feature
+++ b/changelog.d/7439.feature
@@ -1,0 +1,1 @@
+Add support for running replication over Redis when using workers.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -98,10 +98,9 @@ CONDITIONAL_REQUIREMENTS = {
     "sentry": ["sentry-sdk>=0.7.2"],
     "opentracing": ["jaeger-client>=4.0.0", "opentracing>=2.2.0"],
     "jwt": ["pyjwt>=1.6.4"],
-
     # hiredis is not a *strict* dependency, but it makes things much faster.
     # (if it is not installed, we fall back to slow code.)
-    "redis": ["txredisapi>=1.4.7", "hiredis" ],
+    "redis": ["txredisapi>=1.4.7", "hiredis"],
 }
 
 ALL_OPTIONAL_REQUIREMENTS = set()  # type: Set[str]

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -98,7 +98,10 @@ CONDITIONAL_REQUIREMENTS = {
     "sentry": ["sentry-sdk>=0.7.2"],
     "opentracing": ["jaeger-client>=4.0.0", "opentracing>=2.2.0"],
     "jwt": ["pyjwt>=1.6.4"],
-    "redis": ["txredisapi>=1.4.7"],
+
+    # hiredis is not a *strict* dependency, but it makes things much faster.
+    # (if it is not installed, we fall back to slow code.)
+    "redis": ["txredisapi>=1.4.7", "hiredis" ],
 }
 
 ALL_OPTIONAL_REQUIREMENTS = set()  # type: Set[str]


### PR DESCRIPTION
For the record, the reason we need this is as follows:

each RDATA command comes down the redis pipe as a subscription message. txredisapi as written needs at least three reactor ticks to read each subscription message from the tcp buffer. Hence, once the process gets loaded, it starts getting behind, and eventually redis knifes the connection. it then takes ages for the master to work its way through the backlog, before it reconnects again, during which any commands from any workers are dropped.