### PR TITLE
Allow expired accounts to logout

### DIFF
--- a/changelog.d/7443.bugfix
+++ b/changelog.d/7443.bugfix
@@ -1,0 +1,1 @@
+Allow expired user accounts to log out their device sessions.

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -176,11 +176,9 @@ class Auth(object):
             allow_guest: If False, will raise an AuthError if the user making the
                 request is a guest.
             rights: The operation being performed; the access token must allow this
-            allow_expired: Whether to allow the request through even if the account is
-                expired. If true, Synapse will still require an access token to be
-                provided but won't check if the account it belongs to has expired. This
-                works thanks to /login delivering access tokens regardless of accounts'
-                expiration.
+            allow_expired: If True, allow the request through even if the account
+                is expired, or session token lifetime has ended. Note that
+                /login will deliver access tokens regardless of expiration.
 
         Returns:
             defer.Deferred: resolves to a `synapse.types.Requester` object

--- a/synapse/rest/client/v1/logout.py
+++ b/synapse/rest/client/v1/logout.py
@@ -34,10 +34,10 @@ class LogoutRestServlet(RestServlet):
         return 200, {}
 
     async def on_POST(self, request):
-        requester = await self.auth.get_user_by_req(request)
+        requester = await self.auth.get_user_by_req(request, allow_expired=True)
 
         if requester.device_id is None:
-            # the acccess token wasn't associated with a device.
+            # The access token wasn't associated with a device.
             # Just delete the access token
             access_token = self.auth.get_access_token_from_request(request)
             await self._auth_handler.delete_access_token(access_token)

--- a/synapse/rest/client/v1/logout.py
+++ b/synapse/rest/client/v1/logout.py
@@ -62,7 +62,7 @@ class LogoutAllRestServlet(RestServlet):
         return 200, {}
 
     async def on_POST(self, request):
-        requester = await self.auth.get_user_by_req(request)
+        requester = await self.auth.get_user_by_req(request, allow_expired=True)
         user_id = requester.user.to_string()
 
         # first delete all of the user's devices

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -431,25 +431,8 @@ class AccountValidityTestCase(unittest.HomeserverTestCase):
         self.render(request)
         self.assertEquals(channel.result["code"], b"200", channel.result)
 
-    def test_logging_out_all_devices_of_expired_user(self):
-        user_id = self.register_user("kermit", "monkey")
+        # Log the user in again (allowed for expired accounts)
         tok = self.login("kermit", "monkey")
-
-        self.register_user("admin", "adminpassword", admin=True)
-        admin_tok = self.login("admin", "adminpassword")
-
-        url = "/_matrix/client/unstable/admin/account_validity/validity"
-        params = {
-            "user_id": user_id,
-            "expiration_ts": 0,
-            "enable_renewal_emails": False,
-        }
-        request_data = json.dumps(params)
-        request, channel = self.make_request(
-            b"POST", url, request_data, access_token=admin_tok
-        )
-        self.render(request)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
 
         # Try to log out all of the user's sessions
         request, channel = self.make_request(b"POST", "/logout/all", access_token=tok)


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/5756

This PR prevents an `InvalidClientTokenError` or `AuthError` being raised when a user is expired for the `/logout` and `/logout/all` endpoints.