### PR TITLE
Drop support for redis.dbid

### DIFF
--- a/changelog.d/7450.feature
+++ b/changelog.d/7450.feature
@@ -1,0 +1,1 @@
+Add support for running replication over Redis when using workers.

--- a/synapse/config/redis.py
+++ b/synapse/config/redis.py
@@ -31,5 +31,4 @@ class RedisConfig(Config):
 
         self.redis_host = redis_config.get("host", "localhost")
         self.redis_port = redis_config.get("port", 6379)
-        self.redis_dbid = redis_config.get("dbid")
         self.redis_password = redis_config.get("password")

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -131,10 +131,9 @@ class ReplicationCommandHandler:
             import txredisapi
 
             logger.info(
-                "Connecting to redis (host=%r port=%r DBID=%r)",
+                "Connecting to redis (host=%r port=%r)",
                 hs.config.redis_host,
                 hs.config.redis_port,
-                hs.config.redis_dbid,
             )
 
             # We need two connections to redis, one for the subscription stream and
@@ -145,7 +144,6 @@ class ReplicationCommandHandler:
             outbound_redis_connection = txredisapi.lazyConnection(
                 host=hs.config.redis_host,
                 port=hs.config.redis_port,
-                dbid=hs.config.redis_dbid,
                 password=hs.config.redis.redis_password,
                 reconnect=True,
             )


### PR DESCRIPTION
Since we only use pubsub, the dbid is irrelevant.