### PR TITLE
Rework UI Auth session validation

### DIFF
--- a/changelog.d/7455.bugfix
+++ b/changelog.d/7455.bugfix
@@ -1,0 +1,1 @@
+Ensure that a user inteactive authentication session is tied to a single request.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -340,26 +340,26 @@ class AuthHandler(BaseHandler):
             # without a "password" parameter. See the changes to
             # synapse.rest.client.v2_alpha.register.RegisterRestServlet.on_POST
             # in commit 544722bad23fc31056b9240189c3cbbbf0ffd3f9.
-            if clientdict:
-                # Ensure that the queried operation does not vary between stages of
-                # the UI authentication session. This is done by generating a stable
-                # comparator based on the URI, method, and body (minus the auth dict)
-                # and storing it during the initial query. Subsequent queries ensure
-                # that this comparator has not changed.
-                #
-                # For backwards compatibility the registration endpoint persists any
-                # changes instead of validating them.
-                if validate_operation:
-                    comparator = (uri, method, clientdict)
-                    if (session.uri, session.method, session.clientdict) != comparator:
-                        raise SynapseError(
-                            403,
-                            "Requested operation has changed during the UI authentication session.",
-                        )
-                else:
-                    await self.store.set_ui_auth_clientdict(sid, clientdict)
-            else:
+            if not clientdict:
                 clientdict = session.clientdict
+
+            # Ensure that the queried operation does not vary between stages of
+            # the UI authentication session. This is done by generating a stable
+            # comparator based on the URI, method, and body (minus the auth dict)
+            # and storing it during the initial query. Subsequent queries ensure
+            # that this comparator has not changed.
+            #
+            # For backwards compatibility the registration endpoint persists any
+            # changes instead of validating them.
+            if validate_operation:
+                comparator = (uri, method, clientdict)
+                if (session.uri, session.method, session.clientdict) != comparator:
+                    raise SynapseError(
+                        403,
+                        "Requested operation has changed during the UI authentication session.",
+                    )
+            else:
+                await self.store.set_ui_auth_clientdict(sid, clientdict)
 
         if not authdict:
             raise InteractiveAuthIncompleteError(

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -317,7 +317,7 @@ class AuthHandler(BaseHandler):
             except StoreError:
                 raise SynapseError(400, "Unknown session ID: %s" % (sid,))
 
-            if not clientdict:
+            if clientdict:
                 # This was designed to allow the client to omit the parameters
                 # and just supply the session in subsequent calls so it split
                 # auth between devices by just sharing the session, (eg. so you
@@ -327,6 +327,8 @@ class AuthHandler(BaseHandler):
                 # on a homeserver.
                 # Revisit: Assuming the REST APIs do sensible validation, the data
                 # isn't arbitrary.
+                await self.store.set_ui_auth_clientdict(sid, clientdict)
+            else:
                 clientdict = session.clientdict
 
         if not authdict:

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -317,6 +317,11 @@ class AuthHandler(BaseHandler):
             except StoreError:
                 raise SynapseError(400, "Unknown session ID: %s" % (sid,))
 
+            # Note that the registration endpoint explicitly removes the
+            # "initial_device_display_name" parameter if it is provided
+            # without a "password" parameter. See the changes to
+            # synapse.rest.client.v2_alpha.register.RegisterRestServlet.on_POST
+            # in commit 544722bad23fc31056b9240189c3cbbbf0ffd3f9.
             if clientdict:
                 # This was designed to allow the client to omit the parameters
                 # and just supply the session in subsequent calls so it split

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -278,8 +278,9 @@ class AuthHandler(BaseHandler):
             description: A human readable string to be displayed to the user that
                          describes the operation happening on their account.
 
-            validate_operation: Whether it should be validate that the operation
-                                happening on the account has not changed.
+            validate_operation: Whether to validate that the operation happening
+                                on the account has not changed. If this is false,
+                                the clientdict is persisted instead of validated.
 
         Returns:
             A tuple of (creds, params, session_id).

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -329,18 +329,6 @@ class AuthHandler(BaseHandler):
                 # isn't arbitrary.
                 clientdict = session.clientdict
 
-            # Ensure that the queried operation does not vary between stages of
-            # the UI authentication session. This is done by generating a stable
-            # comparator based on the URI, method, and body (minus the auth dict)
-            # and storing it during the initial query. Subsequent queries ensure
-            # that this comparator has not changed.
-            comparator = (uri, method, clientdict)
-            if (session.uri, session.method, session.clientdict) != comparator:
-                raise SynapseError(
-                    403,
-                    "Requested operation has changed during the UI authentication session.",
-                )
-
         if not authdict:
             raise InteractiveAuthIncompleteError(
                 self._auth_dict_for_flows(flows, session.session_id)

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -516,7 +516,7 @@ class RegisterRestServlet(RestServlet):
             body,
             self.hs.get_ip_from_request(request),
             "register a new account",
-            validate_operation=False,
+            validate_clientdict=False,
         )
 
         # Check that we're not trying to register a denied 3pid.

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -516,6 +516,7 @@ class RegisterRestServlet(RestServlet):
             body,
             self.hs.get_ip_from_request(request),
             "register a new account",
+            validate_operation=False,
         )
 
         # Check that we're not trying to register a denied 3pid.

--- a/synapse/storage/data_stores/main/ui_auth.py
+++ b/synapse/storage/data_stores/main/ui_auth.py
@@ -172,6 +172,27 @@ class UIAuthWorkerStore(SQLBaseStore):
 
         return results
 
+    async def set_ui_auth_clientdict(
+        self, session_id: str, clientdict: JsonDict
+    ) -> None:
+        """
+        Store an updated clientdict for a given session ID.
+
+        Args:
+            session_id: The ID of this session as returned from check_auth
+            clientdict:
+                The dictionary from the client root level, not the 'auth' key.
+        """
+        # The clientdict gets stored as JSON.
+        clientdict_json = json.dumps(clientdict)
+
+        self.db.simple_update_one(
+            table="ui_auth_sessions",
+            keyvalues={"session_id": session_id},
+            updatevalues={"clientdict": clientdict_json},
+            desc="set_ui_auth_client_dict",
+        )
+
     async def set_ui_auth_session_data(self, session_id: str, key: str, value: Any):
         """
         Store a key-value pair into the sessions data associated with this

--- a/tests/rest/client/v2_alpha/test_auth.py
+++ b/tests/rest/client/v2_alpha/test_auth.py
@@ -182,6 +182,9 @@ class FallbackAuthTests(unittest.HomeserverTestCase):
         self.render(request)
         self.assertEqual(channel.code, 403)
 
+    # This behavior is currently disabled.
+    test_cannot_change_operation.skip = True
+
     def test_complete_operation_unknown_session(self):
         """
         Attempting to mark an invalid session as complete should error.

--- a/tox.ini
+++ b/tox.ini
@@ -207,6 +207,7 @@ commands = mypy \
             synapse/util/caches/stream_change_cache.py \
             tests/replication/tcp/streams \
             tests/test_utils \
+            tests/rest/client/v2_alpha/test_auth.py \
             tests/util/test_stream_change_cache.py
 
 # To find all folders that pass mypy you run:


### PR DESCRIPTION
This reworks the UI Auth session validation per #7452. 

* The registration endpoint is less strict on ensuring that the given parameters have changed during registration. This is a backwards compatibility path for clients.
* The client dict gets persisted at each step of the authentication for registration.
* The UI Auth tests are heavily modified to clean them up and add a few other scenarios.

It is worth comparing this code to the v1.12.4:

https://github.com/matrix-org/synapse/blob/release-v1.12.4/synapse/handlers/auth.py#L265-L278

The overall structure is much more similar now, but sometimes we validate and sometimes we persist.