### PR TITLE
Add Caddy 2 example to reverse proxy doc

### DIFF
--- a/changelog.d/7463.doc
+++ b/changelog.d/7463.doc
@@ -1,0 +1,1 @@
+Add additional reverse proxy example for Caddy v2. Contributed by Jeff Peeler.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -62,7 +62,7 @@ the reverse proxy and the homeserver.
 > **NOTE**: Do not add a `/` after the port in `proxy_pass`, otherwise nginx will
 canonicalise/normalise the URI.
 
-### Caddy
+### Caddy 1
 
         matrix.example.com {
           proxy /_matrix http://localhost:8008 {
@@ -74,6 +74,16 @@ canonicalise/normalise the URI.
           proxy / http://localhost:8008 {
             transparent
           }
+        }
+
+### Caddy 2
+
+        matrix.example.com {
+          reverse_proxy /_matrix/* http://localhost:8008
+        }
+
+        example.com:8448 {
+          reverse_proxy http://localhost:8008
         }
 
 ### Apache


### PR DESCRIPTION
The specific headers that are passed using this new configuration format are Host and X-Forwarded-For, which should be all that's required (https://caddy.community/t/v2-reverse-proxy-transparent/6480/8).

FWIW, it sounds like Caddy 1 is going to become unsupported in the very near future.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
