### PR TITLE
Workaround for failure to wrap reason in Failure

### DIFF
--- a/changelog.d/7473.bugfix
+++ b/changelog.d/7473.bugfix
@@ -1,0 +1,1 @@
+Workaround for an upstream Twisted bug that caused Synapse to become unresponsive after startup.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/7441

Checks that `reason` has been properly wrapped in a `Failure`. If not, wraps it manually.