### PR TITLE
Add missing event type at Docker conf template

### DIFF
--- a/changelog.d/7476.docker
+++ b/changelog.d/7476.docker
@@ -1,0 +1,1 @@
+Fixed missing room_invite_state_types entry from Docker config template.

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -178,6 +178,7 @@ room_invite_state_types:
     - "m.room.join_rules"
     - "m.room.canonical_alias"
     - "m.room.avatar"
+    - "m.room.encryption"
     - "m.room.name"
 
 {% if SYNAPSE_APPSERVICES %}


### PR DESCRIPTION
Fixed missing room_invite_state_types entry from Docker config template.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
