### PR TITLE
Warn, instead of erroring, if the client dict changes during UI Auth.

### DIFF
--- a/changelog.d/7483.bugfix
+++ b/changelog.d/7483.bugfix
@@ -1,0 +1,1 @@
+Ensure that a user inteactive authentication session is tied to a single request.

--- a/changelog.d/7483.bugfix
+++ b/changelog.d/7483.bugfix
@@ -1,1 +1,1 @@
-Ensure that a user inteactive authentication session is tied to a single request.
+Restore compatibility with non-compliant clients during the user inteactive authentication process.

--- a/changelog.d/7483.bugfix
+++ b/changelog.d/7483.bugfix
@@ -1,1 +1,1 @@
-Restore compatibility with non-compliant clients during the user inteactive authentication process.
+Restore compatibility with non-compliant clients during the user interactive authentication process.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -367,10 +367,10 @@ class AuthHandler(BaseHandler):
                         "will remove this capability."
                     )
 
-            # For backwards compatibility the registration endpoint persists
-            # changes to the client dict instead of validating them.
-            else:
-                await self.store.set_ui_auth_clientdict(sid, clientdict)
+            # For backwards compatibility, changes to the client dict are
+            # persisted as clients modify them throughout their user interactive
+            # authentication flow.
+            await self.store.set_ui_auth_clientdict(sid, clientdict)
 
         if not authdict:
             raise InteractiveAuthIncompleteError(

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -252,7 +252,6 @@ class AuthHandler(BaseHandler):
         clientdict: Dict[str, Any],
         clientip: str,
         description: str,
-        validate_clientdict: bool = True,
     ) -> Tuple[dict, dict, str]:
         """
         Takes a dictionary sent by the client in the login / registration
@@ -277,10 +276,6 @@ class AuthHandler(BaseHandler):
 
             description: A human readable string to be displayed to the user that
                          describes the operation happening on their account.
-
-            validate_clientdict: Whether to validate that the operation happening
-                                 on the account has not changed. If this is false,
-                                 the client dict is persisted instead of validated.
 
         Returns:
             A tuple of (creds, params, session_id).
@@ -359,13 +354,12 @@ class AuthHandler(BaseHandler):
                     "Requested operation has changed during the UI authentication session.",
                 )
 
-            if validate_clientdict:
-                if session.clientdict != clientdict:
-                    logger.warning(
-                        "Requested operation has changed during the UI "
-                        "authentication session. A future version of Synapse "
-                        "will remove this capability."
-                    )
+            if session.clientdict != clientdict:
+                logger.warning(
+                    "Requested operation has changed during the UI "
+                    "authentication session. A future version of Synapse "
+                    "will remove this capability."
+                )
 
             # For backwards compatibility, changes to the client dict are
             # persisted as clients modify them throughout their user interactive

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -516,7 +516,6 @@ class RegisterRestServlet(RestServlet):
             body,
             self.hs.get_ip_from_request(request),
             "register a new account",
-            validate_clientdict=False,
         )
 
         # Check that we're not trying to register a denied 3pid.

--- a/tests/rest/client/v2_alpha/test_auth.py
+++ b/tests/rest/client/v2_alpha/test_auth.py
@@ -316,6 +316,9 @@ class UIAuthTests(unittest.HomeserverTestCase):
             },
         )
 
+    # This test is currently skipped since it is allowed for non-spec compliant clients.
+    test_cannot_change_body.skip = "Skipped to allow for non-compliant clients"  # type: ignore
+
     def test_cannot_change_uri(self):
         """
         The initial requested URI cannot be modified during the user interactive authentication session.

--- a/tests/rest/client/v2_alpha/test_auth.py
+++ b/tests/rest/client/v2_alpha/test_auth.py
@@ -245,7 +245,11 @@ class UIAuthTests(unittest.HomeserverTestCase):
         """
         The client dict can be modified during the user interactive authentication session.
 
-        Note that this is not spec compliant, but is necessary for clients to work.
+        Note that it is not spec compliant to modify the client dict during a
+        user interactive authentication session, but many clients currently do.
+
+        When Synapse is updated to be spec compliant, the call to re-use the
+        session ID should be rejected.
         """
         # Create a second login.
         self.login("test", self.user_pass)

--- a/tests/rest/client/v2_alpha/test_auth.py
+++ b/tests/rest/client/v2_alpha/test_auth.py
@@ -133,47 +133,6 @@ class FallbackAuthTests(unittest.HomeserverTestCase):
         # We're given a registered user.
         self.assertEqual(channel.json_body["user_id"], "@user:test")
 
-    def test_legacy_registration(self):
-        """
-        Registration allows the parameters to vary through the process.
-        """
-
-        # Make the initial request to register. (Later on a different password
-        # will be used.)
-        # Returns a 401 as per the spec
-        channel = self.register(
-            401, {"username": "user", "type": "m.login.password", "password": "bar"},
-        )
-
-        # Grab the session
-        session = channel.json_body["session"]
-        # Assert our configured public key is being given
-        self.assertEqual(
-            channel.json_body["params"]["m.login.recaptcha"]["public_key"], "brokencake"
-        )
-
-        # Complete the recaptcha step.
-        self.recaptcha(session, 200)
-
-        # also complete the dummy auth
-        self.register(200, {"auth": {"session": session, "type": "m.login.dummy"}})
-
-        # Now we should have fulfilled a complete auth flow, including
-        # the recaptcha fallback step. Make the initial request again, but
-        # with a changed password. This still completes.
-        channel = self.register(
-            200,
-            {
-                "username": "user",
-                "type": "m.login.password",
-                "password": "foo",  # Note that this is different.
-                "auth": {"session": session},
-            },
-        )
-
-        # We're given a registered user.
-        self.assertEqual(channel.json_body["user_id"], "@user:test")
-
     def test_complete_operation_unknown_session(self):
         """
         Attempting to mark an invalid session as complete should error.
@@ -282,9 +241,11 @@ class UIAuthTests(unittest.HomeserverTestCase):
             },
         )
 
-    def test_cannot_change_body(self):
+    def test_can_change_body(self):
         """
-        The initial requested client dict cannot be modified during the user interactive authentication session.
+        The client dict can be modified during the user interactive authentication session.
+
+        Note that this is not spec compliant, but is necessary for clients to work.
         """
         # Create a second login.
         self.login("test", self.user_pass)
@@ -302,9 +263,9 @@ class UIAuthTests(unittest.HomeserverTestCase):
         self.assertIn({"stages": ["m.login.password"]}, channel.json_body["flows"])
 
         # Make another request providing the UI auth flow, but try to delete the
-        # second device. This results in an error.
+        # second device.
         self.delete_devices(
-            403,
+            200,
             {
                 "devices": [device_ids[1]],
                 "auth": {
@@ -315,9 +276,6 @@ class UIAuthTests(unittest.HomeserverTestCase):
                 },
             },
         )
-
-    # This test is currently skipped since it is allowed for non-spec compliant clients.
-    test_cannot_change_body.skip = "Skipped to allow for non-compliant clients"  # type: ignore
 
     def test_cannot_change_uri(self):
         """


### PR DESCRIPTION
Per some of our discussions we need to back-off on verifying the client dictionary since it seems these frequently change in a non-compliant way during UI authentication operations. We do still verify that the URI and method haven't been modified, but only warn loudly if the client dictionary has been.

This will not warn for the registration endpoint, but will persist the modifications to the client dict.

It is our intention in a future version to tighten this up again, but that might need some spec work.

Fixes #7471

## Questions

* Do we need to always persist the modifications to the client dict?
* Do we want to log the device or anything in the warning? The log line should include the user already I think.
* Should the changelog entry be different than the original PRs now that we've done an RC?