### PR TITLE
Enforce MSC2209: auth rules for notifications in power level event

### DIFF
--- a/changelog.d/7502.feature
+++ b/changelog.d/7502.feature
@@ -1,0 +1,1 @@
+Add additional authentication checks for m.room.power_levels event per [MSC2209](https://github.com/matrix-org/matrix-doc/pull/2209).

--- a/synapse/api/room_versions.py
+++ b/synapse/api/room_versions.py
@@ -62,7 +62,7 @@ class RoomVersion(object):
 
     # bool: MSC2209: Check 'notifications' key while verifying
     # m.room.power_levels auth rules.
-    check_notifications_auth = attr.ib(type=bool)
+    limit_notifications_power_levels = attr.ib(type=bool)
 
 
 class RoomVersions(object):
@@ -73,7 +73,7 @@ class RoomVersions(object):
         StateResolutionVersions.V1,
         enforce_key_validity=False,
         special_case_aliases_auth=True,
-        check_notifications_auth=False,
+        limit_notifications_power_levels=False,
     )
     V2 = RoomVersion(
         "2",
@@ -82,7 +82,7 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=False,
         special_case_aliases_auth=True,
-        check_notifications_auth=False,
+        limit_notifications_power_levels=False,
     )
     V3 = RoomVersion(
         "3",
@@ -91,7 +91,7 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=False,
         special_case_aliases_auth=True,
-        check_notifications_auth=False,
+        limit_notifications_power_levels=False,
     )
     V4 = RoomVersion(
         "4",
@@ -100,7 +100,7 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=False,
         special_case_aliases_auth=True,
-        check_notifications_auth=False,
+        limit_notifications_power_levels=False,
     )
     V5 = RoomVersion(
         "5",
@@ -109,7 +109,7 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=True,
         special_case_aliases_auth=True,
-        check_notifications_auth=False,
+        limit_notifications_power_levels=False,
     )
     MSC2432_DEV = RoomVersion(
         "org.matrix.msc2432",
@@ -118,7 +118,7 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=True,
         special_case_aliases_auth=False,
-        check_notifications_auth=False,
+        limit_notifications_power_levels=False,
     )
     MSC2209_DEV = RoomVersion(
         "org.matrix.msc2209",
@@ -127,7 +127,7 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=True,
         special_case_aliases_auth=True,
-        check_notifications_auth=True,
+        limit_notifications_power_levels=True,
     )
 
 

--- a/synapse/api/room_versions.py
+++ b/synapse/api/room_versions.py
@@ -58,7 +58,11 @@ class RoomVersion(object):
     enforce_key_validity = attr.ib()  # bool
 
     # bool: before MSC2261/MSC2432, m.room.aliases had special auth rules and redaction rules
-    special_case_aliases_auth = attr.ib(type=bool, default=False)
+    special_case_aliases_auth = attr.ib(type=bool)
+
+    # bool: MSC2209: Check 'notifications' key while verifying
+    # m.room.power_levels auth rules.
+    check_notifications_auth = attr.ib(type=bool)
 
 
 class RoomVersions(object):
@@ -69,6 +73,7 @@ class RoomVersions(object):
         StateResolutionVersions.V1,
         enforce_key_validity=False,
         special_case_aliases_auth=True,
+        check_notifications_auth=False,
     )
     V2 = RoomVersion(
         "2",
@@ -77,6 +82,7 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=False,
         special_case_aliases_auth=True,
+        check_notifications_auth=False,
     )
     V3 = RoomVersion(
         "3",
@@ -85,6 +91,7 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=False,
         special_case_aliases_auth=True,
+        check_notifications_auth=False,
     )
     V4 = RoomVersion(
         "4",
@@ -93,6 +100,7 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=False,
         special_case_aliases_auth=True,
+        check_notifications_auth=False,
     )
     V5 = RoomVersion(
         "5",
@@ -101,6 +109,7 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=True,
         special_case_aliases_auth=True,
+        check_notifications_auth=False,
     )
     MSC2432_DEV = RoomVersion(
         "org.matrix.msc2432",
@@ -109,6 +118,16 @@ class RoomVersions(object):
         StateResolutionVersions.V2,
         enforce_key_validity=True,
         special_case_aliases_auth=False,
+        check_notifications_auth=False,
+    )
+    MSC2209_DEV = RoomVersion(
+        "org.matrix.msc2209",
+        RoomDisposition.UNSTABLE,
+        EventFormatVersions.V3,
+        StateResolutionVersions.V2,
+        enforce_key_validity=True,
+        special_case_aliases_auth=True,
+        check_notifications_auth=True,
     )
 
 
@@ -121,5 +140,6 @@ KNOWN_ROOM_VERSIONS = {
         RoomVersions.V4,
         RoomVersions.V5,
         RoomVersions.MSC2432_DEV,
+        RoomVersions.MSC2209_DEV,
     )
 }  # type: Dict[str, RoomVersion]

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -486,7 +486,7 @@ def _check_power_levels(room_version_obj, event, auth_events):
 
     # MSC2209 specifies these checks should also be done for the "notifications"
     # key.
-    if room_version_obj.check_notifications_auth:
+    if room_version_obj.limit_notifications_power_levels:
         old_list = current_state.content.get("notifications", {})
         new_list = event.content.get("notifications", {})
         for ev_id in set(list(old_list) + list(new_list)):

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -181,7 +181,7 @@ def check(
     _can_send_event(event, auth_events)
 
     if event.type == EventTypes.PowerLevels:
-        _check_power_levels(event, auth_events)
+        _check_power_levels(room_version_obj, event, auth_events)
 
     if event.type == EventTypes.Redaction:
         check_redaction(room_version_obj, event, auth_events)
@@ -442,7 +442,7 @@ def check_redaction(room_version_obj: RoomVersion, event, auth_events):
     raise AuthError(403, "You don't have permission to redact events")
 
 
-def _check_power_levels(event, auth_events):
+def _check_power_levels(room_version_obj, event, auth_events):
     user_list = event.content.get("users", {})
     # Validate users
     for k, v in user_list.items():
@@ -483,6 +483,14 @@ def _check_power_levels(event, auth_events):
     new_list = event.content.get("events", {})
     for ev_id in set(list(old_list) + list(new_list)):
         levels_to_check.append((ev_id, "events"))
+
+    # MSC2209 specifies these checks should also be done for the "notifications"
+    # key.
+    if room_version_obj.check_notifications_auth:
+        old_list = current_state.content.get("notifications", {})
+        new_list = event.content.get("notifications", {})
+        for ev_id in set(list(old_list) + list(new_list)):
+            levels_to_check.append((ev_id, "notifications"))
 
     old_state = current_state.content
     new_state = event.content


### PR DESCRIPTION
Fixes #7501 

This adds a new flag to `RoomVersion` to specify when to enforce the additional rules on power level events, it then implements the logic to enforce this. Includes a basic test.