### PR TITLE
Fix b'GET' in prometheus metrics

### DIFF
--- a/changelog.d/7503.bugfix
+++ b/changelog.d/7503.bugfix
@@ -1,0 +1,1 @@
+Fix incorrect `method` label on `synapse_http_matrixfederationclient_{requests,responses}` prometheus metrics.

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -408,7 +408,7 @@ class MatrixFederationHttpClient(object):
                         _sec_timeout,
                     )
 
-                    outgoing_requests_counter.labels(method_bytes).inc()
+                    outgoing_requests_counter.labels(request.method).inc()
 
                     try:
                         with Measure(self.clock, "outbound_request"):
@@ -434,7 +434,9 @@ class MatrixFederationHttpClient(object):
                         logger.info("Failed to send request: %s", e)
                         raise_from(RequestSendFailed(e, can_retry=True), e)
 
-                    incoming_responses_counter.labels(method_bytes, response.code).inc()
+                    incoming_responses_counter.labels(
+                        request.method, response.code
+                    ).inc()
 
                     set_tag(tags.HTTP_STATUS_CODE, response.code)
 


### PR DESCRIPTION
Fixes this nonsense:

![image](https://user-images.githubusercontent.com/1389908/81954248-8a23f480-9600-11ea-9d77-7e4b7b2fe8d1.png)
