### PR TITLE
Fix a small typo in the arguments of simple_update in update_remote_profile_cache

### DIFF
--- a/changelog.d/7511.bugfix
+++ b/changelog.d/7511.bugfix
@@ -1,1 +1,1 @@
-Fix a typo that broke the update remote profile background process. Bug introduced in #2429.
+Fix a long-standing bug that broke the update remote profile background process.

--- a/changelog.d/7511.bugfix
+++ b/changelog.d/7511.bugfix
@@ -1,0 +1,1 @@
+Fix a typo in a storage function of remote profile caches.

--- a/changelog.d/7511.bugfix
+++ b/changelog.d/7511.bugfix
@@ -1,1 +1,1 @@
-Fix a typo in a storage function of remote profile caches.
+Fix a typo that broke the update remote profile background process. Bug introduced in #2429.

--- a/synapse/storage/data_stores/main/profile.py
+++ b/synapse/storage/data_stores/main/profile.py
@@ -110,7 +110,7 @@ class ProfileStore(ProfileWorkerStore):
         return self.db.simple_update(
             table="remote_profile_cache",
             keyvalues={"user_id": user_id},
-            values={
+            updatevalues={
                 "displayname": displayname,
                 "avatar_url": avatar_url,
                 "last_check": self._clock.time_msec(),


### PR DESCRIPTION
`values` is not an argument to `simple_update`, but `updatevalues` is. I believe this was an error when referencing the above function, which uses `simple_upsert`, which does have a `values` argument.