### PR TITLE
Hash passwords earlier in the registration process

### DIFF
--- a/changelog.d/7523.bugfix
+++ b/changelog.d/7523.bugfix
@@ -1,0 +1,1 @@
+Hash passwords as early as possible during registration.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -147,7 +147,7 @@ class RegistrationHandler(BaseHandler):
         Args:
             localpart: The local part of the user ID to register. If None,
               one will be generated.
-            password_hash (unicode): The hashed password to assign to this user so they can
+            password_hash (str|None): The hashed password to assign to this user so they can
               login again. This can be None which means they cannot login again
               via a password (e.g. the user is an application service user).
             user_type (str|None): type of user. One of the values from

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -132,7 +132,7 @@ class RegistrationHandler(BaseHandler):
     def register_user(
         self,
         localpart=None,
-        password=None,
+        password_hash=None,
         guest_access_token=None,
         make_guest=False,
         admin=False,
@@ -147,7 +147,7 @@ class RegistrationHandler(BaseHandler):
         Args:
             localpart: The local part of the user ID to register. If None,
               one will be generated.
-            password (unicode): The password to assign to this user so they can
+            password_hash (unicode): The hashed password to assign to this user so they can
               login again. This can be None which means they cannot login again
               via a password (e.g. the user is an application service user).
             user_type (str|None): type of user. One of the values from
@@ -164,11 +164,6 @@ class RegistrationHandler(BaseHandler):
         yield self.check_registration_ratelimit(address)
 
         yield self.auth.check_auth_blocking(threepid=threepid)
-        password_hash = None
-        if password:
-            password_hash = yield defer.ensureDeferred(
-                self._auth_handler.hash(password)
-            )
 
         if localpart is not None:
             yield self.check_username(localpart, guest_access_token=guest_access_token)


### PR DESCRIPTION
The registration endpoint now calculates the password hash early and passes that to all other code, including the user interactive authentication process.
