### PR TITLE
Ensure worker config exists in systemd service

### DIFF
--- a/changelog.d/7528.doc
+++ b/changelog.d/7528.doc
@@ -1,0 +1,1 @@
+Change the systemd worker service to check that the worker config file exists instead of silently failing. Contributed by David Vo.

--- a/docs/systemd-with-workers/system/matrix-synapse-worker@.service
+++ b/docs/systemd-with-workers/system/matrix-synapse-worker@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Synapse %i
-
+AssertPathExists=/etc/matrix-synapse/workers/%i.yaml
 # This service should be restarted when the synapse target is restarted.
 PartOf=matrix-synapse.target
 


### PR DESCRIPTION
Whilst working with PC-Admin to set up workers, we noticed it was too easy to typo worker names when enabling the corresponding systemd service.

This makes systemd check that the worker config file exists when starting, immediately giving an error message instead of silently failing and forever restarting the broken service.

An example error message:
```console
$ sudo systemctl start matrix-synapse-worker@federation_sender
Assertion failed on job for matrix-synapse-worker@federation_sender.service.
```

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
