### PR TITLE
Return 200 OK for all OPTIONS requests

### DIFF
--- a/changelog.d/7534.misc
+++ b/changelog.d/7534.misc
@@ -1,0 +1,1 @@
+Add a listener to workers that don't have the media repo enabled which returns 200 OK for OPTIONS requests.

--- a/changelog.d/7534.misc
+++ b/changelog.d/7534.misc
@@ -1,1 +1,1 @@
-Add a listener to workers that don't have the media repo enabled which returns 200 OK for OPTIONS requests.
+All endpoints now respond with a 200 OK for `OPTIONS` requests.

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -22,7 +22,6 @@ from typing import Dict, Iterable
 from typing_extensions import ContextManager
 
 from twisted.internet import defer, reactor
-from twisted.web.resource import NoResource
 
 import synapse
 import synapse.events
@@ -41,7 +40,7 @@ from synapse.config.logger import setup_logging
 from synapse.federation import send_queue
 from synapse.federation.transport.server import TransportLayerServer
 from synapse.handlers.presence import BasePresenceHandler, get_interested_parties
-from synapse.http.server import JsonResource, OptionsOnlyResource
+from synapse.http.server import JsonResource, OptionsResource
 from synapse.http.servlet import RestServlet, parse_json_object_from_request
 from synapse.http.site import SynapseSite
 from synapse.logging.context import LoggingContext
@@ -574,17 +573,7 @@ class GenericWorkerServer(HomeServer):
                 if name == "replication":
                     resources[REPLICATION_PREFIX] = ReplicationRestResource(self)
 
-            # Avoid 404s for requests to the media repo on workers which do not
-            # have the media listener enabled.
-            if "media" not in res["names"]:
-                resources.update(
-                    {
-                        MEDIA_PREFIX: OptionsOnlyResource(),
-                        LEGACY_MEDIA_PREFIX: OptionsOnlyResource(),
-                    }
-                )
-
-        root_resource = create_resource_tree(resources, NoResource())
+        root_resource = create_resource_tree(resources, OptionsResource())
 
         _base.listen_tcp(
             bind_addresses,

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -41,7 +41,7 @@ from synapse.config.logger import setup_logging
 from synapse.federation import send_queue
 from synapse.federation.transport.server import TransportLayerServer
 from synapse.handlers.presence import BasePresenceHandler, get_interested_parties
-from synapse.http.server import JsonResource
+from synapse.http.server import JsonResource, OptionsOnlyResource
 from synapse.http.servlet import RestServlet, parse_json_object_from_request
 from synapse.http.site import SynapseSite
 from synapse.logging.context import LoggingContext
@@ -573,6 +573,16 @@ class GenericWorkerServer(HomeServer):
 
                 if name == "replication":
                     resources[REPLICATION_PREFIX] = ReplicationRestResource(self)
+
+            # Avoid 404s for requests to the media repo on workers which do not
+            # have the media listener enabled.
+            if "media" not in res["names"]:
+                resources.update(
+                    {
+                        MEDIA_PREFIX: OptionsOnlyResource(),
+                        LEGACY_MEDIA_PREFIX: OptionsOnlyResource(),
+                    }
+                )
 
         root_resource = create_resource_tree(resources, NoResource())
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -31,7 +31,7 @@ from prometheus_client import Gauge
 from twisted.application import service
 from twisted.internet import defer, reactor
 from twisted.python.failure import Failure
-from twisted.web.resource import EncodingResourceWrapper, IResource, NoResource
+from twisted.web.resource import EncodingResourceWrapper, IResource
 from twisted.web.server import GzipEncoderFactory
 from twisted.web.static import File
 
@@ -52,7 +52,11 @@ from synapse.config._base import ConfigError
 from synapse.config.homeserver import HomeServerConfig
 from synapse.federation.transport.server import TransportLayerServer
 from synapse.http.additional_resource import AdditionalResource
-from synapse.http.server import RootRedirect
+from synapse.http.server import (
+    OptionsResource,
+    RootOptionsRedirectResource,
+    RootRedirect,
+)
 from synapse.http.site import SynapseSite
 from synapse.logging.context import LoggingContext
 from synapse.metrics import METRICS_PREFIX, MetricsResource, RegistryProxy
@@ -121,11 +125,11 @@ class SynapseHomeServer(HomeServer):
 
         # try to find something useful to redirect '/' to
         if WEB_CLIENT_PREFIX in resources:
-            root_resource = RootRedirect(WEB_CLIENT_PREFIX)
+            root_resource = RootOptionsRedirectResource(WEB_CLIENT_PREFIX)
         elif STATIC_PREFIX in resources:
-            root_resource = RootRedirect(STATIC_PREFIX)
+            root_resource = RootOptionsRedirectResource(STATIC_PREFIX)
         else:
-            root_resource = NoResource()
+            root_resource = OptionsResource()
 
         root_resource = create_resource_tree(resources, root_resource)
 

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -404,6 +404,32 @@ class DirectServeResource(resource.Resource):
         return NOT_DONE_YET
 
 
+class OptionsOnlyResource(resource.Resource):
+    """
+    A resource which responds only to OPTION requests for itself and all children.
+
+    All other requests return a 404.
+    """
+    def render(self, request):
+        if request.method == b"OPTIONS":
+            code, response_json_object = _options_handler(request)
+
+        else:
+            # Otherwise, 404.
+            code, response_json_object = 404, {}
+
+        return respond_with_json(
+            request,
+            code,
+            response_json_object,
+            send_cors=False,
+            canonical_json=False,
+        )
+
+    def getChild(self, name, request):
+        return self  # select ourselves as the child to render
+
+
 def _options_handler(request):
     """Request handler for OPTIONS requests
 

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -410,6 +410,7 @@ class OptionsOnlyResource(resource.Resource):
 
     All other requests return a 404.
     """
+
     def render(self, request):
         if request.method == b"OPTIONS":
             code, response_json_object = _options_handler(request)
@@ -419,11 +420,7 @@ class OptionsOnlyResource(resource.Resource):
             code, response_json_object = 404, {}
 
         return respond_with_json(
-            request,
-            code,
-            response_json_object,
-            send_cors=False,
-            canonical_json=False,
+            request, code, response_json_object, send_cors=False, canonical_json=False,
         )
 
     def getChild(self, name, request):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -175,12 +175,13 @@ class OptionsResourceTests(unittest.TestCase):
 
         class DummyResource(Resource):
             isLeaf = True
+
             def render(self, request):
                 return request.path
 
         # Setup a resource with some children.
         self.resource = OptionsResource()
-        self.resource.putChild(b'res', DummyResource())
+        self.resource.putChild(b"res", DummyResource())
 
     def _make_request(self, method, path):
         """Create a request from the method/path and return a channel with the response."""


### PR DESCRIPTION
This is an attempt to fix #7313.  

~~For workers which don't have a `media` listener it adds dummy endpoints which return a 200 OK for `OPTIONS` requests to themselves and any leaf below them. Any other requests method (`POST`, `PUT`, `GET`, etc.) is a 404.~~

For all endpoints under the root endpoint it will return a 200 OK for `OPTIONS` requests. Other requests will act as "normal".

I do have some questions:
* [x] Should this only be on workers?
* [x] This will now return 200 for completely bogus URLs (`/_matrix/media/r0/foo/bar`). Is that OK?
* [x] I will likely want to write some tests once some of the above are answered.