### PR TITLE
Hash passwords earlier in the password reset process

### DIFF
--- a/changelog.d/7538.bugfix
+++ b/changelog.d/7538.bugfix
@@ -1,0 +1,1 @@
+ Hash passwords as early as possible during password reset.

--- a/synapse/handlers/set_password.py
+++ b/synapse/handlers/set_password.py
@@ -35,15 +35,12 @@ class SetPasswordHandler(BaseHandler):
     async def set_password(
         self,
         user_id: str,
-        new_password: str,
+        password_hash: str,
         logout_devices: bool,
         requester: Optional[Requester] = None,
     ):
         if not self.hs.config.password_localdb_enabled:
             raise SynapseError(403, "Password change disabled", errcode=Codes.FORBIDDEN)
-
-        self._password_policy_handler.validate_password(new_password)
-        password_hash = await self._auth_handler.hash(new_password)
 
         try:
             await self.store.user_set_password_hash(user_id, password_hash)

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -222,8 +222,14 @@ class UserRestServletV2(RestServlet):
                 else:
                     new_password = body["password"]
                     logout_devices = True
+
+                    new_password_hash = await self.auth_handler.hash(new_password)
+
                     await self.set_password_handler.set_password(
-                        target_user.to_string(), new_password, logout_devices, requester
+                        target_user.to_string(),
+                        new_password_hash,
+                        logout_devices,
+                        requester,
                     )
 
             if "deactivated" in body:
@@ -523,6 +529,7 @@ class ResetPasswordRestServlet(RestServlet):
         self.store = hs.get_datastore()
         self.hs = hs
         self.auth = hs.get_auth()
+        self.auth_handler = hs.get_auth_handler()
         self._set_password_handler = hs.get_set_password_handler()
 
     async def on_POST(self, request, target_user_id):
@@ -539,8 +546,10 @@ class ResetPasswordRestServlet(RestServlet):
         new_password = params["new_password"]
         logout_devices = params.get("logout_devices", True)
 
+        new_password_hash = await self.auth_handler.hash(new_password)
+
         await self._set_password_handler.set_password(
-            target_user_id, new_password, logout_devices, requester
+            target_user_id, new_password_hash, logout_devices, requester
         )
         return 200, {}
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -228,7 +228,7 @@ class PasswordRestServlet(RestServlet):
         body = parse_json_object_from_request(request)
 
         # we do basic sanity checks here because the auth layer will store these
-        # in sessions. Pull out the username/password provided to us.
+        # in sessions. Pull out the new password provided to us.
         if "new_password" in body:
             new_password = body.pop("new_password")
             if not isinstance(new_password, str) or len(new_password) > 512:

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -431,8 +431,8 @@ class RegisterRestServlet(RestServlet):
                 raise SynapseError(400, "Invalid password")
             self.password_policy_handler.validate_password(password)
 
-            # If the password is valid, hash it and store it back on the request.
-            # This ensures the hashed password is handled everywhere.
+            # If the password is valid, hash it and store it back on the body.
+            # This ensures that only the hashed password is handled everywhere.
             if "password_hash" in body:
                 raise SynapseError(400, "Unexpected property: password_hash")
             body["password_hash"] = await self.auth_handler.hash(password)


### PR DESCRIPTION
This is essentially #7523, but for the password reset process. This makes the two sets of code much more similar:

* The validation done on both is now the same.
* The validation on the new password is done *before* the UI Auth process.
* Both now hash passwords immediately.

~~I targeted this against 1.13.0 since it would be nice to include this in a 1.13.1 if one is done. It should retarget fine against develop.~~