### PR TITLE
Remove cosmic and disco which are both EOL.

### DIFF
--- a/changelog.d/7539.misc
+++ b/changelog.d/7539.misc
@@ -1,1 +1,1 @@
-Remove Ubuntu Cosmic and Disco from the list of supported distributions due to end-of-life.
+Remove Ubuntu Cosmic and Disco from the list of distributions which we provide `.deb`s for, due to end-of-life.

--- a/changelog.d/7539.misc
+++ b/changelog.d/7539.misc
@@ -1,0 +1,1 @@
+Remove Ubuntu Cosmic and Disco from the list of supported distributions due to end-of-life.

--- a/scripts-dev/build_debian_packages
+++ b/scripts-dev/build_debian_packages
@@ -24,8 +24,6 @@ DISTS = (
     "debian:sid",
     "ubuntu:xenial",
     "ubuntu:bionic",
-    "ubuntu:cosmic",
-    "ubuntu:disco",
     "ubuntu:eoan",
     "ubuntu:focal",
 )


### PR DESCRIPTION
Per the release of v1.13.0 Ubuntu Cosmic and Disco have reached EOL in July 2019 and January 2020, respectively.