### PR TITLE
Fix bug in persist events when dealing with non member types.

### DIFF
--- a/changelog.d/7548.bugfix
+++ b/changelog.d/7548.bugfix
@@ -1,0 +1,1 @@
+Fix bug where a local user leaving a room could fail under rare circumstances.

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -740,8 +740,8 @@ class EventsPersistenceStorage(object):
         # whose state has changed as we've already their new state above.
         users_to_ignore = [
             state_key
-            for _, state_key in itertools.chain(delta.to_insert, delta.to_delete)
-            if self.is_mine_id(state_key)
+            for typ, state_key in itertools.chain(delta.to_insert, delta.to_delete)
+            if typ == EventTypes.Member and self.is_mine_id(state_key)
         ]
 
         if await self.main_store.is_local_host_in_room_ignoring_users(


### PR DESCRIPTION
`_is_server_still_joined` will throw if it is given state updates with non-user ID state keys with local user leaves. This is actually rarely a problem since local leaves almost always get persisted by themselves.

(I discovered this on a branch that was otherwise broken, so I haven't seen this in the wild)