### PR TITLE
Pass in a non-empty RelayState for user interactive authentication with SAML

### DIFF
--- a/changelog.d/7552.bugfix
+++ b/changelog.d/7552.bugfix
@@ -1,0 +1,1 @@
+Fix "Missing RelayState parameter" error when using user interactive authentication with SAML for some SAML providers.

--- a/synapse/rest/client/v2_alpha/auth.py
+++ b/synapse/rest/client/v2_alpha/auth.py
@@ -177,7 +177,10 @@ class AuthRestServlet(RestServlet):
                 )
 
             elif self._saml_enabled:
-                client_redirect_url = b""
+                # Some SAML identity providers (e.g. Google) require a
+                # RelayState parameter on requests. It is not necessary here, so
+                # pass in a dummy redirect URL (which will never get used).
+                client_redirect_url = b"unused"
                 sso_redirect_url = self._saml_handler.handle_redirect_request(
                     client_redirect_url, session
                 )


### PR DESCRIPTION
To repeat some of #7484, it seems that some SAML identity providers (e.g. Google) require that a `RelayState` parameter is passed in, even though it is optional. We do not use a relay state for UI auth, but can provide a dummy one in that case.

Fixes #7484