### PR TITLE
Fix stacktrace mangling in `patch_inline_callbacks`

### DIFF
--- a/changelog.d/7554.misc
+++ b/changelog.d/7554.misc
@@ -1,0 +1,1 @@
+Fix some test code to not mangle stacktraces, to make it easier to debug errors.

--- a/synapse/util/patch_inline_callbacks.py
+++ b/synapse/util/patch_inline_callbacks.py
@@ -186,10 +186,15 @@ def _check_yield_points(f: Callable, changes: List[str]):
                     )
                     raise Exception(err)
 
+            # the wrapped function yielded a Deferred: yield it back up to the parent
+            # inlineCallbacks().
             try:
                 result = yield d
-            except Exception as e:
-                result = Failure(e)
+            except Exception:
+                # this will fish an earlier Failure out of the stack where possible, and
+                # thus is preferable to passing in an exeception to the Failure
+                # constructor, since it results in less stack-mangling.
+                result = Failure()
 
             if current_context() != expected_context:
 


### PR DESCRIPTION
`Failure()` is more cunning than `Failure(e)`.