### PR TITLE
Refresh apt cache when building dh-virtualenv docker image

### DIFF
--- a/changelog.d/7555.misc
+++ b/changelog.d/7555.misc
@@ -1,0 +1,1 @@
+Refresh apt cache when building dh_virtualenv docker image.

--- a/docker/Dockerfile-dhvirtualenv
+++ b/docker/Dockerfile-dhvirtualenv
@@ -31,8 +31,10 @@ RUN mkdir /dh-virtualenv
 RUN wget -q -O /dh-virtualenv.tar.gz https://github.com/matrix-org/dh-virtualenv/archive/matrixorg-20200519.tar.gz
 RUN tar -xv --strip-components=1 -C /dh-virtualenv -f /dh-virtualenv.tar.gz
 
-# install its build deps
-RUN cd /dh-virtualenv \
+# install its build deps. We do another apt-cache-update here, because we might
+# be using a stale cache from docker build.
+RUN apt-get update -qq -o Acquire::Languages=none \
+    && cd /dh-virtualenv \
     && env DEBIAN_FRONTEND=noninteractive mk-build-deps -ri -t "apt-get -y --no-install-recommends"
 
 # build it


### PR DESCRIPTION
When we tried to build debs for 1.13.0, the build failed because docker used a
base docker image which had a stale apt cache.

Fixes: #7540

(This was basically caused by #7526, which meant that we had to rebuild dh-virtualenv.)