### PR TITLE
Fix exception reporting due to HTTP request errors.

### DIFF
--- a/changelog.d/7556.misc
+++ b/changelog.d/7556.misc
@@ -1,0 +1,1 @@
+Stop logging some expected HTTP request errors as exceptions.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -40,6 +40,7 @@ from synapse.api.errors import (
     Codes,
     FederationDeniedError,
     FederationError,
+    HttpResponseException,
     RequestSendFailed,
     SynapseError,
 )
@@ -1036,6 +1037,12 @@ class FederationHandler(BaseHandler):
                     # TODO: We can probably do something more intelligent here.
                     return True
                 except SynapseError as e:
+                    logger.info("Failed to backfill from %s because %s", dom, e)
+                    continue
+                except HttpResponseException as e:
+                    if 400 <= e.code < 500:
+                        raise e.to_synapse_error()
+
                     logger.info("Failed to backfill from %s because %s", dom, e)
                     continue
                 except CodeMessageException as e:


### PR DESCRIPTION
These are business as usual errors, rather than stuff we want to log at error.