### PR TITLE
Fix incorrect placeholder syntax in database prepartion code

### DIFF
--- a/changelog.d/7575.bugfix
+++ b/changelog.d/7575.bugfix
@@ -1,0 +1,1 @@
+Fix str placeholders in an instance of `PrepareDatabaseException`. Introduced in Synapse v1.8.0.

--- a/changelog.d/7575.misc
+++ b/changelog.d/7575.misc
@@ -1,1 +1,0 @@
-Fix str placeholders in an instance of `PrepareDatabaseException`.

--- a/changelog.d/7575.misc
+++ b/changelog.d/7575.misc
@@ -1,0 +1,1 @@
+Fix str placeholders in an instance of `PrepareDatabaseException`.

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -366,9 +366,8 @@ def _upgrade_existing_database(
         if duplicates:
             # We don't support using the same file name in the same delta version.
             raise PrepareDatabaseException(
-                "Found multiple delta files with the same name in v%d: %s",
-                v,
-                duplicates,
+                "Found multiple delta files with the same name in v%d: %s"
+                % (v, duplicates,)
             )
 
         # We sort to ensure that we apply the delta files in a consistent


### PR DESCRIPTION
We were using `logger` syntax which isn't supported by `Exception`s.