### PR TITLE
Don't apply cache factor to event cache.

### DIFF
--- a/changelog.d/7578.bugfix
+++ b/changelog.d/7578.bugfix
@@ -1,0 +1,1 @@
+Fix cache config to not apply cache factor to event cache. Regression in v1.14.0rc1.

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -294,6 +294,9 @@ class LruCache(object):
         Returns:
             bool: Whether the cache changed size or not.
         """
+        if not self.apply_cache_factor_from_config:
+            return False
+
         new_size = int(self._original_max_size * factor)
         if new_size != self.max_size:
             self.max_size = new_size

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -81,6 +81,7 @@ class LruCache(object):
         """
         cache = cache_type()
         self.cache = cache  # Used for introspection.
+        self.apply_cache_factor_from_config = apply_cache_factor_from_config
 
         # Save the original max size, and apply the default size factor.
         self._original_max_size = max_size

--- a/tests/config/test_cache.py
+++ b/tests/config/test_cache.py
@@ -125,3 +125,19 @@ class CacheConfigTests(TestCase):
         cache = LruCache(100)
         add_resizable_cache("foo", cache_resize_callback=cache.set_cache_factor)
         self.assertEqual(cache.max_size, 150)
+
+    def test_apply_cache_factor_from_config(self):
+        """Caches can disable applying cache factor updates, mainly used by
+        event cache size.
+        """
+
+        config = {"caches": {"event_cache_size": "10k"}}
+        t = TestConfig()
+        t.read_config(config, config_dir_path="", data_dir_path="")
+
+        cache = LruCache(
+            max_size=t.caches.event_cache_size, apply_cache_factor_from_config=False,
+        )
+        add_resizable_cache("event_cache", cache_resize_callback=cache.set_cache_factor)
+
+        self.assertEqual(cache.max_size, 10240)


### PR DESCRIPTION
This is already correctly done when we instansiate the cache, but wasn't
when it got reloaded (which always happens at least once on startup).

Broke in #6391