### PR TITLE
Ensure ReplicationStreamer is always started when replication enabled.

### DIFF
--- a/changelog.d/7579.bugfix
+++ b/changelog.d/7579.bugfix
@@ -1,0 +1,1 @@
+Fix bug where `ReplicationStreamer` was not always started when replication was enabled. Bug introduced in v1.14.0rc1.

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -159,6 +159,9 @@ class ReplicationCommandHandler:
                 hs.config.redis_port,
             )
 
+            # First let's ensure that we have a ReplicationStreamer started.
+            hs.get_replication_streamer()
+
             # We need two connections to redis, one for the subscription stream and
             # one to send commands to (as you can't send further redis commands to a
             # connection after SUBSCRIBE is called).


### PR DESCRIPTION
Fixes #7566.