### PR TITLE
Fix sample config docs error

### DIFF
--- a/changelog.d/7581.doc
+++ b/changelog.d/7581.doc
@@ -1,0 +1,1 @@
+Fix OIDC client_auth_method commented out value in sample config.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1546,7 +1546,7 @@ oidc_config:
     # auth method to use when exchanging the token.
     # Valid values are "client_secret_basic" (default), "client_secret_post" and "none".
     #
-    #client_auth_method: "client_auth_basic"
+    #client_auth_method: "client_secret_basic"
 
     # list of scopes to ask. This should include the "openid" scope. Defaults to ["openid"].
     #

--- a/synapse/config/oidc_config.py
+++ b/synapse/config/oidc_config.py
@@ -112,7 +112,7 @@ class OIDCConfig(Config):
             # auth method to use when exchanging the token.
             # Valid values are "client_secret_basic" (default), "client_secret_post" and "none".
             #
-            #client_auth_method: "client_auth_basic"
+            #client_auth_method: "client_secret_basic"
 
             # list of scopes to ask. This should include the "openid" scope. Defaults to ["openid"].
             #


### PR DESCRIPTION
'client_auth_method' commented out value was erronously 'client_auth_basic',
when code and docstring says it should be 'client_secret_basic'.

Signed-off-by: Jason Robinson <jasonr@matrix.org>
