### PR TITLE
Fix 'FederationGroupsRoomsServlet' API when group has room server is not in.

### DIFF
--- a/changelog.d/7599.bugfix
+++ b/changelog.d/7599.bugfix
@@ -1,0 +1,1 @@
+Fix bug where returning rooms for a group would fail if it included a room that the server was not in.

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -253,9 +253,20 @@ class RoomListHandler(BaseHandler):
         """
         result = {"room_id": room_id, "num_joined_members": num_joined_users}
 
+        if with_alias:
+            aliases = yield self.store.get_aliases_for_room(
+                room_id, on_invalidate=cache_context.invalidate
+            )
+            if aliases:
+                result["aliases"] = aliases
+
         current_state_ids = yield self.store.get_current_state_ids(
             room_id, on_invalidate=cache_context.invalidate
         )
+
+        if not current_state_ids:
+            # We're not in the room, so may as well bail out here.
+            return result
 
         event_map = yield self.store.get_events(
             [
@@ -289,14 +300,7 @@ class RoomListHandler(BaseHandler):
         create_event = current_state.get((EventTypes.Create, ""))
         result["m.federate"] = create_event.content.get("m.federate", True)
 
-        if with_alias:
-            aliases = yield self.store.get_aliases_for_room(
-                room_id, on_invalidate=cache_context.invalidate
-            )
-            if aliases:
-                result["aliases"] = aliases
-
-        name_event = yield current_state.get((EventTypes.Name, ""))
+        name_event = current_state.get((EventTypes.Name, ""))
         if name_event:
             name = name_event.content.get("name", None)
             if name:


### PR DESCRIPTION
This was throwing up exceptions in sentry.