### PR TITLE
Advertise Python 3.8 support in setup.py

### DIFF
--- a/changelog.d/7602.doc
+++ b/changelog.d/7602.doc
@@ -1,1 +1,1 @@
-Advertise Python 3.8 support in setup.py.
+Advertise Python 3.8 support in `setup.py`.

--- a/changelog.d/7602.doc
+++ b/changelog.d/7602.doc
@@ -1,0 +1,1 @@
+Advertise Python 3.8 support in setup.py.

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     scripts=["synctl"] + glob.glob("scripts/*"),
     cmdclass={"test": TestCommand},


### PR DESCRIPTION
Synapse supports Python 3.8. We've been [using it in CI](https://github.com/matrix-org/pipelines/blob/2513aea6bf613131e4d613f7fccd780363d10eb6/synapse/pipeline.yml#L216) for a while now.