### PR TITLE
Remove "user_id" from GET /presence

### DIFF
--- a/changelog.d/7606.bugfix
+++ b/changelog.d/7606.bugfix
@@ -1,0 +1,1 @@
+Remove `user_id` from `GET /_matrix/client/r0/presence/{userId}/status` to match spec.

--- a/changelog.d/7606.bugfix
+++ b/changelog.d/7606.bugfix
@@ -1,1 +1,1 @@
-Remove `user_id` from `GET /_matrix/client/r0/presence/{userId}/status` to match spec.
+Remove `user_id` from the response to `GET /_matrix/client/r0/presence/{userId}/status` to match the specification.

--- a/synapse/rest/client/v1/presence.py
+++ b/synapse/rest/client/v1/presence.py
@@ -51,7 +51,9 @@ class PresenceStatusRestServlet(RestServlet):
                 raise AuthError(403, "You are not allowed to see their presence.")
 
         state = await self.presence_handler.get_state(target_user=user)
-        state = format_user_presence_state(state, self.clock.time_msec(), include_user_id=False)
+        state = format_user_presence_state(
+            state, self.clock.time_msec(), include_user_id=False
+        )
 
         return 200, state
 

--- a/synapse/rest/client/v1/presence.py
+++ b/synapse/rest/client/v1/presence.py
@@ -51,7 +51,7 @@ class PresenceStatusRestServlet(RestServlet):
                 raise AuthError(403, "You are not allowed to see their presence.")
 
         state = await self.presence_handler.get_state(target_user=user)
-        state = format_user_presence_state(state, self.clock.time_msec())
+        state = format_user_presence_state(state, self.clock.time_msec(), include_user_id=False)
 
         return 200, state
 


### PR DESCRIPTION
https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-presence-userid-status doesn't include a `user_id`, and given the request URL includes the user_id I suspect there is limited value in diverging from the spec.