### PR TITLE
Don't fail all of an iteration of the device list retry loop on error

### DIFF
--- a/changelog.d/7609.bugfix
+++ b/changelog.d/7609.bugfix
@@ -1,1 +1,1 @@
-Prevent an entire iteration of the device list resync loop to fail if one server responds with a malformed result.
+Prevent an entire iteration of the device list resync loop from failing if one server responds with a malformed result.

--- a/changelog.d/7609.bugfix
+++ b/changelog.d/7609.bugfix
@@ -1,0 +1,1 @@
+Prevent an entire iteration of the device list resync loop to fail if one server responds with a malformed result.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -749,6 +749,7 @@ class DeviceListUpdater(object):
             request:
             https://matrix.org/docs/spec/server_server/r0.1.2#get-matrix-federation-v1-user-devices-userid
         """
+        logger.debug("Attempting to resync the device list for %s", user_id)
         log_kv({"message": "Doing resync to update device list."})
         # Fetch all devices for the user.
         origin = get_domain_from_id(user_id)

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -705,13 +705,7 @@ class DeviceListUpdater(object):
             # Iterate over the set of user IDs.
             for user_id in need_resync:
                 try:
-                    # Try to resync the current user's devices list. Exception handling
-                    # isn't necessary here, since user_device_resync catches all
-                    # instances of "Exception" that might be raised from the federation
-                    # request. This means that if an exception is raised by this
-                    # function, it must be because of a database issue, which means
-                    # _maybe_retry_device_resync probably won't be able to go much
-                    # further anyway.
+                    # Try to resync the current user's devices list.
                     result = yield self.user_device_resync(
                         user_id=user_id, mark_failed_as_stale=False,
                     )

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -704,22 +704,33 @@ class DeviceListUpdater(object):
             need_resync = yield self.store.get_user_ids_requiring_device_list_resync()
             # Iterate over the set of user IDs.
             for user_id in need_resync:
-                # Try to resync the current user's devices list. Exception handling
-                # isn't necessary here, since user_device_resync catches all instances
-                # of "Exception" that might be raised from the federation request. This
-                # means that if an exception is raised by this function, it must be
-                # because of a database issue, which means _maybe_retry_device_resync
-                # probably won't be able to go much further anyway.
-                result = yield self.user_device_resync(
-                    user_id=user_id, mark_failed_as_stale=False,
-                )
-                # user_device_resync only returns a result if it managed to successfully
-                # resync and update the database. Updating the table of users requiring
-                # resync isn't necessary here as user_device_resync already does it
-                # (through self.store.update_remote_device_list_cache).
-                if result:
+                try:
+                    # Try to resync the current user's devices list. Exception handling
+                    # isn't necessary here, since user_device_resync catches all
+                    # instances of "Exception" that might be raised from the federation
+                    # request. This means that if an exception is raised by this
+                    # function, it must be because of a database issue, which means
+                    # _maybe_retry_device_resync probably won't be able to go much
+                    # further anyway.
+                    result = yield self.user_device_resync(
+                        user_id=user_id, mark_failed_as_stale=False,
+                    )
+
+                    # user_device_resync only returns a result if it managed to
+                    # successfully resync and update the database. Updating the table
+                    # of users requiring resync isn't necessary here as
+                    # user_device_resync already does it (through
+                    # self.store.update_remote_device_list_cache).
+                    if result:
+                        logger.debug(
+                            "Successfully resynced the device list for %s", user_id,
+                        )
+                except Exception as e:
+                    # If there was an issue resyncing this user, e.g. if the remote
+                    # server sent a malformed result, just log the error instead of
+                    # aborting all the subsequent resyncs.
                     logger.debug(
-                        "Successfully resynced the device list for %s" % user_id,
+                        "Could not resync the device list for %s: %s", user_id, e,
                     )
         finally:
             # Allow future calls to retry resyncinc out of sync device lists.


### PR DESCRIPTION
Without this patch, if an error happens which isn't caught by `user_device_resync`, then `_maybe_retry_device_resync` would fail, without retrying the next users in the iteration. This patch fixes this so that it now only logs an error in this case.

The reason we're logging as debug here is because if a server is consistently making this fail for a user then we'd end up flooding the logs with these errors, at a rate of one line every 30s. Though it might be fine to log it as info, and I can be convinced either way.
