### PR TITLE
Add config option to selectively delegate different operations to account threepid delegates

### DIFF
--- a/changelog.d/7611.feature
+++ b/changelog.d/7611.feature
@@ -1,0 +1,1 @@
+Add a `delegate_for` configuration flag to `account_threepid_delegates` to allow selectively delegating certain 3PID validation services.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1160,9 +1160,9 @@ account_validity:
 #  - matrix.org
 #  - vector.im
 
-# Handle threepid (email/phone etc) registration and password resets through a set of
-# *trusted* identity servers. Note that this allows the configured identity server to
-# reset passwords for accounts!
+# Handle threepid (email/phone etc) registration and/or password resets through a set of
+# *trusted* identity servers. Note that this potentially allows the configured external
+# service to reset passwords for accounts!
 #
 # Be aware that if `email` is not set, and SMTP options have not been
 # configured in the email config block, registration and user password resets via
@@ -1185,6 +1185,16 @@ account_validity:
 account_threepid_delegates:
     #email: https://example.com     # Delegate email sending to example.com
     #msisdn: http://localhost:8090  # Delegate SMS sending to this local process
+
+    # Choose which services are delegated. These apply to both email and msisdn
+    # identities.
+    #
+    # * adding_threepid: when adding an email or phone number to your homeserver
+    # * password_resets: when verifying your email or phone number during password reset
+    #
+    # Default is delegating for all services, or [adding_threepid, password_resets].
+    #
+    #delegate_for: [adding_threepid]
 
 # Whether users are allowed to change their displayname after it has
 # been initially set. Useful when provisioning users based on the

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -19,6 +19,7 @@ from distutils.util import strtobool
 import pkg_resources
 
 from synapse.config._base import Config, ConfigError
+from synapse.config.emailconfig import ThreepidService
 from synapse.types import RoomAlias
 from synapse.util.stringutils import random_string_with_symbols
 
@@ -115,6 +116,20 @@ class RegistrationConfig(Config):
                 "`account_threepid_delegate.msisdn` is set, such that "
                 "clients know where to submit validation tokens to. Please "
                 "configure `public_baseurl`."
+            )
+
+        delegate_for = account_threepid_delegates.get(
+            "delegate_for",
+            [ThreepidService.ADDING_THREEPID, ThreepidService.PASSWORD_RESET],
+        )
+        try:
+            self.account_threepid_delegate_delegate_for = [
+                ThreepidService(service_type) for service_type in delegate_for
+            ]
+        except ValueError as e:
+            # This will be raised if a provided service_type does not exist
+            raise ConfigError(
+                "Option account_threepid_delegates.delegate_for: %s" % (e,)
             )
 
         self.default_identity_server = config.get("default_identity_server")
@@ -307,9 +322,9 @@ class RegistrationConfig(Config):
         #  - matrix.org
         #  - vector.im
 
-        # Handle threepid (email/phone etc) registration and password resets through a set of
-        # *trusted* identity servers. Note that this allows the configured identity server to
-        # reset passwords for accounts!
+        # Handle threepid (email/phone etc) registration and/or password resets through a set of
+        # *trusted* identity servers. Note that this potentially allows the configured external
+        # service to reset passwords for accounts!
         #
         # Be aware that if `email` is not set, and SMTP options have not been
         # configured in the email config block, registration and user password resets via
@@ -332,6 +347,16 @@ class RegistrationConfig(Config):
         account_threepid_delegates:
             #email: https://example.com     # Delegate email sending to example.com
             #msisdn: http://localhost:8090  # Delegate SMS sending to this local process
+
+            # Choose which services are delegated. These apply to both email and msisdn
+            # identities.
+            #
+            # * adding_threepid: when adding an email or phone number to your homeserver
+            # * password_resets: when verifying your email or phone number during password reset
+            #
+            # Default is delegating for all services, or [adding_threepid, password_resets].
+            #
+            #delegate_for: [adding_threepid]
 
         # Whether users are allowed to change their displayname after it has
         # been initially set. Useful when provisioning users based on the

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -35,7 +35,7 @@ from synapse.api.errors import (
     HttpResponseException,
     SynapseError,
 )
-from synapse.config.emailconfig import ThreepidBehaviour
+from synapse.config.emailconfig import ThreepidBehaviour, ThreepidService  # noqa: F401
 from synapse.http.client import SimpleHttpClient
 from synapse.util.hash import sha256_and_url_safe_base64
 from synapse.util.stringutils import assert_valid_client_secret, random_string
@@ -296,6 +296,7 @@ class IdentityHandler(BaseHandler):
         client_secret,
         send_attempt,
         send_email_func,
+        service,
         next_link=None,
     ):
         """Send a threepid validation email for password reset or
@@ -308,6 +309,8 @@ class IdentityHandler(BaseHandler):
             send_email_func (func): A function that takes an email address, token,
                                     client_secret and session_id, sends an email
                                     and returns a Deferred.
+            service (ThreepidService): The type of threepid service that
+                this validation session will authorise
             next_link (str|None): The URL to redirect the user to after validation
 
         Returns:
@@ -372,6 +375,7 @@ class IdentityHandler(BaseHandler):
             next_link,
             token,
             token_expires,
+            service,
         )
 
         return session_id

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -47,7 +47,10 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
         self.config = hs.config
         self.identity_handler = hs.get_handlers().identity_handler
 
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
+        if (
+            self.config.threepid_behaviour_email_password_reset
+            == ThreepidBehaviour.LOCAL
+        ):
             template_html, template_text = load_jinja2_templates(
                 self.config.email_template_dir,
                 [
@@ -66,7 +69,7 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
             )
 
     async def on_POST(self, request):
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.OFF:
+        if self.config.threepid_behaviour_email_password_reset == ThreepidBehaviour.OFF:
             if self.config.local_threepid_handling_disabled_due_to_email_config:
                 logger.warning(
                     "User password resets have been disabled due to lack of email config"
@@ -106,7 +109,10 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
 
             raise SynapseError(400, "Email not found", Codes.THREEPID_NOT_FOUND)
 
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.REMOTE:
+        if (
+            self.config.threepid_behaviour_email_password_reset
+            == ThreepidBehaviour.REMOTE
+        ):
             assert self.hs.config.account_threepid_delegate_email
 
             # Have the configured identity server handle the request
@@ -151,7 +157,10 @@ class PasswordResetSubmitTokenServlet(RestServlet):
         self.config = hs.config
         self.clock = hs.get_clock()
         self.store = hs.get_datastore()
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
+        if (
+            self.config.threepid_behaviour_email_password_reset
+            == ThreepidBehaviour.LOCAL
+        ):
             (self.failure_email_template,) = load_jinja2_templates(
                 self.config.email_template_dir,
                 [self.config.email_password_reset_template_failure_html],
@@ -163,7 +172,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
             raise SynapseError(
                 400, "This medium is currently not supported for password resets"
             )
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.OFF:
+        if self.config.threepid_behaviour_email_password_reset == ThreepidBehaviour.OFF:
             if self.config.local_threepid_handling_disabled_due_to_email_config:
                 logger.warning(
                     "Password reset emails have been disabled due to lack of an email config"
@@ -327,7 +336,7 @@ class DeactivateAccountRestServlet(RestServlet):
 
         requester = await self.auth.get_user_by_req(request)
 
-        # allow ASes to dectivate their own users
+        # allow ASes to deactivate their own users
         if requester.app_service:
             await self._deactivate_account_handler.deactivate_account(
                 requester.user.to_string(), erase
@@ -362,7 +371,7 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
         self.identity_handler = hs.get_handlers().identity_handler
         self.store = self.hs.get_datastore()
 
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
+        if self.config.threepid_behaviour_email_add_threepid == ThreepidBehaviour.LOCAL:
             template_html, template_text = load_jinja2_templates(
                 self.config.email_template_dir,
                 [
@@ -379,7 +388,7 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
             )
 
     async def on_POST(self, request):
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.OFF:
+        if self.config.threepid_behaviour_email_add_threepid == ThreepidBehaviour.OFF:
             if self.config.local_threepid_handling_disabled_due_to_email_config:
                 logger.warning(
                     "Adding emails have been disabled due to lack of an email config"
@@ -416,7 +425,10 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
 
             raise SynapseError(400, "Email is already in use", Codes.THREEPID_IN_USE)
 
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.REMOTE:
+        if (
+            self.config.threepid_behaviour_email_add_threepid
+            == ThreepidBehaviour.REMOTE
+        ):
             assert self.hs.config.account_threepid_delegate_email
 
             # Have the configured identity server handle the request
@@ -522,14 +534,14 @@ class AddThreepidEmailSubmitTokenServlet(RestServlet):
         self.config = hs.config
         self.clock = hs.get_clock()
         self.store = hs.get_datastore()
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
+        if self.config.threepid_behaviour_email_add_threepid == ThreepidBehaviour.LOCAL:
             (self.failure_email_template,) = load_jinja2_templates(
                 self.config.email_template_dir,
                 [self.config.email_add_threepid_template_failure_html],
             )
 
     async def on_GET(self, request):
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.OFF:
+        if self.config.threepid_behaviour_email_add_threepid == ThreepidBehaviour.OFF:
             if self.config.local_threepid_handling_disabled_due_to_email_config:
                 logger.warning(
                     "Adding emails have been disabled due to lack of an email config"
@@ -537,7 +549,10 @@ class AddThreepidEmailSubmitTokenServlet(RestServlet):
             raise SynapseError(
                 400, "Adding an email to your account is disabled on this server"
             )
-        elif self.config.threepid_behaviour_email == ThreepidBehaviour.REMOTE:
+        elif (
+            self.config.threepid_behaviour_email_add_threepid
+            == ThreepidBehaviour.REMOTE
+        ):
             raise SynapseError(
                 400,
                 "This homeserver is not validating threepids. Use an identity server "

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -19,7 +19,7 @@ from http import HTTPStatus
 
 from synapse.api.constants import LoginType
 from synapse.api.errors import Codes, SynapseError, ThreepidValidationError
-from synapse.config.emailconfig import ThreepidBehaviour
+from synapse.config.emailconfig import ThreepidBehaviour, ThreepidService
 from synapse.http.server import finish_request
 from synapse.http.servlet import (
     RestServlet,
@@ -130,7 +130,8 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
                 client_secret,
                 send_attempt,
                 self.mailer.send_password_reset_mail,
-                next_link,
+                service=ThreepidService.PASSWORD_RESET,
+                next_link=next_link,
             )
 
             # Wrap the session id in a JSON object
@@ -446,7 +447,8 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
                 client_secret,
                 send_attempt,
                 self.mailer.send_add_threepid_mail,
-                next_link,
+                service=ThreepidService.ADDING_THREEPID,
+                next_link=next_link,
             )
 
             # Wrap the session id in a JSON object

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -79,7 +79,12 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
         self.identity_handler = hs.get_handlers().identity_handler
         self.config = hs.config
 
-        if self.hs.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
+        # Only load resources to validate registration emails if smtp details are configured
+        # on the homeserver
+        if (
+            self.hs.config.threepid_behaviour_email_add_threepid
+            == ThreepidBehaviour.LOCAL
+        ):
             from synapse.push.mailer import Mailer, load_jinja2_templates
 
             template_html, template_text = load_jinja2_templates(
@@ -100,7 +105,10 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
             )
 
     async def on_POST(self, request):
-        if self.hs.config.threepid_behaviour_email == ThreepidBehaviour.OFF:
+        if (
+            self.hs.config.threepid_behaviour_email_add_threepid
+            == ThreepidBehaviour.OFF
+        ):
             if self.hs.config.local_threepid_handling_disabled_due_to_email_config:
                 logger.warning(
                     "Email registration has been disabled due to lack of email config"
@@ -139,7 +147,10 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
 
             raise SynapseError(400, "Email is already in use", Codes.THREEPID_IN_USE)
 
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.REMOTE:
+        if (
+            self.config.threepid_behaviour_email_add_threepid
+            == ThreepidBehaviour.REMOTE
+        ):
             assert self.hs.config.account_threepid_delegate_email
 
             # Have the configured identity server handle the request
@@ -253,13 +264,13 @@ class RegistrationSubmitTokenServlet(RestServlet):
         self.clock = hs.get_clock()
         self.store = hs.get_datastore()
 
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
+        if self.config.threepid_behaviour_email_add_threepid == ThreepidBehaviour.LOCAL:
             (self.failure_email_template,) = load_jinja2_templates(
                 self.config.email_template_dir,
                 [self.config.email_registration_template_failure_html],
             )
 
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
+        if self.config.threepid_behaviour_email_add_threepid == ThreepidBehaviour.LOCAL:
             (self.failure_email_template,) = load_jinja2_templates(
                 self.config.email_template_dir,
                 [self.config.email_registration_template_failure_html],
@@ -270,7 +281,7 @@ class RegistrationSubmitTokenServlet(RestServlet):
             raise SynapseError(
                 400, "This medium is currently not supported for registration"
             )
-        if self.config.threepid_behaviour_email == ThreepidBehaviour.OFF:
+        if self.config.threepid_behaviour_email_add_threepid == ThreepidBehaviour.OFF:
             if self.config.local_threepid_handling_disabled_due_to_email_config:
                 logger.warning(
                     "User registration via email has been disabled due to lack of email config"

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -31,7 +31,7 @@ from synapse.api.errors import (
 from synapse.config import ConfigError
 from synapse.config.captcha import CaptchaConfig
 from synapse.config.consent_config import ConsentConfig
-from synapse.config.emailconfig import ThreepidBehaviour
+from synapse.config.emailconfig import ThreepidBehaviour, ThreepidService
 from synapse.config.ratelimiting import FederationRateLimitConfig
 from synapse.config.registration import RegistrationConfig
 from synapse.config.server import is_threepid_reserved
@@ -168,7 +168,8 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
                 client_secret,
                 send_attempt,
                 self.mailer.send_registration_mail,
-                next_link,
+                service=ThreepidService.ADDING_THREEPID,
+                next_link=next_link,
             )
 
             # Wrap the session id in a JSON object

--- a/synapse/storage/data_stores/main/schema/delta/58/04threepid_validation_session_service.sql
+++ b/synapse/storage/data_stores/main/schema/delta/58/04threepid_validation_session_service.sql
@@ -1,0 +1,39 @@
+/* Copyright 2020 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* We would like to be able to classify threepid validation sessions
+ * by service.
+ */
+
+/* We also need to drop the existing sessions as it's not possible to reliably
+ * classify them. This will result in UIA sessions needing to be restarted after
+ * homeserver upgrade, but the impact of this is rather minimal.
+ */
+
+DROP TABLE threepid_validation_session;
+
+/* We choose to recreate the table instead of adding a column as SQLite does not
+ * support adding a new NOT NULL column to a table, even if it is empty.
+ * https://stackoverflow.com/q/3170634
+ */
+CREATE TABLE threepid_validation_session (
+    session_id TEXT PRIMARY KEY,
+    medium TEXT NOT NULL,
+    address TEXT NOT NULL,
+    client_secret TEXT NOT NULL,
+    last_send_attempt BIGINT NOT NULL,
+    validated_at BIGINT,
+    service TEXT NOT NULL  -- New column
+);


### PR DESCRIPTION
~~Add a `registration_only` configuration flag to `account_threepid_delegates` to allow only delegating 3PID registration, and letting Synapse handle password resets.~~

---

This PR adds a `delegate_for` config option to `account_threepid_delegates` which allows you to decide which services should be delegated to configured account threepid delegates, and which should remain as operations for the local Synapse to handle.

For context: `account_threepid_delegates` are intended to allow Synapse to ask a third-party process (usually an identity service) to handle sending emails/text messages for it. More information is available in the [config option comment](https://github.com/matrix-org/synapse/blob/24110255cd5f304bd380e8f58c30137489e7522e/docs/sample_config.yaml#L1163-L1184).

The reason this PR is so chunky is due to some refactoring around the complicated configuration handling of the `account_threepid_delegates` config option. This could probably be taken out into a separate PR, though it's a little fiddly.

I've tried my best to make this easy to review by commit, with explanations in each commit message.

~anoa