### PR TITLE
Fix exceptions when fetching events from a down host.

### DIFF
--- a/changelog.d/7622.bugfix
+++ b/changelog.d/7622.bugfix
@@ -1,0 +1,1 @@
+Fix exceptions when fetching events from a remote host fails.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -501,7 +501,7 @@ class FederationHandler(BaseHandler):
                 min_depth=min_depth,
                 timeout=60000,
             )
-        except RequestSendFailed as e:
+        except (RequestSendFailed, HttpResponseException, NotRetryingDestination) as e:
             # We failed to get the missing events, but since we need to handle
             # the case of `get_missing_events` not returning the necessary
             # events anyway, it is safe to simply log the error and continue.


### PR DESCRIPTION
We already caught some exceptions, but not all.

This fixes exceptions such as:

```
HttpResponseException: 502: b'Bad Gateway'
  File "synapse/handlers/federation.py", line 271, in on_receive_pdu
    origin, pdu, prevs, min_depth
  File "synapse/handlers/federation.py", line 502, in _get_missing_events_for_pdu
    timeout=60000,
  File "synapse/federation/federation_client.py", line 957, in get_missing_events
    timeout=timeout,
  File "twisted/internet/defer.py", line 1416, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "synapse/federation/transport/client.py", line 564, in get_missing_events
    timeout=timeout,
  File "twisted/internet/defer.py", line 1416, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "twisted/python/failure.py", line 512, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "synapse/http/matrixfederationclient.py", line 722, in post_json
    ignore_backoff=ignore_backoff,
  File "twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "synapse/http/matrixfederationclient.py", line 492, in _send_request
    raise e
Exception: Error fetching missing prev_events for <event_id>: 502: b'Bad Gateway'
  File "synapse/federation/federation_server.py", line 279, in process_pdus_for_room
    await self._handle_received_pdu(origin, pdu)
  File "synapse/federation/federation_server.py", line 658, in _handle_received_pdu
    await self.handler.on_receive_pdu(origin, pdu, sent_to_us_directly=True)
  File "synapse/handlers/federation.py", line 276, in on_receive_pdu
    % (event_id, e)
```