### PR TITLE
`synctl restart` should start synapse if it wasn't running

### DIFF
--- a/changelog.d/7624.bugfix
+++ b/changelog.d/7624.bugfix
@@ -1,0 +1,1 @@
+Make `synctl restart` start synapse if it wasn't running.

--- a/synctl
+++ b/synctl
@@ -328,7 +328,7 @@ def main():
         if start_stop_synapse:
             if not stop(pidfile, "synapse.app.homeserver"):
                 has_stopped = False
-        if not has_stopped:
+        if not has_stopped and action == "stop":
             sys.exit(1)
 
     # Wait for synapse to actually shutdown before starting it again


### PR DESCRIPTION
This partially reverts #6598. On reflection, not starting Synapse if it wasn't previously running is rather surprising.