### PR TITLE
Check if the localpart is reserved for guests earlier in the registration flow

### DIFF
--- a/changelog.d/7625.misc
+++ b/changelog.d/7625.misc
@@ -1,0 +1,1 @@
+Check if the localpart is reserved for guests users earlier in the registration flow, as well as when responding to requests on `/register/available`.

--- a/changelog.d/7625.misc
+++ b/changelog.d/7625.misc
@@ -1,1 +1,1 @@
-Check if the localpart is reserved for guests users earlier in the registration flow, as well as when responding to requests on `/register/available`.
+Check if the localpart of a Matrix ID is reserved for guest users earlier in the registration flow, as well as when responding to requests to `/register/available`.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -128,7 +128,7 @@ class RegistrationHandler(BaseHandler):
                     errcode=Codes.FORBIDDEN,
                 )
 
-        if guest_access_token is not None:
+        if guest_access_token is None:
             try:
                 int(localpart)
                 raise SynapseError(

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -128,6 +128,15 @@ class RegistrationHandler(BaseHandler):
                     errcode=Codes.FORBIDDEN,
                 )
 
+        if guest_access_token is not None:
+            try:
+                int(localpart)
+                raise SynapseError(
+                    400, "Numeric user IDs are reserved for guest users."
+                )
+            except ValueError:
+                pass
+
     @defer.inlineCallbacks
     def register_user(
         self,
@@ -169,15 +178,6 @@ class RegistrationHandler(BaseHandler):
             yield self.check_username(localpart, guest_access_token=guest_access_token)
 
             was_guest = guest_access_token is not None
-
-            if not was_guest:
-                try:
-                    int(localpart)
-                    raise SynapseError(
-                        400, "Numeric user IDs are reserved for guest users."
-                    )
-                except ValueError:
-                    pass
 
             user = UserID(localpart, self.hs.hostname)
             user_id = user.to_string()


### PR DESCRIPTION
This is so the user is warned about the username not being valid as soon as possible, rather than only once they've finished UIA.

Fixes #7576 