### PR TITLE
Accept a device ID to the login fallback endpoint.

### DIFF
--- a/changelog.d/7629.bugfix
+++ b/changelog.d/7629.bugfix
@@ -1,0 +1,1 @@
+Pass device information through to the login endpoint when using the login fallback.

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -69,7 +69,7 @@ var show_login = function(inhibit_redirect) {
     // If inhibit_redirect is false, and SSO is the only supported login method,
     // we can redirect straight to the SSO page.
     if (matrixLogin.serverAcceptsSso) {
-        // Before submitted SSO, set the current query parameters into a cookie
+        // Before submitting SSO, set the current query parameters into a cookie
         // for retrieval later.
         var qs = parseQsFromUrl();
         setCookie(COOKIE_KEY, JSON.stringify(qs));

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -14,10 +14,13 @@ var submitLogin = function(type, data) {
     // Add the login type.
     data.type = type;
 
-    // Add the device ID, if one was provided.
+    // Add the device information, if it was provided.
     var qs = parseQsFromUrl();
     if (qs.device_id) {
         data.device_id = qs.device_id;
+    }
+    if (qs.initial_device_display_name) {
+        data.initial_device_display_name = qs.initial_device_display_name;
     }
 
     $.post(matrixLogin.endpoint, JSON.stringify(data), function(response) {


### PR DESCRIPTION
This modifies the login fallback page to accept a query parameter (`device_id`) which will get passed into the login endpoint during the login process.

This also reworks some of the `login.js` code to reduce duplicated code.

Fixes #5755

MSC: https://github.com/matrix-org/matrix-doc/pull/2604

## Questions

* Should we also accept an `initial_device_display_name` query parameter? It does not look any of the [other parameters](https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-login) would be useful to accept since they're part of the login process. 