### PR TITLE
Enable the standardized m.login.sso flow for UI Auth

### DIFF
--- a/changelog.d/7630.feature
+++ b/changelog.d/7630.feature
@@ -1,0 +1,1 @@
+Support the standardized `m.login.sso` user-interactive authentication flow.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -61,7 +61,7 @@ class LoginType(object):
     MSISDN = "m.login.msisdn"
     RECAPTCHA = "m.login.recaptcha"
     TERMS = "m.login.terms"
-    SSO = "org.matrix.login.sso"
+    SSO = "m.login.sso"
     DUMMY = "m.login.dummy"
 
     # Only for C/S API v1


### PR DESCRIPTION
Updates the UI Auth SSO flow to `m.login.sso` (from `org.matrix.login.sso`) now that the client-server API r0.6.1 was published.

Fixes #7531

It is unclear if we should keep the old `org.matrix.login.sso`.