### PR TITLE
Enable the token login type is provided for OpenID connect.

### DIFF
--- a/changelog.d/7631.bugfix
+++ b/changelog.d/7631.bugfix
@@ -1,1 +1,1 @@
-Support the `m.login.token` login flow when OpenID Connect is enabled.
+Advertise the `m.login.token` login flow when OpenID Connect is enabled.

--- a/changelog.d/7631.bugfix
+++ b/changelog.d/7631.bugfix
@@ -1,0 +1,1 @@
+Support the `m.login.token` login flow when OpenID Connect is enabled.

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -99,25 +99,20 @@ class LoginRestServlet(RestServlet):
             flows.append({"type": LoginRestServlet.JWT_TYPE})
 
         if self.cas_enabled:
-            flows.append({"type": LoginRestServlet.SSO_TYPE})
-
             # we advertise CAS for backwards compat, though MSC1721 renamed it
             # to SSO.
             flows.append({"type": LoginRestServlet.CAS_TYPE})
 
+        if self.cas_enabled or self.saml2_enabled or self.oidc_enabled:
+            flows.append({"type": LoginRestServlet.SSO_TYPE})
             # While its valid for us to advertise this login type generally,
             # synapse currently only gives out these tokens as part of the
-            # CAS login flow.
+            # SSO login flow.
             # Generally we don't want to advertise login flows that clients
             # don't know how to implement, since they (currently) will always
             # fall back to the fallback API if they don't understand one of the
             # login flow types returned.
             flows.append({"type": LoginRestServlet.TOKEN_TYPE})
-        elif self.saml2_enabled:
-            flows.append({"type": LoginRestServlet.SSO_TYPE})
-            flows.append({"type": LoginRestServlet.TOKEN_TYPE})
-        elif self.oidc_enabled:
-            flows.append({"type": LoginRestServlet.SSO_TYPE})
 
         flows.extend(
             ({"type": t} for t in self.auth_handler.get_supported_login_types())


### PR DESCRIPTION
Adds the token login flow (in addition to SSO) when OIDC is enabled. This was overlooked in the initial implementation.

I left the `m.login.cas` legacy login flow since it is part of r0.4.0, which Synapse reports as still being supported.