### PR TITLE
Discard RDATA from already seen positions

### DIFF
--- a/changelog.d/7648.bugfix
+++ b/changelog.d/7648.bugfix
@@ -1,0 +1,1 @@
+In working mode, ensure that replicated data has not already been received.

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -740,8 +740,7 @@ class GenericWorkerReplicationHandler(ReplicationDataHandler):
 
     async def on_position(self, stream_name: str, instance_name: str, token: int):
         await super().on_position(stream_name, instance_name, token)
-        if stream_name == TypingStream.NAME:
-            self.typing_handler.process_replication_rows(token, [])
+        await self.on_rdata(stream_name, instance_name, token, [])
 
     def stop_pusher(self, user_id, app_id, pushkey):
         if not self.notify_pushers:

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -740,6 +740,7 @@ class GenericWorkerReplicationHandler(ReplicationDataHandler):
 
     async def on_position(self, stream_name: str, instance_name: str, token: int):
         await super().on_position(stream_name, instance_name, token)
+        # Also call on_rdata to ensure that stream positions are properly reset.
         await self.on_rdata(stream_name, instance_name, token, [])
 
     def stop_pusher(self, user_id, app_id, pushkey):

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -738,6 +738,11 @@ class GenericWorkerReplicationHandler(ReplicationDataHandler):
         except Exception:
             logger.exception("Error processing replication")
 
+    async def on_position(self, stream_name: str, instance_name: str, token: int):
+        await super().on_position(stream_name, instance_name, token)
+        if stream_name == TypingStream.NAME:
+            self.typing_handler.process_replication_rows(token, [])
+
     def stop_pusher(self, user_id, app_id, pushkey):
         if not self.notify_pushers:
             return

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -149,7 +149,7 @@ class RdataCommand(Command):
 
 
 class PositionCommand(Command):
-    """Sent by the server to tell the client the stream postition without
+    """Sent by the server to tell the client the stream position without
     needing to send an RDATA.
 
     Format::
@@ -188,7 +188,7 @@ class ErrorCommand(_SimpleCommand):
 
 
 class PingCommand(_SimpleCommand):
-    """Sent by either side as a keep alive. The data is arbitary (often timestamp)
+    """Sent by either side as a keep alive. The data is arbitrary (often timestamp)
     """
 
     NAME = "PING"

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -321,7 +321,9 @@ class ReplicationCommandHandler:
                 current_token = stream.current_token(cmd.instance_name)
 
                 # Discard this data if this token is earlier than the current
-                # position.
+                # position. Note that streams can be reset (in which case you
+                # expect an earlier token), but that must be preceded by a
+                # POSITION command.
                 if cmd.token <= current_token:
                     logger.debug(
                         "Discarding RDATA from stream %s at position %s before previous position %s",

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -327,7 +327,7 @@ class ReplicationCommandHandler:
                         "Discarding RDATA from stream %s at POSITION %s before previous POSITION %s",
                         stream_name,
                         cmd.token,
-                        current_token
+                        current_token,
                     )
                 else:
                     await self.on_rdata(stream_name, cmd.instance_name, cmd.token, rows)

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -324,7 +324,7 @@ class ReplicationCommandHandler:
                 # position.
                 if cmd.token <= current_token:
                     logger.debug(
-                        "Discarding RDATA from stream %s at POSITION %s before previous POSITION %s",
+                        "Discarding RDATA from stream %s at position %s before previous position %s",
                         stream_name,
                         cmd.token,
                         current_token,

--- a/tests/replication/tcp/streams/test_events.py
+++ b/tests/replication/tcp/streams/test_events.py
@@ -403,7 +403,7 @@ class EventsStreamTestCase(BaseStreamTestCase):
 
         # Essentially repeat the above, but move the stream position forward (as
         # if the stream jumped).
-        command_handler.get_streams()['events'].last_token = token + 100
+        command_handler.get_streams()["events"].last_token = token + 100
         # Reset the data.
         self.test_handler.received_rdata_rows = []
 

--- a/tests/replication/tcp/streams/test_events.py
+++ b/tests/replication/tcp/streams/test_events.py
@@ -66,11 +66,6 @@ class EventsStreamTestCase(BaseStreamTestCase):
         # also one state event
         state_event = self._inject_state_event()
 
-        # tell the notifier to catch up to avoid duplicate rows.
-        # workaround for https://github.com/matrix-org/synapse/issues/7360
-        # FIXME remove this when the above is fixed
-        self.replicate()
-
         # check we're testing what we think we are: no rows should yet have been
         # received
         self.assertEqual([], self.test_handler.received_rdata_rows)
@@ -173,11 +168,6 @@ class EventsStreamTestCase(BaseStreamTestCase):
 
         # one more bit of state that doesn't get rolled back
         state2 = self._inject_state_event()
-
-        # tell the notifier to catch up to avoid duplicate rows.
-        # workaround for https://github.com/matrix-org/synapse/issues/7360
-        # FIXME remove this when the above is fixed
-        self.replicate()
 
         # check we're testing what we think we are: no rows should yet have been
         # received
@@ -326,11 +316,6 @@ class EventsStreamTestCase(BaseStreamTestCase):
             )
             prev_events = [e.event_id]
             pl_events.append(e)
-
-        # tell the notifier to catch up to avoid duplicate rows.
-        # workaround for https://github.com/matrix-org/synapse/issues/7360
-        # FIXME remove this when the above is fixed
-        self.replicate()
 
         # check we're testing what we think we are: no rows should yet have been
         # received

--- a/tests/replication/tcp/streams/test_typing.py
+++ b/tests/replication/tcp/streams/test_typing.py
@@ -125,10 +125,6 @@ class TypingStreamTestCase(BaseStreamTestCase):
         )
         typing._reset()
 
-        # Reset the test code.
-        self.test_handler.on_rdata.reset_mock()
-        self.test_handler.on_rdata.assert_not_called()
-
         # Reconnect.
         self.reconnect()
         self.pump(0.1)
@@ -136,6 +132,10 @@ class TypingStreamTestCase(BaseStreamTestCase):
         # We should now see an attempt to connect to the master
         request = self.handle_http_replication_attempt()
         self.assert_request_is_get_repl_stream_updates(request, "typing")
+
+        # Reset the test code.
+        self.test_handler.on_rdata.reset_mock()
+        self.test_handler.on_rdata.assert_not_called()
 
         # Push additional data.
         typing._push_update(member=RoomMember(ROOM_ID_2, USER_ID_2), typing=False)

--- a/tests/replication/tcp/streams/test_typing.py
+++ b/tests/replication/tcp/streams/test_typing.py
@@ -21,6 +21,10 @@ from synapse.replication.tcp.streams import TypingStream
 from tests.replication._base import BaseStreamTestCase
 
 USER_ID = "@feeling:blue"
+USER_ID_2 = "@da-ba-dee:blue"
+
+ROOM_ID = "!bar:blue"
+ROOM_ID_2 = "!foo:blue"
 
 
 class TypingStreamTestCase(BaseStreamTestCase):
@@ -30,11 +34,9 @@ class TypingStreamTestCase(BaseStreamTestCase):
     def test_typing(self):
         typing = self.hs.get_typing_handler()
 
-        room_id = "!bar:blue"
-
         self.reconnect()
 
-        typing._push_update(member=RoomMember(room_id, USER_ID), typing=True)
+        typing._push_update(member=RoomMember(ROOM_ID, USER_ID), typing=True)
 
         self.reactor.advance(0)
 
@@ -47,7 +49,7 @@ class TypingStreamTestCase(BaseStreamTestCase):
         self.assertEqual(stream_name, "typing")
         self.assertEqual(1, len(rdata_rows))
         row = rdata_rows[0]  # type: TypingStream.TypingStreamRow
-        self.assertEqual(room_id, row.room_id)
+        self.assertEqual(ROOM_ID, row.room_id)
         self.assertEqual([USER_ID], row.user_ids)
 
         # Now let's disconnect and insert some data.
@@ -55,7 +57,7 @@ class TypingStreamTestCase(BaseStreamTestCase):
 
         self.test_handler.on_rdata.reset_mock()
 
-        typing._push_update(member=RoomMember(room_id, USER_ID), typing=False)
+        typing._push_update(member=RoomMember(ROOM_ID, USER_ID), typing=False)
 
         self.test_handler.on_rdata.assert_not_called()
 
@@ -74,7 +76,7 @@ class TypingStreamTestCase(BaseStreamTestCase):
         self.assertEqual(stream_name, "typing")
         self.assertEqual(1, len(rdata_rows))
         row = rdata_rows[0]
-        self.assertEqual(room_id, row.room_id)
+        self.assertEqual(ROOM_ID, row.room_id)
         self.assertEqual([], row.user_ids)
 
     def test_reset(self):
@@ -86,11 +88,9 @@ class TypingStreamTestCase(BaseStreamTestCase):
         """
         typing = self.hs.get_typing_handler()
 
-        room_id = "!bar:blue"
-
         self.reconnect()
 
-        typing._push_update(member=RoomMember(room_id, USER_ID), typing=True)
+        typing._push_update(member=RoomMember(ROOM_ID, USER_ID), typing=True)
 
         self.reactor.advance(0)
 
@@ -103,7 +103,7 @@ class TypingStreamTestCase(BaseStreamTestCase):
         self.assertEqual(stream_name, "typing")
         self.assertEqual(1, len(rdata_rows))
         row = rdata_rows[0]  # type: TypingStream.TypingStreamRow
-        self.assertEqual(room_id, row.room_id)
+        self.assertEqual(ROOM_ID, row.room_id)
         self.assertEqual([USER_ID], row.user_ids)
 
         # Jump the stream ahead manually, the state of the master is not
@@ -117,7 +117,7 @@ class TypingStreamTestCase(BaseStreamTestCase):
 
         self.test_handler.on_rdata.reset_mock()
 
-        typing._push_update(member=RoomMember(room_id, USER_ID), typing=False)
+        typing._push_update(member=RoomMember(ROOM_ID_2, USER_ID_2), typing=False)
 
         self.test_handler.on_rdata.assert_not_called()
 
@@ -136,5 +136,5 @@ class TypingStreamTestCase(BaseStreamTestCase):
         self.assertEqual(stream_name, "typing")
         self.assertEqual(1, len(rdata_rows))
         row = rdata_rows[0]
-        self.assertEqual(room_id, row.room_id)
+        self.assertEqual(ROOM_ID_2, row.room_id)
         self.assertEqual([], row.user_ids)


### PR DESCRIPTION
When processing `RDATA` commands via replication, discard any `RDATA` that has already been seen. This is calculated via asking the stream to get the "current position" and comparing to the incoming token.

Fixes #7360

## To Do

* Handle streams that can reset (e.g. `typing` and `federation`).
* Add tests for resetting the above.