### PR TITLE
fix typo in sample_config.yaml

### DIFF
--- a/changelog.d/7652.doc
+++ b/changelog.d/7652.doc
@@ -1,1 +1,1 @@
-spelling correction in sample_config.yaml
+spelling correction in sample_config.yaml.

--- a/changelog.d/7652.doc
+++ b/changelog.d/7652.doc
@@ -1,1 +1,1 @@
-spelling correction in sample_config.yaml.
+Spelling correction in sample_config.yaml.

--- a/changelog.d/7652.doc
+++ b/changelog.d/7652.doc
@@ -1,0 +1,1 @@
+spelling correction in sample_config.yaml

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -283,7 +283,7 @@ listeners:
 # number of monthly active users.
 #
 # 'limit_usage_by_mau' disables/enables monthly active user blocking. When
-# anabled and a limit is reached the server returns a 'ResourceLimitError'
+# enabled and a limit is reached the server returns a 'ResourceLimitError'
 # with error type Codes.RESOURCE_LIMIT_EXCEEDED
 #
 # 'max_mau_value' is the hard limit of monthly active users above which

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -856,7 +856,7 @@ class ServerConfig(Config):
         # number of monthly active users.
         #
         # 'limit_usage_by_mau' disables/enables monthly active user blocking. When
-        # anabled and a limit is reached the server returns a 'ResourceLimitError'
+        # enabled and a limit is reached the server returns a 'ResourceLimitError'
         # with error type Codes.RESOURCE_LIMIT_EXCEEDED
         #
         # 'max_mau_value' is the hard limit of monthly active users above which


### PR DESCRIPTION
Just a simple typo fix.

Signed-off-by: wondratsch <28294257+wondratsch@users.noreply.github.com>
