### PR TITLE
Clean-up the fallback login code

### DIFF
--- a/synapse/static/client/login/index.html
+++ b/synapse/static/client/login/index.html
@@ -10,16 +10,15 @@
 </head>
 <body onload="matrixLogin.onLoad()">
     <div id="container">
-        <br/>
         <h1 id="title"></h1>
 
-        <span id="feedback" style="color: #f00"></span>
+        <span id="feedback"></span>
 
         <div id="loading">
             <img src="spinner.gif" />
         </div>
 
-        <div id="sso_flow" class="login_flow" style="display:none">
+        <div id="sso_flow" class="login_flow" style="display: none;">
             Single-sign on:
             <form id="sso_form" action="/_matrix/client/r0/login/sso/redirect" method="get">
                 <input id="sso_redirect_url" type="hidden" name="redirectUrl" value=""/>
@@ -27,7 +26,7 @@
             </form>
         </div>
 
-        <div id="password_flow" class="login_flow" style="display:none">
+        <div id="password_flow" class="login_flow" style="display: none;">
             Password Authentication:
             <form onsubmit="matrixLogin.passwordLogin(); return false;">
                 <input id="user_id" size="32" type="text" placeholder="Matrix ID (e.g. bob)" autocapitalize="off" autocorrect="off" />
@@ -39,7 +38,7 @@
             </form>
         </div>
 
-        <div id="no_login_types" type="button" class="login_flow" style="display:none">
+        <div id="no_login_types" type="button" class="login_flow" style="display: none;">
             Log in currently unavailable.
         </div>
     </div>

--- a/synapse/static/client/login/index.html
+++ b/synapse/static/client/login/index.html
@@ -1,11 +1,12 @@
 <!doctype html>
 <html>
 <head>
-<title> Login </title>
-<meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0'>
-<link rel="stylesheet" href="style.css">
-<script src="js/jquery-3.4.1.min.js"></script>
-<script src="js/login.js"></script>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title> Login </title>
+    <meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0'>
+    <link rel="stylesheet" href="style.css">
+    <script src="js/jquery-3.4.1.min.js"></script>
+    <script src="js/login.js"></script>
 </head>
 <body onload="matrixLogin.onLoad()">
     <center>

--- a/synapse/static/client/login/index.html
+++ b/synapse/static/client/login/index.html
@@ -9,7 +9,7 @@
     <script src="js/login.js"></script>
 </head>
 <body onload="matrixLogin.onLoad()">
-    <center>
+    <div id="container">
         <br/>
         <h1 id="title"></h1>
 
@@ -42,6 +42,6 @@
         <div id="no_login_types" type="button" class="login_flow" style="display:none">
             Log in currently unavailable.
         </div>
-    </center>
+    </div>
 </body>
 </html>

--- a/synapse/static/client/login/index.html
+++ b/synapse/static/client/login/index.html
@@ -29,7 +29,7 @@
 
         <div id="password_flow" class="login_flow" style="display:none">
             Password Authentication:
-            <form onsubmit="matrixLogin.password_login(); return false;">
+            <form onsubmit="matrixLogin.passwordLogin(); return false;">
                 <input id="user_id" size="32" type="text" placeholder="Matrix ID (e.g. bob)" autocapitalize="off" autocorrect="off" />
                 <br/>
                 <input id="password" size="32" type="password" placeholder="Password"/>

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -22,7 +22,7 @@ const COOKIE_KEY = "synapse_login_fallback_qs";
  */
 function submitLogin(type, data, extra, callback) {
     console.log("Logging in with " + type);
-    set_title(TITLE_POST_AUTH);
+    setTitle(TITLE_POST_AUTH);
 
     // Add the login type.
     data.type = type;
@@ -49,7 +49,7 @@ function submitLogin(type, data, extra, callback) {
 function errorFunc(err) {
     // We want to show the error to the user rather than redirecting immediately to the
     // SSO portal (if SSO is the only login option), so we inhibit the redirect.
-    show_login(true);
+    showLogin(true);
 
     if (err.responseJSON && err.responseJSON.error) {
         setFeedbackString(err.responseJSON.error + " (" + err.responseJSON.errcode + ")");
@@ -75,10 +75,10 @@ function setFeedbackString(text) {
  * * Configures and shows the SSO form, if the server supports SSO.
  * * Otherwise, shows the password form.
  */
-function show_login(inhibit_redirect) {
-    set_title(TITLE_PRE_AUTH);
+function showLogin(inhibitRedirect) {
+    setTitle(TITLE_PRE_AUTH);
 
-    // If inhibit_redirect is false, and SSO is the only supported login method,
+    // If inhibitRedirect is false, and SSO is the only supported login method,
     // we can redirect straight to the SSO page.
     if (matrixLogin.serverAcceptsSso) {
         // Set the redirect to come back to this page, a login token will get
@@ -92,7 +92,7 @@ function show_login(inhibit_redirect) {
 
         // If password is not supported and redirects are allowed, then submit
         // the form (redirecting to the SSO provider).
-        if (!inhibit_redirect && !matrixLogin.serverAcceptsPassword) {
+        if (!inhibitRedirect && !matrixLogin.serverAcceptsPassword) {
             $("#sso_form").submit();
             return;
         }
@@ -116,7 +116,7 @@ function show_login(inhibit_redirect) {
 /*
  * Hides the forms and shows a loading throbber.
  */
-function show_spinner() {
+function showSpinner() {
     $("#password_flow").hide();
     $("#sso_flow").hide();
     $("#no_login_types").hide();
@@ -126,7 +126,7 @@ function show_spinner() {
 /*
  * Helper to show the page's main title.
  */
-function set_title(title) {
+function setTitle(title) {
     $("#title").text(title);
 }
 
@@ -135,7 +135,7 @@ function set_title(title) {
  *
  * This populates matrixLogin.serverAccepts* variables.
  */
-function fetch_login_flows(cb) {
+function fetchLoginFlows(cb) {
     $.get(matrixLogin.endpoint, function(response) {
         for (var i = 0; i < response.flows.length; i++) {
             var flow = response.flows[i];
@@ -157,10 +157,10 @@ function fetch_login_flows(cb) {
  * Called on load to fetch login flows and attempt SSO login (if a token is available).
  */
 matrixLogin.onLoad = function() {
-    fetch_login_flows(function() {
+    fetchLoginFlows(function() {
         // (Maybe) attempt logging in via SSO if a token is available.
-        if (!try_token()) {
-            show_login(false);
+        if (!tryTokenLogin()) {
+            showLogin(false);
         }
     });
 };
@@ -168,13 +168,13 @@ matrixLogin.onLoad = function() {
 /*
  * Submit simple user & password login.
  */
-matrixLogin.password_login = function() {
+matrixLogin.passwordLogin = function() {
     var user = $("#user_id").val();
     var pwd = $("#password").val();
 
     setFeedbackString("");
 
-    show_spinner();
+    showSpinner();
     submitLogin(
         "m.login.password",
         {user: user, password: pwd},
@@ -262,7 +262,7 @@ function deleteCookie(key) {
  * Submits the login token if one is found in the query parameters. Returns a
  * boolean of whether the login token was found or not.
  */
-function try_token() {
+function tryTokenLogin() {
     // Check if the login token is in the query parameters.
     var qs = parseQsFromUrl();
 
@@ -274,7 +274,7 @@ function try_token() {
     // Retrieve the original query parameters (from before the SSO redirect).
     // They are stored as JSON in a cookie.
     var cookies = parseCookies();
-    var original_query_params = JSON.parse(cookies[COOKIE_KEY] || "{}")
+    var originalQueryParams = JSON.parse(cookies[COOKIE_KEY] || "{}")
 
     // If the login is successful, delete the cookie.
     function callback() {
@@ -284,7 +284,7 @@ function try_token() {
     submitLogin(
         "m.login.token",
         {token: loginToken},
-        original_query_params,
+        originalQueryParams,
         callback);
 
     return true;

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -20,7 +20,7 @@ const COOKIE_KEY = "synapse_login_fallback_qs";
  *     login request, e.g. device_id.
  * callback: (Optional) Function to call on successful login.
  */
-var submitLogin = function(type, data, extra, callback) {
+function submitLogin(type, data, extra, callback) {
     console.log("Logging in with " + type);
     set_title(TITLE_POST_AUTH);
 
@@ -41,9 +41,9 @@ var submitLogin = function(type, data, extra, callback) {
         }
         matrixLogin.onLogin(response);
     }).fail(errorFunc);
-};
+}
 
-var errorFunc = function(err) {
+function errorFunc(err) {
     // We want to show the error to the user rather than redirecting immediately to the
     // SSO portal (if SSO is the only login option), so we inhibit the redirect.
     show_login(true);
@@ -54,13 +54,13 @@ var errorFunc = function(err) {
     else {
         setFeedbackString("Request failed: " + err.status);
     }
-};
+}
 
-var setFeedbackString = function(text) {
+function setFeedbackString(text) {
     $("#feedback").text(text);
-};
+}
 
-var show_login = function(inhibit_redirect) {
+function show_login(inhibit_redirect) {
     // Set the redirect to come back to this page, a login token will get added
     // and handled after the redirect.
     var this_page = window.location.origin + window.location.pathname;
@@ -94,20 +94,20 @@ var show_login = function(inhibit_redirect) {
     set_title(TITLE_PRE_AUTH);
 
     $("#loading").hide();
-};
+}
 
-var show_spinner = function() {
+function show_spinner() {
     $("#password_flow").hide();
     $("#sso_flow").hide();
     $("#no_login_types").hide();
     $("#loading").show();
-};
+}
 
-var set_title = function(title) {
+function set_title(title) {
     $("#title").text(title);
-};
+}
 
-var fetch_info = function(cb) {
+function fetch_info(cb) {
     $.get(matrixLogin.endpoint, function(response) {
         var serverAcceptsPassword = false;
         for (var i=0; i<response.flows.length; i++) {
@@ -155,7 +155,7 @@ matrixLogin.onLogin = function(response) {
 /*
  * Process the query parameters from the current URL into an object.
  */
-var parseQsFromUrl = function() {
+function parseQsFromUrl() {
     var pos = window.location.href.indexOf("?");
     if (pos == -1) {
         return {};
@@ -174,12 +174,12 @@ var parseQsFromUrl = function() {
         result[key] = val;
     });
     return result;
-};
+}
 
 /*
  * Process the cookies and return an object.
  */
-var parseCookies = function() {
+function parseCookies() {
     var allCookies = document.cookie;
     var result = {};
     allCookies.split(";").forEach(function(part) {
@@ -196,32 +196,32 @@ var parseCookies = function() {
         result[key] = val;
     });
     return result;
-};
+}
 
 /*
  * Set a cookie that is valid for 1 hour.
  */
-var setCookie = function(key, value) {
+function setCookie(key, value) {
     // The maximum age is set in seconds.
     var maxAge = 60 * 60;
     // Set the cookie, this defaults to the current domain and path.
     document.cookie = key + "=" + encodeURIComponent(value) + ";max-age=" + maxAge + ";sameSite=lax";
-};
+}
 
 /*
  * Removes a cookie by key.
  */
-var deleteCookie = function(key) {
+function deleteCookie(key) {
     // Delete a cookie by setting the expiration to 0. (Note that the value
     // doesn't matter.)
     document.cookie = key + "=deleted;expires=0";
-};
+}
 
 /*
  * Submits the login token if one is found in the query parameters. Returns a
  * boolean of whether the login token was found or not.
  */
-var try_token = function() {
+function try_token() {
     // Check if the login token is in the query parameters.
     var qs = parseQsFromUrl();
 
@@ -236,7 +236,7 @@ var try_token = function() {
     var original_query_params = JSON.parse(cookies[COOKIE_KEY] || "{}")
 
     // If the login is successful, delete the cookie.
-    var callback = function() {
+    function callback() {
         deleteCookie(COOKIE_KEY);
     }
 
@@ -247,4 +247,4 @@ var try_token = function() {
         callback);
 
     return true;
-};
+}

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -5,11 +5,11 @@ window.matrixLogin = {
 };
 
 // Titles get updated through the process to give users feedback.
-var TITLE_PRE_AUTH = "Log in with one of the following methods";
-var TITLE_POST_AUTH = "Logging in...";
+const TITLE_PRE_AUTH = "Log in with one of the following methods";
+const TITLE_POST_AUTH = "Logging in...";
 
 // The cookie used to store the original query parameters when using SSO.
-var COOKIE_KEY = "synapse_login_fallback_qs";
+const COOKIE_KEY = "synapse_login_fallback_qs";
 
 /*
  * Submit a login request.

--- a/synapse/static/client/login/js/login.js
+++ b/synapse/static/client/login/js/login.js
@@ -76,14 +76,15 @@ function setFeedbackString(text) {
  * * Otherwise, shows the password form.
  */
 function show_login(inhibit_redirect) {
-    // Set the redirect to come back to this page, a login token will get added
-    // and handled after the redirect.
-    var this_page = window.location.origin + window.location.pathname;
-    $("#sso_redirect_url").val(this_page);
+    set_title(TITLE_PRE_AUTH);
 
     // If inhibit_redirect is false, and SSO is the only supported login method,
     // we can redirect straight to the SSO page.
     if (matrixLogin.serverAcceptsSso) {
+        // Set the redirect to come back to this page, a login token will get
+        // added as a query parameter and handled after the redirect.
+        $("#sso_redirect_url").val(window.location.origin + window.location.pathname);
+
         // Before submitting SSO, set the current query parameters into a cookie
         // for retrieval later.
         var qs = parseQsFromUrl();
@@ -108,8 +109,6 @@ function show_login(inhibit_redirect) {
     if (!matrixLogin.serverAcceptsPassword && !matrixLogin.serverAcceptsSso) {
         $("#no_login_types").show();
     }
-
-    set_title(TITLE_PRE_AUTH);
 
     $("#loading").hide();
 }

--- a/synapse/static/client/login/style.css
+++ b/synapse/static/client/login/style.css
@@ -47,18 +47,16 @@ form {
     text-align: center;
 }
 
+/*
+ * A wrapper around each login flow.
+ */
 .login_flow {
     width: 300px;
     text-align: left;
     padding: 10px;
     margin-bottom: 40px;
 
-    -webkit-border-radius: 10px;
-    -moz-border-radius: 10px;
     border-radius: 10px;
-
-    -webkit-box-shadow: 0px 0px 20px 0px rgba(0,0,0,0.15);
-    -moz-box-shadow: 0px 0px 20px 0px rgba(0,0,0,0.15);
     box-shadow: 0px 0px 20px 0px rgba(0,0,0,0.15);
 
     background-color: #f8f8f8;

--- a/synapse/static/client/login/style.css
+++ b/synapse/static/client/login/style.css
@@ -62,3 +62,10 @@ form {
     background-color: #f8f8f8;
     border: 1px #ccc solid;
 }
+
+/*
+ * Used to show error content.
+ */
+#feedback {
+    color: #ff0000;  /* Red */
+}

--- a/synapse/static/client/login/style.css
+++ b/synapse/static/client/login/style.css
@@ -31,6 +31,22 @@ form {
     margin: 10px 0 0 0;
 }
 
+/*
+ * Add some padding to the viewport.
+ */
+#container {
+    padding: 10px;
+}
+/*
+ * Center all direct children of the main form.
+ */
+#container > * {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+}
+
 .login_flow {
     width: 300px;
     text-align: left;


### PR DESCRIPTION
This handles a review comment (https://github.com/matrix-org/synapse/pull/7629#discussion_r436685963) and a bunch of other misc. changes to the fallback login code to with an aim to:
* Be more consistent in styling.
* Be a bit more modern.

I do note that the spec says:
> The page will attempt to call the JavaScript function `window.onLogin` when login has been successfully completed.

But it seems the code calls `window.matrixLogin.onLogin` unless I'm missing something?