### PR TITLE
Increase the default SAML session expirary time to 15 minutes.

### DIFF
--- a/changelog.d/7664.misc
+++ b/changelog.d/7664.misc
@@ -1,0 +1,1 @@
+Increase the default SAML session expirary time to 15 minutes.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1456,7 +1456,7 @@ saml2_config:
   # complete the authentication process, if allow_unsolicited is unset.
   # The default is 15 minutes.
   #
-  #saml_session_lifetime: 15m
+  #saml_session_lifetime: 5m
 
   # An external module can be provided here as a custom solution to
   # mapping attributes returned from a saml provider onto a matrix user.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1454,9 +1454,9 @@ saml2_config:
 
   # The lifetime of a SAML session. This defines how long a user has to
   # complete the authentication process, if allow_unsolicited is unset.
-  # The default is 5 minutes.
+  # The default is 15 minutes.
   #
-  #saml_session_lifetime: 5m
+  #saml_session_lifetime: 15m
 
   # An external module can be provided here as a custom solution to
   # mapping attributes returned from a saml provider onto a matrix user.

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -160,7 +160,7 @@ class SAML2Config(Config):
 
         # session lifetime: in milliseconds
         self.saml2_session_lifetime = self.parse_duration(
-            saml2_config.get("saml_session_lifetime", "5m")
+            saml2_config.get("saml_session_lifetime", "15m")
         )
 
         template_dir = saml2_config.get("template_dir")
@@ -286,9 +286,9 @@ class SAML2Config(Config):
 
           # The lifetime of a SAML session. This defines how long a user has to
           # complete the authentication process, if allow_unsolicited is unset.
-          # The default is 5 minutes.
+          # The default is 15 minutes.
           #
-          #saml_session_lifetime: 5m
+          #saml_session_lifetime: 15m
 
           # An external module can be provided here as a custom solution to
           # mapping attributes returned from a saml provider onto a matrix user.

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -288,7 +288,7 @@ class SAML2Config(Config):
           # complete the authentication process, if allow_unsolicited is unset.
           # The default is 15 minutes.
           #
-          #saml_session_lifetime: 15m
+          #saml_session_lifetime: 5m
 
           # An external module can be provided here as a custom solution to
           # mapping attributes returned from a saml provider onto a matrix user.


### PR DESCRIPTION
This is hopefully a partial fix for #7056. It increases the default SAML session timeout from 5m to 15m. I debated if we should add a note to the config saying "this should match your SAML IdP" or something like that?

Note that this is the time that the user has to *complete the login*, not the time that there session is active once they've completed authentication.