### PR TITLE
Convert the typing handler to async/await.

### DIFF
--- a/changelog.d/7679.misc
+++ b/changelog.d/7679.misc
@@ -1,0 +1,1 @@
+Convert typing handler to async/await.

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -129,6 +129,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
         def check_user_in_room(room_id, user_id):
             if user_id not in [u.to_string() for u in self.room_members]:
                 raise AuthError(401, "User is not in the room")
+            return defer.succeed(None)
 
         hs.get_auth().check_user_in_room = check_user_in_room
 
@@ -138,7 +139,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
         self.datastore.get_joined_hosts_for_room = get_joined_hosts_for_room
 
         def get_current_users_in_room(room_id):
-            return {str(u) for u in self.room_members}
+            return defer.succeed({str(u) for u in self.room_members})
 
         hs.get_state_handler().get_current_users_in_room = get_current_users_in_room
 

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -164,7 +164,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
 
         self.assertEquals(self.event_source.get_current_key(), 0)
 
-        self.successResultOf(
+        self.get_success(
             self.handler.started_typing(
                 target_user=U_APPLE, auth_user=U_APPLE, room_id=ROOM_ID, timeout=20000
             )
@@ -191,7 +191,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
     def test_started_typing_remote_send(self):
         self.room_members = [U_APPLE, U_ONION]
 
-        self.successResultOf(
+        self.get_success(
             self.handler.started_typing(
                 target_user=U_APPLE, auth_user=U_APPLE, room_id=ROOM_ID, timeout=20000
             )
@@ -266,7 +266,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
 
         self.assertEquals(self.event_source.get_current_key(), 0)
 
-        self.successResultOf(
+        self.get_success(
             self.handler.stopped_typing(
                 target_user=U_APPLE, auth_user=U_APPLE, room_id=ROOM_ID
             )
@@ -306,7 +306,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
 
         self.assertEquals(self.event_source.get_current_key(), 0)
 
-        self.successResultOf(
+        self.get_success(
             self.handler.started_typing(
                 target_user=U_APPLE, auth_user=U_APPLE, room_id=ROOM_ID, timeout=10000
             )
@@ -345,7 +345,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
 
         # SYN-230 - see if we can still set after timeout
 
-        self.successResultOf(
+        self.get_success(
             self.handler.started_typing(
                 target_user=U_APPLE, auth_user=U_APPLE, room_id=ROOM_ID, timeout=10000
             )


### PR DESCRIPTION
There's a couple of odd methods in here, in particular:
* `_stopped_typing` was yielded, but wasn't a `Deferred`.
* `get_new_events` doesn't need to be a coroutine, but I think it expects to be one based on the callers.
* `get_success` need to be used in tests instead of `getSuccessOf` for old deps, I think.