### PR TITLE
Require parameterized package version to be at least 0.7.0.

### DIFF
--- a/changelog.d/7680.misc
+++ b/changelog.d/7680.misc
@@ -1,0 +1,1 @@
+Require `parameterized` package version to be at least 0.7.0.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -95,7 +95,8 @@ CONDITIONAL_REQUIREMENTS = {
     "oidc": ["authlib>=0.14.0"],
     "systemd": ["systemd-python>=231"],
     "url_preview": ["lxml>=3.5.0"],
-    "test": ["mock>=2.0", "parameterized"],
+    # parameterized_class decorator was introduced in parameterized 0.7.0
+    "test": ["mock>=2.0", "parameterized>=0.7.0"],
     "sentry": ["sentry-sdk>=0.7.2"],
     "opentracing": ["jaeger-client>=4.0.0", "opentracing>=2.2.0"],
     "jwt": ["pyjwt>=1.6.4"],


### PR DESCRIPTION
Older versions of `parameterized` package have no `parameterized_class` decorator.
This decorator is used in tests.