### PR TITLE
Wrap register_device coroutine in an ensureDeferred

### DIFF
--- a/changelog.d/7684.bugfix
+++ b/changelog.d/7684.bugfix
@@ -1,0 +1,1 @@
+Fix a bug that would crash Synapse on start when using certain password auth providers. Broke in #7649.

--- a/changelog.d/7684.bugfix
+++ b/changelog.d/7684.bugfix
@@ -1,1 +1,1 @@
-Fix a bug that would crash Synapse on start when using certain password auth providers. Broke in #7649.
+Fix a bug that would crash Synapse on start when using certain password auth providers. Broke in release v1.15.0.

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -110,7 +110,7 @@ class ModuleApi(object):
             "Using deprecated ModuleApi.register which creates a dummy user device."
         )
         user_id = yield self.register_user(localpart, displayname, emails)
-        _, access_token = yield self.register_device(user_id)
+        _, access_token = yield defer.ensureDeferred(self.register_device(user_id))
         return user_id, access_token
 
     def register_user(self, localpart, displayname=None, emails=[]):

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -110,7 +110,7 @@ class ModuleApi(object):
             "Using deprecated ModuleApi.register which creates a dummy user device."
         )
         user_id = yield self.register_user(localpart, displayname, emails)
-        _, access_token = yield defer.ensureDeferred(self.register_device(user_id))
+        _, access_token = yield self.register_device(user_id)
         return user_id, access_token
 
     def register_user(self, localpart, displayname=None, emails=[]):
@@ -126,7 +126,7 @@ class ModuleApi(object):
                 'errcode' property for more information on the reason for failure
 
         Returns:
-            Deferred[str]: user_id
+            defer.Deferred[str]: user_id
         """
         return defer.ensureDeferred(
             self._hs.get_registration_handler().register_user(
@@ -149,10 +149,12 @@ class ModuleApi(object):
         Returns:
             defer.Deferred[tuple[str, str]]: Tuple of device ID and access token
         """
-        return self._hs.get_registration_handler().register_device(
-            user_id=user_id,
-            device_id=device_id,
-            initial_display_name=initial_display_name,
+        return defer.ensureDeferred(
+            self._hs.get_registration_handler().register_device(
+                user_id=user_id,
+                device_id=device_id,
+                initial_display_name=initial_display_name,
+            )
         )
 
     def record_user_external_id(

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from synapse.module_api import ModuleApi
+
+from tests.unittest import HomeserverTestCase
+
+
+class ModuleApiTestCase(HomeserverTestCase):
+    def prepare(self, reactor, clock, homeserver):
+        self.store = homeserver.get_datastore()
+        self.module_api = ModuleApi(homeserver, homeserver.get_auth_handler())
+
+    def test_can_register_user(self):
+        """Tests that an external module can register a user"""
+        # Register a new user
+        user_id, access_token = self.get_success(
+            self.module_api.register(
+                "bob", displayname="Bobberino", emails=["bob@bobinator.bob"]
+            )
+        )
+
+        # Check that the new user exists with all provided attributes
+        self.assertEqual(user_id, "@bob:test")
+        self.assertTrue(access_token)
+        self.assertTrue(self.store.get_user_by_id(user_id))
+
+        # Check that the email was assigned
+        emails = self.get_success(self.store.user_get_threepids(user_id))
+        self.assertEqual(len(emails), 1)
+
+        email = emails[0]
+        self.assertEqual(email["medium"], "email")
+        self.assertEqual(email["address"], "bob@bobinator.bob")
+
+        # Should these be 0?
+        self.assertEqual(email["validated_at"], 0)
+        self.assertEqual(email["added_at"], 0)
+
+        # Check that the displayname was assigned
+        displayname = self.get_success(self.store.get_profile_displayname("bob"))
+        self.assertEqual(displayname, "Bobberino")


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/7683

Broke in: #7649

We had a `yield` acting on a coroutine. To be fair this one is a bit difficult to notice as there's a function in the middle that just passes the coroutine along.