### PR TITLE
Update m.id.phone to use 'phone' instead of 'number'

### DIFF
--- a/changelog.d/7687.bugfix
+++ b/changelog.d/7687.bugfix
@@ -1,1 +1,1 @@
-Correct Synapse's definition of `m.id.phone`, changing `number` to `phone`. Bug introduced in #1994.
+Correct Synapse's definition of `m.id.phone`, changing `number` to `phone`. Bug introduced in v0.20.0-rc1.

--- a/changelog.d/7687.bugfix
+++ b/changelog.d/7687.bugfix
@@ -1,0 +1,1 @@
+Correct Synapse's definition of `m.id.phone`, changing `number` to `phone`. Bug introduced in #1994.

--- a/changelog.d/7687.bugfix
+++ b/changelog.d/7687.bugfix
@@ -1,1 +1,1 @@
-Correct Synapse's definition of `m.id.phone`, changing `number` to `phone`. Bug introduced in v0.20.0-rc1.
+Accept the proper field (`phone`) for the `m.id.phone` identifier type. The legacy field of `number` is still accepted as a fallback. Bug introduced in v0.20.0-rc1.

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -61,8 +61,8 @@ def login_id_thirdparty_from_phone(identifier):
     Returns: Login identifier dict of type 'm.id.threepid'
     """
     if "country" not in identifier or (
-        # XXX: We used to require `number` instead of `phone`. The spec
-        # defines `phone`. So accept both
+        # The specification requires a "phone" field, while Synapse used to require a "number"
+        # field. Accept both for backwards compatibility.
         "phone" not in identifier
         and "number" not in identifier
     ):

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -60,10 +60,18 @@ def login_id_thirdparty_from_phone(identifier):
 
     Returns: Login identifier dict of type 'm.id.threepid'
     """
-    if "country" not in identifier or "phone" not in identifier:
+    if "country" not in identifier or (
+        # XXX: We used to require `number` instead of `phone`. The spec
+        # defines `phone`. So accept both
+        "phone" not in identifier
+        and "number" not in identifier
+    ):
         raise SynapseError(400, "Invalid phone-type identifier")
 
-    msisdn = phone_number_to_msisdn(identifier["country"], identifier["phone"])
+    # Accept both "phone" and "number" as valid keys in m.id.phone
+    phone_number = identifier.get("phone", identifier["number"])
+
+    msisdn = phone_number_to_msisdn(identifier["country"], phone_number)
 
     return {"type": "m.id.thirdparty", "medium": "msisdn", "address": msisdn}
 

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -60,10 +60,10 @@ def login_id_thirdparty_from_phone(identifier):
 
     Returns: Login identifier dict of type 'm.id.threepid'
     """
-    if "country" not in identifier or "number" not in identifier:
+    if "country" not in identifier or "phone" not in identifier:
         raise SynapseError(400, "Invalid phone-type identifier")
 
-    msisdn = phone_number_to_msisdn(identifier["country"], identifier["number"])
+    msisdn = phone_number_to_msisdn(identifier["country"], identifier["phone"])
 
     return {"type": "m.id.thirdparty", "medium": "msisdn", "address": msisdn}
 


### PR DESCRIPTION
The spec [states](https://matrix.org/docs/spec/client_server/r0.6.1#phone-number) that `m.id.phone` requires the field `country` and `phone`.

In Synapse, we've been enforcing `country` and `number`.

I am not currently sure whether this affects any client implementations.

This issue was introduced in #1994.