### PR TITLE
Fix warnings about losing log context

### DIFF
--- a/changelog.d/7688.bugfix
+++ b/changelog.d/7688.bugfix
@@ -1,1 +1,1 @@
-Ensure the log context is kept during user interactive authentication. The bug was introduced in 1.13.0rc1.
+Fix "Starting db txn 'get_completed_ui_auth_stages' from sentinel context" warning. The bug was introduced in 1.13.0rc1.

--- a/changelog.d/7688.bugfix
+++ b/changelog.d/7688.bugfix
@@ -1,0 +1,1 @@
+Ensure the log context is kept during user interactive authentication. The bug was introduced in 1.13.0rc1.

--- a/synapse/storage/data_stores/main/ui_auth.py
+++ b/synapse/storage/data_stores/main/ui_auth.py
@@ -186,7 +186,7 @@ class UIAuthWorkerStore(SQLBaseStore):
         # The clientdict gets stored as JSON.
         clientdict_json = json.dumps(clientdict)
 
-        self.db.simple_update_one(
+        await self.db.simple_update_one(
             table="ui_auth_sessions",
             keyvalues={"session_id": session_id},
             updatevalues={"clientdict": clientdict_json},


### PR DESCRIPTION
There was a missing await call causing the log context to get lost in the UI Auth code (sometimes).

This was introduced in #7455.