### PR TITLE
Fix a typo when comparing the URI & method during UI Auth.

### DIFF
--- a/changelog.d/7689.bugfix
+++ b/changelog.d/7689.bugfix
@@ -1,0 +1,1 @@
+Compare the URI and method during user interactive authentication (instead of the URI twice). Bug introduced in 1.13.0rc1.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -297,7 +297,7 @@ class AuthHandler(BaseHandler):
 
         # Convert the URI and method to strings.
         uri = request.uri.decode("utf-8")
-        method = request.uri.decode("utf-8")
+        method = request.method.decode("utf-8")
 
         # If there's no session ID, create a new session.
         if not sid:


### PR DESCRIPTION
This does mean that some active UI auth session will be broken when this is deployed since the comparator is changing. I'm not sure there's a good way around that. (I guess we could try comparing with the old values, but that seems a bit silly of a workaround to introduce.)

This was introduced in #7302.