### PR TITLE
make sure etag is a string for GET room_keys/version

### DIFF
--- a/changelog.d/7691.bugfix
+++ b/changelog.d/7691.bugfix
@@ -1,1 +1,1 @@
-Fix an incorrect type in the `GET room_keys/version` endpoint.
+Fix a long standing bug where the response to the `GET room_keys/version` endpoint had the incorrect type for the `etag` field.

--- a/changelog.d/7691.bugfix
+++ b/changelog.d/7691.bugfix
@@ -1,0 +1,1 @@
+Fix an incorrect type in the `GET room_keys/version` endpoint.

--- a/synapse/handlers/e2e_room_keys.py
+++ b/synapse/handlers/e2e_room_keys.py
@@ -351,6 +351,7 @@ class E2eRoomKeysHandler(object):
                     raise
 
             res["count"] = yield self.store.count_e2e_room_keys(user_id, res["version"])
+            res["etag"] = str(res["etag"])
             return res
 
     @trace

--- a/tests/handlers/test_e2e_room_keys.py
+++ b/tests/handlers/test_e2e_room_keys.py
@@ -96,6 +96,7 @@ class E2eRoomKeysHandlerTestCase(unittest.TestCase):
         # check we can retrieve it as the current version
         res = yield self.handler.get_version_info(self.local_user)
         version_etag = res["etag"]
+        self.assertIsInstance(version_etag, str)
         del res["etag"]
         self.assertDictEqual(
             res,


### PR DESCRIPTION
Thanks to sorunome for noticing.

The spec says that `etag` should be a string, but it's stored in the DB as an int, so we need to convert it before we return it.