### PR TITLE
Add support for using rust-python-jaeger-reporter

### DIFF
--- a/changelog.d/7697.misc
+++ b/changelog.d/7697.misc
@@ -1,1 +1,1 @@
-Add support for using `rust-python-jaeger-reporter` library to reduct jaeger tracing overhead.
+Add support for using `rust-python-jaeger-reporter` library to reduce jaeger tracing overhead.

--- a/changelog.d/7697.misc
+++ b/changelog.d/7697.misc
@@ -1,0 +1,1 @@
+Add support for using `rust-python-jaeger-reporter` library to reduct jaeger tracing overhead.

--- a/mypy.ini
+++ b/mypy.ini
@@ -78,3 +78,6 @@ ignore_missing_imports = True
 
 [mypy-authlib.*]
 ignore_missing_imports = True
+
+[mypy-rust_python_jaeger_reporter.*]
+ignore_missing_imports = True

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -353,6 +353,7 @@ def init_tracer(hs: "HomeServer"):
 
     # If we have the rust jaeger reporter available let's use that.
     if RustReporter:
+        logger.info("Using rust_python_jaeger_reporter library")
         tracer = config.create_tracer(RustReporter(), config.sampler)
         opentracing.set_global_tracer(tracer)
     else:

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -241,7 +241,7 @@ try:
         """Wrap the reporter to ensure `report_span` never throws.
         """
 
-        _reporter = attr.ib(type=Reporter, default=lambda: Reporter())
+        _reporter = attr.ib(type=Reporter, default=attr.Factory(Reporter))
 
         def set_process(self, *args, **kwargs):
             return self._reporter.set_process(*args, **kwargs)


### PR DESCRIPTION
This uses https://github.com/erikjohnston/rust-jaeger-python-client (which is published as a wheel on pypi). I'm not entirely sure we want to do this, but it does provide better performance than the pure python reporter.

FWIW the python version uses auto generated code via thrift to implement their reporter, the rust version does exactly the same and uses the auto generated thrift code. 