### PR TITLE
Fix "There was no active span when trying to log." error

### DIFF
--- a/changelog.d/7698.bugfix
+++ b/changelog.d/7698.bugfix
@@ -1,1 +1,1 @@
-Fix logged error during device resync in opentracing. Broke in #7453.
+Fix logged error during device resync in opentracing. Broke in v1.14.0.

--- a/changelog.d/7698.bugfix
+++ b/changelog.d/7698.bugfix
@@ -1,0 +1,1 @@
+Fix logged error during device resync in opentracing. Broke in #7453.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -691,6 +691,7 @@ class DeviceListUpdater(object):
 
         return False
 
+    @trace
     @defer.inlineCallbacks
     def _maybe_retry_device_resync(self):
         """Retry to resync device lists that are out of sync, except if another retry is


### PR DESCRIPTION
This was due to `user_device_resync` being called from a background process

Broke in #7453.