### PR TITLE
Support running multiple media repos.

### DIFF
--- a/changelog.d/7706.feature
+++ b/changelog.d/7706.feature
@@ -1,0 +1,1 @@
+Add support for running multiple media repository workers. See [docs/workers.md](docs/workers.md) for instructions.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -308,7 +308,7 @@ expose the `media` resource. For example:
 ```
 
 Note that if running multiple media repositories they must be on the same server
-and you must configure which single instance to run the background tasks, e.g.:
+and you must configure a single instance to run the background tasks, e.g.:
 
 ```yaml
     media_instance_running_background_jobs: "media-repository-1"

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -308,11 +308,10 @@ expose the `media` resource. For example:
 ```
 
 Note that if running multiple media repositories they must be on the same server
-and all but one of the workers must set the following to false to ensure only
-one media repository instance runs the background jobs:
+and you must configure which single instance to run the background tasks, e.g.:
 
 ```yaml
-    worker_run_media_background_jobs: false
+    media_instance_running_background_jobs: "media-repository-1"
 ```
 
 ### `synapse.app.client_reader`

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -307,7 +307,13 @@ expose the `media` resource. For example:
            - media
 ```
 
-Note this worker cannot be load-balanced: only one instance should be active.
+Note that if running multiple media repositories they must be on the same server
+and all but one of the workers must set the following to false to ensure only
+one media repository instance runs the background jobs:
+
+```yaml
+    worker_run_media_background_jobs: false
+```
 
 ### `synapse.app.client_reader`
 

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -94,6 +94,12 @@ class ContentRepositoryConfig(Config):
         else:
             self.can_load_media_repo = True
 
+        # Whether this instance should be the one to run the background jobs to
+        # e.g clean up old URL previews.
+        self.run_media_background_jobs = config.get(
+            "worker_run_media_background_jobs", True
+        )
+
         self.max_upload_size = self.parse_size(config.get("max_upload_size", "10M"))
         self.max_image_pixels = self.parse_size(config.get("max_image_pixels", "32M"))
         self.max_spider_size = self.parse_size(config.get("max_spider_size", "10M"))

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -96,8 +96,8 @@ class ContentRepositoryConfig(Config):
 
         # Whether this instance should be the one to run the background jobs to
         # e.g clean up old URL previews.
-        self.run_media_background_jobs = config.get(
-            "worker_run_media_background_jobs", True
+        self.media_instance_running_background_jobs = config.get(
+            "media_instance_running_background_jobs",
         )
 
         self.max_upload_size = self.parse_size(config.get("max_upload_size", "10M"))

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -85,8 +85,13 @@ class PreviewUrlResource(DirectServeResource):
         self.primary_base_path = media_repo.primary_base_path
         self.media_storage = media_storage
 
+        # We run the background jobs if we're the instance specified (or no
+        # instance is specified, where we assume there is only one instance
+        # serving media).
+        instance_running_jobs = hs.config.media.media_instance_running_background_jobs
         self._worker_run_media_background_jobs = (
-            hs.config.media.run_media_background_jobs
+            instance_running_jobs is None
+            or instance_running_jobs == hs.get_instance_name()
         )
 
         self.url_preview_url_blacklist = hs.config.url_preview_url_blacklist


### PR DESCRIPTION
This requires a new config option to specify which media repo should be responsible for running background jobs to e.g. clear out expired URL preview caches. 

This is a bit of an icky way of doing it, though I think somewhat consistent with how we do worker configs currently. There are a couple of other options here:

1. Use distributed lock based on Redis, this is a bit difficult due to redis not having native support for this (the documentation suggests using a thing called [Redlock](https://redis.io/topics/distlock), but the fact that [Kleppman](http://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html) thinks its unsound is not exactly confidence inspiring). An argument could be made that we're probably will need to do something like this at some point though.
2. Change the way we do our config to instead list which instances are responsible for media operations in the main config and chose the first to be responsible for running the background jobs. This has the advantage that a) its impossible to mess up and b) its similar to how we specify which worker is responsible for event persistence.

TBH though, it feels like we shouldn't block this behind trying to implement a distributed lock or changing how we configure workers