### PR TITLE
Fix "argument of type 'ObservableDeferred' is not iterable" error

### DIFF
--- a/changelog.d/7708.bugfix
+++ b/changelog.d/7708.bugfix
@@ -1,0 +1,1 @@
+Fixs a long standing bug which resulted in an exception: "TypeError: argument of type 'ObservableDeferred' is not iterable".

--- a/synapse/storage/data_stores/main/receipts.py
+++ b/synapse/storage/data_stores/main/receipts.py
@@ -24,6 +24,7 @@ from twisted.internet import defer
 from synapse.storage._base import SQLBaseStore, make_in_list_sql_clause
 from synapse.storage.database import Database
 from synapse.storage.util.id_generators import StreamIdGenerator
+from synapse.util.async_helpers import ObservableDeferred
 from synapse.util.caches.descriptors import cached, cachedInlineCallbacks, cachedList
 from synapse.util.caches.stream_change_cache import StreamChangeCache
 
@@ -300,10 +301,10 @@ class ReceiptsWorkerStore(SQLBaseStore):
             room_id, None, update_metrics=False
         )
 
-        # first handle the Deferred case
-        if isinstance(res, defer.Deferred):
-            if res.called:
-                res = res.result
+        # first handle the ObservableDeferred case
+        if isinstance(res, ObservableDeferred):
+            if res.has_called():
+                res = res.get_result()
             else:
                 res = None
 

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -93,7 +93,7 @@ class ObservableDeferred(object):
 
         This returns a brand new deferred that is resolved when the underlying
         deferred is resolved. Interacting with the returned deferred does not
-        effect the underdlying deferred.
+        effect the underlying deferred.
         """
         if not self._result:
             d = defer.Deferred()


### PR DESCRIPTION
Fixes #3234

Per the comment in the file this is an `ObservableDeferred` not a `Deferred` and since the former is not a subclass of the latter then the type check is not working.

I believe I've adapted the code OK, but I'm not really sure how to test this.