### PR TITLE
Ignore the UI Auth sessions when porting from sqlite to postgresql

### DIFF
--- a/changelog.d/7711.bugfix
+++ b/changelog.d/7711.bugfix
@@ -1,0 +1,1 @@
+Fixes a bug where the `synapse_port_db` file fails when the `ui_auth_sessions` table is non-empty. This bug has existed since v1.13.0rc1.

--- a/changelog.d/7711.bugfix
+++ b/changelog.d/7711.bugfix
@@ -1,1 +1,1 @@
-Fixes a bug where the `synapse_port_db` file fails when the `ui_auth_sessions` table is non-empty. This bug has existed since v1.13.0rc1.
+The `synapse_port_db` script no longer fails when the `ui_auth_sessions` table is non-empty. This bug has existed since v1.13.0rc1.

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -127,6 +127,16 @@ APPEND_ONLY_TABLES = [
 ]
 
 
+IGNORED_TABLES = {
+    "user_directory",
+    "user_directory_search",
+    "users_who_share_rooms",
+    "users_in_pubic_room",
+    "ui_auth_sessions",
+    "ui_auth_sessions_credentials",
+}
+
+
 # Error returned by the run function. Used at the top-level part of the script to
 # handle errors and return codes.
 end_error = None
@@ -289,13 +299,8 @@ class Porter(object):
             )
             return
 
-        if table in (
-            "user_directory",
-            "user_directory_search",
-            "users_who_share_rooms",
-            "users_in_pubic_room",
-        ):
-            # We don't port these tables, as they're a faff and we can regenreate
+        if table in IGNORED_TABLES:
+            # We don't port these tables, as they're a faff and we can regenerate
             # them anyway.
             self.progress.update(table, table_size)  # Mark table as done
             return


### PR DESCRIPTION
Adds the two UI auth sessions tables to the set of tables to ignore, also pulls that list of tables out as a constant (and makes it a set).

Fixes #7654 