### PR TITLE
Fix unread counts in sync

### DIFF
--- a/changelog.d/7716.feature
+++ b/changelog.d/7716.feature
@@ -1,0 +1,1 @@
+Add a per-room counter for unread messages in responses to `/sync` requests. Implements [MSC2625](https://github.com/matrix-org/matrix-doc/pull/2625).

--- a/synapse/push/push_tools.py
+++ b/synapse/push/push_tools.py
@@ -42,7 +42,7 @@ def get_badge_count(store, user_id):
             # We're populating this badge using the unread_count (instead of the
             # notify_count) as this badge is the number of missed messages, not the
             # number of missed notifications.
-            badge += 1 if notifs["unread_count"] else 0
+            badge += 1 if notifs.get("unread_count") else 0
     return badge
 
 

--- a/synapse/storage/data_stores/main/event_push_actions.py
+++ b/synapse/storage/data_stores/main/event_push_actions.py
@@ -123,7 +123,7 @@ class EventPushActionsWorkerStore(SQLBaseStore):
         txn.execute(sql, (room_id, last_read_event_id))
         results = txn.fetchall()
         if len(results) == 0:
-            return {"notify_count": 0, "highlight_count": 0}
+            return {"notify_count": 0, "highlight_count": 0, "unread_count": 0}
 
         stream_ordering = results[0][0]
 


### PR DESCRIPTION
* Always return an unread_count in get_unread_event_push_actions_by_room_for_user
* Don't always expect unread_count to be there so we don't take out sync entirely if something goes wrong