### PR TITLE
Sync ignored table names in synapse_port_db to current database schema

### DIFF
--- a/changelog.d/7717.bugfix
+++ b/changelog.d/7717.bugfix
@@ -1,0 +1,1 @@
+Sync the list of tables ignored by `synapose_port_db` with the current database schema.

--- a/changelog.d/7717.bugfix
+++ b/changelog.d/7717.bugfix
@@ -1,1 +1,1 @@
-Sync the list of tables ignored by `synapse_port_db` with the current database schema.
+Fix the tables ignored by `synapse_port_db` to be in sync the current database schema.

--- a/changelog.d/7717.bugfix
+++ b/changelog.d/7717.bugfix
@@ -1,1 +1,1 @@
-Sync the list of tables ignored by `synapose_port_db` with the current database schema.
+Sync the list of tables ignored by `synapse_port_db` with the current database schema.

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -128,10 +128,19 @@ APPEND_ONLY_TABLES = [
 
 
 IGNORED_TABLES = {
+    # We don't port these tables, as they're a faff and we can regenerate
+    # them anyway.
     "user_directory",
-    "user_directory_search",
-    "users_who_share_rooms",
-    "users_in_pubic_room",
+    "user_directory_search_content",
+    "user_directory_search_docsize",
+    "user_directory_search_segdir",
+    "user_directory_search_segments",
+    "user_directory_search_stat",
+    "user_directory_search_pos",
+    "users_who_share_private_rooms",
+    "users_in_public_room",
+    # UI auth sessions have foreign keys so additional care needs to be taken,
+    # the sessions are transient anyway, so ignore them.
     "ui_auth_sessions",
     "ui_auth_sessions_credentials",
 }
@@ -300,8 +309,6 @@ class Porter(object):
             return
 
         if table in IGNORED_TABLES:
-            # We don't port these tables, as they're a faff and we can regenerate
-            # them anyway.
             self.progress.update(table, table_size)  # Mark table as done
             return
 

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -131,6 +131,7 @@ IGNORED_TABLES = {
     # We don't port these tables, as they're a faff and we can regenerate
     # them anyway.
     "user_directory",
+    "user_directory_search",
     "user_directory_search_content",
     "user_directory_search_docsize",
     "user_directory_search_segdir",


### PR DESCRIPTION
Noticed in #7711, it seems some of the tables we ignore in `synapse_port_db` don't exist anymore. I took a try at syncing the list to the real tables.