### PR TITLE
Set Content-Length for Metrics requests

### DIFF
--- a/changelog.d/7730.bugfix
+++ b/changelog.d/7730.bugfix
@@ -1,1 +1,1 @@
-Set `Content-Length` on HTTP responses from the metrics handler.
+Fix missing `Content-Length` on HTTP responses from the metrics handler.

--- a/changelog.d/7730.bugfix
+++ b/changelog.d/7730.bugfix
@@ -1,0 +1,1 @@
+Set `Content-Length` on HTTP responses from the metrics handler.

--- a/synapse/metrics/_exposition.py
+++ b/synapse/metrics/_exposition.py
@@ -208,6 +208,7 @@ class MetricsHandler(BaseHTTPRequestHandler):
             raise
         self.send_response(200)
         self.send_header("Content-Type", CONTENT_TYPE_LATEST)
+        self.send_header("Content-Length", str(len(output)))
         self.end_headers()
         self.wfile.write(output)
 
@@ -261,4 +262,6 @@ class MetricsResource(Resource):
 
     def render_GET(self, request):
         request.setHeader(b"Content-Type", CONTENT_TYPE_LATEST.encode("ascii"))
-        return generate_latest(self.registry)
+        response = generate_latest(self.registry)
+        request.setHeader(b"Content-Length", str(len(response)))
+        return response


### PR DESCRIPTION
HTTP requires the response to contain a Content-Length header unless chunked encoding is being used.
Prometheus metrics endpoint did not set this, causing software such as prometheus-proxy to not be able to scrape synapse for metrics.

Test by cURL:ing the metrics endpoint on a patched Synapse server:

```
> GET / HTTP/1.1
> Host: [redacted]:9000
> User-Agent: curl/7.64.0
> Accept: */*
>
* HTTP 1.0, assume close after body
< HTTP/1.0 200 OK
< Server: BaseHTTP/0.6 Python/3.7.3
< Date: Sun, 21 Jun 2020 17:15:59 GMT
< Content-Type: text/plain; version=0.0.4; charset=utf-8
< Content-Length: 270468
```

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog).
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
