### PR TITLE
Move flake8 to end. Don't exit script on failure

### DIFF
--- a/changelog.d/7738.misc
+++ b/changelog.d/7738.misc
@@ -1,0 +1,1 @@
+Prevent a failure in a linting tool blocking the others from being run. Move flake8 to the end as it takes the longest.

--- a/changelog.d/7738.misc
+++ b/changelog.d/7738.misc
@@ -1,1 +1,1 @@
-Prevent a failure in a linting tool blocking the others from being run. Move flake8 to the end as it takes the longest.
+Move `flake8` to the end of `scripts-dev/lint.sh` as it takes the longest and could cause the script to exit early.

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -2,10 +2,8 @@
 #
 # Runs linting scripts over the local Synapse checkout
 # isort - sorts import statements
-# flake8 - lints and finds mistakes
 # black - opinionated code formatter
-
-set -e
+# flake8 - lints and finds mistakes
 
 if [ $# -ge 1 ]
 then
@@ -16,6 +14,6 @@ fi
 
 echo "Linting these locations: $files"
 isort -y -rc $files
-flake8 $files
 python3 -m black $files
 ./scripts-dev/config-lint.sh
+flake8 $files

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -5,6 +5,8 @@
 # black - opinionated code formatter
 # flake8 - lints and finds mistakes
 
+set -e
+
 if [ $# -ge 1 ]
 then
   files=$*


### PR DESCRIPTION
* `flake8` currently takes the longest to execute, so move it to the end
* prevent linting from stopped on non-0 exit code. this would require the script to be re-run to get through all of the tools