### PR TITLE
Explain the purpose of the "tests" conditional dependency requirement

### DIFF
--- a/changelog.d/7751.misc
+++ b/changelog.d/7751.misc
@@ -1,1 +1,1 @@
-Explain the "test" conditional requirement for dependencies are not all of the modules necessary to run the unit tests.
+Explain the "test" conditional requirement for dependencies is not all of the modules necessary to run the unit tests.

--- a/changelog.d/7751.misc
+++ b/changelog.d/7751.misc
@@ -1,0 +1,1 @@
+Explain the "test" conditional requirement for dependencies are not all of the modules necessary to run the unit tests.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -93,6 +93,10 @@ CONDITIONAL_REQUIREMENTS = {
     "oidc": ["authlib>=0.14.0"],
     "systemd": ["systemd-python>=231"],
     "url_preview": ["lxml>=3.5.0"],
+    # Dependencies which are exclusively required by unit test code. This is
+    # NOT a list of all modules that are necessary to run the unit tests.
+    # Tests assume that all optional dependencies are installed.
+    #
     # parameterized_class decorator was introduced in parameterized 0.7.0
     "test": ["mock>=2.0", "parameterized>=0.7.0"],
     "sentry": ["sentry-sdk>=0.7.2"],


### PR DESCRIPTION
`jwt`, provided the the `pyjwt` module, is required by our unit tests

https://github.com/matrix-org/synapse/blob/831b31e563eb181a8bc0311a8c28519ef9f131a1/tests/rest/client/v1/test_login.py#L7

This PR adds the module to the `test` conditional requirement.

This does mean that we have to change a version number in two places if we ever want to update `pyjwt`s minimum version. Is there a way to consolidate this? (I'm aware I could define a version string outside of the `CONDITIONAL_REQUIREMENTS` dict, but is there a better way?)

EDIT: This PR has been updated to explain that `"test"` is not supposed to be all of the modules necessary to run the unit tests, but rather those modules that are exclusively required by unit test code.