### PR TITLE
Add early returns to `_check_for_soft_fail`

### DIFF
--- a/changelog.d/7769.misc
+++ b/changelog.d/7769.misc
@@ -1,0 +1,1 @@
+Add early returns to `_check_for_soft_fail`.


### PR DESCRIPTION
my editor was complaining about unset variables, so let's add some early
returns to fix that and reduce indentation/cognitive load.