### PR TITLE
Allow YAML config file to contain None

### DIFF
--- a/changelog.d/7779.bugfix
+++ b/changelog.d/7779.bugfix
@@ -1,1 +1,1 @@
-Allow **synctl** config files to contain `None`. Useful when some config files are fully commented.
+Fix synctl to handle empty config files correctly.

--- a/changelog.d/7779.bugfix
+++ b/changelog.d/7779.bugfix
@@ -1,1 +1,1 @@
-Fix synctl to handle empty config files correctly.
+Fix synctl to handle empty config files correctly. Contributed by @kotovalexarian.

--- a/changelog.d/7779.bugfix
+++ b/changelog.d/7779.bugfix
@@ -1,1 +1,1 @@
-Allow YAML config file to contain None. Useful when config file is fully commented.
+Allow **synctl** config files to contain `None`. Useful when some config files are fully commented.

--- a/changelog.d/7779.bugfix
+++ b/changelog.d/7779.bugfix
@@ -1,0 +1,1 @@
+Allow YAML config file to contain None. Useful when config file is fully commented.

--- a/synctl
+++ b/synctl
@@ -239,7 +239,8 @@ def main():
     for config_file in config_files:
         with open(config_file) as file_stream:
             yaml_config = yaml.safe_load(file_stream)
-        config.update(yaml_config)
+        if yaml_config is not None:
+            config.update(yaml_config)
 
     pidfile = config["pid_file"]
     cache_factor = config.get("synctl_cache_factor")


### PR DESCRIPTION
Useful when config file is fully commented. Otherwise we get error:

```
Traceback (most recent call last):
  File "/opt/matrix/synapse/venv/bin/synctl", line 380, in <module>
    main()
  File "/opt/matrix/synapse/venv/bin/synctl", line 244, in main
    config.update(yaml_config)
TypeError: 'NoneType' object is not iterable
```