### PR TITLE
Pass additional headers from the worker to the main process.

### DIFF
--- a/changelog.d/7797.bugfix
+++ b/changelog.d/7797.bugfix
@@ -1,0 +1,1 @@
+Fixes a long standing bug in worker mode where worker information was saved in the devices table instead of the original IP address and user agent.

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -215,7 +215,9 @@ class KeyUploadServlet(RestServlet):
                 for header in (b"Authorization", b"User-Agent")
             }
             # Add the previous hop the the X-Forwarded-For header.
-            x_forwarded_for = request.requestHeaders.getRawHeaders(b"X-Forwarded-For", [])
+            x_forwarded_for = request.requestHeaders.getRawHeaders(
+                b"X-Forwarded-For", []
+            )
             if isinstance(request.client, (address.IPv4Address, address.IPv6Address)):
                 previous_host = request.client.host.encode("ascii")
                 # If the header exists, add to the comma-separated list of the first

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -21,7 +21,7 @@ from typing import Dict, Iterable, Optional, Set
 
 from typing_extensions import ContextManager
 
-from twisted.internet import defer, reactor
+from twisted.internet import address, defer, reactor
 
 import synapse
 import synapse.events
@@ -215,14 +215,15 @@ class KeyUploadServlet(RestServlet):
                 for header in (b"Authorization", b"User-Agent")
             }
             # Add the previous hop the the X-Forwarded-For header.
-            x_forwarded_for = request.requestHeaders.getRawHeaders(b"X-Forwarded-For")
-            previous_host = request.client.host.encode("ascii")
-            # If the header exists, add to the comma-separated list of the first
-            # instance of the header. Otherwise, generate a new header.
-            if x_forwarded_for:
-                x_forwarded_for[0] += b", " + previous_host
-            else:
-                x_forwarded_for = [previous_host]
+            x_forwarded_for = request.requestHeaders.getRawHeaders(b"X-Forwarded-For", [])
+            if isinstance(request.client, (address.IPv4Address, address.IPv6Address)):
+                previous_host = request.client.host.encode("ascii")
+                # If the header exists, add to the comma-separated list of the first
+                # instance of the header. Otherwise, generate a new header.
+                if x_forwarded_for:
+                    x_forwarded_for[0] += b", " + previous_host
+                else:
+                    x_forwarded_for = [previous_host]
             headers[b"X-Forwarded-For"] = x_forwarded_for
 
             try:

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -223,7 +223,9 @@ class KeyUploadServlet(RestServlet):
                 # If the header exists, add to the comma-separated list of the first
                 # instance of the header. Otherwise, generate a new header.
                 if x_forwarded_for:
-                    x_forwarded_for[0] += b", " + previous_host
+                    x_forwarded_for = [
+                        x_forwarded_for[0] + b", " + previous_host
+                    ] + x_forwarded_for[1:]
                 else:
                     x_forwarded_for = [previous_host]
             headers[b"X-Forwarded-For"] = x_forwarded_for

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -210,11 +210,10 @@ class KeyUploadServlet(RestServlet):
             # Proxy headers from the original request, such as the auth headers
             # (in case the access token is there) and the original IP /
             # User-Agent of the request.
-            headers = {}
-            for header in (b"Authorization", b"X-Forwarded-For", b"User-Agent"):
-                header_value = request.requestHeaders.getRawHeaders(header)
-                if header_value:
-                    headers[header] = header_value
+            headers = {
+                header: request.requestHeaders.getRawHeaders(header, [])
+                for header in (b"Authorization", b"X-Forwarded-For", b"User-Agent")
+            }
 
             try:
                 result = await self.http_client.post_json_get_json(


### PR DESCRIPTION
I believe that this will fix #6396 by passing the `X-Forwarded-For` and `User-Agent` headers from the worker to the main process when proxying requests.

Note that a User-Agent is usually generated, but will get overridden if provided as a header:

https://github.com/matrix-org/synapse/blob/a3f11567d930b7da0db068c3b313f6f4abbf12a1/synapse/http/client.py#L400-L406