### PR TITLE
Starting with apt 1.6, https support has moved into the main package …

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -259,6 +259,13 @@ Synapse via https://packages.matrix.org/debian/. They are available for Debian
 
 ```
 sudo apt install -y lsb-release wget apt-transport-https
+```
+for Debian/Ubuntu versions shipping `apt` < 1.6 (Debian < 10 / Ubuntu < 18.04), or
+```
+sudo apt install -y lsb-release wget
+```
+for Debian 10 / Ubuntu 18.04 and newer, followed by
+```
 sudo wget -O /usr/share/keyrings/matrix-org-archive-keyring.gpg https://packages.matrix.org/debian/matrix-org-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/matrix-org-archive-keyring.gpg] https://packages.matrix.org/debian/ $(lsb_release -cs) main" |
     sudo tee /etc/apt/sources.list.d/matrix-org.list

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -260,11 +260,15 @@ Synapse via https://packages.matrix.org/debian/. They are available for Debian
 ```
 sudo apt install -y lsb-release wget apt-transport-https
 ```
+
 for Debian/Ubuntu versions shipping `apt` < 1.6 (Debian < 10 / Ubuntu < 18.04), or
+
 ```
 sudo apt install -y lsb-release wget
 ```
+
 for Debian 10 / Ubuntu 18.04 and newer, followed by
+
 ```
 sudo wget -O /usr/share/keyrings/matrix-org-archive-keyring.gpg https://packages.matrix.org/debian/matrix-org-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/matrix-org-archive-keyring.gpg] https://packages.matrix.org/debian/ $(lsb_release -cs) main" |

--- a/changelog.d/7801.doc
+++ b/changelog.d/7801.doc
@@ -1,0 +1,1 @@
+Change documentation reg. apt-transport-https package, which is no longer needed on Debian 10/Ubuntu 18.04 and newer.

--- a/changelog.d/7801.doc
+++ b/changelog.d/7801.doc
@@ -1,1 +1,1 @@
-Change documentation reg. apt-transport-https package, which is no longer needed on Debian 10/Ubuntu 18.04 and newer.
+Change the installation documentation regarding the `apt-transport-https` package, which is no longer needed on Debian 10/Ubuntu 18.04 and newer.


### PR DESCRIPTION
…and apt-transport-https has become a transitional dummy package.

Signed-off-by: Dirk Heinrichs <dirk.heinrichs@altum.de>