### PR TITLE
Install canonicaljson from branch for testing.

### DIFF
--- a/changelog.d/7803.misc
+++ b/changelog.d/7803.misc
@@ -1,0 +1,1 @@
+Install canonicaljson from a branch for testing.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -43,7 +43,7 @@ REQUIREMENTS = [
     "jsonschema>=2.5.1",
     "frozendict>=1",
     "unpaddedbase64>=1.1.0",
-    "canonicaljson>=1.1.3",
+    "canonicaljson@https://github.com/matrix-org/python-canonicaljson/archive/clokep/remove-simple-json.zip",
     # we use the type definitions added in signedjson 1.1.
     "signedjson>=1.1.0",
     "pynacl>=1.2.1",


### PR DESCRIPTION
This installs a canonicaljson that does not use simplejson. My goal here is to get CI to run across the various builds we have. 👍 

**This should not be merged**

Part of #7674.