### PR TITLE
Improve stacktraces from exceptions in background processes

### DIFF
--- a/changelog.d/7808.misc
+++ b/changelog.d/7808.misc
@@ -1,0 +1,1 @@
+Improve stacktraces from exceptions in background processes.


### PR DESCRIPTION
use `Failure()` to fish out the real exception.