### PR TITLE
Clean up `update_membership` declaration

### DIFF
--- a/changelog.d/7809.bugfix
+++ b/changelog.d/7809.bugfix
@@ -1,0 +1,1 @@
+Fix 'stuck invites' which happen when we are unable to reject a room invite received over federation.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -109,7 +109,7 @@ class RoomMemberHandler(object):
         txn_id: Optional[str],
         requester: Requester,
         content: JsonDict,
-    ) -> Tuple[Optional[str], int]:
+    ) -> Tuple[str, int]:
         """
         Rejects an out-of-band invite we have received from a remote server
 
@@ -268,7 +268,7 @@ class RoomMemberHandler(object):
         ratelimit: bool = True,
         content: Optional[dict] = None,
         require_consent: bool = True,
-    ) -> Tuple[Optional[str], int]:
+    ) -> Tuple[str, int]:
         key = (room_id,)
 
         with (await self.member_linearizer.queue(key)):
@@ -299,7 +299,7 @@ class RoomMemberHandler(object):
         ratelimit: bool = True,
         content: Optional[dict] = None,
         require_consent: bool = True,
-    ) -> Tuple[Optional[str], int]:
+    ) -> Tuple[str, int]:
         content_specified = bool(content)
         if content is None:
             content = {}
@@ -1006,7 +1006,7 @@ class RoomMemberMasterHandler(RoomMemberHandler):
         txn_id: Optional[str],
         requester: Requester,
         content: JsonDict,
-    ) -> Tuple[Optional[str], int]:
+    ) -> Tuple[str, int]:
         """
         Rejects an out-of-band invite received from a remote user
 

--- a/synapse/handlers/room_member_worker.py
+++ b/synapse/handlers/room_member_worker.py
@@ -67,7 +67,7 @@ class RoomMemberWorkerHandler(RoomMemberHandler):
         txn_id: Optional[str],
         requester: Requester,
         content: dict,
-    ) -> Tuple[Optional[str], int]:
+    ) -> Tuple[str, int]:
         """
         Rejects an out-of-band invite received from a remote user
 

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -217,10 +217,8 @@ class RoomStateEventRestServlet(TransactionRestServlet):
             )
             event_id = event.event_id
 
-        ret = {}  # type: dict
-        if event_id:
-            set_tag("event_id", event_id)
-            ret = {"event_id": event_id}
+        set_tag("event_id", event_id)
+        ret = {"event_id": event_id}
         return 200, ret
 
 


### PR DESCRIPTION
as of #7804, `remote_reject_invite`, and hence everything up the stack, now always returns an event id, so we can remove some dead code.