### PR TITLE
Fix `can only concatenate list (not "tuple") to list` exception

### DIFF
--- a/changelog.d/7810.bugfix
+++ b/changelog.d/7810.bugfix
@@ -1,0 +1,1 @@
+Fix 'stuck invites' which happen when we are unable to reject a room invite received over federation.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -1072,7 +1072,7 @@ class RoomMemberMasterHandler(RoomMemberHandler):
             alg, h = compute_event_reference_hash(invite_event)
             invite_hash = (invite_event.event_id, {alg: encode_base64(h)})
 
-        auth_events = invite_event.auth_events + (invite_hash,)
+        auth_events = tuple(invite_event.auth_events) + (invite_hash,)
         prev_events = (invite_hash,)
 
         # we cap depth of generated events, to ensure that they are not


### PR DESCRIPTION
It seems auth_events can be either a list or a tuple, depending on Things.