### PR TITLE
Add types to the server code and remove unused parameter

### DIFF
--- a/changelog.d/7813.misc
+++ b/changelog.d/7813.misc
@@ -1,0 +1,1 @@
+Add type hints to the http server code and remove an unused parameter.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -22,7 +22,7 @@ import types
 import urllib
 from http import HTTPStatus
 from io import BytesIO
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Tuple, Union
 
 import jinja2
 from canonicaljson import encode_canonical_json, encode_pretty_printed_json, json
@@ -511,7 +511,6 @@ def respond_with_json(
     code: int,
     json_object: Any,
     send_cors: bool = False,
-    response_code_message: Optional[str] = None,
     pretty_print: bool = False,
     canonical_json: bool = True,
 ) -> NOT_DONE_YET:
@@ -533,21 +532,11 @@ def respond_with_json(
         else:
             json_bytes = json.dumps(json_object).encode("utf-8")
 
-    return respond_with_json_bytes(
-        request,
-        code,
-        json_bytes,
-        send_cors=send_cors,
-        response_code_message=response_code_message,
-    )
+    return respond_with_json_bytes(request, code, json_bytes, send_cors=send_cors)
 
 
 def respond_with_json_bytes(
-    request: Request,
-    code: int,
-    json_bytes: bytes,
-    send_cors: bool = False,
-    response_code_message: Optional[str] = None,
+    request: Request, code: int, json_bytes: bytes, send_cors: bool = False,
 ) -> NOT_DONE_YET:
     """Sends encoded JSON in response to the given request.
 
@@ -560,7 +549,7 @@ def respond_with_json_bytes(
     Returns:
         twisted.web.server.NOT_DONE_YET"""
 
-    request.setResponseCode(code, message=response_code_message)
+    request.setResponseCode(code)
     request.setHeader(b"Content-Type", b"application/json")
     request.setHeader(b"Content-Length", b"%d" % (len(json_bytes),))
     request.setHeader(b"Cache-Control", b"no-cache, no-store, must-revalidate")

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -22,7 +22,7 @@ import types
 import urllib
 from http import HTTPStatus
 from io import BytesIO
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Tuple, Union
 
 import jinja2
 from canonicaljson import encode_canonical_json, encode_pretty_printed_json, json
@@ -513,7 +513,7 @@ def respond_with_json(
     send_cors: bool = False,
     pretty_print: bool = False,
     canonical_json: bool = True,
-) -> Optional[NOT_DONE_YET]:
+):
     """Sends encoded JSON in response to the given request.
 
     Args:
@@ -526,6 +526,9 @@ def respond_with_json(
             resulting JSON bytes.
         canonical_json: Whether to use the canonicaljson algorithm when encoding
             the JSON bytes.
+
+    Returns:
+        twisted.web.server.NOT_DONE_YET if the request is still active.
     """
     # could alternatively use request.notifyFinish() and flip a flag when
     # the Deferred fires, but since the flag is RIGHT THERE it seems like
@@ -550,7 +553,7 @@ def respond_with_json(
 
 def respond_with_json_bytes(
     request: Request, code: int, json_bytes: bytes, send_cors: bool = False,
-) -> NOT_DONE_YET:
+):
     """Sends encoded JSON in response to the given request.
 
     Args:
@@ -559,6 +562,9 @@ def respond_with_json_bytes(
         json_bytes: The json bytes to use as the response body.
         send_cors: Whether to send Cross-Origin Resource Sharing headers
             https://fetch.spec.whatwg.org/#http-cors-protocol
+
+    Returns:
+        twisted.web.server.NOT_DONE_YET if the request is still active.
     """
 
     request.setResponseCode(code)

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -217,7 +217,7 @@ class _AsyncResource(resource.Resource, metaclass=abc.ABCMeta):
         return NOT_DONE_YET
 
     @wrap_async_request_handler
-    async def _async_render_wrapper(self, request: Request):
+    async def _async_render_wrapper(self, request: SynapseRequest):
         """This is a wrapper that delegates to `_async_render` and handles
         exceptions, return values, metrics, etc.
         """

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -567,11 +567,11 @@ def respond_with_json_bytes(
 
 
 def set_cors_headers(request: Request):
-    """Set the CORs headers so that javascript running in a web browsers can
+    """Set the CORS headers so that javascript running in a web browsers can
     use this API
 
     Args:
-        request: The http request to add CORs to.
+        request: The http request to add CORS to.
     """
     request.setHeader(b"Access-Control-Allow-Origin", b"*")
     request.setHeader(

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -22,7 +22,7 @@ import types
 import urllib
 from http import HTTPStatus
 from io import BytesIO
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import jinja2
 from canonicaljson import encode_canonical_json, encode_pretty_printed_json, json
@@ -513,7 +513,7 @@ def respond_with_json(
     send_cors: bool = False,
     pretty_print: bool = False,
     canonical_json: bool = True,
-) -> NOT_DONE_YET:
+) -> Optional[NOT_DONE_YET]:
     # could alternatively use request.notifyFinish() and flip a flag when
     # the Deferred fires, but since the flag is RIGHT THERE it seems like
     # a waste.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -514,6 +514,19 @@ def respond_with_json(
     pretty_print: bool = False,
     canonical_json: bool = True,
 ) -> Optional[NOT_DONE_YET]:
+    """Sends encoded JSON in response to the given request.
+
+    Args:
+        request: The http request to respond to.
+        code: The HTTP response code.
+        json_object: The object to serialize to JSON.
+        send_cors: Whether to send Cross-Origin Resource Sharing headers
+            https://fetch.spec.whatwg.org/#http-cors-protocol
+        pretty_print: Whether to include indentation and line-breaks in the
+            resulting JSON bytes.
+        canonical_json: Whether to use the canonicaljson algorithm when encoding
+            the JSON bytes.
+    """
     # could alternatively use request.notifyFinish() and flip a flag when
     # the Deferred fires, but since the flag is RIGHT THERE it seems like
     # a waste.
@@ -546,8 +559,7 @@ def respond_with_json_bytes(
         json_bytes: The json bytes to use as the response body.
         send_cors: Whether to send Cross-Origin Resource Sharing headers
             https://fetch.spec.whatwg.org/#http-cors-protocol
-    Returns:
-        twisted.web.server.NOT_DONE_YET"""
+    """
 
     request.setResponseCode(code)
     request.setHeader(b"Content-Type", b"application/json")

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -534,7 +534,7 @@ def respond_with_json(
         logger.warning(
             "Not sending response to request %s, already disconnected.", request
         )
-        return
+        return None
 
     if pretty_print:
         json_bytes = encode_pretty_printed_json(json_object) + b"\n"


### PR DESCRIPTION
This does two unrelated things, minus them being in the same code:
* Removes the `response_code_message`, which is unused.
* Adds some additional type hints.