### PR TITLE
Drop incorrectly-added table `local_rejections_stream`.

### DIFF
--- a/changelog.d/7816.bugfix
+++ b/changelog.d/7816.bugfix
@@ -1,0 +1,1 @@
+Drop table `local_rejections_stream` which was incorrectly added in Synapse 1.16.0.

--- a/synapse/storage/data_stores/main/schema/delta/58/10drop_local_rejections_stream.sql
+++ b/synapse/storage/data_stores/main/schema/delta/58/10drop_local_rejections_stream.sql
@@ -1,0 +1,22 @@
+/* Copyright 2020 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+The version of synapse 1.16.0 on pypi incorrectly contained a migration which
+added a table called 'local_rejections_stream'. This table is not used, and
+we drop it here for anyone who was affected.
+*/
+
+DROP TABLE IF NOT EXISTS local_rejections_stream;


### PR DESCRIPTION
Synapse 1.16.0, as released on pypi, incorrectly included a database schema migration which added a table `local_rejections_stream`.

This PR is intended to be part of 1.16.1, and drops the incorrectly-added table.

For reference, I've uploaded the incorrect migration at https://gist.github.com/richvdh/ca812c5eab96427b983ad7fd09f74357.

Other releases of Synapse 1.16.0, including the debian packages and docker images, were not affected, but we will release the updated version there too for consistency.