### PR TITLE
Fix recursion error when fetching auth chain over federation

### DIFF
--- a/changelog.d/7817.bugfix
+++ b/changelog.d/7817.bugfix
@@ -1,0 +1,1 @@
+Fix bug where Synapse fails to process an incoming event over federation if the server is missing too much of the event's auth chain.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -65,12 +65,13 @@ def check(
 
     room_id = event.room_id
 
-    # I'm not really expecting to get auth events in the wrong room, but let's
-    # sanity-check it
+    # We need to ensure that the auth events are actually for the same room, to
+    # stop people from using powers they've been granted in other rooms for
+    # example.
     for auth_event in auth_events.values():
         if auth_event.room_id != room_id:
             raise AuthError(
-                500,
+                403,
                 "During auth for event %s in room %s, found event %s in the state "
                 "which is in room %s"
                 % (event.event_id, room_id, auth_event.event_id, auth_event.room_id),

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -69,10 +69,11 @@ def check(
     # sanity-check it
     for auth_event in auth_events.values():
         if auth_event.room_id != room_id:
-            raise Exception(
+            raise AuthError(
+                500,
                 "During auth for event %s in room %s, found event %s in the state "
                 "which is in room %s"
-                % (event.event_id, room_id, auth_event.event_id, auth_event.room_id)
+                % (event.event_id, room_id, auth_event.event_id, auth_event.room_id),
             )
 
     if do_sig_check:

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1175,7 +1175,7 @@ class FederationHandler(BaseHandler):
         # of requested events.
 
         persisted_events = await self.store.get_events(
-            (event.auth_event_ids() for event in event_map.values()),
+            (aid for event in event_map.values() for aid in event.auth_event_ids()),
             allow_rejected=True,
         )
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -619,8 +619,8 @@ class FederationHandler(BaseHandler):
         be in the given room.
 
         This function *does not* recursively get missing auth events of the
-        newly fetched events. Callers must include any missing events from the
-        auth chain.
+        newly fetched events. Callers must include in the `event_ids` argument
+        any missing events from the auth chain.
 
         Returns:
             map from event_id to event
@@ -1136,8 +1136,8 @@ class FederationHandler(BaseHandler):
         """Fetch the given events from a server, and persist them as outliers.
 
         This function *does not* recursively get missing auth events of the
-        newly fetched events. Callers must include any missing events from the
-        auth chain.
+        newly fetched events. Callers must include in the `event_ids` argument
+        any missing events from the auth chain.
 
         Logs a warning if we can't find the given event.
         """
@@ -1158,7 +1158,7 @@ class FederationHandler(BaseHandler):
                         )
                         return
 
-                    event_map[event.event_id]
+                    event_map[event.event_id] = event
 
                 except Exception as e:
                     logger.warning(
@@ -1171,7 +1171,7 @@ class FederationHandler(BaseHandler):
         await concurrently_execute(get_event, events, 5)
 
         # Make a map of auth events for each event. We do this after fetching
-        # all the events as some of the events auth events will be in the list
+        # all the events as some of the events' auth events will be in the list
         # of requested events.
 
         persisted_events = await self.store.get_events(

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -618,9 +618,10 @@ class FederationHandler(BaseHandler):
         will be omitted from the result. Likewise, any events which turn out not to
         be in the given room.
 
-        This function *does not* recursively get missing auth events of the
-        newly fetched events. Callers must include in the `event_ids` argument
-        any missing events from the auth chain.
+        This function *does not* automatically get missing auth events of the
+        newly fetched events. Callers must include the full auth chain of
+        of the missing events in the `event_ids` argument, to ensure that any
+        missing auth events are correctly fetched.
 
         Returns:
             map from event_id to event
@@ -1136,7 +1137,7 @@ class FederationHandler(BaseHandler):
         """Fetch the given events from a server, and persist them as outliers.
 
         This function *does not* recursively get missing auth events of the
-        newly fetched events. Callers must include in the `event_ids` argument
+        newly fetched events. Callers must include in the `events` argument
         any missing events from the auth chain.
 
         Logs a warning if we can't find the given event.


### PR DESCRIPTION
When fetching the state of a room over federation we receive the event
IDs of the state and auth chain. We then fetch those events that we
don't already have.

However, we used a function that recursively fetched any missing auth
events for the fetched events, which can lead to a lot of recursion if
the server is missing most of the auth chain. This work is entirely
pointless because would have queued up the missing events in the auth
chain to be fetched already.

Let's just diable the recursion, since it only gets called from one
place anyway.
