### PR TITLE
Fix handling of "off" in encryption_enabled_by_default_for_room_type

### DIFF
--- a/changelog.d/7822.bugfix
+++ b/changelog.d/7822.bugfix
@@ -1,0 +1,1 @@
+Fix a bug causing Synapse to misinterpret the value `off` for `encryption_enabled_by_default_for_room_type` in its configuration file(s) if that value isn't surrounded by quotes. This bug was introduced in v1.16.0.

--- a/synapse/config/room.py
+++ b/synapse/config/room.py
@@ -50,7 +50,12 @@ class RoomConfig(Config):
                 RoomCreationPreset.PRIVATE_CHAT,
                 RoomCreationPreset.TRUSTED_PRIVATE_CHAT,
             ]
-        elif encryption_for_room_type == RoomDefaultEncryptionTypes.OFF:
+        elif (
+            encryption_for_room_type == RoomDefaultEncryptionTypes.OFF
+            or not encryption_for_room_type
+        ):
+            # PyYAML translates "off" into False if it's unquoted, so we also need to
+            # check for encryption_for_room_type being False.
             self.encryption_enabled_by_default_for_room_presets = []
         else:
             raise ConfigError(

--- a/synapse/config/room.py
+++ b/synapse/config/room.py
@@ -52,7 +52,7 @@ class RoomConfig(Config):
             ]
         elif (
             encryption_for_room_type == RoomDefaultEncryptionTypes.OFF
-            or not encryption_for_room_type
+            or encryption_for_room_type is False
         ):
             # PyYAML translates "off" into False if it's unquoted, so we also need to
             # check for encryption_for_room_type being False.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/7821, introduced in https://github.com/matrix-org/synapse/pull/7639

Turns out PyYAML translates `off` into a `False` boolean if it's
unquoted (see https://stackoverflow.com/questions/36463531/pyyaml-automatically-converting-certain-keys-to-boolean-values),
which seems to be a liberal interpretation of this bit of the YAML spec: https://yaml.org/spec/1.1/current.html#id864510

An alternative fix would be to implement the solution mentioned in the
SO post linked above, but I'm aware it might break existing setups
(which might use these values in the configuration file) so it's
probably better just to add an extra check for this one. We should be
aware that this is a thing for the next times we do that though.

I didn't find any other occurrence of this bug elsewhere in the
codebase.