### PR TITLE
Allow email subjects to be customised through Synapse's configuration

### DIFF
--- a/changelog.d/7846.feature
+++ b/changelog.d/7846.feature
@@ -1,0 +1,1 @@
+Allow email subjects to be customised through Synapse's configuration.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1844,8 +1844,8 @@ email:
   #
   #notif_from: "Your Friendly %(app)s homeserver <noreply@example.com>"
 
-  # app_name defines the default value for '%(app)s' in notif_from. It
-  # defaults to 'Matrix'.
+  # app_name defines the default value for '%(app)s' in notif_from and email
+  # subjects. It defaults to 'Matrix'.
   #
   #app_name: my_branded_matrix_server
 
@@ -1913,6 +1913,73 @@ email:
   # https://github.com/matrix-org/synapse/tree/master/synapse/res/templates
   #
   #template_dir: "res/templates"
+
+  # Subjects to use when sending emails from Synapse.
+  #
+  # The placeholder '%(app)s' will be replaced with the value of the 'app_name'
+  # setting above, or by a value dictated by the Matrix client application.
+  #
+  # If a subject isn't overridden in this configuration file, the value used as
+  # its example will be used.
+  #
+  subjects:
+
+    # Subjects for notification emails.
+    #
+    # On top of the '%(app)s' placeholder, these can use the following
+    # placeholders:
+    #
+    #   * '%(person)s', which will be replaced by the display name of the user(s)
+    #      that sent the message(s), e.g. "Alice and Bob".
+    #   * '%(room)s', which will be replaced by the name of the room the
+    #      message(s) have been sent to, e.g. "My super room".
+    #
+    # See the example provided for each setting to see which placeholder can be
+    # used and how to use them.
+    #
+    # Subject to use to notify about one message from one or more user(s) in a
+    # room which has a name.
+    #message_from_person_in_room: "[%(app)s] You have a message on %(app)s from %(person)s in the %(room)s room..."
+    #
+    # Subject to use to notify about one message from one or more user(s) in a
+    # room which doesn't have a name.
+    #message_from_person: "[%(app)s] You have a message on %(app)s from %(person)s..."
+    #
+    # Subject to use to notify about multiple messages from one or more users in
+    # a room which doesn't have a name.
+    #messages_from_person: "[%(app)s] You have messages on %(app)s from %(person)s..."
+    #
+    # Subject to use to notify about multiple messages in a room which has a
+    # name.
+    #messages_in_room: "[%(app)s] You have messages on %(app)s in the %(room)s room..."
+    #
+    # Subject to use to notify about multiple messages in multiple rooms.
+    #messages_in_room_and_others: "[%(app)s] You have messages on %(app)s in the %(room)s room and others..."
+    #
+    # Subject to use to notify about multiple messages from multiple persons in
+    # multiple rooms. This is similar to the setting above except it's used when
+    # the room in which the notification was triggered has no name.
+    #messages_from_person_and_others: "[%(app)s] You have messages on %(app)s from %(person)s and others..."
+    #
+    # Subject to use to notify about an invite to a room which has a name.
+    #invite_from_person_to_room: "[%(app)s] %(person)s has invited you to join the %(room)s room on %(app)s..."
+    #
+    # Subject to use to notify about an invite to a room which doesn't have a
+    # name.
+    #invite_from_person: "[%(app)s] %(person)s has invited you to chat on %(app)s..."
+
+    # Subject for emails related to account administration.
+    #
+    # On top of the '%(app)s' placeholder, these one can use the
+    # '%(server_name)s' placeholder, which will be replaced by the value of the
+    # 'server_name' setting in your Synapse configuration.
+    #
+    # Subject to use when sending a password reset email.
+    #password_reset: "[%(server_name)s] Password reset"
+    #
+    # Subject to use when sending a verification email to assert an address's
+    # ownership.
+    #email_validation: "[%(server_name)s] Validate your email"
 
 
 # Password providers allow homeserver administrators to integrate

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1922,7 +1922,7 @@ email:
   # If a subject isn't overridden in this configuration file, the value used as
   # its example will be used.
   #
-  subjects:
+  #subjects:
 
     # Subjects for notification emails.
     #

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -431,7 +431,7 @@ class EmailConfig(Config):
           # If a subject isn't overridden in this configuration file, the value used as
           # its example will be used.
           #
-          subjects:
+          #subjects:
 
             # Subjects for notification emails.
             #

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -22,8 +22,8 @@ import os
 from enum import Enum
 from typing import Optional
 
-import pkg_resources
 import attr
+import pkg_resources
 
 from ._base import Config, ConfigError
 

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -316,7 +316,8 @@ class EmailConfig(Config):
             )
 
     def generate_config_section(self, config_dir_path, server_name, **kwargs):
-        return """\
+        return (
+            """\
         # Configuration for sending emails from Synapse.
         #
         email:
@@ -489,7 +490,9 @@ class EmailConfig(Config):
             # Subject to use when sending a verification email to assert an address's
             # ownership.
             #email_validation: "%(email_validation)s"
-        """ % DEFAULT_SUBJECTS
+        """
+            % DEFAULT_SUBJECTS
+        )
 
 
 class ThreepidBehaviour(Enum):

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import email.utils
 import os
 from enum import Enum
-from typing import Optional
+from typing import Dict, Optional
 
 import pkg_resources
 
@@ -307,7 +307,7 @@ class EmailConfig(Config):
                 if not os.path.isfile(p):
                     raise ConfigError("Unable to find email template file %s" % (p,))
 
-        self.email_subjects = {}
+        self.email_subjects = {}  # type: Dict[str, str]
         subjects_config = email_config.get("subjects", {})
         for subject_id, default_subject in DEFAULT_SUBJECTS.items():
             self.email_subjects[subject_id] = subjects_config.get(

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -20,9 +20,10 @@ from __future__ import print_function
 import email.utils
 import os
 from enum import Enum
-from typing import Dict, Optional
+from typing import Optional
 
 import pkg_resources
+import attr
 
 from ._base import Config, ConfigError
 
@@ -44,6 +45,20 @@ DEFAULT_SUBJECTS = {
     "password_reset": "[%(server_name)s] Password reset",
     "email_validation": "[%(server_name)s] Validate your email",
 }
+
+
+@attr.s
+class EmailSubjectConfig:
+    message_from_person_in_room = attr.ib(type=str)
+    message_from_person = attr.ib(type=str)
+    messages_from_person = attr.ib(type=str)
+    messages_in_room = attr.ib(type=str)
+    messages_in_room_and_others = attr.ib(type=str)
+    messages_from_person_and_others = attr.ib(type=str)
+    invite_from_person = attr.ib(type=str)
+    invite_from_person_to_room = attr.ib(type=str)
+    password_reset = attr.ib(type=str)
+    email_validation = attr.ib(type=str)
 
 
 class EmailConfig(Config):
@@ -307,12 +322,43 @@ class EmailConfig(Config):
                 if not os.path.isfile(p):
                     raise ConfigError("Unable to find email template file %s" % (p,))
 
-        self.email_subjects = {}  # type: Dict[str, str]
         subjects_config = email_config.get("subjects", {})
-        for subject_id, default_subject in DEFAULT_SUBJECTS.items():
-            self.email_subjects[subject_id] = subjects_config.get(
-                subject_id, default_subject,
-            )
+        self.email_subjects = EmailSubjectConfig(
+            message_from_person_in_room=subjects_config.get(
+                "message_from_person_in_room",
+                DEFAULT_SUBJECTS["message_from_person_in_room"],
+            ),
+            message_from_person=subjects_config.get(
+                "message_from_person", DEFAULT_SUBJECTS["message_from_person"],
+            ),
+            messages_from_person=subjects_config.get(
+                "messages_from_person", DEFAULT_SUBJECTS["messages_from_person"],
+            ),
+            messages_in_room=subjects_config.get(
+                "messages_in_room", DEFAULT_SUBJECTS["messages_in_room"],
+            ),
+            messages_in_room_and_others=subjects_config.get(
+                "messages_in_room_and_others",
+                DEFAULT_SUBJECTS["messages_in_room_and_others"],
+            ),
+            messages_from_person_and_others=subjects_config.get(
+                "messages_from_person_and_others",
+                DEFAULT_SUBJECTS["messages_from_person_and_others"],
+            ),
+            invite_from_person=subjects_config.get(
+                "invite_from_person", DEFAULT_SUBJECTS["invite_from_person"],
+            ),
+            invite_from_person_to_room=subjects_config.get(
+                "invite_from_person_to_room",
+                DEFAULT_SUBJECTS["invite_from_person_to_room"],
+            ),
+            password_reset=subjects_config.get(
+                "password_reset", DEFAULT_SUBJECTS["password_reset"],
+            ),
+            email_validation=subjects_config.get(
+                "email_validation", DEFAULT_SUBJECTS["email_validation"],
+            ),
+        )
 
     def generate_config_section(self, config_dir_path, server_name, **kwargs):
         return (

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -323,42 +323,12 @@ class EmailConfig(Config):
                     raise ConfigError("Unable to find email template file %s" % (p,))
 
         subjects_config = email_config.get("subjects", {})
-        self.email_subjects = EmailSubjectConfig(
-            message_from_person_in_room=subjects_config.get(
-                "message_from_person_in_room",
-                DEFAULT_SUBJECTS["message_from_person_in_room"],
-            ),
-            message_from_person=subjects_config.get(
-                "message_from_person", DEFAULT_SUBJECTS["message_from_person"],
-            ),
-            messages_from_person=subjects_config.get(
-                "messages_from_person", DEFAULT_SUBJECTS["messages_from_person"],
-            ),
-            messages_in_room=subjects_config.get(
-                "messages_in_room", DEFAULT_SUBJECTS["messages_in_room"],
-            ),
-            messages_in_room_and_others=subjects_config.get(
-                "messages_in_room_and_others",
-                DEFAULT_SUBJECTS["messages_in_room_and_others"],
-            ),
-            messages_from_person_and_others=subjects_config.get(
-                "messages_from_person_and_others",
-                DEFAULT_SUBJECTS["messages_from_person_and_others"],
-            ),
-            invite_from_person=subjects_config.get(
-                "invite_from_person", DEFAULT_SUBJECTS["invite_from_person"],
-            ),
-            invite_from_person_to_room=subjects_config.get(
-                "invite_from_person_to_room",
-                DEFAULT_SUBJECTS["invite_from_person_to_room"],
-            ),
-            password_reset=subjects_config.get(
-                "password_reset", DEFAULT_SUBJECTS["password_reset"],
-            ),
-            email_validation=subjects_config.get(
-                "email_validation", DEFAULT_SUBJECTS["email_validation"],
-            ),
-        )
+        subjects = {}
+
+        for key, default in DEFAULT_SUBJECTS.items():
+            subjects[key] = subjects_config.get(key, default)
+
+        self.email_subjects = EmailSubjectConfig(**subjects)
 
     def generate_config_section(self, config_dir_path, server_name, **kwargs):
         return (

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -132,9 +132,8 @@ class Mailer(object):
 
         await self.send_email(
             email_address,
-            self.email_subjects["password_reset"] % {
-                "server_name": self.hs.config.server_name,
-            },
+            self.email_subjects["password_reset"]
+            % {"server_name": self.hs.config.server_name},
             template_vars,
         )
 
@@ -161,9 +160,8 @@ class Mailer(object):
 
         await self.send_email(
             email_address,
-            self.email_subjects["email_validation"] % {
-                "server_name": self.hs.config.server_name,
-            },
+            self.email_subjects["email_validation"]
+            % {"server_name": self.hs.config.server_name},
             template_vars,
         )
 
@@ -191,9 +189,8 @@ class Mailer(object):
 
         await self.send_email(
             email_address,
-            self.email_subjects["email_validation"] % {
-                "server_name": self.hs.config.server_name,
-            },
+            self.email_subjects["email_validation"]
+            % {"server_name": self.hs.config.server_name},
             template_vars,
         )
 
@@ -265,9 +262,7 @@ class Mailer(object):
             "reason": reason,
         }
 
-        await self.send_email(
-            email_address, summary_text, template_vars
-        )
+        await self.send_email(email_address, summary_text, template_vars)
 
     async def send_email(self, email_address, subject, template_vars):
         """Send an email with the given information and template text"""

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -27,6 +27,7 @@ import jinja2
 
 from synapse.api.constants import EventTypes
 from synapse.api.errors import StoreError
+from synapse.config.emailconfig import EmailSubjectConfig
 from synapse.logging.context import make_deferred_yieldable
 from synapse.push.presentable_names import (
     calculate_room_name,
@@ -104,7 +105,7 @@ class Mailer(object):
         self.state_handler = self.hs.get_state_handler()
         self.storage = hs.get_storage()
         self.app_name = app_name
-        self.email_subjects = hs.config.email_subjects
+        self.email_subjects = hs.config.email_subjects  # type: EmailSubjectConfig
 
         logger.info("Created Mailer for app_name %s" % app_name)
 
@@ -131,7 +132,7 @@ class Mailer(object):
 
         await self.send_email(
             email_address,
-            self.email_subjects["password_reset"]
+            self.email_subjects.password_reset
             % {"server_name": self.hs.config.server_name},
             template_vars,
         )
@@ -159,7 +160,7 @@ class Mailer(object):
 
         await self.send_email(
             email_address,
-            self.email_subjects["email_validation"]
+            self.email_subjects.email_validation
             % {"server_name": self.hs.config.server_name},
             template_vars,
         )
@@ -188,7 +189,7 @@ class Mailer(object):
 
         await self.send_email(
             email_address,
-            self.email_subjects["email_validation"]
+            self.email_subjects.email_validation
             % {"server_name": self.hs.config.server_name},
             template_vars,
         )
@@ -461,12 +462,12 @@ class Mailer(object):
                 inviter_name = name_from_member_event(inviter_member_event)
 
                 if room_name is None:
-                    return self.email_subjects["invite_from_person"] % {
+                    return self.email_subjects.invite_from_person % {
                         "person": inviter_name,
                         "app": self.app_name,
                     }
                 else:
-                    return self.email_subjects["invite_from_person_to_room"] % {
+                    return self.email_subjects.invite_from_person_to_room % {
                         "person": inviter_name,
                         "room": room_name,
                         "app": self.app_name,
@@ -484,13 +485,13 @@ class Mailer(object):
                     sender_name = name_from_member_event(state_event)
 
                 if sender_name is not None and room_name is not None:
-                    return self.email_subjects["message_from_person_in_room"] % {
+                    return self.email_subjects.message_from_person_in_room % {
                         "person": sender_name,
                         "room": room_name,
                         "app": self.app_name,
                     }
                 elif sender_name is not None:
-                    return self.email_subjects["message_from_person"] % {
+                    return self.email_subjects.message_from_person % {
                         "person": sender_name,
                         "app": self.app_name,
                     }
@@ -498,7 +499,7 @@ class Mailer(object):
                 # There's more than one notification for this room, so just
                 # say there are several
                 if room_name is not None:
-                    return self.email_subjects["messages_in_room"] % {
+                    return self.email_subjects.messages_in_room % {
                         "room": room_name,
                         "app": self.app_name,
                     }
@@ -519,7 +520,7 @@ class Mailer(object):
                         ]
                     )
 
-                    return self.email_subjects["messages_from_person"] % {
+                    return self.email_subjects.messages_from_person % {
                         "person": descriptor_from_member_events(member_events.values()),
                         "app": self.app_name,
                     }
@@ -528,7 +529,7 @@ class Mailer(object):
 
             # ...but we still refer to the 'reason' room which triggered the mail
             if reason["room_name"] is not None:
-                return self.email_subjects["messages_in_room_and_others"] % {
+                return self.email_subjects.messages_in_room_and_others % {
                     "room": reason["room_name"],
                     "app": self.app_name,
                 }
@@ -548,7 +549,7 @@ class Mailer(object):
                     [room_state_ids[room_id][("m.room.member", s)] for s in sender_ids]
                 )
 
-                return self.email_subjects["messages_from_person_and_others"] % {
+                return self.email_subjects.messages_from_person_and_others % {
                     "person": descriptor_from_member_events(member_events.values()),
                     "app": self.app_name,
                 }


### PR DESCRIPTION
This PR allows a server admin to customise the subjects used by Synapse to send emails. Can be reviewed commit by commit.

Fixes https://github.com/matrix-org/synapse/issues/6112