### PR TITLE
Avoid brand new rooms in `delete_old_current_state_events`

### DIFF
--- a/changelog.d/7854.bugfix
+++ b/changelog.d/7854.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.10.0 which could cause a "no create event in auth events" error during room creation.

--- a/synapse/storage/data_stores/main/state.py
+++ b/synapse/storage/data_stores/main/state.py
@@ -399,7 +399,7 @@ class MainStateBackgroundUpdateStore(RoomMemberWorkerStore):
 
             txn.execute(sql, (last_room_id, room_ids[-1]))
             creating_rooms = to_delete.difference(row[0] for row in txn)
-            logger.info("skipping rooms which are being deleted: %s", creating_rooms)
+            logger.info("skipping rooms which are being created: %s", creating_rooms)
 
             to_delete.difference_update(creating_rooms)
 


### PR DESCRIPTION
When considering rooms to clean up in `delete_old_current_state_events`, skip rooms which we are creating, which otherwise look a bit like rooms we have left.

Fixes #7834.