### PR TITLE
Add a default limit to get/sync operations

### DIFF
--- a/changelog.d/7858.misc
+++ b/changelog.d/7858.misc
@@ -1,1 +1,1 @@
-The default value of `filter_timeline_limit` was changed from -1 (no limit) to 500.
+The default value of `filter_timeline_limit` was changed from -1 (no limit) to 100.

--- a/changelog.d/7858.misc
+++ b/changelog.d/7858.misc
@@ -1,0 +1,1 @@
+The default value of `filter_timeline_limit` was changed from -1 (no limit) to 500.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -102,7 +102,7 @@ pid_file: DATADIR/homeserver.pid
 #gc_thresholds: [700, 10, 10]
 
 # Set the limit on the returned events in the timeline in the get
-# and sync operations. The default value is 500. -1 means no upper limit.
+# and sync operations. The default value is 100. -1 means no upper limit.
 #
 # Uncomment the following to increase the limit to 5000.
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -102,7 +102,9 @@ pid_file: DATADIR/homeserver.pid
 #gc_thresholds: [700, 10, 10]
 
 # Set the limit on the returned events in the timeline in the get
-# and sync operations. The default value is -1, means no upper limit.
+# and sync operations. The default value is 500. -1 means no upper limit.
+#
+# Uncomment the following to increase the limit to 5000.
 #
 #filter_timeline_limit: 5000
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -207,7 +207,7 @@ class ServerConfig(Config):
         # errors when attempting to search for messages.
         self.enable_search = config.get("enable_search", True)
 
-        self.filter_timeline_limit = config.get("filter_timeline_limit", -1)
+        self.filter_timeline_limit = config.get("filter_timeline_limit", 500)
 
         # Whether we should block invites sent to users on this server
         # (other than those sent by local server admins)
@@ -693,7 +693,9 @@ class ServerConfig(Config):
         #gc_thresholds: [700, 10, 10]
 
         # Set the limit on the returned events in the timeline in the get
-        # and sync operations. The default value is -1, means no upper limit.
+        # and sync operations. The default value is 500. -1 means no upper limit.
+        #
+        # Uncomment the following to increase the limit to 5000.
         #
         #filter_timeline_limit: 5000
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -207,7 +207,7 @@ class ServerConfig(Config):
         # errors when attempting to search for messages.
         self.enable_search = config.get("enable_search", True)
 
-        self.filter_timeline_limit = config.get("filter_timeline_limit", 500)
+        self.filter_timeline_limit = config.get("filter_timeline_limit", 100)
 
         # Whether we should block invites sent to users on this server
         # (other than those sent by local server admins)
@@ -693,7 +693,7 @@ class ServerConfig(Config):
         #gc_thresholds: [700, 10, 10]
 
         # Set the limit on the returned events in the timeline in the get
-        # and sync operations. The default value is 500. -1 means no upper limit.
+        # and sync operations. The default value is 100. -1 means no upper limit.
         #
         # Uncomment the following to increase the limit to 5000.
         #

--- a/synapse/rest/client/v2_alpha/_base.py
+++ b/synapse/rest/client/v2_alpha/_base.py
@@ -22,6 +22,7 @@ from twisted.internet import defer
 
 from synapse.api.errors import InteractiveAuthIncompleteError
 from synapse.api.urls import CLIENT_API_PREFIX
+from synapse.types import JsonDict
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,15 @@ def client_patterns(path_regex, releases=(0,), unstable=True, v1=False):
     return patterns
 
 
-def set_timeline_upper_limit(filter_json, filter_timeline_limit):
+def set_timeline_upper_limit(filter_json: JsonDict, filter_timeline_limit: int) -> None:
+    """
+    Enforces a maximum limit of a timeline query.
+
+    Params:
+        filter_json: The timeline query to modify.
+        filter_timeline_limit: The maximum limit to allow, passing -1 will
+            disable enforcing a maximum limit.
+    """
     if filter_timeline_limit < 0:
         return  # no upper limits
     timeline = filter_json.get("room", {}).get("timeline", {})


### PR DESCRIPTION
This changes the default value of `filter_timeline_limit` from -1 (no limit) to 500. The 500 was chosen mostly arbitrarily, but could probably use some more thought of what it should be!

Fixes #7733