### PR TITLE
Reject attempts to join empty rooms over federation

### DIFF
--- a/changelog.d/7859.bugfix
+++ b/changelog.d/7859.bugfix
@@ -1,0 +1,1 @@
+Fix a bug which allowed empty rooms to be rejoined over federation.


### PR DESCRIPTION
We shouldn't allow others to make_join through us if we've left the room. By analogy with the behaviour when the server has *never* been in the room, reject such attempts with a 404.

Fixes #7835. Fixes #6958.


See also https://github.com/matrix-org/matrix-doc/pull/2688.
