### PR TITLE
Fix the trace function for async functions.

### DIFF
--- a/changelog.d/7872.bugfix
+++ b/changelog.d/7872.bugfix
@@ -1,1 +1,1 @@
-Fix a long standing bug where the tracing of async functions was broken.
+Fix a long standing bug where the tracing of async functions with opentracing was broken.

--- a/changelog.d/7872.bugfix
+++ b/changelog.d/7872.bugfix
@@ -1,0 +1,1 @@
+Fix a long standing bug where the tracing of async functions was broken.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -737,6 +737,9 @@ def trace(func=None, opname=None):
 
             @wraps(func)
             async def _trace_inner(*args, **kwargs):
+                if opentracing is None:
+                    return await func(*args, **kwargs)
+
                 with start_active_span(_opname) as scope:
                     try:
                         return await func(*args, **kwargs)
@@ -749,6 +752,9 @@ def trace(func=None, opname=None):
             # decorated with inlineDeferred.
             @wraps(func)
             def _trace_inner(*args, **kwargs):
+                if opentracing is None:
+                    return func(*args, **kwargs)
+
                 scope = start_active_span(_opname)
                 scope.__enter__()
 

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -736,9 +736,6 @@ def trace(func=None, opname=None):
         if inspect.iscoroutinefunction(func):
             @wraps(func)
             async def _trace_inner(*args, **kwargs):
-                if opentracing is None:
-                    return await func(*args, **kwargs)
-
                 scope = start_active_span(_opname)
                 scope.__enter__()
 
@@ -757,9 +754,6 @@ def trace(func=None, opname=None):
             # decorated with inlineDeferred.
             @wraps(func)
             def _trace_inner(*args, **kwargs):
-                if opentracing is None:
-                    return func(*args, **kwargs)
-
                 scope = start_active_span(_opname)
                 scope.__enter__()
 

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -734,6 +734,7 @@ def trace(func=None, opname=None):
         _opname = opname if opname else func.__name__
 
         if inspect.iscoroutinefunction(func):
+
             @wraps(func)
             async def _trace_inner(*args, **kwargs):
                 scope = start_active_span(_opname)


### PR DESCRIPTION
I *think* this is the proper fix for the `@trace` decorator with async functions, but I'm not 100% sure.

I think there might be an issue open for some things missing from tracing, which could be this?

The diff should be better without whitespace changes.