### PR TITLE
Fix bug which could cause replication command processing to wedge

### DIFF
--- a/changelog.d/7875.misc
+++ b/changelog.d/7875.misc
@@ -1,0 +1,1 @@
+Optimise queueing of inbound replication commands.


### PR DESCRIPTION
`_process_command` was not correctly wraped in try/except, so if it threw an
exception, we wouldn't go on to process the rest of the queued commands, which
would mean that every subsequent command would cause an assertion failure.

This reshuffles the logic so that there is only one call to `_process_command`.