### PR TITLE
Change "unknown room ver" logging to warning.

### DIFF
--- a/changelog.d/7881.misc
+++ b/changelog.d/7881.misc
@@ -1,0 +1,1 @@
+Change "unknown room version" logging from 'error' to 'warning'.

--- a/synapse/storage/data_stores/main/events_worker.py
+++ b/synapse/storage/data_stores/main/events_worker.py
@@ -639,7 +639,7 @@ class EventsWorkerStore(SQLBaseStore):
             else:
                 room_version = KNOWN_ROOM_VERSIONS.get(room_version_id)
                 if not room_version:
-                    logger.error(
+                    logger.warning(
                         "Event %s in room %s has unknown room version %s",
                         event_id,
                         d["room_id"],


### PR DESCRIPTION
It's somewhat expected for us to have unknown room versions in the
database due to room version experiments.