### PR TITLE
Return an empty body for OPTIONS requests.

### DIFF
--- a/changelog.d/7886.misc
+++ b/changelog.d/7886.misc
@@ -1,0 +1,1 @@
+Return an empty body for OPTIONS requests.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -442,21 +442,6 @@ class StaticResource(File):
         return super().render_GET(request)
 
 
-def _options_handler(request):
-    """Request handler for OPTIONS requests
-
-    This is a request handler suitable for return from
-    _get_handler_for_request. It returns a 200 and an empty body.
-
-    Args:
-        request (twisted.web.http.Request):
-
-    Returns:
-        Tuple[int, dict]: http code, response body.
-    """
-    return 200, {}
-
-
 def _unrecognised_request_handler(request):
     """Request handler for unrecognised requests
 
@@ -490,11 +475,13 @@ class OptionsResource(resource.Resource):
     """Responds to OPTION requests for itself and all children."""
 
     def render_OPTIONS(self, request):
-        code, response_json_object = _options_handler(request)
+        request.setResponseCode(204)
+        request.setHeader(b"Content-Length", b"0")
+        request.setHeader(b"Cache-Control", b"no-cache, no-store, must-revalidate")
 
-        return respond_with_json(
-            request, code, response_json_object, send_cors=True, canonical_json=False,
-        )
+        set_cors_headers(request)
+
+        return b""
 
     def getChildWithDefault(self, path, request):
         if request.method == b"OPTIONS":

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -477,7 +477,6 @@ class OptionsResource(resource.Resource):
     def render_OPTIONS(self, request):
         request.setResponseCode(204)
         request.setHeader(b"Content-Length", b"0")
-        request.setHeader(b"Cache-Control", b"no-cache, no-store, must-revalidate")
 
         set_cors_headers(request)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -201,8 +201,8 @@ class OptionsResourceTests(unittest.TestCase):
     def test_unknown_options_request(self):
         """An OPTIONS requests to an unknown URL still returns 200 OK."""
         channel = self._make_request(b"OPTIONS", b"/foo/")
-        self.assertEqual(channel.result["code"], b"200")
-        self.assertEqual(channel.result["body"], b"{}")
+        self.assertEqual(channel.result["code"], b"204")
+        self.assertNotIn("body", channel.result)
 
         # Ensure the correct CORS headers have been added
         self.assertTrue(
@@ -221,8 +221,8 @@ class OptionsResourceTests(unittest.TestCase):
     def test_known_options_request(self):
         """An OPTIONS requests to an known URL still returns 200 OK."""
         channel = self._make_request(b"OPTIONS", b"/res/")
-        self.assertEqual(channel.result["code"], b"200")
-        self.assertEqual(channel.result["body"], b"{}")
+        self.assertEqual(channel.result["code"], b"204")
+        self.assertNotIn("body", channel.result)
 
         # Ensure the correct CORS headers have been added
         self.assertTrue(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -199,7 +199,7 @@ class OptionsResourceTests(unittest.TestCase):
         return channel
 
     def test_unknown_options_request(self):
-        """An OPTIONS requests to an unknown URL still returns 200 OK."""
+        """An OPTIONS requests to an unknown URL still returns 204 No Content."""
         channel = self._make_request(b"OPTIONS", b"/foo/")
         self.assertEqual(channel.result["code"], b"204")
         self.assertNotIn("body", channel.result)
@@ -219,7 +219,7 @@ class OptionsResourceTests(unittest.TestCase):
         )
 
     def test_known_options_request(self):
-        """An OPTIONS requests to an known URL still returns 200 OK."""
+        """An OPTIONS requests to an known URL still returns 204 No Content."""
         channel = self._make_request(b"OPTIONS", b"/res/")
         self.assertEqual(channel.result["code"], b"204")
         self.assertNotIn("body", channel.result)


### PR DESCRIPTION
Fixes #7857 by returning an empty body for `OPTIONS`.

I was unsure about including the `Cache-Control` header, but it is set on JSON responses...