### PR TITLE
Change sample config's postgres user to synapse_user

### DIFF
--- a/changelog.d/7889.doc
+++ b/changelog.d/7889.doc
@@ -1,0 +1,1 @@
+Change the sample config postgres user section to use `synapse_user` instead of `synapse` to align with the documentation.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -685,7 +685,7 @@ caches:
 #database:
 #  name: psycopg2
 #  args:
-#    user: synapse
+#    user: synapse_user
 #    password: secretpassword
 #    database: synapse
 #    host: localhost

--- a/synapse/config/database.py
+++ b/synapse/config/database.py
@@ -55,7 +55,7 @@ DEFAULT_CONFIG = """\
 #database:
 #  name: psycopg2
 #  args:
-#    user: synapse
+#    user: synapse_user
 #    password: secretpassword
 #    database: synapse
 #    host: localhost


### PR DESCRIPTION
The [postgres setup docs](https://github.com/matrix-org/synapse/blob/develop/docs/postgres.md#set-up-database) recommend setting up your database with user `synapse_user`.

However, uncommenting the postgres defaults in the sample config leave you with user `synapse`.

This PR switches the sample config to recommend `synapse_user`. Took a me a second to figure this out, so assume this will beneficial to others.