### PR TITLE
Add a clarification for the public_baseurl property.

### DIFF
--- a/changelog.d/7906.doc
+++ b/changelog.d/7906.doc
@@ -1,0 +1,1 @@
+Added an explanatory note for the the public_baseurl property. Contributed by zblesk.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -47,7 +47,9 @@ pid_file: DATADIR/homeserver.pid
 # (not including _matrix/...). This is the same URL a user would
 # enter into the 'custom HS URL' field on their client. If you
 # use synapse with a reverse proxy, this should be the URL to reach
-# synapse via the proxy.
+# synapse via the proxy. If you use delegation and your synapse URL 
+# is different from the one specified in server_name, this URL should
+# point to Synapse itself.
 #
 #public_baseurl: https://example.com/
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -47,7 +47,7 @@ pid_file: DATADIR/homeserver.pid
 # (not including _matrix/...). This is the same URL a user would
 # enter into the 'custom HS URL' field on their client. If you
 # use synapse with a reverse proxy, this should be the URL to reach
-# synapse via the proxy. If you use delegation and your synapse URL 
+# synapse via the proxy. If you use delegation and your synapse URL
 # is different from the one specified in server_name, this URL should
 # point to Synapse itself.
 #

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -638,7 +638,7 @@ class ServerConfig(Config):
         # (not including _matrix/...). This is the same URL a user would
         # enter into the 'custom HS URL' field on their client. If you
         # use synapse with a reverse proxy, this should be the URL to reach
-        # synapse via the proxy. If you use delegation and your synapse URL 
+        # synapse via the proxy. If you use delegation and your synapse URL
         # is different from the one specified in server_name, this URL should
         # point to Synapse itself.
         #

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -638,7 +638,9 @@ class ServerConfig(Config):
         # (not including _matrix/...). This is the same URL a user would
         # enter into the 'custom HS URL' field on their client. If you
         # use synapse with a reverse proxy, this should be the URL to reach
-        # synapse via the proxy.
+        # synapse via the proxy. If you use delegation and your synapse URL 
+        # is different from the one specified in server_name, this URL should
+        # point to Synapse itself.
         #
         #public_baseurl: https://example.com/
 


### PR DESCRIPTION
I have been a bit confused about the correct way to set the `public_baseurl` and did it wrong. I've realized the mistake with some help from the folks in #synapse:matrix.org and they suggested I try and add a clarification to the sample file. So that's what I'm trying to do. 

Signed-off-by: Ladislav Benc <ladislav.benc@protonmail.com>