### PR TITLE
Follow-up to admin API to re-activate accounts

### DIFF
--- a/changelog.d/7908.feature
+++ b/changelog.d/7908.feature
@@ -1,0 +1,1 @@
+Add the ability to re-activate an account from the admin API.

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -230,5 +230,8 @@ class DeactivateAccountHandler(BaseHandler):
         Args:
             user_id: ID of user to be deactivated
         """
-        # Mark the user as activate.
+        # Ensure the user is not marked as erased.
+        await self.store.mark_user_not_erased(user_id)
+
+        # Mark the user as active.
         await self.store.set_user_deactivated_status(user_id, False)

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -223,8 +223,10 @@ class DeactivateAccountHandler(BaseHandler):
         """
         Activate an account that was previously deactivated.
 
-        This marks the user as activate in the database, but does not
-        attempt to rejoin rooms, re-add threepids, etc.
+        This marks the user as active and not erased in the database, but does
+        not attempt to rejoin rooms, re-add threepids, etc.
+
+        If enabled, the user will be re-added to the user directory.
 
         The user will also need a password hash set to actually login.
 

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -30,6 +30,7 @@ class DeactivateAccountHandler(BaseHandler):
 
     def __init__(self, hs):
         super(DeactivateAccountHandler, self).__init__(hs)
+        self.hs = hs
         self._auth_handler = hs.get_auth_handler()
         self._device_handler = hs.get_device_handler()
         self._room_member_handler = hs.get_room_member_handler()
@@ -222,14 +223,22 @@ class DeactivateAccountHandler(BaseHandler):
         """
         Activate an account that was previously deactivated.
 
-        This simply marks the user as activate in the database and does not
+        This marks the user as activate in the database, but does not
         attempt to rejoin rooms, re-add threepids, etc.
 
         The user will also need a password hash set to actually login.
 
         Args:
-            user_id: ID of user to be deactivated
+            user_id: ID of user to be re-activated
         """
+        # Add the user to the directory, if necessary.
+        user = UserID.from_string(user_id)
+        if self.hs.config.user_directory_search_all_users:
+            profile = await self.store.get_profileinfo(user.localpart)
+            await self.user_directory_handler.handle_local_profile_change(
+                user_id, profile
+            )
+
         # Ensure the user is not marked as erased.
         await self.store.mark_user_not_erased(user_id)
 

--- a/synapse/storage/data_stores/main/user_erasure_store.py
+++ b/synapse/storage/data_stores/main/user_erasure_store.py
@@ -104,7 +104,9 @@ class UserErasureStore(UserErasureWorkerStore):
                 return
 
             # They are there, delete them.
-            self.simple_delete_one_txn(txn, "erased_users", keyvalues={"user_id": user_id})
+            self.simple_delete_one_txn(
+                txn, "erased_users", keyvalues={"user_id": user_id}
+            )
 
             self._invalidate_cache_and_stream(txn, self.is_user_erased, (user_id,))
 


### PR DESCRIPTION
A follow-up to #7847 (which fixed #7220) to fix a couple of bugs, now the re-activated user is:

* Re-added to the user directory.
* Removed from the `erased_users` table.