### PR TITLE
Element CSS and logo in email templates

### DIFF
--- a/changelog.d/7919.misc
+++ b/changelog.d/7919.misc
@@ -1,0 +1,1 @@
+Use Element CSS and logo in notification emails when app name is Element.

--- a/synapse/res/templates/mail-Element.css
+++ b/synapse/res/templates/mail-Element.css
@@ -1,0 +1,7 @@
+.header {
+    border-bottom: 4px solid #e4f7ed ! important;
+}
+
+.notif_link a, .footer a {
+    color: #76CFA6 ! important;
+}

--- a/synapse/res/templates/notice_expiry.html
+++ b/synapse/res/templates/notice_expiry.html
@@ -22,6 +22,8 @@
                                     <img src="http://riot.im/img/external/riot-logo-email.png" width="83" height="83" alt="[Riot]"/>
                                 {% elif app_name == "Vector" %}
                                     <img src="http://matrix.org/img/vector-logo-email.png" width="64" height="83" alt="[Vector]"/>
+                                {% elif app_name == "Element" %}
+                                    <img src="https://static.element.io/images/email-logo.png" width="83" height="83" alt="[Element]"/>
                                 {% else %}
                                     <img src="http://matrix.org/img/matrix-120x51.png" width="120" height="51" alt="[matrix]"/>
                                 {% endif %}

--- a/synapse/res/templates/notif_mail.html
+++ b/synapse/res/templates/notif_mail.html
@@ -22,6 +22,8 @@
                                     <img src="http://riot.im/img/external/riot-logo-email.png" width="83" height="83" alt="[Riot]"/>
                                 {% elif app_name == "Vector" %}
                                     <img src="http://matrix.org/img/vector-logo-email.png" width="64" height="83" alt="[Vector]"/>
+                                {% elif app_name == "Element" %}
+                                    <img src="https://static.element.io/images/email-logo.png" width="83" height="83" alt="[Element]"/>
                                 {% else %}
                                     <img src="http://matrix.org/img/matrix-120x51.png" width="120" height="51" alt="[matrix]"/>
                                 {% endif %}


### PR DESCRIPTION
Use Element CSS and logo in notification emails when app name is Element.

Couldn't find a branch for this so persisting from EMS.

Signed-off-by: Jason Robinson <jasonr@matrix.org>