### PR TITLE
Support oEmbed for media previews.

### DIFF
--- a/changelog.d/7920.feature
+++ b/changelog.d/7920.feature
@@ -1,0 +1,1 @@
+Support oEmbed for media previews.

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -82,7 +82,7 @@ for endpoint, globs in _oembed_globs.items():
         #
         # 1. The scheme must be one of HTTP / HTTPS (and have no globs).
         # 2. The domain can have globs, but we limit it to characters that can
-        #    reasonably be  a domain part.
+        #    reasonably be a domain part.
         #    TODO: This does not attempt to handle Unicode domain names.
         # 3. Other parts allow a glob to be any one, or more, characters.
         results = urlparse.urlparse(glob)
@@ -103,7 +103,7 @@ for endpoint, globs in _oembed_globs.items():
 
 @attr.s
 class OEmbedResult:
-    # Content or URL must be provided.
+    # Either HTML content or URL must be provided.
     html = attr.ib(type=Optional[str])
     url = attr.ib(type=Optional[str])
     title = attr.ib(type=str)
@@ -442,7 +442,7 @@ class PreviewUrlResource(DirectServeJsonResource):
         except Exception as e:
             # Trap any exception and let the code follow as usual.
             # FIXME: pass through 404s and other error messages nicely
-            logger.warning("Error downloading %s: %r", url, e)
+            logger.warning("Error downloading oEmbed metadata: %s: %r", url, e)
             raise OEmbedError() from e
 
     async def _download_url(self, url, user):

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -96,7 +96,7 @@ for endpoint, globs in _oembed_globs.items():
                 results.scheme,
                 re.escape(results.netloc).replace("\\*", "[a-zA-Z0-9_-]+"),
             ]
-            + list(map(lambda part: re.escape(part).replace("\\*", ".+"), results[2:]))
+            + [re.escape(part).replace("\\*", ".+") for part in results[2:]]
         )
         _oembed_patterns[re.compile(pattern)] = endpoint
 
@@ -104,11 +104,11 @@ for endpoint, globs in _oembed_globs.items():
 @attr.s
 class OEmbedResult:
     # Content or URL must be provided.
-    html = attr.attrib(type=Optional[str])
-    url = attr.attrib(type=Optional[str])
-    title = attr.attrib(type=str)
+    html = attr.ib(type=Optional[str])
+    url = attr.ib(type=Optional[str])
+    title = attr.ib(type=str)
     # Number of seconds to cache the content.
-    cache_age = attr.attrib(type=int)
+    cache_age = attr.ib(type=int)
 
 
 class OEmbedError(Exception):

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -440,10 +440,15 @@ class PreviewUrlResource(DirectServeJsonResource):
 
             raise OEmbedError("Incompatible oEmbed information.")
 
+        except OEmbedError as e:
+            # Trap OEmbedErrors first so we can directly re-raise them.
+            logger.warning("Error parsing oEmbed metadata from %s: %r", url, e)
+            raise
+
         except Exception as e:
             # Trap any exception and let the code follow as usual.
             # FIXME: pass through 404s and other error messages nicely
-            logger.warning("Error downloading oEmbed metadata: %s: %r", url, e)
+            logger.warning("Error downloading oEmbed metadata from %s: %r", url, e)
             raise OEmbedError() from e
 
     async def _download_url(self, url, user):

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -57,6 +57,8 @@ _content_type_match = re.compile(r'.*; *charset="?(.*?)"?(;|$)', flags=re.I)
 OG_TAG_NAME_MAXLEN = 50
 OG_TAG_VALUE_MAXLEN = 1000
 
+ONE_HOUR = 60 * 60 * 1000
+
 # A map of globs to API endpoints.
 _oembed_globs = {
     # Twitter.
@@ -157,7 +159,7 @@ class PreviewUrlResource(DirectServeJsonResource):
             cache_name="url_previews",
             clock=self.clock,
             # don't spider URLs more often than once an hour
-            expiry_ms=60 * 60 * 1000,
+            expiry_ms=ONE_HOUR,
         )
 
         if self._worker_run_media_background_jobs:
@@ -514,7 +516,7 @@ class PreviewUrlResource(DirectServeJsonResource):
 
                 # FIXME: we should calculate a proper expiration based on the
                 # Cache-Control and Expire headers.  But for now, assume 1 hour.
-                expires = 60 * 60 * 1000
+                expires = ONE_HOUR
                 etag = headers["ETag"][0] if "ETag" in headers else None
         else:
             html_bytes = oembed_result.html.encode("utf-8")  # type: ignore
@@ -526,7 +528,7 @@ class PreviewUrlResource(DirectServeJsonResource):
             download_name = oembed_result.title
             length = len(html_bytes)
             # If a specific cache age was not given, assume 1 hour.
-            expires = oembed_result.cache_age or (60 * 60 * 1000)
+            expires = oembed_result.cache_age or ONE_HOUR
             uri = oembed_url
             code = 200
             etag = None
@@ -618,7 +620,7 @@ class PreviewUrlResource(DirectServeJsonResource):
         # These may be cached for a bit on the client (i.e., they
         # may have a room open with a preview url thing open).
         # So we wait a couple of days before deleting, just in case.
-        expire_before = now - 2 * 24 * 60 * 60 * 1000
+        expire_before = now - 2 * 24 * ONE_HOUR
         media_ids = await self.store.get_url_cache_media_before(expire_before)
 
         removed_media = []

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -26,6 +26,7 @@ import traceback
 from typing import Dict, Optional
 from urllib import parse as urlparse
 
+import attr
 from canonicaljson import json
 
 from twisted.internet import defer
@@ -55,6 +56,38 @@ _content_type_match = re.compile(r'.*; *charset="?(.*?)"?(;|$)', flags=re.I)
 
 OG_TAG_NAME_MAXLEN = 50
 OG_TAG_VALUE_MAXLEN = 1000
+
+# A map of globs to API endpoints.
+_oembed_globs = {
+    # Twitter.
+    "https://publish.twitter.com/oembed": [
+        "https://twitter.com/*/status/*",
+        "https://*.twitter.com/*/status/*",
+        "https://twitter.com/*/moments/*",
+        "https://*.twitter.com/*/moments/*",
+        # Include the HTTP versions too.
+        "http://twitter.com/*/status/*",
+        "http://*.twitter.com/*/status/*",
+        "http://twitter.com/*/moments/*",
+        "http://*.twitter.com/*/moments/*",
+    ],
+}
+# Convert the globs to regular expressions.
+_oembed_patterns = {}
+for endpoint, globs in _oembed_globs.items():
+    for glob in globs:
+        pattern = re.compile(re.escape(glob).replace("\\*", ".+"))
+        _oembed_patterns[pattern] = endpoint
+
+
+@attr.s
+class OEmbedResult:
+    # Content or URL must be provided.
+    html = attr.attrib(type=str)
+    url = attr.attrib(type=str)
+    title = attr.attrib(type=str)
+    # Number of seconds to cache the content.
+    cache_age = attr.attrib(type=int)
 
 
 class PreviewUrlResource(DirectServeJsonResource):
@@ -310,6 +343,81 @@ class PreviewUrlResource(DirectServeJsonResource):
 
         return jsonog.encode("utf8")
 
+    def _get_oembed_url(self, url: str) -> Optional[str]:
+        """
+        Check whether the URL should be downloaded as oEmbed content instead.
+
+        Params:
+            url: The URL to check.
+
+        Returns:
+            A URL to use instead or None if the original URL should be used.
+        """
+        for url_pattern, endpoint in _oembed_patterns.items():
+            if url_pattern.fullmatch(url):
+                return endpoint
+
+    async def _get_oembed_content(
+        self, endpoint: str, url: str
+    ) -> Optional[OEmbedResult]:
+        """
+        Request content from an oEmbed endpoint.
+
+        Params:
+            endpoint: The oEmbed API endpoint.
+            url: The URL to pass to the API.
+
+        Returns:
+            A tuple of a string and boolean. If the boolean is true the str is a
+            URL and should be downloaded. If it is false, the string is HTML
+            content to use.
+        """
+        try:
+            logger.debug("Trying to get oEmbed content for url '%s'", url)
+            result = await self.client.get_json(
+                endpoint,
+                # TODO Specify max height / width.
+                # Note that only the JSON format is supported.
+                args={"url": url},
+            )
+
+            # Ensure there's a version of 1.0.
+            if result.get("version") != "1.0":
+                return None
+
+            oembed_type = result.get("type")
+
+            # Ensure the cache age is None or an int.
+            cache_age = result.get("cache_age")
+            if cache_age:
+                cache_age = int(cache_age)
+
+            oembed_result = OEmbedResult(None, None, result.get("title"), cache_age)
+
+            # HTML content.
+            if oembed_type == "rich":
+                oembed_result.html = result.get("html")
+                return oembed_result
+
+            if oembed_type == "photo":
+                oembed_result.url = result.get("url")
+                return oembed_result
+
+            # TODO can we do anything better for the video type besides using
+            #  the thumbnail?
+
+            if "thumbnail_url" in result:
+                oembed_result.url = result.get("thumbnail_url")
+                return oembed_result
+
+            return None
+
+        except Exception as e:
+            # Trap any exception and let the code follow as usual.
+            # FIXME: pass through 404s and other error messages nicely
+            logger.warning("Error downloading %s: %r", url, e)
+            return None
+
     async def _download_url(self, url, user):
         # TODO: we should probably honour robots.txt... except in practice
         # we're most likely being explicitly triggered by a human rather than a
@@ -319,54 +427,87 @@ class PreviewUrlResource(DirectServeJsonResource):
 
         file_info = FileInfo(server_name=None, file_id=file_id, url_cache=True)
 
-        with self.media_storage.store_into_file(file_info) as (f, fname, finish):
-            try:
-                logger.debug("Trying to get preview for url '%s'", url)
-                length, headers, uri, code = await self.client.get_file(
-                    url,
-                    output_stream=f,
-                    max_size=self.max_spider_size,
-                    headers={"Accept-Language": self.url_preview_accept_language},
-                )
-            except SynapseError:
-                # Pass SynapseErrors through directly, so that the servlet
-                # handler will return a SynapseError to the client instead of
-                # blank data or a 500.
-                raise
-            except DNSLookupError:
-                # DNS lookup returned no results
-                # Note: This will also be the case if one of the resolved IP
-                # addresses is blacklisted
-                raise SynapseError(
-                    502,
-                    "DNS resolution failure during URL preview generation",
-                    Codes.UNKNOWN,
-                )
-            except Exception as e:
-                # FIXME: pass through 404s and other error messages nicely
-                logger.warning("Error downloading %s: %r", url, e)
+        # If this URL can be accessed via oEmbed, use that instead.
+        url_to_download = url
+        oembed_url = self._get_oembed_url(url)
+        if oembed_url:
+            # The result might be a new URL to download, or it might be HTML content.
+            oembed_result = await self._get_oembed_content(oembed_url, url)
+            if oembed_result:
+                if oembed_result.url:
+                    url_to_download = oembed_result.url
+                elif oembed_result.html:
+                    url_to_download = None
 
-                raise SynapseError(
-                    500,
-                    "Failed to download content: %s"
-                    % (traceback.format_exception_only(sys.exc_info()[0], e),),
-                    Codes.UNKNOWN,
-                )
-            await finish()
+        if url_to_download:
+            with self.media_storage.store_into_file(file_info) as (f, fname, finish):
+                try:
+                    logger.debug("Trying to get preview for url '%s'", url_to_download)
+                    length, headers, uri, code = await self.client.get_file(
+                        url_to_download,
+                        output_stream=f,
+                        max_size=self.max_spider_size,
+                        headers={"Accept-Language": self.url_preview_accept_language},
+                    )
+                except SynapseError:
+                    # Pass SynapseErrors through directly, so that the servlet
+                    # handler will return a SynapseError to the client instead of
+                    # blank data or a 500.
+                    raise
+                except DNSLookupError:
+                    # DNS lookup returned no results
+                    # Note: This will also be the case if one of the resolved IP
+                    # addresses is blacklisted
+                    raise SynapseError(
+                        502,
+                        "DNS resolution failure during URL preview generation",
+                        Codes.UNKNOWN,
+                    )
+                except Exception as e:
+                    # FIXME: pass through 404s and other error messages nicely
+                    logger.warning("Error downloading %s: %r", url_to_download, e)
+
+                    raise SynapseError(
+                        500,
+                        "Failed to download content: %s"
+                        % (traceback.format_exception_only(sys.exc_info()[0], e),),
+                        Codes.UNKNOWN,
+                    )
+                await finish()
+
+                if b"Content-Type" in headers:
+                    media_type = headers[b"Content-Type"][0].decode("ascii")
+                else:
+                    media_type = "application/octet-stream"
+
+                download_name = get_filename_from_headers(headers)
+
+                # FIXME: we should calculate a proper expiration based on the
+                # Cache-Control and Expire headers.  But for now, assume 1 hour.
+                expires = 60 * 60 * 1000
+                etag = headers["ETag"][0] if "ETag" in headers else None
+        else:
+            html_bytes = oembed_result.html.encode("utf-8")
+            with self.media_storage.store_into_file(file_info) as (f, fname, finish):
+                f.write(html_bytes)
+                await finish()
+
+            media_type = "text/html"
+            download_name = oembed_result.title
+            length = len(html_bytes)
+            # If a specific cache age was not given, assume 1 hour.
+            expires = oembed_result.cache_age or (60 * 60 * 1000)
+            uri = oembed_url
+            code = 200
+            etag = None
 
         try:
-            if b"Content-Type" in headers:
-                media_type = headers[b"Content-Type"][0].decode("ascii")
-            else:
-                media_type = "application/octet-stream"
             time_now_ms = self.clock.time_msec()
-
-            download_name = get_filename_from_headers(headers)
 
             await self.store.store_local_media(
                 media_id=file_id,
                 media_type=media_type,
-                time_now_ms=self.clock.time_msec(),
+                time_now_ms=time_now_ms,
                 upload_name=download_name,
                 media_length=length,
                 user_id=user,
@@ -389,10 +530,8 @@ class PreviewUrlResource(DirectServeJsonResource):
             "filename": fname,
             "uri": uri,
             "response_code": code,
-            # FIXME: we should calculate a proper expiration based on the
-            # Cache-Control and Expire headers.  But for now, assume 1 hour.
-            "expires": 60 * 60 * 1000,
-            "etag": headers["ETag"][0] if "ETag" in headers else None,
+            "expires": expires,
+            "etag": etag,
         }
 
     def _start_expire_url_cache_data(self):

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -76,8 +76,29 @@ _oembed_globs = {
 _oembed_patterns = {}
 for endpoint, globs in _oembed_globs.items():
     for glob in globs:
-        pattern = re.compile(re.escape(glob).replace("\\*", ".+"))
-        _oembed_patterns[pattern] = endpoint
+        # Convert the glob into a sane regular expression to match against. The
+        # rules followed will be slightly different for the domain portion vs.
+        # the rest.
+        #
+        # 1. The scheme must be one of HTTP / HTTPS (and have no globs).
+        # 2. The domain can have globs, but we limit it to characters that can
+        #    reasonably be  a domain part.
+        #    TODO: This does not attempt to handle Unicode domain names.
+        # 3. Other parts allow a glob to be any one, or more, characters.
+        results = urlparse.urlparse(glob)
+
+        # Ensure the scheme does not have wildcards (and is a sane scheme).
+        if results.scheme not in {"http", "https"}:
+            raise ValueError("Insecure oEmbed glob scheme: %s" % (results.scheme,))
+
+        pattern = urlparse.urlunparse(
+            [
+                results.scheme,
+                re.escape(results.netloc).replace("\\*", "[a-zA-Z0-9_-]+"),
+            ]
+            + list(map(lambda part: re.escape(part).replace("\\*", ".+"), results[2:]))
+        )
+        _oembed_patterns[re.compile(pattern)] = endpoint
 
 
 @attr.s

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -432,8 +432,7 @@ class PreviewUrlResource(DirectServeJsonResource):
                 oembed_result.url = result.get("url")
                 return oembed_result
 
-            # TODO can we do anything better for the video type besides using
-            #  the thumbnail?
+            # TODO Handle link and video types.
 
             if "thumbnail_url" in result:
                 oembed_result.url = result.get("thumbnail_url")

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -108,7 +108,7 @@ class OEmbedResult:
     # Either HTML content or URL must be provided.
     html = attr.ib(type=Optional[str])
     url = attr.ib(type=Optional[str])
-    title = attr.ib(type=str)
+    title = attr.ib(type=Optional[str])
     # Number of seconds to cache the content.
     cache_age = attr.ib(type=int)
 

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -16,9 +16,9 @@ import json
 import os
 import re
 
-import attr
-
 from mock import patch
+
+import attr
 
 from twisted.internet._resolver import HostResolution
 from twisted.internet.address import IPv4Address, IPv6Address
@@ -571,9 +571,14 @@ class URLPreviewTests(unittest.HomeserverTestCase):
     def test_oembed_url(self):
         """Test changing a URL via OEmbed."""
         # Route the HTTP version to an HTTP endpoint so that the tests work.
-        with patch.dict(_oembed_patterns, {
-            re.compile("http://twitter\\.com/.+/status/.+"): "http://publish.twitter.com/oembed",
-        }):
+        with patch.dict(
+            _oembed_patterns,
+            {
+                re.compile(
+                    "http://twitter\\.com/.+/status/.+"
+                ): "http://publish.twitter.com/oembed",
+            },
+        ):
 
             self.lookups["publish.twitter.com"] = [(IPv4Address, "8.8.8.8")]
             self.lookups["cdn.twitter.com"] = [(IPv4Address, "8.8.8.8")]
@@ -593,7 +598,9 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             )
 
             request, channel = self.make_request(
-                "GET", "url_preview?url=http://twitter.com/matrixdotorg/status/12345", shorthand=False
+                "GET",
+                "url_preview?url=http://twitter.com/matrixdotorg/status/12345",
+                shorthand=False,
             )
             request.render(self.preview_url)
             self.pump()
@@ -634,9 +641,14 @@ class URLPreviewTests(unittest.HomeserverTestCase):
     def test_oembed_html(self):
         """Test an OEmbed endpoint which returns HTML."""
         # Route the HTTP version to an HTTP endpoint so that the tests work.
-        with patch.dict(_oembed_patterns, {
-            re.compile("http://twitter\\.com/.+/status/.+"): "http://publish.twitter.com/oembed",
-        }):
+        with patch.dict(
+            _oembed_patterns,
+            {
+                re.compile(
+                    "http://twitter\\.com/.+/status/.+"
+                ): "http://publish.twitter.com/oembed",
+            },
+        ):
 
             self.lookups["publish.twitter.com"] = [(IPv4Address, "8.8.8.8")]
 
@@ -648,7 +660,9 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             end_content = json.dumps(result).encode("utf-8")
 
             request, channel = self.make_request(
-                "GET", "url_preview?url=http://twitter.com/matrixdotorg/status/12345", shorthand=False
+                "GET",
+                "url_preview?url=http://twitter.com/matrixdotorg/status/12345",
+                shorthand=False,
             )
             request.render(self.preview_url)
             self.pump()
@@ -669,5 +683,6 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             self.pump()
             self.assertEqual(channel.code, 200)
             self.assertEqual(
-                channel.json_body, {"og:title": None, "og:description": "Content Preview"}
+                channel.json_body,
+                {"og:title": None, "og:description": "Content Preview"},
             )

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -575,9 +575,10 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             _oembed_patterns,
             {
                 re.compile(
-                    "http://twitter\\.com/.+/status/.+"
+                    "http\\:\\/\\/twitter\\.com\\/.+\\/status\\/.+"
                 ): "http://publish.twitter.com/oembed",
             },
+            clear=True,
         ):
 
             self.lookups["publish.twitter.com"] = [(IPv4Address, "8.8.8.8")]
@@ -647,9 +648,10 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             _oembed_patterns,
             {
                 re.compile(
-                    "http://twitter\\.com/.+/status/.+"
+                    "http\\:\\/\\/twitter\\.com\\/.+\\/status\\/.+"
                 ): "http://publish.twitter.com/oembed",
             },
+            clear=True,
         ):
 
             self.lookups["publish.twitter.com"] = [(IPv4Address, "8.8.8.8")]

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -575,7 +575,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             _oembed_patterns,
             {
                 re.compile(
-                    "http\\:\\/\\/twitter\\.com\\/.+\\/status\\/.+"
+                    "http://twitter\\.com/.+/status/.+"
                 ): "http://publish.twitter.com/oembed",
             },
             clear=True,
@@ -648,7 +648,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             _oembed_patterns,
             {
                 re.compile(
-                    "http\\:\\/\\/twitter\\.com\\/.+\\/status\\/.+"
+                    "http://twitter\\.com/.+/status/.+"
                 ): "http://publish.twitter.com/oembed",
             },
             clear=True,

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -569,7 +569,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         )
 
     def test_oembed_url(self):
-        """Test changing a URL via OEmbed."""
+        """Test changing a URL via oEmbed."""
         # Route the HTTP version to an HTTP endpoint so that the tests work.
         with patch.dict(
             _oembed_patterns,
@@ -641,7 +641,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             )
 
     def test_oembed_html(self):
-        """Test an OEmbed endpoint which returns HTML."""
+        """Test an oEmbed endpoint which returns HTML."""
         # Route the HTTP version to an HTTP endpoint so that the tests work.
         with patch.dict(
             _oembed_patterns,

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -566,8 +566,8 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             server.data,
         )
 
-    def test_oembed_url(self):
-        """Test changing a URL via oEmbed."""
+    def test_oembed_photo(self):
+        """Test an oEmbed endpoint which returns a 'photo' type which redirects the preview to a new URL."""
         # Route the HTTP version to an HTTP endpoint so that the tests work.
         with patch.dict(
             "synapse.rest.media.v1.preview_url_resource._oembed_patterns",
@@ -639,8 +639,8 @@ class URLPreviewTests(unittest.HomeserverTestCase):
                 channel.json_body, {"og:title": "Some Title", "og:description": "hi"}
             )
 
-    def test_oembed_html(self):
-        """Test an oEmbed endpoint which returns HTML."""
+    def test_oembed_rich(self):
+        """Test an oEmbed endpoint which returns HTML content via the 'rich' type."""
         # Route the HTTP version to an HTTP endpoint so that the tests work.
         with patch.dict(
             "synapse.rest.media.v1.preview_url_resource._oembed_patterns",

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -618,6 +618,8 @@ class URLPreviewTests(unittest.HomeserverTestCase):
                 + oembed_content
             )
 
+            self.pump()
+
             client = self.reactor.tcpClients[1][2].buildProtocol(None)
             server = AccumulatingProtocol()
             server.makeConnection(FakeTransport(client, self.reactor))

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -573,7 +573,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             "synapse.rest.media.v1.preview_url_resource._oembed_patterns",
             {
                 re.compile(
-                    "http://twitter\\.com/.+/status/.+"
+                    r"http://twitter\.com/.+/status/.+"
                 ): "http://publish.twitter.com/oembed",
             },
             clear=True,
@@ -646,7 +646,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             "synapse.rest.media.v1.preview_url_resource._oembed_patterns",
             {
                 re.compile(
-                    "http://twitter\\.com/.+/status/.+"
+                    r"http://twitter\.com/.+/status/.+"
                 ): "http://publish.twitter.com/oembed",
             },
             clear=True,

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -134,7 +134,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.reactor.nameResolver = Resolver()
 
     def test_cache_returns_correct_type(self):
-        self.lookups["matrix.org"] = [(IPv4Address, "8.8.8.8")]
+        self.lookups["matrix.org"] = [(IPv4Address, "10.1.2.3")]
 
         request, channel = self.make_request(
             "GET", "url_preview?url=http://matrix.org", shorthand=False
@@ -190,7 +190,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         )
 
     def test_non_ascii_preview_httpequiv(self):
-        self.lookups["matrix.org"] = [(IPv4Address, "8.8.8.8")]
+        self.lookups["matrix.org"] = [(IPv4Address, "10.1.2.3")]
 
         end_content = (
             b"<html><head>"
@@ -224,7 +224,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.assertEqual(channel.json_body["og:title"], "\u0434\u043a\u0430")
 
     def test_non_ascii_preview_content_type(self):
-        self.lookups["matrix.org"] = [(IPv4Address, "8.8.8.8")]
+        self.lookups["matrix.org"] = [(IPv4Address, "10.1.2.3")]
 
         end_content = (
             b"<html><head>"
@@ -257,7 +257,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.assertEqual(channel.json_body["og:title"], "\u0434\u043a\u0430")
 
     def test_overlong_title(self):
-        self.lookups["matrix.org"] = [(IPv4Address, "8.8.8.8")]
+        self.lookups["matrix.org"] = [(IPv4Address, "10.1.2.3")]
 
         end_content = (
             b"<html><head>"
@@ -295,7 +295,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         """
         IP addresses can be previewed directly.
         """
-        self.lookups["example.com"] = [(IPv4Address, "8.8.8.8")]
+        self.lookups["example.com"] = [(IPv4Address, "10.1.2.3")]
 
         request, channel = self.make_request(
             "GET", "url_preview?url=http://example.com", shorthand=False
@@ -442,7 +442,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         # Hardcode the URL resolving to the IP we want.
         self.lookups["example.com"] = [
             (IPv4Address, "1.1.1.2"),
-            (IPv4Address, "8.8.8.8"),
+            (IPv4Address, "10.1.2.3"),
         ]
 
         request, channel = self.make_request(
@@ -521,7 +521,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         """
         Accept-Language header is sent to the remote server
         """
-        self.lookups["example.com"] = [(IPv4Address, "8.8.8.8")]
+        self.lookups["example.com"] = [(IPv4Address, "10.1.2.3")]
 
         # Build and make a request to the server
         request, channel = self.make_request(
@@ -579,8 +579,8 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             clear=True,
         ):
 
-            self.lookups["publish.twitter.com"] = [(IPv4Address, "8.8.8.8")]
-            self.lookups["cdn.twitter.com"] = [(IPv4Address, "8.8.8.8")]
+            self.lookups["publish.twitter.com"] = [(IPv4Address, "10.1.2.3")]
+            self.lookups["cdn.twitter.com"] = [(IPv4Address, "10.1.2.3")]
 
             result = {
                 "version": "1.0",
@@ -652,7 +652,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
             clear=True,
         ):
 
-            self.lookups["publish.twitter.com"] = [(IPv4Address, "8.8.8.8")]
+            self.lookups["publish.twitter.com"] = [(IPv4Address, "10.1.2.3")]
 
             result = {
                 "version": "1.0",

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -27,8 +27,6 @@ from twisted.python.failure import Failure
 from twisted.test.proto_helpers import AccumulatingProtocol
 from twisted.web._newclient import ResponseDone
 
-from synapse.rest.media.v1.preview_url_resource import _oembed_patterns
-
 from tests import unittest
 from tests.server import FakeTransport
 
@@ -572,7 +570,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         """Test changing a URL via oEmbed."""
         # Route the HTTP version to an HTTP endpoint so that the tests work.
         with patch.dict(
-            _oembed_patterns,
+            "synapse.rest.media.v1.preview_url_resource._oembed_patterns",
             {
                 re.compile(
                     "http://twitter\\.com/.+/status/.+"
@@ -645,7 +643,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         """Test an oEmbed endpoint which returns HTML."""
         # Route the HTTP version to an HTTP endpoint so that the tests work.
         with patch.dict(
-            _oembed_patterns,
+            "synapse.rest.media.v1.preview_url_resource._oembed_patterns",
             {
                 re.compile(
                     "http://twitter\\.com/.+/status/.+"


### PR DESCRIPTION
Fixes #7643.

This fixes Twitter previews by querying for oEmbed information instead of the originally requested URL. It is mostly generic (so additional oEmbed endpoints can be added), but it isn't end-user configurable at the moment.

The gist of the changes to the preview algorithm is:

1. Check if the requested URL matches any of the oEmbed patterns, if so:
    1. Query the oEmbed endpoint for the JSON metadata.
    2. If the metadata is a photo or has a thumbnail, use that instead of the original URL and continue the normal preview code.
    3. If the metadata is HTML, use the HTML directly.

A big section of `_download_url` got indented, but was otherwise unchanged.

A couple of questions I have:
* Does it make sense to make this user configurable?
* Parsing of the globs to regular expressions at module load time seems kind of meh, but is easy. I wonder if we should have a separate handler or something for oEmbed?
* Are there other services we want to add? (Note that there's a JSON file which contains all the providers, we could fetch it programmatically or include it.)

Note that this does NOT attempt to support "discovery" via `<link>` tags. (Nor does it handle XML.)

## Testing steps

1. Enable URL previews in your homeserver (I think this involes `enable_media_repo`, `url_preview_enabled`, `url_preview_ip_range_blacklist`).
2. Join a room.
3. Enable URL previews for that room in the settings.
4. Send a link that should get previewed and make sure it still works.
5. Send a Twitter link to get previewed (e.g. https://twitter.com/matrixdotorg/status/1285937589791399936) and see a preview text.