### PR TITLE
Perform JSON-encoding of CS API responses in a background thread

### DIFF
--- a/changelog.d/7926.misc
+++ b/changelog.d/7926.misc
@@ -1,0 +1,1 @@
+Perform JSON-encoding of CS API responses in a background thread.

--- a/synapse/http/additional_resource.py
+++ b/synapse/http/additional_resource.py
@@ -38,7 +38,7 @@ class AdditionalResource(DirectServeJsonResource):
             handler ((twisted.web.server.Request) -> twisted.internet.defer.Deferred):
                 function to be called to handle the request.
         """
-        super().__init__()
+        super().__init__(hs)
         self._handler = handler
 
     def _async_render(self, request):

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -44,7 +44,7 @@ from synapse.api.errors import (
     UnrecognizedRequestError,
 )
 from synapse.http.site import SynapseRequest
-from synapse.logging.context import defer_to_thread, defer_to_threadpool, preserve_fn
+from synapse.logging.context import defer_to_thread, preserve_fn
 from synapse.logging.opentracing import trace_servlet
 from synapse.util.caches import intern_dict
 

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -88,7 +88,7 @@ class RemoteKey(DirectServeJsonResource):
     isLeaf = True
 
     def __init__(self, hs):
-        super().__init__()
+        super().__init__(hs)
 
         self.fetcher = ServerKeyFetcher(hs)
         self.store = hs.get_datastore()

--- a/synapse/rest/media/v1/config_resource.py
+++ b/synapse/rest/media/v1/config_resource.py
@@ -21,7 +21,7 @@ class MediaConfigResource(DirectServeJsonResource):
     isLeaf = True
 
     def __init__(self, hs):
-        super().__init__()
+        super().__init__(hs)
         config = hs.get_config()
         self.clock = hs.get_clock()
         self.auth = hs.get_auth()

--- a/synapse/rest/media/v1/download_resource.py
+++ b/synapse/rest/media/v1/download_resource.py
@@ -26,7 +26,7 @@ class DownloadResource(DirectServeJsonResource):
     isLeaf = True
 
     def __init__(self, hs, media_repo):
-        super().__init__()
+        super().__init__(hs)
         self.media_repo = media_repo
         self.server_name = hs.hostname
 

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -61,7 +61,7 @@ class PreviewUrlResource(DirectServeJsonResource):
     isLeaf = True
 
     def __init__(self, hs, media_repo, media_storage):
-        super().__init__()
+        super().__init__(hs)
 
         self.auth = hs.get_auth()
         self.clock = hs.get_clock()

--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -34,7 +34,7 @@ class ThumbnailResource(DirectServeJsonResource):
     isLeaf = True
 
     def __init__(self, hs, media_repo, media_storage):
-        super().__init__()
+        super().__init__(hs)
 
         self.store = hs.get_datastore()
         self.media_repo = media_repo

--- a/synapse/rest/media/v1/upload_resource.py
+++ b/synapse/rest/media/v1/upload_resource.py
@@ -26,7 +26,7 @@ class UploadResource(DirectServeJsonResource):
     isLeaf = True
 
     def __init__(self, hs, media_repo):
-        super().__init__()
+        super().__init__(hs)
 
         self.media_repo = media_repo
         self.filepaths = media_repo.filepaths


### PR DESCRIPTION
This is an implementation of the solution proposed in https://github.com/matrix-org/synapse/issues/6998#issuecomment-591670938; viz. moving JSON-encoding out to a background thread.

