### PR TITLE
Skip serializing /sync response if client has disconnected

### DIFF
--- a/changelog.d/7927.misc
+++ b/changelog.d/7927.misc
@@ -1,0 +1,1 @@
+Optimisation to /sync handling: skip serializing the response if the client has already disconnected.

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -178,6 +178,12 @@ class SyncRestServlet(RestServlet):
                 full_state=full_state,
             )
 
+        # the client may have disconnected by now; don't bother to serialize the
+        # response if so.
+        if request._disconnected:
+            logger.info("Client has disconnected; not serializing response.")
+            return 200, {}
+
         time_now = self.clock.time_msec()
         response_content = await self.encode_response(
             time_now, sync_result, requester.access_token_id, filter_collection


### PR DESCRIPTION
... it's a load of work which may be entirely redundant.