### PR TITLE
Reorder database docs to promote postgresql.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ Almost all installations should opt to use PostgreSQL. Advantages include:
 For information on how to install and use PostgreSQL, please see
 `docs/postgres.md <docs/postgres.md>`_.
 
-By default Synapse uses SQLite in and doing so trades performance for convenience.
+By default Synapse uses SQLite and in doing so trades performance for convenience.
 SQLite is only recommended in Synapse for testing purposes or for servers with
 light workloads.
 

--- a/README.rst
+++ b/README.rst
@@ -188,12 +188,8 @@ Using PostgreSQL
 ================
 
 Synapse offers two database engines:
- * `SQLite <https://sqlite.org/>`_
  * `PostgreSQL <https://www.postgresql.org>`_
-
-By default Synapse uses SQLite in and doing so trades performance for convenience.
-SQLite is only recommended in Synapse for testing purposes or for servers with
-light workloads.
+ * `SQLite <https://sqlite.org/>`_
 
 Almost all installations should opt to use PostgreSQL. Advantages include:
 
@@ -206,6 +202,10 @@ Almost all installations should opt to use PostgreSQL. Advantages include:
 
 For information on how to install and use PostgreSQL, please see
 `docs/postgres.md <docs/postgres.md>`_.
+
+By default Synapse uses SQLite in and doing so trades performance for convenience.
+SQLite is only recommended in Synapse for testing purposes or for servers with
+light workloads.
 
 .. _reverse-proxy:
 

--- a/changelog.d/7933.doc
+++ b/changelog.d/7933.doc
@@ -1,0 +1,1 @@
+Reorder database paragraphs to promote postgres over sqlite.


### PR DESCRIPTION
At the moment, the list and the first paragraph promote sqlite, but the third paragraph says "Almost all should use postgresql".  We should encourage people to deploy postgres by ordering the text, even if sqlite is still the default on a unconfigured server.
