### PR TITLE
Update the auth providers to be async.

### DIFF
--- a/changelog.d/7935.misc
+++ b/changelog.d/7935.misc
@@ -1,0 +1,1 @@
+Convert the auth providers to be async/await.

--- a/docs/password_auth_providers.md
+++ b/docs/password_auth_providers.md
@@ -19,14 +19,14 @@ password auth provider module implementations:
 
 Password auth provider classes must provide the following methods:
 
-* `parse_config(cls, config)`
+* `parse_config(config)`
   This method is passed the `config` object for this module from the
   homeserver configuration file.
 
   It should perform any appropriate sanity checks on the provided
   configuration, and return an object which is then passed into
 
-  This method should have the `@classmethod` decoration.
+  This method should have the `@staticmethod` decoration.
 
 * `__init__(self, config, account_handler)`
 

--- a/docs/password_auth_providers.md
+++ b/docs/password_auth_providers.md
@@ -19,102 +19,103 @@ password auth provider module implementations:
 
 Password auth provider classes must provide the following methods:
 
-*class* `SomeProvider.parse_config`(*config*)
+* `parse_config(cls, config)`
+  This method is passed the `config` object for this module from the
+  homeserver configuration file.
 
-> This method is passed the `config` object for this module from the
-> homeserver configuration file.
->
-> It should perform any appropriate sanity checks on the provided
-> configuration, and return an object which is then passed into
-> `__init__`.
+  It should perform any appropriate sanity checks on the provided
+  configuration, and return an object which is then passed into
 
-*class* `SomeProvider`(*config*, *account_handler*)
+  This method should have the `@classmethod` decoration.
 
-> The constructor is passed the config object returned by
-> `parse_config`, and a `synapse.module_api.ModuleApi` object which
-> allows the password provider to check if accounts exist and/or create
-> new ones.
+* `__init__(self, config, account_handler)`
+
+  The constructor is passed the config object returned by
+  `parse_config`, and a `synapse.module_api.ModuleApi` object which
+  allows the password provider to check if accounts exist and/or create
+  new ones.
 
 ## Optional methods
 
-Password auth provider classes may optionally provide the following
-methods.
+Password auth provider classes may optionally provide the following methods:
 
-*class* `SomeProvider.get_db_schema_files`()
+* `get_db_schema_files(self)`
 
-> This method, if implemented, should return an Iterable of
-> `(name, stream)` pairs of database schema files. Each file is applied
-> in turn at initialisation, and a record is then made in the database
-> so that it is not re-applied on the next start.
+  This method, if implemented, should return an Iterable of
+  `(name, stream)` pairs of database schema files. Each file is applied
+  in turn at initialisation, and a record is then made in the database
+  so that it is not re-applied on the next start.
 
-`someprovider.get_supported_login_types`()
+* `get_supported_login_types(self)`
 
-> This method, if implemented, should return a `dict` mapping from a
-> login type identifier (such as `m.login.password`) to an iterable
-> giving the fields which must be provided by the user in the submission
-> to the `/login` api. These fields are passed in the `login_dict`
-> dictionary to `check_auth`.
->
-> For example, if a password auth provider wants to implement a custom
-> login type of `com.example.custom_login`, where the client is expected
-> to pass the fields `secret1` and `secret2`, the provider should
-> implement this method and return the following dict:
->
->     {"com.example.custom_login": ("secret1", "secret2")}
+  This method, if implemented, should return a `dict` mapping from a
+  login type identifier (such as `m.login.password`) to an iterable
+  giving the fields which must be provided by the user in the submission
+  to [the `/login` API](https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-login).
+  These fields are passed in the `login_dict` dictionary to `check_auth`.
 
-`someprovider.check_auth`(*username*, *login_type*, *login_dict*)
+  For example, if a password auth provider wants to implement a custom
+  login type of `com.example.custom_login`, where the client is expected
+  to pass the fields `secret1` and `secret2`, the provider should
+  implement this method and return the following dict:
 
-> This method is the one that does the real work. If implemented, it
-> will be called for each login attempt where the login type matches one
-> of the keys returned by `get_supported_login_types`.
->
-> It is passed the (possibly unqualified) `user` provided by the client,
-> the login type, and a dictionary of login secrets passed by the
-> client.
->
-> The method should return an `Awaitable` object, which resolves
-> to the canonical `@localpart:domain` user id if authentication is
-> successful, and `None` if not.
->
-> Alternatively, the `Awaitable` can resolve to a `(str, func)` tuple, in
-> which case the second field is a callback which will be called with
-> the result from the `/login` call (including `access_token`,
-> `device_id`, etc.)
+  ```python
+  {"com.example.custom_login": ("secret1", "secret2")}
+  ```
 
-`someprovider.check_3pid_auth`(*medium*, *address*, *password*)
+* `check_auth(self, username, login_type, login_dict)`
 
-> This method, if implemented, is called when a user attempts to
-> register or log in with a third party identifier, such as email. It is
-> passed the medium (ex. "email"), an address (ex.
-> "<jdoe@example.com>") and the user's password.
->
-> The method should return an `Awaitable` object, which resolves
-> to a `str` containing the user's (canonical) User ID if
-> authentication was successful, and `None` if not.
->
-> As with `check_auth`, the `Awaitable` may alternatively resolve to a
-> `(user_id, callback)` tuple.
+  This method does the real work. If implemented, it
+  will be called for each login attempt where the login type matches one
+  of the keys returned by `get_supported_login_types`.
 
-`someprovider.check_password`(*user_id*, *password*)
+  It is passed the (possibly unqualified) `user` field provided by the client,
+  the login type, and a dictionary of login secrets passed by the
+  client.
 
-> This method provides a simpler interface than
-> `get_supported_login_types` and `check_auth` for password auth
-> providers that just want to provide a mechanism for validating
-> `m.login.password` logins.
->
-> If implemented, it will be called to check logins with an
-> `m.login.password` login type. It is passed a qualified
-> `@localpart:domain` user id, and the password provided by the user.
->
-> The method should return an `Awaitable` object, which resolves
-> to `True` if authentication is successful, and `False` if not.
+  The method should return an `Awaitable` object, which resolves
+  to the canonical `@localpart:domain` user ID if authentication is
+  successful, and `None` if not.
 
-`someprovider.on_logged_out`(*user_id*, *device_id*, *access_token*)
+  Alternatively, the `Awaitable` can resolve to a `(str, func)` tuple, in
+  which case the second field is a callback which will be called with
+  the result from the `/login` call (including `access_token`,
+  `device_id`, etc.)
 
-> This method, if implemented, is called when a user logs out. It is
-> passed the qualified user ID, the ID of the deactivated device (if
-> any: access tokens are occasionally created without an associated
-> device ID), and the (now deactivated) access token.
->
-> It may return an `Awaitable` object; the logout request will
-> wait for the deferred to complete but the result is ignored.
+* `check_3pid_auth(self, medium, address, password)`
+
+  This method, if implemented, is called when a user attempts to
+  register or log in with a third party identifier, such as email. It is
+  passed the medium (ex. "email"), an address (ex.
+  "<jdoe@example.com>") and the user's password.
+
+  The method should return an `Awaitable` object, which resolves
+  to a `str` containing the user's (canonical) User id if
+  authentication was successful, and `None` if not.
+
+  As with `check_auth`, the `Awaitable` may alternatively resolve to a
+  `(user_id, callback)` tuple.
+
+* `check_password(self, user_id, password)`
+
+  This method provides a simpler interface than
+  `get_supported_login_types` and `check_auth` for password auth
+  providers that just want to provide a mechanism for validating
+  `m.login.password` logins.
+
+  If implemented, it will be called to check logins with an
+  `m.login.password` login type. It is passed a qualified
+  `@localpart:domain` user id, and the password provided by the user.
+
+  The method should return an `Awaitable` object, which resolves
+  to `True` if authentication is successful, and `False` if not.
+
+* `on_logged_out(self, user_id, device_id, access_token)`
+
+  This method, if implemented, is called when a user logs out. It is
+  passed the qualified user ID, the ID of the deactivated device (if
+  any: access tokens are occasionally created without an associated
+  device ID), and the (now deactivated) access token.
+
+  It may return an `Awaitable` object; the logout request will
+  wait for the `Awaitable` to complete, but the result is ignored.

--- a/docs/password_auth_providers.md
+++ b/docs/password_auth_providers.md
@@ -68,15 +68,15 @@ methods.
 > will be called for each login attempt where the login type matches one
 > of the keys returned by `get_supported_login_types`.
 >
-> It is passed the (possibly UNqualified) `user` provided by the client,
+> It is passed the (possibly unqualified) `user` provided by the client,
 > the login type, and a dictionary of login secrets passed by the
 > client.
 >
-> The method should return a Twisted `Deferred` object, which resolves
+> The method should return an `Awaitable` object, which resolves
 > to the canonical `@localpart:domain` user id if authentication is
 > successful, and `None` if not.
 >
-> Alternatively, the `Deferred` can resolve to a `(str, func)` tuple, in
+> Alternatively, the `Awaitable` can resolve to a `(str, func)` tuple, in
 > which case the second field is a callback which will be called with
 > the result from the `/login` call (including `access_token`,
 > `device_id`, etc.)
@@ -88,11 +88,11 @@ methods.
 > passed the medium (ex. "email"), an address (ex.
 > "<jdoe@example.com>") and the user's password.
 >
-> The method should return a Twisted `Deferred` object, which resolves
+> The method should return an `Awaitable` object, which resolves
 > to a `str` containing the user's (canonical) User ID if
 > authentication was successful, and `None` if not.
 >
-> As with `check_auth`, the `Deferred` may alternatively resolve to a
+> As with `check_auth`, the `Awaitable` may alternatively resolve to a
 > `(user_id, callback)` tuple.
 
 `someprovider.check_password`(*user_id*, *password*)
@@ -102,11 +102,11 @@ methods.
 > providers that just want to provide a mechanism for validating
 > `m.login.password` logins.
 >
-> Iif implemented, it will be called to check logins with an
+> If implemented, it will be called to check logins with an
 > `m.login.password` login type. It is passed a qualified
 > `@localpart:domain` user id, and the password provided by the user.
 >
-> The method should return a Twisted `Deferred` object, which resolves
+> The method should return an `Awaitable` object, which resolves
 > to `True` if authentication is successful, and `False` if not.
 
 `someprovider.on_logged_out`(*user_id*, *device_id*, *access_token*)
@@ -116,5 +116,5 @@ methods.
 > any: access tokens are occasionally created without an associated
 > device ID), and the (now deactivated) access token.
 >
-> It may return a Twisted `Deferred` object; the logout request will
+> It may return an `Awaitable` object; the logout request will
 > wait for the deferred to complete but the result is ignored.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -863,11 +863,15 @@ class AuthHandler(BaseHandler):
         # see if any of our auth providers want to know about this
         for provider in self.password_providers:
             if hasattr(provider, "on_logged_out"):
-                await provider.on_logged_out(
+                # This might return an awaitable, if it does block the log out
+                # until it completes.
+                result = provider.on_logged_out(
                     user_id=str(user_info["user"]),
                     device_id=user_info["device_id"],
                     access_token=access_token,
                 )
+                if result:
+                    await result
 
         # delete pushers associated with this access token
         if user_info["token_id"] is not None:

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import inspect
 import logging
 import time
 import unicodedata
@@ -870,7 +871,7 @@ class AuthHandler(BaseHandler):
                     device_id=user_info["device_id"],
                     access_token=access_token,
                 )
-                if result:
+                if inspect.isawaitable(result):
                     await result
 
         # delete pushers associated with this access token


### PR DESCRIPTION
This updates the built in auth providers to use async/await.

The callers were already converted to async/await so this shouldn't cause an issue. The third-party providers should still work (since you can `await` a `Deferred`).

I don't find the documentation here to be great:
* I've updated it to refer to `Awaitables` instead of `Deferred`
* I reformatted it so that it isn't all inside of block quotes.

This also fixes a bug I found by reading the documentation closer -- `on_logged_out` **may** return an `Awaitable`, but doesn't have to.