### PR TITLE
Use the standard library JSON.

### DIFF
--- a/changelog.d/7936.misc
+++ b/changelog.d/7936.misc
@@ -1,0 +1,1 @@
+Switch to the JSON implementation from the standard library.

--- a/changelog.d/7936.misc
+++ b/changelog.d/7936.misc
@@ -1,1 +1,1 @@
-Switch to the JSON implementation from the standard library.
+Switch to the JSON implementation from the standard library and bump the minimum version of the canonicaljson library to 1.2.0.

--- a/synapse/__init__.py
+++ b/synapse/__init__.py
@@ -17,8 +17,11 @@
 """ This is a reference implementation of a Matrix homeserver.
 """
 
+import json
 import os
 import sys
+
+from canonicaljson import set_json_library
 
 # Check that we're not running on an unsupported Python version.
 if sys.version_info < (3, 5):
@@ -35,6 +38,9 @@ try:
     DNSDatagramProtocol.noisy = False
 except ImportError:
     pass
+
+# Use the standard library json implementation instead of simplejson.
+set_json_library(json)
 
 __version__ = "1.18.0rc1"
 

--- a/synapse/__init__.py
+++ b/synapse/__init__.py
@@ -26,6 +26,9 @@ if sys.version_info < (3, 5):
     print("Synapse requires Python 3.5 or above.")
     sys.exit(1)
 
+# Twisted and canonicaljson will fail to import when this file is executed to
+# get the __version__ during a fresh install. That's OK and subsequent calls to
+# actually start Synapse will import these libraries fine.
 try:
     from twisted.internet import protocol
     from twisted.internet.protocol import Factory

--- a/synapse/__init__.py
+++ b/synapse/__init__.py
@@ -21,8 +21,6 @@ import json
 import os
 import sys
 
-from canonicaljson import set_json_library
-
 # Check that we're not running on an unsupported Python version.
 if sys.version_info < (3, 5):
     print("Synapse requires Python 3.5 or above.")
@@ -40,7 +38,12 @@ except ImportError:
     pass
 
 # Use the standard library json implementation instead of simplejson.
-set_json_library(json)
+try:
+    from canonicaljson import set_json_library
+
+    set_json_library(json)
+except ImportError:
+    pass
 
 __version__ = "1.18.0rc1"
 

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -43,7 +43,8 @@ REQUIREMENTS = [
     "jsonschema>=2.5.1",
     "frozendict>=1",
     "unpaddedbase64>=1.1.0",
-    "canonicaljson>=1.1.3",
+    # TODO This will require canonicaljson >= 1.2.0.
+    "canonicaljson@https://github.com/matrix-org/python-canonicaljson/archive/clokep/chooseable-json.zip",
     # we use the type definitions added in signedjson 1.1.
     "signedjson>=1.1.0",
     "pynacl>=1.2.1",

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -43,8 +43,7 @@ REQUIREMENTS = [
     "jsonschema>=2.5.1",
     "frozendict>=1",
     "unpaddedbase64>=1.1.0",
-    # TODO This will require canonicaljson >= 1.2.0.
-    "canonicaljson@https://github.com/matrix-org/python-canonicaljson/archive/clokep/chooseable-json.zip",
+    "canonicaljson>=1.2.0",
     # we use the type definitions added in signedjson 1.1.
     "signedjson>=1.1.0",
     "pynacl>=1.2.1",


### PR DESCRIPTION
* Updates canonicaljson minimum version to 1.2.0 ~~(currently to a branch, but we'll need to make this a release)~~.
* Calls the new API from canonicaljson to specify using the standard library JSON library (instead of simplejson).

Fixes #7674 