### PR TITLE
Convert presence handler helpers to async/await.

### DIFF
--- a/changelog.d/7939.misc
+++ b/changelog.d/7939.misc
@@ -1,0 +1,1 @@
+Convert presence handler helpers to async/await.

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -453,7 +453,9 @@ class FederationSender(object):
         """Given a list of states populate self.pending_presence_by_dest and
         poke to send a new transaction to each destination
         """
-        hosts_and_states = yield get_interested_remotes(self.store, states, self.state)
+        hosts_and_states = yield defer.ensureDeferred(
+            get_interested_remotes(self.store, states, self.state)
+        )
 
         for destinations, states in hosts_and_states:
             for destination in destinations:

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -1300,7 +1300,7 @@ async def get_interested_parties(
         states
 
     Returns:
-        2-tuple: `(room_ids_to_states, users_to_states)`,
+        A 2-tuple of `(room_ids_to_states, users_to_states)`,
         with each item being a dict of `entity_name` -> `[UserPresenceState]`
     """
     room_ids_to_states = {}  # type: Dict[str, List[UserPresenceState]]

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -37,6 +37,8 @@ from synapse.logging.context import run_in_background
 from synapse.logging.utils import log_function
 from synapse.metrics import LaterGauge
 from synapse.metrics.background_process_metrics import run_as_background_process
+from synapse.state import StateHandler
+from synapse.storage.data_stores.main import DataStore
 from synapse.storage.presence import UserPresenceState
 from synapse.types import JsonDict, UserID, get_domain_from_id
 from synapse.util.async_helpers import Linearizer
@@ -1313,19 +1315,22 @@ async def get_interested_parties(
     return room_ids_to_states, users_to_states
 
 
-async def get_interested_remotes(store, states, state_handler):
+async def get_interested_remotes(
+    store: DataStore, states: List[UserPresenceState], state_handler: StateHandler
+) -> List[Tuple[List[str], List[UserPresenceState]]]:
     """Given a list of presence states figure out which remote servers
     should be sent which.
 
     All the presence states should be for local users only.
 
     Args:
-        store (DataStore)
-        states (list(UserPresenceState))
+        store
+        states
+        state_handler
 
     Returns:
-        A list of ([destinations], [UserPresenceState]), where for
-        each row the list of UserPresenceState should be sent to each
+        A list of 2-tuples of destinations and states, where for
+        each tuple the list of UserPresenceState should be sent to each
         destination
     """
     hosts_and_states = []

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -1290,12 +1290,13 @@ def handle_update(prev_state, new_state, is_mine, wheel_timer, now):
 
 
 async def get_interested_parties(
-    store, states: List[UserPresenceState]
+    store: DataStore, states: List[UserPresenceState]
 ) -> Tuple[Dict[str, List[UserPresenceState]], Dict[str, List[UserPresenceState]]]:
     """Given a list of states return which entities (rooms, users)
     are interested in the given states.
 
     Args:
+        store
         states
 
     Returns:

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -893,16 +893,9 @@ class PresenceHandler(BasePresenceHandler):
 
             await self._on_user_joined_room(room_id, state_key)
 
-    async def _on_user_joined_room(self, room_id, user_id):
+    async def _on_user_joined_room(self, room_id: str, user_id: str) -> None:
         """Called when we detect a user joining the room via the current state
         delta stream.
-
-        Args:
-            room_id (str)
-            user_id (str)
-
-        Returns:
-            Deferred
         """
 
         if self.is_mine_id(user_id):


### PR DESCRIPTION
Converts a couple of helpers to async/await and adds type info.

Not sure why I skipped this initially, but it was straightforward now (probably was a cross-dependency between modules or something).