### PR TITLE
Remove hacky error handling for inlineDeferreds.

### DIFF
--- a/changelog.d/7950.misc
+++ b/changelog.d/7950.misc
@@ -1,0 +1,1 @@
+Simplify error handling in federation handler.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1887,9 +1887,6 @@ class FederationHandler(BaseHandler):
             origin, event, state=state, auth_events=auth_events, backfilled=backfilled
         )
 
-        # reraise does not allow inlineCallbacks to preserve the stacktrace, so we
-        # hack around with a try/finally instead.
-        success = False
         try:
             if (
                 not event.internal_metadata.is_outlier()
@@ -1903,12 +1900,10 @@ class FederationHandler(BaseHandler):
             await self.persist_events_and_notify(
                 [(event, context)], backfilled=backfilled
             )
-            success = True
-        finally:
-            if not success:
-                run_in_background(
-                    self.store.remove_push_actions_from_staging, event.event_id
-                )
+        except Exception:
+            run_in_background(
+                self.store.remove_push_actions_from_staging, event.event_id
+            )
 
         return context
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1904,6 +1904,7 @@ class FederationHandler(BaseHandler):
             run_in_background(
                 self.store.remove_push_actions_from_staging, event.event_id
             )
+            raise
 
         return context
 

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -872,7 +872,6 @@ class EventCreationHandler(object):
                 )
                 stream_id = result["stream_id"]
                 event.internal_metadata.stream_ordering = stream_id
-                success = True
                 return stream_id
 
             stream_id = await self.persist_and_notify_client_event(

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -885,6 +885,7 @@ class EventCreationHandler(object):
             run_in_background(
                 self.store.remove_push_actions_from_staging, event.event_id
             )
+            raise
 
     async def _validate_canonical_alias(
         self, directory_handler, room_alias_str: str, expected_room_id: str


### PR DESCRIPTION
This cleans-up some code I had ignored when converting the federation handler to async/await. I think it isn't necessary once this code got converted, but I'm not really sure. It was added in #3989 by @richvdh so I'm hoping he can confirm this shouldn't be necessary anymore!