### PR TITLE
Fix error reporting when using `opentracing.trace`

### DIFF
--- a/changelog.d/7961.bugfix
+++ b/changelog.d/7961.bugfix
@@ -1,0 +1,1 @@
+Fix sometimes returning 500 instead of the actual error response when using opentracing.

--- a/changelog.d/7961.bugfix
+++ b/changelog.d/7961.bugfix
@@ -1,1 +1,1 @@
-Fix sometimes returning 500 instead of the actual error response when using opentracing.
+Fix a long standing bug where the tracing of async functions with opentracing was broken.

--- a/synapse/logging/scopecontextmanager.py
+++ b/synapse/logging/scopecontextmanager.py
@@ -116,6 +116,8 @@ class _LogContextScope(Scope):
         if self._enter_logcontext:
             self.logcontext.__enter__()
 
+        return self
+
     def __exit__(self, type, value, traceback):
         if type == twisted.internet.defer._DefGen_Return:
             super(_LogContextScope, self).__exit__(None, None, None)


### PR DESCRIPTION
In particular `start_active_span` returns a scope, which is meant to be a context manager that returns itself, but it didn't. This fixes that.

We also clean some other stuff up, we don't actually need to set `error=True` tag manually, that happens for us, and there is no point having the if opentracing guard there given we both have it up a layer and `start_active_span` returns a null context manager anyway.

Broke in #7872 

Stack trace:

```
AttributeError: 'NoneType' object has no attribute 'span'
  File "synapse/http/server.py", line 228, in _async_render_wrapper
    callback_return = await self._async_render(request)
  File "synapse/http/server.py", line 399, in _async_render
    callback_return = await raw_callback_return
  File "synapse/rest/client/v2_alpha/room_keys.py", line 134, in on_PUT
    ret = await self.e2e_room_keys_handler.upload_room_keys(user_id, version, body)
  File "synapse/logging/opentracing.py", line 747, in _trace_inner
    scope.span.set_tag(tags.ERROR, True)
```