### PR TITLE
Add script for finding files with unix line terminators

### DIFF
--- a/changelog.d/7965.misc
+++ b/changelog.d/7965.misc
@@ -1,0 +1,1 @@
+Add a script to detect source code files using non-unix line terminators.

--- a/scripts-dev/check_line_terminators.sh
+++ b/scripts-dev/check_line_terminators.sh
@@ -24,4 +24,4 @@
 # The script will emit exit code 1 if any files that do not use unix line
 # terminators are found, 0 otherwise.
 
-find . -path './.git/*' -prune -o -type f -print0 | xargs -0 grep -l $'\r$' && ( echo 'found files with CRLF line endings'; exit 1 )
+find . -path './.git/*' -prune -o -type f -print0 | xargs -0 grep -I -l $'\r$' && ( echo 'found files with CRLF line endings'; exit 1 )

--- a/scripts-dev/check_line_terminators.sh
+++ b/scripts-dev/check_line_terminators.sh
@@ -24,4 +24,8 @@
 # The script will emit exit code 1 if any files that do not use unix line
 # terminators are found, 0 otherwise.
 
+# cd to the root of the repository
+cd `dirname $0`/..
+
+# Find and print files with non-unix line terminators
 find . -path './.git/*' -prune -o -type f -print0 | xargs -0 grep -I -l $'\r$' && ( echo 'found files with CRLF line endings'; exit 1 )

--- a/scripts-dev/check_line_terminators.sh
+++ b/scripts-dev/check_line_terminators.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script checks that line terminators in all repository files (excluding
+# those in the .git directory) feature unix line terminators.
+#
+# Usage:
+#
+# ./check_line_terminators.sh
+#
+# The script will emit exit code 1 if any files that do not use unix line
+# terminators are found, 0 otherwise.
+
+find . -path './.git/*' -prune -o -type f -print0 | xargs -0 grep -l $'\r$' && ( echo 'found files with CRLF line endings'; exit 1 )


### PR DESCRIPTION
This PRs adds a script to check for unix-line terminators in the repo. It will be used to address https://github.com/matrix-org/synapse/issues/7943 by adding the check to CI.

I've changed the original script slightly as proposed in https://github.com/matrix-org/pipelines/pull/81#discussion_r460580664 by:

- changing `{`, `}` braces to `(`, `)` as the former did not seem to be correct syntax(?)
- noted `#!/bin/bash` (as opposed to `#!/bin/sh`) at the top of the file as `$'...'` [is not POSIX compliant](https://github.com/koalaman/shellcheck/wiki/SC2039#c-style-escapes)

Edit:

- Added `-I` to the `grep` invocation to ignore binary files which often had `\r` in them.

Unfortunately, upon running this script, `grep` seems to consider `*.pyc` files as having unix terminators as they contain `\r` (they're binary files). This won't matter so much in CI as `*.pyc` files are unlikely to exist, but it may still be nice to filter those somehow.

cc @richvdh 