### PR TITLE
Typing worker needs to handle stream update requests

### DIFF
--- a/changelog.d/7967.bugfix
+++ b/changelog.d/7967.bugfix
@@ -1,0 +1,1 @@
+Add experimental support for moving typing off master.

--- a/changelog.d/7967.bugfix
+++ b/changelog.d/7967.bugfix
@@ -1,1 +1,1 @@
-Add experimental support for moving typing off master.
+Fix experimental support for moving typing off master when worker is restarted, which is broken in v1.18.0-rc1.

--- a/synapse/replication/http/__init__.py
+++ b/synapse/replication/http/__init__.py
@@ -39,10 +39,10 @@ class ReplicationRestResource(JsonResource):
         federation.register_servlets(hs, self)
         presence.register_servlets(hs, self)
         membership.register_servlets(hs, self)
+        streams.register_servlets(hs, self)
 
         # The following can't currently be instantiated on workers.
         if hs.config.worker.worker_app is None:
             login.register_servlets(hs, self)
             register.register_servlets(hs, self)
             devices.register_servlets(hs, self)
-            streams.register_servlets(hs, self)


### PR DESCRIPTION
IIRC this doesn't break tests because its only hit on reconnection, or something.

Basically, when a process needs to fetch missing updates for the `typing` stream it needs to query the writer instance via HTTP (as we don't write typing notifications to the DB), the problem was that the endpoint (`streams`) was only registered on master and specifically not on the typing writer worker. 