### PR TITLE
Fix exit code for `check_line_terminators.sh`

### DIFF
--- a/changelog.d/7970.misc
+++ b/changelog.d/7970.misc
@@ -1,0 +1,1 @@
+Add a script to detect source code files using non-unix line terminators.

--- a/scripts-dev/check_line_terminators.sh
+++ b/scripts-dev/check_line_terminators.sh
@@ -28,4 +28,7 @@
 cd `dirname $0`/..
 
 # Find and print files with non-unix line terminators
-find . -path './.git/*' -prune -o -type f -print0 | xargs -0 grep -I -l $'\r$' && ( echo 'found files with CRLF line endings'; exit 1 )
+if find . -path './.git/*' -prune -o -type f -print0 | xargs -0 grep -I -l $'\r$'; then
+    echo -e '\e[31mERROR: found files with CRLF line endings. See above.\e[39m'
+    exit 1
+fi


### PR DESCRIPTION
If there are *no* files with CRLF line endings, then the xargs exits with a
non-zero exit code (as expected), but then, since that is the last thing to
happen in the script, the script as a whole exits non-zero, making the whole
thing fail.

using `if/then/fi` instead of `&& (...)` means that the script exits with a
zero exit code.