### PR TITLE
Add additional logging for SAML sessions.

### DIFF
--- a/changelog.d/7971.misc
+++ b/changelog.d/7971.misc
@@ -1,0 +1,1 @@
+Log the SAML session ID during creation.

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -96,6 +96,9 @@ class SamlHandler:
             relay_state=client_redirect_url
         )
 
+        # Since SAML sessions timeout it is useful to log when they were created.
+        logger.info("Initiating a new SAML session: %s" % (reqid,))
+
         now = self._clock.time_msec()
         self._outstanding_requests_dict[reqid] = Saml2SessionData(
             creation_time=now, ui_auth_session_id=ui_auth_session_id,


### PR DESCRIPTION
This adds a log line which simply states when the SAML session was created. I think this will allow us to more concretely see why sessions are "unsolicited" in #7056. I think by comparing the times from this line to the unsolicited one we can hopefully determine:

* Is this a really old session someone is coming back to?
* Have we never seen this ID before?
* If it still seems valid, was there a restart? A different working? Something else?