### PR TITLE
Remove from the event_relations table when purging historical events.

### DIFF
--- a/changelog.d/7978.bugfix
+++ b/changelog.d/7978.bugfix
@@ -1,1 +1,1 @@
-Fix 'Duplicate key value violates unique constraint "event_relations_id"' when message retention is configured.
+Fix a long standing bug: 'Duplicate key value violates unique constraint "event_relations_id"' when message retention is configured.

--- a/changelog.d/7978.bugfix
+++ b/changelog.d/7978.bugfix
@@ -1,0 +1,1 @@
+Fix 'Duplicate key value violates unique constraint "event_relations_id"' when message retention is configured.

--- a/synapse/storage/data_stores/main/purge_events.py
+++ b/synapse/storage/data_stores/main/purge_events.py
@@ -62,6 +62,7 @@ class PurgeEventsStore(StateGroupWorkerStore, SQLBaseStore):
         #     event_json
         #     event_push_actions
         #     event_reference_hashes
+        #     event_relations
         #     event_search
         #     event_to_state_groups
         #     events
@@ -209,6 +210,7 @@ class PurgeEventsStore(StateGroupWorkerStore, SQLBaseStore):
             "event_edges",
             "event_forward_extremities",
             "event_reference_hashes",
+            "event_relations",
             "event_search",
             "rejections",
         ):


### PR DESCRIPTION
This attempts to fix #7693 by adding the `event_relations` table to the list of table to purge events from in `PurgeEventsStore.purge_history`.

I think this is sane, but not sure how well tested this code-path is.