### PR TITLE
Ensure the msg property of HttpResponseException is a string.

### DIFF
--- a/changelog.d/7979.misc
+++ b/changelog.d/7979.misc
@@ -1,0 +1,1 @@
+Switch to the JSON implementation from the standard library and bump the minimum version of the canonicaljson library to 1.2.0.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -395,7 +395,9 @@ class SimpleHttpClient(object):
         if 200 <= response.code < 300:
             return json.loads(body.decode("utf-8"))
         else:
-            raise HttpResponseException(response.code, response.phrase, body)
+            raise HttpResponseException(
+                response.code, response.phrase.decode("ascii", errors="replace"), body
+            )
 
     @defer.inlineCallbacks
     def post_json_get_json(self, uri, post_json, headers=None):
@@ -436,7 +438,9 @@ class SimpleHttpClient(object):
         if 200 <= response.code < 300:
             return json.loads(body.decode("utf-8"))
         else:
-            raise HttpResponseException(response.code, response.phrase, body)
+            raise HttpResponseException(
+                response.code, response.phrase.decode("ascii", errors="replace"), body
+            )
 
     @defer.inlineCallbacks
     def get_json(self, uri, args={}, headers=None):
@@ -509,7 +513,9 @@ class SimpleHttpClient(object):
         if 200 <= response.code < 300:
             return json.loads(body.decode("utf-8"))
         else:
-            raise HttpResponseException(response.code, response.phrase, body)
+            raise HttpResponseException(
+                response.code, response.phrase.decode("ascii", errors="replace"), body
+            )
 
     @defer.inlineCallbacks
     def get_raw(self, uri, args={}, headers=None):
@@ -544,7 +550,9 @@ class SimpleHttpClient(object):
         if 200 <= response.code < 300:
             return body
         else:
-            raise HttpResponseException(response.code, response.phrase, body)
+            raise HttpResponseException(
+                response.code, response.phrase.decode("ascii", errors="replace"), body
+            )
 
     # XXX: FIXME: This is horribly copy-pasted from matrixfederationclient.
     # The two should be factored out.

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -447,6 +447,7 @@ class MatrixFederationHttpClient(object):
                     ).inc()
 
                     set_tag(tags.HTTP_STATUS_CODE, response.code)
+                    response_phrase = response.phrase.decode("ascii", errors="replace")
 
                     if 200 <= response.code < 300:
                         logger.debug(
@@ -454,7 +455,7 @@ class MatrixFederationHttpClient(object):
                             request.txn_id,
                             request.destination,
                             response.code,
-                            response.phrase.decode("ascii", errors="replace"),
+                            response_phrase,
                         )
                         pass
                     else:
@@ -463,7 +464,7 @@ class MatrixFederationHttpClient(object):
                             request.txn_id,
                             request.destination,
                             response.code,
-                            response.phrase.decode("ascii", errors="replace"),
+                            response_phrase,
                         )
                         # :'(
                         # Update transactions table?
@@ -487,7 +488,7 @@ class MatrixFederationHttpClient(object):
                             )
                             body = None
 
-                        e = HttpResponseException(response.code, response.phrase, body)
+                        e = HttpResponseException(response.code, response_phrase, body)
 
                         # Retry if the error is a 429 (Too Many Requests),
                         # otherwise just raise a standard HttpResponseException


### PR DESCRIPTION
While working on #7674 I had missed that the `phrase` property of a treq responses is bytes, not a string. This gets used to create `HttpResponseException`, which doesn't match what is expected there.

The `phrase` gets set as `HttpResponseException.msg`, which can be JSON serialized when `to_synapse_error` is called and the original error body did not have an `error` property:

https://github.com/matrix-org/synapse/blob/35450519dee869e5641cff94ed35acd3bdaa8a42/synapse/api/errors.py#L601-L602

Reported from @richvdh with the stack:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/synapse/synapse/synapse/http/server.py", line 232, in _async_render_wrapper
    self._send_response(request, code, response)
  File "/usr/lib/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/opt/synapse/synapse/synapse/logging/opentracing.py", line 815, in trace_servlet
    yield
  File "/opt/synapse/synapse/synapse/http/server.py", line 228, in _async_render_wrapper
    callback_return = await self._async_render(request)
  File "/opt/synapse/synapse/synapse/http/server.py", line 254, in _async_render
    callback_return = await raw_callback_return
  File "/opt/synapse/synapse/synapse/rest/media/v1/thumbnail_resource.py", line 70, in _async_render_GET
    request, server_name, media_id, width, height, method, m_type
  File "/opt/synapse/synapse/synapse/rest/media/v1/thumbnail_resource.py", line 246, in _respond_remote_thumbnail
    media_info = await self.media_repo.get_remote_media_info(server_name, media_id)
  File "/opt/synapse/synapse/synapse/rest/media/v1/media_repository.py", line 278, in get_remote_media_info
    server_name, media_id
  File "/usr/lib/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/opt/synapse/synapse/synapse/util/async_helpers.py", line 263, in _ctx_manager
    yield
  File "/opt/synapse/synapse/synapse/rest/media/v1/media_repository.py", line 278, in get_remote_media_info
    server_name, media_id
  File "/opt/synapse/synapse/synapse/rest/media/v1/media_repository.py", line 326, in _get_remote_media_impl
    media_info = await self._download_remote_file(server_name, media_id, file_id)
  File "/opt/synapse/synapse/synapse/rest/media/v1/media_repository.py", line 401, in _download_remote_file
    await finish()
  File "/usr/lib/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/opt/synapse/synapse/synapse/rest/media/v1/media_storage.py", line 128, in store_into_file
    yield f, fname, finish
  File "/opt/synapse/synapse/synapse/rest/media/v1/media_repository.py", line 384, in _download_remote_file
    raise e.to_synapse_error()
synapse.api.errors.ProxiedRequestError: 404: b'Not Found'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/synapse/synapse/synapse/http/site.py", line 162, in processing
    yield
  File "/opt/synapse/synapse/synapse/http/server.py", line 168, in wrapped_async_request_handler
    await h(self, request)
  File "/opt/synapse/synapse/synapse/http/server.py", line 238, in _async_render_wrapper
    self._send_error_response(f, request)
  File "/opt/synapse/synapse/synapse/http/server.py", line 300, in _send_error_response
    return_json_error(f, request)
  File "/opt/synapse/synapse/synapse/http/server.py", line 101, in return_json_error
    pretty_print=_request_user_agent_is_curl(request),
  File "/opt/synapse/synapse/synapse/http/server.py", line 533, in respond_with_json
    json_bytes = encode_canonical_json(json_object)
  File "/opt/synapse/env3/lib/python3.5/site-packages/canonicaljson.py", line 159, in encode_canonical_json
    s = _canonical_encoder.encode(json_object)
  File "/usr/lib/python3.5/json/encoder.py", line 198, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.5/json/encoder.py", line 256, in iterencode
    return _iterencode(o, 0)
  File "/opt/synapse/env3/lib/python3.5/site-packages/canonicaljson.py", line 32, in _default
    obj.__class__.__name__)
TypeError: Object of type bytes is not JSON serializable
```