### PR TITLE
Ensure that remove_pusher is always async

### DIFF
--- a/changelog.d/7981.misc
+++ b/changelog.d/7981.misc
@@ -1,0 +1,1 @@
+Convert various parts of the codebase to async/await.

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -628,7 +628,7 @@ class GenericWorkerServer(HomeServer):
 
         self.get_tcp_replication().start_replication(self)
 
-    def remove_pusher(self, app_id, push_key, user_id):
+    async def remove_pusher(self, app_id, push_key, user_id):
         self.get_tcp_replication().send_remove_pusher(app_id, push_key, user_id)
 
     def build_replication_data_handler(self):

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import inspect
 import logging
 
 from prometheus_client import Counter
@@ -297,11 +296,7 @@ class HttpPusher(object):
                     )
                 else:
                     logger.info("Pushkey %s was rejected: removing", pk)
-                    # remove_pusher might return an awaitable (for the main
-                    # process) or None (for a worker process).
-                    result = self.hs.remove_pusher(self.app_id, pk, self.user_id)
-                    if inspect.isawaitable(result):
-                        await result
+                    await self.hs.remove_pusher(self.app_id, pk, self.user_id)
         return True
 
     async def _build_notification_dict(self, event, tweaks, badge):

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import inspect
 import logging
 
 from prometheus_client import Counter
@@ -296,7 +297,11 @@ class HttpPusher(object):
                     )
                 else:
                     logger.info("Pushkey %s was rejected: removing", pk)
-                    await self.hs.remove_pusher(self.app_id, pk, self.user_id)
+                    # remove_pusher might return an awaitable (for the main
+                    # process) or None (for a worker process).
+                    result = self.hs.remove_pusher(self.app_id, pk, self.user_id)
+                    if inspect.isawaitable(result):
+                        await result
         return True
 
     async def _build_notification_dict(self, event, tweaks, badge):


### PR DESCRIPTION
Ensure that both the main process and worker version of `remove_pusher` is awaitable.

This calls either the [main process version](https://github.com/matrix-org/synapse/blob/f2e38ca86711a8f80cf45d3182e426ed8967fc81/synapse/server.py#L597) or [the worker version](https://github.com/matrix-org/synapse/blob/84d099ae1192af0f38d26f9a32e38bd4c0ad304e/synapse/app/generic_worker.py#L631), which return different things.

Should fix https://sentry.matrix.org/sentry/synapse-matrixorg/issues/119196/