### PR TITLE
Implement handling of HEAD requests

### DIFF
--- a/changelog.d/7999.bugfix
+++ b/changelog.d/7999.bugfix
@@ -1,1 +1,1 @@
-Fix a long standing bug where HEAD requests were not properly rendered.
+Fix a long standing bug where HTTP HEAD requests resulted in a 400 error.

--- a/changelog.d/7999.bugfix
+++ b/changelog.d/7999.bugfix
@@ -1,0 +1,1 @@
+Fix a long standing bug where HEAD requests were not properly rendered.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -579,7 +579,7 @@ def set_cors_headers(request: Request):
     """
     request.setHeader(b"Access-Control-Allow-Origin", b"*")
     request.setHeader(
-        b"Access-Control-Allow-Methods", b"GET, POST, PUT, DELETE, OPTIONS"
+        b"Access-Control-Allow-Methods", b"GET, HEAD, POST, PUT, DELETE, OPTIONS"
     )
     request.setHeader(
         b"Access-Control-Allow-Headers",

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -216,6 +216,14 @@ class _AsyncResource(resource.Resource, metaclass=abc.ABCMeta):
         defer.ensureDeferred(self._async_render_wrapper(request))
         return NOT_DONE_YET
 
+    def _async_render_HEAD(self, request):
+        """
+        The default handling of HEAD method is to treat it as a GET request.
+
+        This is an async version of twisted.web.resource.Resource.render_HEAD.
+        """
+        return self._async_render_GET(request)
+
     @wrap_async_request_handler
     async def _async_render_wrapper(self, request: SynapseRequest):
         """This is a wrapper that delegates to `_async_render` and handles

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -242,12 +242,12 @@ class _AsyncResource(resource.Resource, metaclass=abc.ABCMeta):
         no appropriate method exists. Can be overriden in sub classes for
         different routing.
         """
-        method = request.method.decode("ascii")
         # Treat HEAD requests as GET requests.
-        if method == "HEAD":
-            method = "GET"
+        request_method = request.method.decode("ascii")
+        if request_method == "HEAD":
+            request_method = "GET"
 
-        method_handler = getattr(self, "_async_render_%s" % (method,), None)
+        method_handler = getattr(self, "_async_render_%s" % (request_method,), None)
         if method_handler:
             raw_callback_return = method_handler(request)
 
@@ -364,11 +364,15 @@ class JsonResource(DirectServeJsonResource):
             A tuple of the callback to use, the name of the servlet, and the
             key word arguments to pass to the callback
         """
+        # Treat HEAD requests as GET requests.
         request_path = request.path.decode("ascii")
+        request_method = request.method
+        if request_method == b"HEAD":
+            request_method = b"GET"
 
         # Loop through all the registered callbacks to check if the method
         # and path regex match
-        for path_entry in self.path_regexs.get(request.method, []):
+        for path_entry in self.path_regexs.get(request_method, []):
             m = path_entry.pattern.match(request_path)
             if m:
                 # We found a match!

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -293,7 +293,7 @@ class RestServlet(object):
                         method, patterns, method_handler, servlet_classname
                     )
 
-                    # If there's not HEAD handler, but there is a GET handler,
+                    # If there's no HEAD handler, but there is a GET handler,
                     # register it again.
                     if method == "GET" and not hasattr(self, "on_HEAD"):
                         http_server.register_paths(

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -270,7 +270,6 @@ class RestServlet(object):
     instance methods associated with the corresponding HTTP method:
 
       on_GET
-      on_HEAD
       on_PUT
       on_POST
       on_DELETE
@@ -285,20 +284,13 @@ class RestServlet(object):
         if hasattr(self, "PATTERNS"):
             patterns = self.PATTERNS
 
-            for method in ("GET", "HEAD", "PUT", "POST", "OPTIONS", "DELETE"):
+            for method in ("GET", "PUT", "POST", "OPTIONS", "DELETE"):
                 if hasattr(self, "on_%s" % (method,)):
                     servlet_classname = self.__class__.__name__
                     method_handler = getattr(self, "on_%s" % (method,))
                     http_server.register_paths(
                         method, patterns, method_handler, servlet_classname
                     )
-
-                    # If there's no HEAD handler, but there is a GET handler,
-                    # register it again.
-                    if method == "GET" and not hasattr(self, "on_HEAD"):
-                        http_server.register_paths(
-                            "HEAD", patterns, method_handler, servlet_classname
-                        )
 
         else:
             raise NotImplementedError("RestServlet must register something.")

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -270,6 +270,7 @@ class RestServlet(object):
     instance methods associated with the corresponding HTTP method:
 
       on_GET
+      on_HEAD
       on_PUT
       on_POST
       on_DELETE
@@ -284,13 +285,20 @@ class RestServlet(object):
         if hasattr(self, "PATTERNS"):
             patterns = self.PATTERNS
 
-            for method in ("GET", "PUT", "POST", "OPTIONS", "DELETE"):
+            for method in ("GET", "HEAD", "PUT", "POST", "OPTIONS", "DELETE"):
                 if hasattr(self, "on_%s" % (method,)):
                     servlet_classname = self.__class__.__name__
                     method_handler = getattr(self, "on_%s" % (method,))
                     http_server.register_paths(
                         method, patterns, method_handler, servlet_classname
                     )
+
+                    # If there's not HEAD handler, but there is a GET handler,
+                    # register it again.
+                    if method == "GET" and not hasattr(self, "on_HEAD"):
+                        http_server.register_paths(
+                            "HEAD", patterns, method_handler, servlet_classname
+                        )
 
         else:
             raise NotImplementedError("RestServlet must register something.")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -315,6 +315,7 @@ class WrapHtmlRequestHandlerTests(unittest.TestCase):
 
     def test_head_request(self):
         """A head request should work by being turned into a GET request."""
+
         def callback(request):
             request.write(b"response")
             request.finish()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -312,3 +312,18 @@ class WrapHtmlRequestHandlerTests(unittest.TestCase):
         self.assertEqual(location_headers, [b"/no/over/there"])
         cookies_headers = [v for k, v in headers if k == b"Set-Cookie"]
         self.assertEqual(cookies_headers, [b"session=yespls"])
+
+    def test_head_request(self):
+        """A head request should work by being turned into a GET request."""
+        def callback(request):
+            request.write(b"response")
+            request.finish()
+
+        res = WrapHtmlRequestHandlerTests.TestResource()
+        res.callback = callback
+
+        request, channel = make_request(self.reactor, b"HEAD", b"/path")
+        render(request, res, self.reactor)
+
+        self.assertEqual(channel.result["code"], b"200")
+        self.assertNotIn("body", channel.result)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -157,6 +157,29 @@ class JsonResourceTests(unittest.TestCase):
         self.assertEqual(channel.json_body["error"], "Unrecognized request")
         self.assertEqual(channel.json_body["errcode"], "M_UNRECOGNIZED")
 
+    def test_head_request(self):
+        """
+        JsonResource.handler_for_request gives correctly decoded URL args to
+        the callback, while Twisted will give the raw bytes of URL query
+        arguments.
+        """
+
+        def _callback(request, **kwargs):
+            return 200, {"result": True}
+
+        res = JsonResource(self.homeserver)
+        res.register_paths(
+            "GET", [re.compile("^/_matrix/foo$")], _callback, "test_servlet",
+        )
+
+        # The path was registered as GET, but this is a HEAD request.
+        request, channel = make_request(self.reactor, b"HEAD", b"/_matrix/foo")
+        render(request, res, self.reactor)
+
+        self.assertEqual(channel.result["code"], b"200")
+        self.assertNotIn("body", channel.result)
+        self.assertEqual(channel.headers.getRawHeaders(b"Content-Length"), [b"15"])
+
 
 class OptionsResourceTests(unittest.TestCase):
     def setUp(self):
@@ -255,7 +278,7 @@ class WrapHtmlRequestHandlerTests(unittest.TestCase):
         self.reactor = ThreadedMemoryReactorClock()
 
     def test_good_response(self):
-        def callback(request):
+        async def callback(request):
             request.write(b"response")
             request.finish()
 
@@ -275,7 +298,7 @@ class WrapHtmlRequestHandlerTests(unittest.TestCase):
         with the right location.
         """
 
-        def callback(request, **kwargs):
+        async def callback(request, **kwargs):
             raise RedirectException(b"/look/an/eagle", 301)
 
         res = WrapHtmlRequestHandlerTests.TestResource()
@@ -295,7 +318,7 @@ class WrapHtmlRequestHandlerTests(unittest.TestCase):
         returned too
         """
 
-        def callback(request, **kwargs):
+        async def callback(request, **kwargs):
             e = RedirectException(b"/no/over/there", 304)
             e.cookies.append(b"session=yespls")
             raise e
@@ -316,7 +339,7 @@ class WrapHtmlRequestHandlerTests(unittest.TestCase):
     def test_head_request(self):
         """A head request should work by being turned into a GET request."""
 
-        def callback(request):
+        async def callback(request):
             request.write(b"response")
             request.finish()
 


### PR DESCRIPTION
In order to handle `HEAD` requests properly in our `_AsyncResource` we need to handle it for `DirectServe*Resource` and then also for `JsonResource` separately.

* Adds a default `_async_render_HEAD` method which just calls `_async_render_GET` (this is essentially [Twisted's implementation](https://github.com/twisted/twisted/blob/twisted-20.3.0/src/twisted/web/resource.py#L268-L275), but made async).
* For each servlet: when register `on_GET`, also register `on_HEAD` if there isn't an override for `on_HEAD`.
* Updates the CORS headers to say they supported `HEAD`.

I debated if it made more sense to just convert the `HEAD` method to `GET` in [`JsonResource._get_handler_for_request`](https://github.com/matrix-org/synapse/blob/c4e88397bc477d41d4920b29fde96ea33f39d6f5/synapse/http/server.py#L377), open to suggestions about this! (It could be a smaller memory footprint, but probably a bit less flexible?)

Fixes #6008, fixes #6746, fixes #7994 