### PR TITLE
Remove signature check on v1 identity server lookups

### DIFF
--- a/changelog.d/8001.misc
+++ b/changelog.d/8001.misc
@@ -1,1 +1,1 @@
-Remove the signature check for v1 Identity Service lookup responses as they are effectively useless.
+Remove redundant and unreliable signature check for v1 Identity Service lookup responses.

--- a/changelog.d/8001.misc
+++ b/changelog.d/8001.misc
@@ -1,0 +1,1 @@
+Remove the signature check for v1 Identity Service lookup responses as they are effectively useless.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/5253

We've [decided](https://github.com/matrix-org/synapse/issues/5253#issuecomment-665976308) to remove the signature check for v1 lookups. See the below discussion:

![image](https://user-images.githubusercontent.com/1342360/88961719-4fe00000-d29d-11ea-815d-9dd721d00114.png)

The signature check has been removed in v2 lookups. v1 lookups are currently deprecated. As mentioned in the above linked issue, this verification was causing deployments for the vector.im and matrix.org IS deployments, and this change is the simplest solution, without being unjustified.

Implementations are encouraged to use the v2 lookup API as it has [increased privacy benefits](https://github.com/matrix-org/matrix-doc/pull/2134).