### PR TITLE
Link to the contributing guide if newsfragment check fails

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -138,7 +138,7 @@ commands = /bin/sh -c "isort -c --df --sp setup.cfg synapse tests scripts-dev sc
 skip_install = True
 deps = towncrier>=18.6.0rc1
 commands =
-   python -m towncrier.check --compare-with=origin/develop
+   python -m towncrier.check --compare-with=origin/develop || echo "Please see the contributing guide for help: https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog"
 
 [testenv:check-sampleconfig]
 commands = {toxinidir}/scripts-dev/generate_sample_config --check


### PR DESCRIPTION
There are now multiple cases of community contributors being confused about what to do when the newsfragment check fails:

* https://github.com/matrix-org/synapse/pull/7906#issuecomment-661086316
* https://github.com/matrix-org/synapse/pull/7314#issuecomment-666253337

When `python -m towncrier.check --compare-with=origin/develop` fails, it exits with error code `1`, otherwise exit code `0` when the check succeeds. We use this to `echo` a link to the changelog contributing guide when the check fails, to hopefully allow contributors to be informed and solve the issue themselves.