### PR TITLE
Convert the crypto module to async/await

### DIFF
--- a/changelog.d/8003.misc
+++ b/changelog.d/8003.misc
@@ -1,0 +1,1 @@
+Convert various parts of the codebase to async/await.

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -324,15 +324,12 @@ class Keyring(object):
 
         remaining_requests = {rq for rq in verify_requests if not rq.key_ready.called}
 
-        @defer.inlineCallbacks
-        def do_iterations():
+        async def do_iterations():
             with Measure(self.clock, "get_server_verify_keys"):
                 for f in self._key_fetchers:
                     if not remaining_requests:
                         return
-                    yield defer.ensureDeferred(
-                        self._attempt_key_fetches_with_fetcher(f, remaining_requests)
-                    )
+                    await self._attempt_key_fetches_with_fetcher(f, remaining_requests)
 
                 # look for any requests which weren't satisfied
                 with PreserveLoggingContext():

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -829,22 +829,18 @@ class ServerKeyFetcher(BaseV2KeyFetcher):
         return keys
 
 
-@defer.inlineCallbacks
-def _handle_key_deferred(verify_request):
+async def _handle_key_deferred(verify_request) -> None:
     """Waits for the key to become available, and then performs a verification
 
     Args:
         verify_request (VerifyJsonRequest):
-
-    Returns:
-        Deferred[None]
 
     Raises:
         SynapseError if there was a problem performing the verification
     """
     server_name = verify_request.server_name
     with PreserveLoggingContext():
-        _, key_id, verify_key = yield verify_request.key_ready
+        _, key_id, verify_key = await verify_request.key_ready
 
     json_object = verify_request.json_object
 

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -282,15 +282,14 @@ class Keyring(object):
         except Exception:
             logger.exception("Error starting key lookups")
 
-    @defer.inlineCallbacks
-    def wait_for_previous_lookups(self, server_names):
+    async def wait_for_previous_lookups(self, server_names) -> None:
         """Waits for any previous key lookups for the given servers to finish.
 
         Args:
             server_names (Iterable[str]): list of servers which we want to look up
 
         Returns:
-            Deferred[None]: resolves once all key lookups for the given servers have
+            Resolves once all key lookups for the given servers have
                 completed. Follows the synapse rules of logcontext preservation.
         """
         loop_count = 1
@@ -308,7 +307,7 @@ class Keyring(object):
                 loop_count,
             )
             with PreserveLoggingContext():
-                yield defer.DeferredList((w[1] for w in wait_on))
+                await defer.DeferredList((w[1] for w in wait_on))
 
             loop_count += 1
 

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -330,7 +330,9 @@ class Keyring(object):
                     for f in self._key_fetchers:
                         if not remaining_requests:
                             return
-                        await self._attempt_key_fetches_with_fetcher(f, remaining_requests)
+                        await self._attempt_key_fetches_with_fetcher(
+                            f, remaining_requests
+                        )
 
                     # look for any requests which weren't satisfied
                     with PreserveLoggingContext():

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -223,8 +223,7 @@ class Keyring(object):
 
         return results
 
-    @defer.inlineCallbacks
-    def _start_key_lookups(self, verify_requests):
+    async def _start_key_lookups(self, verify_requests):
         """Sets off the key fetches for each verify request
 
         Once each fetch completes, verify_request.key_ready will be resolved.
@@ -245,7 +244,7 @@ class Keyring(object):
                 server_to_request_ids.setdefault(server_name, set()).add(request_id)
 
             # Wait for any previous lookups to complete before proceeding.
-            yield self.wait_for_previous_lookups(server_to_request_ids.keys())
+            await self.wait_for_previous_lookups(server_to_request_ids.keys())
 
             # take out a lock on each of the servers by sticking a Deferred in
             # key_downloads


### PR DESCRIPTION
This converts `synapse.crypto` to async/await. I was having issues with the tests here, so there's a bunch of commits (like a function each), but the overall changes are reasonable to look at.