### PR TITLE
Stop the parent process flushing the logs on exit

### DIFF
--- a/changelog.d/8011.bugfix
+++ b/changelog.d/8011.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug which caused two copies of some log lines to be written when synctl was used along with a MemoryHandler logger.

--- a/changelog.d/8011.misc
+++ b/changelog.d/8011.misc
@@ -1,1 +1,0 @@
-Replace daemonize library with a local implementation.

--- a/changelog.d/8012.bugfix
+++ b/changelog.d/8012.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug which caused two copies of some log lines to be written when synctl was used along with a MemoryHandler logger.

--- a/synapse/util/daemonize.py
+++ b/synapse/util/daemonize.py
@@ -60,8 +60,14 @@ def daemonize_process(pid_file: str, logger: logging.Logger, chdir: str = "/") -
     process_id = os.fork()
 
     if process_id != 0:
-        # parent process
-        sys.exit(0)
+        # parent process: exit.
+
+        # we use os._exit to avoid running the atexit handlers. In particular, that
+        # means we don't flush the logs. This is important because if we are using
+        # a MemoryHandler, we could have logs buffered which are now buffered in both
+        # the main and the child process, so if we let the main process flush the logs,
+        # we'll get two copies.
+        os._exit(0)
 
     # This is the child process. Continue.
 


### PR DESCRIPTION
This solves the problem that the first few lines are logged twice on matrix.org. Hopefully the comments explain it.

~~Based on #8011.~~