### PR TITLE
Spruce up the check-newsfragment CI output

### DIFF
--- a/changelog.d/8024.misc
+++ b/changelog.d/8024.misc
@@ -1,0 +1,1 @@
+Reduce less useful output in the newsfragment CI step. Add a link to the changelog section of the contributing guide on error.

--- a/scripts-dev/check-newsfragment
+++ b/scripts-dev/check-newsfragment
@@ -16,6 +16,8 @@ pr="$BUILDKITE_PULL_REQUEST"
 if ! git diff --quiet FETCH_HEAD... -- debian; then
     if git diff --quiet FETCH_HEAD... -- debian/changelog; then
         echo "Updates to debian directory, but no update to the changelog." >&2
+        echo "Please see the contributing guide for more information:" >&2
+        echo "https://github.com/matrix-org/synapse/blob/develop/CONTRIBUTING.md#debian-changelog" >&2
         exit 1
     fi
 fi
@@ -26,7 +28,12 @@ if ! git diff --name-only FETCH_HEAD... | grep -qv '^debian/'; then
     exit 0
 fi
 
-tox -qe check-newsfragment
+# Print a link to the contributing guide if the user makes a mistake
+CONTRIBUTING_GUIDE_TEXT="Please see the contributing guide for more information:
+https://github.com/matrix-org/synapse/blob/develop/CONTRIBUTING.md#changelog"
+
+# If check-newsfragment returns a non-zero exit code, print the contributing guide and exit
+tox -qe check-newsfragment || (echo -e "$CONTRIBUTING_GUIDE_TEXT" >&2 && exit 1)
 
 echo
 echo "--------------------------"
@@ -38,6 +45,7 @@ for f in `git diff --name-only FETCH_HEAD... -- changelog.d`; do
     lastchar=`tr -d '\n' < $f | tail -c 1`
     if [ $lastchar != '.' -a $lastchar != '!' ]; then
         echo -e "\e[31mERROR: newsfragment $f does not end with a '.' or '!'\e[39m" >&2
+        echo -e "$CONTRIBUTING_GUIDE_TEXT" >&2
         exit 1
     fi
 
@@ -47,5 +55,6 @@ done
 
 if [[ -n "$pr" && "$matched" -eq 0 ]]; then
     echo -e "\e[31mERROR: Did not find a news fragment with the right number: expected changelog.d/$pr.*.\e[39m" >&2
+    echo -e "$CONTRIBUTING_GUIDE_TEXT" >&2
     exit 1
 fi

--- a/scripts-dev/check-newsfragment
+++ b/scripts-dev/check-newsfragment
@@ -16,7 +16,7 @@ pr="$BUILDKITE_PULL_REQUEST"
 if ! git diff --quiet FETCH_HEAD... -- debian; then
     if git diff --quiet FETCH_HEAD... -- debian/changelog; then
         echo "Updates to debian directory, but no update to the changelog." >&2
-        echo "Please see the contributing guide for more information:" >&2
+        echo "!! Please see the contributing guide for more information:" >&2
         echo "https://github.com/matrix-org/synapse/blob/develop/CONTRIBUTING.md#debian-changelog" >&2
         exit 1
     fi
@@ -29,7 +29,7 @@ if ! git diff --name-only FETCH_HEAD... | grep -qv '^debian/'; then
 fi
 
 # Print a link to the contributing guide if the user makes a mistake
-CONTRIBUTING_GUIDE_TEXT="Please see the contributing guide for more information:
+CONTRIBUTING_GUIDE_TEXT="!! Please see the contributing guide for more information:
 https://github.com/matrix-org/synapse/blob/develop/CONTRIBUTING.md#changelog"
 
 # If check-newsfragment returns a non-zero exit code, print the contributing guide and exit

--- a/scripts-dev/check-newsfragment
+++ b/scripts-dev/check-newsfragment
@@ -3,6 +3,8 @@
 # A script which checks that an appropriate news file has been added on this
 # branch.
 
+echo -e "+++ \033[32mChecking newsfragment\033[m"
+
 set -e
 
 # make sure that origin/develop is up to date

--- a/scripts-dev/check-newsfragment
+++ b/scripts-dev/check-newsfragment
@@ -18,7 +18,7 @@ pr="$BUILDKITE_PULL_REQUEST"
 if ! git diff --quiet FETCH_HEAD... -- debian; then
     if git diff --quiet FETCH_HEAD... -- debian/changelog; then
         echo "Updates to debian directory, but no update to the changelog." >&2
-        echo "!! Please see the contributing guide for more information:" >&2
+        echo "!! Please see the contributing guide for help writing your changelog entry:" >&2
         echo "https://github.com/matrix-org/synapse/blob/develop/CONTRIBUTING.md#debian-changelog" >&2
         exit 1
     fi
@@ -31,7 +31,7 @@ if ! git diff --name-only FETCH_HEAD... | grep -qv '^debian/'; then
 fi
 
 # Print a link to the contributing guide if the user makes a mistake
-CONTRIBUTING_GUIDE_TEXT="!! Please see the contributing guide for more information:
+CONTRIBUTING_GUIDE_TEXT="!! Please see the contributing guide for help writing your changelog entry:
 https://github.com/matrix-org/synapse/blob/develop/CONTRIBUTING.md#changelog"
 
 # If check-newsfragment returns a non-zero exit code, print the contributing guide and exit


### PR DESCRIPTION
This PR:

* Reduces the amount of noise in the `check-newsfragment` CI output by hiding the dependency installation output by default.
* Prints a link to the changelog/debian changelog section of the contributing guide if an error is found.

Previous output:

![image](https://user-images.githubusercontent.com/1342360/89215007-bcba0980-d5bf-11ea-9a07-93bf8c0d11b9.png)

New output:

![image](https://user-images.githubusercontent.com/1342360/89215477-a52f5080-d5c0-11ea-9665-e0738d9e70ad.png)
