### PR TITLE
Remove consensus logic from inbound federation.

### DIFF
--- a/changelog.d/8025.bugfix
+++ b/changelog.d/8025.bugfix
@@ -1,0 +1,1 @@
+Fix bug where state (e.g. power levels) would reset incorrectly when receiving an event from a remote server.


### PR DESCRIPTION
The logic is "designed" to "handle" the case where the servers view of
the state at an event doesn't match what the remote server set as the
auth events. With some hand waving the server would try and come to some
sort of conclusion of which side was correct, involving state
resolution, but this could come up with interesting results.

The entire process is unspecced and buggy, so let's just remove it.

This fixes situations where the server seemingly randomly changed the state of the room, particularly around power levels or join rules.