### PR TITLE
Fix async/await calls for broken media providers.

### DIFF
--- a/changelog.d/8027.misc
+++ b/changelog.d/8027.misc
@@ -1,0 +1,1 @@
+Convert various parts of the codebase to async/await.


### PR DESCRIPTION
We added some code to handle media storage providers which don't follow the interface (e.g. the S3 storage provider) in #7873. Those were necessary until the `StorageProviderWrapper` was converted, as that passed through some return values directly from each storage provider. #7947 converted the `StorageProviderWrapper`, but failed to add the same guards as #7873. This fixes all of the above code:

* The `MediaRepository` code and `MediaStorage` code are corrected to refer to `StorageProviderWrapper`, which always has proper async functions.
* The `StorageProviderWrapper` has guards added to allow underlying backends to not match the interface.

This fixes a regression from #7947, which is not yet released.