### PR TITLE
bug report template: move comments into comment

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -4,11 +4,11 @@ about: Create a report to help us improve
 
 ---
 
+<!--
+
 **THIS IS NOT A SUPPORT CHANNEL!**
 **IF YOU HAVE SUPPORT QUESTIONS ABOUT RUNNING OR CONFIGURING YOUR OWN HOME SERVER**,
 please ask in **#synapse:matrix.org** (using a matrix.org account if necessary)
-
-<!--
 
 If you want to report a security issue, please see https://matrix.org/security-disclosure-policy/
 


### PR DESCRIPTION
apparently it was moved outside the comment in #7379. honestly, if people don't read it inside the comment, I can't see they are going to read it outside either. Meanwhile having it outside the comment means that 50% of our bug reports start with "**THIS IS NOT A SUPPORT CHANNEL!!!!1111!!one**".