### PR TITLE
Add an assertion on prev_events in create_new_client_event

### DIFF
--- a/changelog.d/8041.misc
+++ b/changelog.d/8041.misc
@@ -1,0 +1,1 @@
+Add an assertion on prev_events in create_new_client_event.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -768,6 +768,15 @@ class EventCreationHandler(object):
         else:
             prev_event_ids = await self.store.get_prev_events_for_room(builder.room_id)
 
+        # we now ought to have some prev_events (unless it's a create event).
+        #
+        # do a quick sanity check here, rather than waiting until we've created the
+        # event and then try to auth it (which fails with a somewhat confusing "No
+        # create event in auth events")
+        assert (
+            builder.type == EventTypes.Create or len(prev_event_ids) > 0
+        ), "Attempting to create an event with no prev_events"
+
         event = await builder.build(prev_event_ids=prev_event_ids)
         context = await self.state.compute_event_context(event)
         if requester:

--- a/tests/storage/test_redaction.py
+++ b/tests/storage/test_redaction.py
@@ -251,6 +251,10 @@ class RedactionTestCase(unittest.HomeserverTestCase):
             def room_id(self):
                 return self._base_builder.room_id
 
+            @property
+            def type(self):
+                return self._base_builder.type
+
         event_1, context_1 = self.get_success(
             self.event_creation_handler.create_new_client_event(
                 EventIdManglingBuilder(


### PR DESCRIPTION
I think this would have caught all the cases in
https://github.com/matrix-org/synapse/issues/7642 - and I think a 500 makes
more sense here than a 403.