### PR TITLE
Don't log OPTIONS request at INFO

### DIFF
--- a/changelog.d/8049.misc
+++ b/changelog.d/8049.misc
@@ -1,0 +1,1 @@
+Log `OPTIONS` requests at `DEBUG` rather than `INFO` level to reduce amount logged at `INFO`.

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -319,7 +319,13 @@ class SynapseRequest(Request):
     def _should_log_request(self) -> bool:
         """Whether we should log at INFO that we processed the request.
         """
-        return self.path != b"/health"
+        if self.path == b"/health":
+            return False
+
+        if self.method == b"OPTIONS":
+            return False
+
+        return True
 
 
 class XForwardedForRequest(SynapseRequest):


### PR DESCRIPTION
This is to try and reduce superfluous logs. I'm not 100% sure we should do this.

Based on https://github.com/matrix-org/synapse/pull/8048

