### PR TITLE
Run `remove_push_actions_from_staging` in foreground

### DIFF
--- a/changelog.d/8081.bugfix
+++ b/changelog.d/8081.bugfix
@@ -1,0 +1,1 @@
+Fix `Re-starting finished log context PUT-nnnn` warning when event persistence failed.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -891,9 +891,7 @@ class EventCreationHandler(object):
         except Exception:
             # Ensure that we actually remove the entries in the push actions
             # staging area, if we calculated them.
-            run_in_background(
-                self.store.remove_push_actions_from_staging, event.event_id
-            )
+            await self.store.remove_push_actions_from_staging(event.event_id)
             raise
 
     async def _validate_canonical_alias(


### PR DESCRIPTION
If we got an error persisting an event, we would try to remove the push actions
asynchronously, which would lead to a 'Re-starting finished log context'
warning.

I don't think there's any need for this to be asynchronous.