### PR TITLE
Return the previous stream token if a non-member event is a duplicate.

### DIFF
--- a/changelog.d/8093.bugfix
+++ b/changelog.d/8093.bugfix
@@ -1,0 +1,1 @@
+Return the previous stream token if a non-member event is a duplicate.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -667,14 +667,14 @@ class EventCreationHandler(object):
         assert self.hs.is_mine(user), "User must be our own: %s" % (user,)
 
         if event.is_state():
-            prev_state = await self.deduplicate_state_event(event, context)
-            if prev_state is not None:
+            prev_event = await self.deduplicate_state_event(event, context)
+            if prev_event is not None:
                 logger.info(
                     "Not bothering to persist state event %s duplicated by %s",
                     event.event_id,
-                    prev_state.event_id,
+                    prev_event.event_id,
                 )
-                return prev_state
+                return await self.store.get_stream_token_for_event(prev_event.event_id)
 
         return await self.handle_new_client_event(
             requester=requester, event=event, context=context, ratelimit=ratelimit
@@ -682,27 +682,32 @@ class EventCreationHandler(object):
 
     async def deduplicate_state_event(
         self, event: EventBase, context: EventContext
-    ) -> None:
+    ) -> Optional[EventBase]:
         """
         Checks whether event is in the latest resolved state in context.
 
-        If so, returns the version of the event in context.
-        Otherwise, returns None.
+        Args:
+            event: The event to check for duplication.
+            context: The event context.
+
+        Returns:
+            The previous verion of the event is returned, if it is found in the
+            event context. Otherwise, None is returned.
         """
         prev_state_ids = await context.get_prev_state_ids()
         prev_event_id = prev_state_ids.get((event.type, event.state_key))
         if not prev_event_id:
-            return
+            return None
         prev_event = await self.store.get_event(prev_event_id, allow_none=True)
         if not prev_event:
-            return
+            return None
 
         if prev_event and event.user_id == prev_event.user_id:
             prev_content = encode_canonical_json(prev_event.content)
             next_content = encode_canonical_json(event.content)
             if prev_content == next_content:
                 return prev_event
-        return
+        return None
 
     async def create_and_send_nonmember_event(
         self,


### PR DESCRIPTION
Right now we have some type-hints which are lies. If `send_nonmember_event` is called with a duplicate event, it actually returns an `EventBase` object, not an `int`. This trickles through a bunch of functions (via `create_and_send_nonmember_event`), but I don't think there's an actual bug being caused. I *think* all the callers of this that use the last stream ID end up in `create_room`, which uses it here:

https://github.com/matrix-org/synapse/blob/dc22090a6735b2366f45271178ca7a087560f520/synapse/handlers/room.py#L777-L780

This was spun out of #8071 since it isn't really related there.