### PR TITLE
Remove : from allowed client_secret chars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,13 +4,12 @@ For the next release
 Removal warning
 ---------------
 
-Some older clients added `:` to the `client_secret` parameter of various endpoints, however the
-Client-Server API specification
-[disallows this](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-register-email-requesttoken).
-Adding `:` in a `client_secret` string has been allowed for some time to allow that client to update,
-and we are now removing it, as most users have updated. Further context can be found at [\#6766](https://github.com/matrix-org/synapse/issues/6766).
-
-We are not currently aware of any other clients that send incorrect `client_secret` values.
+Some older clients used a
+[disallowed character](https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-register-email-requesttoken)
+(`:`) in the `client_secret` parameter of various endpoints. The incorrect
+behaviour was allowed for backwards compatibility, but is now being removed
+from Synapse as most users have updated their client. Further context can be
+found at [\#6766](https://github.com/matrix-org/synapse/issues/6766).
 
 
 Synapse 1.19.0 (2020-08-17)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,18 @@
+For the next release
+====================
+
+Removal warning
+---------------
+
+Some older clients added `:` to the `client_secret` parameter of various endpoints, however the
+Client-Server API specification
+[disallows this](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-register-email-requesttoken).
+Adding `:` in a `client_secret` string has been allowed for some time to allow that client to update,
+and we are now removing it, as most users have updated. Further context can be found at https://github.com/matrix-org/synapse/issues/6766.
+
+We are not currently aware of any other clients that send incorrect `client_secret` values.
+
+
 Synapse 1.19.0 (2020-08-17)
 ===========================
 

--- a/changelog.d/8101.bugfix
+++ b/changelog.d/8101.bugfix
@@ -1,0 +1,1 @@
+Synapse now correctly enforces the valid characters in the `client_secret` parameter used in various endpoints.

--- a/changelog.d/8101.removal
+++ b/changelog.d/8101.removal
@@ -1,1 +1,0 @@
-Disallow `:` characters from being included in `client_secret` parameters across all related endpoints. This is a breaking change.

--- a/changelog.d/8101.removal
+++ b/changelog.d/8101.removal
@@ -1,0 +1,1 @@
+Disallow `:` characters from being included in `client_secret` parameters across all related endpoints. This is a breaking change.

--- a/synapse/util/stringutils.py
+++ b/synapse/util/stringutils.py
@@ -24,9 +24,7 @@ from synapse.api.errors import Codes, SynapseError
 _string_with_symbols = string.digits + string.ascii_letters + ".,;:^&*-_+=#~@"
 
 # https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-register-email-requesttoken
-# Note: The : character is allowed here for older clients, but will be removed in a
-# future release. Context: https://github.com/matrix-org/synapse/issues/6766
-client_secret_regex = re.compile(r"^[0-9a-zA-Z\.\=\_\-\:]+$")
+client_secret_regex = re.compile(r"^[0-9a-zA-Z\.\=\_\-]+$")
 
 # random_string and random_string_with_symbols are used for a range of things,
 # some cryptographically important, some less so. We use SystemRandom to make sure

--- a/tests/util/test_stringutils.py
+++ b/tests/util/test_stringutils.py
@@ -28,9 +28,6 @@ class StringUtilsTestCase(unittest.TestCase):
             "_--something==_",
             "...--==-18913",
             "8Dj2odd-e9asd.cd==_--ddas-secret-",
-            # We temporarily allow : characters: https://github.com/matrix-org/synapse/issues/6766
-            # To be removed in a future release
-            "SECRET:1234567890",
         ]
 
         bad = [


### PR DESCRIPTION
Closes: https://github.com/matrix-org/synapse/issues/6766

Equivalent Sydent PR: https://github.com/matrix-org/sydent/pull/309

I believe it's now time to remove the extra allowed `:` from `client_secret` parameters.