### PR TITLE
Add resources.consent conditional dependency back

### DIFF
--- a/changelog.d/8107.feature
+++ b/changelog.d/8107.feature
@@ -1,0 +1,1 @@
+Use the default template file when its equivalent is not found in a custom template directory.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -26,7 +26,6 @@ import yaml
 
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
 from synapse.http.endpoint import parse_and_validate_server_name
-from synapse.python_dependencies import DependencyException, check_requirements
 
 from ._base import Config, ConfigError
 
@@ -507,8 +506,6 @@ class ServerConfig(Config):
                     ),
                 )
             )
-
-        _check_resource_config(self.listeners)
 
         self.cleanup_extremities_with_dummy_events = config.get(
             "cleanup_extremities_with_dummy_events", True
@@ -1133,20 +1130,3 @@ def _warn_if_webclient_configured(listeners: Iterable[ListenerConfig]) -> None:
                 if name == "webclient":
                     logger.warning(NO_MORE_WEB_CLIENT_WARNING)
                     return
-
-
-def _check_resource_config(listeners: Iterable[ListenerConfig]) -> None:
-    resource_names = {
-        res_name
-        for listener in listeners
-        if listener.http_options
-        for res in listener.http_options.resources
-        for res_name in res.names
-    }
-
-    for resource in resource_names:
-        if resource == "consent":
-            try:
-                check_requirements("resources.consent")
-            except DependencyException as e:
-                raise ConfigError(e.message)

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -78,7 +78,6 @@ CONDITIONAL_REQUIREMENTS = {
     "matrix-synapse-ldap3": ["matrix-synapse-ldap3>=0.1"],
     # we use execute_batch, which arrived in psycopg 2.7.
     "postgres": ["psycopg2>=2.7"],
-    "resources.consent": [],
     # ACME support is required to provision TLS certificates from authorities
     # that use the protocol, such as Let's Encrypt.
     "acme": [

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -78,6 +78,7 @@ CONDITIONAL_REQUIREMENTS = {
     "matrix-synapse-ldap3": ["matrix-synapse-ldap3>=0.1"],
     # we use execute_batch, which arrived in psycopg 2.7.
     "postgres": ["psycopg2>=2.7"],
+    "resources.consent": [],
     # ACME support is required to provision TLS certificates from authorities
     # that use the protocol, such as Let's Encrypt.
     "acme": [


### PR DESCRIPTION
This conditional dependency was removed as part of https://github.com/matrix-org/synapse/pull/8037. Turns out that the codebase checks for this removed key explicitly:

https://github.com/matrix-org/synapse/blob/5c43c43240a85ca6b65ad327b6a5b1c9e29bd653/synapse/config/server.py#L1150

This was breaking Element-Web's CI and possibly other things we're unaware of.

~~Rather than remove that check, we're re-adding the option now in case anything else may break.~~ It doesn't seem like there's much else to check. We've opted to remove the check. Hopefully this is the last time it will need to be revisited.