### PR TITLE
Add a link to the matrix-synapse-rest-password-provider.

### DIFF
--- a/changelog.d/8111.doc
+++ b/changelog.d/8111.doc
@@ -1,1 +1,1 @@
-Link to the matrix-synapse-rest-password-provider in the password provider documentation.
+Link to matrix-synapse-rest-password-provider in the password provider documentation.

--- a/changelog.d/8111.doc
+++ b/changelog.d/8111.doc
@@ -1,0 +1,1 @@
+Link to the matrix-synapse-rest-password-provider in the password provider documentation.

--- a/docs/password_auth_providers.md
+++ b/docs/password_auth_providers.md
@@ -14,6 +14,7 @@ password auth provider module implementations:
 
 * [matrix-synapse-ldap3](https://github.com/matrix-org/matrix-synapse-ldap3/)
 * [matrix-synapse-shared-secret-auth](https://github.com/devture/matrix-synapse-shared-secret-auth)
+* [matrix-synapse-rest-password-provider](https://github.com/ma1uta/matrix-synapse-rest-password-provider)
 
 ## Required methods
 


### PR DESCRIPTION
Add a link to matrix-synapse-rest-password-provider. I linked to the ma1uta fork since that seems to be the active fork.