### PR TITLE
Fix the return type of send_nonmember_events.

### DIFF
--- a/changelog.d/8112.misc
+++ b/changelog.d/8112.misc
@@ -1,0 +1,1 @@
+Return the previous stream token if a non-member event is a duplicate.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -674,7 +674,7 @@ class EventCreationHandler(object):
                     event.event_id,
                     prev_event.event_id,
                 )
-                return await self.store.get_stream_token_for_event(prev_event.event_id)
+                return await self.store.get_stream_id_for_event(prev_event.event_id)
 
         return await self.handle_new_client_event(
             requester=requester, event=event, context=context, ratelimit=ratelimit


### PR DESCRIPTION
This is a follow-up to #8093. Once #8074 was merged mypy started failing due to knowing proper return types to `get_stream_token_for_event`.

This moves the innards of `get_stream_token_for_event` to another function to return the `int` stream ID. I'm unsure if this is right or not though...