### PR TITLE
Convert runWithConnection to async.

### DIFF
--- a/changelog.d/8121.misc
+++ b/changelog.d/8121.misc
@@ -1,0 +1,1 @@
+Convert various parts of the codebase to async/await.

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -175,7 +175,7 @@ def run_as_background_process(desc: str, func, *args, **kwargs):
     It returns a Deferred which completes when the function completes, but it doesn't
     follow the synapse logcontext rules, which makes it appropriate for passing to
     clock.looping_call and friends (or for firing-and-forgetting in the middle of a
-    normal synapse inlineCallbacks function).
+    normal synapse async function).
 
     Args:
         desc: a description for this background process type


### PR DESCRIPTION
This is very small, but I don't want it to get caught up with converting `runInteraction` (since that seems like it'll be a large PR).

This does add a `ensureDeferred` which makes me wonder if it is even worth it, but... 🤷 