### PR TITLE
Only expose a single port by default for docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,6 +66,6 @@ COPY ./docker/conf /conf
 
 VOLUME ["/data"]
 
-EXPOSE 8008/tcp 8009/tcp 8448/tcp
+EXPOSE 8448/tcp
 
 ENTRYPOINT ["/start.py"]


### PR DESCRIPTION
### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Exposing three ports by default seems a bit excessive to me so I thought I'd suggest trimming it down to one. They don't technically harm anything but it forces them to show up during status checks and such, which can be annoying when trying to find out what ports are actually in use. I left the HTTPS port since it could be a compromise between none and three, but let me know if this isn't a desirable change.