### PR TITLE
Ensure a group ID is valid before trying to get rooms for it.

### DIFF
--- a/changelog.d/8129.bugfix
+++ b/changelog.d/8129.bugfix
@@ -1,0 +1,1 @@
+Return a proper error code when the rooms of an invalid group are requested.

--- a/synapse/rest/client/v2_alpha/groups.py
+++ b/synapse/rest/client/v2_alpha/groups.py
@@ -16,6 +16,7 @@
 
 import logging
 
+from synapse.api.errors import SynapseError
 from synapse.http.servlet import RestServlet, parse_json_object_from_request
 from synapse.types import GroupID
 
@@ -324,6 +325,9 @@ class GroupRoomServlet(RestServlet):
     async def on_GET(self, request, group_id):
         requester = await self.auth.get_user_by_req(request, allow_guest=True)
         requester_user_id = requester.user.to_string()
+
+        if not GroupID.is_valid(group_id):
+            raise SynapseError(400, "%s was not legal group ID" % (group_id,))
 
         result = await self.groups_handler.get_rooms_in_group(
             group_id, requester_user_id


### PR DESCRIPTION
This should fix a Sentry issue which looked very easy to fix: https://sentry.matrix.org/sentry/synapse-matrixorg/issues/116599/

These requests are being made somewhat regularly, although I'm not sure why.