### PR TITLE
Update the test federation client to handle streaming responses

### DIFF
--- a/changelog.d/8130.misc
+++ b/changelog.d/8130.misc
@@ -1,0 +1,1 @@
+Update the test federation client to handle streaming responses.


### PR DESCRIPTION
Now that the server supports streaming back JSON responses, it would be nice to
show the response as it is streamed, in the test tool.