### PR TITLE
Improve the error code when trying to register with a name reserved for guests.

### DIFF
--- a/changelog.d/8135.bugfix
+++ b/changelog.d/8135.bugfix
@@ -1,0 +1,1 @@
+Clarify the error code if a user tries to register with a numeric ID. This bug was introduced in v1.15.0.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -124,7 +124,9 @@ class RegistrationHandler(BaseHandler):
             try:
                 int(localpart)
                 raise SynapseError(
-                    400, "Numeric user IDs are reserved for guest users."
+                    400,
+                    "Numeric user IDs are reserved for guest users.",
+                    errcode=Codes.INVALID_USERNAME,
                 )
             except ValueError:
                 pass


### PR DESCRIPTION
Fixes #8125

This will help clients show a better error message to users.