### PR TITLE
Fix flaky shadow ban tests -- do not add a delay in tests.

### DIFF
--- a/changelog.d/8152.feature
+++ b/changelog.d/8152.feature
@@ -1,0 +1,1 @@
+Add support for shadow-banning users (ignoring any message send requests).

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -21,7 +21,7 @@
 import json
 from urllib import parse as urlparse
 
-from mock import Mock
+from mock import Mock, patch
 
 import synapse.rest.admin
 from synapse.api.constants import EventContentFields, EventTypes, Membership
@@ -1976,6 +1976,8 @@ class RoomCanonicalAliasTestCase(unittest.HomeserverTestCase):
         self._set_canonical_alias({"alt_aliases": ["@unknown:test"]}, expected_code=400)
 
 
+# To avoid the tests timing out don't add a delay to "annoy the requester".
+@patch("random.randint", new=lambda a, b: 0)
 class ShadowBannedTestCase(unittest.HomeserverTestCase):
     servlets = [
         synapse.rest.admin.register_servlets_for_client_rest_resource,


### PR DESCRIPTION
This avoids adding a delay to the request-response cycle during tests.

I tested this by modifying [a sleep call](https://github.com/matrix-org/synapse/blob/cbbf9126cbd2ace90c1c0f615b87bcec30fdcbd8/synapse/handlers/room_member.py#L317) to use `random.randint(10, 10)` (instead of a number randomly between 1 and 10). This caused the test to always fail. With this change the test will pass.

Fixes #8150