### PR TITLE
Do not allow send_nonmember_event to be called with shadow-banned users.

### DIFF
--- a/changelog.d/8158.feature
+++ b/changelog.d/8158.feature
@@ -1,0 +1,1 @@
+ Add support for shadow-banning users (ignoring any message send requests).

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -653,10 +653,12 @@ class EventCreationHandler(object):
         Persists and notifies local clients and federation of an event.
 
         Args:
-            requester
-            event the event to send.
-            context: the context of the event.
+            requester: The requester sending the event.
+            event: The event to send.
+            context: The context of the event.
             ratelimit: Whether to rate limit this send.
+            ignore_shadow_ban: True if shadow-banned users should be allowed to
+                send this event.
 
         Return:
             The stream_id of the persisted event.
@@ -733,6 +735,14 @@ class EventCreationHandler(object):
         Creates an event, then sends it.
 
         See self.create_event and self.send_nonmember_event.
+
+        Args:
+            requester: The requester sending the event.
+            event_dict: An entire event.
+            ratelimit: Whether to rate limit this send.
+            txn_id: The transaction ID.
+            ignore_shadow_ban: True if shadow-banned users should be allowed to
+                send this event.
 
         Raises:
             ShadowBanError if the requester has been shadow-banned.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -759,7 +759,11 @@ class EventCreationHandler(object):
                 raise SynapseError(403, spam_error, Codes.FORBIDDEN)
 
             stream_id = await self.send_nonmember_event(
-                requester, event, context, ratelimit=ratelimit
+                requester,
+                event,
+                context,
+                ratelimit=ratelimit,
+                ignore_shadow_ban=ignore_shadow_ban,
             )
         return event, stream_id
 


### PR DESCRIPTION
This is very similar to #8142, but for `send_nonmember_event` (instead of `create_and_send_nonmember_event`). This has very few callers:

* Used when upgrading rooms (this was handled in #8142).
* Used to send dummy events.
* Used in `create_and_send_nonmember_event` but that will already have raised an exception. 😄 

All-in-all this doesn't offer much more protection with our current APIs, but means that we internally treat `create_and_send_nonmember_event` and `send_nonmember_event` the same and guards against a future misuse of `send_nonmember_event`.