### PR TITLE
Remove remaining is_guest argument uses from get_room_data calls

### DIFF
--- a/changelog.d/8181.misc
+++ b/changelog.d/8181.misc
@@ -1,0 +1,1 @@
+Remove unused `is_guest` parameter from, and add safeguard to, `MessageHandler.get_room_data`.

--- a/tests/rest/client/test_shadow_banned.py
+++ b/tests/rest/client/test_shadow_banned.py
@@ -264,7 +264,6 @@ class ProfileTestCase(_ShadowBannedBase):
                 room_id,
                 "m.room.member",
                 self.banned_user_id,
-                False,
             )
         )
         self.assertEqual(

--- a/tests/rest/client/test_shadow_banned.py
+++ b/tests/rest/client/test_shadow_banned.py
@@ -223,11 +223,7 @@ class ProfileTestCase(_ShadowBannedBase):
         message_handler = self.hs.get_message_handler()
         event = self.get_success(
             message_handler.get_room_data(
-                self.banned_user_id,
-                room_id,
-                "m.room.member",
-                self.banned_user_id,
-                False,
+                self.banned_user_id, room_id, "m.room.member", self.banned_user_id,
             )
         )
         self.assertEqual(

--- a/tests/rest/client/test_shadow_banned.py
+++ b/tests/rest/client/test_shadow_banned.py
@@ -260,10 +260,7 @@ class ProfileTestCase(_ShadowBannedBase):
         message_handler = self.hs.get_message_handler()
         event = self.get_success(
             message_handler.get_room_data(
-                self.banned_user_id,
-                room_id,
-                "m.room.member",
-                self.banned_user_id,
+                self.banned_user_id, room_id, "m.room.member", self.banned_user_id,
             )
         )
         self.assertEqual(


### PR DESCRIPTION
https://github.com/matrix-org/synapse/pull/8174 removed the `is_guest` parameter from `get_room_data`, at the same time that #8157 was merged using it, colliding together to break unit tests on develop.

This PR removes the `is_guest` parameter from the call in the broken test.

Uses the same changelog as #8174.