### PR TITLE
Move and refactor LoginRestServlet helper methods

### DIFF
--- a/changelog.d/8182.misc
+++ b/changelog.d/8182.misc
@@ -1,0 +1,1 @@
+Refactor some of `LoginRestServlet`'s helper methods, and move them to `AuthHandler` for easier reuse.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -100,11 +100,6 @@ def login_id_phone_to_thirdparty(identifier: JsonDict) -> Dict[str, str]:
     Returns:
         An equivalent m.id.thirdparty identifier dict
     """
-    if "type" not in identifier:
-        raise SynapseError(
-            400, "Invalid phone-type identifier", errcode=Codes.MISSING_PARAM
-        )
-
     if "country" not in identifier or (
         # The specification requires a "phone" field, while Synapse used to require a "number"
         # field. Accept both for backwards compatibility.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -52,7 +52,9 @@ from ._base import BaseHandler
 logger = logging.getLogger(__name__)
 
 
-def convert_client_dict_legacy_fields_to_identifier(submission: JsonDict) -> Dict[str, str]:
+def convert_client_dict_legacy_fields_to_identifier(
+    submission: JsonDict,
+) -> Dict[str, str]:
     """
     Convert a legacy-formatted login submission to an identifier dict.
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -43,7 +43,7 @@ from synapse.http.site import SynapseRequest
 from synapse.logging.context import defer_to_thread
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.module_api import ModuleApi
-from synapse.types import Requester, UserID
+from synapse.types import JsonDict, Requester, UserID
 from synapse.util import stringutils as stringutils
 from synapse.util.msisdn import phone_number_to_msisdn
 from synapse.util.threepids import canonicalise_email
@@ -53,9 +53,7 @@ from ._base import BaseHandler
 logger = logging.getLogger(__name__)
 
 
-def convert_client_dict_legacy_fields_to_identifier(
-    submission: Dict[str, Union[str, Dict]]
-):
+def convert_client_dict_legacy_fields_to_identifier(submission: JsonDict):
     """
     Convert a legacy-formatted login submission to an identifier dict.
 
@@ -92,7 +90,7 @@ def convert_client_dict_legacy_fields_to_identifier(
         )
 
 
-def login_id_phone_to_thirdparty(identifier: Dict[str, str]) -> Dict[str, str]:
+def login_id_phone_to_thirdparty(identifier: JsonDict) -> Dict[str, str]:
     """
     Convert a phone login identifier type to a generic threepid identifier.
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -96,7 +96,7 @@ def convert_client_dict_legacy_fields_to_identifier(
         raise SynapseError(400, "Invalid login submission", Codes.INVALID_PARAM)
 
     # Ensure the identifier has a type
-    if "type" not in ["identifier"]:
+    if "type" not in identifier:
         raise SynapseError(
             400, "'identifier' dict has no key 'type'", errcode=Codes.MISSING_PARAM,
         )

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -19,8 +19,8 @@ from typing import Awaitable, Callable, Dict, Optional
 from synapse.api.errors import Codes, LoginError, SynapseError
 from synapse.api.ratelimiting import Ratelimiter
 from synapse.handlers.auth import (
+    convert_client_dict_legacy_fields_to_identifier,
     login_id_thirdparty_from_phone,
-    login_submission_legacy_convert,
 )
 from synapse.http.server import finish_request
 from synapse.http.servlet import (
@@ -153,14 +153,8 @@ class LoginRestServlet(RestServlet):
             login_submission.get("address"),
             login_submission.get("user"),
         )
-        login_submission_legacy_convert(login_submission)
-
-        if "identifier" not in login_submission:
-            raise SynapseError(400, "Missing param: identifier")
-
+        convert_client_dict_legacy_fields_to_identifier(login_submission)
         identifier = login_submission["identifier"]
-        if "type" not in identifier:
-            raise SynapseError(400, "Login identifier has no type")
 
         # convert phone type identifiers to generic threepids
         if identifier["type"] == "m.id.phone":

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -20,7 +20,7 @@ from synapse.api.errors import Codes, LoginError, SynapseError
 from synapse.api.ratelimiting import Ratelimiter
 from synapse.handlers.auth import (
     convert_client_dict_legacy_fields_to_identifier,
-    login_id_thirdparty_from_phone,
+    login_id_phone_to_thirdparty,
 )
 from synapse.http.server import finish_request
 from synapse.http.servlet import (
@@ -158,7 +158,7 @@ class LoginRestServlet(RestServlet):
 
         # convert phone type identifiers to generic threepids
         if identifier["type"] == "m.id.phone":
-            identifier = login_id_thirdparty_from_phone(identifier)
+            identifier = login_id_phone_to_thirdparty(identifier)
 
         # convert threepid identifiers to user IDs
         if identifier["type"] == "m.id.thirdparty":

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -153,8 +153,7 @@ class LoginRestServlet(RestServlet):
             login_submission.get("address"),
             login_submission.get("user"),
         )
-        convert_client_dict_legacy_fields_to_identifier(login_submission)
-        identifier = login_submission["identifier"]
+        identifier = convert_client_dict_legacy_fields_to_identifier(login_submission)
 
         # convert phone type identifiers to generic threepids
         if identifier["type"] == "m.id.phone":

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -18,6 +18,10 @@ from typing import Awaitable, Callable, Dict, Optional
 
 from synapse.api.errors import Codes, LoginError, SynapseError
 from synapse.api.ratelimiting import Ratelimiter
+from synapse.handlers.auth import (
+    login_id_thirdparty_from_phone,
+    login_submission_legacy_convert,
+)
 from synapse.http.server import finish_request
 from synapse.http.servlet import (
     RestServlet,
@@ -28,54 +32,9 @@ from synapse.http.site import SynapseRequest
 from synapse.rest.client.v2_alpha._base import client_patterns
 from synapse.rest.well_known import WellKnownBuilder
 from synapse.types import JsonDict, UserID
-from synapse.util.msisdn import phone_number_to_msisdn
 from synapse.util.threepids import canonicalise_email
 
 logger = logging.getLogger(__name__)
-
-
-def login_submission_legacy_convert(submission):
-    """
-    If the input login submission is an old style object
-    (ie. with top-level user / medium / address) convert it
-    to a typed object.
-    """
-    if "user" in submission:
-        submission["identifier"] = {"type": "m.id.user", "user": submission["user"]}
-        del submission["user"]
-
-    if "medium" in submission and "address" in submission:
-        submission["identifier"] = {
-            "type": "m.id.thirdparty",
-            "medium": submission["medium"],
-            "address": submission["address"],
-        }
-        del submission["medium"]
-        del submission["address"]
-
-
-def login_id_thirdparty_from_phone(identifier):
-    """
-    Convert a phone login identifier type to a generic threepid identifier
-    Args:
-        identifier(dict): Login identifier dict of type 'm.id.phone'
-
-    Returns: Login identifier dict of type 'm.id.threepid'
-    """
-    if "country" not in identifier or (
-        # The specification requires a "phone" field, while Synapse used to require a "number"
-        # field. Accept both for backwards compatibility.
-        "phone" not in identifier
-        and "number" not in identifier
-    ):
-        raise SynapseError(400, "Invalid phone-type identifier")
-
-    # Accept both "phone" and "number" as valid keys in m.id.phone
-    phone_number = identifier.get("phone", identifier["number"])
-
-    msisdn = phone_number_to_msisdn(identifier["country"], phone_number)
-
-    return {"type": "m.id.thirdparty", "medium": "msisdn", "address": msisdn}
 
 
 class LoginRestServlet(RestServlet):


### PR DESCRIPTION
This is split out from https://github.com/matrix-org/synapse/pull/7438, which had gotten rather large.

`LoginRestServlet` has a couple helper methods, `login_submission_legacy_convert` and `login_id_thirdparty_from_phone`. They're primarily used for converting legacy user login submissions to "identifier" dicts ([see spec](https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-login)). Identifying information such as usernames or 3PID information used to be top-level in the login body. They're now supposed to be put inside an [identifier](https://matrix.org/docs/spec/client_server/r0.6.1#identifier-types) parameter instead.

#7438's purpose is to allow using the new identifier parameter during User-Interactive Authentication, which is currently handled in AuthHandler. That's why I've moved these helper methods there. I also moved the refactoring of these method from #7438 as they're relevant.

One debatable point is that @clokep [mentioned](https://github.com/matrix-org/synapse/pull/7438#pullrequestreview-429894980) that conversion of the login submission dictionary could be done at the REST layer, instead of in AuthHandler. This could work. There's 6 endpoints calling `validate_user_via_ui_auth` that I can see. We could do the conversion in each of those, but that sounds like it might duplication code too much to me. Open to feedback on this!

Best reviewed commit-by-commit.