### PR TITLE
simple_search_list_txn should return None, not 0.

### DIFF
--- a/changelog.d/8187.misc
+++ b/changelog.d/8187.misc
@@ -1,0 +1,1 @@
+Add type hints to `synapse.storage.database`.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -28,7 +28,6 @@ from typing import (
     Optional,
     Tuple,
     TypeVar,
-    Union,
     overload,
 )
 
@@ -1655,7 +1654,7 @@ class DatabasePool(object):
         term: Optional[str],
         col: str,
         retcols: Iterable[str],
-    ) -> Union[List[Dict[str, Any]], int]:
+    ) -> Optional[List[Dict[str, Any]]]:
         """Executes a SELECT query on the named table, which may return zero or
         more rows, returning the result as a list of dicts.
 
@@ -1667,14 +1666,14 @@ class DatabasePool(object):
             retcols: the names of the columns to return
 
         Returns:
-            0 if no term is given, otherwise a list of dictionaries.
+            None if no term is given, otherwise a list of dictionaries.
         """
         if term:
             sql = "SELECT %s FROM %s WHERE %s LIKE ?" % (", ".join(retcols), table, col)
             termvalues = ["%%" + term + "%%"]
             txn.execute(sql, termvalues)
         else:
-            return 0
+            return None
 
         return cls.cursor_to_dict(txn)
 


### PR DESCRIPTION
This was noticed in https://github.com/matrix-org/synapse/pull/8127#discussion_r473211386, fixing it separately since it was unrelated.

It looks like there's only a single caller to this:

https://github.com/matrix-org/synapse/blob/30426c7063a7e5567ac21cd10267651ef1935360/synapse/storage/databases/main/__init__.py#L562-L578

Which also gets called from a single spot:

https://github.com/matrix-org/synapse/blob/97962ad17b204be0a88ef0cd3026f11c359fdb4a/synapse/rest/admin/users.py#L596-L616

The comments around that endpoint seems to be lies (and I think that that endpoint is just completely broken?)