### PR TITLE
Ensure that the OIDC remote ID is a string.

### DIFF
--- a/changelog.d/8190.bugfix
+++ b/changelog.d/8190.bugfix
@@ -1,0 +1,1 @@
+Fix logging in via OpenID Connect with a provider that uses integer user IDs.

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -869,8 +869,8 @@ class OidcHandler:
             raise MappingException(
                 "Failed to extract subject from OIDC response: %s" % (e,)
             )
-        # Some OIDC providers use integer IDs, but Synapse expects them to be
-        # strings. Really make sure it is a string.
+        # Some OIDC providers use integer IDs, but Synapse expects external IDs
+        # to be strings.
         remote_user_id = str(remote_user_id)
 
         logger.info(

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -869,6 +869,9 @@ class OidcHandler:
             raise MappingException(
                 "Failed to extract subject from OIDC response: %s" % (e,)
             )
+        # Some OIDC providers use integer IDs, but Synapse expects them to be
+        # strings. Really make sure it is a string.
+        remote_user_id = str(remote_user_id)
 
         logger.info(
             "Looking for existing mapping for user %s:%s",


### PR DESCRIPTION
Some OpenID Connect providers (such [as GitHub](https://docs.github.com/en/rest/reference/users#get-the-authenticated-user)) use integer IDs which get returned via the OAuth flows. This causes an error when we attempt to save the remote ID into the database.

This is worked around by casting the remote ID to a string. I debated whether we should leave this up to the `OidcMappingProvider`, but we'll probably just have to end up explaining to people that you really need to return a string from that. I could be convinced it is up to `OidcMappingProvider` to abide by the specification it is given though.

Fixes #7795