### PR TITLE
Fix `wait_for_stream_position` for multiple waiters.

### DIFF
--- a/changelog.d/8196.misc
+++ b/changelog.d/8196.misc
@@ -1,0 +1,1 @@
+Fix `wait_for_stream_position` to allow multiple waiters on same stream ID.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -66,8 +66,10 @@ REQUIREMENTS = [
     "msgpack>=0.5.2",
     "phonenumbers>=8.2.0",
     "prometheus_client>=0.0.18,<0.9.0",
-    # we use attrs `order` param, which arrived in 19.2.0
-    "attrs>=19.2.0",
+    # we use attr.validators.deep_iterable, which arrived in 19.1.0 (Note:
+    # Fedora 31 only has 19.1, so if we want to upgrade we should wait until 33
+    # is out in November.)
+    "attrs>=19.1.0",
     "netaddr>=0.7.18",
     "Jinja2>=2.9",
     "bleach>=1.4.3",

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -66,8 +66,8 @@ REQUIREMENTS = [
     "msgpack>=0.5.2",
     "phonenumbers>=8.2.0",
     "prometheus_client>=0.0.18,<0.9.0",
-    # we use attr.validators.deep_iterable, which arrived in 19.1.0
-    "attrs>=19.1.0",
+    # we use attrs `order` param, which arrived in 19.2.0
+    "attrs>=19.2.0",
     "netaddr>=0.7.18",
     "Jinja2>=2.9",
     "bleach>=1.4.3",

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -14,11 +14,8 @@
 # limitations under the License.
 """A replication client for use by synapse workers.
 """
-import heapq
 import logging
 from typing import TYPE_CHECKING, Dict, List, Tuple
-
-import attr
 
 from twisted.internet.defer import Deferred
 from twisted.internet.protocol import ReconnectingClientFactory
@@ -111,7 +108,9 @@ class ReplicationDataHandler:
 
         # Map from stream to list of deferreds waiting for the stream to
         # arrive at a particular position. The lists are sorted by stream position.
-        self._streams_to_waiters = {}  # type: Dict[str, List[_WaitForPositionEntry]]
+        self._streams_to_waiters = (
+            {}
+        )  # type: Dict[str, List[Tuple[int, Deferred[None]]]]
 
     async def on_rdata(
         self, stream_name: str, instance_name: str, token: int, rows: list
@@ -169,11 +168,11 @@ class ReplicationDataHandler:
         # `len(list)` works for both cases.
         index_of_first_deferred_not_called = len(waiting_list)
 
-        for idx, entry in enumerate(waiting_list):
-            if entry.position <= token:
+        for idx, (position, deferred) in enumerate(waiting_list):
+            if position <= token:
                 try:
                     with PreserveLoggingContext():
-                        entry.deferred.callback(None)
+                        deferred.callback(None)
                 except Exception:
                     # The deferred has been cancelled or timed out.
                     pass
@@ -221,7 +220,8 @@ class ReplicationDataHandler:
 
         # We insert into the list using heapq as it is more efficient than
         # pushing then resorting each time.
-        heapq.heappush(waiting_list, _WaitForPositionEntry(position, deferred))
+        waiting_list.append((position, deferred))
+        waiting_list.sort(key=lambda t: t[0])
 
         # We measure here to get in flight counts and average waiting time.
         with Measure(self._clock, "repl.wait_for_stream_position"):
@@ -230,15 +230,3 @@ class ReplicationDataHandler:
             logger.info(
                 "Finished waiting for repl stream %r to reach %s", stream_name, position
             )
-
-
-@attr.s(
-    frozen=True, slots=True, order=True,
-)
-class _WaitForPositionEntry:
-    """Entry for type `_streams_to_waiters` that is comparable. A tuple can't
-    be used as `Deferred` is not comparable.
-    """
-
-    position = attr.ib(type=int)
-    deferred = attr.ib(type=Deferred, order=False)

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -218,8 +218,6 @@ class ReplicationDataHandler:
 
         waiting_list = self._streams_to_waiters.setdefault(stream_name, [])
 
-        # We insert into the list using heapq as it is more efficient than
-        # pushing then resorting each time.
         waiting_list.append((position, deferred))
         waiting_list.sort(key=lambda t: t[0])
 


### PR DESCRIPTION
This fixes a bug where having multiple callers waiting on the same stream and position will cause it to try and compare two deferreds, which fails (due to the sorted list having an entry of `Tuple[int, Deferred]`).