### PR TITLE
Convert an errant inlineCallbacks in appservice

### DIFF
--- a/changelog.d/8207.misc
+++ b/changelog.d/8207.misc
@@ -1,0 +1,1 @@
+Convert various parts of the codebase to async/await.


### PR DESCRIPTION
I think I skipped this because of the `ResponseCache` usage, but there's no issue there, so this converts the last remaining `inlineCallback` in the appservice code.