### PR TITLE
Use TLSv1.2 for fake servers in tests

### DIFF
--- a/changelog.d/8208.misc
+++ b/changelog.d/8208.misc
@@ -1,0 +1,1 @@
+Fix tests on distros which disable TLSv1.0.

--- a/changelog.d/8208.misc
+++ b/changelog.d/8208.misc
@@ -1,1 +1,1 @@
-Fix tests on distros which disable TLSv1.0.
+Fix tests on distros which disable TLSv1.0. Contributed by @danc86.

--- a/tests/http/__init__.py
+++ b/tests/http/__init__.py
@@ -145,7 +145,7 @@ class TestServerTLSConnectionFactory(object):
         self._cert_file = create_test_cert_file(sanlist)
 
     def serverConnectionForTLS(self, tlsProtocol):
-        ctx = SSL.Context(SSL.TLSv1_2_METHOD)
+        ctx = SSL.Context(SSL.SSLv23_METHOD)
         ctx.use_certificate_file(self._cert_file)
         ctx.use_privatekey_file(get_test_key_file())
         return Connection(ctx, None)

--- a/tests/http/__init__.py
+++ b/tests/http/__init__.py
@@ -145,7 +145,7 @@ class TestServerTLSConnectionFactory(object):
         self._cert_file = create_test_cert_file(sanlist)
 
     def serverConnectionForTLS(self, tlsProtocol):
-        ctx = SSL.Context(SSL.TLSv1_METHOD)
+        ctx = SSL.Context(SSL.TLSv1_2_METHOD)
         ctx.use_certificate_file(self._cert_file)
         ctx.use_privatekey_file(get_test_key_file())
         return Connection(ctx, None)


### PR DESCRIPTION
Some Linux distros have begun disabling TLSv1.0 and TLSv1.1 by default
for security reasons, for example in Fedora 33 onwards:

https://fedoraproject.org/wiki/Changes/StrongCryptoSettings2

Use TLSv1.2 for the fake TLS servers created in the test suite, to avoid
failures due to OpenSSL disallowing TLSv1.0:

    <twisted.python.failure.Failure OpenSSL.SSL.Error: [('SSL routines',
    'ssl_choose_client_version', 'unsupported protocol')]>

You can reproduce the failures by setting `MinProtocol = TLSv1.2` in the `[crypto_policy]` section of the system-wide OpenSSL config (`/etc/pki/tls/openssl.cnf` on Fedora, maybe elsewhere on other systems).

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
