### PR TITLE
Do not install setuptools 50.0 on Python 3.5

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,7 +73,7 @@ mkdir -p ~/synapse
 virtualenv -p python3 ~/synapse/env
 source ~/synapse/env/bin/activate
 pip install --upgrade pip
-pip install --upgrade setuptools!=50.0
+pip install --upgrade setuptools!=50.0  # setuptools==50.0 fails on some older Python versions
 pip install matrix-synapse
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,7 +73,7 @@ mkdir -p ~/synapse
 virtualenv -p python3 ~/synapse/env
 source ~/synapse/env/bin/activate
 pip install --upgrade pip
-pip install --upgrade setuptools
+pip install --upgrade setuptools!=50.0
 pip install matrix-synapse
 ```
 

--- a/changelog.d/8212.bugfix
+++ b/changelog.d/8212.bugfix
@@ -1,1 +1,1 @@
-Do not install setuptools 50.0 on Python 3.5, which leads to a broken configuration.
+Do not install setuptools 50.0. It can lead to a broken configuration on some older Python versions.

--- a/changelog.d/8212.bugfix
+++ b/changelog.d/8212.bugfix
@@ -1,0 +1,1 @@
+Do not install setuptools 50.0 on Python 3.5, which leads to a broken configuration.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -74,6 +74,9 @@ REQUIREMENTS = [
     "Jinja2>=2.9",
     "bleach>=1.4.3",
     "typing-extensions>=3.7.4",
+    # setuptools is required by a variety of dependencies, unfortunately version
+    # 50.0 is incompatible with Python 3.5, see https://github.com/pypa/setuptools/issues/2352
+    'setuptools!=50.0;python_version<"3.6"',
 ]
 
 CONDITIONAL_REQUIREMENTS = {

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -75,8 +75,9 @@ REQUIREMENTS = [
     "bleach>=1.4.3",
     "typing-extensions>=3.7.4",
     # setuptools is required by a variety of dependencies, unfortunately version
-    # 50.0 is incompatible with Python 3.5, see https://github.com/pypa/setuptools/issues/2352
-    'setuptools!=50.0;python_version<"3.6"',
+    # 50.0 is incompatible with older Python versions, see
+    # https://github.com/pypa/setuptools/issues/2352
+    'setuptools!=50.0',
 ]
 
 CONDITIONAL_REQUIREMENTS = {

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -77,7 +77,7 @@ REQUIREMENTS = [
     # setuptools is required by a variety of dependencies, unfortunately version
     # 50.0 is incompatible with older Python versions, see
     # https://github.com/pypa/setuptools/issues/2352
-    'setuptools!=50.0',
+    "setuptools!=50.0",
 ]
 
 CONDITIONAL_REQUIREMENTS = {


### PR DESCRIPTION
It seems that setuptools 50.0 breaks on Python 3.5, this avoids using that configuration. See pypa/setuptools#2352