### PR TITLE
Convert the main methods run by the reactor to async.

### DIFF
--- a/changelog.d/8213.misc
+++ b/changelog.d/8213.misc
@@ -1,0 +1,1 @@
+Convert various parts of the codebase to async/await.

--- a/synapse/app/admin_cmd.py
+++ b/synapse/app/admin_cmd.py
@@ -79,8 +79,7 @@ class AdminCmdServer(HomeServer):
         pass
 
 
-@defer.inlineCallbacks
-def export_data_command(hs, args):
+async def export_data_command(hs, args):
     """Export data for a user.
 
     Args:
@@ -91,10 +90,8 @@ def export_data_command(hs, args):
     user_id = args.user_id
     directory = args.output_directory
 
-    res = yield defer.ensureDeferred(
-        hs.get_handlers().admin_handler.export_user_data(
-            user_id, FileExfiltrationWriter(user_id, directory=directory)
-        )
+    res = await hs.get_handlers().admin_handler.export_user_data(
+        user_id, FileExfiltrationWriter(user_id, directory=directory)
     )
     print(res)
 
@@ -232,11 +229,10 @@ def start(config_options):
     # We also make sure that `_base.start` gets run before we actually run the
     # command.
 
-    @defer.inlineCallbacks
     def run(_reactor):
         with LoggingContext("command"):
-            yield _base.start(ss, [])
-            yield args.func(ss, args)
+            _base.start(ss, [])
+            return defer.ensureDeferred(args.func(ss, args))
 
     _base.start_worker_reactor(
         "synapse-admin-cmd", config, run_command=lambda: task.react(run)

--- a/synapse/app/admin_cmd.py
+++ b/synapse/app/admin_cmd.py
@@ -233,7 +233,7 @@ def start(config_options):
     def run(_reactor):
         with LoggingContext("command"):
             _base.start(ss, [])
-            yield args.func(ss, args)
+            yield defer.ensureDeferred(args.func(ss, args))
 
     _base.start_worker_reactor(
         "synapse-admin-cmd", config, run_command=lambda: task.react(run)

--- a/synapse/app/admin_cmd.py
+++ b/synapse/app/admin_cmd.py
@@ -229,10 +229,11 @@ def start(config_options):
     # We also make sure that `_base.start` gets run before we actually run the
     # command.
 
+    @defer.inlineCallbacks
     def run(_reactor):
         with LoggingContext("command"):
             _base.start(ss, [])
-            return defer.ensureDeferred(args.func(ss, args))
+            yield args.func(ss, args)
 
     _base.start_worker_reactor(
         "synapse-admin-cmd", config, run_command=lambda: task.react(run)

--- a/synapse/app/admin_cmd.py
+++ b/synapse/app/admin_cmd.py
@@ -229,14 +229,15 @@ def start(config_options):
     # We also make sure that `_base.start` gets run before we actually run the
     # command.
 
-    @defer.inlineCallbacks
-    def run(_reactor):
+    async def run():
         with LoggingContext("command"):
             _base.start(ss, [])
-            yield defer.ensureDeferred(args.func(ss, args))
+            await args.func(ss, args)
 
     _base.start_worker_reactor(
-        "synapse-admin-cmd", config, run_command=lambda: task.react(run)
+        "synapse-admin-cmd",
+        config,
+        run_command=lambda: task.react(lambda _reactor: defer.ensureDeferred(run())),
     )
 
 


### PR DESCRIPTION
There's a couple of spots we "run" the reactor and generally the calls to those need to be Deferreds. This converts the functions that get called to `async` and then uses `ensureDeferred` around the resulting `Awaitable`.