### PR TITLE
Convert Clock.sleep to async.

### DIFF
--- a/changelog.d/8215.misc
+++ b/changelog.d/8215.misc
@@ -1,0 +1,1 @@
+Convert various parts of the codebase to async/await.

--- a/synapse/util/__init__.py
+++ b/synapse/util/__init__.py
@@ -56,12 +56,11 @@ class Clock(object):
 
     _reactor = attr.ib()
 
-    @defer.inlineCallbacks
-    def sleep(self, seconds):
+    async def sleep(self, seconds):
         d = defer.Deferred()
         with context.PreserveLoggingContext():
             self._reactor.callLater(seconds, d.callback, seconds)
-            res = yield d
+            res = await d
         return res
 
     def time(self):

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -314,7 +314,7 @@ class Linearizer(object):
             #
             # (This needs to happen while we hold the lock, and the context manager's exit
             # code must be synchronous, so this is the only sensible place.)
-            return self._clock.sleep(0)
+            return defer.ensureDeferred(self._clock.sleep(0))
 
         def eb(e):
             logger.info("defer %r got err %r", new_defer, e)

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -134,10 +134,6 @@ class KeyringTestCase(unittest.HomeserverTestCase):
 
                 yield make_deferred_yieldable(res_deferreds[0])
 
-                # let verify_json_objects_for_server finish its work before we kill the
-                # logcontext
-                yield self.clock.sleep(0)
-
         d0 = first_lookup()
 
         # wait a tick for it to send the request to the perspectives server
@@ -159,10 +155,6 @@ class KeyringTestCase(unittest.HomeserverTestCase):
                 )
                 res_deferreds_2[0].addBoth(self.check_context, None)
                 yield make_deferred_yieldable(res_deferreds_2[0])
-
-                # let verify_json_objects_for_server finish its work before we kill the
-                # logcontext
-                yield self.clock.sleep(0)
 
         d2 = second_lookup()
 

--- a/tests/rest/client/test_transactions.py
+++ b/tests/rest/client/test_transactions.py
@@ -45,7 +45,7 @@ class HttpTransactionCacheTestCase(unittest.TestCase):
     def test_logcontexts_with_async_result(self):
         @defer.inlineCallbacks
         def cb():
-            yield Clock(reactor).sleep(0)
+            yield defer.ensureDeferred(Clock(reactor).sleep(0))
             return "yay"
 
         @defer.inlineCallbacks

--- a/tests/util/test_linearizer.py
+++ b/tests/util/test_linearizer.py
@@ -86,7 +86,7 @@ class LinearizerTestCase(unittest.TestCase):
                 with (yield linearizer.queue("")):
                     self.assertEqual(current_context(), lc)
                     if sleep:
-                        yield Clock(reactor).sleep(0)
+                        yield defer.ensureDeferred(Clock(reactor).sleep(0))
 
                 self.assertEqual(current_context(), lc)
 


### PR DESCRIPTION
This converts `Clock.sleep` to async.

I removed some sleep calls in the tests without ill effect, but I'm not 100% sure that removing them is OK. (Although if the tests still pass it kind of implies that they were either not necessary or that the tests isn't testing what we hope it is.)