### PR TITLE
Fix errors when updating the user directory with invalid data

### DIFF
--- a/changelog.d/8223.bugfix
+++ b/changelog.d/8223.bugfix
@@ -1,0 +1,1 @@
+Fixes a longstanding bug where user directory updates could break when unexpected profile data was included in events.

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -161,6 +161,9 @@ class BaseProfileHandler(BaseHandler):
                     Codes.FORBIDDEN,
                 )
 
+        if not isinstance(new_displayname, str):
+            raise SynapseError(400, "Invalid displayname")
+
         if len(new_displayname) > MAX_DISPLAYNAME_LEN:
             raise SynapseError(
                 400, "Displayname is too long (max %i)" % (MAX_DISPLAYNAME_LEN,)
@@ -234,6 +237,9 @@ class BaseProfileHandler(BaseHandler):
                 raise SynapseError(
                     400, "Changing avatar is disabled on this server", Codes.FORBIDDEN
                 )
+
+        if not isinstance(new_avatar_url, str):
+            raise SynapseError(400, "Invalid displayname")
 
         if len(new_avatar_url) > MAX_AVATAR_URL_LEN:
             raise SynapseError(

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -203,8 +203,15 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
 
                 # Update each user in the user directory.
                 for user_id, profile in users_with_profile.items():
+                    # If the display name or avatar URL are unexpected types, overwrite them.
+                    display_name, avatar_url = profile
+                    if not isinstance(display_name, str):
+                        display_name = None
+                    if not isinstance(avatar_url, str):
+                        avatar_url = None
+
                     await self.update_profile_in_user_dir(
-                        user_id, profile.display_name, profile.avatar_url
+                        user_id, display_name, avatar_url
                     )
 
                 to_insert = set()

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -203,15 +203,8 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
 
                 # Update each user in the user directory.
                 for user_id, profile in users_with_profile.items():
-                    # If the display name or avatar URL are unexpected types, overwrite them.
-                    display_name, avatar_url = profile
-                    if not isinstance(display_name, str):
-                        display_name = None
-                    if not isinstance(avatar_url, str):
-                        avatar_url = None
-
                     await self.update_profile_in_user_dir(
-                        user_id, display_name, avatar_url
+                        user_id, profile.display_name, profile.avatar_url
                     )
 
                 to_insert = set()
@@ -376,6 +369,11 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         """
         Update or add a user's profile in the user directory.
         """
+        # If the display name or avatar URL are unexpected types, overwrite them.
+        if not isinstance(display_name, str):
+            display_name = None
+        if not isinstance(avatar_url, str):
+            avatar_url = None
 
         def _update_profile_in_user_dir_txn(txn):
             new_entry = self.db_pool.simple_upsert_txn(


### PR DESCRIPTION
* Raise (better) exceptions when setting the (local) display name or avatar URL to a non-string. (This wasn't directly related to #8220, but I noticed it while poking around.)
* If an unexpected profile name / avatar URL is received remotely we either:
    * Do not update it and use the previous one.
    * Replace it with `None`.

This fixes #8220.