### PR TITLE
Add /_synapse/client to the reverse proxy docs

### DIFF
--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -75,6 +75,18 @@ for example:
      wget https://packages.matrix.org/debian/pool/main/m/matrix-synapse-py3/matrix-synapse-py3_1.3.0+stretch1_amd64.deb
      dpkg -i matrix-synapse-py3_1.3.0+stretch1_amd64.deb
 
+Upgrading to v1.20.0
+====================
+
+Forwarding ``/_synapse/client`` through your reverse proxy
+----------------------------------------------------------
+
+The `reverse proxy documentation
+<https://github.com/matrix-org/synapse/blob/develop/docs/reverse_proxy.md>`_ has been updated
+to include reverse proxy directives for ``/_synapse/client/*`` endpoints. As the user password
+reset flow now uses endpoints under this prefix, **you must update your reverse proxy
+configurations for user password reset to work**.
+
 Upgrading to v1.18.0
 ====================
 

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -87,6 +87,12 @@ to include reverse proxy directives for ``/_synapse/client/*`` endpoints. As the
 reset flow now uses endpoints under this prefix, **you must update your reverse proxy
 configurations for user password reset to work**.
 
+Additionally, note that the `Synapse worker documentation
+<https://github.com/matrix-org/synapse/blob/develop/docs/workers.md>`_ has been updated to
+ state that the ``/_synapse/client/password_reset/email/submit_token`` endpoint can be handled
+by all workers. If you make use of Synapse's worker feature, please update your reverse proxy
+configuration to reflect this change.
+
 Upgrading to v1.18.0
 ====================
 

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -75,7 +75,7 @@ for example:
      wget https://packages.matrix.org/debian/pool/main/m/matrix-synapse-py3/matrix-synapse-py3_1.3.0+stretch1_amd64.deb
      dpkg -i matrix-synapse-py3_1.3.0+stretch1_amd64.deb
 
-Upgrading to v1.20.0
+Upgrading to v1.21.0
 ====================
 
 Forwarding ``/_synapse/client`` through your reverse proxy

--- a/changelog.d/8227.doc
+++ b/changelog.d/8227.doc
@@ -1,0 +1,1 @@
+Add `/synapse/client` to the reverse proxy documentation.

--- a/changelog.d/8227.doc
+++ b/changelog.d/8227.doc
@@ -1,1 +1,1 @@
-Add `/synapse/client` to the reverse proxy documentation.
+Add `/_synapse/client` to the reverse proxy documentation.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -25,7 +25,7 @@ for more details of the algorithm used for federation connections, and
 
 Endpoints that are part of the standardised Matrix specification are
 located under `/_matrix`, whereas endpoints specific to Synapse are
-located under `/_synapse`.
+located under `/_synapse/client`.
 
 Let's assume that we expect clients to connect to our server at
 `https://matrix.example.com`, and other servers to connect at
@@ -130,9 +130,9 @@ frontend https
   # Matrix client traffic
   acl matrix-host hdr(host) -i matrix.example.com
   acl matrix-path path_beg /_matrix
-  acl synapse-client-path path_beg /_matrix
+  acl matrix-path path_beg /_synapse/client
 
-  use_backend matrix if matrix-host matrix-path || matrix-host synapse-client-path
+  use_backend matrix if matrix-host matrix-path
 
 frontend matrix-federation
   bind :::8448 v4v6 ssl crt /etc/ssl/haproxy/synapse.pem alpn h2,http/1.1
@@ -163,5 +163,5 @@ Each configured HTTP listener has a `/health` endpoint which always returns
 
 Endpoints for administering your Synapse instance are placed under
 `/_synapse/admin`. These require authentication through an access token of an
-admin user. Nevertheless, it is not advised to expose these ports to the public
-internet.
+admin user. However as access to these endpoints grants the caller a lot of power,
+we do not recommend exposing them to the public internet without good reason.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -217,6 +217,7 @@ expressions:
     ^/_matrix/client/(api/v1|r0|unstable)/joined_groups$
     ^/_matrix/client/(api/v1|r0|unstable)/publicised_groups$
     ^/_matrix/client/(api/v1|r0|unstable)/publicised_groups/
+    ^/_synapse/client/password_reset/email/submit_token$
 
     # Registration/login requests
     ^/_matrix/client/(api/v1|r0|unstable)/login$


### PR DESCRIPTION
Fixes: https://github.com/matrix-org/synapse/issues/8154

This PR adds a information about forwarding `/_synapse/client` endpoints through your reverse proxy. The first of these endpoints are introduced in https://github.com/matrix-org/synapse/pull/8004.

Question: Do we need to update `workers.md` with this endpoint as well?