### PR TITLE
wrap `_get_e2e_device_keys_and_signatures_txn` in a non-txn method

### DIFF
--- a/changelog.d/8231.misc
+++ b/changelog.d/8231.misc
@@ -1,0 +1,1 @@
+Refactor queries for device keys and cross-signatures.

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -255,9 +255,7 @@ class DeviceWorkerStore(SQLBaseStore):
             List of objects representing an device update EDU
         """
         devices = (
-            await self.db_pool.runInteraction(
-                "get_e2e_device_keys_and_signatures_txn",
-                self._get_e2e_device_keys_and_signatures_txn,
+            await self.get_e2e_device_keys_and_signatures(
                 query_map.keys(),
                 include_all_devices=True,
                 include_deleted_devices=True,

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -141,7 +141,7 @@ class EndToEndKeyWorkerStore(SQLBaseStore):
 
             include_all_devices: whether to return devices without device keys
 
-            include_deleted_devices:whether to include null entries for
+            include_deleted_devices: whether to include null entries for
                 devices which no longer exist (but were in the query_list).
                 This option only takes effect if include_all_devices is true.
 

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -60,7 +60,7 @@ class EndToEndKeyWorkerStore(SQLBaseStore):
         """
         now_stream_id = self.get_device_stream_token()
 
-        devices = await self._get_e2e_device_keys_and_signatures([(user_id, None)])
+        devices = await self.get_e2e_device_keys_and_signatures([(user_id, None)])
 
         if devices:
             user_devices = devices[user_id]


### PR DESCRIPTION
We have three things which all call `_get_e2e_device_keys_and_signatures_txn`
with their own `runInteraction`. Factor out the common code.