### PR TITLE
Add an overload for simple_select_one_onecol_txn.

### DIFF
--- a/changelog.d/8235.misc
+++ b/changelog.d/8235.misc
@@ -1,0 +1,1 @@
+Add type hints to `StreamStore`.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1149,6 +1149,30 @@ class DatabasePool(object):
             allow_none=allow_none,
         )
 
+    @overload
+    @classmethod
+    def simple_select_one_onecol_txn(
+        cls,
+        txn: LoggingTransaction,
+        table: str,
+        keyvalues: Dict[str, Any],
+        retcol: Iterable[str],
+        allow_none: Literal[False] = False,
+    ) -> Any:
+        ...
+
+    @overload
+    @classmethod
+    def simple_select_one_onecol_txn(
+        cls,
+        txn: LoggingTransaction,
+        table: str,
+        keyvalues: Dict[str, Any],
+        retcol: Iterable[str],
+        allow_none: Literal[True] = True,
+    ) -> Optional[Any]:
+        ...
+
     @classmethod
     def simple_select_one_onecol_txn(
         cls,


### PR DESCRIPTION
Not sure why, but after #8232 was merged mypy was failing on develop for me:

> synapse/storage/databases/main/stream.py:614: error: Incompatible return value type (got "Optional[Any]", expected "int") [return-value]

