### PR TITLE
Fix a regression from calling read_templates.

### DIFF
--- a/changelog.d/8252.feature
+++ b/changelog.d/8252.feature
@@ -1,0 +1,1 @@
+Use the default template file when its equivalent is not found in a custom template directory.

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -171,7 +171,7 @@ class SAML2Config(Config):
 
         self.saml2_error_html_template = self.read_templates(
             ["saml_error.html"], saml2_config.get("template_dir")
-        )
+        )[0]
 
     def _default_saml_config_dict(
         self, required_attributes: set, optional_attributes: set


### PR DESCRIPTION
After thinking about #8248, I think we should do the quick fix to ensure we don't have a regression, then do the refactoring on top.