### PR TITLE
Fix `MultiWriterIdGenerator.current_position`.

### DIFF
--- a/changelog.d/8257.misc
+++ b/changelog.d/8257.misc
@@ -1,0 +1,1 @@
+Fix non-user visible bug in implementation of `MultiWriterIdGenerator.get_current_token_for_writer`.

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -351,7 +351,7 @@ class MultiWriterIdGenerator:
 
     def _mark_id_as_finished(self, next_id: int):
         """The ID has finished being processed so we should advance the
-        current poistion if possible.
+        current position if possible.
         """
 
         with self._lock:
@@ -369,7 +369,7 @@ class MultiWriterIdGenerator:
                 min_unfinshed = min(self._unfinished_ids)
                 for s in self._finished_ids:
                     if s < min_unfinshed:
-                        if not new_cur or new_cur < s:
+                        if new_cur is None or new_cur < s:
                             new_cur = s
                     else:
                         finished.add(s)


### PR DESCRIPTION
It did not correctly handle IDs finishing being persisted out of order, resulting in the `current_position` lagging until new IDs are persisted.

Currently this is only used for the cache invalidation stream over replication, so this should not have had an observable impact (since we invalidate caches *all* the time). While #7986 had landed this caused flakey sytests (https://github.com/matrix-org/sytest/issues/948) as they wouldn't write anything until the stream position had advanced. 