### PR TITLE
Fix stack overflow when logging system encounters an error

### DIFF
--- a/changelog.d/8268.bugfix
+++ b/changelog.d/8268.bugfix
@@ -1,0 +1,1 @@
+Fix stack overflow when stderr is redirected to the logging system, and the logging system encounters an error.


### PR DESCRIPTION
When stderr is redirected to a logger, it's possible to get into an infinite loop which results in a stack overflow if the logging system encounters an error.

Work around it by detecting the reentrant call and writing to the real stderr instead.

Fixes: #4202, #4240.