### PR TITLE
Fix unread count failing on NULL values

### DIFF
--- a/changelog.d/8270.feature
+++ b/changelog.d/8270.feature
@@ -1,0 +1,1 @@
+Add unread messages count to sync responses, as specified in [MSC2654](https://github.com/matrix-org/matrix-doc/pull/2654).

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -177,7 +177,12 @@ class EventPushActionsWorkerStore(SQLBaseStore):
 
         if row:
             notif_count += row[0]
-            unread_count += row[1]
+
+            if row[1] is not None:
+                # The unread_count column of event_push_summary is NULLable, so we need
+                # to make sure we don't try increasing the unread counts if it's NULL
+                # for this row.
+                unread_count += row[1]
 
         return {
             "notify_count": notif_count,


### PR DESCRIPTION
Fix unread counts making sync fail if the value of the `unread_count`
column in `event_push_summary` is `None`.