### PR TITLE
Catch-up after Federation Outage (split, 4): catch-up loop

### DIFF
--- a/changelog.d/8272.bugfix
+++ b/changelog.d/8272.bugfix
@@ -1,0 +1,1 @@
+Fix messages over federation being lost until an event is sent into the same room.

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -488,6 +488,10 @@ class PerDestinationQueue:
                     "This should not happen." % event_ids
                 )
 
+            if logger.isEnabledFor(logging.DEBUG):
+                rooms = (p.room_id for p in catchup_pdus)
+                logger.debug("Catching up rooms to %s: %r", self._destination, rooms)
+
             success = await self._transaction_manager.send_new_transaction(
                 self._destination, catchup_pdus, []
             )

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -452,8 +452,7 @@ class PerDestinationQueue:
         # get at most 50 catchup room/PDUs
         while True:
             event_ids = await self._store.get_catch_up_room_event_ids(
-                self._destination,
-                self._last_successful_stream_ordering,
+                self._destination, self._last_successful_stream_ordering,
             )
 
             if not event_ids:
@@ -461,7 +460,11 @@ class PerDestinationQueue:
                 # of a race condition, so we check that no new events have been
                 # skipped due to us being in catch-up mode
 
-                if self._catchup_last_skipped is not None and self._catchup_last_skipped > self._last_successful_stream_ordering:
+                if (
+                    self._catchup_last_skipped is not None
+                    and self._catchup_last_skipped
+                    > self._last_successful_stream_ordering
+                ):
                     # another event has been skipped because we were in catch-up mode
                     continue
 

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -159,6 +159,8 @@ class PerDestinationQueue:
             # only enqueue the PDU if we are not catching up (False) or do not
             # yet know if we are to catch up (None)
             self._pending_pdus.append(pdu)
+        else:
+            self._catchup_last_skipped = pdu.internal_metadata.stream_ordering
 
         self.attempt_new_transaction()
 

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -494,7 +494,7 @@ class PerDestinationQueue:
                 return
 
             sent_transactions_counter.inc()
-            final_pdu, _ = catchup_pdus[-1]
+            final_pdu = catchup_pdus[-1]
             self._last_successful_stream_ordering = cast(
                 int, final_pdu.internal_metadata.stream_ordering
             )

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -487,19 +487,19 @@ class PerDestinationQueue:
                 )
 
             success = await self._transaction_manager.send_new_transaction(
-                self._destination, catch_up_pdus, []
+                self._destination, catchup_pdus, []
             )
 
             if not success:
                 return
 
             sent_transactions_counter.inc()
-            final_pdu, _ = catch_up_pdus[-1]
+            final_pdu, _ = catchup_pdus[-1]
             self._last_successful_stream_ordering = cast(
                 int, final_pdu.internal_metadata.stream_ordering
             )
             await self._store.set_destination_last_successful_stream_ordering(
-                self._destination, self._last_successful_stream_order
+                self._destination, self._last_successful_stream_ordering
             )
 
     def _get_rr_edus(self, force_flush: bool) -> Iterable[Edu]:

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -105,6 +105,10 @@ class PerDestinationQueue:
         # being in catch-up mode, or None if not applicable.
         self._catchup_last_skipped = None  # type: Optional[int]
 
+        # Cache of the last successfully-transmitted stream ordering for this
+        # destination (we are the only updater so this is safe)
+        self._last_successful_stream_ordering = None  # type: Optional[int]
+
         # a list of pending PDUs
         self._pending_pdus = []  # type: List[EventBase]
 

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -100,8 +100,8 @@ class PerDestinationQueue:
         self._catching_up = True  # type: bool
 
         # The stream_ordering of the most recent PDU that was discarded due to
-        # being in catch-up mode, or None if not applicable.
-        self._catchup_last_skipped = None  # type: Optional[int]
+        # being in catch-up mode.
+        self._catchup_last_skipped = 0  # type: int
 
         # Cache of the last successfully-transmitted stream ordering for this
         # destination (we are the only updater so this is safe)
@@ -462,11 +462,7 @@ class PerDestinationQueue:
                 # of a race condition, so we check that no new events have been
                 # skipped due to us being in catch-up mode
 
-                if (
-                    self._catchup_last_skipped is not None
-                    and self._catchup_last_skipped
-                    > self._last_successful_stream_ordering
-                ):
+                if self._catchup_last_skipped > self._last_successful_stream_ordering:
                     # another event has been skipped because we were in catch-up mode
                     continue
 

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -489,9 +489,9 @@ class PerDestinationQueue:
                     "This should not happen." % event_ids
                 )
 
-            if logger.isEnabledFor(logging.DEBUG):
+            if logger.isEnabledFor(logging.INFO):
                 rooms = (p.room_id for p in catchup_pdus)
-                logger.debug("Catching up rooms to %s: %r", self._destination, rooms)
+                logger.info("Catching up rooms to %s: %r", self._destination, rooms)
 
             success = await self._transaction_manager.send_new_transaction(
                 self._destination, catchup_pdus, []

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -155,7 +155,11 @@ class PerDestinationQueue:
         Args:
             pdu: pdu to send
         """
-        self._pending_pdus.append(pdu)
+        if not self._catching_up:
+            # only enqueue the PDU if we are not catching up (False) or do not
+            # yet know if we are to catch up (None)
+            self._pending_pdus.append(pdu)
+
         self.attempt_new_transaction()
 
     def send_presence(self, states: Iterable[UserPresenceState]) -> None:

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -444,10 +444,11 @@ class PerDestinationQueue:
 
         if self._last_successful_stream_ordering is None:
             # if it's still None, then this means we don't have the information
-            # in our database (oh, the perils of being a new feature).
-            # So we can't actually do anything here, and in this case, we don't
-            # know what to catch up, sadly.
-            # Trying to catch up right now is futile, so let's stop.
+            # in our database ­ we haven't successfully sent a PDU to this server
+            # (at least since the introduction of the feature tracking
+            # last_successful_stream_ordering).
+            # Sadly, this means we can't do anything here as we don't know what
+            # needs catching up — so catching up is futile; let's stop.
             self._catching_up = False
             return
 

--- a/synapse/storage/databases/main/transactions.py
+++ b/synapse/storage/databases/main/transactions.py
@@ -15,7 +15,7 @@
 
 import logging
 from collections import namedtuple
-from typing import Iterable, Optional, Tuple, List
+from typing import Iterable, List, Optional, Tuple
 
 from canonicaljson import encode_canonical_json
 
@@ -373,9 +373,7 @@ class TransactionStore(SQLBaseStore):
         )
 
     async def get_catch_up_room_event_ids(
-        self,
-        destination: str,
-        last_successful_stream_ordering: int,
+        self, destination: str, last_successful_stream_ordering: int,
     ) -> List[str]:
         """
         Returns at most 50 event IDs and their corresponding stream_orderings
@@ -399,9 +397,7 @@ class TransactionStore(SQLBaseStore):
 
     @staticmethod
     def _get_catch_up_room_event_ids_txn(
-        txn,
-        destination: str,
-        last_successful_stream_ordering: int,
+        txn, destination: str, last_successful_stream_ordering: int,
     ) -> List[str]:
         q = """
                 SELECT event_id FROM destination_rooms

--- a/synapse/storage/databases/main/transactions.py
+++ b/synapse/storage/databases/main/transactions.py
@@ -15,7 +15,7 @@
 
 import logging
 from collections import namedtuple
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Optional, Tuple, List
 
 from canonicaljson import encode_canonical_json
 
@@ -371,3 +371,48 @@ class TransactionStore(SQLBaseStore):
             values={"last_successful_stream_ordering": last_successful_stream_ordering},
             desc="set_last_successful_stream_ordering",
         )
+
+    async def get_catch_up_room_event_ids(
+        self,
+        destination: str,
+        last_successful_stream_ordering: int,
+    ) -> List[str]:
+        """
+        Returns at most 50 event IDs and their corresponding stream_orderings
+        that correspond to the oldest events that have not yet been sent to
+        the destination.
+
+        Args:
+            destination: the destination in question
+            last_successful_stream_ordering: the stream_ordering of the
+                most-recently successfully-transmitted event to the destination
+
+        Returns:
+            list of event_ids
+        """
+        return await self.db_pool.runInteraction(
+            "get_catch_up_room_event_ids",
+            self._get_catch_up_room_event_ids_txn,
+            destination,
+            last_successful_stream_ordering,
+        )
+
+    @staticmethod
+    def _get_catch_up_room_event_ids_txn(
+        txn,
+        destination: str,
+        last_successful_stream_ordering: int,
+    ) -> List[str]:
+        q = """
+                SELECT event_id FROM destination_rooms
+                 JOIN events USING (stream_ordering)
+                WHERE destination = ?
+                  AND stream_ordering > ?
+                ORDER BY stream_ordering
+                LIMIT 50
+            """
+        txn.execute(
+            q, (destination, last_successful_stream_ordering),
+        )
+        event_ids = [row[0] for row in txn]
+        return event_ids

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -1,5 +1,10 @@
+from typing import Tuple, List
+
 from mock import Mock
 
+from synapse.events import EventBase
+from synapse.federation.sender import PerDestinationQueue, TransactionManager
+from synapse.federation.units import Edu
 from synapse.rest import admin
 from synapse.rest.client.v1 import login, room
 
@@ -156,3 +161,160 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
             row_2["stream_ordering"],
             "Send succeeded but not marked as last_successful_stream_ordering",
         )
+
+    @override_config({"send_federation": True})  # critical to federate
+    def test_catch_up_from_blank_state(self):
+        """
+        Runs an overall test of federation catch-up from scratch.
+        Further tests will focus on more narrow aspects and edge-cases, but I
+        hope to provide an overall view with this test.
+        """
+        # bring the other server online
+        self.is_online = True
+
+        # let's make some events for the other server to receive
+        self.register_user("u1", "you the one")
+        u1_token = self.login("u1", "you the one")
+        room_1 = self.helper.create_room_as("u1", tok=u1_token)
+        room_2 = self.helper.create_room_as("u1", tok=u1_token)
+
+        # also critical to federate
+        self.get_success(
+            event_injection.inject_member_event(self.hs, room_1, "@user:host2", "join")
+        )
+        self.get_success(
+            event_injection.inject_member_event(self.hs, room_2, "@user:host2", "join")
+        )
+
+        self.helper.send_state(
+            room_1, event_type="m.room.topic", body={"topic": "wombat"}, tok=u1_token
+        )
+
+        # check: PDU received for topic event
+        self.assertEqual(len(self.pdus), 1)
+        self.assertEqual(self.pdus[0]["type"], "m.room.topic")
+
+        # take the remote offline
+        self.is_online = False
+
+        # send another event
+        self.helper.send(room_1, "hi user!", tok=u1_token)
+
+        # check: things didn't go well since the remote is down
+        self.assertEqual(len(self.failed_pdus), 1)
+        self.assertEqual(self.failed_pdus[0]["content"]["body"], "hi user!")
+
+        # let's delete the federation transmission queue
+        # (this pretends we are starting up fresh.)
+        self.assertFalse(
+            self.hs.get_federation_sender()
+                ._per_destination_queues["host2"]
+                .transmission_loop_running
+        )
+        del self.hs.get_federation_sender()._per_destination_queues["host2"]
+
+        # let's also clear any backoffs
+        self.get_success(
+            self.hs.get_datastore().set_destination_retry_timings("host2", None, 0, 0)
+        )
+
+        # bring the remote online and clear the received pdu list
+        self.is_online = True
+        self.pdus = []
+
+        # now we need to initiate a federation transaction somehow…
+        # to do that, let's send another event (because it's simple to do)
+        # (do it to another room otherwise the catch-up logic decides it doesn't
+        # need to catch up room_1 — something I overlooked when first writing
+        # this test)
+        self.helper.send(room_2, "wombats!", tok=u1_token)
+
+        # we should now have received both PDUs
+        self.assertEqual(len(self.pdus), 2)
+        self.assertEqual(self.pdus[0]["content"]["body"], "hi user!")
+        self.assertEqual(self.pdus[1]["content"]["body"], "wombats!")
+
+    def make_fake_destination_queue(
+        self, destination: str = "host2"
+    ) -> Tuple[PerDestinationQueue, List[EventBase]]:
+        """
+        Makes a fake per-destination queue.
+        """
+        transaction_manager = TransactionManager(self.hs)
+        per_dest_queue = PerDestinationQueue(self.hs, transaction_manager, destination)
+        results_list = []
+
+        async def fake_send(
+            destination_tm: str,
+            pending_pdus: List[EventBase],
+            _pending_edus: List[Edu],
+        ) -> bool:
+            assert destination == destination_tm
+            results_list.extend(pending_pdus)
+            return True  # success!
+
+        transaction_manager.send_new_transaction = fake_send
+
+        return per_dest_queue, results_list
+
+    @override_config({"send_federation": True})
+    def test_catch_up_loop(self):
+        """
+        Tests the behaviour of _catch_up_transmission_loop.
+        """
+
+        # ARRANGE:
+        #  - a local user (u1)
+        #  - 3 rooms which u1 is joined to (and remote user @user:host2 is
+        #    joined to)
+        #  - some events (1 to 5) in those rooms
+        #      we have 'already sent' events 1 and 2 to host2
+        per_dest_queue, sent_pdus = self.make_fake_destination_queue()
+
+        self.register_user("u1", "you the one")
+        u1_token = self.login("u1", "you the one")
+        room_1 = self.helper.create_room_as("u1", tok=u1_token)
+        room_2 = self.helper.create_room_as("u1", tok=u1_token)
+        room_3 = self.helper.create_room_as("u1", tok=u1_token)
+        self.get_success(
+            event_injection.inject_member_event(self.hs, room_1, "@user:host2", "join")
+        )
+        self.get_success(
+            event_injection.inject_member_event(self.hs, room_2, "@user:host2", "join")
+        )
+        self.get_success(
+            event_injection.inject_member_event(self.hs, room_3, "@user:host2", "join")
+        )
+
+        # create some events
+        self.helper.send(room_1, "you hear me!!", tok=u1_token)
+        event_id_2 = self.helper.send(room_2, "wombats!", tok=u1_token)["event_id"]
+        self.helper.send(room_3, "Matrix!", tok=u1_token)
+        event_id_4 = self.helper.send(room_2, "rabbits!", tok=u1_token)["event_id"]
+        event_id_5 = self.helper.send(room_3, "Synapse!", tok=u1_token)["event_id"]
+
+        # destination_rooms should already be populated, but let us pretend that we already
+        # sent (successfully) up to and including event id 2
+        event_2 = self.get_success(self.hs.get_datastore().get_event(event_id_2))
+
+        # also fetch event 5 so we know its last_successful_stream_ordering later
+        event_5 = self.get_success(self.hs.get_datastore().get_event(event_id_5))
+
+        self.get_success(
+            self.hs.get_datastore().set_destination_last_successful_stream_ordering(
+                "host2", event_2.internal_metadata.stream_ordering
+            )
+        )
+
+        # ACT
+        self.get_success(per_dest_queue._catch_up_transmission_loop())
+
+        # ASSERT, noticing in particular:
+        # - event 3 not sent out, because event 5 replaces it
+        # - order is least recent first, so event 5 comes after event 4
+        # - catch-up is completed
+        self.assertEqual(len(sent_pdus), 2)
+        self.assertEqual(sent_pdus[0].event_id, event_id_4)
+        self.assertEqual(sent_pdus[1].event_id, event_id_5)
+        self.assertFalse(per_dest_queue._catching_up)
+        self.assertEqual(per_dest_queue._last_successful_stream_ordering, event_5.internal_metadata.stream_ordering)

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List
+from typing import List, Tuple
 
 from mock import Mock
 
@@ -208,8 +208,8 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
         # (this pretends we are starting up fresh.)
         self.assertFalse(
             self.hs.get_federation_sender()
-                ._per_destination_queues["host2"]
-                .transmission_loop_running
+            ._per_destination_queues["host2"]
+            .transmission_loop_running
         )
         del self.hs.get_federation_sender()._per_destination_queues["host2"]
 
@@ -317,4 +317,7 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
         self.assertEqual(sent_pdus[0].event_id, event_id_4)
         self.assertEqual(sent_pdus[1].event_id, event_id_5)
         self.assertFalse(per_dest_queue._catching_up)
-        self.assertEqual(per_dest_queue._last_successful_stream_ordering, event_5.internal_metadata.stream_ordering)
+        self.assertEqual(
+            per_dest_queue._last_successful_stream_ordering,
+            event_5.internal_metadata.stream_ordering,
+        )

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -73,6 +73,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
                 "delivered_txn",
                 "get_received_txn_response",
                 "set_received_txn_response",
+                "get_destination_last_successful_stream_ordering",
                 "get_destination_retry_timings",
                 "get_devices_by_remote",
                 "maybe_store_room_on_invite",
@@ -118,6 +119,10 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
 
         self.datastore.get_device_updates_by_remote.side_effect = lambda destination, from_stream_id, limit: make_awaitable(
             (0, [])
+        )
+
+        self.datastore.get_destination_last_successful_stream_ordering.return_value = make_awaitable(
+            None
         )
 
         def get_received_txn_response(*args):


### PR DESCRIPTION
This is basically the final PR for this feature/bugfix — though as an extension I would like to check for needed catch-ups on startup and proactively deal with outstanding catchups when Synapse has just been restarted…