### PR TITLE
Add a config option for validating 'next_link' parameters against a domain whitelist

### DIFF
--- a/changelog.d/8275.feature
+++ b/changelog.d/8275.feature
@@ -1,0 +1,1 @@
+Add a config option to specify a whitelist of domains that a user can be redirected to after validating their email or phone number.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -442,7 +442,7 @@ retention:
 # process.
 #
 # The whitelist is applied whether the homeserver or an
-# account_threepid_delegate is handling validation.
+# identity server is handling validation.
 #
 # The default value is no whitelist functionality; all domains are
 # allowed. Setting this value to an empty list will instead disallow

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -432,6 +432,24 @@ retention:
 #
 #request_token_inhibit_3pid_errors: true
 
+# A list of domains that the domain portion of 'next_link' parameters
+# must match.
+#
+# This parameter is optionally provided by clients while requesting
+# validation of an email or phone number, and maps to a link that
+# users will be automatically redirected to after validation
+# succeeds. Clients can make use this parameter to aid the validation
+# process.
+#
+# The whitelist is applied whether the homeserver or an
+# account_threepid_delegate is handling validation.
+#
+# The default value is no whitelist functionality; all domains are
+# allowed. Setting this value to an empty list will instead disallow
+# all domains.
+#
+#next_link_domain_whitelist: ["matrix.org"]
+
 
 ## TLS ##
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -1038,7 +1038,7 @@ class ServerConfig(Config):
         # process.
         #
         # The whitelist is applied whether the homeserver or an
-        # account_threepid_delegate is handling validation.
+        # identity server is handling validation.
         #
         # The default value is no whitelist functionality; all domains are
         # allowed. Setting this value to an empty list will instead disallow

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -543,14 +543,15 @@ class ServerConfig(Config):
         )  # type: set
 
         # Whitelist of domain names that given next_link parameters must have
-        next_link_domain_whitelist = config.get("next_link_domain_whitelist")
-        if next_link_domain_whitelist is not None and not isinstance(
-            next_link_domain_whitelist, list
-        ):
-            raise ConfigError("'next_link_domain_whitelist' must be a list")
+        self.next_link_domain_whitelist = config.get("next_link_domain_whitelist")
+        if self.next_link_domain_whitelist is not None:
+            if not isinstance(self.next_link_domain_whitelist, list):
+                raise ConfigError("'next_link_domain_whitelist' must be a list")
 
-        # Turn the list into a set to improve lookup speed.
-        self.next_link_domain_whitelist = set(next_link_domain_whitelist)  # type: set
+            # Turn the list into a set to improve lookup speed.
+            self.next_link_domain_whitelist = set(
+                self.next_link_domain_whitelist
+            )  # type: set
 
     def has_tls_listener(self) -> bool:
         return any(listener.tls for listener in self.listeners)

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -544,7 +544,9 @@ class ServerConfig(Config):
 
         # Whitelist of domain names that given next_link parameters must have
         next_link_domain_whitelist = config.get("next_link_domain_whitelist")
-        if not isinstance(next_link_domain_whitelist, list):
+        if next_link_domain_whitelist is not None and not isinstance(
+            next_link_domain_whitelist, list
+        ):
             raise ConfigError("'next_link_domain_whitelist' must be a list")
 
         # Turn the list into a set to improve lookup speed.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -19,7 +19,7 @@ import logging
 import os.path
 import re
 from textwrap import indent
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Set
 
 import attr
 import yaml
@@ -543,15 +543,17 @@ class ServerConfig(Config):
         )  # type: set
 
         # Whitelist of domain names that given next_link parameters must have
-        self.next_link_domain_whitelist = config.get("next_link_domain_whitelist")
-        if self.next_link_domain_whitelist is not None:
-            if not isinstance(self.next_link_domain_whitelist, list):
+        next_link_domain_whitelist = config.get(
+            "next_link_domain_whitelist"
+        )  # type: Optional[List[str]]
+
+        self.next_link_domain_whitelist = None  # type: Optional[Set[str]]
+        if next_link_domain_whitelist is not None:
+            if not isinstance(next_link_domain_whitelist, list):
                 raise ConfigError("'next_link_domain_whitelist' must be a list")
 
             # Turn the list into a set to improve lookup speed.
-            self.next_link_domain_whitelist = set(
-                self.next_link_domain_whitelist
-            )  # type: set
+            self.next_link_domain_whitelist = set(next_link_domain_whitelist)
 
     def has_tls_listener(self) -> bool:
         return any(listener.tls for listener in self.listeners)

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -542,6 +542,14 @@ class ServerConfig(Config):
             users_new_default_push_rules
         )  # type: set
 
+        # Whitelist of domain names that given next_link parameters must have
+        next_link_domain_whitelist = config.get("next_link_domain_whitelist")
+        if not isinstance(next_link_domain_whitelist, list):
+            raise ConfigError("'next_link_domain_whitelist' must be a list")
+
+        # Turn the list into a set to improve lookup speed.
+        self.next_link_domain_whitelist = set(next_link_domain_whitelist)  # type: set
+
     def has_tls_listener(self) -> bool:
         return any(listener.tls for listener in self.listeners)
 
@@ -1014,6 +1022,24 @@ class ServerConfig(Config):
         # act as if no error happened and return a fake session ID ('sid') to clients.
         #
         #request_token_inhibit_3pid_errors: true
+
+        # A list of domains that the domain portion of 'next_link' parameters
+        # must match.
+        #
+        # This parameter is optionally provided by clients while requesting
+        # validation of an email or phone number, and maps to a link that
+        # users will be automatically redirected to after validation
+        # succeeds. Clients can make use this parameter to aid the validation
+        # process.
+        #
+        # The whitelist is applied whether the homeserver or an
+        # account_threepid_delegate is handling validation.
+        #
+        # The default value is no whitelist functionality; all domains are
+        # allowed. Setting this value to an empty list will instead disallow
+        # all domains.
+        #
+        #next_link_domain_whitelist: ["matrix.org"]
         """
             % locals()
         )

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -904,7 +904,7 @@ def assert_valid_next_link(hs: "HomeServer", next_link: str):
     next_link_parsed = urlparse(next_link)
 
     # Scheme must not point to the local drive
-    if next_link_parsed.scheme.startswith("file:///"):
+    if next_link_parsed.scheme == "file":
         valid = False
 
     # If the domain whitelist is set, the domain must be in it

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -903,8 +903,8 @@ def assert_valid_next_link(hs: "HomeServer", next_link: str):
     # Parse the contents of the URL
     next_link_parsed = urlparse(next_link)
 
-    # Scheme must be http(s)
-    if next_link_parsed.scheme not in ["http", "https"]:
+    # Scheme must not point to the local drive
+    if next_link_parsed.scheme.startswith("file:///"):
         valid = False
 
     # If the domain whitelist is set, the domain must be in it

--- a/tests/rest/client/v2_alpha/test_account.py
+++ b/tests/rest/client/v2_alpha/test_account.py
@@ -720,7 +720,7 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
         next_link: Optional[str] = None,
         expect_code: int = 200,
     ) -> str:
-        """Request validating and adding an email to a user account
+        """Request a validation token to add an email address to a user's account
 
         Args:
             email: The email address to validate

--- a/tests/rest/client/v2_alpha/test_account.py
+++ b/tests/rest/client/v2_alpha/test_account.py
@@ -669,6 +669,29 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual(200, int(channel.result["code"]), msg=channel.result["body"])
         self.assertFalse(channel.json_body["threepids"])
 
+    @override_config({"next_link_domain_whitelist": None})
+    def test_next_link(self):
+        """Tests a valid next_link parameter value with no whitelist (good case)"""
+        self._request_token(
+            "something@example.com",
+            "some_secret",
+            next_link="https://example.com/a/good/site",
+            expect_code=200,
+        )
+
+    @override_config({"next_link_domain_whitelist": None})
+    def test_next_link_exotic_protocol(self):
+        """Tests using a esoteric protocol as a next_link parameter value.
+        Someone may be hosting a client on IPFS etc.
+        """
+        self._request_token(
+            "something@example.com",
+            "some_secret",
+            next_link="some-protocol://abcdefghijklmopqrstuvwxyz",
+            expect_code=200,
+        )
+
+    @override_config({"next_link_domain_whitelist": None})
     def test_next_link_file_uri(self):
         """Tests next_link parameters cannot be file URI"""
         # Attempt to use a next_link value that points to the local disk
@@ -705,7 +728,9 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
 
     @override_config({"next_link_domain_whitelist": []})
     def test_empty_next_link_domain_whitelist(self):
-        """Tests an empty next_lint_domain_whitelist value means next_link is disallowed"""
+        """Tests an empty next_lint_domain_whitelist value, meaning next_link is essentially
+        disallowed
+        """
         self._request_token(
             "something@example.com",
             "some_secret",

--- a/tests/rest/client/v2_alpha/test_account.py
+++ b/tests/rest/client/v2_alpha/test_account.py
@@ -14,11 +14,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import json
 import os
 import re
 from email.parser import Parser
+from typing import Optional
 
 import pkg_resources
 
@@ -29,6 +29,7 @@ from synapse.rest.client.v1 import login, room
 from synapse.rest.client.v2_alpha import account, register
 
 from tests import unittest
+from tests.unittest import override_config
 
 
 class PasswordResetTestCase(unittest.HomeserverTestCase):
@@ -668,16 +669,79 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual(200, int(channel.result["code"]), msg=channel.result["body"])
         self.assertFalse(channel.json_body["threepids"])
 
-    def _request_token(self, email, client_secret):
+    def test_next_link_file_uri(self):
+        """Tests next_link parameters cannot be file URI"""
+        # Attempt to use a next_link value that points to the local disk
+        self._request_token(
+            "something@example.com",
+            "some_secret",
+            next_link="file:///host/path",
+            expect_code=400,
+        )
+
+    @override_config({"next_link_domain_whitelist": ["example.com", "example.org"]})
+    def test_next_link_domain_whitelist(self):
+        """Tests next_link parameters must fit the whitelist if provided"""
+        self._request_token(
+            "something@example.com",
+            "some_secret",
+            next_link="https://example.com/some/good/page",
+            expect_code=200,
+        )
+
+        self._request_token(
+            "something@example.com",
+            "some_secret",
+            next_link="https://example.org/some/also/good/page",
+            expect_code=200,
+        )
+
+        self._request_token(
+            "something@example.com",
+            "some_secret",
+            next_link="https://bad.example.org/some/bad/page",
+            expect_code=400,
+        )
+
+    @override_config({"next_link_domain_whitelist": []})
+    def test_empty_next_link_domain_whitelist(self):
+        """Tests an empty next_lint_domain_whitelist value means next_link is disallowed"""
+        self._request_token(
+            "something@example.com",
+            "some_secret",
+            next_link="https://example.com/a/page",
+            expect_code=400,
+        )
+
+    def _request_token(
+        self,
+        email: str,
+        client_secret: str,
+        next_link: Optional[str] = None,
+        expect_code: int = 200,
+    ) -> str:
+        """Request validating and adding an email to a user account
+
+        Args:
+            email: The email address to validate
+            client_secret: A secret string
+            next_link: A link to redirect the user to after validation
+            expect_code: Expected return code of the call
+
+        Returns:
+            The ID of the new threepid validation session
+        """
+        body = {"client_secret": client_secret, "email": email, "send_attempt": 1}
+        if next_link:
+            body["next_link"] = next_link
+
         request, channel = self.make_request(
-            "POST",
-            b"account/3pid/email/requestToken",
-            {"client_secret": client_secret, "email": email, "send_attempt": 1},
+            "POST", b"account/3pid/email/requestToken", body,
         )
         self.render(request)
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEquals(expect_code, channel.code, channel.result)
 
-        return channel.json_body["sid"]
+        return channel.json_body.get("sid")
 
     def _request_token_invalid_email(
         self, email, expected_errcode, expected_error, client_secret="foobar",


### PR DESCRIPTION
This is a config option ported over from DINUM's Sydent: https://github.com/matrix-org/sydent/pull/285

They've switched to validating 3PIDs via Synapse rather than Sydent, and would like to retain this functionality.

This original purpose for this change is phishing prevention. This solution could also potentially be replaced by a similar one to https://github.com/matrix-org/synapse/pull/8004, but across all `*/submit_token` endpoint.

This option may still be useful to enterprise even with that safeguard in place though, if they want to be absolutely sure that their employees don't follow links to other domains.