### PR TITLE
Systemd docs: configure workers to start after main process.

### DIFF
--- a/changelog.d/8276.misc
+++ b/changelog.d/8276.misc
@@ -1,0 +1,1 @@
+Do not attempt to upgrade upgrade database schema on worker processes.

--- a/docs/systemd-with-workers/system/matrix-synapse-worker@.service
+++ b/docs/systemd-with-workers/system/matrix-synapse-worker@.service
@@ -1,8 +1,13 @@
 [Unit]
 Description=Synapse %i
 AssertPathExists=/etc/matrix-synapse/workers/%i.yaml
+
 # This service should be restarted when the synapse target is restarted.
 PartOf=matrix-synapse.target
+
+# if this is started at the same time as the main, let the main process start
+# first, to initialise the database schema.
+After=matrix-synapse.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Now that we refuse to run schema updates on workers (#8266), it's better if the workers start after the main process when doing a whole-system restart.