### PR TITLE
Use the right constructor for log records

### DIFF
--- a/changelog.d/8278.bugfix
+++ b/changelog.d/8278.bugfix
@@ -1,0 +1,1 @@
+Fix a bug which cause the logging system to report errors, if `DEBUG` was enabled and no `context` filter was applied.

--- a/synapse/logging/utils.py
+++ b/synapse/logging/utils.py
@@ -29,11 +29,11 @@ def _log_debug_as_f(f, msg, msg_args):
         lineno = f.__code__.co_firstlineno
         pathname = f.__code__.co_filename
 
-        record = logging.LogRecord(
+        record = logger.makeRecord(
             name=name,
             level=logging.DEBUG,
-            pathname=pathname,
-            lineno=lineno,
+            fn=pathname,
+            lno=lineno,
             msg=msg,
             args=msg_args,
             exc_info=None,


### PR DESCRIPTION
Update `log_function` to use the right factory to create log records, to make
sure that they have `request` attributes.

Fixes: #8267.