### PR TITLE
Add base pushrule to notify for jitsi conferences

### DIFF
--- a/changelog.d/8286.feature
+++ b/changelog.d/8286.feature
@@ -1,0 +1,1 @@
+Add push rule for jitsi conferences

--- a/changelog.d/8286.feature
+++ b/changelog.d/8286.feature
@@ -1,1 +1,1 @@
-Add push rule for jitsi conferences
+Add push rule for jitsi conferences.

--- a/changelog.d/8286.feature
+++ b/changelog.d/8286.feature
@@ -1,1 +1,1 @@
-Add push rule for jitsi conferences.
+Add a push rule that highlights when a jitsi conference is created in a room.

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -498,6 +498,30 @@ BASE_APPEND_UNDERRIDE_RULES = [
         ],
         "actions": ["notify", {"set_tweak": "highlight", "value": False}],
     },
+    {
+        "rule_id": "global/underride/.im.vector.jitsi",
+        "conditions": [
+            {
+                "kind": "event_match",
+                "key": "type",
+                "pattern": "im.vector.modular.widgets",
+                "_id": "_type_modular_widgets",
+            },
+            {
+                "kind": "event_match",
+                "key": "content.type",
+                "pattern": "jitsi",
+                "_id": "_content_type_jitsi",
+            },
+            {
+                "kind": "event_match",
+                "key": "state_key",
+                "pattern": "*",
+                "_id": "_is_state_event",
+            },
+        ],
+        "actions": ["notify", {"set_tweak": "highlight", "value": False}],
+    },
 ]
 
 


### PR DESCRIPTION
This could be customised to trigger a different kind of notification in the future, but for now it's a normal non-highlight one.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
* <del>[ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)</del>
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
