### PR TITLE
Power level content override config

### DIFF
--- a/changelog.d/8289.feature
+++ b/changelog.d/8289.feature
@@ -1,0 +1,1 @@
+Makes hard coded power level event content override for new rooms configurable in homeserver.yaml.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2208,6 +2208,36 @@ spam_checker:
 #
 #encryption_enabled_by_default_for_room_type: invite
 
+# Don't use this unless you are sure you know what you're doing and have
+# a strong understanding of the matrix protocol. Here's the relevant docs:
+# https://matrix.org/docs/spec/client_server/latest#m-room-power-levels
+#
+# Any values declared in this option will override the named power level
+# event content unconditionally.
+#
+power_level_content_override:
+  #
+  # Power level event content fields:
+  #ban: 50
+  #events_default: 50
+  #invite: 50
+  #kick: 50
+  #redact: 50
+  #state_default: 50
+  #users_default: 50
+
+  # Events list to be sent in the power level event
+  #
+  events:
+    #m.room.avatar: 50
+    #m.room.canonical_alias: 50
+    #m.room.encryption: 50
+    #m.room.history_visibility: 50
+    #m.room.name: 50
+    #m.room.power_levels: 50
+    #m.room.server_acl: 50
+    #m.room.tombstone: 50
+
 
 # Uncomment to allow non-server-admin users to create groups on this server
 #


### PR DESCRIPTION
Makes hard coded power level event content override for new rooms configrable in homeserver.yaml.

Signed-off-by: Aaron Haslett <aaronhaslett@catalyst.net.nz>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ x ] Pull request is based on the develop branch
* [ x ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ x ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ x ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
