### PR TITLE
Remove MSC2666 info from upgrade/workers doc as it's still experimental

### DIFF
--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -1,16 +1,3 @@
-Upgrading to v1.20.0
-====================
-
-Shared rooms endpoint (MSC2666)
--------------------------------
-
-This release contains a new unstable endpoint `/_matrix/client/unstable/uk.half-shot.msc2666/user/shared_rooms/.*`
-for fetching rooms one user has in common with another. This feature requires the
-`update_user_directory` config flag to be `True`. If you are you are using a `synapse.app.user_dir`
-worker, requests to this endpoint must be handled by that worker. 
-See `docs/workers.md <docs/workers.md>`_ for more details.
-
-
 Upgrading Synapse
 =================
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -380,7 +380,6 @@ Handles searches in the user directory. It can handle REST endpoints matching
 the following regular expressions:
 
     ^/_matrix/client/(api/v1|r0|unstable)/user_directory/search$
-    ^/_matrix/client/unstable/uk.half-shot.msc2666/user/shared_rooms/.*$
 
 When using this worker you must also set `update_user_directory: False` in the
 shared configuration file to stop the main synapse running background


### PR DESCRIPTION
https://github.com/matrix-org/synapse/pull/7785 added some information to tell homeserver admins how to correctly update their routing to make use of the new features in MSC2666.

However, this feature is still experimental as the MSC has not yet landed. Things may change, and as such we don't want to have to amend the documentation and inform sysadmins each time it does.

Thus we're removing these docs for now, but will bring them back when the feature becomes stable.