### PR TITLE
Admin API for querying rooms where a user is a member

### DIFF
--- a/changelog.d/8306.feature
+++ b/changelog.d/8306.feature
@@ -1,1 +1,1 @@
-Admin API for querying rooms where a user is a member. Contributed by @dklimpel.
+Add an admin API for querying rooms where a user is a member. Contributed by @dklimpel.

--- a/changelog.d/8306.feature
+++ b/changelog.d/8306.feature
@@ -1,0 +1,1 @@
+Admin API for querying rooms where a user is a member. Contributed by @dklimpel.

--- a/docs/admin_api/user_admin_api.rst
+++ b/docs/admin_api/user_admin_api.rst
@@ -304,6 +304,43 @@ To use it, you will need to authenticate by providing an ``access_token`` for a
 server admin: see `README.rst <README.rst>`_.
 
 
+List room memberships of an user
+================================
+Gets a list of all ``room_id`` that a specific ``user_id`` is member.
+
+The API is::
+
+  GET /_synapse/admin/v1/users/<user_id>/rooms
+
+To use it, you will need to authenticate by providing an ``access_token`` for a
+server admin: see `README.rst <README.rst>`_.
+
+A response body like the following is returned:
+
+.. code:: json
+
+    {
+        "rooms": [
+            "!DuGcnbhHGaSZQoNQR:matrix.org",
+            "!ZtSaPCawyWtxfWiIy:matrix.org"
+        ],
+        "total": 2
+    }
+
+**Parameters**
+
+The following parameters should be set in the URL:
+
+- ``user_id`` - fully qualified: for example, ``@user:server.com``.
+
+**Response**
+
+The following fields are returned in the JSON response body:
+
+- ``rooms`` - An array of ``room_id``.
+- ``total`` - Number of rooms.
+
+
 User devices
 ============
 

--- a/docs/admin_api/user_admin_api.rst
+++ b/docs/admin_api/user_admin_api.rst
@@ -310,7 +310,7 @@ Gets a list of all ``room_id`` that a specific ``user_id`` is member.
 
 The API is::
 
-  GET /_synapse/admin/v1/users/<user_id>/rooms
+  GET /_synapse/admin/v1/users/<user_id>/joined_rooms
 
 To use it, you will need to authenticate by providing an ``access_token`` for a
 server admin: see `README.rst <README.rst>`_.
@@ -320,7 +320,7 @@ A response body like the following is returned:
 .. code:: json
 
     {
-        "rooms": [
+        "joined_rooms": [
             "!DuGcnbhHGaSZQoNQR:matrix.org",
             "!ZtSaPCawyWtxfWiIy:matrix.org"
         ],
@@ -337,7 +337,7 @@ The following parameters should be set in the URL:
 
 The following fields are returned in the JSON response body:
 
-- ``rooms`` - An array of ``room_id``.
+- ``joined_rooms`` - An array of ``room_id``.
 - ``total`` - Number of rooms.
 
 

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -49,6 +49,7 @@ from synapse.rest.admin.users import (
     ResetPasswordRestServlet,
     SearchUsersRestServlet,
     UserAdminServlet,
+    UserMembershipRestServlet,
     UserRegisterServlet,
     UserRestServletV2,
     UsersRestServlet,
@@ -209,6 +210,7 @@ def register_servlets(hs, http_server):
     SendServerNoticeServlet(hs).register(http_server)
     VersionServlet(hs).register(http_server)
     UserAdminServlet(hs).register(http_server)
+    UserMembershipRestServlet(hs).register(http_server)
     UserRestServletV2(hs).register(http_server)
     UsersRestServletV2(hs).register(http_server)
     DeviceRestServlet(hs).register(http_server)

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -29,6 +29,7 @@ from synapse.http.servlet import (
     parse_string,
 )
 from synapse.rest.admin._base import (
+    admin_patterns,
     assert_requester_is_admin,
     assert_user_is_admin,
     historical_admin_path_patterns,
@@ -683,3 +684,29 @@ class UserAdminServlet(RestServlet):
         await self.store.set_server_admin(target_user, set_admin_to)
 
         return 200, {}
+
+
+class UserMembershipRestServlet(RestServlet):
+    """
+    Get room list of an user.
+    """
+
+    PATTERNS = admin_patterns("/users/(?P<user_id>[^/]+)/rooms$")
+
+    def __init__(self, hs):
+        self.hs = hs
+        self.auth = hs.get_auth()
+        self.store = hs.get_datastore()
+
+    async def on_GET(self, request, user_id):
+        await assert_requester_is_admin(self.auth, request)
+
+        if not self.hs.is_mine(UserID.from_string(user_id)):
+            raise SynapseError(400, "Can only lookup local users")
+
+        room_ids = await self.store.get_rooms_for_user(user_id)
+        if not room_ids:
+            raise NotFoundError("User not found")
+
+        ret = {"rooms": list(room_ids), "total": len(room_ids)}
+        return 200, ret

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -691,17 +691,17 @@ class UserMembershipRestServlet(RestServlet):
     Get room list of an user.
     """
 
-    PATTERNS = admin_patterns("/users/(?P<user_id>[^/]+)/rooms$")
+    PATTERNS = admin_patterns("/users/(?P<user_id>[^/]+)/joined_rooms$")
 
     def __init__(self, hs):
-        self.hs = hs
+        self.is_mine = hs.is_mine
         self.auth = hs.get_auth()
         self.store = hs.get_datastore()
 
     async def on_GET(self, request, user_id):
         await assert_requester_is_admin(self.auth, request)
 
-        if not self.hs.is_mine(UserID.from_string(user_id)):
+        if not self.is_mine(UserID.from_string(user_id)):
             raise SynapseError(400, "Can only lookup local users")
 
         room_ids = await self.store.get_rooms_for_user(user_id)

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -708,5 +708,5 @@ class UserMembershipRestServlet(RestServlet):
         if not room_ids:
             raise NotFoundError("User not found")
 
-        ret = {"rooms": list(room_ids), "total": len(room_ids)}
+        ret = {"joined_rooms": list(room_ids), "total": len(room_ids)}
         return 200, ret

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -22,8 +22,8 @@ from mock import Mock
 
 import synapse.rest.admin
 from synapse.api.constants import UserTypes
-from synapse.api.errors import HttpResponseException, ResourceLimitError
-from synapse.rest.client.v1 import login
+from synapse.api.errors import Codes, HttpResponseException, ResourceLimitError
+from synapse.rest.client.v1 import login, room
 from synapse.rest.client.v2_alpha import sync
 
 from tests import unittest
@@ -995,3 +995,95 @@ class UserRestTestCase(unittest.HomeserverTestCase):
 
         # Ensure they're still alive
         self.assertEqual(0, channel.json_body["deactivated"])
+
+
+class UserMembershipRestTestCase(unittest.HomeserverTestCase):
+
+    servlets = [
+        synapse.rest.admin.register_servlets,
+        login.register_servlets,
+        sync.register_servlets,
+        room.register_servlets,
+    ]
+
+    def prepare(self, reactor, clock, hs):
+        self.store = hs.get_datastore()
+
+        self.admin_user = self.register_user("admin", "pass", admin=True)
+        self.admin_user_tok = self.login("admin", "pass")
+
+        self.other_user = self.register_user("user", "pass")
+        self.url = "/_synapse/admin/v1/users/%s/rooms" % urllib.parse.quote(
+            self.other_user
+        )
+
+    def test_no_auth(self):
+        """
+        Try to list rooms of an user without authentication.
+        """
+        request, channel = self.make_request("GET", self.url, b"{}")
+        self.render(request)
+
+        self.assertEqual(401, int(channel.result["code"]), msg=channel.result["body"])
+        self.assertEqual(Codes.MISSING_TOKEN, channel.json_body["errcode"])
+
+    def test_requester_is_no_admin(self):
+        """
+        If the user is not a server admin, an error is returned.
+        """
+        other_user_token = self.login("user", "pass")
+
+        request, channel = self.make_request(
+            "GET", self.url, access_token=other_user_token,
+        )
+        self.render(request)
+
+        self.assertEqual(403, int(channel.result["code"]), msg=channel.result["body"])
+        self.assertEqual(Codes.FORBIDDEN, channel.json_body["errcode"])
+
+    def test_user_does_not_exist(self):
+        """
+        Tests that a lookup for a user that does not exist returns a 404
+        """
+        url = "/_synapse/admin/v1/users/@unknown_person:test/rooms"
+        request, channel = self.make_request(
+            "GET", url, access_token=self.admin_user_tok,
+        )
+        self.render(request)
+
+        self.assertEqual(404, channel.code, msg=channel.json_body)
+        self.assertEqual(Codes.NOT_FOUND, channel.json_body["errcode"])
+
+    def test_user_is_not_local(self):
+        """
+        Tests that a lookup for a user that is not a local returns a 400
+        """
+        url = "/_synapse/admin/v1/users/@unknown_person:unknown_domain/rooms"
+
+        request, channel = self.make_request(
+            "GET", url, access_token=self.admin_user_tok,
+        )
+        self.render(request)
+
+        self.assertEqual(400, channel.code, msg=channel.json_body)
+        self.assertEqual("Can only lookup local users", channel.json_body["error"])
+
+    def test_get_rooms(self):
+        """
+        Tests that a normal lookup for rooms is successfully
+        """
+        # Create rooms and join
+        other_user_tok = self.login("user", "pass")
+        number_rooms = 5
+        for n in range(number_rooms):
+            self.helper.create_room_as(self.other_user, tok=other_user_tok)
+
+        # Get rooms
+        request, channel = self.make_request(
+            "GET", self.url, access_token=self.admin_user_tok,
+        )
+        self.render(request)
+
+        self.assertEqual(200, channel.code, msg=channel.json_body)
+        self.assertEqual(number_rooms, channel.json_body["total"])
+        self.assertEqual(number_rooms, len(channel.json_body["rooms"]))

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -1013,7 +1013,7 @@ class UserMembershipRestTestCase(unittest.HomeserverTestCase):
         self.admin_user_tok = self.login("admin", "pass")
 
         self.other_user = self.register_user("user", "pass")
-        self.url = "/_synapse/admin/v1/users/%s/rooms" % urllib.parse.quote(
+        self.url = "/_synapse/admin/v1/users/%s/joined_rooms" % urllib.parse.quote(
             self.other_user
         )
 
@@ -1045,7 +1045,7 @@ class UserMembershipRestTestCase(unittest.HomeserverTestCase):
         """
         Tests that a lookup for a user that does not exist returns a 404
         """
-        url = "/_synapse/admin/v1/users/@unknown_person:test/rooms"
+        url = "/_synapse/admin/v1/users/@unknown_person:test/joined_rooms"
         request, channel = self.make_request(
             "GET", url, access_token=self.admin_user_tok,
         )
@@ -1058,7 +1058,7 @@ class UserMembershipRestTestCase(unittest.HomeserverTestCase):
         """
         Tests that a lookup for a user that is not a local returns a 400
         """
-        url = "/_synapse/admin/v1/users/@unknown_person:unknown_domain/rooms"
+        url = "/_synapse/admin/v1/users/@unknown_person:unknown_domain/joined_rooms"
 
         request, channel = self.make_request(
             "GET", url, access_token=self.admin_user_tok,

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -1086,4 +1086,4 @@ class UserMembershipRestTestCase(unittest.HomeserverTestCase):
 
         self.assertEqual(200, channel.code, msg=channel.json_body)
         self.assertEqual(number_rooms, channel.json_body["total"])
-        self.assertEqual(number_rooms, len(channel.json_body["rooms"]))
+        self.assertEqual(number_rooms, len(channel.json_body["joined_rooms"]))


### PR DESCRIPTION
Add a new admin API `GET /_synapse/admin/v1/users/<user_id>/rooms` to
list all rooms where a user is a member.

Fixes: #8299

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Signed-off-by: Dirk Klimpel dirk@klimpel.org