### PR TITLE
Allow appservice users to /login

### DIFF
--- a/changelog.d/8320.feature
+++ b/changelog.d/8320.feature
@@ -1,0 +1,1 @@
+Add `uk.half-shot.unstable.login.appservice` login type to allow appservices to login.

--- a/changelog.d/8320.feature
+++ b/changelog.d/8320.feature
@@ -1,1 +1,1 @@
-Add `uk.half-shot.unstable.login.appservice` login type to allow appservices to login.
+Add `uk.half-shot.msc2778.login.application_service` login type to allow appservices to login.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -57,7 +57,6 @@ class JoinRules:
 
 class LoginType:
     PASSWORD = "m.login.password"
-    APPSERVICE = "uk.half-shot.msc2778.login.application_service"
     EMAIL_IDENTITY = "m.login.email.identity"
     MSISDN = "m.login.msisdn"
     RECAPTCHA = "m.login.recaptcha"

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -57,7 +57,7 @@ class JoinRules:
 
 class LoginType:
     PASSWORD = "m.login.password"
-    APPSERVICE = "uk.half-shot.unstable.login.appservice"
+    APPSERVICE = "uk.half-shot.msc2778.login.application_service"
     EMAIL_IDENTITY = "m.login.email.identity"
     MSISDN = "m.login.msisdn"
     RECAPTCHA = "m.login.recaptcha"

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -57,6 +57,7 @@ class JoinRules:
 
 class LoginType:
     PASSWORD = "m.login.password"
+    APPSERVICE = "uk.half-shot.unstable.login.appservice"
     EMAIL_IDENTITY = "m.login.email.identity"
     MSISDN = "m.login.msisdn"
     RECAPTCHA = "m.login.recaptcha"

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -40,12 +40,12 @@ logger = logging.getLogger(__name__)
 
 class LoginRestServlet(RestServlet):
     PATTERNS = client_patterns("/login$", v1=True)
-    APPSERVICE_TYPE = "uk.half-shot.msc2778.login.application_service"
     CAS_TYPE = "m.login.cas"
     SSO_TYPE = "m.login.sso"
     TOKEN_TYPE = "m.login.token"
     JWT_TYPE = "org.matrix.login.jwt"
     JWT_TYPE_DEPRECATED = "m.login.jwt"
+    APPSERVICE_TYPE = "uk.half-shot.msc2778.login.application_service"
 
     def __init__(self, hs):
         super(LoginRestServlet, self).__init__()

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -16,7 +16,6 @@
 import logging
 from typing import Awaitable, Callable, Dict, Optional
 
-from synapse.api.constants import LoginType
 from synapse.api.errors import Codes, LoginError, SynapseError
 from synapse.api.ratelimiting import Ratelimiter
 from synapse.appservice import ApplicationService

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -111,6 +111,8 @@ class LoginRestServlet(RestServlet):
             ({"type": t} for t in self.auth_handler.get_supported_login_types())
         )
 
+        flows.append({"type": LoginRestServlet.APPSERVICE_TYPE})
+
         return 200, {"flows": flows}
 
     def on_OPTIONS(self, request: SynapseRequest):

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 
 class LoginRestServlet(RestServlet):
     PATTERNS = client_patterns("/login$", v1=True)
+    APPSERVICE_TYPE = "uk.half-shot.msc2778.login.application_service"
     CAS_TYPE = "m.login.cas"
     SSO_TYPE = "m.login.sso"
     TOKEN_TYPE = "m.login.token"
@@ -240,7 +241,7 @@ class LoginRestServlet(RestServlet):
         else:
             qualified_user_id = UserID(identifier["user"], self.hs.hostname).to_string()
 
-        if login_submission["type"] == LoginType.APPSERVICE:
+        if login_submission["type"] == LoginRestServlet.APPSERVICE_TYPE:
             if appservice is None or not appservice.is_interested_in_user(
                 qualified_user_id
             ):

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -144,7 +144,7 @@ class LoginRestServlet(RestServlet):
         return 200, result
 
     async def _do_other_login(
-        self, login_submission: JsonDict, appservice: ApplicationService
+        self, login_submission: JsonDict, appservice: Optional[ApplicationService]
     ) -> Dict[str, str]:
         """Handle non-token/saml/jwt logins
 

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -240,7 +240,12 @@ class LoginRestServlet(RestServlet):
         else:
             qualified_user_id = UserID(identifier["user"], self.hs.hostname).to_string()
 
-        if login_submission["type"] == LoginType.APPSERVICE and appservice is not None:
+        if login_submission["type"] == LoginType.APPSERVICE:
+            if appservice is None or not appservice.is_interested_in_user(
+                qualified_user_id
+            ):
+                raise LoginError(403, "Invalid access_token", errcode=Codes.FORBIDDEN)
+
             result = await self._complete_login(qualified_user_id, login_submission)
             return result
 

--- a/tests/rest/client/v1/test_login.py
+++ b/tests/rest/client/v1/test_login.py
@@ -764,7 +764,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
     def register_as_user(self, username):
         request, channel = self.make_request(
             b"POST",
-            f"/_matrix/client/r0/register?access_token={self.service.token}",
+            "/_matrix/client/r0/register?access_token=%s" % (self.service.token,),
             {"username": username},
         )
         self.render(request)

--- a/tests/rest/client/v1/test_login.py
+++ b/tests/rest/client/v1/test_login.py
@@ -7,8 +7,9 @@ from mock import Mock
 import jwt
 
 import synapse.rest.admin
+from synapse.appservice import ApplicationService
 from synapse.rest.client.v1 import login, logout
-from synapse.rest.client.v2_alpha import devices
+from synapse.rest.client.v2_alpha import devices, register
 from synapse.rest.client.v2_alpha.account import WhoamiRestServlet
 
 from tests import unittest
@@ -748,3 +749,74 @@ class JWTPubKeyTestCase(unittest.HomeserverTestCase):
             channel.json_body["error"],
             "JWT validation failed: Signature verification failed",
         )
+
+
+AS_USER = "as_user_alice"
+
+
+class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
+    servlets = [
+        login.register_servlets,
+        register.register_servlets,
+        lambda hs, http_server: WhoamiRestServlet(hs).register(http_server),
+    ]
+
+    def register_as_user(self, username):
+        request, channel = self.make_request(
+            b"POST",
+            f"/_matrix/client/r0/register?access_token={self.service.token}",
+            {"username": username},
+        )
+        self.render(request)
+
+    def make_homeserver(self, reactor, clock):
+        self.hs = self.setup_test_homeserver()
+
+        self.service = ApplicationService(
+            id="unique_identifier",
+            token="some_token",
+            hostname="example.com",
+            sender="@asbot:example.com",
+            namespaces={
+                ApplicationService.NS_USERS: [
+                    {"regex": r"@as_user.*", "exclusive": False}
+                ],
+                ApplicationService.NS_ROOMS: [],
+                ApplicationService.NS_ALIASES: [],
+            },
+        )
+
+        self.hs.get_datastore().services_cache.append(self.service)
+        return self.hs
+
+    def test_login_appservice_user(self):
+        """Test that an appservice user can use /login
+        """
+        self.register_as_user(AS_USER)
+
+        params = {
+            "type": login.LoginRestServlet.APPSERVICE_TYPE,
+            "identifier": {"type": "m.id.user", "user": AS_USER},
+        }
+        request, channel = self.make_request(
+            b"POST", LOGIN_URL, params, access_token=self.service.token
+        )
+
+        self.render(request)
+        self.assertEquals(channel.result["code"], b"200", channel.result)
+
+    def test_login_appservice_user_bot(self):
+        """Test that the appservice bot can use /login
+        """
+        self.register_as_user(AS_USER)
+
+        params = {
+            "type": login.LoginRestServlet.APPSERVICE_TYPE,
+            "identifier": {"type": "m.id.user", "user": self.service.sender},
+        }
+        request, channel = self.make_request(
+            b"POST", LOGIN_URL, params, access_token=self.service.token
+        )
+
+        self.render(request)
+        self.assertEquals(channel.result["code"], b"200", channel.result)


### PR DESCRIPTION
This PR adds the `uk.half-shot.msc2778.login.application_service` login `type`, which allows users to login using an appservice token. This is going to be used as part of the encrypted bridges project, as we need to generate device_ids for users.

This should be ready for review now. And now with tests!

[MSC2778](https://github.com/matrix-org/matrix-doc/pull/2778)
