### PR TITLE
Update test logging to be able to accept braces

### DIFF
--- a/changelog.d/8335.misc
+++ b/changelog.d/8335.misc
@@ -1,0 +1,1 @@
+Fix test logging to allow braces in log output.

--- a/tests/test_utils/logging_setup.py
+++ b/tests/test_utils/logging_setup.py
@@ -29,8 +29,7 @@ class ToTwistedHandler(logging.Handler):
         log_entry = self.format(record)
         log_level = record.levelname.lower().replace("warning", "warn")
         self.tx_log.emit(
-            twisted.logger.LogLevel.levelWithName(log_level),
-            log_entry.replace("{", r"(").replace("}", r")"),
+            twisted.logger.LogLevel.levelWithName(log_level), "{entry}", entry=log_entry
         )
 
 


### PR DESCRIPTION
The old method simply replaced braces with parentheses before sending it off into twisted logging, this was a hack, it's now been properly fixed.

The reason why the hack is needed, and this roundabout is needed, is because twisted logging works with "new-style formatting" (PEP 3101), or simply "brace formatting" (`"{thing}".format({thing=1})`), if braces were preserved (in what is essentially the "format" string), the twisted logger will attempt to interpret them according to the new-style formatting, and produce an error.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`
