### PR TITLE
Update sync method to leave out unneeded bytes

### DIFF
--- a/changelog.d/8336.bugfix
+++ b/changelog.d/8336.bugfix
@@ -1,0 +1,1 @@
+Remove optional keys from `/sync` response according to spec.

--- a/tests/server_notices/test_consent.py
+++ b/tests/server_notices/test_consent.py
@@ -76,8 +76,11 @@ class ConsentNoticesTests(unittest.HomeserverTestCase):
         self.render(request)
         self.assertEqual(channel.code, 200)
 
+        invite_keys = list(channel.json_body.get("rooms", {}).get("invite", {}).keys())
+        self.assertTrue(len(invite_keys) > 0, channel.json_body)
+
         # Get the Room ID to join
-        room_id = list(channel.json_body["rooms"]["invite"].keys())[0]
+        room_id = invite_keys[0]
 
         # Join the room
         request, channel = self.make_request(

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -308,7 +308,7 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
         request, channel = self.make_request("GET", "/sync?timeout=0", access_token=tok)
         self.render(request)
 
-        invites = channel.json_body["rooms"]["invite"]
+        invites = channel.json_body.get("rooms", {}).get("invite", [])
         self.assertEqual(len(invites), 0, invites)
 
     def test_invite_with_notice(self):
@@ -366,7 +366,7 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
             # We could also pick another user and sync with it, which would return an
             # invite to a system notices room, but it doesn't matter which user we're
             # using so we use the last one because it saves us an extra sync.
-            invites = channel.json_body["rooms"]["invite"]
+            invites = channel.json_body.get("rooms", {}).get("invite", [])
 
         # Make sure we have an invite to process.
         self.assertEqual(len(invites), 1, invites)


### PR DESCRIPTION
(And fix some tests to stop assuming unilateral presence of sync keys)

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

(Partially) addresses #6579 (`room.join` is not optimized)

**Note: This PR is *potentially breaking*, it still adheres to the [spec](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-sync), but some clients or libraries could have (up to this point) fully assumed that all keys are present in the `/sync` object.**

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`