### PR TITLE
Use _check_sigs_and_hash_and_fetch to validate backfill requests

### DIFF
--- a/changelog.d/8350.bugfix
+++ b/changelog.d/8350.bugfix
@@ -1,0 +1,1 @@
+Partially mitigate bug where newly joined servers couldn't get past events in a room when there is a malformed event.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -217,11 +217,9 @@ class FederationClient(FederationBase):
             for p in transaction_data["pdus"]
         ]
 
-        # FIXME: We should handle signature failures more gracefully.
-        pdus[:] = await make_deferred_yieldable(
-            defer.gatherResults(
-                self._check_sigs_and_hashes(room_version, pdus), consumeErrors=True,
-            ).addErrback(unwrapFirstError)
+        # Check signatures and hash of pdus, removing any from the list that fail checks
+        pdus[:] = await self._check_sigs_and_hash_and_fetch(
+            dest, pdus, outlier=True, room_version=room_version
         )
 
         return pdus

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -219,7 +219,7 @@ class FederationClient(FederationBase):
 
         # Check signatures and hash of pdus, removing any from the list that fail checks
         pdus[:] = await self._check_sigs_and_hash_and_fetch(
-            dest, pdus, outlier=True, room_version=room_version
+            dest, pdus, outlier=True, room_version=room_version, check_db=False
         )
 
         return pdus
@@ -348,6 +348,7 @@ class FederationClient(FederationBase):
         room_version: RoomVersion,
         outlier: bool = False,
         include_none: bool = False,
+        check_db: bool = True,
     ) -> List[EventBase]:
         """Takes a list of PDUs and checks the signatures and hashes of each
         one. If a PDU fails its signature check then we check if we have it in

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -219,7 +219,7 @@ class FederationClient(FederationBase):
 
         # Check signatures and hash of pdus, removing any from the list that fail checks
         pdus[:] = await self._check_sigs_and_hash_and_fetch(
-            dest, pdus, outlier=True, room_version=room_version, check_db=False
+            dest, pdus, outlier=True, room_version=room_version
         )
 
         return pdus
@@ -348,7 +348,6 @@ class FederationClient(FederationBase):
         room_version: RoomVersion,
         outlier: bool = False,
         include_none: bool = False,
-        check_db: bool = True,
     ) -> List[EventBase]:
         """Takes a list of PDUs and checks the signatures and hashes of each
         one. If a PDU fails its signature check then we check if we have it in


### PR DESCRIPTION
This PR is a partial fix to backfilling rooms with malformed events. It will
allow for backfilling a partial set of events in the room, but will not fix your
backfill eventually running out.

This could be cleaner, as `_check_sigs_and_hash_and_fetch` is intended
for attempting to pull an event from the database/(re)pull it from the
server that originally sent the event if checking the signature of the
event fails.

During backfill we *know* that we won't have the event in our database,
however it is still useful to be able to query the original sending
server as the server we're backfilling from may be acting maliciously.

The main benefit and reason for using this method however is that
`_check_sigs_and_hash_and_fetch` will drop an event during backfill if
it cannot be successfully validated, whereas the current code will
simply fail the backfill request - resulting in the client's /messages
request silently being dropped.