### PR TITLE
Fix a bad merge of release-v1.20.0 to develop

### DIFF
--- a/changelog.d/8354.misc
+++ b/changelog.d/8354.misc
@@ -1,0 +1,1 @@
+Fix bad merge from `release-v1.20.0` branch to `develop`.

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -385,7 +385,7 @@ class PaginationHandler:
                         )
 
                 await self.hs.get_handlers().federation_handler.maybe_backfill(
-                    room_id, curr_topo, limit=source_config.limit,
+                    room_id, curr_topo, limit=pagin_config.limit,
                 )
 
             to_room_key = None


### PR DESCRIPTION
When merging from `release-v1.20.0` to `develop` (see 00db7786de526edc9635f6a5d12f725c31d2f3f5) there was a merge conflict in `synapse/handlers/pagination.py`, I resolved it (correctly, I think) but the non-conflict parts were incompatible.

This attempts to fix that.