### PR TITLE
Fix missing null character check on guest_access room state

### DIFF
--- a/changelog.d/8373.bugfix
+++ b/changelog.d/8373.bugfix
@@ -1,0 +1,1 @@
+Include `guest_access` in the fields that are checked for null bytes when updating `room_stats_state`. Broke in v1.7.2.

--- a/synapse/storage/databases/main/stats.py
+++ b/synapse/storage/databases/main/stats.py
@@ -210,6 +210,7 @@ class StatsStore(StateDeltasStore):
         * topic
         * avatar
         * canonical_alias
+        * guest_access
 
         A is_federatable key can also be included with a boolean value.
 
@@ -234,6 +235,7 @@ class StatsStore(StateDeltasStore):
             "topic",
             "avatar",
             "canonical_alias",
+            "guest_access",
         ):
             field = fields.get(col, sentinel)
             if field is not sentinel and (not isinstance(field, str) or "\0" in field):


### PR DESCRIPTION
When updating the `room_stats_state` table, we try to check for null bytes slipping in to the content for state events. It turns out we had added `guest_access` as a field to room_stats_state without including it in the null byte check.

Lo and behold, a null byte in a `m.room.guest_access` event then breaks `room_stats_state` updates.

This PR adds the check for `guest_access`, as well as adding an assert if a field is added to `room_stats_state` without being either explicitly included or not included in the null byte check.

I *think* this broke in https://github.com/matrix-org/synapse/commit/6e834e94fcc97811e4cc8185e86c6b9da06eb28e#diff-9fb8e219f876ae3f280bc88c8b9ea972R285.