### PR TITLE
Add note to reverse_proxy.md about disabling Apache's mod_security2

### DIFF
--- a/changelog.d/8375.doc
+++ b/changelog.d/8375.doc
@@ -1,0 +1,1 @@
+Add note to the reverse proxy settings documentation about disabling Apache's mod_security2. Contributed by Julian Fietkau (@jfietkau).

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -121,6 +121,14 @@ example.com:8448 {
 
 **NOTE**: ensure the  `nocanon` options are included.
 
+**NOTE 2**: It appears that Synapse is currently incompatible with the ModSecurity module for Apache (`mod_security2`). If you need it enabled for other services on your web server, you can disable it for Synapse's two VirtualHosts by including the following lines before each of the two `</VirtualHost>` above:
+
+```
+<IfModule security2_module>
+    SecRuleEngine off
+</IfModule>
+```
+
 ### HAProxy
 
 ```


### PR DESCRIPTION
After installing and enabling mod_security2 on my Apache web server, I noticed that Synapse users were unable to send messages. It was still possible to create and modify rooms, but all clients would only show errors to the effect of "Unable to send message" whenever users tried to send anything.

Hence, this change adds a note and a few lines of configuration settings for Apache users to disable ModSecurity for Synapse's virtual hosts. I can confirm that with this change, Synapse is fully functional again even with ModSecurity enabled by default for other virtual hosts on the same server.

I am not proficient enough with ModSecurity to diagnose the exact setting or rule that causes the issue, but disabling it altogether for the Synapse virtual host is not an issue for my use case. My Synapse installation does not use federation and I have not tested whether the "*:8448" virtual host also requires this change to function, but I included it to be safe.

As provided here, the configuration change does not cause errors even if ModSecurity is disabled or not installed at all. It could therefore be added to the default configuration without causing issues, if the maintainers prefer.

Feel free to let me know if the wording needs adjustment, I am an ESL speaker.

Signed-off-by: Julian Fietkau <github@julian-fietkau.de>