### PR TITLE
Mark the shadow_banned column as boolean in synapse_port_db.

### DIFF
--- a/changelog.d/8386.bugfix
+++ b/changelog.d/8386.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.20.0 which caused the `synapse_port_db` script to fail.

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -89,6 +89,7 @@ BOOLEAN_COLUMNS = {
     "redactions": ["have_censored"],
     "room_stats_state": ["is_federatable"],
     "local_media_repository": ["safe_from_quarantine"],
+    "users": ["shadow_banned"],
 }
 
 


### PR DESCRIPTION
This fixes #8384, but not the underlying issue of why tests didn't fail.