### PR TITLE
Docker: support passing additional commandline args to synapse

### DIFF
--- a/changelog.d/8390.docker
+++ b/changelog.d/8390.docker
@@ -1,0 +1,1 @@
+Added support for passing commandline args to the synapse process. Contributed by @samuel-p.

--- a/changelog.d/8390.docker
+++ b/changelog.d/8390.docker
@@ -1,1 +1,1 @@
-Added support for passing commandline args to the synapse process. Contributed by @samuel-p.
+Add support for passing commandline args to the synapse process. Contributed by @samuel-p.

--- a/docker/README.md
+++ b/docker/README.md
@@ -83,7 +83,7 @@ docker logs synapse
 If all is well, you should now be able to connect to http://localhost:8008 and
 see a confirmation message.
 
-The following environment variables are supported in run mode:
+The following environment variables are supported in `run` mode:
 
 * `SYNAPSE_CONFIG_DIR`: where additional config files are stored. Defaults to
   `/data`.
@@ -93,6 +93,18 @@ The following environment variables are supported in run mode:
    Defaults to `synapse.app.homeserver`, which is suitable for non-worker mode.
 * `UID`, `GID`: the user and group id to run Synapse as. Defaults to `991`, `991`.
 * `TZ`: the [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) the container will run with. Defaults to `UTC`.
+
+For more complex setups (e.g. for workers) you can also pass your args directly to synapse using `run` mode. For example like this:
+
+```
+docker run -d --name synapse \
+    --mount type=volume,src=synapse-data,dst=/data \
+    -p 8008:8008 \
+    matrixdotorg/synapse:latest run \
+    -m synapse.app.generic_worker \
+    --config-path=/data/homeserver.yaml \
+    --config-path=/data/generic_worker.yaml
+```
 
 ## Generating an (admin) user
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -106,6 +106,8 @@ docker run -d --name synapse \
     --config-path=/data/generic_worker.yaml
 ```
 
+If you do not provide `-m`, the value of the `SYNAPSE_WORKER` environment variable is used. If you do not provide at least one `--config-path` or `-c`, the value of the `SYNAPSE_CONFIG_PATH` environment variable is used instead.
+
 ## Generating an (admin) user
 
 After synapse is running, you may wish to create a user via `register_new_matrix_user`.

--- a/docker/start.py
+++ b/docker/start.py
@@ -210,7 +210,7 @@ def main(args, environ):
     if "-m" not in args:
         args = ["-m", synapse_worker] + args
 
-    if not filter(lambda p: p.startswith("--config-path"), args):
+    if not any(p.startswith("--config-path") for p in args):
         config_dir = environ.get("SYNAPSE_CONFIG_DIR", "/data")
         config_path = environ.get(
             "SYNAPSE_CONFIG_PATH", config_dir + "/homeserver.yaml"

--- a/docker/start.py
+++ b/docker/start.py
@@ -179,7 +179,7 @@ def run_generate_config(environ, ownership):
 
 
 def main(args, environ):
-    mode = args[1] if len(args) > 1 else None
+    mode = args[1] if len(args) > 1 else "run"
     desired_uid = int(environ.get("UID", "991"))
     desired_gid = int(environ.get("GID", "991"))
     synapse_worker = environ.get("SYNAPSE_WORKER", "synapse.app.homeserver")
@@ -205,48 +205,53 @@ def main(args, environ):
             config_dir, config_path, environ, ownership
         )
 
-    args = ["python"] + args[1:]
+    if mode == "run":
+        args = args[2:]
 
-    if "-m" not in args:
-        args = ["-m", synapse_worker] + args
+        if "-m" not in args:
+            args = ["-m", synapse_worker] + args
 
-    if not any(p.startswith("--config-path") for p in args):
-        config_dir = environ.get("SYNAPSE_CONFIG_DIR", "/data")
-        config_path = environ.get(
-            "SYNAPSE_CONFIG_PATH", config_dir + "/homeserver.yaml"
-        )
+        # if there are no config files passed to synapse, try adding the default file
+        if not any(p.startswith("--config-path") for p in args):
+            config_dir = environ.get("SYNAPSE_CONFIG_DIR", "/data")
+            config_path = environ.get(
+                "SYNAPSE_CONFIG_PATH", config_dir + "/homeserver.yaml"
+            )
 
-        if not os.path.exists(config_path):
-            if "SYNAPSE_SERVER_NAME" in environ:
-                error(
-                    """\
+            if not os.path.exists(config_path):
+                if "SYNAPSE_SERVER_NAME" in environ:
+                    error(
+                        """\
 Config file '%s' does not exist.
    
 The synapse docker image no longer supports generating a config file on-the-fly
 based on environment variables. You can migrate to a static config file by
 running with 'migrate_config'. See the README for more details.
 """
+                        % (config_path,)
+                    )
+
+                error(
+                    "Config file '%s' does not exist. You should either create a new "
+                    "config file by running with the `generate` argument (and then edit "
+                    "the resulting file before restarting) or specify the path to an "
+                    "existing config file with the SYNAPSE_CONFIG_PATH variable."
                     % (config_path,)
                 )
 
-            error(
-                "Config file '%s' does not exist. You should either create a new "
-                "config file by running with the `generate` argument (and then edit "
-                "the resulting file before restarting) or specify the path to an "
-                "existing config file with the SYNAPSE_CONFIG_PATH variable."
-                % (config_path,)
-            )
-
-        if "--config-path=" + config_path not in args:
             args += ["--config-path", config_path]
 
-    log("Starting synapse with args " + " ".join(args))
+        log("Starting synapse with args " + " ".join(args))
 
-    if ownership is not None:
-        args = ["gosu", ownership] + args
-        os.execv("/usr/sbin/gosu", args)
-    else:
-        os.execv("/usr/local/bin/python", args)
+        args = ["python"] + args
+        if ownership is not None:
+            args = ["gosu", ownership] + args
+            os.execv("/usr/sbin/gosu", args)
+        else:
+            os.execv("/usr/local/bin/python", args)
+        return
+
+    error("Unknown execution mode '%s'" % (mode,))
 
 
 if __name__ == "__main__":

--- a/docker/start.py
+++ b/docker/start.py
@@ -205,7 +205,8 @@ def main(args, environ):
             config_dir, config_path, environ, ownership
         )
 
-    if mode == "run":
+    if mode != "run":
+        error("Unknown execution mode '%s'" % (mode,))
         args = args[2:]
 
         if "-m" not in args:

--- a/docker/start.py
+++ b/docker/start.py
@@ -212,7 +212,9 @@ def main(args, environ):
 
     if not filter(lambda p: p.startswith("--config-path"), args):
         config_dir = environ.get("SYNAPSE_CONFIG_DIR", "/data")
-        config_path = environ.get("SYNAPSE_CONFIG_PATH", config_dir + "/homeserver.yaml")
+        config_path = environ.get(
+            "SYNAPSE_CONFIG_PATH", config_dir + "/homeserver.yaml"
+        )
 
         if not os.path.exists(config_path):
             if "SYNAPSE_SERVER_NAME" in environ:
@@ -238,7 +240,7 @@ running with 'migrate_config'. See the README for more details.
         if "--config-path=" + config_path not in args:
             args += ["--config-path", config_path]
 
-    log("Starting synapse with args " + ' '.join(args))
+    log("Starting synapse with args " + " ".join(args))
 
     if ownership is not None:
         args = ["gosu", ownership] + args


### PR DESCRIPTION
Updated the docker `start.py` to allow passing commandline args to the synapse process (fixes #6662).

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

`Signed-off-by: Samuel Philipp <codes@samuel-philipp.de>`