### PR TITLE
Hotfix: disable autoescape by default when rendering Jinja2 templates

### DIFF
--- a/changelog.d/8394.bugfix
+++ b/changelog.d/8394.bugfix
@@ -1,0 +1,1 @@
+Fix URLs being accidentally escaped in Jinja2 templates. Broke in v1.20.0.

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -194,7 +194,10 @@ class Config:
             return file_stream.read()
 
     def read_templates(
-        self, filenames: List[str], custom_template_directory: Optional[str] = None,
+        self,
+        filenames: List[str],
+        custom_template_directory: Optional[str] = None,
+        autoescape: bool = False,
     ) -> List[jinja2.Template]:
         """Load a list of template files from disk using the given variables.
 
@@ -209,6 +212,9 @@ class Config:
 
             custom_template_directory: A directory to try to look for the templates
                 before using the default Synapse template directory instead.
+
+            autoescape: Whether to autoescape variables before inserting them into the
+                template.
 
         Raises:
             ConfigError: if the file's path is incorrect or otherwise cannot be read.
@@ -233,7 +239,7 @@ class Config:
             search_directories.insert(0, custom_template_directory)
 
         loader = jinja2.FileSystemLoader(search_directories)
-        env = jinja2.Environment(loader=loader, autoescape=True)
+        env = jinja2.Environment(loader=loader, autoescape=autoescape)
 
         # Update the environment with our custom filters
         env.filters.update(

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -169,8 +169,10 @@ class SAML2Config(Config):
             saml2_config.get("saml_session_lifetime", "15m")
         )
 
+        # We enable autoescape here as the message may potentially come from a
+        # remote resource
         self.saml2_error_html_template = self.read_templates(
-            ["saml_error.html"], saml2_config.get("template_dir")
+            ["saml_error.html"], saml2_config.get("template_dir"), autoescape=True
         )[0]
 
     def _default_saml_config_dict(


### PR DESCRIPTION
#8037 changed the default `autoescape` option when rendering Jinja2 templates from `False` to `True`. This caused some bugs, noticeably around redirect URLs being escaped in SAML2 auth confirmation templates, causing those URLs to break for users.

This change returns the previous behaviour as it stood. We may want to look at each template individually and see whether autoescaping is a good idea at some point, but for now lets just fix the breakage.