### PR TITLE
Escape the error description on the sso_error template.

### DIFF
--- a/changelog.d/8405.feature
+++ b/changelog.d/8405.feature
@@ -1,0 +1,1 @@
+Consolidate the SSO error template across all configuration.

--- a/synapse/res/templates/sso_error.html
+++ b/synapse/res/templates/sso_error.html
@@ -12,7 +12,7 @@
     <p>
         There was an error during authentication:
     </p>
-    <div id="errormsg" style="margin:20px 80px">{{ error_description }}</div>
+    <div id="errormsg" style="margin:20px 80px">{{ error_description | e }}</div>
     <p>
         If you are seeing this page after clicking a link sent to you via email, make
         sure you only click the confirmation link once, and that you open the


### PR DESCRIPTION
We started auto-escaping all templates in #8037, but then backed this out in #8394. When merging forward into develop the fixes for #8394 were gone due to the template being merged with another template in #8248, so this essentially re-applies the fix from #8394 to the new code in develop.

The only concerning value in the template is `error_description` so it is now escaped.