### PR TITLE
Correctly retry replication HTTP requests on timeout

### DIFF
--- a/changelog.d/8412.bugfix
+++ b/changelog.d/8412.bugfix
@@ -1,0 +1,1 @@
+Fix retries of HTTP requests between Synapse workers when the requests time out.

--- a/synapse/config/_base.pyi
+++ b/synapse/config/_base.pyi
@@ -35,6 +35,7 @@ from synapse.config import (
     workers,
 )
 
+
 class ConfigError(Exception): ...
 
 MISSING_REPORT_STATS_CONFIG_INSTRUCTIONS: str

--- a/synapse/replication/http/_base.py
+++ b/synapse/replication/http/_base.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import abc
 import logging
 import re
@@ -26,6 +25,7 @@ from synapse.api.errors import (
     RequestSendFailed,
     SynapseError,
 )
+from synapse.http import RequestTimedOutError
 from synapse.logging.opentracing import inject_active_span_byte_dict, trace
 from synapse.util.caches.response_cache import ResponseCache
 from synapse.util.stringutils import random_string
@@ -195,6 +195,9 @@ class ReplicationEndpoint(metaclass=abc.ABCMeta):
                         break
                     except CodeMessageException as e:
                         if e.code != 504 or not cls.RETRY_ON_TIMEOUT:
+                            raise
+                    except RequestTimedOutError:
+                        if not cls.RETRY_ON_TIMEOUT:
                             raise
 
                     logger.warning("%s request timed out", cls.NAME)


### PR DESCRIPTION
This, in conjunction with #8400, should hopefully fix #7792. The idea being that we'll keep retrying when we get a timeout (rather than raising).