### PR TITLE
Allow additional SSO properties to be passed to the client

### DIFF
--- a/changelog.d/8413.feature
+++ b/changelog.d/8413.feature
@@ -1,0 +1,1 @@
+Support passing additional single sign-on parameters to the client.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1741,7 +1741,7 @@ oidc_config:
       # Note that these are non-standard and clients will ignore them without modifications.
       #
       #extra_attributes:
-        #birthdate: "{ user.birthdate }"
+        #birthdate: "{{ user.birthdate }}"
 
 
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1735,6 +1735,14 @@ oidc_config:
       #
       #display_name_template: "{{ user.given_name }} {{ user.last_name }}"
 
+      # Jinja2 templates for extra attributes to send back to the client during
+      # login.
+      #
+      # Note that these are non-standard and clients will ignore them without modifications.
+      #
+      #extra_attributes:
+        #birthdate: "{ user.birthdate }"
+
 
 
 # Enable CAS for registration and login.

--- a/docs/sso_mapping_providers.md
+++ b/docs/sso_mapping_providers.md
@@ -74,8 +74,10 @@ A custom mapping provider must specify the following methods:
       - `token` - A dictionary which includes information necessary to make
                   further requests to the OpenID provider.
     - Returns a dictionary that is suitable to be serialized to JSON. This
-      dictionary will be returned under the `extra_attributes` key in the
-      response during a successful login.
+      will be returned as part of the response during a successful login.
+      
+      Note that care should be taken to not overwrite any of the parameters
+      usually returned as part of the [login response](https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-login).
 
 ### Default OpenID Mapping Provider
 

--- a/docs/sso_mapping_providers.md
+++ b/docs/sso_mapping_providers.md
@@ -57,7 +57,7 @@ A custom mapping provider must specify the following methods:
     - This method must return a string, which is the unique identifier for the
       user. Commonly the ``sub`` claim of the response.
 * `map_user_attributes(self, userinfo, token)`
-    - This method should be async.
+    - This method must be async.
     - Arguments:
       - `userinfo` - A `authlib.oidc.core.claims.UserInfo` object to extract user
                      information from.
@@ -66,6 +66,16 @@ A custom mapping provider must specify the following methods:
     - Returns a dictionary with two keys:
       - localpart: A required string, used to generate the Matrix ID.
       - displayname: An optional string, the display name for the user.
+* `get_extra_attributes(self, userinfo, token)`
+    - This method must be async.
+    - Arguments:
+      - `userinfo` - A `authlib.oidc.core.claims.UserInfo` object to extract user
+                     information from.
+      - `token` - A dictionary which includes information necessary to make
+                  further requests to the OpenID provider.
+    - Returns a dictionary that is suitable to be serialized to JSON. This
+      dictionary will be returned under the `extra_attributes` key in the
+      response during a successful login.
 
 ### Default OpenID Mapping Provider
 

--- a/docs/sso_mapping_providers.md
+++ b/docs/sso_mapping_providers.md
@@ -75,7 +75,7 @@ A custom mapping provider must specify the following methods:
                   further requests to the OpenID provider.
     - Returns a dictionary that is suitable to be serialized to JSON. This
       will be returned as part of the response during a successful login.
-      
+
       Note that care should be taken to not overwrite any of the parameters
       usually returned as part of the [login response](https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-login).
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -243,6 +243,22 @@ for the room are in flight:
 
     ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/messages$
 
+Additionally, the following endpoints should be included if Synapse is configured
+to use SSO (you only need to include the ones for whichever SSO provider you're
+using):
+
+    # OpenID Connect requests.
+    ^/_matrix/client/(api/v1|r0|unstable)/login/sso/redirect$
+    ^/_synapse/oidc/callback$
+
+    # SAML requests.
+    ^/_matrix/client/(api/v1|r0|unstable)/login/sso/redirect$
+    ^/_matrix/saml2/authn_response$
+
+    # CAS requests.
+    ^/_matrix/client/(api/v1|r0|unstable)/login/(cas|sso)/redirect$
+    ^/_matrix/client/(api/v1|r0|unstable)/login/cas/ticket$
+
 Note that a HTTP listener with `client` and `federation` resources must be
 configured in the `worker_listeners` option in the worker config.
 

--- a/synapse/config/oidc_config.py
+++ b/synapse/config/oidc_config.py
@@ -204,6 +204,14 @@ class OIDCConfig(Config):
               # If unset, no displayname will be set.
               #
               #display_name_template: "{{{{ user.given_name }}}} {{{{ user.last_name }}}}"
+
+              # Jinja2 templates for extra attributes to send back to the client during
+              # login.
+              #
+              # Note that these are non-standard and clients will ignore them without modifications.
+              #
+              #extra_attributes:
+                #birthdate: "{{ user.birthdate }}"
         """.format(
             mapping_provider=DEFAULT_USER_MAPPING_PROVIDER
         )

--- a/synapse/config/oidc_config.py
+++ b/synapse/config/oidc_config.py
@@ -211,7 +211,7 @@ class OIDCConfig(Config):
               # Note that these are non-standard and clients will ignore them without modifications.
               #
               #extra_attributes:
-                #birthdate: "{{ user.birthdate }}"
+                #birthdate: "{{{{ user.birthdate }}}}"
         """.format(
             mapping_provider=DEFAULT_USER_MAPPING_PROVIDER
         )

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1267,9 +1267,7 @@ class AuthHandler(BaseHandler):
 
         extra_attributes = self._extra_attributes.get(login_result["user_id"])
         if extra_attributes:
-            login_result.update(
-                (("extra_attributes", extra_attributes.extra_attributes),)
-            )
+            login_result.update(extra_attributes.extra_attributes)
 
     def _expire_sso_extra_attributes(self) -> None:
         """

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -1074,7 +1074,13 @@ class JinjaOidcMappingProvider(OidcMappingProvider[JinjaOidcMappingConfig]):
 
         extra_attributes = {}  # type Dict[str, Template]
         if "extra_attributes" in config:
-            for key, value in config["extra_attributes"].items():
+            extra_attributes_config = config.get("extra_attributes") or {}
+            if not isinstance(extra_attributes_config, dict):
+                raise ConfigError(
+                    "oidc_config.user_mapping_provider.config.extra_attributes must be a dict"
+                )
+
+            for key, value in extra_attributes_config.items():
                 try:
                     extra_attributes[key] = env.from_string(value)
                 except Exception as e:

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -1115,5 +1115,9 @@ class JinjaOidcMappingProvider(OidcMappingProvider[JinjaOidcMappingConfig]):
     async def get_extra_attributes(self, userinfo: UserInfo, token: Token) -> JsonDict:
         extras = {}  # type: Dict[str, str]
         for key, template in self._config.extra_attributes.items():
-            extras[key] = template.render(user=userinfo).strip()
+            try:
+                extras[key] = template.render(user=userinfo).strip()
+            except Exception as e:
+                # Log an error and skip this value (don't break login for this).
+                logger.error("Failed to render OIDC extra attribute %s: %s" % (key, e))
         return extras

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -711,7 +711,7 @@ class OidcHandler:
         # method if it exists. It might also raise NotImplementedError.
         extra_attributes = None
         get_extra_attributes = getattr(
-            self._user_mapping_provider, "get_extra_attributes"
+            self._user_mapping_provider, "get_extra_attributes", None
         )
         if get_extra_attributes:
             try:
@@ -996,7 +996,7 @@ class OidcMappingProvider(Generic[C]):
     async def map_user_attributes(
         self, userinfo: UserInfo, token: Token
     ) -> UserAttribute:
-        """Map a ``UserInfo`` objects into user attributes.
+        """Map a `UserInfo` object into user attributes.
 
         Args:
             userinfo: An object representing the user given by the OIDC provider
@@ -1008,7 +1008,7 @@ class OidcMappingProvider(Generic[C]):
         raise NotImplementedError()
 
     async def get_extra_attributes(self, userinfo: UserInfo, token: Token) -> JsonDict:
-        """Map a ``UserInfo`` objects into additional attributes passed to the client during login.
+        """Map a `UserInfo` object into additional attributes passed to the client during login.
 
         Args:
             userinfo: An object representing the user given by the OIDC provider
@@ -1080,7 +1080,7 @@ class JinjaOidcMappingProvider(OidcMappingProvider[JinjaOidcMappingConfig]):
                 except Exception as e:
                     raise ConfigError(
                         "invalid jinja template for oidc_config.user_mapping_provider.config.extra_attributes.%s: %r"
-                        % (key, e,)
+                        % (key, e)
                     )
 
         return JinjaOidcMappingConfig(

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -708,16 +708,13 @@ class OidcHandler:
             return
 
         # Mapping providers might not have get_extra_attributes: only call this
-        # method if it exists. It might also raise NotImplementedError.
+        # method if it exists.
         extra_attributes = None
         get_extra_attributes = getattr(
             self._user_mapping_provider, "get_extra_attributes", None
         )
         if get_extra_attributes:
-            try:
-                extra_attributes = await get_extra_attributes(userinfo, token)
-            except NotImplementedError:
-                pass
+            extra_attributes = await get_extra_attributes(userinfo, token)
 
         # and finally complete the login
         if ui_auth_session_id:
@@ -1017,7 +1014,7 @@ class OidcMappingProvider(Generic[C]):
         Returns:
             A dict containing additional attributes. Must be JSON serializable.
         """
-        raise NotImplementedError()
+        return {}
 
 
 # Used to clear out "None" values in templates

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -297,12 +297,12 @@ class LoginRestServlet(RestServlet):
         Args:
             user_id: ID of the user to register.
             login_submission: Dictionary of login information.
-            callback: Callback function to run after registration.
+            callback: Callback function to run after login.
             create_non_existent_users: Whether to create the user if they don't
                 exist. Defaults to False.
 
         Returns:
-            result: Dictionary of account information after successful registration.
+            result: Dictionary of account information after successful login.
         """
 
         # Before we actually log them in we check if they've already logged in

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -619,10 +619,8 @@ class OidcHandlerTestCase(HomeserverTestCase):
             "phone": "1234567",
         }
         user_id = "@foo:domain.org"
-        self.handler._render_error = Mock(return_value=None)
         self.handler._exchange_code = simple_async_mock(return_value=token)
         self.handler._parse_id_token = simple_async_mock(return_value=userinfo)
-        self.handler._fetch_userinfo = simple_async_mock(return_value=userinfo)
         self.handler._map_userinfo_to_user = simple_async_mock(return_value=user_id)
         self.handler._auth_handler.complete_sso_login = simple_async_mock()
         request = Mock(

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -401,13 +401,12 @@ class OidcHandlerTestCase(HomeserverTestCase):
         client_redirect_url = "http://client/redirect"
         user_agent = "Browser"
         ip_address = "10.0.0.1"
-        session = self.handler._generate_oidc_session_token(
+        request.getCookie.return_value = self.handler._generate_oidc_session_token(
             state=state,
             nonce=nonce,
             client_redirect_url=client_redirect_url,
             ui_auth_session_id=None,
         )
-        request.getCookie.return_value = session
 
         request.args = {}
         request.args[b"code"] = [code.encode("utf-8")]
@@ -627,27 +626,22 @@ class OidcHandlerTestCase(HomeserverTestCase):
             spec=["args", "getCookie", "addCookie", "requestHeaders", "getClientIP"]
         )
 
-        code = "code"
         state = "state"
-        nonce = "nonce"
         client_redirect_url = "http://client/redirect"
-        user_agent = "Browser"
-        ip_address = "10.0.0.1"
-        session = self.handler._generate_oidc_session_token(
+        request.getCookie.return_value = self.handler._generate_oidc_session_token(
             state=state,
-            nonce=nonce,
+            nonce="nonce",
             client_redirect_url=client_redirect_url,
             ui_auth_session_id=None,
         )
-        request.getCookie.return_value = session
 
         request.args = {}
-        request.args[b"code"] = [code.encode("utf-8")]
+        request.args[b"code"] = [b"code"]
         request.args[b"state"] = [state.encode("utf-8")]
 
         request.requestHeaders = Mock(spec=["getRawHeaders"])
-        request.requestHeaders.getRawHeaders.return_value = [user_agent.encode("ascii")]
-        request.getClientIP.return_value = ip_address
+        request.requestHeaders.getRawHeaders.return_value = [b"Browser"]
+        request.getClientIP.return_value = "10.0.0.1"
 
         yield defer.ensureDeferred(self.handler.handle_oidc_callback(request))
 

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -420,7 +420,7 @@ class OidcHandlerTestCase(HomeserverTestCase):
         yield defer.ensureDeferred(self.handler.handle_oidc_callback(request))
 
         self.handler._auth_handler.complete_sso_login.assert_called_once_with(
-            user_id, request, client_redirect_url, None,
+            user_id, request, client_redirect_url, {},
         )
         self.handler._exchange_code.assert_called_once_with(code)
         self.handler._parse_id_token.assert_called_once_with(token, nonce=nonce)
@@ -454,7 +454,7 @@ class OidcHandlerTestCase(HomeserverTestCase):
         yield defer.ensureDeferred(self.handler.handle_oidc_callback(request))
 
         self.handler._auth_handler.complete_sso_login.assert_called_once_with(
-            user_id, request, client_redirect_url, None,
+            user_id, request, client_redirect_url, {},
         )
         self.handler._exchange_code.assert_called_once_with(code)
         self.handler._parse_id_token.assert_not_called()


### PR DESCRIPTION
This adds a feature that additional SSO properties can be passed down to the client, note that this is only implemented for OpenID Connect, but I believe it is abstracted enough that it should be easily implemented for SAML/CAS.

This works by processing the OIDC response claims and storing additional information and then using Synapse's login callback mechanism to add fields to the login response. The mapping provider has gained an additional method (`get_extra_attributes`) in order to support this, but the code handles this method not existing. The built-in mapping provider (which uses Jinja2) was updated to provide this functionality via the config file.
