### PR TITLE
Don't check whether a 3pid is allowed to register during password reset

### DIFF
--- a/changelog.d/8414.bugfix
+++ b/changelog.d/8414.bugfix
@@ -1,0 +1,1 @@
+Remove unnecessary 3PID registration check when resetting password via an email address. Bug introduced in v0.34.0rc2.

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -96,13 +96,6 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
         send_attempt = body["send_attempt"]
         next_link = body.get("next_link")  # Optional param
 
-        if not check_3pid_allowed(self.hs, "email", email):
-            raise SynapseError(
-                403,
-                "Your email domain is not authorized on this server",
-                Codes.THREEPID_DENIED,
-            )
-
         # Raise if the provided next_link value isn't valid
         assert_valid_next_link(self.hs, next_link)
 


### PR DESCRIPTION
This endpoint should only deal with emails that have already been approved, and are attached to the user's account. There's no need to re-check them here.

This can cause password resets to fail if a user signed up while there was one 3PID policy on the server, and then tries to reset their password after a different policy has been put in place that denies their existing email address.