### PR TITLE
Update description of server_name config option

### DIFF
--- a/changelog.d/8415.doc
+++ b/changelog.d/8415.doc
@@ -1,0 +1,1 @@
+Improve description of `server_name` config option in `homserver.yaml`.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -33,7 +33,7 @@
 
 ## Server ##
 
-# The public facing domain of the server
+# The public-facing domain of the server
 #
 # The server_name name will appear at the end of usernames and room addresses
 # created on this server. For example if the server_name was example.com,

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -42,8 +42,9 @@
 # In most cases you should avoid using a matrix specific subdomain such as
 # matrix.example.com or synapse.example.com as the server_name for the same
 # reasons you wouldn't use user@email.example.com as your email address.
-# See docs/delegate.md for information on how to host Synapse on a subdomain
-# while preserving a clean server_name.
+# See https://github.com/matrix-org/synapse/blob/master/docs/delegate.md
+# for information on how to host Synapse on a subdomain while preserving
+# a clean server_name.
 #
 # The server_name cannot be changed later so it is important to
 # configure this correctly before you start Synapse. It should be all

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -33,10 +33,22 @@
 
 ## Server ##
 
-# The domain name of the server, with optional explicit port.
-# This is used by remote servers to connect to this server,
-# e.g. matrix.org, localhost:8080, etc.
-# This is also the last part of your UserID.
+# The public facing domain of the server
+#
+# The server_name name will appear at the end of usernames and room addresses
+# created on this server. For example if the server_name was example.com,
+# usernames on this server would be in the format @user:example.com
+#
+# In most cases you should avoid using a matrix specific subdomain such as
+# matrix.example.com or synapse.example.com as the server_name for the same
+# reasons you wouldn't use user@email.example.com as your email address.
+# See docs/delegate.md for information on how to host Synapse on a subdomain
+# while preserving a clean server_name.
+#
+# The server_name cannot be changed later so it is important to
+# configure this correctly before you start Synapse. It should be all
+# lowercase and may contain an explicit port.
+# Examples: matrix.org, localhost:8080
 #
 server_name: "SERVERNAME"
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -641,10 +641,22 @@ class ServerConfig(Config):
             """\
         ## Server ##
 
-        # The domain name of the server, with optional explicit port.
-        # This is used by remote servers to connect to this server,
-        # e.g. matrix.org, localhost:8080, etc.
-        # This is also the last part of your UserID.
+        # The public facing domain of the server
+        #
+        # The server_name name will appear at the end of usernames and room addresses
+        # created on this server. For example if the server_name was example.com,
+        # usernames on this server would be in the format @user:example.com
+        #
+        # In most cases you should avoid using a matrix specific subdomain such as
+        # matrix.example.com or synapse.example.com as the server_name for the same
+        # reasons you wouldn't use user@email.example.com as your email address.
+        # See docs/delegate.md for information on how to host Synapse on a subdomain
+        # while preserving a clean server_name.
+        #
+        # The server_name cannot be changed later so it is important to
+        # configure this correctly before you start Synapse. It should be all
+        # lowercase and may contain an explicit port.
+        # Examples: matrix.org, localhost:8080
         #
         server_name: "%(server_name)s"
 

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -650,8 +650,9 @@ class ServerConfig(Config):
         # In most cases you should avoid using a matrix specific subdomain such as
         # matrix.example.com or synapse.example.com as the server_name for the same
         # reasons you wouldn't use user@email.example.com as your email address.
-        # See docs/delegate.md for information on how to host Synapse on a subdomain
-        # while preserving a clean server_name.
+        # See https://github.com/matrix-org/synapse/blob/master/docs/delegate.md
+        # for information on how to host Synapse on a subdomain while preserving
+        # a clean server_name.
         #
         # The server_name cannot be changed later so it is important to
         # configure this correctly before you start Synapse. It should be all

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -641,7 +641,7 @@ class ServerConfig(Config):
             """\
         ## Server ##
 
-        # The public facing domain of the server
+        # The public-facing domain of the server
         #
         # The server_name name will appear at the end of usernames and room addresses
         # created on this server. For example if the server_name was example.com,


### PR DESCRIPTION
This is an attempt to get fewer people setting up their server with a server name of matrix.whatever.tld. Any suggestions for improvements here are welcome but I think this is already much better than the current 5 year old description of `server_name`.

This also mentions that the server name should be lowercase like mentioned in #7728 but that issue should probably still be kept open until it is actually validated.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
