### PR TITLE
Don't table scan events on worker startup

### DIFF
--- a/changelog.d/8419.feature
+++ b/changelog.d/8419.feature
@@ -1,0 +1,1 @@
+Add experimental support for sharding event persister.

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -466,7 +466,7 @@ class MultiWriterIdGenerator:
         """Returns the position of the given writer.
         """
 
-        # If we don't have an entry for the given instance name, we assume its a
+        # If we don't have an entry for the given instance name, we assume it's a
         # new writer.
         #
         # For new writers we assume their initial position to be the current

--- a/tests/storage/test_id_generators.py
+++ b/tests/storage/test_id_generators.py
@@ -421,6 +421,13 @@ class MultiWriterIdGeneratorTestCase(HomeserverTestCase):
         self.get_success(_get_next_async())
         self.assertEqual(id_gen_3.get_persisted_upto_position(), 6)
 
+        # If we add back the old "first" then we shouldn't see the persisted up
+        # to position revert back to 3.
+        id_gen_5 = self._create_id_generator("five", writers=["first", "third"])
+        self.assertEqual(id_gen_5.get_persisted_upto_position(), 6)
+        self.assertEqual(id_gen_5.get_current_token_for_writer("first"), 6)
+        self.assertEqual(id_gen_5.get_current_token_for_writer("third"), 6)
+
     def test_sequence_consistency(self):
         """Test that we error out if the table and sequence diverges.
         """


### PR DESCRIPTION
We previously assumed "new" writers (one's not in the `stream_positions` table) as starting with position 0. When workers got the correct position for the new writer via `POSITION` the worker would try and fetch all updates between 0 and the new position, which results in table scan of events table for the events stream. 

Broke in #8294 