### PR TITLE
Report metrics on expensive rooms for state res

### DIFF
--- a/changelog.d/8420.feature
+++ b/changelog.d/8420.feature
@@ -1,0 +1,1 @@
+Add experimental reporting of metrics on expensive rooms for state-resolution.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -21,7 +21,7 @@ import itertools
 import logging
 from collections.abc import Container
 from http import HTTPStatus
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import attr
 from signedjson.key import decode_verify_key_bytes
@@ -69,7 +69,7 @@ from synapse.replication.http.federation import (
     ReplicationFederationSendEventsRestServlet,
     ReplicationStoreRoomOnInviteRestServlet,
 )
-from synapse.state import StateResolutionStore, resolve_events_with_store
+from synapse.state import StateResolutionStore
 from synapse.storage.databases.main.events_worker import EventRedactBehaviour
 from synapse.types import (
     JsonDict,
@@ -84,6 +84,9 @@ from synapse.util.async_helpers import Linearizer, concurrently_execute
 from synapse.util.retryutils import NotRetryingDestination
 from synapse.util.stringutils import shortstr
 from synapse.visibility import filter_events_for_server
+
+if TYPE_CHECKING:
+    from synapse.server import HomeServer
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +119,7 @@ class FederationHandler(BaseHandler):
         rooms.
     """
 
-    def __init__(self, hs):
+    def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
 
         self.hs = hs
@@ -126,6 +129,7 @@ class FederationHandler(BaseHandler):
         self.state_store = self.storage.state
         self.federation_client = hs.get_federation_client()
         self.state_handler = hs.get_state_handler()
+        self._state_resolution_handler = hs.get_state_resolution_handler()
         self.server_name = hs.hostname
         self.keyring = hs.get_keyring()
         self.action_generator = hs.get_action_generator()
@@ -381,8 +385,7 @@ class FederationHandler(BaseHandler):
                                 event_map[x.event_id] = x
 
                     room_version = await self.store.get_room_version_id(room_id)
-                    state_map = await resolve_events_with_store(
-                        self.clock,
+                    state_map = await self._state_resolution_handler.resolve_events_with_store(
                         room_id,
                         room_version,
                         state_maps,


### PR DESCRIPTION
This aims to make it easier to see which rooms are causing the most CPU and database activity for state resolution.

We report two things:
 * Every two minutes, we write an entry to the log recording listing the 10 "most expensive" rooms by each metric (CPU time and DB time). This is disabled by default: to enable, configure the `synapse.state.metrics` logger to DEBUG.

* We also expose, via prometheus, a pair of metrics (`synapse_state_res_db_for_biggest_room_seconds_total` and `synapse_state_res_cpu_for_biggest_room_seconds_total`) which keeps a *running total* of the time spent resolving the *single* most expensive room (over any given 2-minute period).

  As it is a running total, it will be necessary to take the derivative (for example: `rate(synapse_state_res_cpu_for_biggest_room_seconds_total[60s])` to get a meaningful value. (Doing so gives a unitless value, measuring the fraction of CPU/DB time spent state-resolving the single most expensive room). This could then be used as an alert to indicate that state resolution is getting expensive in one or more rooms.

This PR can be reviewed per-commit.