### PR TITLE
Fix bug in remote thumbnail search

### DIFF
--- a/changelog.d/8438.bugfix
+++ b/changelog.d/8438.bugfix
@@ -1,0 +1,1 @@
+Fix a regression in v1.21.0rc1 which broke thumbnails of remote media.

--- a/synapse/rest/media/v1/media_storage.py
+++ b/synapse/rest/media/v1/media_storage.py
@@ -159,29 +159,27 @@ class MediaStorage:
         if os.path.exists(local_path):
             logger.debug("responding with local file %s", local_path)
             return FileResponder(open(local_path, "rb"))
+        logger.debug("local file %s did not exist", local_path)
 
         if legacy_path:
-            logger.debug(
-                "local file %s did not exist; checking legacy name", local_path
-            )
             legacy_local_path = os.path.join(self.local_media_directory, legacy_path)
             if os.path.exists(legacy_local_path):
                 logger.debug("responding with local file %s", legacy_local_path)
                 return FileResponder(open(legacy_local_path, "rb"))
+            logger.debug("legacy local file %s did not exist", legacy_local_path)
 
         for provider in self.storage_providers:
             res = await provider.fetch(path, file_info)  # type: Any
             if res:
                 logger.debug("Streaming %s from %s", path, provider)
                 return res
+            logger.debug("%s not found on %s", path, provider)
             if legacy_path:
-                logger.debug(
-                    "Provider %s did not find %s; checking legacy name", provider, path
-                )
                 res = await provider.fetch(legacy_path, file_info)
                 if res:
                     logger.debug("Streaming %s from %s", legacy_path, provider)
                     return res
+                logger.debug("%s not found on %s", legacy_path, provider)
 
         return None
 


### PR DESCRIPTION
https://github.com/matrix-org/synapse/pull/7124 changed the behaviour of remote thumbnails so that the thumbnailing method was included in the filename of the thumbnail. To support existing files, it included a fallback so that we would check the old filename if the new filename didn't exist.

Unfortunately, it didn't apply this logic to storage providers, so any thumbnails stored on such a storage provider was broken.