### PR TITLE
Do not expose the experimental appservice login flow to clients.

### DIFF
--- a/changelog.d/8440.bugfix
+++ b/changelog.d/8440.bugfix
@@ -1,0 +1,1 @@
+Do not expose the experimental `uk.half-shot.msc2778.login.application_service` flow in the login API.

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -111,8 +111,6 @@ class LoginRestServlet(RestServlet):
             ({"type": t} for t in self.auth_handler.get_supported_login_types())
         )
 
-        flows.append({"type": LoginRestServlet.APPSERVICE_TYPE})
-
         return 200, {"flows": flows}
 
     def on_OPTIONS(self, request: SynapseRequest):


### PR DESCRIPTION
This was breaking logins for Element iOS.

Related to #8320