### PR TITLE
Fix malformed log line in new federation "catch up" logic

### DIFF
--- a/changelog.d/8442.bugfix
+++ b/changelog.d/8442.bugfix
@@ -1,0 +1,1 @@
+Fix malformed log line in new federation "catch up" logic.

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -490,7 +490,7 @@ class PerDestinationQueue:
                 )
 
             if logger.isEnabledFor(logging.INFO):
-                rooms = (p.room_id for p in catchup_pdus)
+                rooms = [p.room_id for p in catchup_pdus]
                 logger.info("Catching up rooms to %s: %r", self._destination, rooms)
 
             success = await self._transaction_manager.send_new_transaction(


### PR DESCRIPTION
logging a generator isn't terribly helpful.