### PR TITLE
Include a public_baseurl in demo script.

### DIFF
--- a/changelog.d/8443.misc
+++ b/changelog.d/8443.misc
@@ -1,0 +1,1 @@
+Configure `public_baseurl` when using demo scripts.

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -30,6 +30,8 @@ for port in 8080 8081 8082; do
     if ! grep -F "Customisation made by demo/start.sh" -q  $DIR/etc/$port.config; then
         printf '\n\n# Customisation made by demo/start.sh\n' >> $DIR/etc/$port.config
 
+        echo "public_baseurl: http://localhost:$port/" >> $DIR/etc/$port.config
+
         echo 'enable_registration: true' >> $DIR/etc/$port.config
 
         # Warning, this heredoc depends on the interaction of tabs and spaces. Please don't


### PR DESCRIPTION
This sets `public_baseurl` when using the demo `start.sh` script. I find I run into this being `None` frequently when enabling "extra" features (SSO, etc.)

Can this even be `None` in the first place? Is that a valid configuration? Should we assert that in a single place instead of many places?