### PR TITLE
Fix DB query on startup for negative streams.

### DIFF
--- a/changelog.d/8447.bugfix
+++ b/changelog.d/8447.bugfix
@@ -1,0 +1,1 @@
+Fix DB query on startup for negative streams which caused long start up times. Introduced in #8374.

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -341,7 +341,7 @@ class MultiWriterIdGenerator:
                 "cmp": "<=" if self._positive else ">=",
             }
             sql = self._db.engine.convert_param_style(sql)
-            cur.execute(sql, (min_stream_id,))
+            cur.execute(sql, (min_stream_id * self._return_factor,))
 
             self._persisted_upto_position = min_stream_id
 


### PR DESCRIPTION
For negative streams we have to negate the internal stream ID before
querying the DB.

The effect of this bug was to query far too many rows, slowing start up
time, but we would correctly filter the results afterwards so there was
no ill effect.
