### PR TITLE
Remove redundant loads of stream_ordering for events

### DIFF
--- a/changelog.d/8452.misc
+++ b/changelog.d/8452.misc
@@ -1,0 +1,1 @@
+Remove redundant databae loads of stream_ordering for events we already have.

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -312,14 +312,6 @@ class EventBase(metaclass=abc.ABCMeta):
         """
         return [e for e, _ in self.auth_events]
 
-    @property
-    def stream_ordering(self) -> Optional[int]:
-        """Returns the stream ordering of this event.
-
-        None if the event has not yet been persisted.
-        """
-        return self.internal_metadata.stream_ordering
-
 
 class FrozenEvent(EventBase):
     format_version = EventFormatVersions.V1  # All events of this type are V1

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -310,6 +310,14 @@ class EventBase(metaclass=abc.ABCMeta):
         """
         return [e for e, _ in self.auth_events]
 
+    @property
+    def stream_ordering(self) -> Optional[int]:
+        """Returns the stream ordering of this event.
+
+        None if the event has not yet been persisted.
+        """
+        return self.internal_metadata._dict.get("stream_ordering")
+
 
 class FrozenEvent(EventBase):
     format_version = EventFormatVersions.V1  # All events of this type are V1

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -97,12 +97,15 @@ class DefaultDictProperty(DictProperty):
 
 
 class _EventInternalMetadata:
-    __slots__ = ["_dict"]
+    __slots__ = ["_dict", "stream_ordering"]
 
     def __init__(self, internal_metadata_dict: JsonDict):
         # we have to copy the dict, because it turns out that the same dict is
         # reused. TODO: fix that
         self._dict = dict(internal_metadata_dict)
+
+        # the stream ordering of this event. None, until it has been persisted.
+        self.stream_ordering = None  # type: Optional[int]
 
     outlier = DictProperty("outlier")  # type: bool
     out_of_band_membership = DictProperty("out_of_band_membership")  # type: bool
@@ -113,7 +116,6 @@ class _EventInternalMetadata:
     redacted = DictProperty("redacted")  # type: bool
     txn_id = DictProperty("txn_id")  # type: str
     token_id = DictProperty("token_id")  # type: str
-    stream_ordering = DictProperty("stream_ordering")  # type: int
 
     # XXX: These are set by StreamWorkerStore._set_before_and_after.
     # I'm pretty sure that these are never persisted to the database, so shouldn't
@@ -316,7 +318,7 @@ class EventBase(metaclass=abc.ABCMeta):
 
         None if the event has not yet been persisted.
         """
-        return self.internal_metadata._dict.get("stream_ordering")
+        return self.internal_metadata.stream_ordering
 
 
 class FrozenEvent(EventBase):

--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -49,6 +49,9 @@ def prune_event(event: EventBase) -> EventBase:
         pruned_event_dict, event.room_version, event.internal_metadata.get_dict()
     )
 
+    # copy the internal fields
+    pruned_event.internal_metadata.stream_ordering = event.stream_ordering
+
     # Mark the event as redacted
     pruned_event.internal_metadata.redacted = True
 

--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -50,7 +50,9 @@ def prune_event(event: EventBase) -> EventBase:
     )
 
     # copy the internal fields
-    pruned_event.internal_metadata.stream_ordering = event.stream_ordering
+    pruned_event.internal_metadata.stream_ordering = (
+        event.internal_metadata.stream_ordering
+    )
 
     # Mark the event as redacted
     pruned_event.internal_metadata.redacted = True

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -297,6 +297,8 @@ class FederationSender:
         sent_pdus_destination_dist_total.inc(len(destinations))
         sent_pdus_destination_dist_count.inc()
 
+        assert pdu.internal_metadata.stream_ordering
+
         # track the fact that we have a PDU for these destinations,
         # to allow us to perform catch-up later on if the remote is unreachable
         # for a while.

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -158,6 +158,7 @@ class PerDestinationQueue:
             # yet know if we have anything to catch up (None)
             self._pending_pdus.append(pdu)
         else:
+            assert pdu.internal_metadata.stream_ordering
             self._catchup_last_skipped = pdu.internal_metadata.stream_ordering
 
         self.attempt_new_transaction()
@@ -361,6 +362,7 @@ class PerDestinationQueue:
                         last_successful_stream_ordering = (
                             final_pdu.internal_metadata.stream_ordering
                         )
+                        assert last_successful_stream_ordering
                         await self._store.set_destination_last_successful_stream_ordering(
                             self._destination, last_successful_stream_ordering
                         )

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -3008,6 +3008,9 @@ class FederationHandler(BaseHandler):
         elif event.internal_metadata.is_outlier():
             return
 
+        # the event has been persisted so it should have a stream ordering.
+        assert event.internal_metadata.stream_ordering
+
         event_pos = PersistedEventPosition(
             self._instance_name, event.internal_metadata.stream_ordering
         )

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -683,8 +683,8 @@ class EventCreationHandler:
                     prev_event.event_id,
                 )
                 # we know it was persisted, so must have a stream ordering
-                assert prev_event.stream_ordering
-                return prev_event.stream_ordering
+                assert prev_event.internal_metadata.stream_ordering
+                return prev_event.internal_metadata.stream_ordering
 
         return await self.handle_new_client_event(
             requester=requester, event=event, context=context, ratelimit=ratelimit

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -682,7 +682,9 @@ class EventCreationHandler:
                     event.event_id,
                     prev_event.event_id,
                 )
-                return await self.store.get_stream_id_for_event(prev_event.event_id)
+                # we know it was persisted, so must have a stream ordering
+                assert prev_event.stream_ordering
+                return prev_event.stream_ordering
 
         return await self.handle_new_client_event(
             requester=requester, event=event, context=context, ratelimit=ratelimit

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -195,8 +195,8 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         if duplicate is not None:
             # Discard the new event since this membership change is a no-op.
             # we know it was persisted, so must have a stream ordering.
-            assert duplicate.stream_ordering
-            return duplicate.event_id, duplicate.stream_ordering
+            assert duplicate.internal_metadata.stream_ordering
+            return duplicate.event_id, duplicate.internal_metadata.stream_ordering
 
         prev_state_ids = await context.get_prev_state_ids()
 
@@ -444,8 +444,11 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 if same_sender and same_membership and same_content:
                     # duplicate event.
                     # we know it was persisted, so must have a stream ordering.
-                    assert old_state.stream_ordering
-                    return (old_state.event_id, old_state.stream_ordering)
+                    assert old_state.internal_metadata.stream_ordering
+                    return (
+                        old_state.event_id,
+                        old_state.internal_metadata.stream_ordering,
+                    )
 
             if old_membership in ["ban", "leave"] and action == "kick":
                 raise AuthError(403, "The target user is not in the room")

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -110,7 +110,9 @@ class PurgeHistoryRestServlet(RestServlet):
             if event.room_id != room_id:
                 raise SynapseError(400, "Event is for wrong room.")
 
-            room_token = RoomStreamToken(event.depth, event.stream_ordering)
+            room_token = RoomStreamToken(
+                event.depth, event.internal_metadata.stream_ordering
+            )
             token = await room_token.to_string(self.store)
 
             logger.info("[purge] purging up to token %s (event_id %s)", token, event_id)

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -57,6 +57,7 @@ from synapse.rest.admin.users import (
     UsersRestServletV2,
     WhoisRestServlet,
 )
+from synapse.types import RoomStreamToken
 from synapse.util.versionstring import get_version_string
 
 logger = logging.getLogger(__name__)
@@ -109,7 +110,7 @@ class PurgeHistoryRestServlet(RestServlet):
             if event.room_id != room_id:
                 raise SynapseError(400, "Event is for wrong room.")
 
-            room_token = await self.store.get_topological_token_for_event(event_id)
+            room_token = RoomStreamToken(event.depth, event.stream_ordering)
             token = await room_token.to_string(self.store)
 
             logger.info("[purge] purging up to token %s (event_id %s)", token, event_id)

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -331,6 +331,10 @@ class PersistEventsStore:
         min_stream_order = events_and_contexts[0][0].internal_metadata.stream_ordering
         max_stream_order = events_and_contexts[-1][0].internal_metadata.stream_ordering
 
+        # stream orderings should have been assigned by now
+        assert min_stream_order
+        assert max_stream_order
+
         self._update_forward_extremities_txn(
             txn,
             new_forward_extremities=new_forward_extremeties,

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -822,7 +822,7 @@ class EventsWorkerStore(SQLBaseStore):
                   rej.reason
                 FROM events AS e
                   JOIN event_json AS ej USING (event_id)
-                  LEFT JOIN rooms r USING (room_id)
+                  LEFT JOIN rooms r ON r.room_id = e.room_id
                   LEFT JOIN rejections as rej USING (event_id)
                 WHERE """
 

--- a/synapse/storage/databases/main/stream.py
+++ b/synapse/storage/databases/main/stream.py
@@ -589,19 +589,6 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore, metaclass=abc.ABCMeta):
             )
             return "t%d-%d" % (topo, token)
 
-    async def get_stream_id_for_event(self, event_id: str) -> int:
-        """The stream ID for an event
-        Args:
-            event_id: The id of the event to look up a stream token for.
-        Raises:
-            StoreError if the event wasn't in the database.
-        Returns:
-            A stream ID.
-        """
-        return await self.db_pool.runInteraction(
-            "get_stream_id_for_event", self.get_stream_id_for_event_txn, event_id,
-        )
-
     def get_stream_id_for_event_txn(
         self, txn: LoggingTransaction, event_id: str, allow_none=False,
     ) -> int:

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -248,6 +248,8 @@ class EventsPersistenceStorage:
         await make_deferred_yieldable(deferred)
 
         event_stream_id = event.internal_metadata.stream_ordering
+        # stream ordering should have been assigned by now
+        assert event_stream_id
 
         pos = PersistedEventPosition(self._instance_name, event_stream_id)
         return pos, self.main_store.get_room_max_token()


### PR DESCRIPTION
If we already have the event, we already have its stream ordering.