### PR TITLE
Reduce duplication in event ordering lookup methods

### DIFF
--- a/changelog.d/8453.misc
+++ b/changelog.d/8453.misc
@@ -1,0 +1,1 @@
+Remove redundant event ordering lookup methods.

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -373,9 +373,7 @@ class PaginationHandler:
                     # case "JOIN" would have been returned.
                     assert member_event_id
 
-                    leave_token = await self.store.get_topological_token_for_event(
-                        member_event_id
-                    )
+                    leave_token = await self.store.get_event_ordering(member_event_id)
                     assert leave_token.topological is not None
 
                     if leave_token.topological < curr_topo:

--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -47,9 +47,11 @@ class ReadMarkerHandler(BaseHandler):
 
             if existing_read_marker:
                 # Only update if the new marker is ahead in the stream
-                should_update = await self.store.is_event_after(
-                    event_id, existing_read_marker["event_id"]
+                token1 = await self.store.get_event_ordering(event_id)
+                token2 = await self.store.get_event_ordering(
+                    existing_read_marker["event_id"]
                 )
+                should_update = token1 > token2
 
             if should_update:
                 content = {"event_id": event_id}

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -25,7 +25,7 @@ from typing_extensions import Literal
 from twisted.internet import defer
 
 from synapse.api.constants import EventTypes
-from synapse.api.errors import NotFoundError, SynapseError
+from synapse.api.errors import NotFoundError
 from synapse.api.room_versions import (
     KNOWN_ROOM_VERSIONS,
     EventFormatVersions,
@@ -43,7 +43,7 @@ from synapse.storage.database import DatabasePool
 from synapse.storage.engines import PostgresEngine
 from synapse.storage.util.id_generators import MultiWriterIdGenerator, StreamIdGenerator
 from synapse.types import Collection, get_domain_from_id
-from synapse.util.caches.descriptors import Cache, cached
+from synapse.util.caches.descriptors import Cache
 from synapse.util.iterutils import batch_iter
 from synapse.util.metrics import Measure
 
@@ -1259,27 +1259,6 @@ class EventsWorkerStore(SQLBaseStore):
         )
 
         return rows, to_token, True
-
-    async def is_event_after(self, event_id1, event_id2):
-        """Returns True if event_id1 is after event_id2 in the stream
-        """
-        to_1, so_1 = await self.get_event_ordering(event_id1)
-        to_2, so_2 = await self.get_event_ordering(event_id2)
-        return (to_1, so_1) > (to_2, so_2)
-
-    @cached(max_entries=5000)
-    async def get_event_ordering(self, event_id):
-        res = await self.db_pool.simple_select_one(
-            table="events",
-            retcols=["topological_ordering", "stream_ordering"],
-            keyvalues={"event_id": event_id},
-            allow_none=True,
-        )
-
-        if not res:
-            raise SynapseError(404, "Could not find event %s" % (event_id,))
-
-        return (int(res["topological_ordering"]), int(res["stream_ordering"]))
 
     async def get_next_event_to_expire(self) -> Optional[Tuple[str, int]]:
         """Retrieve the entry with the lowest expiry timestamp in the event_expiry

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -902,17 +902,13 @@ class RoomMessageListTestCase(RoomBase):
 
         # Send a first message in the room, which will be removed by the purge.
         first_event_id = self.helper.send(self.room_id, "message 1")["event_id"]
-        first_token = self.get_success(
-            store.get_topological_token_for_event(first_event_id)
-        )
+        first_token = self.get_success(store.get_event_ordering(first_event_id))
         first_token_str = self.get_success(first_token.to_string(store))
 
         # Send a second message in the room, which won't be removed, and which we'll
         # use as the marker to purge events before.
         second_event_id = self.helper.send(self.room_id, "message 2")["event_id"]
-        second_token = self.get_success(
-            store.get_topological_token_for_event(second_event_id)
-        )
+        second_token = self.get_success(store.get_event_ordering(second_event_id))
         second_token_str = self.get_success(second_token.to_string(store))
 
         # Send a third event in the room to ensure we don't fall under any edge case

--- a/tests/storage/test_purge.py
+++ b/tests/storage/test_purge.py
@@ -47,9 +47,7 @@ class PurgeTests(HomeserverTestCase):
         storage = self.hs.get_storage()
 
         # Get the topological token
-        token = self.get_success(
-            store.get_topological_token_for_event(last["event_id"])
-        )
+        token = self.get_success(store.get_event_ordering(last["event_id"]))
         token_str = self.get_success(token.to_string(self.hs.get_datastore()))
 
         # Purge everything before this topological token
@@ -77,9 +75,7 @@ class PurgeTests(HomeserverTestCase):
         storage = self.hs.get_datastore()
 
         # Set the topological token higher than it should be
-        token = self.get_success(
-            storage.get_topological_token_for_event(last["event_id"])
-        )
+        token = self.get_success(storage.get_event_ordering(last["event_id"]))
         event = "t{}-{}".format(token.topological + 1, token.stream + 1)
 
         # Purge everything before this topological token


### PR DESCRIPTION
`get_topological_token_for_event` and `get_event_ordering` were doing almost the same thing: the difference was only in the format of the result (`tuple` vs `RoomStreamOrdering`).

This commit combines the two. `get_event_ordering` had a cache which may have been tuned so we stick with that name, but update it to return a `RoomStreamOrdering` for better type safety. We also put it in `StreamWorkerStore` rather than `EventsWorkerStore` since that's where all the other "ordering" methods are.

So then we have to update all the places `get_topological_token_for_event` was called, to call `get_event_ordering` instead, and we have to update all the places `get_event_ordering` was called (just `is_event_after`) to handle `RoomStreamToken`s intstead of tuples.

`is_event_after` was only called in once place and we may as well inline it.

~~Based on #8452.~~