### PR TITLE
Reduce serialization errors in MultiWriterIdGen

### DIFF
--- a/changelog.d/8456.misc
+++ b/changelog.d/8456.misc
@@ -1,0 +1,1 @@
+Reduce number of serialization errors of `MultiWriterIdGenerator._update_table`.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -600,8 +600,12 @@ class DatabasePool:
                 its first argument, followed by `args` and `kwargs`.
 
             db_autocommit: Whether to run the function in "autocommit" mode,
-                i.e. outside of a transaction. This is useful for transaction
-                that are only a single query. Currently only affects postgres.
+                i.e. outside of a transaction. This is useful for transactions
+                that are only a single query. 
+                
+                Currently, this is only implemented for Postgres. SQLite will still
+                run the function inside a transaction.
+                
                 WARNING: This means that if func fails half way through then
                 the changes will *not* be rolled back. `func` may also get
                 called multiple times if the transaction is retried, so must

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -601,11 +601,11 @@ class DatabasePool:
 
             db_autocommit: Whether to run the function in "autocommit" mode,
                 i.e. outside of a transaction. This is useful for transactions
-                that are only a single query. 
-                
+                that are only a single query.
+
                 Currently, this is only implemented for Postgres. SQLite will still
                 run the function inside a transaction.
-                
+
                 WARNING: This means that if func fails half way through then
                 the changes will *not* be rolled back. `func` may also get
                 called multiple times if the transaction is retried, so must
@@ -694,7 +694,7 @@ class DatabasePool:
 
                 try:
                     if db_autocommit:
-                        self.engine.set_autocommit(conn, True)
+                        self.engine.attempt_to_set_autocommit(conn, True)
 
                     db_conn = LoggingDatabaseConnection(
                         conn, self.engine, "runWithConnection"
@@ -702,7 +702,7 @@ class DatabasePool:
                     return func(db_conn, *args, **kwargs)
                 finally:
                     if db_autocommit:
-                        self.engine.set_autocommit(conn, False)
+                        self.engine.attempt_to_set_autocommit(conn, False)
 
         return await make_deferred_yieldable(
             self._db_pool.runWithConnection(inner_func, *args, **kwargs)

--- a/synapse/storage/engines/_base.py
+++ b/synapse/storage/engines/_base.py
@@ -103,3 +103,11 @@ class BaseDatabaseEngine(Generic[ConnectionType], metaclass=abc.ABCMeta):
         """Whether the connection is currently in a transaction.
         """
         ...
+
+    @abc.abstractmethod
+    def set_autocommit(self, conn: Connection, autocommit: bool):
+        """Set the connections autocommit mode.
+
+        When True queries are run outside of transactions.
+        """
+        ...

--- a/synapse/storage/engines/_base.py
+++ b/synapse/storage/engines/_base.py
@@ -97,3 +97,9 @@ class BaseDatabaseEngine(Generic[ConnectionType], metaclass=abc.ABCMeta):
         """Gets a string giving the server version. For example: '3.22.0'
         """
         ...
+
+    @abc.abstractmethod
+    def in_transaction(self, conn: Connection) -> bool:
+        """Whether the connection is currently in a transaction.
+        """
+        ...

--- a/synapse/storage/engines/_base.py
+++ b/synapse/storage/engines/_base.py
@@ -105,9 +105,12 @@ class BaseDatabaseEngine(Generic[ConnectionType], metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def set_autocommit(self, conn: Connection, autocommit: bool):
-        """Set the connections autocommit mode.
+    def attempt_to_set_autocommit(self, conn: Connection, autocommit: bool):
+        """Attempt to set the connections autocommit mode.
 
         When True queries are run outside of transactions.
+
+        Note: This has no effect on SQLite3, so callers still need to
+        commit/rollback the connections.
         """
         ...

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -15,7 +15,8 @@
 
 import logging
 
-from ._base import BaseDatabaseEngine, IncorrectDatabaseSetup
+from synapse.storage.engines._base import BaseDatabaseEngine, IncorrectDatabaseSetup
+from synapse.storage.types import Connection
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +120,7 @@ class PostgresEngine(BaseDatabaseEngine):
             cursor.execute("SET synchronous_commit TO OFF")
 
         cursor.close()
+        db_conn.commit()
 
     @property
     def can_native_upsert(self):
@@ -171,3 +173,6 @@ class PostgresEngine(BaseDatabaseEngine):
             return "%i.%i" % (numver / 10000, numver % 10000)
         else:
             return "%i.%i.%i" % (numver / 10000, (numver % 10000) / 100, numver % 100)
+
+    def in_transaction(self, conn: Connection) -> bool:
+        return conn.status != self.module.extensions.STATUS_READY  # type: ignore

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -108,7 +108,6 @@ class PostgresEngine(BaseDatabaseEngine):
         db_conn.set_isolation_level(
             self.module.extensions.ISOLATION_LEVEL_REPEATABLE_READ
         )
-        db_conn.set_session(self.module.extensions.ISOLATION_LEVEL_REPEATABLE_READ)
 
         # Set the bytea output to escape, vs the default of hex
         cursor = db_conn.cursor()

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -177,5 +177,5 @@ class PostgresEngine(BaseDatabaseEngine):
     def in_transaction(self, conn: Connection) -> bool:
         return conn.status != self.module.extensions.STATUS_READY  # type: ignore
 
-    def set_autocommit(self, conn: Connection, autocommit: bool):
+    def attempt_to_set_autocommit(self, conn: Connection, autocommit: bool):
         return conn.set_session(autocommit=autocommit)  # type: ignore

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -108,6 +108,7 @@ class PostgresEngine(BaseDatabaseEngine):
         db_conn.set_isolation_level(
             self.module.extensions.ISOLATION_LEVEL_REPEATABLE_READ
         )
+        db_conn.set_session(self.module.extensions.ISOLATION_LEVEL_REPEATABLE_READ)
 
         # Set the bytea output to escape, vs the default of hex
         cursor = db_conn.cursor()
@@ -176,3 +177,6 @@ class PostgresEngine(BaseDatabaseEngine):
 
     def in_transaction(self, conn: Connection) -> bool:
         return conn.status != self.module.extensions.STATUS_READY  # type: ignore
+
+    def set_autocommit(self, conn: Connection, autocommit: bool):
+        return conn.set_session(autocommit=autocommit)  # type: ignore

--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -17,6 +17,7 @@ import threading
 import typing
 
 from synapse.storage.engines import BaseDatabaseEngine
+from synapse.storage.types import Connection
 
 if typing.TYPE_CHECKING:
     import sqlite3  # noqa: F401
@@ -86,6 +87,7 @@ class Sqlite3Engine(BaseDatabaseEngine["sqlite3.Connection"]):
 
         db_conn.create_function("rank", 1, _rank)
         db_conn.execute("PRAGMA foreign_keys = ON;")
+        db_conn.commit()
 
     def is_deadlock(self, error):
         return False
@@ -104,6 +106,9 @@ class Sqlite3Engine(BaseDatabaseEngine["sqlite3.Connection"]):
             string
         """
         return "%i.%i.%i" % self.module.sqlite_version_info
+
+    def in_transaction(self, conn: Connection) -> bool:
+        return conn.in_transaction  # type: ignore
 
 
 # Following functions taken from: https://github.com/coleifer/peewee

--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -110,6 +110,11 @@ class Sqlite3Engine(BaseDatabaseEngine["sqlite3.Connection"]):
     def in_transaction(self, conn: Connection) -> bool:
         return conn.in_transaction  # type: ignore
 
+    def set_autocommit(self, conn: Connection, autocommit: bool):
+        # Twisted doesn't let us set attributes on the connections, so we can't
+        # set the connection to autocommit mode.
+        pass
+
 
 # Following functions taken from: https://github.com/coleifer/peewee
 

--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -110,7 +110,7 @@ class Sqlite3Engine(BaseDatabaseEngine["sqlite3.Connection"]):
     def in_transaction(self, conn: Connection) -> bool:
         return conn.in_transaction  # type: ignore
 
-    def set_autocommit(self, conn: Connection, autocommit: bool):
+    def attempt_to_set_autocommit(self, conn: Connection, autocommit: bool):
         # Twisted doesn't let us set attributes on the connections, so we can't
         # set the connection to autocommit mode.
         pass

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -598,10 +598,13 @@ class _MultiWriterCtxManager:
     stream_ids = attr.ib(type=List[int], factory=list)
 
     async def __aenter__(self) -> Union[int, List[int]]:
+        # It's safe to run this in autocommit mode as fetching values from a
+        # sequence ignores transaction semantics anyway.
         self.stream_ids = await self.id_gen._db.runInteraction(
             "_load_next_mult_id",
             self.id_gen._load_next_mult_id_txn,
             self.multiple_ids or 1,
+            db_autocommit=True,
         )
 
         # Assert the fetched ID is actually greater than any ID we've already

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -24,6 +24,7 @@ from typing_extensions import Deque
 
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.storage.database import DatabasePool, LoggingTransaction
+from synapse.storage.types import Cursor
 from synapse.storage.util.sequence import PostgresSequenceGenerator
 
 logger = logging.getLogger(__name__)
@@ -548,7 +549,7 @@ class MultiWriterIdGenerator:
                 # do.
                 break
 
-    def _update_stream_positions_table_txn(self, txn: LoggingTransaction):
+    def _update_stream_positions_table_txn(self, txn: Cursor):
         """Update the `stream_positions` table with newly persisted position.
         """
 

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -56,6 +56,7 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         engine = create_engine(sqlite_config)
         fake_engine = Mock(wraps=engine)
         fake_engine.can_native_upsert = False
+        fake_engine.in_transaction.return_value = False
 
         db = DatabasePool(Mock(), Mock(config=sqlite_config), fake_engine)
         db._db_pool = self.db_pool


### PR DESCRIPTION
We call `_update_stream_positions_table_txn` a lot, which is an UPSERT
that can conflict in `REPEATABLE READ` isolation level. Instead of doing
a transaction consisting of a single query we may as well run it outside
of a transaction.