### PR TITLE
Ensure that event.redacts exists before handling it as a string

### DIFF
--- a/changelog.d/8457.bugfix
+++ b/changelog.d/8457.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where backfilling a room with an event that was missing the `redacts` field would break.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -446,7 +446,9 @@ def check_redaction(
 
     if room_version_obj.event_format == EventFormatVersions.V1:
         redacter_domain = get_domain_from_id(event.event_id)
-        redactee_domain = get_domain_from_id(event.redacts)
+        redactee_domain = None
+        if event.redacts:
+            redactee_domain = get_domain_from_id(event.redacts)
         if redacter_domain == redactee_domain:
             return True
     else:

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -446,9 +446,9 @@ def check_redaction(
 
     if room_version_obj.event_format == EventFormatVersions.V1:
         redacter_domain = get_domain_from_id(event.event_id)
-        redactee_domain = None
-        if event.redacts:
-            redactee_domain = get_domain_from_id(event.redacts)
+        if not isinstance(event.redacts, str):
+            return False
+        redactee_domain = get_domain_from_id(event.redacts)
         if redacter_domain == redactee_domain:
             return True
     else:


### PR DESCRIPTION
This seems to handle another case of #6771, although I'm not confident it is the correct change. (It will essentially mean that if `event.redacts` is `None` than an `AuthError` will raise.)

Fixes #8397