### PR TITLE
Update manhole documentation for async/await.

### DIFF
--- a/changelog.d/8462.doc
+++ b/changelog.d/8462.doc
@@ -1,0 +1,1 @@
+Update the directions for using the manhole with coroutines.

--- a/docs/manhole.md
+++ b/docs/manhole.md
@@ -42,5 +42,5 @@ As a simple example, retrieving an event from the database:
 ```pycon
 >>> from twisted.internet import defer
 >>> defer.ensureDeferred(hs.get_datastore().get_event('$1416420717069yeQaw:matrix.org'))
-<FrozenEvent event_id='$1416420717069yeQaw:matrix.org', type='m.room.create', state_key=''>
+<Deferred at 0x7ff253fc6998 current result: <FrozenEvent event_id='$1416420717069yeQaw:matrix.org', type='m.room.create', state_key=''>>
 ```

--- a/docs/manhole.md
+++ b/docs/manhole.md
@@ -35,9 +35,12 @@ This gives a Python REPL in which `hs` gives access to the
 `synapse.server.HomeServer` object - which in turn gives access to many other
 parts of the process.
 
+Note that any call which returns a coroutine will need to be wrapped in `ensureDeferred`.
+
 As a simple example, retrieving an event from the database:
 
-```
->>> hs.get_datastore().get_event('$1416420717069yeQaw:matrix.org')
-<Deferred at 0x7ff253fc6998 current result: <FrozenEvent event_id='$1416420717069yeQaw:matrix.org', type='m.room.create', state_key=''>>
+```pycon
+>>> from twisted.internet import defer
+>>> defer.ensureDeferred(hs.get_datastore().get_event('$1416420717069yeQaw:matrix.org'))
+<FrozenEvent event_id='$1416420717069yeQaw:matrix.org', type='m.room.create', state_key=''>
 ```


### PR DESCRIPTION
Updates the docs to use `defer.ensureDeferred` to schedule coroutines with the reactor.

Related to #7988.