### PR TITLE
Fix third-party event modules for `check_visibility_can_be_modified` check

### DIFF
--- a/changelog.d/8467.feature
+++ b/changelog.d/8467.feature
@@ -1,0 +1,1 @@
+Allow `ThirdPartyEventRules` modules to query and manipulate whether a room is in the public rooms directory.

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -131,7 +131,9 @@ class ThirdPartyEventRules:
         if self.third_party_rules is None:
             return True
 
-        check_func = getattr(self.third_party_rules, "check_visibility_can_be_modified")
+        check_func = getattr(
+            self.third_party_rules, "check_visibility_can_be_modified", None
+        )
         if not check_func or not isinstance(check_func, Callable):
             return True
 

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -49,7 +49,7 @@ class ThirdPartyRulesTestCase(unittest.HomeserverTestCase):
     def make_homeserver(self, reactor, clock):
         config = self.default_config()
         config["third_party_event_rules"] = {
-            "module": "tests.rest.client.third_party_rules.ThirdPartyRulesTestModule",
+            "module": __name__ + ".ThirdPartyRulesTestModule",
             "config": {},
         }
 


### PR DESCRIPTION
PR #8292 tried to maintain backwards compat with modules which don't provide a
`check_visibility_can_be_modified` method, but the tests weren't being run,
and the check didn't work.