### PR TITLE
Allow modules to create and send events into rooms

### DIFF
--- a/changelog.d/8479.feature
+++ b/changelog.d/8479.feature
@@ -1,0 +1,1 @@
+Add the ability to send non-membership events into a room via the `ModuleApi`.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -868,13 +868,13 @@ class EventCreationHandler:
         else:
             room_version = await self.store.get_room_version_id(event.room_id)
 
-            event_allowed = await self.third_party_event_rules.check_event_allowed(
-                event, context
+        event_allowed = await self.third_party_event_rules.check_event_allowed(
+            event, context
+        )
+        if not event_allowed:
+            raise SynapseError(
+                403, "This event is not allowed in this context", Codes.FORBIDDEN
             )
-            if not event_allowed:
-                raise SynapseError(
-                    403, "This event is not allowed in this context", Codes.FORBIDDEN
-                )
 
         if event.internal_metadata.is_out_of_band_membership():
             # the only sort of out-of-band-membership events we expect to see here

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -340,7 +340,8 @@ class ModuleApi:
             state_key: The event's state key. None if this is not a state event.
 
         Returns:
-            The event that was sent.
+            The event that was sent. If state event deduplication happened, then
+                the previous, duplicate event instead.
 
         Raises:
             SynapseError if the event was not allowed.

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -368,7 +368,12 @@ class ModuleApi:
         requester = create_requester(sender)
 
         if not self._event_creation_handler:
-            self._event_creation_handler = self._hs.get_event_creation_handler()
+            # Convince mypy that get_event_creation_handler will not return None
+            event_creation_handler = (
+                self._hs.get_event_creation_handler()
+            )  # type: EventCreationHandler
+
+            self._event_creation_handler = event_creation_handler
 
         # Create and send the event
         event, _ = await self._event_creation_handler.create_and_send_nonmember_event(

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -55,7 +55,7 @@ class ModuleApi:
         # We expose these as properties below in order to attach a helpful docstring.
         self._http_client = hs.get_simple_http_client()  # type: SimpleHttpClient
         self._public_room_list_manager = PublicRoomListManager(hs)
-        self._event_creation_handler = None  # type: Optional[EventCreationHandler]
+        self._event_creation_handler = hs.get_event_creation_handler()
 
     @property
     def http_client(self):
@@ -366,14 +366,6 @@ class ModuleApi:
 
         # Create a requester object
         requester = create_requester(sender)
-
-        if not self._event_creation_handler:
-            # Convince mypy that get_event_creation_handler will not return None
-            event_creation_handler = (
-                self._hs.get_event_creation_handler()
-            )  # type: EventCreationHandler
-
-            self._event_creation_handler = event_creation_handler
 
         # Create and send the event
         event, _ = await self._event_creation_handler.create_and_send_nonmember_event(

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -20,7 +20,6 @@ from twisted.internet import defer
 
 from synapse.api.constants import EventTypes
 from synapse.events import EventBase
-from synapse.handlers.message import EventCreationHandler
 from synapse.http.client import SimpleHttpClient
 from synapse.http.site import SynapseRequest
 from synapse.logging.context import make_deferred_yieldable, run_in_background

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -349,8 +349,7 @@ class ModuleApi:
         """
         if event_type == EventTypes.Member:
             raise Exception(
-                "ThirdPartyEventRules modules are not currently able to send "
-                "m.room.member events"
+                "Synapse modules are not currently able to send m.room.member events"
             )
 
         # Build event dictionary

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -54,7 +54,6 @@ class ModuleApi:
         # We expose these as properties below in order to attach a helpful docstring.
         self._http_client = hs.get_simple_http_client()  # type: SimpleHttpClient
         self._public_room_list_manager = PublicRoomListManager(hs)
-        self._event_creation_handler = hs.get_event_creation_handler()
 
     @property
     def http_client(self):
@@ -367,7 +366,10 @@ class ModuleApi:
         requester = create_requester(sender)
 
         # Create and send the event
-        event, _ = await self._event_creation_handler.create_and_send_nonmember_event(
+        (
+            event,
+            _,
+        ) = await self._hs.get_event_creation_handler().create_and_send_nonmember_event(
             requester, event_dict, ratelimit=False, ignore_shadow_ban=True,
         )
 

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -15,7 +15,6 @@
 from mock import Mock
 
 from synapse.events import EventBase
-from synapse.module_api import ModuleApi
 from synapse.rest import admin
 from synapse.rest.client.v1 import login, room
 from synapse.types import create_requester
@@ -33,6 +32,7 @@ class ModuleApiTestCase(HomeserverTestCase):
     def prepare(self, reactor, clock, homeserver):
         self.store = homeserver.get_datastore()
         self.module_api = homeserver.get_module_api()
+        self.event_creation_handler = homeserver.get_event_creation_handler()
 
     def test_can_register_user(self):
         """Tests that an external module can register a user"""
@@ -101,8 +101,6 @@ class ModuleApiTestCase(HomeserverTestCase):
             },
             ratelimit=False,
             ignore_shadow_ban=True,
-            ignore_spam_check=True,
-            ignore_third_party_event_rules=True,
         )
 
         # Create and send a state event
@@ -140,8 +138,6 @@ class ModuleApiTestCase(HomeserverTestCase):
             },
             ratelimit=False,
             ignore_shadow_ban=True,
-            ignore_spam_check=True,
-            ignore_third_party_event_rules=True,
         )
 
         # Check that we can't send membership events

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -79,10 +79,14 @@ class ModuleApiTestCase(HomeserverTestCase):
 
         # Create and send a non-state event
         content = {"body": "I am a puppet", "msgtype": "m.text"}
+        event_dict = {
+            "room_id": room_id,
+            "type": "m.room.message",
+            "content": content,
+            "sender": user_id,
+        }
         event = self.get_success(
-            self.module_api.create_and_send_event_into_room(
-                user_id, room_id, event_type="m.room.message", content=content,
-            )
+            self.module_api.create_and_send_event_into_room(event_dict)
         )  # type: EventBase
         self.assertEqual(event.sender, user_id)
         self.assertEqual(event.type, "m.room.message")
@@ -93,12 +97,7 @@ class ModuleApiTestCase(HomeserverTestCase):
         # Check that the event was sent
         self.event_creation_handler.create_and_send_nonmember_event.assert_called_with(
             create_requester(user_id),
-            {
-                "type": "m.room.message",
-                "content": content,
-                "room_id": room_id,
-                "sender": user_id,
-            },
+            event_dict,
             ratelimit=False,
             ignore_shadow_ban=True,
         )
@@ -111,14 +110,15 @@ class ModuleApiTestCase(HomeserverTestCase):
             "users_default": 0,
             "events": {"test.event.type": 25},
         }
+        event_dict = {
+            "room_id": room_id,
+            "type": "m.room.power_levels",
+            "content": content,
+            "sender": user_id,
+            "state_key": "",
+        }
         event = self.get_success(
-            self.module_api.create_and_send_event_into_room(
-                user_id,
-                room_id,
-                event_type="m.room.power_levels",
-                content=content,
-                state_key="",
-            )
+            self.module_api.create_and_send_event_into_room(event_dict)
         )  # type: EventBase
         self.assertEqual(event.sender, user_id)
         self.assertEqual(event.type, "m.room.power_levels")
@@ -144,15 +144,15 @@ class ModuleApiTestCase(HomeserverTestCase):
         content = {
             "membership": "leave",
         }
+        event_dict = {
+            "room_id": room_id,
+            "type": "m.room.member",
+            "content": content,
+            "sender": user_id,
+            "state_key": user_id,
+        }
         self.get_failure(
-            self.module_api.create_and_send_event_into_room(
-                user_id,
-                room_id,
-                event_type="m.room.message",
-                content=content,
-                state_key=user_id,
-            ),
-            Exception,
+            self.module_api.create_and_send_event_into_room(event_dict), Exception
         )
 
     def test_public_rooms(self):

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -152,9 +152,15 @@ class ThirdPartyRulesTestCase(unittest.HomeserverTestCase):
             "msgtype": "m.text",
             "body": "Hello!",
         }
+        event_dict = {
+            "room_id": self.room_id,
+            "type": "m.room.message",
+            "content": content,
+            "sender": self.user_id,
+        }
         event = self.get_success(
             current_rules_module().module_api.create_and_send_event_into_room(
-                self.user_id, self.room_id, "m.room.message", content,
+                event_dict
             )
         )  # type: EventBase
 


### PR DESCRIPTION
This PR allows Synapse modules making use of the `ModuleApi` to create and send non-membership events into a room. This can useful to have modules send messages, or change power levels in a room etc. Note that they must send event through a user that's already in the room.

The non-membership event limitation is currently arbitrary, as it's another chunk of work and not necessary at the moment.

I'm expecting this to conflict with https://github.com/matrix-org/synapse/pull/8463. I'd like to get that one merged first before merging this one.

Reviewable commit-by-commit.