### PR TITLE
Fix returning incorrect prev_batch token in incremental sync

### DIFF
--- a/changelog.d/8486.bugfix
+++ b/changelog.d/8486.bugfix
@@ -1,0 +1,1 @@
+Fix incremental sync returning an incorrect `prev_batch` token in timeline section, which when used to paginate returned events that were included in the incremental sync. Broken since v0.16.0.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -460,8 +460,13 @@ class SyncHandler:
                 recents = []
 
             if not limited or block_all_timeline:
+                prev_batch_token = now_token
+                if recents:
+                    room_key = recents[0].internal_metadata.before
+                    prev_batch_token = now_token.copy_and_replace("room_key", room_key)
+
                 return TimelineBatch(
-                    events=recents, prev_batch=now_token, limited=False
+                    events=recents, prev_batch=prev_batch_token, limited=False
                 )
 
             filtering_factor = 2


### PR DESCRIPTION
Currently passing the `prev_batch` token to `/messages` incorrectly returns the events in the sync response.

SyTest: https://github.com/matrix-org/sytest/pull/971

Broke by https://github.com/matrix-org/synapse/commit/faad233ea61cfff2c377609fa1d3c64d39f8a039 which was released in v0.16.0