### PR TITLE
Clarify error message when plugin config parsers raise an error

### DIFF
--- a/changelog.d/8492.misc
+++ b/changelog.d/8492.misc
@@ -1,0 +1,1 @@
+Clarify error message when plugin config parsers raise an error.

--- a/synapse/util/module_loader.py
+++ b/synapse/util/module_loader.py
@@ -36,7 +36,7 @@ def load_module(provider):
     try:
         provider_config = provider_class.parse_config(provider.get("config"))
     except Exception as e:
-        raise ConfigError("Failed to parse config for %r: %r" % (provider["module"], e))
+        raise ConfigError("Failed to parse config for %r: %s" % (provider["module"], e))
 
     return provider_class, provider_config
 


### PR DESCRIPTION
This turns:

    Failed to parse config for 'myplugin': Exception('error message')

into:

    Failed to parse config for 'myplugin': error message.