### PR TITLE
Fix threadsafety in ThreadedMemoryReactorClock

### DIFF
--- a/changelog.d/8497.misc
+++ b/changelog.d/8497.misc
@@ -1,0 +1,1 @@
+Fix a threadsafety bug in unit tests.

--- a/tests/server.py
+++ b/tests/server.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections import deque
 from io import SEEK_END, BytesIO
-from typing import Any, Callable, Deque, List
+from typing import Callable, Deque
 
 import attr
 from zope.interface import implementer
@@ -307,8 +307,7 @@ class ThreadedMemoryReactorClock(MemoryReactorClock):
         return conn
 
     def advance(self, amount):
-        # run any "callFromThread" callbacks before anything registered with
-        # "callLater"
+        # first run any "callFromThread" callbacks
         while True:
             try:
                 callback = self._thread_callbacks.popleft()
@@ -316,6 +315,7 @@ class ThreadedMemoryReactorClock(MemoryReactorClock):
                 break
             callback()
 
+        # now let MemoryReactorClock run any pending "callLater" callbacks.
         super().advance(amount)
 
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -325,8 +325,8 @@ class ThreadedMemoryReactorClock(MemoryReactorClock):
             # our database queries can complete in a single call to `advance` [1] which
             # simplifies tests.
             #
-            # [1]: we replace the threadbool backing the db connection pool with a
-            # mock ThreadPool which doesn't really use threads; but still use
+            # [1]: we replace the threadpool backing the db connection pool with a
+            # mock ThreadPool which doesn't really use threads; but we still use
             # reactor.callFromThread to feed results back from the db functions to the
             # main thread.
             super().advance(0)

--- a/tests/server.py
+++ b/tests/server.py
@@ -2,9 +2,10 @@ import json
 import logging
 from collections import deque
 from io import SEEK_END, BytesIO
-from typing import Callable, Deque
+from typing import Callable
 
 import attr
+from typing_extensions import Deque
 from zope.interface import implementer
 
 from twisted.internet import address, threads, udp


### PR DESCRIPTION
This could, very occasionally, cause:

```
tests.test_visibility.FilterEventsForServerTestCase.test_large_room
===============================================================================
[ERROR]
Traceback (most recent call last):
  File "/src/tests/rest/media/v1/test_media_storage.py", line 86, in test_ensure_media_is_in_local_cache
    self.wait_on_thread(x)
  File "/src/tests/unittest.py", line 296, in wait_on_thread
    self.reactor.advance(0.01)
  File "/src/.tox/py35/lib/python3.5/site-packages/twisted/internet/task.py", line 826, in advance
    self._sortCalls()
  File "/src/.tox/py35/lib/python3.5/site-packages/twisted/internet/task.py", line 787, in _sortCalls
    self.calls.sort(key=lambda a: a.getTime())
builtins.ValueError: list modified during sort

tests.rest.media.v1.test_media_storage.MediaStorageTests.test_ensure_media_is_in_local_cache
```