### PR TITLE
invalidate the cache when a fallback key is uploaded

### DIFF
--- a/changelog.d/8501.bugfix
+++ b/changelog.d/8501.bugfix
@@ -1,1 +1,0 @@
-Invalidate the cache when a fallback key is uploaded.

--- a/changelog.d/8501.bugfix
+++ b/changelog.d/8501.bugfix
@@ -1,0 +1,1 @@
+Invalidate the cache when a fallback key is uploaded.

--- a/changelog.d/8501.feature
+++ b/changelog.d/8501.feature
@@ -1,0 +1,1 @@
+Add support for olm fallback keys ([MSC2732](https://github.com/matrix-org/matrix-doc/pull/2732)).

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -398,6 +398,10 @@ class EndToEndKeyWorkerStore(SQLBaseStore):
                 desc="set_e2e_fallback_key",
             )
 
+        await self.invalidate_cache_and_stream(
+            "get_e2e_unused_fallback_key_types", (user_id, device_id)
+        )
+
     @cached(max_entries=10000)
     async def get_e2e_unused_fallback_key_types(
         self, user_id: str, device_id: str

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -33,7 +33,7 @@ class E2eKeysHandlerTestCase(unittest.TestCase):
         super().__init__(*args, **kwargs)
         self.hs = None  # type: synapse.server.HomeServer
         self.handler = None  # type: synapse.handlers.e2e_keys.E2eKeysHandler
-        self.store = None # type: synapse.storage.Storage
+        self.store = None  # type: synapse.storage.Storage
 
     @defer.inlineCallbacks
     def setUp(self):

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -33,6 +33,7 @@ class E2eKeysHandlerTestCase(unittest.TestCase):
         super().__init__(*args, **kwargs)
         self.hs = None  # type: synapse.server.HomeServer
         self.handler = None  # type: synapse.handlers.e2e_keys.E2eKeysHandler
+        self.store = None # type: synapse.storage.Storage
 
     @defer.inlineCallbacks
     def setUp(self):
@@ -40,6 +41,7 @@ class E2eKeysHandlerTestCase(unittest.TestCase):
             self.addCleanup, handlers=None, federation_client=mock.Mock()
         )
         self.handler = synapse.handlers.e2e_keys.E2eKeysHandler(self.hs)
+        self.store = self.hs.get_datastore()
 
     @defer.inlineCallbacks
     def test_query_local_devices_no_devices(self):
@@ -178,6 +180,12 @@ class E2eKeysHandlerTestCase(unittest.TestCase):
         fallback_key = {"alg1:k1": "key1"}
         otk = {"alg1:k2": "key2"}
 
+        # we shouldn't have any unused fallback keys yet
+        res = yield defer.ensureDeferred(
+            self.store.get_e2e_unused_fallback_key_types(local_user, device_id)
+        )
+        self.assertEqual(res, [])
+
         yield defer.ensureDeferred(
             self.handler.upload_keys_for_user(
                 local_user,
@@ -185,6 +193,12 @@ class E2eKeysHandlerTestCase(unittest.TestCase):
                 {"org.matrix.msc2732.fallback_keys": fallback_key},
             )
         )
+
+        # we should now have an unused alg1 key
+        res = yield defer.ensureDeferred(
+            self.store.get_e2e_unused_fallback_key_types(local_user, device_id)
+        )
+        self.assertEqual(res, ["alg1"])
 
         # claiming an OTK when no OTKs are available should return the fallback
         # key
@@ -197,6 +211,12 @@ class E2eKeysHandlerTestCase(unittest.TestCase):
             res,
             {"failures": {}, "one_time_keys": {local_user: {device_id: fallback_key}}},
         )
+
+        # we shouldn't have any unused fallback keys again
+        res = yield defer.ensureDeferred(
+            self.store.get_e2e_unused_fallback_key_types(local_user, device_id)
+        )
+        self.assertEqual(res, [])
 
         # claiming an OTK again should return the same fallback key
         res = yield defer.ensureDeferred(


### PR DESCRIPTION
Fixes a bug introduced in #8312.