### PR TITLE
Expose the experimental appservice login flow to clients.

### DIFF
--- a/changelog.d/8504.bugfix
+++ b/changelog.d/8504.bugfix
@@ -1,0 +1,1 @@
+Expose the `uk.half-shot.msc2778.login.application_service` to clients from the login API. This feature was added in v1.21.0, but was not exposed as a potential login flow.

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -111,6 +111,8 @@ class LoginRestServlet(RestServlet):
             ({"type": t} for t in self.auth_handler.get_supported_login_types())
         )
 
+        flows.append({"type": LoginRestServlet.APPSERVICE_TYPE})
+
         return 200, {"flows": flows}
 
     def on_OPTIONS(self, request: SynapseRequest):


### PR DESCRIPTION
This essentially reverts #8440. Is related to #8320. 

It would be good to get confirmation that vector-im/element-ios#3711 is fixed before releasing this.