### PR TITLE
Explicitly install test dependencies when building deb packages

### DIFF
--- a/debian/build_virtualenv
+++ b/debian/build_virtualenv
@@ -42,7 +42,7 @@ dh_virtualenv \
     --preinstall="mock" \
     --extra-pip-arg="--no-cache-dir" \
     --extra-pip-arg="--compile" \
-    --extras="all,systemd"
+    --extras="all,systemd,test"
 
 PACKAGE_BUILD_DIR="debian/matrix-synapse-py3"
 VIRTUALENV_DIR="${PACKAGE_BUILD_DIR}${DH_VIRTUALENV_INSTALL_ROOT}/matrix-synapse"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+matrix-synapse-py3 (1.21.0+nmu1) UNRELEASED; urgency=medium
+
+  * Explicitly install "test" python dependencies.
+
+ -- Andrew Morgan <andrewm@matrix.org>  Mon, 12 Oct 2020 17:30:30 +0100
+
 matrix-synapse-py3 (1.21.0) stable; urgency=medium
 
   * New synapse release 1.21.0.


### PR DESCRIPTION
After https://github.com/matrix-org/synapse/pull/8377, the deb packages no longer indirectly installed the `"test"` dependencies, causing debian packages to fail to build while carrying out the unit tests.

This PR installs `test` dependencies explicitly when building debian packages.