### PR TITLE
Remove racey assertion in MultiWriterIDGenerator

### DIFF
--- a/changelog.d/8530.bugfix
+++ b/changelog.d/8530.bugfix
@@ -1,0 +1,1 @@
+Fix rare bug where sending an event would fail due to a racey assertion.

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -618,14 +618,7 @@ class _MultiWriterCtxManager:
             db_autocommit=True,
         )
 
-        # Assert the fetched ID is actually greater than any ID we've already
-        # seen. If not, then the sequence and table have got out of sync
-        # somehow.
         with self.id_gen._lock:
-            assert max(self.id_gen._current_positions.values(), default=0) < min(
-                self.stream_ids
-            )
-
             self.id_gen._unfinished_ids.update(self.stream_ids)
 
         if self.multiple_ids is None:


### PR DESCRIPTION
We asserted that the IDs returned by postgres sequence was greater than
any we had seen, however this is technically racey as we may update the
current positions out of order.

We now assert that the sequences are correct on startup, so the
assertion is no longer really required, so we remove them.

(I have only seen this once, so in practice I think this is rare)