### PR TITLE
Clean-up old transaction IDs on the background worker.

### DIFF
--- a/changelog.d/8544.feature
+++ b/changelog.d/8544.feature
@@ -1,0 +1,1 @@
+Allow running background tasks in a separate worker process.

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -136,7 +136,7 @@ class EventsWorkerStore(SQLBaseStore):
                     db_conn, "events", "stream_ordering", step=-1
                 )
 
-        if not hs.config.worker.worker_app:
+        if hs.config.run_background_tasks:
             # We periodically clean out old transaction ID mappings
             self._clock.looping_call(
                 run_as_background_process,


### PR DESCRIPTION
This is a minor clean-up since #8476 wasn't based on develop initially. It moves the periodic task added in that PR to be run on the background worker instead of the main process.

Related to #8500.