### PR TITLE
Include a simple message in email notifications that include encrypted content

### DIFF
--- a/changelog.d/8545.bugfix
+++ b/changelog.d/8545.bugfix
@@ -1,0 +1,1 @@
+Fix a long standing bug where email notifications for encrypted messages were blank.

--- a/synapse/res/templates/notif.html
+++ b/synapse/res/templates/notif.html
@@ -20,16 +20,22 @@
                 <div class="sender_name">{% if message.msgtype == "m.emote" %}*{% endif %} {{ message.sender_name }}</div>
             {% endif %}
             <div class="message_body">
-                {% if message.msgtype == "m.text" %}
-                    {{ message.body_text_html }}
-                {% elif message.msgtype == "m.emote" %}
-                    {{ message.body_text_html }}
-                {% elif message.msgtype == "m.notice" %}
-                    {{ message.body_text_html }}
-                {% elif message.msgtype == "m.image" %}
-                    <img src="{{ message.image_url|mxc_to_http(640, 480, scale) }}" />
-                {% elif message.msgtype == "m.file" %}
-                    <span class="filename">{{ message.body_text_plain }}</span>
+                {% if message.event_type == "m.room.encrypted" %}
+                    An encrypted message.
+                {% elif message.event_type == "m.room.message" %}
+                    {% if message.msgtype == "m.text" %}
+                        {{ message.body_text_html }}
+                    {% elif message.msgtype == "m.emote" %}
+                        {{ message.body_text_html }}
+                    {% elif message.msgtype == "m.notice" %}
+                        {{ message.body_text_html }}
+                    {% elif message.msgtype == "m.image" %}
+                        <img src="{{ message.image_url|mxc_to_http(640, 480, scale) }}" />
+                    {% elif message.msgtype == "m.file" %}
+                        <span class="filename">{{ message.body_text_plain }}</span>
+                    {% else %}
+                        An unknown event.
+                    {% endif %}
                 {% endif %}
             </div>
         </td>

--- a/synapse/res/templates/notif.html
+++ b/synapse/res/templates/notif.html
@@ -34,7 +34,7 @@
                     {%- elif message.msgtype == "m.file" %}
                         <span class="filename">{{ message.body_text_plain }}</span>
                     {%- else %}
-                        An unknown event.
+                        A message with unrecognised content.
                     {%- endif %}
                 {%- endif %}
             </div>

--- a/synapse/res/templates/notif.html
+++ b/synapse/res/templates/notif.html
@@ -1,47 +1,47 @@
-{% for message in notif.messages %}
+{%- for message in notif.messages %}
     <tr class="{{ "historical_message" if message.is_historical else "message" }}">
         <td class="sender_avatar">
-            {% if loop.index0 == 0 or notif.messages[loop.index0 - 1].sender_name != notif.messages[loop.index0].sender_name %}
-                {% if message.sender_avatar_url %}
+            {%- if loop.index0 == 0 or notif.messages[loop.index0 - 1].sender_name != notif.messages[loop.index0].sender_name %}
+                {%- if message.sender_avatar_url %}
                     <img alt="" class="sender_avatar" src="{{ message.sender_avatar_url|mxc_to_http(32,32) }}"  />
-                {% else %}
-                    {% if message.sender_hash % 3 == 0 %}
+                {%- else %}
+                    {%- if message.sender_hash % 3 == 0 %}
                         <img class="sender_avatar" src="https://riot.im/img/external/avatar-1.png"  />
-                    {% elif message.sender_hash % 3 == 1 %}
+                    {%- elif message.sender_hash % 3 == 1 %}
                         <img class="sender_avatar" src="https://riot.im/img/external/avatar-2.png"  />
-                    {% else %}
+                    {%- else %}
                         <img class="sender_avatar" src="https://riot.im/img/external/avatar-3.png"  />
-                    {% endif %}
-                {% endif %}
-            {% endif %}
+                    {%- endif %}
+                {%- endif %}
+            {%- endif %}
         </td>
         <td class="message_contents">
-            {% if loop.index0 == 0 or notif.messages[loop.index0 - 1].sender_name != notif.messages[loop.index0].sender_name %}
-                <div class="sender_name">{% if message.msgtype == "m.emote" %}*{% endif %} {{ message.sender_name }}</div>
-            {% endif %}
+            {%- if loop.index0 == 0 or notif.messages[loop.index0 - 1].sender_name != notif.messages[loop.index0].sender_name %}
+                <div class="sender_name">{%- if message.msgtype == "m.emote" %}*{%- endif %} {{ message.sender_name }}</div>
+            {%- endif %}
             <div class="message_body">
-                {% if message.event_type == "m.room.encrypted" %}
+                {%- if message.event_type == "m.room.encrypted" %}
                     An encrypted message.
-                {% elif message.event_type == "m.room.message" %}
-                    {% if message.msgtype == "m.text" %}
+                {%- elif message.event_type == "m.room.message" %}
+                    {%- if message.msgtype == "m.text" %}
                         {{ message.body_text_html }}
-                    {% elif message.msgtype == "m.emote" %}
+                    {%- elif message.msgtype == "m.emote" %}
                         {{ message.body_text_html }}
-                    {% elif message.msgtype == "m.notice" %}
+                    {%- elif message.msgtype == "m.notice" %}
                         {{ message.body_text_html }}
-                    {% elif message.msgtype == "m.image" %}
+                    {%- elif message.msgtype == "m.image" %}
                         <img src="{{ message.image_url|mxc_to_http(640, 480, scale) }}" />
-                    {% elif message.msgtype == "m.file" %}
+                    {%- elif message.msgtype == "m.file" %}
                         <span class="filename">{{ message.body_text_plain }}</span>
-                    {% else %}
+                    {%- else %}
                         An unknown event.
-                    {% endif %}
-                {% endif %}
+                    {%- endif %}
+                {%- endif %}
             </div>
         </td>
         <td class="message_time">{{ message.ts|format_ts("%H:%M") }}</td>
     </tr>
-{% endfor %}
+{%- endfor %}
 <tr class="notif_link">
     <td></td>
     <td>

--- a/synapse/res/templates/notif.txt
+++ b/synapse/res/templates/notif.txt
@@ -13,7 +13,6 @@ An encrypted message.
 {{ message.body_text_plain }}
 {%- elif message.msgtype == "m.file" %}
 {{ message.body_text_plain }}
-{%- elif message.msgtype == "m.room.encrypted" %}
 {%- else %}
 An unknown event.
 {%- endif %}

--- a/synapse/res/templates/notif.txt
+++ b/synapse/res/templates/notif.txt
@@ -1,23 +1,23 @@
-{% for message in notif.messages %}
-{% if message.event_type == "m.room.encrypted" %}
+{%- for message in notif.messages %}
+{%- if message.event_type == "m.room.encrypted" %}
 An encrypted message.
-{% elif message.event_type == "m.room.message" %}
-{% if message.msgtype == "m.emote" %}* {% endif %}{{ message.sender_name }} ({{ message.ts|format_ts("%H:%M") }})
-{% if message.msgtype == "m.text" %}
+{%- elif message.event_type == "m.room.message" %}
+{%- if message.msgtype == "m.emote" %}* {%- endif %}{{ message.sender_name }} ({{ message.ts|format_ts("%H:%M") }})
+{%- if message.msgtype == "m.text" %}
 {{ message.body_text_plain }}
-{% elif message.msgtype == "m.emote" %}
+{%- elif message.msgtype == "m.emote" %}
 {{ message.body_text_plain }}
-{% elif message.msgtype == "m.notice" %}
+{%- elif message.msgtype == "m.notice" %}
 {{ message.body_text_plain }}
-{% elif message.msgtype == "m.image" %}
+{%- elif message.msgtype == "m.image" %}
 {{ message.body_text_plain }}
-{% elif message.msgtype == "m.file" %}
+{%- elif message.msgtype == "m.file" %}
 {{ message.body_text_plain }}
-{% elif message.msgtype == "m.room.encrypted" %}
-{% else %}
+{%- elif message.msgtype == "m.room.encrypted" %}
+{%- else %}
 An unknown event.
-{% endif %}
-{% endif %}
-{% endfor %}
+{%- endif %}
+{%- endif %}
+{%- endfor %}
 
 View {{ room.title }} at {{ notif.link }}

--- a/synapse/res/templates/notif.txt
+++ b/synapse/res/templates/notif.txt
@@ -1,4 +1,7 @@
 {% for message in notif.messages %}
+{% if message.event_type == "m.room.encrypted" %}
+An encrypted message.
+{% elif message.event_type == "m.room.message" %}
 {% if message.msgtype == "m.emote" %}* {% endif %}{{ message.sender_name }} ({{ message.ts|format_ts("%H:%M") }})
 {% if message.msgtype == "m.text" %}
 {{ message.body_text_plain }}
@@ -10,6 +13,10 @@
 {{ message.body_text_plain }}
 {% elif message.msgtype == "m.file" %}
 {{ message.body_text_plain }}
+{% elif message.msgtype == "m.room.encrypted" %}
+{% else %}
+An unknown event.
+{% endif %}
 {% endif %}
 {% endfor %}
 

--- a/synapse/res/templates/notif.txt
+++ b/synapse/res/templates/notif.txt
@@ -14,7 +14,7 @@ An encrypted message.
 {%- elif message.msgtype == "m.file" %}
 {{ message.body_text_plain }}
 {%- else %}
-An unknown event.
+A message with unrecognised content.
 {%- endif %}
 {%- endif %}
 {%- endfor %}

--- a/synapse/res/templates/notif_mail.html
+++ b/synapse/res/templates/notif_mail.html
@@ -2,8 +2,8 @@
 <html lang="en">
     <head>
         <style type="text/css">
-            {% include 'mail.css' without context %}
-            {% include "mail-%s.css" % app_name ignore missing without context %}
+            {%- include 'mail.css' without context %}
+            {%- include "mail-%s.css" % app_name ignore missing without context %}
         </style>
     </head>
     <body>
@@ -18,21 +18,21 @@
                                 <div class="summarytext">{{ summary_text }}</div>
                             </td>
                             <td class="logo">
-                                {% if app_name == "Riot" %}
+                                {%- if app_name == "Riot" %}
                                     <img src="http://riot.im/img/external/riot-logo-email.png" width="83" height="83" alt="[Riot]"/>
-                                {% elif app_name == "Vector" %}
+                                {%- elif app_name == "Vector" %}
                                     <img src="http://matrix.org/img/vector-logo-email.png" width="64" height="83" alt="[Vector]"/>
-                                {% elif app_name == "Element" %}
+                                {%- elif app_name == "Element" %}
                                     <img src="https://static.element.io/images/email-logo.png" width="83" height="83" alt="[Element]"/>
-                                {% else %}
+                                {%- else %}
                                     <img src="http://matrix.org/img/matrix-120x51.png" width="120" height="51" alt="[matrix]"/>
-                                {% endif %}
+                                {%- endif %}
                             </td>
                         </tr>
                     </table>
-                    {% for room in rooms %}
-                        {% include 'room.html' with context %}
-                    {% endfor %}
+                    {%- for room in rooms %}
+                        {%- include 'room.html' with context %}
+                    {%- endfor %}
                     <div class="footer">
                         <a href="{{ unsubscribe_link }}">Unsubscribe</a>
                         <br/>
@@ -41,12 +41,12 @@
                             Sending email at {{ reason.now|format_ts("%c") }} due to activity in room {{ reason.room_name }} because
                             an event was received at {{ reason.received_at|format_ts("%c") }}
                             which is more than {{ "%.1f"|format(reason.delay_before_mail_ms / (60*1000)) }} ({{ reason.delay_before_mail_ms }}) mins ago,
-                            {% if reason.last_sent_ts %}
+                            {%- if reason.last_sent_ts %}
                                 and the last time we sent a mail for this room was {{ reason.last_sent_ts|format_ts("%c") }},
                                 which is more than {{ "%.1f"|format(reason.throttle_ms / (60*1000)) }} (current throttle_ms) mins ago.
-                            {% else %}
+                            {%- else %}
                                 and we don't have a last time we sent a mail for this room.
-                            {% endif %}
+                            {%- endif %}
                         </div>
                     </div>
                 </td>

--- a/synapse/res/templates/notif_mail.txt
+++ b/synapse/res/templates/notif_mail.txt
@@ -2,9 +2,9 @@ Hi {{ user_display_name }},
 
 {{ summary_text }}
 
-{% for room in rooms %}
-{% include 'room.txt' with context %}
-{% endfor %}
+{%- for room in rooms %}
+{%- include 'room.txt' with context %}
+{%- endfor %}
 
 You can disable these notifications at {{ unsubscribe_link }}
 

--- a/synapse/res/templates/room.html
+++ b/synapse/res/templates/room.html
@@ -1,23 +1,23 @@
 <table class="room">
     <tr class="room_header">
         <td class="room_avatar">
-            {% if room.avatar_url %}
+            {%- if room.avatar_url %}
                 <img alt="" src="{{ room.avatar_url|mxc_to_http(48,48) }}" />
-            {% else %}
-                {% if room.hash % 3 == 0 %}
+            {%- else %}
+                {%- if room.hash % 3 == 0 %}
                     <img alt="" src="https://riot.im/img/external/avatar-1.png"  />
-                {% elif room.hash % 3 == 1 %}
+                {%- elif room.hash % 3 == 1 %}
                     <img alt="" src="https://riot.im/img/external/avatar-2.png"  />
-                {% else %}
+                {%- else %}
                     <img alt="" src="https://riot.im/img/external/avatar-3.png"  />
-                {% endif %}
-            {% endif %}
+                {%- endif %}
+            {%- endif %}
         </td>
         <td class="room_name" colspan="2">
             {{ room.title }}
         </td>
     </tr>
-    {% if room.invite %}
+    {%- if room.invite %}
         <tr>
             <td></td>
             <td>
@@ -25,9 +25,9 @@
             </td>
             <td></td>
         </tr>
-    {% else %}
-        {% for notif in room.notifs %}
-            {% include 'notif.html' with context %}
-        {% endfor %}
-    {% endif %}
+    {%- else %}
+        {%- for notif in room.notifs %}
+            {%- include 'notif.html' with context %}
+        {%- endfor %}
+    {%- endif %}
 </table>

--- a/synapse/res/templates/room.txt
+++ b/synapse/res/templates/room.txt
@@ -1,9 +1,9 @@
 {{ room.title }}
 
-{% if room.invite %}
+{%- if room.invite %}
     You've been invited, join at {{ room.link }}
-{% else %}
-    {% for notif in room.notifs %}
-        {% include 'notif.txt' with context %}
-    {% endfor %}
-{% endif %}
+{%- else %}
+    {%- for notif in room.notifs %}
+        {%- include 'notif.txt' with context %}
+    {%- endfor %}
+{%- endif %}

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -166,9 +166,7 @@ class EmailPusherTests(HomeserverTestCase):
         self.helper.join(room=room, user=self.others[0].id, tok=self.others[0].token)
 
         # The other user sends some messages
-        self.helper.send_event(
-            room, "m.room.encrypted", {}, tok=self.others[0].token
-        )
+        self.helper.send_event(room, "m.room.encrypted", {}, tok=self.others[0].token)
 
         # We should get emailed about that message
         self._check_for_mail()

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -158,8 +158,23 @@ class EmailPusherTests(HomeserverTestCase):
         # We should get emailed about those messages
         self._check_for_mail()
 
+    def test_encrypted_message(self):
+        room = self.helper.create_room_as(self.user_id, tok=self.access_token)
+        self.helper.invite(
+            room=room, src=self.user_id, tok=self.access_token, targ=self.others[0].id
+        )
+        self.helper.join(room=room, user=self.others[0].id, tok=self.others[0].token)
+
+        # The other user sends some messages
+        self.helper.send_event(
+            room, "m.room.encrypted", {}, tok=self.others[0].token
+        )
+
+        # We should get emailed about that message
+        self._check_for_mail()
+
     def _check_for_mail(self):
-        "Check that the user receives an email notification"
+        """Check that the user receives an email notification"""
 
         # Get the stream ordering before it gets sent
         pushers = self.get_success(


### PR DESCRIPTION
This does two separate things and is probably best reviewed commit by commit:

* Includes a simple message: "An encrypted message." if a notification is trigged by an encrypted message.
* Uses JInja's [whitespace control syntax](https://jinja.palletsprojects.com/en/2.10.x/templates/#whitespace-control) to avoid adding unnecessary whitespace to the email (this looks awful for the text email in particular). (An alternative to this would be to tweak how we render the templates, which would affect all templates we render.)

Note that the added test doesn't *really* test #8416 as it passes before this branch, but it seemed simple to add.

Fixes #8416.