### PR TITLE
Optimise createRoom with multiple invites

### DIFF
--- a/changelog.d/8559.misc
+++ b/changelog.d/8559.misc
@@ -1,1 +1,1 @@
-Optimise `/createRoom` fwith multiple invited users.
+Optimise `/createRoom` with multiple invited users.

--- a/changelog.d/8559.misc
+++ b/changelog.d/8559.misc
@@ -1,0 +1,1 @@
+Optimise `/createRoom` fwith multiple invited users.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -310,7 +310,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         key = (room_id,)
 
         with (await self.member_linearizer.queue(key)):
-            result = await self._update_membership(
+            result = await self.update_membership_locked(
                 requester,
                 target,
                 room_id,
@@ -325,7 +325,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
 
         return result
 
-    async def _update_membership(
+    async def update_membership_locked(
         self,
         requester: Requester,
         target: UserID,
@@ -338,6 +338,10 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         content: Optional[dict] = None,
         require_consent: bool = True,
     ) -> Tuple[str, int]:
+        """Helper for update_membership.
+
+        Assumes that the membership linearizer is already held for the room.
+        """
         content_specified = bool(content)
         if content is None:
             content = {}


### PR DESCRIPTION
By not dropping the membership lock between invites, we can stop joins from grabbing the lock when we're half-done and slowing the whole thing down.

(Is this a DoS vector? If someone invites thousands of people to a room, they will receive the invite, but won't be able to accept it until the invites have stopped churning? Though we should guard against abusive createRooms anyway.)