### PR TITLE
Start an opentracing span for background processes.

### DIFF
--- a/changelog.d/8567.bugfix
+++ b/changelog.d/8567.bugfix
@@ -1,0 +1,1 @@
+Fix increase in the number of `There was no active span...` errors logged when using OpenTracing.


### PR DESCRIPTION
This should reduce the number of `There was no active span` errors we
see.

Fixes #8510.
