### PR TITLE
Fix mypy error: auth handler "checkpw" internal function type mismatch

### DIFF
--- a/changelog.d/8569.misc
+++ b/changelog.d/8569.misc
@@ -1,0 +1,1 @@
+Fix mypy typing assertion error in `handlers/auth.py`.

--- a/changelog.d/8569.misc
+++ b/changelog.d/8569.misc
@@ -1,1 +1,1 @@
-Fix mypy typing assertion error in `handlers/auth.py`.
+Fix mypy not properly checking across the codebase, additionally, fix a typing assertion error in `handlers/auth.py`.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1122,20 +1122,20 @@ class AuthHandler(BaseHandler):
             Whether self.hash(password) == stored_hash.
         """
 
-        def _do_validate_hash():
+        def _do_validate_hash(checked_hash: bytes):
             # Normalise the Unicode in the password
             pw = unicodedata.normalize("NFKC", password)
 
             return bcrypt.checkpw(
                 pw.encode("utf8") + self.hs.config.password_pepper.encode("utf8"),
-                stored_hash,
+                checked_hash,
             )
 
         if stored_hash:
             if not isinstance(stored_hash, bytes):
                 stored_hash = stored_hash.encode("ascii")
 
-            return await defer_to_thread(self.hs.get_reactor(), _do_validate_hash)
+            return await defer_to_thread(self.hs.get_reactor(), _do_validate_hash, stored_hash)
         else:
             return False
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1135,7 +1135,9 @@ class AuthHandler(BaseHandler):
             if not isinstance(stored_hash, bytes):
                 stored_hash = stored_hash.encode("ascii")
 
-            return await defer_to_thread(self.hs.get_reactor(), _do_validate_hash, stored_hash)
+            return await defer_to_thread(
+                self.hs.get_reactor(), _do_validate_hash, stored_hash
+            )
         else:
             return False
 

--- a/tox.ini
+++ b/tox.ini
@@ -158,7 +158,6 @@ commands=
     coverage html
 
 [testenv:mypy]
-skip_install = True
 deps =
     {[base]deps}
     mypy==0.782


### PR DESCRIPTION
> (Wants bytes, got Union[bytes, str] due to context closure inheritance)

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`