### PR TITLE
Support macOS in synmark

### DIFF
--- a/changelog.d/8578.misc
+++ b/changelog.d/8578.misc
@@ -1,0 +1,1 @@
+Support macOS on the `synmark` benchmark runner.

--- a/synmark/__init__.py
+++ b/synmark/__init__.py
@@ -15,7 +15,10 @@
 
 import sys
 
-from twisted.internet import epollreactor
+try:
+    from twisted.internet.epollreactor import EPollReactor as Reactor
+except ImportError:
+    from twisted.internet.pollreactor import PollReactor as Reactor
 from twisted.internet.main import installReactor
 
 from synapse.config.homeserver import HomeServerConfig
@@ -63,7 +66,7 @@ def make_reactor():
     Instantiate and install a Twisted reactor suitable for testing (i.e. not the
     default global one).
     """
-    reactor = epollreactor.EPollReactor()
+    reactor = Reactor()
 
     if "twisted.internet.reactor" in sys.modules:
         del sys.modules["twisted.internet.reactor"]


### PR DESCRIPTION
I feel like we should probably just be using the global reactor, but maybe there was a reason for importing it this way?