### PR TITLE
Remove some extraneous @unittest.INFOs on unit tests

### DIFF
--- a/changelog.d/8592.misc
+++ b/changelog.d/8592.misc
@@ -1,0 +1,1 @@
+Remove extraneous unittest logging decorators from unit tests.

--- a/tests/rest/client/v2_alpha/test_account.py
+++ b/tests/rest/client/v2_alpha/test_account.py
@@ -352,7 +352,6 @@ class DeactivateTestCase(unittest.HomeserverTestCase):
         self.render(request)
         self.assertEqual(request.code, 401)
 
-    @unittest.INFO
     def test_pending_invites(self):
         """Tests that deactivating a user rejects every pending invite for them."""
         store = self.hs.get_datastore()

--- a/tests/rest/client/v2_alpha/test_auth.py
+++ b/tests/rest/client/v2_alpha/test_auth.py
@@ -104,7 +104,6 @@ class FallbackAuthTests(unittest.HomeserverTestCase):
         self.assertEqual(len(attempts), 1)
         self.assertEqual(attempts[0][0]["response"], "a")
 
-    @unittest.INFO
     def test_fallback_captcha(self):
         """Ensure that fallback auth via a captcha works."""
         # Returns a 401 as per the spec


### PR DESCRIPTION
I found some `@unittest.INFO`s lying around that seem to be accidentally included from their respective PRs. Let's axe them.