### PR TITLE
Pin mypy-zope for compatibility with mypy.

### DIFF
--- a/changelog.d/8600.misc
+++ b/changelog.d/8600.misc
@@ -1,0 +1,1 @@
+Update `mypy` static type checker to 0.790.

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ CONDITIONAL_REQUIREMENTS["lint"] = [
     "flake8",
 ]
 
-CONDITIONAL_REQUIREMENTS["mypy"] = ["mypy==0.790", "mypy-zope"]
+CONDITIONAL_REQUIREMENTS["mypy"] = ["mypy==0.790", "mypy-zope==0.2.8"]
 
 # Dependencies which are exclusively required by unit test code. This is
 # NOT a list of all modules that are necessary to run the unit tests.


### PR DESCRIPTION
After merging #8576 I re-installed mypy and got the pip warning:

```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

mypy-zope 0.2.7 requires mypy==0.780, but you'll have mypy 0.790 which is incompatible.
```

Since I already had `mypy-zope` installed it did not update it. I think we should just pin it.