### PR TITLE
Limit AS transactions to 100 events

### DIFF
--- a/changelog.d/8606.feature
+++ b/changelog.d/8606.feature
@@ -1,1 +1,1 @@
-Appservice transactions are limited to 100 persistent and 100 ephemeral events.
+Limit appservice transactions to 100 persistent and 100 ephemeral events.

--- a/changelog.d/8606.feature
+++ b/changelog.d/8606.feature
@@ -1,0 +1,1 @@
+Appservice transactions are limited to 100 persistent and 100 ephemeral events.

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -60,10 +60,10 @@ from synapse.types import JsonDict
 logger = logging.getLogger(__name__)
 
 
-# Maximum number of events to provide in a AS transaction.
+# Maximum number of events to provide in an AS transaction.
 MAX_PERSISTENT_EVENTS_PER_TRANSACTION = 100
 
-# Maximum number of ephemeral events to provide in a AS transaction.
+# Maximum number of ephemeral events to provide in an AS transaction.
 MAX_EPHEMERAL_EVENTS_PER_TRANSACTION = 100
 
 

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -59,7 +59,12 @@ from synapse.types import JsonDict
 
 logger = logging.getLogger(__name__)
 
-MAX_EVENTS_PER_TRANSACTION = 100
+
+# Maximum number of events to provide in a AS transaction.
+MAX_PERSISTENT_EVENTS_PER_TRANSACTION = 100
+
+# Maximum number of ephemeral events to provide in a AS transaction.
+MAX_EPHEMERAL_EVENTS_PER_TRANSACTION = 100
 
 
 class ApplicationServiceScheduler:
@@ -139,12 +144,12 @@ class _ServiceQueuer:
         try:
             while True:
                 all_events = self.queued_events.get(service.id, [])
-                events = all_events[:MAX_EVENTS_PER_TRANSACTION]
-                del all_events[MAX_EVENTS_PER_TRANSACTION:]
+                events = all_events[:MAX_PERSISTENT_EVENTS_PER_TRANSACTION]
+                del all_events[:MAX_PERSISTENT_EVENTS_PER_TRANSACTION]
 
                 all_events_ephemeral = self.queued_ephemeral.get(service.id, [])
-                ephemeral = all_events_ephemeral[:MAX_EVENTS_PER_TRANSACTION]
-                del all_events_ephemeral[MAX_EVENTS_PER_TRANSACTION:]
+                ephemeral = all_events_ephemeral[:MAX_EPHEMERAL_EVENTS_PER_TRANSACTION]
+                del all_events_ephemeral[:MAX_EPHEMERAL_EVENTS_PER_TRANSACTION]
 
                 if not events and not ephemeral:
                     return


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/3536

This change imposes a 100 event limit on both the `event` and `ephemeral` sections of appservice transactions, allowing a maximum of 100 events for each. 