### PR TITLE
Fix email notifications for invites without local state.

### DIFF
--- a/changelog.d/8627.bugfix
+++ b/changelog.d/8627.bugfix
@@ -1,0 +1,1 @@
+Fix email notifications for invites without local state.

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -24,7 +24,7 @@ from typing import Iterable, List, TypeVar
 import bleach
 import jinja2
 
-from synapse.api.constants import EventTypes
+from synapse.api.constants import EventTypes, Membership
 from synapse.api.errors import StoreError
 from synapse.config.emailconfig import EmailSubjectConfig
 from synapse.logging.context import make_deferred_yieldable
@@ -317,9 +317,14 @@ class Mailer:
     async def get_room_vars(
         self, room_id, user_id, notifs, notif_events, room_state_ids
     ):
-        my_member_event_id = room_state_ids[("m.room.member", user_id)]
-        my_member_event = await self.store.get_event(my_member_event_id)
-        is_invite = my_member_event.content["membership"] == "invite"
+        # Check if one of the notifs is an invite event for the user.
+        is_invite = False
+        for n in notifs:
+            ev = notif_events[n["event_id"]]
+            if ev.type == EventTypes.Member and ev.state_key == user_id:
+                if ev.content.get("membership") == Membership.INVITE:
+                    is_invite = True
+                    break
 
         room_name = await calculate_room_name(self.store, room_state_ids, user_id)
 
@@ -461,16 +466,26 @@ class Mailer:
                 self.store, room_state_ids[room_id], user_id, fallback_to_members=False
             )
 
-            my_member_event_id = room_state_ids[room_id][("m.room.member", user_id)]
-            my_member_event = await self.store.get_event(my_member_event_id)
-            if my_member_event.content["membership"] == "invite":
-                inviter_member_event_id = room_state_ids[room_id][
-                    ("m.room.member", my_member_event.sender)
-                ]
-                inviter_member_event = await self.store.get_event(
-                    inviter_member_event_id
+            # See if one of the notifs is an invite event for the user
+            invite_event = None
+            for n in notifs_by_room[room_id]:
+                ev = notif_events[n["event_id"]]
+                if ev.type == EventTypes.Member and ev.state_key == user_id:
+                    if ev.content.get("membership") == Membership.INVITE:
+                        invite_event = ev
+                        break
+
+            if invite_event:
+                inviter_member_event_id = room_state_ids[room_id].get(
+                    ("m.room.member", invite_event.sender)
                 )
-                inviter_name = name_from_member_event(inviter_member_event)
+                inviter_name = invite_event.sender
+                if inviter_member_event_id:
+                    inviter_member_event = await self.store.get_event(
+                        inviter_member_event_id, allow_none=True
+                    )
+                    if inviter_member_event:
+                        inviter_name = name_from_member_event(inviter_member_event)
 
                 if room_name is None:
                     return self.email_subjects.invite_from_person % {

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -131,6 +131,35 @@ class EmailPusherTests(HomeserverTestCase):
         # We should get emailed about that message
         self._check_for_mail()
 
+    def test_invite_sends_email(self):
+        # Create a room and invite the user to it
+        room = self.helper.create_room_as(self.others[0].id, tok=self.others[0].token)
+        self.helper.invite(
+            room=room,
+            src=self.others[0].id,
+            tok=self.others[0].token,
+            targ=self.user_id,
+        )
+
+        # We should get emailed about the invite
+        self._check_for_mail()
+
+    def test_invite_to_empty_room_sends_email(self):
+        # Create a room and invite the user to it
+        room = self.helper.create_room_as(self.others[0].id, tok=self.others[0].token)
+        self.helper.invite(
+            room=room,
+            src=self.others[0].id,
+            tok=self.others[0].token,
+            targ=self.user_id,
+        )
+
+        # Then have the original user leave
+        self.helper.leave(room, self.others[0].id, tok=self.others[0].token)
+
+        # We should get emailed about the invite
+        self._check_for_mail()
+
     def test_multiple_members_email(self):
         # We want to test multiple notifications, so we pause processing of push
         # while we send messages.


### PR DESCRIPTION
This can happen if e.g. the room invited into is no longer on the server (or if all users left the room).

Fixes stack traces such as:

```
KeyError: ('m.room.member', '<user_id>')
  File "synapse/push/emailpusher.py", line 158, in _process
    await self._unsafe_process()
  File "synapse/push/emailpusher.py", line 207, in _unsafe_process
    await self.send_notification(unprocessed, reason)
  File "synapse/push/emailpusher.py", line 322, in send_notification
    self.app_id, self.user_id, self.email, push_actions, reason
  File "synapse/push/mailer.py", line 238, in send_notification_mail
    r, user_id, notifs_by_room[r], notif_events, state_by_room[r]
  File "synapse/push/mailer.py", line 320, in get_room_vars
    my_member_event_id = room_state_ids[("m.room.member", user_id)]
```