### PR TITLE
Don't 500 for invalid group IDs

### DIFF
--- a/changelog.d/8628.bugfix
+++ b/changelog.d/8628.bugfix
@@ -1,0 +1,1 @@
+Fix handling of invalid group IDs to return a 400 rather than log an exception and return a 500.

--- a/synapse/handlers/groups_local.py
+++ b/synapse/handlers/groups_local.py
@@ -17,7 +17,7 @@
 import logging
 
 from synapse.api.errors import HttpResponseException, RequestSendFailed, SynapseError
-from synapse.types import get_domain_from_id
+from synapse.types import GroupID, get_domain_from_id
 
 logger = logging.getLogger(__name__)
 
@@ -28,12 +28,10 @@ def _create_rerouter(func_name):
     """
 
     async def f(self, group_id, *args, **kwargs):
-        try:
-            is_local = self.is_mine_id(group_id)
-        except Exception:
-            raise SynapseError(400, "Invalid group ID")
+        if not GroupID.is_valid(group_id):
+            raise SynapseError(400, "%s was not legal group ID" % (group_id,))
 
-        if is_local:
+        if self.is_mine_id(group_id):
             return await getattr(self.groups_server_handler, func_name)(
                 group_id, *args, **kwargs
             )

--- a/synapse/handlers/groups_local.py
+++ b/synapse/handlers/groups_local.py
@@ -28,7 +28,12 @@ def _create_rerouter(func_name):
     """
 
     async def f(self, group_id, *args, **kwargs):
-        if self.is_mine_id(group_id):
+        try:
+            is_local = self.is_mine_id(group_id)
+        except Exception:
+            raise SynapseError(400, "Invalid group ID")
+
+        if is_local:
             return await getattr(self.groups_server_handler, func_name)(
                 group_id, *args, **kwargs
             )


### PR DESCRIPTION
Fixes exceptions such as:

```
IndexError: list index out of range
  File "synapse/http/server.py", line 230, in _async_render_wrapper
    callback_return = await self._async_render(request)
  File "synapse/http/server.py", line 407, in _async_render
    callback_return = await raw_callback_return
  File "synapse/rest/client/v2_alpha/groups.py", line 45, in on_GET
    group_id, requester_user_id
  File "synapse/handlers/groups_local.py", line 31, in f
    if self.is_mine_id(group_id):
  File "synapse/server.py", line 300, in is_mine_id
    return string.split(":", 1)[1] == self.hostname
```