### PR TITLE
Correct the package name in OpenID Connect install instructions

### DIFF
--- a/changelog.d/8634.misc
+++ b/changelog.d/8634.misc
@@ -1,0 +1,1 @@
+Correct Synapse's PyPI package name in the OpenID Connect installation instructions.

--- a/docs/openid.md
+++ b/docs/openid.md
@@ -37,7 +37,7 @@ as follows:
    provided by `matrix.org` so no further action is needed.
 
  * If you installed Synapse into a virtualenv, run `/path/to/env/bin/pip
-   install synapse[oidc]` to install the necessary dependencies.
+   install matrix-synapse[oidc]` to install the necessary dependencies.
 
  * For other installation mechanisms, see the documentation provided by the
    maintainer.


### PR DESCRIPTION
The OpenID Connect install instructions suggested installing `synapse[oidc]`, but our PyPI package is called [`matrix-synapse`](https://pypi.org/project/matrix-synapse/).