### PR TITLE
Catch exceptions in password_providers

### DIFF
--- a/changelog.d/8636.misc
+++ b/changelog.d/8636.misc
@@ -1,0 +1,1 @@
+Catch exceptions during initialization of `password_providers`. Contributed by Nicolai Søborg.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -172,10 +172,14 @@ class AuthHandler(BaseHandler):
         #   better way to break the loop
         account_handler = ModuleApi(hs, self)
 
-        self.password_providers = [
-            module(config=config, account_handler=account_handler)
-            for module, config in hs.config.password_providers
-        ]
+        self.password_providers = []
+        for module, config in hs.config.password_providers:
+            try:
+                self.password_providers.append(
+                    module(config=config, account_handler=account_handler)
+                )
+            except Exception as e:
+                logger.warn("Error while initializing %r: %s", module, e)
 
         logger.info("Extra password_providers: %r", self.password_providers)
 

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -179,7 +179,7 @@ class AuthHandler(BaseHandler):
                     module(config=config, account_handler=account_handler)
                 )
             except Exception as e:
-                logger.warn("Error while initializing %r: %s", module, e)
+                logger.error("Error while initializing %r: %s", module, e)
                 raise
 
         logger.info("Extra password_providers: %r", self.password_providers)

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -180,6 +180,7 @@ class AuthHandler(BaseHandler):
                 )
             except Exception as e:
                 logger.warn("Error while initializing %r: %s", module, e)
+                raise
 
         logger.info("Extra password_providers: %r", self.password_providers)
 


### PR DESCRIPTION
Catch exceptions during Initialization of `password_providers`.

Currently synapse will just fail to start with no error message if a password provider throws an exception in `__init__`.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
