### PR TITLE
Bugfix in joined_rooms admin API if user has no memberships

### DIFF
--- a/changelog.d/8643.bugfix
+++ b/changelog.d/8643.bugfix
@@ -1,0 +1,1 @@
+Fix a bug in joined_rooms admin API if user has no memberships.

--- a/changelog.d/8643.bugfix
+++ b/changelog.d/8643.bugfix
@@ -1,1 +1,1 @@
-Fix a bug in joined_rooms admin API if user has no memberships.
+Fix a bug in the `joined_rooms` admin API if the user has never joined any rooms. The bug was introduced, along with the API, in v1.21.0.

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -702,9 +702,10 @@ class UserMembershipRestServlet(RestServlet):
         if not self.is_mine(UserID.from_string(user_id)):
             raise SynapseError(400, "Can only lookup local users")
 
-        room_ids = await self.store.get_rooms_for_user(user_id)
-        if not room_ids:
-            raise NotFoundError("User not found")
+        u = await self.store.get_user_by_id(user_id)
+        if u is None:
+            raise NotFoundError("Unknown user")
 
+        room_ids = await self.store.get_rooms_for_user(user_id)
         ret = {"joined_rooms": list(room_ids), "total": len(room_ids)}
         return 200, ret

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -702,8 +702,8 @@ class UserMembershipRestServlet(RestServlet):
         if not self.is_mine(UserID.from_string(user_id)):
             raise SynapseError(400, "Can only lookup local users")
 
-        u = await self.store.get_user_by_id(user_id)
-        if u is None:
+        user = await self.store.get_user_by_id(user_id)
+        if user is None:
             raise NotFoundError("Unknown user")
 
         room_ids = await self.store.get_rooms_for_user(user_id)

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -1082,6 +1082,21 @@ class UserMembershipRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual(400, channel.code, msg=channel.json_body)
         self.assertEqual("Can only lookup local users", channel.json_body["error"])
 
+    def test_no_memberships(self):
+        """
+        Tests that a normal lookup for rooms is successfully
+        if user has no memberships
+        """
+        # Get rooms
+        request, channel = self.make_request(
+            "GET", self.url, access_token=self.admin_user_tok,
+        )
+        self.render(request)
+
+        self.assertEqual(200, channel.code, msg=channel.json_body)
+        self.assertEqual(0, channel.json_body["total"])
+        self.assertEqual(0, len(channel.json_body["joined_rooms"]))
+
     def test_get_rooms(self):
         """
         Tests that a normal lookup for rooms is successfully

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -1016,7 +1016,6 @@ class UserMembershipRestTestCase(unittest.HomeserverTestCase):
     servlets = [
         synapse.rest.admin.register_servlets,
         login.register_servlets,
-        sync.register_servlets,
         room.register_servlets,
     ]
 


### PR DESCRIPTION
Whan you call `GET /users/<user_id>/joined_rooms` and user has no joined rooms, you get an error `Unknown user`.
This PR fix it, to get an empty list and adds an unit test.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Signed-off-by: Dirk Klimpel dirk@klimpel.org