### PR TITLE
Fix user_daily_visits to not have duplicate rows for UA.

### DIFF
--- a/changelog.d/8654.bugfix
+++ b/changelog.d/8654.bugfix
@@ -1,0 +1,1 @@
+Fix `user_daily_visits` to not have duplicate rows for UA. Broke in v1.22.0rc1.

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -284,7 +284,7 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
             # A note on user_agent. Technically a given device can have multiple
             # user agents, so we need to decide which one to pick. We could have
             # handled this in number of ways, but given that we don't care
-            # _that_ much  wehave gone for MAX(). For more details of the other
+            # _that_ much we have gone for MAX(). For more details of the other
             # options considered see
             # https://github.com/matrix-org/synapse/pull/8503#discussion_r502306111
             sql = """

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -282,9 +282,10 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
             now = self._clock.time_msec()
 
             # A note on user_agent. Technically a given device can have multiple
-            # user agents, so we need to decide which one to pick. We could have handled this
-            # in number of ways, but given that we don't _that_ much have gone for MAX()
-            # For more details of the other options considered see
+            # user agents, so we need to decide which one to pick. We could have
+            # handled this in number of ways, but given that we don't care
+            # _that_ much  wehave gone for MAX(). For more details of the other
+            # options considered see
             # https://github.com/matrix-org/synapse/pull/8503#discussion_r502306111
             sql = """
                 INSERT INTO user_daily_visits (user_id, device_id, timestamp, user_agent)
@@ -299,7 +300,7 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                     WHERE last_seen > ? AND last_seen <= ?
                     AND udv.timestamp IS NULL AND users.is_guest=0
                     AND users.appservice_id IS NULL
-                    GROUP BY u.user_id, u.device_id, u.user_agent
+                    GROUP BY u.user_id, u.device_id
             """
 
             # This means that the day has rolled over but there could still


### PR DESCRIPTION
Fixes #8641. Broke in #8503.

We should add a unique index here, but it appears we have duplicated entries from before this change. The table is large enough that we can't just delete duplicates during start up, so we'll have to be a bit more cunning and as such I'm punting that for now.

Targeting the release branch since this is sort of a regression.
