### PR TITLE
Fix filepath of Dex example config

### DIFF
--- a/changelog.d/8657.doc
+++ b/changelog.d/8657.doc
@@ -1,1 +1,1 @@
-Fix the filepath of Dex's example config in the OpenID Connect auth docs.
+Fix the filepath of Dex's example config and the link to Dex's Getting Started guide in the OpenID Connect docs.

--- a/changelog.d/8657.doc
+++ b/changelog.d/8657.doc
@@ -1,0 +1,1 @@
+Fix the filepath of Dex's example config in the OpenID Connect auth docs.

--- a/docs/openid.md
+++ b/docs/openid.md
@@ -73,7 +73,7 @@ staticClients:
   name: 'Synapse'
 ```
 
-Run with `dex serve examples/config-dex.yaml`.
+Run with `dex serve examples/config-dev.yaml`.
 
 Synapse config:
 

--- a/docs/openid.md
+++ b/docs/openid.md
@@ -58,8 +58,7 @@ Here are a few configs for providers that should work with Synapse.
 Although it is designed to help building a full-blown provider with an
 external database, it can be configured with static passwords in a config file.
 
-Follow the [Getting Started
-guide](https://github.com/dexidp/dex/blob/master/Documentation/getting-started.md)
+Follow the [Getting Started guide](https://dexidp.io/docs/getting-started/)
 to install Dex.
 
 Edit `examples/config-dev.yaml` config file from the Dex repo to add a client:


### PR DESCRIPTION
Simple typo in the OpenID connect docs.