### PR TITLE
Minor updates to docs on how to run tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,9 +256,9 @@ directory of your choice::
 Synapse has a number of external dependencies, that are easiest
 to install using pip and a virtualenv::
 
-    virtualenv -p python3 env
-    source env/bin/activate
-    python -m pip install --no-use-pep517 -e ".[all]"
+    python3 -m venv ./env
+    source ./env/bin/activate
+    pip install -e ".[all,test]"
 
 This will run a process of downloading and installing all the needed
 dependencies into a virtual env.
@@ -270,9 +270,9 @@ check that everything is installed as it should be::
 
 This should end with a 'PASSED' result::
 
-    Ran 143 tests in 0.601s
+    Ran 1266 tests in 643.930s
 
-    PASSED (successes=143)
+    PASSED (skips=15, successes=1251)
 
 Running the Integration Tests
 =============================

--- a/changelog.d/8666.doc
+++ b/changelog.d/8666.doc
@@ -1,0 +1,1 @@
+Minor updates to docs on running tests.

--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,6 @@ deps =
     pip>=10
 
 setenv =
-    # we have a pyproject.toml, but don't want pip to use it for building.
-    # (otherwise we get an error about 'editable mode is not supported for
-    # pyproject.toml-style projects').
-    PIP_USE_PEP517 = false
-
     PYTHONDONTWRITEBYTECODE = no_byte_code
     COVERAGE_PROCESS_START = {toxinidir}/.coveragerc
 


### PR DESCRIPTION
The test runner isn't present in the `[all]` set of extras, so the
previous instructions did not work without also installing `[test]`.

Note that this does not include the `[lint]` extras, since those do not
install on all supported Python versions (specifically, isort 5.x
requires Python 3.6, while we still support 3.5). Instructions for that
are included in our pull request template, so we should be fine there.

I've also dropped the `--no-use-pep517` arg to `pip install` since it
seems to have been added to address a temporary regression in pip 19.1
which was fixed in pip 19.1.1 the following month.

Lastly, updated the example output of the test suite to set more
realistic expectations around run time.

Signed-off-by: Dan Callahan <danc@element.io>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
