### PR TITLE
Don't unnecessarily start bg process in replication sending loop.

### DIFF
--- a/changelog.d/8670.misc
+++ b/changelog.d/8670.misc
@@ -1,0 +1,1 @@
+Reduce number of OpenTracing spans started.

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -117,10 +117,6 @@ class ReplicationStreamer:
                 stream.discard_updates_and_advance()
             return
 
-        if self.is_looping:
-            logger.debug("Notifier poke loop already running")
-            return
-
         # We check up front to see if anything has actually changed, as we get
         # poked because of changes that happened on other instances.
         if all(
@@ -129,7 +125,13 @@ class ReplicationStreamer:
         ):
             return
 
+        # If there are updates then we need to set this even if we're already
+        # looping, as the loop needs to know that he might need to loop again.
         self.pending_updates = True
+
+        if self.is_looping:
+            logger.debug("Notifier poke loop already running")
+            return
 
         run_as_background_process("replication_notifier", self._run_notifier_loop)
 


### PR DESCRIPTION
The function ends up getting poked when we receive replication traffic, so I think we end up being poked needlessly *a lot*