### PR TITLE
Patch to temporarily drop cross-user m.key_share_requests

### DIFF
--- a/changelog.d/8675.misc
+++ b/changelog.d/8675.misc
@@ -1,0 +1,1 @@
+Temporarily drop cross-user m.key_share_request to_device messages over performance concerns.

--- a/changelog.d/8675.misc
+++ b/changelog.d/8675.misc
@@ -1,1 +1,1 @@
-Temporarily drop cross-user m.key_share_request to_device messages over performance concerns.
+Temporarily drop cross-user m.room_key_request to_device messages over performance concerns.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -916,7 +916,7 @@ class FederationHandlerRegistry:
             return
 
         # Temporary patch to drop cross-user key share requests
-        if edu_type == "m.key_share_request":
+        if edu_type == "m.room_key_request":
             return
 
         # Check if we have a handler on this instance

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -915,6 +915,10 @@ class FederationHandlerRegistry:
         if not self.config.use_presence and edu_type == "m.presence":
             return
 
+        # Temporary patch to drop cross-user key share requests
+        if edu_type == "m.key_share_request":
+            return
+
         # Check if we have a handler on this instance
         handler = self.edu_handlers.get(edu_type)
         if handler:

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -155,6 +155,10 @@ class DeviceMessageHandler:
         for user_id, by_device in messages.items():
             # we use UserID.from_string to catch invalid user ids
             if self.is_mine(UserID.from_string(user_id)):
+                # Temporary patch to disable sending local cross-user m.key_share_requests.
+                if message_type == "m.key_share_request" and user_id != sender_user_id:
+                    continue
+
                 messages_by_device = {
                     device_id: {
                         "content": message_content,
@@ -166,6 +170,11 @@ class DeviceMessageHandler:
                 if messages_by_device:
                     local_messages[user_id] = messages_by_device
             else:
+                # Temporary patch to disable sending cross-user m.key_share_requests.
+                # This includes all key share requests sent over federation
+                if message_type == "m.key_share_request":
+                    continue
+
                 destination = get_domain_from_id(user_id)
                 remote_messages.setdefault(destination, {})[user_id] = by_device
 

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -153,11 +153,12 @@ class DeviceMessageHandler:
         local_messages = {}
         remote_messages = {}  # type: Dict[str, Dict[str, Dict[str, JsonDict]]]
         for user_id, by_device in messages.items():
+            # Temporary patch to disable sending local cross-user m.key_share_requests.
+            if message_type == "m.key_share_request" and user_id != sender_user_id:
+                continue
+
             # we use UserID.from_string to catch invalid user ids
             if self.is_mine(UserID.from_string(user_id)):
-                # Temporary patch to disable sending local cross-user m.key_share_requests.
-                if message_type == "m.key_share_request" and user_id != sender_user_id:
-                    continue
 
                 messages_by_device = {
                     device_id: {
@@ -170,11 +171,6 @@ class DeviceMessageHandler:
                 if messages_by_device:
                     local_messages[user_id] = messages_by_device
             else:
-                # Temporary patch to disable sending cross-user m.key_share_requests.
-                # This includes all key share requests sent over federation
-                if message_type == "m.key_share_request":
-                    continue
-
                 destination = get_domain_from_id(user_id)
                 remote_messages.setdefault(destination, {})[user_id] = by_device
 

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -159,7 +159,6 @@ class DeviceMessageHandler:
 
             # we use UserID.from_string to catch invalid user ids
             if self.is_mine(UserID.from_string(user_id)):
-
                 messages_by_device = {
                     device_id: {
                         "content": message_content,

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -153,7 +153,7 @@ class DeviceMessageHandler:
         local_messages = {}
         remote_messages = {}  # type: Dict[str, Dict[str, Dict[str, JsonDict]]]
         for user_id, by_device in messages.items():
-            # Temporary patch to disable sending local cross-user m.key_share_requests.
+            # Temporary patch to disable sending local cross-user key requests.
             if message_type == "m.room_key_request" and user_id != sender_user_id:
                 continue
 

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -154,7 +154,7 @@ class DeviceMessageHandler:
         remote_messages = {}  # type: Dict[str, Dict[str, Dict[str, JsonDict]]]
         for user_id, by_device in messages.items():
             # Temporary patch to disable sending local cross-user m.key_share_requests.
-            if message_type == "m.key_share_request" and user_id != sender_user_id:
+            if message_type == "m.room_key_request" and user_id != sender_user_id:
                 continue
 
             # we use UserID.from_string to catch invalid user ids


### PR DESCRIPTION
Cross-user `m.key_share_requests` are a relatively new `to_device` message that allows user to re-request session keys for a message from another user if they were otherwise unable to retrieve them.

Unfortunately, these have had performance concerns on matrix.org. This is a temporary patch to disable them while we investigate a better solution.