### PR TITLE
Gracefully handle a pending connection during shutdown.

### DIFF
--- a/changelog.d/8607.feature
+++ b/changelog.d/8607.feature
@@ -1,0 +1,1 @@
+Support generating structured logs via the standard logging configuration.

--- a/changelog.d/8607.misc
+++ b/changelog.d/8607.misc
@@ -1,1 +1,0 @@
-Re-organize the structured logging code to separate the TCP transport handling from the JSON formatting.

--- a/changelog.d/8685.feature
+++ b/changelog.d/8685.feature
@@ -1,0 +1,1 @@
+Support generating structured logs via the standard logging configuration.

--- a/tests/logging/test_remote_handler.py
+++ b/tests/logging/test_remote_handler.py
@@ -151,3 +151,19 @@ class RemoteHandlerTestCase(LoggerCleanupMixin, TestCase):
             + ["warn %s" % (i,) for i in range(15, 20)],
             logs,
         )
+
+    def test_cancel_connection(self):
+        """
+        Gracefully handle the connection being cancelled.
+        """
+        handler = RemoteHandler(
+            "127.0.0.1", 9000, maximum_buffer=10, _reactor=self.reactor
+        )
+        logger = self.get_logger(handler)
+
+        # Send a message.
+        logger.info("Hello there, %s!", "wally")
+
+        # Do not accept the connection and shutdown. This causes the pending
+        # connection to be cancelled (and should not raise any exceptions).
+        handler.close()


### PR DESCRIPTION
This fixes errors that would appear if Synapse was shutdown with a pending connection in the remote logger.

Without this you would get the following error until the maximum Python stack depth was reached:

```
Traceback (most recent call last):
Failure: twisted.internet.defer.CancelledError: 
```

Part of #8588, this might fix a bug in #8607 but I suspect it existed before that PR.