### PR TITLE
Fix optional parameter in stripped state storage method

### DIFF
--- a/changelog.d/8688.misc
+++ b/changelog.d/8688.misc
@@ -1,0 +1,1 @@
+Abstract some invite-related code in preparation for landing knocking.

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -530,7 +530,7 @@ class EventsWorkerStore(SQLBaseStore):
         self,
         context: EventContext,
         state_types_to_include: List[EventTypes],
-        membership_user_id: Optional[str],
+        membership_user_id: Optional[str] = None,
     ) -> List[JsonDict]:
         """
         Retrieve the stripped state from a room, given an event context to retrieve state


### PR DESCRIPTION
Missed in #8671. The parameter `membership_user_id` is meant to be optional, but functionally I forgot to make it so.

Uses the same changelog as the original PR.