### PR TITLE
Fail tests which fail to await on awaitables

### DIFF
--- a/changelog.d/8690.misc
+++ b/changelog.d/8690.misc
@@ -1,0 +1,1 @@
+Fail tests if they do not await coroutines.

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -230,3 +230,9 @@ class AuthTestCase(unittest.TestCase):
     def _get_macaroon(self):
         token = self.macaroon_generator.generate_short_term_login_token("user_a", 5000)
         return pymacaroons.Macaroon.deserialize(token)
+
+    def test_foo(self):
+        async def foo():
+            pass
+
+        foo()

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -230,9 +230,3 @@ class AuthTestCase(unittest.TestCase):
     def _get_macaroon(self):
         token = self.macaroon_generator.generate_short_term_login_token("user_a", 5000)
         return pymacaroons.Macaroon.deserialize(token)
-
-    def test_foo(self):
-        async def foo():
-            pass
-
-        foo()

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -54,7 +54,7 @@ from tests.server import (
     render,
     setup_test_homeserver,
 )
-from tests.test_utils import event_injection
+from tests.test_utils import event_injection, setup_awaitable_errors
 from tests.test_utils.logging_setup import setup_logging
 from tests.utils import default_config, setupdb
 
@@ -118,6 +118,10 @@ class TestCase(unittest.TestCase):
                     return ret
 
                 logging.getLogger().setLevel(level)
+
+            # Trial messes with the warnings configuration, thus this has to be
+            # done in the context of an individual TestCase.
+            self.addCleanup(setup_awaitable_errors())
 
             return orig()
 


### PR DESCRIPTION
Convert warnings like `RuntimeWarning: coroutine 'AuthTestCase.test_foo.<locals>.foo' was never awaited` to test failures.

I had wanted to do this when working on #7988 and couldn't get it to work. Turns out that Python 3.8 added the needed feature: [`sys.unraisablehook`](https://docs.python.org/3/library/sys.html#sys.unraisablehook). You can combine this with turning warnings into errors to do what we need.

I got a bit nerd sniped by [a posting on the Django developers list](https://groups.google.com/u/1/g/django-developers/c/ea21KjiGiY4/m/7HTnQaS8BwAJ).

The downside is that this *might* catch other warnings outside of the awaitable ones? We could probably do a bit of filtering of the exception to catch this?