### PR TITLE
Notes on SSO logins and media_repository worker

### DIFF
--- a/changelog.d/8701.doc
+++ b/changelog.d/8701.doc
@@ -1,1 +1,1 @@
-Notes on SSO logins and media_repository worker
+Notes on SSO logins and media_repository worker.

--- a/changelog.d/8701.doc
+++ b/changelog.d/8701.doc
@@ -1,0 +1,1 @@
+Notes on SSO logins and media_repository worker

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -262,6 +262,9 @@ using):
 Note that a HTTP listener with `client` and `federation` resources must be
 configured in the `worker_listeners` option in the worker config.
 
+Ensure that all SSO logins go to a single process (usually the main process). 
+Multiple workers not handling the SSO endpoints properly, see
+[#7530](https://github.com/matrix-org/synapse/issues/7530).
 
 #### Load balancing
 
@@ -407,6 +410,8 @@ and you must configure a single instance to run the background tasks, e.g.:
 ```yaml
     media_instance_running_background_jobs: "media-repository-1"
 ```
+
+If a reverse proxy is used, `/_matrix/media/` must be set for the client (e.g. 443) and the federation port (e.g. 8448) if they are different.
 
 ### `synapse.app.user_dir`
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -263,7 +263,7 @@ Note that a HTTP listener with `client` and `federation` resources must be
 configured in the `worker_listeners` option in the worker config.
 
 Ensure that all SSO logins go to a single process (usually the main process). 
-Multiple workers not handling the SSO endpoints properly, see
+For multiple workers not handling the SSO endpoints properly, see
 [#7530](https://github.com/matrix-org/synapse/issues/7530).
 
 #### Load balancing
@@ -411,7 +411,7 @@ and you must configure a single instance to run the background tasks, e.g.:
     media_instance_running_background_jobs: "media-repository-1"
 ```
 
-If a reverse proxy is used, `/_matrix/media/` must be set for the client (e.g. 443) and the federation port (e.g. 8448) if they are different.
+Note that if a reverse proxy is used , then `/_matrix/media/` must be routed for both inbound client and federation requests (if they are handled separately).
 
 ### `synapse.app.user_dir`
 


### PR DESCRIPTION
If SSO login is used (e.g. SAML) in a multi worker setup, it should be mentioned that currently all SAML logins must run on the same worker, see https://github.com/matrix-org/synapse/issues/7530

Also, if you are using different ports (for example 443 and 8448) in a reverse proxy for client and federation, the path `/_matrix/media` on the client and federation port must point to the listener of the `media_repository` worker, otherwise you'll get a 404 on the federation port for the path `/_matrix/media`, if a remote server is trying to get the media object on federation port, see https://github.com/matrix-org/synapse/issues/8695

