### PR TITLE
Add metrics for tracking 3PID /requestToken requests.

### DIFF
--- a/changelog.d/8712.misc
+++ b/changelog.d/8712.misc
@@ -1,0 +1,1 @@
+Add metrics for tracking 3PID `/requestToken` requests.

--- a/changelog.d/8712.misc
+++ b/changelog.d/8712.misc
@@ -1,1 +1,1 @@
-Add metrics for tracking 3PID `/requestToken` requests.
+Add metrics the allow the local sysadmin to track 3PID `/requestToken` requests.

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -505,8 +505,8 @@ last_ticked = time.time()
 # 3PID send info
 threepid_send_requests = Histogram(
     "synapse_threepid_send_requests_with_tries",
-    documentation="Number of requests for a 3pid token by retry count. Note if"
-    " there is a request with rerty count of 4, then there would have been one"
+    documentation="Number of requests for a 3pid token by try count. Note if"
+    " there is a request with retry count of 4, then there would have been one"
     " each for 1, 2 and 3",
     buckets=(1, 2, 3, 4, 5, 10),
     labelnames=("type", "reason"),

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -502,6 +502,16 @@ build_info.labels(
 
 last_ticked = time.time()
 
+# 3PID send info
+threepid_send_requests = Histogram(
+    "synapse_threepid_send_requests_with_tries",
+    documentation="Number of requests for a 3pid token by retry count. Note if"
+    " there is a request with rerty count of 4, then there would have been one"
+    " each for 1, 2 and 3",
+    buckets=(1, 2, 3, 4, 5, 10),
+    labelnames=("type", "reason"),
+)
+
 
 class ReactorLastSeenMetric:
     def collect(self):

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -506,7 +506,7 @@ last_ticked = time.time()
 threepid_send_requests = Histogram(
     "synapse_threepid_send_requests_with_tries",
     documentation="Number of requests for a 3pid token by try count. Note if"
-    " there is a request with retry count of 4, then there would have been one"
+    " there is a request with try count of 4, then there would have been one"
     " each for 1, 2 and 3",
     buckets=(1, 2, 3, 4, 5, 10),
     labelnames=("type", "reason"),

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -38,6 +38,7 @@ from synapse.http.servlet import (
     parse_json_object_from_request,
     parse_string,
 )
+from synapse.metrics import threepid_send_requests
 from synapse.push.mailer import Mailer
 from synapse.util.msisdn import phone_number_to_msisdn
 from synapse.util.stringutils import assert_valid_client_secret, random_string
@@ -142,6 +143,10 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
 
             # Wrap the session id in a JSON object
             ret = {"sid": sid}
+
+        threepid_send_requests.labels(type="email", reason="password_reset").observe(
+            send_attempt
+        )
 
         return 200, ret
 
@@ -411,6 +416,10 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
             # Wrap the session id in a JSON object
             ret = {"sid": sid}
 
+        threepid_send_requests.labels(type="email", reason="add_threepid").observe(
+            send_attempt
+        )
+
         return 200, ret
 
 
@@ -479,6 +488,10 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
             client_secret,
             send_attempt,
             next_link,
+        )
+
+        threepid_send_requests.labels(type="msisdn", reason="add_threepid").observe(
+            send_attempt
         )
 
         return 200, ret

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -45,6 +45,7 @@ from synapse.http.servlet import (
     parse_json_object_from_request,
     parse_string,
 )
+from synapse.metrics import threepid_send_requests
 from synapse.push.mailer import Mailer
 from synapse.util.msisdn import phone_number_to_msisdn
 from synapse.util.ratelimitutils import FederationRateLimiter
@@ -163,6 +164,10 @@ class EmailRegisterRequestTokenRestServlet(RestServlet):
             # Wrap the session id in a JSON object
             ret = {"sid": sid}
 
+        threepid_send_requests.labels(type="email", reason="register").observe(
+            send_attempt
+        )
+
         return 200, ret
 
 
@@ -232,6 +237,10 @@ class MsisdnRegisterRequestTokenRestServlet(RestServlet):
             client_secret,
             send_attempt,
             next_link,
+        )
+
+        threepid_send_requests.labels(type="msisdn", reason="register").observe(
+            send_attempt
         )
 
         return 200, ret


### PR DESCRIPTION
The main use case is to see how many requests are being made, and how
many are second/third/etc attempts. If there are large number of retries
then that likely indicates a delivery problem.

Note: the histogram metrics here is a bit counter intuitive as it is counting the number of total requests, rather how many attempts in a single session. This means that if you have an entry at 5 then you'll also have entries at 1, 2 and 3, which may make consuming this metrics a bit harder than otherwise. However, basing it on session would be quite tricky to implement.

Does part of #8709.