### PR TITLE
Add documentation about documentation to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,22 @@ directory, you will need both a regular newsfragment *and* an entry in the
 debian changelog. (Though typically such changes should be submitted as two
 separate pull requests.)
 
+## Documentation
+
+There is a growing amount of documentation located in the [docs](docs)
+directory. This documentation is intended primarily for sysadmins running their
+own Synapse instance, as well as developers interacting externally with
+Synapse. [docs/dev](docs/dev) exists primarily to house documentation for
+Synapse developers.
+
+New files added to both folders should be written in [Github-Flavoured
+Markdown](https://guides.github.com/features/mastering-markdown/), and attempts
+should be made to migrate existing documents to markdown where possible.
+
+Some documentation also exists in [Synapse's Github
+Wiki](https://github.com/matrix-org/synapse/wiki), although this is primarily
+contributed to by community authors.
+
 ## Sign off
 
 In order to have a concrete record that your contribution is intentional

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,9 @@ There is a growing amount of documentation located in the [docs](docs)
 directory. This documentation is intended primarily for sysadmins running their
 own Synapse instance, as well as developers interacting externally with
 Synapse. [docs/dev](docs/dev) exists primarily to house documentation for
-Synapse developers.
+Synapse developers. [docs/admin_api](docs/admin_api) houses documentation
+regarding Synapse's Admin API, which is used mostly by sysadmins and external
+service developers.
 
 New files added to both folders should be written in [Github-Flavoured
 Markdown](https://guides.github.com/features/mastering-markdown/), and attempts

--- a/changelog.d/8714.doc
+++ b/changelog.d/8714.doc
@@ -1,0 +1,1 @@
+Add information regarding the various sources of, and expected contributions to, Synapse's documentation to `CONTRIBUTING.md`.


### PR DESCRIPTION
This PR adds some documentation that:

* Describes who the audience for the `docs/` and `docs/dev/` directories are, as well as Synapse's wiki page.
* Stresses that we'd like all documentation to be down in markdown.

This came out of https://github.com/matrix-org/synapse/pull/8700#discussion_r516686648.