### PR TITLE
Better error message when a remote resource uses invalid Content-Type

### DIFF
--- a/changelog.d/8719.misc
+++ b/changelog.d/8719.misc
@@ -1,1 +1,1 @@
-Return `502` HTTP error code to the client instead of `500` when a remote server incorrectly sets the `Content-Type` header in response to a JSON request.
+Improve the error message returned when a remote server incorrectly sets the `Content-Type` header in response to a JSON request.

--- a/changelog.d/8719.misc
+++ b/changelog.d/8719.misc
@@ -1,0 +1,1 @@
+Return `502` HTTP error code to the client instead of `500` when a remote server incorrectly sets the `Content-Type` header in response to a JSON request.

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -1064,7 +1064,7 @@ def check_content_type_is_json(headers):
     c_type = headers.getRawHeaders(b"Content-Type")
     if c_type is None:
         raise RequestSendFailed(
-            SynapseError(502, "No Content-Type header received from remote server"),
+            RuntimeError("No Content-Type header received from remote server"),
             can_retry=False,
         )
 
@@ -1072,8 +1072,7 @@ def check_content_type_is_json(headers):
     val, options = cgi.parse_header(c_type)
     if val != "application/json":
         raise RequestSendFailed(
-            SynapseError(
-                502,
+            RuntimeError(
                 "Remote server sent Content-Type header of '%s', not 'application/json'"
                 % c_type,
             ),

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -1063,13 +1063,20 @@ def check_content_type_is_json(headers):
     """
     c_type = headers.getRawHeaders(b"Content-Type")
     if c_type is None:
-        raise RequestSendFailed(RuntimeError("No Content-Type header"), can_retry=False)
+        raise RequestSendFailed(
+            SynapseError(502, "No Content-Type header received from remote server"),
+            can_retry=False,
+        )
 
     c_type = c_type[0].decode("ascii")  # only the first header
     val, options = cgi.parse_header(c_type)
     if val != "application/json":
         raise RequestSendFailed(
-            RuntimeError("Content-Type not application/json: was '%s'" % c_type),
+            SynapseError(
+                502,
+                "Remote server sent Content-Type header of '%s', not 'application/json'"
+                % c_type,
+            ),
             can_retry=False,
         )
 


### PR DESCRIPTION
I noticed while working on #8421 that Synapse will raise a wrapped `RuntimeError` and 500 when a remote server responds to a request with a `Content-Type` header that Synapse was not expecting.

This is a tiny PR to change it to a 502 (Bad Gateway) instead, which I think makes more sense. I also spruced up the error message text a bit.