### PR TITLE
Add an admin API for server media statistics

### DIFF
--- a/changelog.d/8723.feature
+++ b/changelog.d/8723.feature
@@ -1,0 +1,1 @@
+Add an admin API for local server media statistics. Contributed by @dklimpel.

--- a/docs/admin_api/statistics.md
+++ b/docs/admin_api/statistics.md
@@ -1,3 +1,50 @@
+# Server media usage statistics
+
+Returns information about all local media usage of this server.
+Gives the possibility to filter them by time.
+
+The API is:
+
+```
+GET /_synapse/admin/v1/statistics/server/media
+```
+
+To use it, you will need to authenticate by providing an `access_token`
+for a server admin: see [README.rst](README.rst).
+
+A response body like the following is returned:
+
+```json
+{
+  "media_count": 3,
+  "media_length": 210
+}
+```
+
+To paginate, check for `next_token` and if present, call the endpoint
+again with `from` set to the value of `next_token`. This will return a new page.
+
+If the endpoint does not return a `next_token` then there are no more
+reports to paginate through.
+
+**Parameters**
+
+The following parameters should be set in the URL:
+
+* `from_ts` - string representing a positive integer - Considers only
+  files created at this timestamp or later. Unix timestamp in ms.
+* `until_ts` - string representing a positive integer - Considers only
+  files created at this timestamp or earlier. Unix timestamp in ms.
+
+
+**Response**
+
+The following fields are returned in the JSON response body:
+
+* `media_count` - integer - Number of uploaded media.
+* `media_length` - integer - Size of uploaded media in bytes.
+
+
 # Users' media usage statistics
 
 Returns information about all local media usage of users. Gives the

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -47,7 +47,10 @@ from synapse.rest.admin.rooms import (
     ShutdownRoomRestServlet,
 )
 from synapse.rest.admin.server_notice_servlet import SendServerNoticeServlet
-from synapse.rest.admin.statistics import UserMediaStatisticsRestServlet
+from synapse.rest.admin.statistics import (
+    UserMediaStatisticsRestServlet,
+    ServerMediaStatisticsRestServlet,
+)
 from synapse.rest.admin.users import (
     AccountValidityRenewServlet,
     DeactivateAccountRestServlet,
@@ -229,6 +232,7 @@ def register_servlets(hs, http_server):
     DevicesRestServlet(hs).register(http_server)
     DeleteDevicesRestServlet(hs).register(http_server)
     UserMediaStatisticsRestServlet(hs).register(http_server)
+    ServerMediaStatisticsRestServlet(hs).register(http_server)
     EventReportDetailRestServlet(hs).register(http_server)
     EventReportsRestServlet(hs).register(http_server)
     PushersRestServlet(hs).register(http_server)

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -48,8 +48,8 @@ from synapse.rest.admin.rooms import (
 )
 from synapse.rest.admin.server_notice_servlet import SendServerNoticeServlet
 from synapse.rest.admin.statistics import (
-    UserMediaStatisticsRestServlet,
     ServerMediaStatisticsRestServlet,
+    UserMediaStatisticsRestServlet,
 )
 from synapse.rest.admin.users import (
     AccountValidityRenewServlet,

--- a/tests/rest/admin/test_statistics.py
+++ b/tests/rest/admin/test_statistics.py
@@ -602,7 +602,7 @@ class ServerMediaStatisticsTestCase(StatisticsBase):
         self.render(request)
         self.assertEqual(200, int(channel.result["code"]), msg=channel.result["body"])
         self.assertEqual(channel.json_body["media_count"], 3)
-        self.assertGreaterEqual(channel.json_body["media_length"], 0)
+        self.assertGreater(channel.json_body["media_length"], 0)
 
         # filter media starting at `ts1` after creating first media
         # result is 0
@@ -629,7 +629,7 @@ class ServerMediaStatisticsTestCase(StatisticsBase):
         self.render(request)
         self.assertEqual(200, int(channel.result["code"]), msg=channel.result["body"])
         self.assertEqual(channel.json_body["media_count"], 3)
-        self.assertGreaterEqual(channel.json_body["media_length"], 0)
+        self.assertGreater(channel.json_body["media_length"], 0)
 
         # filter media until `ts2` and earlier
         request, channel = self.make_request(
@@ -638,4 +638,4 @@ class ServerMediaStatisticsTestCase(StatisticsBase):
         self.render(request)
         self.assertEqual(200, int(channel.result["code"]), msg=channel.result["body"])
         self.assertEqual(channel.json_body["media_count"], 6)
-        self.assertGreaterEqual(channel.json_body["media_length"], 0)
+        self.assertGreater(channel.json_body["media_length"], 0)


### PR DESCRIPTION
Add `GET /_synapse/admin/v1/statistics/server/media` to get statisics about local media usage.
Related to #6094 and #8700 

I am not sure if we should mark this API as draft.
Maybe is it better move to `GET /_synapse/admin/v1/statistics/server` or `GET /_synapse/admin/v1/statistics` and also add information like number of registered users.
Or should I am add number of registered users to this PR?

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Signed-off-by: Dirk Klimpel dirk@klimpel.org