### PR TITLE
Enable reconnection in DB pool

### DIFF
--- a/changelog.d/8726.bugfix
+++ b/changelog.d/8726.bugfix
@@ -1,0 +1,1 @@
+Fix bug where Synapse would not recover after losing connection to the database.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -88,13 +88,18 @@ def make_pool(
     """Get the connection pool for the database.
     """
 
+    # By default enable `cp_reconnect`. We need to fiddle with db_args in case
+    # someone has explicitly set `cp_reconnect`.
+    db_args = dict(db_config.config.get("args", {}))
+    db_args.setdefault("cp_reconnect", True)
+
     return adbapi.ConnectionPool(
         db_config.config["name"],
         cp_reactor=reactor,
         cp_openfun=lambda conn: engine.on_new_connection(
             LoggingDatabaseConnection(conn, engine, "on_new_connection")
         ),
-        **db_config.config.get("args", {}),
+        **db_args,
     )
 
 


### PR DESCRIPTION
[`adbapi.ConnectionPool`](https://twistedmatrix.com/documents/current/api/twisted.enterprise.adbapi.ConnectionPool.html) let's you turn on auto reconnect of DB connections. This is off by default. As far as I can tell if its not enabled dead connections never get removed from the pool.

Hopefully fixes: #8574