### PR TITLE
Fix port script fails when DB has no backfilled events.

### DIFF
--- a/changelog.d/8729.bugfix
+++ b/changelog.d/8729.bugfix
@@ -1,0 +1,1 @@
+Fix port script fails when DB has no backfilled events. Broke in v1.21.0.

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -820,7 +820,7 @@ class Porter(object):
                     "ALTER SEQUENCE events_stream_seq RESTART WITH %s", (next_id,)
                 )
 
-            txn.execute("SELECT -MIN(stream_ordering) FROM events")
+            txn.execute("SELECT GREATEST(-MIN(stream_ordering), 1) FROM events")
             curr_id = txn.fetchone()[0]
             if curr_id:
                 next_id = curr_id + 1

--- a/scripts/synapse_port_db
+++ b/scripts/synapse_port_db
@@ -822,12 +822,10 @@ class Porter(object):
 
             txn.execute("SELECT GREATEST(-MIN(stream_ordering), 1) FROM events")
             curr_id = txn.fetchone()[0]
-            if curr_id:
-                next_id = curr_id + 1
-                txn.execute(
-                    "ALTER SEQUENCE events_backfill_stream_seq RESTART WITH %s",
-                    (next_id,),
-                )
+            next_id = curr_id + 1
+            txn.execute(
+                "ALTER SEQUENCE events_backfill_stream_seq RESTART WITH %s", (next_id,),
+            )
 
         return self.postgres_store.db_pool.runInteraction(
             "_setup_events_stream_seqs", r


### PR DESCRIPTION
Fixes #8618