### PR TITLE
SAML: allowed clock/time difference from IdP

### DIFF
--- a/changelog.d/8731.misc
+++ b/changelog.d/8731.misc
@@ -1,1 +1,1 @@
-SAML: add `accepted_time_diff` example to `saml2_config:` config to allow clock/time difference from IdP.
+Add an example and documentation for clock skew to the SAML2 sample configuration to allow for clock/time difference between the homserver and IdP. Contributed by @localguru.

--- a/changelog.d/8731.misc
+++ b/changelog.d/8731.misc
@@ -1,0 +1,1 @@
+SAML: add `accepted_time_diff` example to `saml2_config:` config to allow clock/time difference from IDP.

--- a/changelog.d/8731.misc
+++ b/changelog.d/8731.misc
@@ -1,1 +1,1 @@
-SAML: add `accepted_time_diff` example to `saml2_config:` config to allow clock/time difference from IDP.
+SAML: add `accepted_time_diff` example to `saml2_config:` config to allow clock/time difference from IdP.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1545,7 +1545,8 @@ saml2_config:
     #  remote:
     #    - url: https://our_idp/metadata.xml
 
-    # Allowed clock difference in seconds from IdP.
+    # Allowed clock difference in seconds from IdP. Uncomment the below to 
+    # increase the accepted time difference from 0 to 3 seconds.
     #accepted_time_diff: 3
 
     # By default, the user has to go to our login page first. If you'd like

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1545,6 +1545,9 @@ saml2_config:
     #  remote:
     #    - url: https://our_idp/metadata.xml
 
+    # Allowed clock difference in seconds from Identity Provider.
+    #accepted_time_diff: 3
+
     # By default, the user has to go to our login page first. If you'd like
     # to allow IdP-initiated login, set 'allow_unsolicited: true' in a
     # 'service.sp' section:

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1545,7 +1545,7 @@ saml2_config:
     #  remote:
     #    - url: https://our_idp/metadata.xml
 
-    # Allowed clock difference in seconds from IdP. Uncomment the below to 
+    # Allowed clock difference in seconds from IdP. Uncomment the below to
     # increase the accepted time difference from 0 to 3 seconds.
     #accepted_time_diff: 3
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1545,8 +1545,10 @@ saml2_config:
     #  remote:
     #    - url: https://our_idp/metadata.xml
 
-    # Allowed clock difference in seconds from IdP.
+    # Allowed clock difference in seconds between the homeserver and IdP.
+    #
     # Uncomment the below to increase the accepted time difference from 0 to 3 seconds.
+    #
     #accepted_time_diff: 3
 
     # By default, the user has to go to our login page first. If you'd like

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1545,7 +1545,7 @@ saml2_config:
     #  remote:
     #    - url: https://our_idp/metadata.xml
 
-    # Allowed clock difference in seconds from Identity Provider.
+    # Allowed clock difference in seconds from IdP.
     #accepted_time_diff: 3
 
     # By default, the user has to go to our login page first. If you'd like

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1545,8 +1545,8 @@ saml2_config:
     #  remote:
     #    - url: https://our_idp/metadata.xml
 
-    # Allowed clock difference in seconds from IdP. Uncomment the below to
-    # increase the accepted time difference from 0 to 3 seconds.
+    # Allowed clock difference in seconds from IdP.
+    # Uncomment the below to increase the accepted time difference from 0 to 3 seconds.
     #accepted_time_diff: 3
 
     # By default, the user has to go to our login page first. If you'd like

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -256,8 +256,8 @@ class SAML2Config(Config):
             #  remote:
             #    - url: https://our_idp/metadata.xml
 
-            # Allowed clock difference in seconds from IdP. Uncomment the below to
-            # increase the accepted time difference from 0 to 3 seconds.
+            # Allowed clock difference in seconds from IdP.
+            # Uncomment the below to increase the accepted time difference from 0 to 3 seconds.
             #accepted_time_diff: 3
 
             # By default, the user has to go to our login page first. If you'd like

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -256,7 +256,7 @@ class SAML2Config(Config):
             #  remote:
             #    - url: https://our_idp/metadata.xml
 
-            # Allowed clock difference in seconds from Identity Provider.
+            # Allowed clock difference in seconds from IdP.
             #accepted_time_diff: 3
 
             # By default, the user has to go to our login page first. If you'd like

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -258,7 +258,7 @@ class SAML2Config(Config):
 
             # Allowed clock difference in seconds from Identity Provider.
             #accepted_time_diff: 3
-            
+
             # By default, the user has to go to our login page first. If you'd like
             # to allow IdP-initiated login, set 'allow_unsolicited: true' in a
             # 'service.sp' section:

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -256,6 +256,9 @@ class SAML2Config(Config):
             #  remote:
             #    - url: https://our_idp/metadata.xml
 
+            # Allowed clock difference in seconds from Identity Provider.
+            #accepted_time_diff: 3
+            
             # By default, the user has to go to our login page first. If you'd like
             # to allow IdP-initiated login, set 'allow_unsolicited: true' in a
             # 'service.sp' section:

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -256,8 +256,10 @@ class SAML2Config(Config):
             #  remote:
             #    - url: https://our_idp/metadata.xml
 
-            # Allowed clock difference in seconds from IdP.
+            # Allowed clock difference in seconds between the homeserver and IdP.
+            #
             # Uncomment the below to increase the accepted time difference from 0 to 3 seconds.
+            #
             #accepted_time_diff: 3
 
             # By default, the user has to go to our login page first. If you'd like

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -256,7 +256,7 @@ class SAML2Config(Config):
             #  remote:
             #    - url: https://our_idp/metadata.xml
 
-            # Allowed clock difference in seconds from IdP. Uncomment the below to 
+            # Allowed clock difference in seconds from IdP. Uncomment the below to
             # increase the accepted time difference from 0 to 3 seconds.
             #accepted_time_diff: 3
 

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -256,7 +256,8 @@ class SAML2Config(Config):
             #  remote:
             #    - url: https://our_idp/metadata.xml
 
-            # Allowed clock difference in seconds from IdP.
+            # Allowed clock difference in seconds from IdP. Uncomment the below to 
+            # increase the accepted time difference from 0 to 3 seconds.
             #accepted_time_diff: 3
 
             # By default, the user has to go to our login page first. If you'd like


### PR DESCRIPTION
## Allowed clock/time difference in seconds from IdP

Despite an own and reliable NTP configuration (e.g. timesyncd) the clock of the IdP may drift slightly ahead of the system clocks of your matrix-synapse server. These cases of time difference can result in `NotBefore / NotOnOrAfter` assertion fails and a SAML login will not be accepted. You can allow for a small amount of clock drift in seconds using `accepted_time_diff` in `saml2_config` of your `homeserver.yaml` config.

see docs: https://pysaml2.readthedocs.io/en/latest/howto/config.html#accepted-time-diff