### PR TITLE
Improve appservice handler to send only the most recent ephemeral events when no stream_id is stored.

### DIFF
--- a/changelog.d/8744.bugfix
+++ b/changelog.d/8744.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where appservices may be sent an excessive amount of read receipts and presence.

--- a/changelog.d/8744.bugfix
+++ b/changelog.d/8744.bugfix
@@ -1,1 +1,1 @@
-Fix a bug where appservices may be sent an excessive amount of read receipts and presence.
+Fix a bug where appservices may be sent an excessive amount of read receipts and presence. Broke in v1.22.0. 

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -226,7 +226,7 @@ class ApplicationServicesHandler:
         new_token: Optional[int],
         users: Collection[Union[str, UserID]],
     ):
-        logger.info("Checking interested services for %s" % (stream_key))
+        logger.debug("Checking interested services for %s" % (stream_key))
         with Measure(self.clock, "notify_interested_services_ephemeral"):
             for service in services:
                 # Only handle typing if we have the latest token

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -282,6 +282,12 @@ class ApplicationServicesHandler:
         from_key = await self.store.get_type_stream_id_for_appservice(
             service, "presence"
         )
+
+        if from_key == 0:
+            # We don't want to fetch the changes if this is the first time the appservice
+            # has checked for presence, because we will see all changes for all users
+            from_key = None
+
         for user in users:
             if isinstance(user, str):
                 user = UserID.from_string(user)

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -281,7 +281,7 @@ class ApplicationServicesHandler:
         presence_source = self.event_sources.sources["presence"]
         from_key = await self.store.get_type_stream_id_for_appservice(
             service, "presence"
-        )
+        )  # type: Optional[int]
 
         if from_key == 0:
             # We don't want to fetch the changes if this is the first time the appservice

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -281,13 +281,7 @@ class ApplicationServicesHandler:
         presence_source = self.event_sources.sources["presence"]
         from_key = await self.store.get_type_stream_id_for_appservice(
             service, "presence"
-        )  # type: Optional[int]
-
-        if from_key == 0:
-            # We don't want to fetch the changes if this is the first time the appservice
-            # has checked for presence, because we will see all changes for all users
-            from_key = None
-
+        )
         for user in users:
             if isinstance(user, str):
                 user = UserID.from_string(user)

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -158,7 +158,8 @@ class ReceiptEventSource:
         if from_key == to_key:
             return [], to_key
 
-        # We first need to fetch all new receipts
+        # Fetch all read receipts for all rooms, up to a limit of 100. This is ordered
+        # by most recent.
         rooms_to_events = await self.store.get_linearized_receipts_for_all_rooms(
             from_key=from_key, to_key=to_key
         )

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -294,12 +294,16 @@ class ReceiptsWorkerStore(SQLBaseStore, metaclass=abc.ABCMeta):
                 sql = """
                     SELECT * FROM receipts_linearized WHERE
                     stream_id > ? AND stream_id <= ?
+                    ORDER BY stream_id DESC
+                    LIMIT 100
                 """
                 txn.execute(sql, [from_key, to_key])
             else:
                 sql = """
                     SELECT * FROM receipts_linearized WHERE
                     stream_id <= ?
+                    ORDER BY stream_id DESC
+                    LIMIT 100
                 """
 
                 txn.execute(sql, [to_key])

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -278,7 +278,8 @@ class ReceiptsWorkerStore(SQLBaseStore, metaclass=abc.ABCMeta):
     async def get_linearized_receipts_for_all_rooms(
         self, to_key: int, from_key: Optional[int] = None
     ) -> Dict[str, JsonDict]:
-        """Get receipts for all rooms between two stream_ids.
+        """Get receipts for all rooms between two stream_ids, up
+        to a limit of the latest 100 read receipts.
 
         Args:
             to_key: Max stream id to fetch receipts upto.


### PR DESCRIPTION
Fixes #8743 

This changes the AS handler code so that it will appropriately handle new appservices and not hammer the database with large queries. Appservices store their stream_id for read receipts in the database, so they can keep track of how much they need to send in each transaction. However, this value will default to 0 if not found which means the first transaction of read receipts would contain every change made since the creation of the homeserver.

This change aims to make it so that it starts from a reasonable position, which is the last 100 read receipts.