### PR TITLE
Abstract shared SSO code

### DIFF
--- a/changelog.d/8765.misc
+++ b/changelog.d/8765.misc
@@ -1,0 +1,1 @@
+Consolidate logic between the OpenID Connect and SAML code.

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -865,11 +865,11 @@ class OidcHandler(BaseHandler):
         remote_user_id = str(remote_user_id)
 
         # first of all, check if we already have a mapping for this user
-        registered_user_id = await self._sso_handler.get_sso_user_by_remote_user_id(
+        previously_registered_user_id = await self._sso_handler.get_sso_user_by_remote_user_id(
             self._auth_provider_id, remote_user_id,
         )
-        if registered_user_id:
-            return registered_user_id
+        if previously_registered_user_id:
+            return previously_registered_user_id
 
         # Otherwise, generate a new user.
         try:

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -864,20 +864,14 @@ class OidcHandler(BaseHandler):
         # to be strings.
         remote_user_id = str(remote_user_id)
 
-        logger.info(
-            "Looking for existing mapping for user %s:%s",
-            self._auth_provider_id,
-            remote_user_id,
-        )
-
-        registered_user_id = await self.store.get_user_by_external_id(
+        # first of all, check if we already have a mapping for this user
+        registered_user_id = await self._sso_handler.get_sso_user_by_remote_user_id(
             self._auth_provider_id, remote_user_id,
         )
-
-        if registered_user_id is not None:
-            logger.info("Found existing mapping %s", registered_user_id)
+        if registered_user_id:
             return registered_user_id
 
+        # Otherwise, generate a new user.
         try:
             attributes = await self._user_mapping_provider.map_user_attributes(
                 userinfo, token

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -250,11 +250,11 @@ class SamlHandler(BaseHandler):
 
         with (await self._mapping_lock.queue(self._auth_provider_id)):
             # first of all, check if we already have a mapping for this user
-            registered_user_id = await self._sso_handler.get_sso_user_by_remote_user_id(
+            previously_registered_user_id = await self._sso_handler.get_sso_user_by_remote_user_id(
                 self._auth_provider_id, remote_user_id,
             )
-            if registered_user_id:
-                return registered_user_id
+            if previously_registered_user_id:
+                return previously_registered_user_id
 
             # backwards-compatibility hack: see if there is an existing user with a
             # suitable mapping from the uid

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -250,16 +250,10 @@ class SamlHandler(BaseHandler):
 
         with (await self._mapping_lock.queue(self._auth_provider_id)):
             # first of all, check if we already have a mapping for this user
-            logger.info(
-                "Looking for existing mapping for user %s:%s",
-                self._auth_provider_id,
-                remote_user_id,
+            registered_user_id = await self._sso_handler.get_sso_user_by_remote_user_id(
+                self._auth_provider_id, remote_user_id,
             )
-            registered_user_id = await self.store.get_user_by_external_id(
-                self._auth_provider_id, remote_user_id
-            )
-            if registered_user_id is not None:
-                logger.info("Found existing mapping %s", registered_user_id)
+            if registered_user_id:
                 return registered_user_id
 
             # backwards-compatibility hack: see if there is an existing user with a

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from synapse.handlers._base import BaseHandler
+from synapse.http.server import respond_with_html
+
+if TYPE_CHECKING:
+    from synapse.server import HomeServer
+
+logger = logging.getLogger(__name__)
+
+
+class MappingException(Exception):
+    """Used to catch errors when mapping the UserInfo object
+    """
+
+
+class SsoHandler(BaseHandler):
+    def __init__(self, hs: "HomeServer"):
+        super().__init__(hs)
+        self._error_template = hs.config.sso_error_template
+
+    def render_error(
+        self, request, error: str, error_description: Optional[str] = None
+    ) -> None:
+        """Renders the error template and respond with it.
+
+        This is used to show errors to the user. The template of this page can
+        be found under ``synapse/res/templates/sso_error.html``.
+
+        Args:
+            request: The incoming request from the browser.
+                We'll respond with an HTML page describing the error.
+            error: A technical identifier for this error.
+            error_description: A human-readable description of the error.
+        """
+        html = self._error_template.render(
+            error=error, error_description=error_description
+        )
+        respond_with_html(request, 400, html)

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -77,14 +77,14 @@ class SsoHandler(BaseHandler):
             auth_provider_id,
             remote_user_id,
         )
-        registered_user_id = await self.store.get_user_by_external_id(
+        previously_registered_user_id = await self.store.get_user_by_external_id(
             auth_provider_id, remote_user_id,
         )
 
         # A match was found, return the user ID.
-        if registered_user_id is not None:
-            logger.info("Found existing mapping %s", registered_user_id)
-            return registered_user_id
+        if previously_registered_user_id is not None:
+            logger.info("Found existing mapping %s", previously_registered_user_id)
+            return previously_registered_user_id
 
         # No match.
         return None

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -37,10 +37,10 @@ class SsoHandler(BaseHandler):
     def render_error(
         self, request, error: str, error_description: Optional[str] = None
     ) -> None:
-        """Renders the error template and respond with it.
+        """Renders the error template and responds with it.
 
         This is used to show errors to the user. The template of this page can
-        be found under ``synapse/res/templates/sso_error.html``.
+        be found under `synapse/res/templates/sso_error.html`.
 
         Args:
             request: The incoming request from the browser.

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -89,6 +89,7 @@ from synapse.handlers.room_member import RoomMemberMasterHandler
 from synapse.handlers.room_member_worker import RoomMemberWorkerHandler
 from synapse.handlers.search import SearchHandler
 from synapse.handlers.set_password import SetPasswordHandler
+from synapse.handlers.sso import SsoHandler
 from synapse.handlers.stats import StatsHandler
 from synapse.handlers.sync import SyncHandler
 from synapse.handlers.typing import FollowerTypingHandler, TypingWriterHandler
@@ -389,6 +390,10 @@ class HomeServer(metaclass=abc.ABCMeta):
             return TypingWriterHandler(self)
         else:
             return FollowerTypingHandler(self)
+
+    @cache_in_self
+    def get_sso_handler(self):
+        return SsoHandler(self)
 
     @cache_in_self
     def get_sync_handler(self) -> SyncHandler:

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -392,7 +392,7 @@ class HomeServer(metaclass=abc.ABCMeta):
             return FollowerTypingHandler(self)
 
     @cache_in_self
-    def get_sso_handler(self):
+    def get_sso_handler(self) -> SsoHandler:
         return SsoHandler(self)
 
     @cache_in_self


### PR DESCRIPTION
Abstract some of the shared code from SSO providers (SAML and OpenID Connect) to avoid duplication. I'd like to also make the registration algorithms the same (pretty much `SamlHandler._map_saml_response_to_user` and `OidcHandler._map_userinfo_to_user`), but this work will be done as part of #8711, I think.

The main changes are:

* Inherit from `BaseHandler` for `OidcHandler` and `SamlHandler`.
* Create an `SsoHandler` with the following methods:
    * `render_error` (this code was duplicated in #8248 from the OIDC code to the SAML code).
    * `get_sso_user_by_remote_user_id`, which is a bit lame, but does remove some duplicated code.

This should be reviewable commit-by-commit.