### PR TITLE
Only log if an existing localpart was found, extend logged info

### DIFF
--- a/changelog.d/8773.misc
+++ b/changelog.d/8773.misc
@@ -1,0 +1,1 @@
+Minor log line reductions for the SSO mapping code.

--- a/changelog.d/8773.misc
+++ b/changelog.d/8773.misc
@@ -1,1 +1,1 @@
-Minor log line reductions for the SSO mapping code.
+Minor log line improvements for the SSO mapping code used to generate Matrix IDs from SSO IDs.

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -266,11 +266,6 @@ class SamlHandler(BaseHandler):
                 user_id = UserID(
                     map_username_to_mxid_localpart(attrval), self.server_name
                 ).to_string()
-                logger.info(
-                    "Looking for existing account based on mapped %s %s",
-                    self._grandfathered_mxid_source_attribute,
-                    user_id,
-                )
 
                 users = await self.store.get_users_by_id_case_insensitive(user_id)
                 if users:
@@ -317,7 +312,7 @@ class SamlHandler(BaseHandler):
                     "Unable to generate a Matrix ID from the SAML response"
                 )
 
-            logger.info("Mapped SAML user to local part %s", localpart)
+            logger.debug("Mapped SAML user to local part %s", localpart)
             registered_user_id = await self._registration_handler.register_user(
                 localpart=localpart,
                 default_display_name=displayname,

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -267,6 +267,12 @@ class SamlHandler(BaseHandler):
                     map_username_to_mxid_localpart(attrval), self.server_name
                 ).to_string()
 
+                logger.debug(
+                    "Looking for existing account based on mapped %s %s",
+                    self._grandfathered_mxid_source_attribute,
+                    user_id,
+                )
+
                 users = await self.store.get_users_by_id_case_insensitive(user_id)
                 if users:
                     registered_user_id = list(users.keys())[0]

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -72,18 +72,18 @@ class SsoHandler(BaseHandler):
             The mxid of a previously seen user.
         """
         # Check if we already have a mapping for this user.
-        logger.info(
-            "Looking for existing mapping for user %s:%s",
-            auth_provider_id,
-            remote_user_id,
-        )
         previously_registered_user_id = await self.store.get_user_by_external_id(
             auth_provider_id, remote_user_id,
         )
 
         # A match was found, return the user ID.
         if previously_registered_user_id is not None:
-            logger.info("Found existing mapping %s", previously_registered_user_id)
+            logger.info(
+                "Found existing mapping for IdP '%s' and remote_user_id '%s': %s",
+                auth_provider_id,
+                remote_user_id,
+                previously_registered_user_id,
+            )
             return previously_registered_user_id
 
         # No match.

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -71,6 +71,12 @@ class SsoHandler(BaseHandler):
         Returns:
             The mxid of a previously seen user.
         """
+        logger.debug(
+            "Looking for existing mapping for user %s:%s",
+            auth_provider_id,
+            remote_user_id,
+        )
+
         # Check if we already have a mapping for this user.
         previously_registered_user_id = await self.store.get_user_by_external_id(
             auth_provider_id, remote_user_id,


### PR DESCRIPTION
This grew out of a conversation in #8765.

This PR:

* Drops some `info` logs that would fire each time we check to see if an SSO remote user maps to an existing local user, and instead attempts to only log when an existing match is found. The latter is more interesting for when a user is failing to login.
* Adds some more metadata to the failure mode log line.
* Drops one line from `info` to `debug` as it was again on the happy path. I don't think it's something that needs to be logged every time a SAML login goes through.