### PR TITLE
INSTALL: Fix setting content-type on well-known

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -487,7 +487,7 @@ In nginx this would be something like:
 ```
 location /.well-known/matrix/client {
     return 200 '{"m.homeserver": {"base_url": "https://<matrix.example.com>"}}';
-    add_header Content-Type application/json;
+    default_type "application/json";
     add_header Access-Control-Allow-Origin *;
 }
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -487,7 +487,7 @@ In nginx this would be something like:
 ```
 location /.well-known/matrix/client {
     return 200 '{"m.homeserver": {"base_url": "https://<matrix.example.com>"}}';
-    default_type "application/json";
+    default_type application/json;
     add_header Access-Control-Allow-Origin *;
 }
 ```

--- a/changelog.d/8793.doc
+++ b/changelog.d/8793.doc
@@ -1,1 +1,1 @@
-Fixed the example on how to set the `Content-Type` header in nginx for Client Well-Known URI.
+Fix the example on how to set the `Content-Type` header in nginx for the Client Well-Known URI.

--- a/changelog.d/8793.doc
+++ b/changelog.d/8793.doc
@@ -1,0 +1,1 @@
+Fixed the example on how to set the `Content-Type` header in nginx for Client Well-Known URI.


### PR DESCRIPTION
When using `add_header` nginx will literally add a header. If a
`content-type` header is already configured (for example through a
server wide default), this means we end up with 2 content-type headers,
like so:

```
content-type: text/html
content-type: application/json
access-control-allow-origin: *
```

That doesn't make sense. Instead, we want the content type of that
block to only be `application/json` which we can achieve using
`default_type` instead.

Signed-off-by: Daniele Sluijters <daenney@users.noreply.github.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
