### PR TITLE
Fix synctl and duplicate worker spawning

### DIFF
--- a/changelog.d/8798.bugfix
+++ b/changelog.d/8798.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where synctl could spawn duplicate copies of a worker. Contributed by Waylon Cude.

--- a/synctl
+++ b/synctl
@@ -358,6 +358,11 @@ def main():
         for worker in workers:
             env = os.environ.copy()
 
+            # Skip starting a worker if its already running
+            if os.path.exists(worker.pidfile) and pid_running(int(open(worker.pidfile).read())):
+                print(worker.app + " already running")
+                continue
+
             if worker.cache_factor:
                 os.environ["SYNAPSE_CACHE_FACTOR"] = str(worker.cache_factor)
 

--- a/synctl
+++ b/synctl
@@ -359,7 +359,9 @@ def main():
             env = os.environ.copy()
 
             # Skip starting a worker if its already running
-            if os.path.exists(worker.pidfile) and pid_running(int(open(worker.pidfile).read())):
+            if os.path.exists(worker.pidfile) and pid_running(
+                int(open(worker.pidfile).read())
+            ):
                 print(worker.app + " already running")
                 continue
 


### PR DESCRIPTION
Synctl did not check if a worker thread was already running when using
`synctl start` and would naively start a fresh copy. This would
sometimes lead to cases where many duplicate copies of a single worker
would run.

This fix adds a pid check when starting worker threads and synctl will
now refuse to start individual workers if they're already running.

Signed-off-by: Waylon Cude \<waylon.cude@finzdani.net\>

### Pull Request Checklist

* [x]  Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
