### PR TITLE
Allow per-room profile to be used for server notice user

### DIFF
--- a/changelog.d/8799.bugfix
+++ b/changelog.d/8799.bugfix
@@ -1,0 +1,1 @@
+Allow per-room profile to be used for server notice user.

--- a/changelog.d/8799.bugfix
+++ b/changelog.d/8799.bugfix
@@ -1,1 +1,1 @@
-Allow per-room profile to be used for server notice user.
+Allow per-room profiles to be used for the server notice user.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -347,7 +347,17 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             # later on.
             content = dict(content)
 
-        if not self.allow_per_room_profiles or requester.shadow_banned:
+        is_requester_server_notice_user = False
+        if (
+            self._server_notices_mxid is not None
+            and requester.user.to_string() == self._server_notices_mxid
+        ):
+            # allow the server notices mxid to set room-level profile
+            is_requester_server_notice_user = True
+
+        if (
+            not self.allow_per_room_profiles and not is_requester_server_notice_user
+        ) or requester.shadow_banned:
             # Strip profile data, knowing that new profile data will be added to the
             # event's content in event_creation_handler.create_event() using the target's
             # global profile.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -347,13 +347,11 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             # later on.
             content = dict(content)
 
-        is_requester_server_notices_user = False
-        if (
+        # allow the server notices mxid to set room-level profile
+        is_requester_server_notices_user = (
             self._server_notices_mxid is not None
             and requester.user.to_string() == self._server_notices_mxid
-        ):
-            # allow the server notices mxid to set room-level profile
-            is_requester_server_notices_user = True
+        )
 
         if (
             not self.allow_per_room_profiles and not is_requester_server_notices_user

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -347,16 +347,16 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             # later on.
             content = dict(content)
 
-        is_requester_server_notice_user = False
+        is_requester_server_notices_user = False
         if (
             self._server_notices_mxid is not None
             and requester.user.to_string() == self._server_notices_mxid
         ):
             # allow the server notices mxid to set room-level profile
-            is_requester_server_notice_user = True
+            is_requester_server_notices_user = True
 
         if (
-            not self.allow_per_room_profiles and not is_requester_server_notice_user
+            not self.allow_per_room_profiles and not is_requester_server_notices_user
         ) or requester.shadow_banned:
             # Strip profile data, knowing that new profile data will be added to the
             # event's content in event_creation_handler.create_event() using the target's


### PR DESCRIPTION
This applies even if the feature is disabled at the server level with `allow_per_room_profiles`.
The server notice not being a real user it doesn't have an user profile.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
