### PR TITLE
Support trying multiple localparts for OpenID Connect.

### DIFF
--- a/changelog.d/8801.feature
+++ b/changelog.d/8801.feature
@@ -1,0 +1,1 @@
+Support re-trying generating a localpart for OpenID Connect mapping providers.

--- a/changelog.d/8801.feature
+++ b/changelog.d/8801.feature
@@ -1,1 +1,1 @@
-Support re-trying generating a localpart for OpenID Connect mapping providers.
+Add support for re-trying generation of a localpart for OpenID Connect mapping providers.

--- a/docs/sso_mapping_providers.md
+++ b/docs/sso_mapping_providers.md
@@ -63,7 +63,7 @@ A custom mapping provider must specify the following methods:
                      information from.
     - This method must return a string, which is the unique identifier for the
       user. Commonly the ``sub`` claim of the response.
-* `map_user_attributes(self, userinfo, token)`
+* `map_user_attributes(self, userinfo, token, failures)`
     - This method must be async.
     - Arguments:
       - `userinfo` - A `authlib.oidc.core.claims.UserInfo` object to extract user

--- a/docs/sso_mapping_providers.md
+++ b/docs/sso_mapping_providers.md
@@ -70,6 +70,15 @@ A custom mapping provider must specify the following methods:
                      information from.
       - `token` - A dictionary which includes information necessary to make
                   further requests to the OpenID provider.
+      - `failures` - An `int` that represents the amount of times the returned
+                     mxid localpart mapping has failed.  This should be used
+                     to create a deduplicated mxid localpart which should be
+                     returned instead. For example, if this method returns
+                     `john.doe` as the value of `localpart` in the returned
+                     dict, and that is already taken on the homeserver, this
+                     method will be called again with the same parameters but
+                     with failures=1. The method should then return a different
+                     `localpart` value, such as `john.doe1`.
     - Returns a dictionary with two keys:
       - localpart: A required string, used to generate the Matrix ID.
       - displayname: An optional string, the display name for the user.

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -884,8 +884,9 @@ class OidcHandler(BaseHandler):
                 )
             else:
                 # If the mapping provider does not support processing failures,
-                # do not continually generate the same Matrix ID since this will
-                # likely continue to fail.
+                # do not continually generate the same Matrix ID since it will
+                # continue to already be in use. Note that the error raised is
+                # arbitrary and will get turned into a MappingException.
                 if failures:
                     raise RuntimeError(
                         "Mapping provider does not support de-duplicating Matrix IDs"

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -1066,6 +1066,10 @@ class JinjaOidcMappingProvider(OidcMappingProvider[JinjaOidcMappingConfig]):
         # Ensure only valid characters are included in the MXID.
         localpart = map_username_to_mxid_localpart(localpart)
 
+        # Append suffix integer if last call to this function failed to produce
+        # a usable mxid.
+        localpart += str(failures) if failures else ""
+
         display_name = None  # type: Optional[str]
         if self._config.display_name_template is not None:
             display_name = self._config.display_name_template.render(

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -883,6 +883,12 @@ class OidcHandler(BaseHandler):
                     userinfo, token, failures
                 )
             else:
+                # If the mapping provider does not support processing failures,
+                # do not continually generate the same Matrix ID since this will
+                # likely continue to fail.
+                if failures:
+                    raise RuntimeError("Mapping provider does not support de-duplicating Matrix IDs")
+
                 attributes = await self._user_mapping_provider.map_user_attributes(  # type: ignore
                     userinfo, token
                 )

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -867,10 +867,10 @@ class OidcHandler(BaseHandler):
 
         # Older mapping providers don't accept the `failures` argument, so we
         # try and detect support.
-        mapper_args = inspect.getfullargspec(
+        mapper_signature = inspect.signature(
             self._user_mapping_provider.map_user_attributes
         )
-        supports_failures = "failures" in mapper_args.args
+        supports_failures = "failures" in mapper_signature.parameters
 
         async def oidc_response_to_user_attributes(failures: int) -> UserAttributes:
             """

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -887,7 +887,9 @@ class OidcHandler(BaseHandler):
                 # do not continually generate the same Matrix ID since this will
                 # likely continue to fail.
                 if failures:
-                    raise RuntimeError("Mapping provider does not support de-duplicating Matrix IDs")
+                    raise RuntimeError(
+                        "Mapping provider does not support de-duplicating Matrix IDs"
+                    )
 
                 attributes = await self._user_mapping_provider.map_user_attributes(  # type: ignore
                     userinfo, token
@@ -895,14 +897,13 @@ class OidcHandler(BaseHandler):
 
             return attributes
 
-        # TODO Support existing users.
-
         return await self._sso_handler.get_mxid_from_sso(
             self._auth_provider_id,
             remote_user_id,
             user_agent,
             ip_address,
             oidc_response_to_user_attributes,
+            self._allow_existing_users,
         )
 
 

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -872,7 +872,7 @@ class OidcHandler(BaseHandler):
         )
         supports_failures = "failures" in mapper_args.args
 
-        async def oidc_response_to_user_attributes(userinfo, token, failures):
+        async def oidc_response_to_user_attributes(failures):
             """
             Call the mapping provider to map the OIDC userinfo and token to user attributes.
 
@@ -897,8 +897,6 @@ class OidcHandler(BaseHandler):
             user_agent,
             ip_address,
             oidc_response_to_user_attributes,
-            userinfo,
-            token,
         )
 
 

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -257,7 +257,7 @@ class SamlHandler(BaseHandler):
 
             This is backwards compatibility for abstraction for the SSO handler.
             """
-            # Remap the arguments to the mapping provider.
+            # Call the mapping provider.
             result = self._user_mapping_provider.saml_response_to_user_attributes(
                 saml2_auth, failures, client_redirect_url
             )

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -249,9 +249,7 @@ class SamlHandler(BaseHandler):
                 "Failed to extract remote user id from SAML response"
             )
 
-        async def saml_response_to_remapped_user_attributes(
-            saml_response, client_redirect_url, failures
-        ):
+        async def saml_response_to_remapped_user_attributes(failures):
             """
             Call the mapping provider to map a SAML response to user attributes and coerce the result into the standard form.
 
@@ -259,7 +257,7 @@ class SamlHandler(BaseHandler):
             """
             # Remap the arguments to the mapping provider.
             result = self._user_mapping_provider.saml_response_to_user_attributes(
-                saml_response, failures, client_redirect_url
+                saml2_auth, failures, client_redirect_url
             )
             # Remap some of the results.
             if "mxid_localpart" in result:
@@ -301,8 +299,6 @@ class SamlHandler(BaseHandler):
                 user_agent,
                 ip_address,
                 saml_response_to_remapped_user_attributes,
-                saml2_auth,
-                client_redirect_url,
             )
 
     def expire_sessions(self):

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -31,7 +31,6 @@ from synapse.http.site import SynapseRequest
 from synapse.module_api import ModuleApi
 from synapse.types import (
     UserID,
-    contains_invalid_mxid_characters,
     map_username_to_mxid_localpart,
     mxid_localpart_allowed_characters,
 )
@@ -250,14 +249,26 @@ class SamlHandler(BaseHandler):
                 "Failed to extract remote user id from SAML response"
             )
 
-        with (await self._mapping_lock.queue(self._auth_provider_id)):
-            # first of all, check if we already have a mapping for this user
-            previously_registered_user_id = await self._sso_handler.get_sso_user_by_remote_user_id(
-                self._auth_provider_id, remote_user_id,
-            )
-            if previously_registered_user_id:
-                return previously_registered_user_id
+        async def saml_response_to_remapped_user_attributes(
+            saml_response, client_redirect_url, failures
+        ):
+            """
+            Call the mapping provider to map a SAML response to user attributes and coerce the result into the standard form.
 
+            This is backwards compatibility for abstraction for the SSO handler.
+            """
+            # Remap the arguments to the mapping provider.
+            result = self._user_mapping_provider.saml_response_to_user_attributes(
+                saml_response, failures, client_redirect_url
+            )
+            # Remap some of the results.
+            if "mxid_localpart" in result:
+                result["localpart"] = result.pop("mxid_localpart")
+            if "displayname" in result:
+                result["display_name"] = result.pop("displayname")
+            return result
+
+        with (await self._mapping_lock.queue(self._auth_provider_id)):
             # backwards-compatibility hack: see if there is an existing user with a
             # suitable mapping from the uid
             if (
@@ -284,59 +295,15 @@ class SamlHandler(BaseHandler):
                     )
                     return registered_user_id
 
-            # Map saml response to user attributes using the configured mapping provider
-            for i in range(1000):
-                attribute_dict = self._user_mapping_provider.saml_response_to_user_attributes(
-                    saml2_auth, i, client_redirect_url=client_redirect_url,
-                )
-
-                logger.debug(
-                    "Retrieved SAML attributes from user mapping provider: %s "
-                    "(attempt %d)",
-                    attribute_dict,
-                    i,
-                )
-
-                localpart = attribute_dict.get("mxid_localpart")
-                if not localpart:
-                    raise MappingException(
-                        "Error parsing SAML2 response: SAML mapping provider plugin "
-                        "did not return a mxid_localpart value"
-                    )
-
-                displayname = attribute_dict.get("displayname")
-                emails = attribute_dict.get("emails", [])
-
-                # Check if this mxid already exists
-                if not await self.store.get_users_by_id_case_insensitive(
-                    UserID(localpart, self.server_name).to_string()
-                ):
-                    # This mxid is free
-                    break
-            else:
-                # Unable to generate a username in 1000 iterations
-                # Break and return error to the user
-                raise MappingException(
-                    "Unable to generate a Matrix ID from the SAML response"
-                )
-
-            # Since the localpart is provided via a potentially untrusted module,
-            # ensure the MXID is valid before registering.
-            if contains_invalid_mxid_characters(localpart):
-                raise MappingException("localpart is invalid: %s" % (localpart,))
-
-            logger.debug("Mapped SAML user to local part %s", localpart)
-            registered_user_id = await self._registration_handler.register_user(
-                localpart=localpart,
-                default_display_name=displayname,
-                bind_emails=emails,
-                user_agent_ips=(user_agent, ip_address),
+            return await self._sso_handler.get_mxid_from_sso(
+                self._auth_provider_id,
+                remote_user_id,
+                user_agent,
+                ip_address,
+                saml_response_to_remapped_user_attributes,
+                saml2_auth,
+                client_redirect_url,
             )
-
-            await self.store.record_user_external_id(
-                self._auth_provider_id, remote_user_id, registered_user_id
-            )
-            return registered_user_id
 
     def expire_sessions(self):
         expire_before = self.clock.time_msec() - self._saml2_session_lifetime

--- a/synapse/handlers/saml_handler.py
+++ b/synapse/handlers/saml_handler.py
@@ -416,11 +416,11 @@ class DefaultSamlMappingProvider:
             )
 
         # Use the configured mapper for this mxid_source
-        base_mxid_localpart = self._mxid_mapper(mxid_source)
+        localpart = self._mxid_mapper(mxid_source)
 
         # Append suffix integer if last call to this function failed to produce
-        # a usable mxid
-        localpart = base_mxid_localpart + (str(failures) if failures else "")
+        # a usable mxid.
+        localpart += str(failures) if failures else ""
 
         # Retrieve the display name from the saml response
         # If displayname is None, the mxid_localpart will be used instead

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -117,8 +117,31 @@ class SsoHandler(BaseHandler):
         ip_address: str,
         sso_to_matrix_id_mapper: Callable[[int], Awaitable[UserAttributes]],
         allow_existing_users: bool = False,
-    ):
+    ) -> str:
         """
+        Given an SSO ID, retrieve the user ID for it and possibly register the user.
+
+        This first checks if the SSO ID has previously been linked to a matrix ID,
+        if it has that matrix ID is returned regardless of the current mapping
+        logic.
+
+        The mapping function is called (potentially multiple times) to generate
+        a localpart for the user.
+
+        If an unused localpart is generated, the user is registered from the
+        given user-agent and IP address and the SSO ID is linked to this matrix
+        ID for subsequent calls.
+
+        If allow_existing_users is true the mapping function is only called once
+        and results in:
+
+            1. The use of a previously registered matrix ID. In this case, the
+               SSO ID is linked to the matrix ID. (Note it is possible that
+               other SSO IDs are linked to the same matrix ID.)
+            2. An unused localpart, in which case the user is registered (as
+               discussed above).
+            3. An error if the generated localpart matches multiple pre-existing
+               matrix IDs. Generally this should not happen.
 
         Args:
             auth_provider_id: A unique identifier for this SSO provider, e.g.

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -208,7 +208,7 @@ class SsoHandler(BaseHandler):
         if contains_invalid_mxid_characters(attributes.localpart):
             raise MappingException("localpart is invalid: %s" % (attributes.localpart,))
 
-        logger.debug("Mapped SAML user to local part %s", attributes.localpart)
+        logger.debug("Mapped SSO user to local part %s", attributes.localpart)
         registered_user_id = await self._registration_handler.register_user(
             localpart=attributes.localpart,
             default_display_name=attributes.display_name,

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -195,6 +195,10 @@ class SsoHandler(BaseHandler):
             # Check if this mxid already exists
             user_id = UserID(attributes.localpart, self.server_name).to_string()
             users = await self.store.get_users_by_id_case_insensitive(user_id)
+            # Note, if allow_existing_users is true then the loop is guaranteed
+            # to end on the first iteration: either by matching an existing user,
+            # raising an error, or registering a new user. See the docstring for
+            # more in-depth an explanation.
             if users and allow_existing_users:
                 # If an existing matrix ID is returned, then use it.
                 if len(users) == 1:

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional
 
 from synapse.handlers._base import BaseHandler
 from synapse.http.server import respond_with_html
+from synapse.types import UserID, contains_invalid_mxid_characters
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
@@ -30,8 +31,12 @@ class MappingException(Exception):
 
 
 class SsoHandler(BaseHandler):
+    # The number of attempts to ask the mapping provider for when generating an MXID.
+    _MAP_USERNAME_RETRIES = 1000
+
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
+        self._registration_handler = hs.get_registration_handler()
         self._error_template = hs.config.sso_error_template
 
     def render_error(
@@ -94,3 +99,98 @@ class SsoHandler(BaseHandler):
 
         # No match.
         return None
+
+    async def get_mxid_from_sso(
+        self,
+        auth_provider_id: str,
+        remote_user_id: str,
+        user_agent: str,
+        ip_address: str,
+        mapper: "Callable[..., Awaitable[str]]",
+        *args: Any,
+        **kwargs: Any,
+    ):
+        """
+
+        Args:
+            auth_provider_id: A unique identifier for this SSO provider, e.g.
+                "oidc" or "saml".
+            remote_user_id: The unique identifier from the SSO provider.
+            user_agent: The user agent of the client making the request.
+            ip_address: The IP address of the client making the request.
+            mapper: A callable to generate the user attributes. Note that the
+                current number of failures is passed in as the last argument.
+            args: Additional arguments for mapper.
+            kwargs: Additional keyword arguments for mapper.
+
+        Returns:
+             The user ID associated with the SSO response.
+
+        Raises:
+            MappingException if there was a problem mapping the response to a user.
+            RedirectException: some mapping providers may raise this if they need
+                to redirect to an interstitial page.
+
+        """
+        # first of all, check if we already have a mapping for this user
+        previously_registered_user_id = await self.get_sso_user_by_remote_user_id(
+            auth_provider_id, remote_user_id,
+        )
+        if previously_registered_user_id:
+            return previously_registered_user_id
+
+        # Otherwise, generate a new user.
+        for i in range(self._MAP_USERNAME_RETRIES):
+            try:
+                attributes = await mapper(*args, i, **kwargs)
+            except Exception as e:
+                raise MappingException(
+                    "Could not extract user attributes from SSO response: " + str(e)
+                )
+
+            logger.debug(
+                "Retrieved user attributes from user mapping provider: %r (attempt %d)",
+                attributes,
+                i,
+            )
+
+            localpart = attributes["localpart"]
+            if not localpart:
+                raise MappingException(
+                    "Error parsing SSO response: SSO mapping provider plugin "
+                    "did not return a localpart value"
+                )
+
+            # Other potential attributes returned by the mapping provider.
+            display_name = attributes.get("display_name")
+            emails = attributes.get("emails", [])
+
+            # Check if this mxid already exists
+            user_id = UserID(localpart, self.server_name).to_string()
+            if not await self.store.get_users_by_id_case_insensitive(user_id):
+                # This mxid is free
+                break
+        else:
+            # Unable to generate a username in 1000 iterations
+            # Break and return error to the user
+            raise MappingException(
+                "Unable to generate a Matrix ID from the SSO response"
+            )
+
+        # Since the localpart is provided via a potentially untrusted module,
+        # ensure the MXID is valid before registering.
+        if contains_invalid_mxid_characters(localpart):
+            raise MappingException("localpart is invalid: %s" % (localpart,))
+
+        logger.debug("Mapped SAML user to local part %s", localpart)
+        registered_user_id = await self._registration_handler.register_user(
+            localpart=localpart,
+            default_display_name=display_name,
+            bind_emails=emails,
+            user_agent_ips=(user_agent, ip_address),
+        )
+
+        await self.store.record_user_external_id(
+            auth_provider_id, remote_user_id, registered_user_id
+        )
+        return registered_user_id

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -161,7 +161,7 @@ class OidcHandlerTestCase(HomeserverTestCase):
         self.handler._sso_handler.render_error = self.render_error
 
         # Reduce the number of attempts when generating MXIDs.
-        self.handler._MAP_USERNAME_RETRIES = 3
+        self.handler._sso_handler._MAP_USERNAME_RETRIES = 3
 
         return hs
 
@@ -704,7 +704,9 @@ class OidcHandlerTestCase(HomeserverTestCase):
             ),
             MappingException,
         )
-        self.assertEqual(str(e.value), "mxid '@test_user_3:test' is already taken")
+        self.assertEqual(
+            str(e.value), "Unable to generate a Matrix ID from the SSO response"
+        )
 
     @override_config({"oidc_config": {"allow_existing_users": True}})
     def test_map_userinfo_to_existing_user(self):
@@ -850,5 +852,5 @@ class OidcHandlerTestCase(HomeserverTestCase):
             MappingException,
         )
         self.assertEqual(
-            str(e.value), "Unable to generate a Matrix ID from the OpenID response"
+            str(e.value), "Unable to generate a Matrix ID from the SSO response"
         )

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -714,8 +714,27 @@ class OidcHandlerTestCase(HomeserverTestCase):
         self.get_success(
             store.register_user(user_id=user.to_string(), password_hash=None)
         )
+
+        # Map a user via SSO.
         userinfo = {
             "sub": "test",
+            "username": "test_user",
+        }
+        token = {}
+        mxid = self.get_success(
+            self.handler._map_userinfo_to_user(
+                userinfo, token, "user-agent", "10.10.10.10"
+            )
+        )
+        self.assertEqual(mxid, "@test_user:test")
+
+        # Note that a second SSO user can be mapped to the same Matrix ID. (This
+        # requires a unique sub, but something that maps to the same matrix ID,
+        # in this case we'll just use the same username. A more realistic example
+        # would be subs which are email addresses, and mapping from the localpart
+        # of the email, e.g. bob@foo.com and bob@bar.com -> @bob:test.)
+        userinfo = {
+            "sub": "test1",
             "username": "test_user",
         }
         token = {}

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -89,6 +89,14 @@ class TestMappingProviderExtra(TestMappingProvider):
         return {"phone": userinfo["phone"]}
 
 
+class TestMappingProviderFailures(TestMappingProvider):
+    async def map_user_attributes(self, userinfo, token, failures):
+        return {
+            "localpart": userinfo["username"] + (str(failures) if failures else ""),
+            "display_name": None,
+        }
+
+
 def simple_async_mock(return_value=None, raises=None):
     # AsyncMock is not available in python3.5, this mimics part of its behaviour
     async def cb(*args, **kwargs):
@@ -151,6 +159,9 @@ class OidcHandlerTestCase(HomeserverTestCase):
         # Mock the render error method.
         self.render_error = Mock(return_value=None)
         self.handler._sso_handler.render_error = self.render_error
+
+        # Reduce the number of attempts when generating MXIDs.
+        self.handler._MAP_USERNAME_RETRIES = 3
 
         return hs
 
@@ -762,6 +773,7 @@ class OidcHandlerTestCase(HomeserverTestCase):
             "username": "föö",
         }
         token = {}
+
         e = self.get_failure(
             self.handler._map_userinfo_to_user(
                 userinfo, token, "user-agent", "10.10.10.10"
@@ -769,3 +781,55 @@ class OidcHandlerTestCase(HomeserverTestCase):
             MappingException,
         )
         self.assertEqual(str(e.value), "localpart is invalid: föö")
+
+    @override_config(
+        {
+            "oidc_config": {
+                "user_mapping_provider": {
+                    "module": __name__ + ".TestMappingProviderFailures"
+                }
+            }
+        }
+    )
+    def test_map_userinfo_to_user_retries(self):
+        """The mapping provider can retry generating an MXID if the MXID is already in use."""
+        store = self.hs.get_datastore()
+        self.get_success(
+            store.register_user(user_id="@test_user:test", password_hash=None)
+        )
+        userinfo = {
+            "sub": "test",
+            "username": "test_user",
+        }
+        token = {}
+        mxid = self.get_success(
+            self.handler._map_userinfo_to_user(
+                userinfo, token, "user-agent", "10.10.10.10"
+            )
+        )
+        # test_user is already taken, so test_user1 gets registered instead.
+        self.assertEqual(mxid, "@test_user1:test")
+
+        # Register all of the potential users for a particular username.
+        self.get_success(
+            store.register_user(user_id="@tester:test", password_hash=None)
+        )
+        for i in range(1, 3):
+            self.get_success(
+                store.register_user(user_id="@tester%d:test" % i, password_hash=None)
+            )
+
+        # Now attempt to map to a username, this will fail since all potential usernames are taken.
+        userinfo = {
+            "sub": "tester",
+            "username": "tester",
+        }
+        e = self.get_failure(
+            self.handler._map_userinfo_to_user(
+                userinfo, token, "user-agent", "10.10.10.10"
+            ),
+            MappingException,
+        )
+        self.assertEqual(
+            str(e.value), "Unable to generate a Matrix ID from the OpenID response"
+        )

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -705,7 +705,8 @@ class OidcHandlerTestCase(HomeserverTestCase):
             MappingException,
         )
         self.assertEqual(
-            str(e.value), "Unable to generate a Matrix ID from the SSO response"
+            str(e.value),
+            "Could not extract user attributes from SSO response: Mapping provider does not support de-duplicating Matrix IDs",
         )
 
     @override_config({"oidc_config": {"allow_existing_users": True}})


### PR DESCRIPTION
This abstracts code between the SAML and OpenID Connect code to support re-trying to generate the matrix ID localpart. This is useful if the attribute from SSO that is being used to generate the matrix ID is unique (e.g. if you're using the localpart of an email address you might have bob@foo and bob@bar, both would make to `bob`. This allows the second one to end up with `bob1` as a matrix ID.

This is done in a a similar matter to SAML, by passing a `failures` count to the mapping provider. (Note that this is *only done* for a mapping provider which supports it, i.e. it is backwards compatible.) The code changes look a bit larger than they are -- really most of the code is copied from `SamlHandler` to `SsoHandler` and then abstracted.

This should generally be reviewable commit by commit.

Fixes #8711
