### PR TITLE
Allow Date header through CORS

### DIFF
--- a/changelog.d/8804.feature
+++ b/changelog.d/8804.feature
@@ -1,0 +1,1 @@
+Allow Date header through CORS. Contributed by Nicolas Chamo.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -685,7 +685,7 @@ def set_cors_headers(request: Request):
     )
     request.setHeader(
         b"Access-Control-Allow-Headers",
-        b"Origin, X-Requested-With, Content-Type, Accept, Authorization",
+        b"Origin, X-Requested-With, Content-Type, Accept, Authorization, Date",
     )
 
 


### PR DESCRIPTION
Hey there!

I'm Nico and I've previously worked on integrating Matrix into [Decentraland](http://decentraland.org/). We are currently using Matrix to support both our private chat & friends features. 

**The problem**
In order for users to login they must have an Ethereum wallet, and they must sign a recent timestamp. We built a [Password Auth Provider](https://github.com/decentraland/matrix-client/blob/master/providers/decentraland_password_auth_provider.py) that validates that the timestamp is recent enough, and that the signature is also valid. Now, a problem we had, is that the timestamp was generated in the client using the local machine's clock. This caused some issues for users that had it out of sync, so we started using a global API (http://worldtimeapi.org/). Recently, that API started having some issues, so we are re-thinking the strategy. 

**A possible solution**
Ideally, the Synapse server that performs the validation would expose its current time, so there will be no room for "out of sync" issues. A possible option would be to use the [Date](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date) response header, when querying some endpoint that doesn't need the user to be logged in. That header is already being returned by the Synapse server, but it is blocked by CORS. This PR is trying to fix that.

If you are aware of another better way to expose or use the server's clock, please let me know and I'll close this PR.

Signed-off-by: Nicolas Chamo <nicolas@chamo.com.ar>

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)