### PR TITLE
Add typing to membership Replication class methods

### DIFF
--- a/changelog.d/8809.misc
+++ b/changelog.d/8809.misc
@@ -1,0 +1,1 @@
+Remove unnecessary function arguments and add typing to several membership replication classes.

--- a/synapse/replication/http/membership.py
+++ b/synapse/replication/http/membership.py
@@ -190,7 +190,7 @@ class ReplicationUserJoinedLeftRoomRestServlet(ReplicationEndpoint):
 
     @staticmethod
     async def _serialize_payload(  # type: ignore
-        room_id: str, user_id: str, change: str,
+        room_id: str, user_id: str, change: str
     ) -> JsonDict:
         """
         Args:
@@ -206,7 +206,7 @@ class ReplicationUserJoinedLeftRoomRestServlet(ReplicationEndpoint):
         return {}
 
     def _handle_request(  # type: ignore
-        self, request: Request, room_id: str, user_id: str, change: str,
+        self, request: Request, room_id: str, user_id: str, change: str
     ) -> Tuple[int, JsonDict]:
         logger.info("user membership change: %s in %s", user_id, room_id)
 


### PR DESCRIPTION
This PR grew out of [a discussion](https://github.com/matrix-org/synapse/pull/6739#discussion_r529838745) in #6739, and tries to do two things:

1. Add typing to method arguments
2. ~~Remove unnecessary arguments on those methods~~

~~Removing unneeded arguments is fine as `_serialize_payload` is called as:~~

https://github.com/matrix-org/synapse/blob/1781bbe319ce24e8e468f0422519dc5823d8d420/synapse/replication/http/_base.py#L169

~~and `_handle_request` called as:~~

https://github.com/matrix-org/synapse/blob/1781bbe319ce24e8e468f0422519dc5823d8d420/synapse/replication/http/_base.py#L263

~~aka with the arguments `request, **kwargs`.~~ This doesn't work :)

You'll notice that there are a lot of `# type: ignores` in here. This is due to the base methods not matching the overloads here. This is necessary to stop mypy complaining, but if there's a better way than just blanket ignoring things I'd love to know!

I imagine there's likely further work needed in other replication classes, however seeing as the discussion above only concerned membership replication classes, that is all this particular PR addresses.