### PR TITLE
Add more information to S2S OpenID Connect userinfo endpoint

### DIFF
--- a/changelog.d/8816.feature
+++ b/changelog.d/8816.feature
@@ -1,0 +1,1 @@
+Improve S2S OpenID userinfo endpoint by including more profile data, including verified emails, display name and preferred_username (Matrix ID localpart).

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -705,8 +705,11 @@ class OpenIdUserInfo(BaseFederationServlet):
     Content-Type: application/json
 
     {
-        "sub": "@userpart:example.org",
+        "sub": "@userpart:example.org"
     }
+
+    Actual claims returned depened on what information is available for the user.
+    The above shows the minimum guaranteed to be returned as per OpenID Connect spec.
     """
 
     PATH = "/openid/userinfo"
@@ -721,9 +724,9 @@ class OpenIdUserInfo(BaseFederationServlet):
                 {"errcode": "M_MISSING_TOKEN", "error": "Access Token required"},
             )
 
-        user_id = await self.handler.on_openid_userinfo(token.decode("ascii"))
+        userinfo = await self.handler.on_openid_userinfo(token.decode("ascii"))
 
-        if user_id is None:
+        if userinfo is None:
             return (
                 401,
                 {
@@ -732,7 +735,7 @@ class OpenIdUserInfo(BaseFederationServlet):
                 },
             )
 
-        return 200, {"sub": user_id}
+        return 200, userinfo
 
 
 class PublicRoomList(BaseFederationServlet):

--- a/synapse/storage/databases/main/openid.py
+++ b/synapse/storage/databases/main/openid.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from synapse.storage._base import SQLBaseStore
 
@@ -16,6 +16,15 @@ class OpenIdStore(SQLBaseStore):
             },
             desc="insert_open_id_token",
         )
+
+    async def get_user_emails(self, user_id: str) -> Optional[List[str]]:
+        emails = await self.db_pool.simple_select_list(
+            table="user_threepids",
+            keyvalues={"user_id": user_id, "medium": "email"},
+            retcols=("address",),
+            desc="get_user_emails",
+        )
+        return [r["address"] for r in emails]
 
     async def get_user_id_for_open_id_token(
         self, token: str, ts_now_ms: int


### PR DESCRIPTION
Add the following new standard claims:

* name -> display name
* email -> first found verified email, if known
* email_verified -> true, if a verified email found
* preferred_username -> Matrix ID localpart

Additionally, a non-standard claim "mx_other_emails"
is added containing any other found verified emails,
should any be found.

**Privacy implications** to discuss:

This pull request would automatically expand the amount of information available
to for example integration managers. Though users do consent to providing
information about their account to an integration manager, this might be
an unexpected thing for users.

* Is this fine as users already accept access to their profile information (and these
are standard OpenID claims (except for supporting additional emails since Synapse
has no concept of primary email)) OR
* should we make this configurable in Synapse on what OpenID claims to expose OR
* something else?

Signed-off-by: Jason Robinson <jasonr@matrix.org>