### PR TITLE
Strip trailing / from server_url in register_new_matrix_user

### DIFF
--- a/changelog.d/8823.bugfix
+++ b/changelog.d/8823.bugfix
@@ -1,1 +1,1 @@
-Fix register_new_matrix_user failing with Bad Request when trailing slash is included in server URL.
+Fix `register_new_matrix_user` failing with "Bad Request" when trailing slash is included in server URL. Contributed by @angdraug.

--- a/changelog.d/8823.bugfix
+++ b/changelog.d/8823.bugfix
@@ -1,0 +1,1 @@
+Fix register_new_matrix_user failing with Bad Request when trailing slash is included in server URL.

--- a/synapse/_scripts/register_new_matrix_user.py
+++ b/synapse/_scripts/register_new_matrix_user.py
@@ -37,7 +37,7 @@ def request_registration(
     exit=sys.exit,
 ):
 
-    url = "%s/_synapse/admin/v1/register" % (server_location,)
+    url = "%s/_synapse/admin/v1/register" % (server_location.rstrip("/"),)
 
     # Get the nonce
     r = requests.get(url, verify=False)


### PR DESCRIPTION
When server URL provided to register_new_matrix_user includes path
component (e.g. "http://localhost:8008/"), the command fails with
"ERROR! Received 400 Bad Request". Stripping trailing slash from the
server_url command argument makes sure combined endpoint URL remains
valid.

Signed-off-by: Dmitry Borodaenko <angdraug@debian.org>