### PR TITLE
Correctly handle unpersisted events when calculating auth chain difference.

### DIFF
--- a/changelog.d/8827.bugfix
+++ b/changelog.d/8827.bugfix
@@ -1,0 +1,1 @@
+Fix bug where we might not correctly calculate the current state for rooms with multiple extremities.

--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -288,13 +288,16 @@ async def _get_auth_chain_difference(
     # Note: If the `event_map` is empty (which is the common case), we can do a
     # much simpler calculation.
     if event_map:
-        # The list of state sets to pass to the store. This is the same as
-        # `state_sets` except with unpersisted events stripped out and replaced
-        # with persisted events in their auth chain.
+        # The list of state sets to pass to the store, where each state set is a set
+        # of the event ids making up the state. This is similar to `state_sets`,
+        # except that (a) we only have event ids, not the complete
+        # ((type, state_key)->event_id) mappings; and (b) we have stripped out
+        # unpersisted events and replaced them with the persisted events in 
+        # their auth chain.
         state_sets_ids = []  # type: List[Set[str]]
 
-        # List of sets of the unpersisted event IDs reachable (by their auth
-        # chain) from each state set.
+        # For each state set, the unpersisted event IDs reachable (by their auth
+        # chain) from the events in that set.
         unpersisted_set_ids = []  # type: List[Set[str]]
 
         for state_set in state_sets:

--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -292,7 +292,7 @@ async def _get_auth_chain_difference(
         # of the event ids making up the state. This is similar to `state_sets`,
         # except that (a) we only have event ids, not the complete
         # ((type, state_key)->event_id) mappings; and (b) we have stripped out
-        # unpersisted events and replaced them with the persisted events in 
+        # unpersisted events and replaced them with the persisted events in
         # their auth chain.
         state_sets_ids = []  # type: List[Set[str]]
 

--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -19,7 +19,6 @@ import logging
 from typing import (
     Any,
     Callable,
-    Collection,
     Dict,
     Generator,
     Iterable,
@@ -39,7 +38,7 @@ from synapse.api.constants import EventTypes
 from synapse.api.errors import AuthError
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
 from synapse.events import EventBase
-from synapse.types import MutableStateMap, StateMap
+from synapse.types import Collection, MutableStateMap, StateMap
 from synapse.util import Clock
 
 logger = logging.getLogger(__name__)

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -217,6 +217,11 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         self.assertSetEqual(difference, {"a", "b", "c"})
 
         difference = self.get_success(
+            self.store.get_auth_chain_difference([{"a", "c"}, {"b", "c"}])
+        )
+        self.assertSetEqual(difference, {"a", "b"})
+
+        difference = self.get_success(
             self.store.get_auth_chain_difference([{"a"}, {"b"}, {"d"}])
         )
         self.assertSetEqual(difference, {"a", "b", "d", "e"})


### PR DESCRIPTION
We do state res with unpersisted events when calculating the new current state of the room, so that should be the only thing impacted. I don't think this is tooooo big of a deal as:

1. the next time a state event happens in the room the current state should correct itself;
2. in the common case all the unpersisted events' auth events will be pulled in by other state, so will still return the correct result (or one which is sufficiently close to not affect the result); and
3. we mostly use the state at an event to do important operations, which isn't affected by this.