### PR TITLE
Don't offer password login when it is disabled

### DIFF
--- a/changelog.d/8835.bugfix
+++ b/changelog.d/8835.bugfix
@@ -1,0 +1,1 @@
+Fix minor long-standing bug in login, where we would offer the `password` login type if a custom auth provider supported it, even if password login was disabled.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -205,15 +205,21 @@ class AuthHandler(BaseHandler):
         # type in the list. (NB that the spec doesn't require us to do so and
         # clients which favour types that they don't understand over those that
         # they do are technically broken)
-        login_types = []
-        if self._password_enabled:
-            login_types.append(LoginType.PASSWORD)
+
+        # start out by assuming PASSWORD is enabled; we will remove it later if not.
+        login_types = [LoginType.PASSWORD]
+
         for provider in self.password_providers:
             if hasattr(provider, "get_supported_login_types"):
                 for t in provider.get_supported_login_types().keys():
                     if t not in login_types:
                         login_types.append(t)
+
+        if not self._password_enabled:
+            login_types.remove(LoginType.PASSWORD)
+
         self._supported_login_types = login_types
+
         # Login types and UI Auth types have a heavy overlap, but are not
         # necessarily identical. Login types have SSO (and other login types)
         # added in the rest layer, see synapse.rest.client.v1.login.LoginRestServerlet.on_GET.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -207,7 +207,9 @@ class AuthHandler(BaseHandler):
         # they do are technically broken)
 
         # start out by assuming PASSWORD is enabled; we will remove it later if not.
-        login_types = [LoginType.PASSWORD]
+        login_types = []
+        if hs.config.password_localdb_enabled:
+            login_types.append(LoginType.PASSWORD)
 
         for provider in self.password_providers:
             if hasattr(provider, "get_supported_login_types"):

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -264,7 +264,11 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         mock_password_provider.check_password.reset_mock()
 
         # first delete should give a 401
-        session = self._start_delete_device_session(tok1, "dev2")
+        channel = self._delete_device(tok1, "dev2")
+        self.assertEqual(channel.code, 401)
+        # there are no valid flows here!
+        self.assertEqual(channel.json_body["flows"], [])
+        session = channel.json_body["session"]
         mock_password_provider.check_password.assert_not_called()
 
         # now try deleting with the local password

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -528,8 +528,6 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         channel = self._send_password_login("localuser", "localpass")
         self.assertEqual(channel.code, 400, channel.result)
 
-    test_custom_auth_no_local_user_fallback.skip = "currently broken"
-
     def _get_login_flows(self) -> JsonDict:
         _, channel = self.make_request("GET", "/_matrix/client/r0/login")
         self.assertEqual(channel.code, 200, channel.result)


### PR DESCRIPTION
Fix a minor bug where we would offer "m.login.password" login if a custom auth provider supported it, even if password login was disabled.

(It's worth noting that the subsequent attempt to log in would correctly fail - it was just the "available flows" that were wrong.)

~Based on #8819.~