### PR TITLE
Simplify appservice login code

### DIFF
--- a/changelog.d/8847.misc
+++ b/changelog.d/8847.misc
@@ -1,0 +1,1 @@
+Simplify `uk.half-shot.msc2778.login.application_service` login handler.


### PR DESCRIPTION
we don't need to support legacy login dictionaries here.