### PR TITLE
Support "identifier" dicts in UIA

### DIFF
--- a/changelog.d/8848.bugfix
+++ b/changelog.d/8848.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug which caused Synapse to require unspecified parameters during user-interactive authentication.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -833,7 +833,7 @@ class AuthHandler(BaseHandler):
         return self._supported_login_types
 
     async def validate_login(
-        self, login_submission: Dict[str, Any], ratelimit=False,
+        self, login_submission: Dict[str, Any], ratelimit: bool = False,
     ) -> Tuple[str, Optional[Callable[[Dict[str, str]], None]]]:
         """Authenticates the user for the /login API
 

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -358,9 +358,6 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
             "auth": {
                 "type": "test.login_type",
                 "identifier": {"type": "m.id.user", "user": "localuser"},
-                # FIXME "identifier" is ignored
-                #   https://github.com/matrix-org/synapse/issues/5665
-                "user": "localuser",
                 "session": session,
             },
         }
@@ -489,9 +486,6 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
             "auth": {
                 "type": "m.login.password",
                 "identifier": {"type": "m.id.user", "user": "localuser"},
-                # FIXME "identifier" is ignored
-                #   https://github.com/matrix-org/synapse/issues/5665
-                "user": "localuser",
                 "password": "localpass",
                 "session": session,
             },
@@ -541,7 +535,7 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         return self._send_login(type="m.login.password", user=user, password=password)
 
     def _send_login(self, type, user, **params) -> FakeChannel:
-        params.update({"user": user, "type": type})
+        params.update({"identifier": {"type": "m.id.user", "user": user}, "type": type})
         _, channel = self.make_request("POST", "/_matrix/client/r0/login", params)
         return channel
 
@@ -569,9 +563,6 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
                 "auth": {
                     "type": "m.login.password",
                     "identifier": {"type": "m.id.user", "user": user_id},
-                    # FIXME "identifier" is ignored
-                    #   https://github.com/matrix-org/synapse/issues/5665
-                    "user": user_id,
                     "password": password,
                     "session": session,
                 },


### PR DESCRIPTION
The spec requires synapse to support `identifier` dicts for `m.login.password` user-interactive auth, which it did not (instead, it required an undocumented `user` parameter.)

To fix this properly, we need to pull the code that interprets `identifier` into `AuthHandler.validate_login` so that it can be called from the UIA code.

Fixes #5665.

~Based on #8835, #8847~.

Sorry about the size of this; I couldn't really figure out a way to break it down any more.