### PR TITLE
Create a `PasswordProvider` wrapper object

### DIFF
--- a/changelog.d/8849.misc
+++ b/changelog.d/8849.misc
@@ -1,0 +1,1 @@
+Refactor `password_auth_provider` support code.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -997,6 +997,9 @@ class AuthHandler(BaseHandler):
             qualified_user_id = UserID(username, self.hs.hostname).to_string()
 
         login_type = login_submission.get("type")
+        # we already checked that we have a valid login type
+        assert isinstance(login_type, str)
+
         known_login_type = False
 
         for provider in self.password_providers:

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -266,8 +266,9 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         # first delete should give a 401
         channel = self._delete_device(tok1, "dev2")
         self.assertEqual(channel.code, 401)
-        # there are no valid flows here!
-        self.assertEqual(channel.json_body["flows"], [])
+        # m.login.password UIA is permitted because the auth provider allows it,
+        # even though the localdb does not.
+        self.assertEqual(channel.json_body["flows"], ["m.login.password"])
         session = channel.json_body["session"]
         mock_password_provider.check_password.assert_not_called()
 

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -268,7 +268,7 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, 401)
         # m.login.password UIA is permitted because the auth provider allows it,
         # even though the localdb does not.
-        self.assertEqual(channel.json_body["flows"], ["m.login.password"])
+        self.assertEqual(channel.json_body["flows"], [{"stages": ["m.login.password"]}])
         session = channel.json_body["session"]
         mock_password_provider.check_password.assert_not_called()
 


### PR DESCRIPTION
The idea here is to abstract out all the conditional code which tests which
methods a given password provider has, to provide a consistent interface.

~~Based on #8835.~~