### PR TITLE
Fix broken testcase

### DIFF
--- a/changelog.d/8851.misc
+++ b/changelog.d/8851.misc
@@ -1,0 +1,1 @@
+Simplify the way the `HomeServer` object caches its internal attributes.

--- a/tests/rest/admin/test_media.py
+++ b/tests/rest/admin/test_media.py
@@ -192,7 +192,6 @@ class DeleteMediaByDateSizeTestCase(unittest.HomeserverTestCase):
         self.handler = hs.get_device_handler()
         self.media_repo = hs.get_media_repository_resource()
         self.server_name = hs.hostname
-        self.clock = hs.clock
 
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")


### PR DESCRIPTION
This test was broken by #8565. It doesn't need to set set `self.clock`
here anyway - that is done by `setUp`.