### PR TITLE
Do not error if the content-length is not provided when uploading media.

### DIFF
--- a/changelog.d/8862.bugfix
+++ b/changelog.d/8862.bugfix
@@ -1,1 +1,1 @@
-Fix a longstanding bug if the `Content-Length` header was not provided to the upload media resource.
+Fix a longstanding bug where a 500 error would be returned if the `Content-Length` header was not provided to the upload media resource.

--- a/changelog.d/8862.bugfix
+++ b/changelog.d/8862.bugfix
@@ -1,0 +1,1 @@
+Fix a longstanding bug if the `Content-Length` header was not provided to the upload media resource.

--- a/synapse/rest/media/v1/upload_resource.py
+++ b/synapse/rest/media/v1/upload_resource.py
@@ -44,7 +44,7 @@ class UploadResource(DirectServeJsonResource):
         requester = await self.auth.get_user_by_req(request)
         # TODO: The checks here are a bit late. The content will have
         # already been uploaded to a tmp file at this point
-        content_length = request.getHeader(b"Content-Length").decode("ascii")
+        content_length = request.getHeader("Content-Length")
         if content_length is None:
             raise SynapseError(msg="Request must specify a Content-Length", code=400)
         if int(content_length) > self.max_upload_size:


### PR DESCRIPTION
See https://sentry.matrix.org/sentry/synapse-matrixorg/issues/119430/

Turns that [`getHeader` will automatically return a string](https://twistedmatrix.com/documents/current/api/twisted.web.http.Request.html#getHeader) if we request the header key as a string.