### PR TITLE
Fix a buglet in the SAML username mapping provider doc

### DIFF
--- a/changelog.d/8873.doc
+++ b/changelog.d/8873.doc
@@ -1,0 +1,1 @@
+Fix an error in the documentation for the SAML username mapping provider.

--- a/docs/sso_mapping_providers.md
+++ b/docs/sso_mapping_providers.md
@@ -116,11 +116,13 @@ comment these options out and use those specified by the module instead.
 
 A custom mapping provider must specify the following methods:
 
-* `__init__(self, parsed_config)`
+* `__init__(self, parsed_config, module_api)`
    - Arguments:
      - `parsed_config` - A configuration object that is the return value of the
        `parse_config` method. You should set any configuration options needed by
        the module here.
+     - `module_api` - a `synapse.module_api.ModuleApi` object which provides the
+       stable API available for extension modules.
 * `parse_config(config)`
     - This method should have the `@staticmethod` decoration.
     - Arguments:


### PR DESCRIPTION
the constructor is called with a `module_api`.

It's a shame the OIDC equivalent isn't consistent here.