### PR TITLE
Fix a regression that mapping providers should be able to redirect users.

### DIFF
--- a/changelog.d/8878.bugfix
+++ b/changelog.d/8878.bugfix
@@ -1,0 +1,1 @@
+Fix a regression in v1.24.0rc1 which failed to allow SAML mapping providers which were unable to redirect users to an additional page.

--- a/docs/sso_mapping_providers.md
+++ b/docs/sso_mapping_providers.md
@@ -168,6 +168,13 @@ A custom mapping provider must specify the following methods:
                          the value of `mxid_localpart`.
        * `emails` - A list of emails for the new user. If not provided, will
                     default to an empty list.
+       
+       Alternatively it can raise a `synapse.api.errors.RedirectException` to
+       redirect the user to another page. This is useful to prompt the user for
+       additional information, e.g. if you want them to provide their own username.
+       It is the responsibility of the mapping provider to either redirect back
+       to `client_redirect_url` (including any additional information) or to
+       complete registration using methods from the `ModuleApi`.
 
 ### Default SAML Mapping Provider
 

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -888,7 +888,7 @@ class OidcHandler(BaseHandler):
                 # continue to already be in use. Note that the error raised is
                 # arbitrary and will get turned into a MappingException.
                 if failures:
-                    raise RuntimeError(
+                    raise MappingException(
                         "Mapping provider does not support de-duplicating Matrix IDs"
                     )
 

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -197,13 +197,9 @@ class SsoHandler(BaseHandler):
                 raise
             except Exception as e:
                 # Any other exception is unexpected.
-                logger.error(
-                    "Unexpected error when extracting user attributes from SSO response: %s"
-                    % (e,)
-                )
                 raise MappingException(
                     "Could not extract user attributes from SSO response."
-                )
+                ) from e
 
             logger.debug(
                 "Retrieved user attributes from user mapping provider: %r (attempt %d)",

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -705,8 +705,7 @@ class OidcHandlerTestCase(HomeserverTestCase):
             MappingException,
         )
         self.assertEqual(
-            str(e.value),
-            "Could not extract user attributes from SSO response: Mapping provider does not support de-duplicating Matrix IDs",
+            str(e.value), "Mapping provider does not support de-duplicating Matrix IDs",
         )
 
     @override_config({"oidc_config": {"allow_existing_users": True}})


### PR DESCRIPTION
The SAML mapping provider is able to redirect users to an additional page. This is used by [Mozilla's mapping provider](https://github.com/matrix-org/matrix-synapse-saml-mozilla) to allow users to pick their own username. Support for this was broken in #8801, so targeting `release-v1.24.0` as this is a regression in the RC.