### PR TITLE
Fix installing pysaml2 on Python 3.5.

### DIFF
--- a/changelog.d/8898.misc
+++ b/changelog.d/8898.misc
@@ -1,0 +1,1 @@
+Add a maximum version for pysaml2 on Python 3.5.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -97,7 +97,7 @@ CONDITIONAL_REQUIREMENTS = {
         'eliot<1.8.0;python_version<"3.5.3"',
     ],
     "saml2": [
-        # pysaml2 6.4.0 removed compatibility with Python 3.5.
+        # pysaml2 6.4.0 is incompatible with Python 3.5 (see https://github.com/IdentityPython/pysaml2/issues/749)
         "pysaml2>=4.5.0,<6.4.0;python_version<'3.6'",
         "pysaml2>=4.5.0;python_version>='3.6'",
     ],

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -96,7 +96,11 @@ CONDITIONAL_REQUIREMENTS = {
         # python 3.5.2, as per https://github.com/itamarst/eliot/issues/418
         'eliot<1.8.0;python_version<"3.5.3"',
     ],
-    "saml2": ["pysaml2>=4.5.0"],
+    "saml2": [
+        # pysaml2 6.4.0 removed compatibility with Python 3.5.
+        "pysaml2>=4.5.0,<6.4.0;python_version<'3.6'",
+        "pysaml2>=4.5.0;python_version>='3.6'",
+    ],
     "oidc": ["authlib>=0.14.0"],
     "systemd": ["systemd-python>=231"],
     "url_preview": ["lxml>=3.5.0"],


### PR DESCRIPTION
This applies a maximum version for pysaml2 for Python < 3.6 since pysaml2 6.4.0 (released today) removed compatibility with Python 3.5.