### PR TITLE
Refactor `SsoHandler.get_mxid_from_sso`

### DIFF
--- a/changelog.d/8900.feature
+++ b/changelog.d/8900.feature
@@ -1,0 +1,1 @@
+Add support for allowing users to pick their own user ID during a single-sign-on login.

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -22,6 +22,7 @@ from twisted.web.http import Request
 from synapse.api.errors import RedirectException
 from synapse.http.server import respond_with_html
 from synapse.types import UserID, contains_invalid_mxid_characters
+from synapse.util.async_helpers import Linearizer
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
@@ -53,6 +54,9 @@ class SsoHandler:
         self._registration_handler = hs.get_registration_handler()
         self._error_template = hs.config.sso_error_template
         self._auth_handler = hs.get_auth_handler()
+
+        # a lock on the mappings
+        self._mapping_lock = Linearizer(name="sso_user_mapping", clock=hs.get_clock())
 
     def render_error(
         self, request, error: str, error_description: Optional[str] = None
@@ -172,29 +176,33 @@ class SsoHandler:
                 to an additional page. (e.g. to prompt for more information)
 
         """
-        # first of all, check if we already have a mapping for this user
-        previously_registered_user_id = await self.get_sso_user_by_remote_user_id(
-            auth_provider_id, remote_user_id,
-        )
-        if previously_registered_user_id:
-            return previously_registered_user_id
-
-        # Check for grandfathering of users.
-        if grandfather_existing_users:
-            previously_registered_user_id = await grandfather_existing_users()
+        # grab a lock while we try to find a mapping for this user. This seems...
+        # optimistic, especially for implementations that end up redirecting to
+        # interstitial pages.
+        with (await self._mapping_lock.queue(auth_provider_id)):
+            # first of all, check if we already have a mapping for this user
+            previously_registered_user_id = await self.get_sso_user_by_remote_user_id(
+                auth_provider_id, remote_user_id,
+            )
             if previously_registered_user_id:
-                # Future logins should also match this user ID.
-                await self._store.record_user_external_id(
-                    auth_provider_id, remote_user_id, previously_registered_user_id
-                )
                 return previously_registered_user_id
 
-        # Otherwise, generate a new user.
-        attributes = await self._call_attribute_mapper(sso_to_matrix_id_mapper)
-        user_id = await self._register_mapped_user(
-            attributes, auth_provider_id, remote_user_id, user_agent, ip_address,
-        )
-        return user_id
+            # Check for grandfathering of users.
+            if grandfather_existing_users:
+                previously_registered_user_id = await grandfather_existing_users()
+                if previously_registered_user_id:
+                    # Future logins should also match this user ID.
+                    await self._store.record_user_external_id(
+                        auth_provider_id, remote_user_id, previously_registered_user_id
+                    )
+                    return previously_registered_user_id
+
+            # Otherwise, generate a new user.
+            attributes = await self._call_attribute_mapper(sso_to_matrix_id_mapper)
+            user_id = await self._register_mapped_user(
+                attributes, auth_provider_id, remote_user_id, user_agent, ip_address,
+            )
+            return user_id
 
     async def _call_attribute_mapper(
         self, sso_to_matrix_id_mapper: Callable[[int], Awaitable[UserAttributes]],

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -179,7 +179,7 @@ class SsoHandler:
         # grab a lock while we try to find a mapping for this user. This seems...
         # optimistic, especially for implementations that end up redirecting to
         # interstitial pages.
-        with (await self._mapping_lock.queue(auth_provider_id)):
+        with await self._mapping_lock.queue(auth_provider_id):
             # first of all, check if we already have a mapping for this user
             previously_registered_user_id = await self.get_sso_user_by_remote_user_id(
                 auth_provider_id, remote_user_id,


### PR DESCRIPTION
This is a pair of preparatory changes to `SsoHandler.get_mxid_from_sso`. The first is hopefully non-functional, and just factors out a couple of helper methods.

The second moves the `mapping_lock` logic out of SamlHandler down into SsoHandler, where it will be shared with OIDC. (It's not obvious it's doing quite the right thing, but that's not a nettle I particularly want to grasp right now.)