### PR TITLE
Try and drop stale extremities.

### DIFF
--- a/changelog.d/8929.misc
+++ b/changelog.d/8929.misc
@@ -1,1 +1,1 @@
-Automatically drop stale extremities under some specific conditions.
+Automatically drop stale forward-extremities under some specific conditions.

--- a/changelog.d/8929.misc
+++ b/changelog.d/8929.misc
@@ -1,0 +1,1 @@
+Automatically drop stale extremities under some specific conditions.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -95,6 +95,8 @@ class EventTypes:
 
     Presence = "m.presence"
 
+    Dummy = "org.matrix.dummy_event"
+
 
 class RejectedReason:
     AUTH_ERROR = "auth_error"

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1261,7 +1261,7 @@ class EventCreationHandler:
                 event, context = await self.create_event(
                     requester,
                     {
-                        "type": "org.matrix.dummy_event",
+                        "type": EventTypes.Dummy,
                         "content": {},
                         "room_id": room_id,
                         "sender": user_id,

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -615,7 +615,8 @@ class EventsPersistenceStorage:
             is the delta to the existing current state. If both are None then
             there has been no change.
 
-            The function may prune some old extremities if its safe to do so.
+            The function may prune some old entries from the set of new
+            forward extremities if it's safe to do so.
 
             If there has been a change then we only return the delta if its
             already been calculated. Conversely if we do know the delta then

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -595,16 +595,16 @@ class EventsPersistenceStorage:
         a room
 
         Args:
-            room_id (str):
+            room_id:
                 room to which the events are being added. Used for logging etc
 
-            events_context (list[(EventBase, EventContext)]):
+            events_context:
                 events and contexts which are being added to the room
 
-            old_latest_event_ids (iterable[str]):
+            old_latest_event_ids:
                 the old forward extremities for the room.
 
-            new_latest_event_ids (iterable[str]):
+            new_latest_event_ids :
                 the new forward extremities for the room.
 
         Returns:
@@ -802,7 +802,7 @@ class EventsPersistenceStorage:
 
                 new_senders = {get_domain_from_id(e.sender) for e, _ in events_context}
 
-                one_day_ago = self._clock.time_msec() - 20 * 60 * 1000
+                one_day_ago = self._clock.time_msec() - 20 * 60 * 60 * 1000
                 current_depth = max(e.depth for e, _ in events_context)
                 for event in dropped_events.values():
                     if (

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -811,7 +811,7 @@ class EventsPersistenceStorage:
 
         logger.debug("Might drop extremities: %s", dropped_extrems)
 
-        # We only drop events if:
+        # We only drop events from the extremities list if:
         #   1. we're not currently persisting them;
         #   2. they're not our own events (or are dummy events); and
         #   3. they're either:
@@ -819,7 +819,7 @@ class EventsPersistenceStorage:
         #          to calculate); or
         #       2. we are persisting an event from the same domain.
         #
-        # The idea is that we don't want to drop events that are "legitmate"
+        # The idea is that we don't want to drop events that are "legitimate"
         # extremities (that we would want to include as prev events), only
         # "stuck" extremities that are e.g. due to a gap in the graph.
         #

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -842,7 +842,7 @@ class EventsPersistenceStorage:
 
         new_senders = {get_domain_from_id(e.sender) for e, _ in events_context}
 
-        one_day_ago = self._clock.time_msec() - 20 * 60 * 60 * 1000
+        one_day_ago = self._clock.time_msec() - 24 * 60 * 60 * 1000
         current_depth = max(e.depth for e, _ in events_context)
         for event in dropped_events.values():
             if self.is_mine_id(event.sender) and event.type != "org.matrix.dummy_event":

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -845,7 +845,7 @@ class EventsPersistenceStorage:
         one_day_ago = self._clock.time_msec() - 24 * 60 * 60 * 1000
         current_depth = max(e.depth for e, _ in events_context)
         for event in dropped_events.values():
-            if self.is_mine_id(event.sender) and event.type != "org.matrix.dummy_event":
+            if self.is_mine_id(event.sender) and event.type != EventTypes.Dummy:
                 logger.debug("Not dropping own event")
                 return new_latest_event_ids
 

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -116,7 +116,7 @@ async def filter_events_for_client(
         # see events in the room at that point in the DAG, and that shouldn't be decided
         # on those checks.
         if filter_send_to_client:
-            if event.type == "org.matrix.dummy_event":
+            if event.type == EventTypes.Dummy:
                 return None
 
             if not event.is_state() and event.sender in ignore_list:

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -152,3 +152,37 @@ class ExtremPruneTestCase(HomeserverTestCase):
 
         # Check that we haven't dropped the old extremity.
         self.assert_extremities([self.remote_event_1.event_id, remote_event_2.event_id])
+
+    def test_prune_gap_if_old(self):
+        """Test that we drop extremities after a gap when the previous extremity
+        is "old"
+        """
+
+        # Advance the clock for many days to make the old extremity "old". We
+        # also set the depth to "lots".
+        self.reactor.advance(7 * 24 * 60 * 60)
+
+        # Fudge a second event which points to an event we don't have. This is a
+        # state event so that the state changes (otherwise we won't prune the
+        # extremity as they'll have the same state group).
+        remote_event_2 = event_from_pdu_json(
+            {
+                "type": EventTypes.Member,
+                "state_key": "@user:other2",
+                "content": {"membership": Membership.JOIN},
+                "room_id": self.room_id,
+                "sender": "@user:other2",
+                "depth": 10000,
+                "prev_events": ["$some_unknown_message"],
+                "auth_events": [],
+                "origin_server_ts": self.clock.time_msec(),
+            },
+            RoomVersions.V6,
+        )
+
+        state_before_gap = self.get_success(self.state.get_current_state(self.room_id))
+
+        self.persist_event(remote_event_2, state=state_before_gap.values())
+
+        # Check the new extremity is just the new remote event.
+        self.assert_extremities([remote_event_2.event_id])

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from synapse.api.constants import EventTypes, Membership
+from synapse.api.room_versions import RoomVersions
+from synapse.federation.federation_base import event_from_pdu_json
+from synapse.rest import admin
+from synapse.rest.client.v1 import login, room
+
+from tests.unittest import HomeserverTestCase
+
+
+class ExtremPruneTestCase(HomeserverTestCase):
+    servlets = [
+        admin.register_servlets,
+        room.register_servlets,
+        login.register_servlets,
+    ]
+
+    def test_prune_gap(self):
+        """Test that we drop extremities after a gap when we see an event from
+        the same domain.
+        """
+
+        state = self.hs.get_state_handler()
+        persistence = self.hs.get_storage().persistence
+        store = self.hs.get_datastore()
+
+        self.register_user("user", "pass")
+        token = self.login("user", "pass")
+        room_id = self.helper.create_room_as(
+            "user", room_version=RoomVersions.V6.identifier, tok=token
+        )
+
+        body = self.helper.send(room_id, body="Test", tok=token)
+        local_message_event_id = body["event_id"]
+
+        # Fudge a remote event an persist it. This will be the extremity before
+        # the gap.
+        remote_event_1 = event_from_pdu_json(
+            {
+                "type": EventTypes.Message,
+                "content": {},
+                "room_id": room_id,
+                "sender": "@user:other",
+                "depth": 5,
+                "prev_events": [local_message_event_id],
+                "auth_events": [],
+                "origin_server_ts": self.clock.time_msec(),
+            },
+            RoomVersions.V6,
+        )
+
+        context = self.get_success(state.compute_event_context(remote_event_1))
+        self.get_success(persistence.persist_event(remote_event_1, context))
+
+        # Check that the current extremities is the remote event.
+        extremities = self.get_success(store.get_prev_events_for_room(room_id))
+        self.assertCountEqual(extremities, [remote_event_1.event_id])
+
+        # Fudge a second event which points to an event we don't have. This is a
+        # state event so that the state changes (otherwise we won't prune the
+        # extremity as they'll have the same state group).
+        remote_event_2 = event_from_pdu_json(
+            {
+                "type": EventTypes.Member,
+                "state_key": "@user:other",
+                "content": {"membership": Membership.JOIN},
+                "room_id": room_id,
+                "sender": "@user:other",
+                "depth": 10,
+                "prev_events": ["$some_unknown_message"],
+                "auth_events": [],
+                "origin_server_ts": self.clock.time_msec(),
+            },
+            RoomVersions.V6,
+        )
+
+        state_before_gap = self.get_success(state.get_current_state(room_id))
+
+        context = self.get_success(
+            state.compute_event_context(
+                remote_event_2, old_state=state_before_gap.values()
+            )
+        )
+
+        self.get_success(persistence.persist_event(remote_event_2, context))
+
+        # Check the new extremity is just the new remote event.
+        extremities = self.get_success(store.get_prev_events_for_room(room_id))
+        self.assertCountEqual(extremities, [remote_event_2.event_id])
+
+    def test_dont_prune_gap_if_state_different(self):
+        """Test that we don't prune extremities after a gap if the resolved
+        state is different.
+        """
+
+        state = self.hs.get_state_handler()
+        persistence = self.hs.get_storage().persistence
+        store = self.hs.get_datastore()
+
+        self.register_user("user", "pass")
+        token = self.login("user", "pass")
+        room_id = self.helper.create_room_as(
+            "user", room_version=RoomVersions.V6.identifier, tok=token
+        )
+
+        body = self.helper.send(room_id, body="Test", tok=token)
+        local_message_event_id = body["event_id"]
+
+        # Fudge a remote event an persist it. This will be the extremity before
+        # the gap.
+        remote_event_1 = event_from_pdu_json(
+            {
+                "type": EventTypes.Message,
+                "state_key": "@user:other",
+                "content": {},
+                "room_id": room_id,
+                "sender": "@user:other",
+                "depth": 5,
+                "prev_events": [local_message_event_id],
+                "auth_events": [],
+                "origin_server_ts": self.clock.time_msec(),
+            },
+            RoomVersions.V6,
+        )
+
+        context = self.get_success(state.compute_event_context(remote_event_1))
+        self.get_success(persistence.persist_event(remote_event_1, context))
+
+        # Check that the current extremities is the remote event.
+        extremities = self.get_success(store.get_prev_events_for_room(room_id))
+        self.assertCountEqual(extremities, [remote_event_1.event_id])
+
+        # Fudge a second event which points to an event we don't have.
+        remote_event_2 = event_from_pdu_json(
+            {
+                "type": EventTypes.Message,
+                "state_key": "@user:other",
+                "content": {},
+                "room_id": room_id,
+                "sender": "@user:other",
+                "depth": 10,
+                "prev_events": ["$some_unknown_message"],
+                "auth_events": [],
+                "origin_server_ts": self.clock.time_msec(),
+            },
+            RoomVersions.V6,
+        )
+
+        # Now we persist it with state with a dropped history visibility
+        # setting. The state resolution across the old and new event will then
+        # include it, and so the resolved state won't match the new state.
+        state_before_gap = dict(self.get_success(state.get_current_state(room_id)))
+        state_before_gap.pop(("m.room.history_visibility", ""))
+
+        context = self.get_success(
+            state.compute_event_context(
+                remote_event_2, old_state=state_before_gap.values()
+            )
+        )
+
+        self.get_success(persistence.persist_event(remote_event_2, context))
+
+        # Check that we haven't dropped the old extremity.
+        extremities = self.get_success(store.get_prev_events_for_room(room_id))
+        self.assertCountEqual(
+            extremities, [remote_event_1.event_id, remote_event_2.event_id]
+        )

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -45,7 +45,7 @@ class ExtremPruneTestCase(HomeserverTestCase):
         body = self.helper.send(self.room_id, body="Test", tok=token)
         local_message_event_id = body["event_id"]
 
-        # Fudge a remote event an persist it. This will be the extremity before
+        # Fudge a remote event and persist it. This will be the extremity before
         # the gap.
         self.remote_event_1 = event_from_pdu_json(
             {

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -36,13 +36,13 @@ class ExtremPruneTestCase(HomeserverTestCase):
         self.store = self.hs.get_datastore()
 
         self.register_user("user", "pass")
-        token = self.login("user", "pass")
+        self.token = self.login("user", "pass")
 
         self.room_id = self.helper.create_room_as(
-            "user", room_version=RoomVersions.V6.identifier, tok=token
+            "user", room_version=RoomVersions.V6.identifier, tok=self.token
         )
 
-        body = self.helper.send(self.room_id, body="Test", tok=token)
+        body = self.helper.send(self.room_id, body="Test", tok=self.token)
         local_message_event_id = body["event_id"]
 
         # Fudge a remote event and persist it. This will be the extremity before
@@ -216,3 +216,77 @@ class ExtremPruneTestCase(HomeserverTestCase):
 
         # Check the new extremity is just the new remote event.
         self.assert_extremities([self.remote_event_1.event_id, remote_event_2.event_id])
+
+    def test_prune_gap_if_dummy(self):
+        """Test that we drop extremities after a gap when the previous extremity
+        is a local dummy event and "old".
+        """
+
+        body = self.helper.send_event(
+            self.room_id, type="org.matrix.dummy_event", content={}, tok=self.token
+        )
+        local_message_event_id = body["event_id"]
+        self.assert_extremities([local_message_event_id])
+
+        # Advance the clock for many days to make the old extremity "old". We
+        # also set the depth to "lots".
+        self.reactor.advance(7 * 24 * 60 * 60)
+
+        # Fudge a second event which points to an event we don't have. This is a
+        # state event so that the state changes (otherwise we won't prune the
+        # extremity as they'll have the same state group).
+        remote_event_2 = event_from_pdu_json(
+            {
+                "type": EventTypes.Member,
+                "state_key": "@user:other2",
+                "content": {"membership": Membership.JOIN},
+                "room_id": self.room_id,
+                "sender": "@user:other2",
+                "depth": 10000,
+                "prev_events": ["$some_unknown_message"],
+                "auth_events": [],
+                "origin_server_ts": self.clock.time_msec(),
+            },
+            RoomVersions.V6,
+        )
+
+        state_before_gap = self.get_success(self.state.get_current_state(self.room_id))
+
+        self.persist_event(remote_event_2, state=state_before_gap.values())
+
+        # Check the new extremity is just the new remote event.
+        self.assert_extremities([remote_event_2.event_id])
+
+    def test_do_not_prune_gap_if_not_dummy(self):
+        """Test that we do not drop extremities after a gap when the previous extremity
+        is not a dummy event.
+        """
+
+        body = self.helper.send(self.room_id, body="test", tok=self.token)
+        local_message_event_id = body["event_id"]
+        self.assert_extremities([local_message_event_id])
+
+        # Fudge a second event which points to an event we don't have. This is a
+        # state event so that the state changes (otherwise we won't prune the
+        # extremity as they'll have the same state group).
+        remote_event_2 = event_from_pdu_json(
+            {
+                "type": EventTypes.Member,
+                "state_key": "@user:other2",
+                "content": {"membership": Membership.JOIN},
+                "room_id": self.room_id,
+                "sender": "@user:other2",
+                "depth": 10000,
+                "prev_events": ["$some_unknown_message"],
+                "auth_events": [],
+                "origin_server_ts": self.clock.time_msec(),
+            },
+            RoomVersions.V6,
+        )
+
+        state_before_gap = self.get_success(self.state.get_current_state(self.room_id))
+
+        self.persist_event(remote_event_2, state=state_before_gap.values())
+
+        # Check the new extremity is just the new remote event.
+        self.assert_extremities([local_message_event_id, remote_event_2.event_id])

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -30,31 +30,29 @@ class ExtremPruneTestCase(HomeserverTestCase):
         login.register_servlets,
     ]
 
-    def test_prune_gap(self):
-        """Test that we drop extremities after a gap when we see an event from
-        the same domain.
-        """
-
-        state = self.hs.get_state_handler()
-        persistence = self.hs.get_storage().persistence
-        store = self.hs.get_datastore()
+    def prepare(self, reactor, clock, homeserver):
+        self.state = self.hs.get_state_handler()
+        self.persistence = self.hs.get_storage().persistence
+        self.store = self.hs.get_datastore()
 
         self.register_user("user", "pass")
         token = self.login("user", "pass")
-        room_id = self.helper.create_room_as(
+
+        self.room_id = self.helper.create_room_as(
             "user", room_version=RoomVersions.V6.identifier, tok=token
         )
 
-        body = self.helper.send(room_id, body="Test", tok=token)
+        body = self.helper.send(self.room_id, body="Test", tok=token)
         local_message_event_id = body["event_id"]
 
         # Fudge a remote event an persist it. This will be the extremity before
         # the gap.
-        remote_event_1 = event_from_pdu_json(
+        self.remote_event_1 = event_from_pdu_json(
             {
                 "type": EventTypes.Message,
+                "state_key": "@user:other",
                 "content": {},
-                "room_id": room_id,
+                "room_id": self.room_id,
                 "sender": "@user:other",
                 "depth": 5,
                 "prev_events": [local_message_event_id],
@@ -64,12 +62,31 @@ class ExtremPruneTestCase(HomeserverTestCase):
             RoomVersions.V6,
         )
 
-        context = self.get_success(state.compute_event_context(remote_event_1))
-        self.get_success(persistence.persist_event(remote_event_1, context))
+        self.persist_event(self.remote_event_1)
 
         # Check that the current extremities is the remote event.
-        extremities = self.get_success(store.get_prev_events_for_room(room_id))
-        self.assertCountEqual(extremities, [remote_event_1.event_id])
+        self.assert_extremities([self.remote_event_1.event_id])
+
+    def persist_event(self, event, state=None):
+        """Persist the event, with optional state
+        """
+        context = self.get_success(
+            self.state.compute_event_context(event, old_state=state)
+        )
+        self.get_success(self.persistence.persist_event(event, context))
+
+    def assert_extremities(self, expected_extremities):
+        """Assert the current extremities for the room
+        """
+        extremities = self.get_success(
+            self.store.get_prev_events_for_room(self.room_id)
+        )
+        self.assertCountEqual(extremities, expected_extremities)
+
+    def test_prune_gap(self):
+        """Test that we drop extremities after a gap when we see an event from
+        the same domain.
+        """
 
         # Fudge a second event which points to an event we don't have. This is a
         # state event so that the state changes (otherwise we won't prune the
@@ -79,7 +96,7 @@ class ExtremPruneTestCase(HomeserverTestCase):
                 "type": EventTypes.Member,
                 "state_key": "@user:other",
                 "content": {"membership": Membership.JOIN},
-                "room_id": room_id,
+                "room_id": self.room_id,
                 "sender": "@user:other",
                 "depth": 10,
                 "prev_events": ["$some_unknown_message"],
@@ -89,61 +106,17 @@ class ExtremPruneTestCase(HomeserverTestCase):
             RoomVersions.V6,
         )
 
-        state_before_gap = self.get_success(state.get_current_state(room_id))
+        state_before_gap = self.get_success(self.state.get_current_state(self.room_id))
 
-        context = self.get_success(
-            state.compute_event_context(
-                remote_event_2, old_state=state_before_gap.values()
-            )
-        )
-
-        self.get_success(persistence.persist_event(remote_event_2, context))
+        self.persist_event(remote_event_2, state=state_before_gap.values())
 
         # Check the new extremity is just the new remote event.
-        extremities = self.get_success(store.get_prev_events_for_room(room_id))
-        self.assertCountEqual(extremities, [remote_event_2.event_id])
+        self.assert_extremities([remote_event_2.event_id])
 
-    def test_dont_prune_gap_if_state_different(self):
+    def test_do_not_prune_gap_if_state_different(self):
         """Test that we don't prune extremities after a gap if the resolved
         state is different.
         """
-
-        state = self.hs.get_state_handler()
-        persistence = self.hs.get_storage().persistence
-        store = self.hs.get_datastore()
-
-        self.register_user("user", "pass")
-        token = self.login("user", "pass")
-        room_id = self.helper.create_room_as(
-            "user", room_version=RoomVersions.V6.identifier, tok=token
-        )
-
-        body = self.helper.send(room_id, body="Test", tok=token)
-        local_message_event_id = body["event_id"]
-
-        # Fudge a remote event an persist it. This will be the extremity before
-        # the gap.
-        remote_event_1 = event_from_pdu_json(
-            {
-                "type": EventTypes.Message,
-                "state_key": "@user:other",
-                "content": {},
-                "room_id": room_id,
-                "sender": "@user:other",
-                "depth": 5,
-                "prev_events": [local_message_event_id],
-                "auth_events": [],
-                "origin_server_ts": self.clock.time_msec(),
-            },
-            RoomVersions.V6,
-        )
-
-        context = self.get_success(state.compute_event_context(remote_event_1))
-        self.get_success(persistence.persist_event(remote_event_1, context))
-
-        # Check that the current extremities is the remote event.
-        extremities = self.get_success(store.get_prev_events_for_room(room_id))
-        self.assertCountEqual(extremities, [remote_event_1.event_id])
 
         # Fudge a second event which points to an event we don't have.
         remote_event_2 = event_from_pdu_json(
@@ -151,7 +124,7 @@ class ExtremPruneTestCase(HomeserverTestCase):
                 "type": EventTypes.Message,
                 "state_key": "@user:other",
                 "content": {},
-                "room_id": room_id,
+                "room_id": self.room_id,
                 "sender": "@user:other",
                 "depth": 10,
                 "prev_events": ["$some_unknown_message"],
@@ -164,19 +137,18 @@ class ExtremPruneTestCase(HomeserverTestCase):
         # Now we persist it with state with a dropped history visibility
         # setting. The state resolution across the old and new event will then
         # include it, and so the resolved state won't match the new state.
-        state_before_gap = dict(self.get_success(state.get_current_state(room_id)))
+        state_before_gap = dict(
+            self.get_success(self.state.get_current_state(self.room_id))
+        )
         state_before_gap.pop(("m.room.history_visibility", ""))
 
         context = self.get_success(
-            state.compute_event_context(
+            self.state.compute_event_context(
                 remote_event_2, old_state=state_before_gap.values()
             )
         )
 
-        self.get_success(persistence.persist_event(remote_event_2, context))
+        self.get_success(self.persistence.persist_event(remote_event_2, context))
 
         # Check that we haven't dropped the old extremity.
-        extremities = self.get_success(store.get_prev_events_for_room(room_id))
-        self.assertCountEqual(
-            extremities, [remote_event_1.event_id, remote_event_2.event_id]
-        )
+        self.assert_extremities([self.remote_event_1.event_id, remote_event_2.event_id])

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -223,7 +223,7 @@ class ExtremPruneTestCase(HomeserverTestCase):
         """
 
         body = self.helper.send_event(
-            self.room_id, type="org.matrix.dummy_event", content={}, tok=self.token
+            self.room_id, type=EventTypes.Dummy, content={}, tok=self.token
         )
         local_message_event_id = body["event_id"]
         self.assert_extremities([local_message_event_id])

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -98,7 +98,7 @@ class ExtremPruneTestCase(HomeserverTestCase):
                 "content": {"membership": Membership.JOIN},
                 "room_id": self.room_id,
                 "sender": "@user:other",
-                "depth": 10,
+                "depth": 50,
                 "prev_events": ["$some_unknown_message"],
                 "auth_events": [],
                 "origin_server_ts": self.clock.time_msec(),


### PR DESCRIPTION
If we see stale extremities while persisting events, and notice that they don't change the result of state resolution, we drop them.

~~I need to add some tests~~ A couple of tests have been added.