### PR TITLE
Send the location of the web client to the IS when inviting via 3PIDs.

### DIFF
--- a/changelog.d/8930.feature
+++ b/changelog.d/8930.feature
@@ -1,0 +1,1 @@
+Send an optional `web_client_location` argument to the invite endpoint which allows customisation of the email template.

--- a/changelog.d/8930.feature
+++ b/changelog.d/8930.feature
@@ -1,1 +1,1 @@
-Send an optional `web_client_location` argument to the invite endpoint which allows customisation of the email template.
+Add an `email.invite_client_location` configuration option to send a web client location to the invite endpoint on the identity server which allows customisation of the email template.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2133,6 +2133,12 @@ email:
   #
   #validation_token_lifetime: 15m
 
+  # The web client location to direct users to during an invite. This is passed
+  # to the identity server as the org.matrix.web_client_location key. Defaults
+  # to unset, giving no guidance to the identity server.
+  #
+  #invite_client_location: https://app.element.io
+
   # Directory in which Synapse will try to find the template files below.
   # If not set, or the files named below are not found within the template
   # directory, default templates from within the Synapse package will be used.

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -322,6 +322,23 @@ class EmailConfig(Config):
 
         self.email_subjects = EmailSubjectConfig(**subjects)
 
+        # The invite client location should be a HTTP(S) URL or None.
+        self.invite_client_location = email_config.get("invite_client_location") or None
+        if self.invite_client_location and not isinstance(
+            self.invite_client_location, str
+        ):
+            raise ConfigError(
+                "Config option email.invite_client_location must be type str"
+            )
+        if not (
+            self.invite_client_location.startswith("http://")
+            or self.invite_client_location.startswith("https://")
+        ):
+            raise ConfigError(
+                "Config option email.invite_client_location must be a http or https URL",
+                path=("email", "invite_client_location"),
+            )
+
     def generate_config_section(self, config_dir_path, server_name, **kwargs):
         return (
             """\
@@ -388,6 +405,12 @@ class EmailConfig(Config):
           # Defaults to 1h.
           #
           #validation_token_lifetime: 15m
+
+          # The web client location to direct users to during an invite. This is passed
+          # to the identity server as the org.matrix.web_client_location key. Defaults
+          # to unset, giving no guidance to the identity server.
+          #
+          #invite_client_location: https://app.element.io
 
           # Directory in which Synapse will try to find the template files below.
           # If not set, or the files named below are not found within the template

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -324,20 +324,19 @@ class EmailConfig(Config):
 
         # The invite client location should be a HTTP(S) URL or None.
         self.invite_client_location = email_config.get("invite_client_location") or None
-        if self.invite_client_location and not isinstance(
-            self.invite_client_location, str
-        ):
-            raise ConfigError(
-                "Config option email.invite_client_location must be type str"
-            )
-        if not (
-            self.invite_client_location.startswith("http://")
-            or self.invite_client_location.startswith("https://")
-        ):
-            raise ConfigError(
-                "Config option email.invite_client_location must be a http or https URL",
-                path=("email", "invite_client_location"),
-            )
+        if self.invite_client_location:
+            if not isinstance(self.invite_client_location, str):
+                raise ConfigError(
+                    "Config option email.invite_client_location must be type str"
+                )
+            if not (
+                self.invite_client_location.startswith("http://")
+                or self.invite_client_location.startswith("https://")
+            ):
+                raise ConfigError(
+                    "Config option email.invite_client_location must be a http or https URL",
+                    path=("email", "invite_client_location"),
+                )
 
     def generate_config_section(self, config_dir_path, server_name, **kwargs):
         return (

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -55,13 +55,7 @@ class IdentityHandler(BaseHandler):
         self.federation_http_client = hs.get_federation_http_client()
         self.hs = hs
 
-        # Only allow the web client location to be sent if it is an HTTP URL.
-        self._web_client_location = None
-        webclient_loc = hs.config.web_client_location
-        if webclient_loc and (
-            webclient_loc.startswith("http://") or webclient_loc.startswith("https://")
-        ):
-            self._web_client_location = webclient_loc
+        self._web_client_location = hs.config.invite_client_location
 
     async def threepid_from_creds(
         self, id_server: str, creds: Dict[str, str]

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -55,6 +55,14 @@ class IdentityHandler(BaseHandler):
         self.federation_http_client = hs.get_federation_http_client()
         self.hs = hs
 
+        # Only allow the web client location to be sent if it is an HTTP URL.
+        self._web_client_location = None
+        webclient_loc = hs.config.web_client_location
+        if webclient_loc and (
+            webclient_loc.startswith("http://") or webclient_loc.startswith("https://")
+        ):
+            self._web_client_location = webclient_loc
+
     async def threepid_from_creds(
         self, id_server: str, creds: Dict[str, str]
     ) -> Optional[JsonDict]:
@@ -803,6 +811,9 @@ class IdentityHandler(BaseHandler):
             "sender_display_name": inviter_display_name,
             "sender_avatar_url": inviter_avatar_url,
         }
+        # If a custom web client location is available, include it in the request.
+        if self._web_client_location:
+            invite_config["web_client_location"] = self._web_client_location
 
         # Add the identity service access token to the JSON body and use the v2
         # Identity Service endpoints if id_access_token is present

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -813,7 +813,7 @@ class IdentityHandler(BaseHandler):
         }
         # If a custom web client location is available, include it in the request.
         if self._web_client_location:
-            invite_config["web_client_location"] = self._web_client_location
+            invite_config["org.matrix.web_client_location"] = self._web_client_location
 
         # Add the identity service access token to the JSON body and use the v2
         # Identity Service endpoints if id_access_token is present


### PR DESCRIPTION
Sends an additional parameter (`web_client_location`) with the URL to use for a web client when inviting users. This allows Synapse to specify the web app to use in the invite email and is useful if you're hosting a custom Element Web somewhere.

As far as I can tell, the [identity service spec](https://matrix.org/docs/spec/identity_service/latest#post-matrix-identity-v2-store-invite) allows for sending additional arbitrary arguments:

> In addition to the request parameters specified below, an arbitrary number of other parameters may also be specified. These may be used in the invite message generation described below.

See matrix-org/sydent#326 for a corresponding sydent PR.

Fixes #8863