### PR TITLE
Implement delegation_address option

### DIFF
--- a/changelog.d/8934.feature
+++ b/changelog.d/8934.feature
@@ -1,0 +1,1 @@
+Add option for .well-known delegation.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -75,6 +75,11 @@ pid_file: DATADIR/homeserver.pid
 #
 #public_baseurl: https://example.com/
 
+# The address (and optional port) to direct federation traffic to.
+# Setting this option will enable .well-known delegation.
+# See https://github.com/matrix-org/synapse/blob/master/docs/delegate.md
+#delegation_address: synapse.example.com
+
 # Set the soft limit on the number of file descriptors synapse can use
 # Zero is used to indicate synapse should set the soft limit to the
 # hard limit.

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -182,6 +182,7 @@ class SynapseHomeServer(HomeServer):
             client_resource = ClientRestResource(self)
             if compress:
                 client_resource = gz_wrap(client_resource)
+            well_known_resource = WellKnownResource(self)
 
             resources.update(
                 {
@@ -190,7 +191,8 @@ class SynapseHomeServer(HomeServer):
                     "/_matrix/client/unstable": client_resource,
                     "/_matrix/client/v2_alpha": client_resource,
                     "/_matrix/client/versions": client_resource,
-                    "/.well-known/matrix/client": WellKnownResource(self),
+                    "/.well-known/matrix/client": well_known_resource,
+                    "/.well-known/matrix/server": well_known_resource,
                     "/_synapse/admin": AdminRestResource(self),
                 }
             )

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -162,6 +162,7 @@ class ServerConfig(Config):
         self.user_agent_suffix = config.get("user_agent_suffix")
         self.use_frozen_dicts = config.get("use_frozen_dicts", False)
         self.public_baseurl = config.get("public_baseurl")
+        self.delegation_address = config.get("delegation_address", None)
 
         # Whether to enable user presence.
         self.use_presence = config.get("use_presence", True)
@@ -747,6 +748,11 @@ class ServerConfig(Config):
         # synapse via the proxy.
         #
         #public_baseurl: https://example.com/
+
+        # The address (and optional port) to direct federation traffic to.
+        # Setting this option will enable .well-known delegation.
+        # See https://github.com/matrix-org/synapse/blob/master/docs/delegate.md
+        #delegation_address: synapse.example.com
 
         # Set the soft limit on the number of file descriptors synapse can use
         # Zero is used to indicate synapse should set the soft limit to the

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -133,7 +133,7 @@ class LoginRestServlet(RestServlet):
         except KeyError:
             raise SynapseError(400, "Missing JSON keys.")
 
-        well_known_data = self._well_known_builder.get_well_known()
+        well_known_data = self._well_known_builder.get_well_known_client()
         if well_known_data:
             result["well_known"] = well_known_data
         return 200, result

--- a/tests/rest/test_well_known.py
+++ b/tests/rest/test_well_known.py
@@ -24,7 +24,7 @@ class WellKnownTests(unittest.HomeserverTestCase):
         # replace the JsonResource with a WellKnownResource
         return WellKnownResource(self.hs)
 
-    def test_well_known(self):
+    def test_well_known_client(self):
         self.hs.config.public_baseurl = "https://tesths"
         self.hs.config.default_identity_server = "https://testis"
 
@@ -41,11 +41,32 @@ class WellKnownTests(unittest.HomeserverTestCase):
             },
         )
 
-    def test_well_known_no_public_baseurl(self):
+    def test_well_known_client_no_public_baseurl(self):
         self.hs.config.public_baseurl = None
 
         request, channel = self.make_request(
             "GET", "/.well-known/matrix/client", shorthand=False
+        )
+
+        self.assertEqual(request.code, 404)
+
+    def test_well_known_server(self):
+        self.hs.config.delegation_address = "https://tesths:8448"
+
+        request, channel = self.make_request(
+            "GET", "/.well-known/matrix/server", shorthand=False
+        )
+
+        self.assertEqual(request.code, 200)
+        self.assertEqual(
+            channel.json_body, {"m.server": "https://tesths:8448"},
+        )
+
+    def test_well_known_server_no_delegation_address(self):
+        self.hs.config.delegation_address = None
+
+        request, channel = self.make_request(
+            "GET", "/.well-known/matrix/server", shorthand=False
         )
 
         self.assertEqual(request.code, 404)


### PR DESCRIPTION
Adds a new option: `delegation_address` which, when set, will begin serving `.well-known/matrix/server` with the specified address as `m.server`. This allows server hosts to redirect federation traffic without the use of a reverse proxy or SRV record (especially useful if you are using traefik and hiding your instance behind cloudflare).

Closes: #8308. 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
