### PR TITLE
Add type hints to the logging context code.

### DIFF
--- a/changelog.d/8939.misc
+++ b/changelog.d/8939.misc
@@ -1,0 +1,1 @@
+Various clean-ups to the structured logging and logging context code.

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -640,12 +640,18 @@ def nested_logging_context(suffix: str) -> LoggingContext:
     Returns:
         LoggingContext: new logging context.
     """
-    context = current_context()
-    # It is not expected that a nested context would be created in the sentinel context.
-    assert isinstance(context, LoggingContext)
-    return LoggingContext(
-        parent_context=context, request=str(context.request) + "-" + suffix
-    )
+    curr_context = current_context()
+    if not curr_context:
+        logger.warning(
+            "Starting nested logging context from sentinel context: metrics will be lost"
+        )
+        parent_context = None
+        prefix = ""
+    else:
+        assert isinstance(curr_context, LoggingContext)
+        parent_context = curr_context
+        prefix = str(parent_context.request)
+    return LoggingContext(parent_context=parent_context, request=prefix + "-" + suffix)
 
 
 def preserve_fn(f):

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -616,9 +616,7 @@ def set_current_context(context: LoggingContextOrSentinel) -> LoggingContextOrSe
     return current
 
 
-def nested_logging_context(
-    suffix: str, parent_context: Optional[LoggingContext] = None
-) -> LoggingContext:
+def nested_logging_context(suffix: str) -> LoggingContext:
     """Creates a new logging context as a child of another.
 
     The nested logging context will have a 'request' made up of the parent context's
@@ -632,17 +630,14 @@ def nested_logging_context(
             # ... do stuff
 
     Args:
-        suffix (str): suffix to add to the parent context's 'request'.
-        parent_context (LoggingContext|None): parent context. Will use the current context
-            if None.
+        suffix: suffix to add to the parent context's 'request'.
 
     Returns:
         LoggingContext: new logging context.
     """
-    if parent_context is not None:
-        context = parent_context  # type: LoggingContextOrSentinel
-    else:
-        context = current_context()
+    context = current_context()
+    # It is not expected that a nested context would be created in the sentinel context.
+    assert isinstance(context, LoggingContext)
     return LoggingContext(
         parent_context=context, request=str(context.request) + "-" + suffix
     )

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -42,7 +42,6 @@ from synapse.api.errors import StoreError
 from synapse.config.database import DatabaseConnectionConfig
 from synapse.logging.context import (
     LoggingContext,
-    LoggingContextOrSentinel,
     current_context,
     make_deferred_yieldable,
 )
@@ -671,12 +670,15 @@ class DatabasePool:
         Returns:
             The result of func
         """
-        parent_context = current_context()  # type: Optional[LoggingContextOrSentinel]
-        if not parent_context:
+        curr_context = current_context()
+        if not curr_context:
             logger.warning(
                 "Starting db connection from sentinel context: metrics will be lost"
             )
             parent_context = None
+        else:
+            assert isinstance(curr_context, LoggingContext)
+            parent_context = curr_context
 
         start_time = monotonic_time()
 

--- a/synapse/util/metrics.py
+++ b/synapse/util/metrics.py
@@ -108,7 +108,12 @@ class Measure:
     def __init__(self, clock, name):
         self.clock = clock
         self.name = name
-        parent_context = current_context()
+        curr_context = current_context()
+        if not curr_context:
+            parent_context = None
+        else:
+            assert isinstance(curr_context, LoggingContext)
+            parent_context = curr_context
         self._logging_context = LoggingContext(
             "Measure[%s]" % (self.name,), parent_context
         )

--- a/synapse/util/metrics.py
+++ b/synapse/util/metrics.py
@@ -110,6 +110,9 @@ class Measure:
         self.name = name
         curr_context = current_context()
         if not curr_context:
+            logger.warning(
+                "Starting metrics collection from sentinel context: metrics will be lost"
+            )
             parent_context = None
         else:
             assert isinstance(curr_context, LoggingContext)


### PR DESCRIPTION
A bit more prep for #8683.

* Adds additional type hints to the logging code.
* Removes an unused parameter from `nested_logging_context` (I meant for this to go into #8935, sorry about that).

Each commit is reviewable separately.