### PR TITLE
Allow password providers to potentially skip UI authentication.

### DIFF
--- a/changelog.d/8949.feature
+++ b/changelog.d/8949.feature
@@ -1,0 +1,1 @@
+Password providers can now choose to skip user-interactive authentication.

--- a/docs/password_auth_providers.md
+++ b/docs/password_auth_providers.md
@@ -112,6 +112,17 @@ Password auth provider classes may optionally provide the following methods:
   The method should return an `Awaitable` object, which resolves
   to `True` if authentication is successful, and `False` if not.
 
+* `skip_ui_auth(self, user_id, device_id, request)`
+
+  This method, if implemented, is called before a user is prompted to perform
+  user-interactive authentication. It is passed the qualified user ID, and the
+  device ID making the request.
+
+  The method should return an `Awaitable` object, which resolves
+  to `True` if the user-interactive authentication process should be skipped
+  (and the request allowed to proceed),  and `False` if the user-interactive
+  authentication process should continue as normal.
+
 * `on_logged_out(self, user_id, device_id, access_token)`
 
   This method, if implemented, is called when a user logs out. It is


### PR DESCRIPTION
This allows a password provider to implement a new method -- `skip_ui_auth` which returns a boolean to potentially skip UI auth. This will allow plug-ins to potentially skip user-interactive authentication in particular situations.

I'm not 100% sold on this approach, but it seems better than some of the other discussions we've had -- essentially by pushing the logic onto a plug-in author instead of including it in Synapse.

Fixes #8912