### PR TITLE
Fix generate_log_config script

### DIFF
--- a/changelog.d/8952.misc
+++ b/changelog.d/8952.misc
@@ -1,0 +1,1 @@
+Fix bug in `generate_log_config` script which made it write empty files.

--- a/scripts/generate_log_config
+++ b/scripts/generate_log_config
@@ -40,4 +40,6 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    args.output_file.write(DEFAULT_LOG_CONFIG.substitute(log_file=args.log_file))
+    out = args.output_file
+    out.write(DEFAULT_LOG_CONFIG.substitute(log_file=args.log_file))
+    out.flush()


### PR DESCRIPTION
It used to write an empty file if you gave it a -o arg. Empirically, doing a `flush` fixes it...