### PR TITLE
Fix the sample config location for the ip_range_whitelist setting.

### DIFF
--- a/changelog.d/8954.feature
+++ b/changelog.d/8954.feature
@@ -1,0 +1,1 @@
+Apply an IP range blacklist to push and key revocation requests.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -173,6 +173,18 @@ pid_file: DATADIR/homeserver.pid
 #  - 'fe80::/10'
 #  - 'fc00::/7'
 
+# List of IP address CIDR ranges that should be allowed for federation,
+# identity servers, push servers, and for checking key validity for
+# third-party invite events. This is useful for specifying exceptions to
+# wide-ranging blacklisted target IP ranges - e.g. for communication with
+# a push server only visible in your network.
+#
+# This whitelist overrides ip_range_blacklist and defaults to an empty
+# list.
+#
+#ip_range_whitelist:
+#   - '192.168.1.1'
+
 # List of ports that Synapse should listen on, their purpose and their
 # configuration.
 #
@@ -670,18 +682,6 @@ acme:
 #  - lon.example.com
 #  - nyc.example.com
 #  - syd.example.com
-
-# List of IP address CIDR ranges that should be allowed for federation,
-# identity servers, push servers, and for checking key validity for
-# third-party invite events. This is useful for specifying exceptions to
-# wide-ranging blacklisted target IP ranges - e.g. for communication with
-# a push server only visible in your network.
-#
-# This whitelist overrides ip_range_blacklist and defaults to an empty
-# list.
-#
-#ip_range_whitelist:
-#   - '192.168.1.1'
 
 # Report prometheus metrics on the age of PDUs being sent to and received from
 # the following domains. This can be used to give an idea of "delay" on inbound

--- a/synapse/config/federation.py
+++ b/synapse/config/federation.py
@@ -56,18 +56,6 @@ class FederationConfig(Config):
         #  - nyc.example.com
         #  - syd.example.com
 
-        # List of IP address CIDR ranges that should be allowed for federation,
-        # identity servers, push servers, and for checking key validity for
-        # third-party invite events. This is useful for specifying exceptions to
-        # wide-ranging blacklisted target IP ranges - e.g. for communication with
-        # a push server only visible in your network.
-        #
-        # This whitelist overrides ip_range_blacklist and defaults to an empty
-        # list.
-        #
-        #ip_range_whitelist:
-        #   - '192.168.1.1'
-
         # Report prometheus metrics on the age of PDUs being sent to and received from
         # the following domains. This can be used to give an idea of "delay" on inbound
         # and outbound federation, though be aware that any delay can be due to problems

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -832,6 +832,18 @@ class ServerConfig(Config):
         #ip_range_blacklist:
 %(ip_range_blacklist)s
 
+        # List of IP address CIDR ranges that should be allowed for federation,
+        # identity servers, push servers, and for checking key validity for
+        # third-party invite events. This is useful for specifying exceptions to
+        # wide-ranging blacklisted target IP ranges - e.g. for communication with
+        # a push server only visible in your network.
+        #
+        # This whitelist overrides ip_range_blacklist and defaults to an empty
+        # list.
+        #
+        #ip_range_whitelist:
+        #   - '192.168.1.1'
+
         # List of ports that Synapse should listen on, their purpose and their
         # configuration.
         #


### PR DESCRIPTION
This should have been done in #8870, we moved the `ip_range_blacklist` setting in there from federation config to server config, but failed to move `ip_range_whitelist`.

No functional changes, just updating the sample configs.