### PR TITLE
Use the simple dictionary in fts for the user directory

### DIFF
--- a/changelog.d/8959.bugfix
+++ b/changelog.d/8959.bugfix
@@ -1,0 +1,1 @@
+Fix a bug causing common English words to not be considered for a user directory search.

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -393,9 +393,9 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                     sql = """
                         INSERT INTO user_directory_search(user_id, vector)
                         VALUES (?,
-                            setweight(to_tsvector('english', ?), 'A')
-                            || setweight(to_tsvector('english', ?), 'D')
-                            || setweight(to_tsvector('english', COALESCE(?, '')), 'B')
+                            setweight(to_tsvector('simple', ?), 'A')
+                            || setweight(to_tsvector('simple', ?), 'D')
+                            || setweight(to_tsvector('simple', COALESCE(?, '')), 'B')
                         ) ON CONFLICT (user_id) DO UPDATE SET vector=EXCLUDED.vector
                     """
                     txn.execute(
@@ -415,9 +415,9 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                         sql = """
                             INSERT INTO user_directory_search(user_id, vector)
                             VALUES (?,
-                                setweight(to_tsvector('english', ?), 'A')
-                                || setweight(to_tsvector('english', ?), 'D')
-                                || setweight(to_tsvector('english', COALESCE(?, '')), 'B')
+                                setweight(to_tsvector('simple', ?), 'A')
+                                || setweight(to_tsvector('simple', ?), 'D')
+                                || setweight(to_tsvector('simple', COALESCE(?, '')), 'B')
                             )
                         """
                         txn.execute(
@@ -432,9 +432,9 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                     elif new_entry is False:
                         sql = """
                             UPDATE user_directory_search
-                            SET vector = setweight(to_tsvector('english', ?), 'A')
-                                || setweight(to_tsvector('english', ?), 'D')
-                                || setweight(to_tsvector('english', COALESCE(?, '')), 'B')
+                            SET vector = setweight(to_tsvector('simple', ?), 'A')
+                                || setweight(to_tsvector('simple', ?), 'D')
+                                || setweight(to_tsvector('simple', COALESCE(?, '')), 'B')
                             WHERE user_id = ?
                         """
                         txn.execute(
@@ -761,7 +761,7 @@ class UserDirectoryStore(UserDirectoryBackgroundUpdateStore):
                 INNER JOIN user_directory AS d USING (user_id)
                 WHERE
                     %s
-                    AND vector @@ to_tsquery('english', ?)
+                    AND vector @@ to_tsquery('simple', ?)
                 ORDER BY
                     (CASE WHEN d.user_id IS NOT NULL THEN 4.0 ELSE 1.0 END)
                     * (CASE WHEN display_name IS NOT NULL THEN 1.2 ELSE 1.0 END)
@@ -770,13 +770,13 @@ class UserDirectoryStore(UserDirectoryBackgroundUpdateStore):
                         3 * ts_rank_cd(
                             '{0.1, 0.1, 0.9, 1.0}',
                             vector,
-                            to_tsquery('english', ?),
+                            to_tsquery('simple', ?),
                             8
                         )
                         + ts_rank_cd(
                             '{0.1, 0.1, 0.9, 1.0}',
                             vector,
-                            to_tsquery('english', ?),
+                            to_tsquery('simple', ?),
                             8
                         )
                     )

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -21,6 +21,7 @@ from tests.utils import setup_test_homeserver
 ALICE = "@alice:a"
 BOB = "@bob:b"
 BOBBY = "@bobby:a"
+# The localpart isn't 'Bela' on purpose so we can test looking up display names.
 BELA = "@somenickname:a"
 
 

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -21,6 +21,7 @@ from tests.utils import setup_test_homeserver
 ALICE = "@alice:a"
 BOB = "@bob:b"
 BOBBY = "@bobby:a"
+BELA = "@somenickname:a"
 
 
 class UserDirectoryStoreTestCase(unittest.TestCase):
@@ -39,6 +40,9 @@ class UserDirectoryStoreTestCase(unittest.TestCase):
         )
         yield defer.ensureDeferred(
             self.store.update_profile_in_user_dir(BOBBY, "bobby", None)
+        )
+        yield defer.ensureDeferred(
+            self.store.update_profile_in_user_dir(BELA, "Bela", None)
         )
         yield defer.ensureDeferred(
             self.store.add_users_in_public_rooms("!room:id", (ALICE, BOB))
@@ -69,6 +73,24 @@ class UserDirectoryStoreTestCase(unittest.TestCase):
             self.assertDictEqual(
                 r["results"][1],
                 {"user_id": BOBBY, "display_name": "bobby", "avatar_url": None},
+            )
+        finally:
+            self.hs.config.user_directory_search_all_users = False
+
+    @defer.inlineCallbacks
+    def test_search_user_dir_stop_words(self):
+        """Tests that a user can look up another user by searching for the start if its
+        display name even if that name happens to be a common English word that would
+        usually be ignored in full text searches.
+        """
+        self.hs.config.user_directory_search_all_users = True
+        try:
+            r = yield defer.ensureDeferred(self.store.search_user_dir(ALICE, "be", 10))
+            self.assertFalse(r["limited"])
+            self.assertEqual(1, len(r["results"]))
+            self.assertDictEqual(
+                r["results"][0],
+                {"user_id": BELA, "display_name": "Bela", "avatar_url": None},
             )
         finally:
             self.hs.config.user_directory_search_all_users = False


### PR DESCRIPTION
Some user directory searches would fail because PostgreSQL would ignore common English words. For example, when looking up a user with the display name "Bela":

```
$ curl -H "Authorization: Bearer [...]" https://trelawney.brendanabolivier.com/_matrix/client/r0/user_directory/search -d '{"search_term": "b"}'
{"limited":false,"results":[{"user_id":"@sometestuser:labs.abolivier.bzh","display_name":"Bela","avatar_url":null}]}
$ curl -H "Authorization: Bearer [...]" https://trelawney.brendanabolivier.com/_matrix/client/r0/user_directory/search -d '{"search_term": "be"}' 
{"limited":false,"results":[]}
```

In this example, it identifies "be" as a common English word and don't consider it for a full text search.

The fix to this is to use the "simple" dictionary which doesn't have any stop word, i.e. any common word that needs to be ignored when running a full text search. The result of that change in the example above is:

```
$ curl -H "Authorization: Bearer [...]" https://trelawney.brendanabolivier.com/_matrix/client/r0/user_directory/search -d '{"search_term": "b"}'
{"limited":false,"results":[{"user_id":"@sometestuser:labs.abolivier.bzh","display_name":"Bela","avatar_url":null}]}
$ curl -H "Authorization: Bearer [...]" https://trelawney.brendanabolivier.com/_matrix/client/r0/user_directory/search -d '{"search_term": "be"}'
{"limited":false,"results":[{"user_id":"@sometestuser:labs.abolivier.bzh","display_name":"Bela","avatar_url":null}]}
```

Looking up "be" now correctly yields our "Bela" user in the search results.

fwiw my initial intention is mostly to fix this for `search_user_dir` but I've also changed `_update_profile_in_user_dir_txn` that way for consistency.