### PR TITLE
Ensure that a URL exists in the content during push.

### DIFF
--- a/changelog.d/8965.bugfix
+++ b/changelog.d/8965.bugfix
@@ -1,0 +1,1 @@
+Fix a longstanding bug where a `m.image` event without a `url` would cause errors on push.

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -486,7 +486,11 @@ class Mailer:
     def add_image_message_vars(
         self, messagevars: Dict[str, Any], event: EventBase
     ) -> None:
-        messagevars["image_url"] = event.content["url"]
+        """
+        Potentially add an image URL to the message variables.
+        """
+        if "url" in event.content:
+            messagevars["image_url"] = event.content["url"]
 
     async def make_summary_text(
         self,

--- a/synapse/res/templates/notif.html
+++ b/synapse/res/templates/notif.html
@@ -29,7 +29,7 @@
                         {{ message.body_text_html }}
                     {%- elif message.msgtype == "m.notice" %}
                         {{ message.body_text_html }}
-                    {%- elif message.msgtype == "m.image" %}
+                    {%- elif message.msgtype == "m.image" and message.image_url %}
                         <img src="{{ message.image_url|mxc_to_http(640, 480, scale) }}" />
                     {%- elif message.msgtype == "m.file" %}
                         <span class="filename">{{ message.body_text_plain }}</span>


### PR DESCRIPTION
Fixes a somewhat frequent Sentry error: https://sentry.matrix.org/sentry/synapse-matrixorg/issues/123367/events/2813465/

I think it is OK to just not add the URL in this case and the templates will handle it OK.