### PR TITLE
Validate input parameters for the sendToDevice API.

### DIFF
--- a/changelog.d/8975.bugfix
+++ b/changelog.d/8975.bugfix
@@ -1,0 +1,1 @@
+Add validation to the `sendToDevice` API to raise a missing parameters error instead of a 500 error.

--- a/synapse/rest/client/v2_alpha/sendtodevice.py
+++ b/synapse/rest/client/v2_alpha/sendtodevice.py
@@ -17,7 +17,7 @@ import logging
 from typing import Tuple
 
 from synapse.http import servlet
-from synapse.http.servlet import parse_json_object_from_request
+from synapse.http.servlet import assert_params_in_dict, parse_json_object_from_request
 from synapse.logging.opentracing import set_tag, trace
 from synapse.rest.client.transactions import HttpTransactionCache
 
@@ -54,6 +54,7 @@ class SendToDeviceRestServlet(servlet.RestServlet):
         requester = await self.auth.get_user_by_req(request, allow_guest=True)
 
         content = parse_json_object_from_request(request)
+        assert_params_in_dict(content, ("messages",))
 
         sender_user_id = requester.user.to_string()
 

--- a/synapse/rest/client/v2_alpha/sendtodevice.py
+++ b/synapse/rest/client/v2_alpha/sendtodevice.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 
 import logging
+from typing import Tuple
 
 from synapse.http import servlet
-from synapse.http.servlet import parse_json_object_from_request
+from synapse.http.servlet import assert_params_in_dict, parse_json_object_from_request
 from synapse.logging.opentracing import set_tag, trace
 from synapse.rest.client.transactions import HttpTransactionCache
 
@@ -53,18 +54,16 @@ class SendToDeviceRestServlet(servlet.RestServlet):
         requester = await self.auth.get_user_by_req(request, allow_guest=True)
 
         content = parse_json_object_from_request(request)
+        assert_params_in_dict(content, ("messages",))
 
-        # Messages is optional, but there is nothing for the server to do if it
-        # is not provided (or is empty).
-        messages = content.get("messages")
-        if messages:
-            sender_user_id = requester.user.to_string()
+        sender_user_id = requester.user.to_string()
 
-            await self.device_message_handler.send_device_message(
-                sender_user_id, message_type, messages
-            )
+        await self.device_message_handler.send_device_message(
+            sender_user_id, message_type, content["messages"]
+        )
 
-        return 200, {}
+        response = (200, {})  # type: Tuple[int, dict]
+        return response
 
 
 def register_servlets(hs, http_server):


### PR DESCRIPTION
Properly handle if the `messages` parameter isn't provided.

See https://sentry.matrix.org/sentry/synapse-matrixorg/issues/127685/
