### PR TITLE
Drop the local_invites table.

### DIFF
--- a/changelog.d/8979.misc
+++ b/changelog.d/8979.misc
@@ -1,0 +1,1 @@
+Drop the unused `local_invites` table.

--- a/synapse/storage/databases/main/schema/delta/58/27local_invites.sql
+++ b/synapse/storage/databases/main/schema/delta/58/27local_invites.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- This is unused since Synapse v1.17.0.
+DROP TABLE local_invites;

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1598,7 +1598,6 @@ PURGE_TABLES = [
     "event_push_summary",
     "pusher_throttle",
     "group_summary_rooms",
-    "local_invites",
     "room_account_data",
     "room_tags",
     # "state_groups",  # Current impl leaves orphaned state groups around.


### PR DESCRIPTION
Per #7807, I think we can drop this table since `local_invites` has been unused since v1.17.0.