### PR TITLE
Support PyJWT v2.0.0.

### DIFF
--- a/changelog.d/8986.misc
+++ b/changelog.d/8986.misc
@@ -1,0 +1,1 @@
+Support using PyJWT v2.0.0 in the test suite.

--- a/tests/rest/client/v1/test_login.py
+++ b/tests/rest/client/v1/test_login.py
@@ -475,8 +475,12 @@ class JWTTestCase(unittest.HomeserverTestCase):
         self.hs.config.jwt_algorithm = self.jwt_algorithm
         return self.hs
 
-    def jwt_encode(self, token, secret=jwt_secret):
-        return jwt.encode(token, secret, self.jwt_algorithm).decode("ascii")
+    def jwt_encode(self, token: str, secret: str = jwt_secret) -> str:
+        # PyJWT 2.0.0 changed the return type of jwt.encode from bytes to str.
+        result = jwt.encode(token, secret, self.jwt_algorithm)
+        if isinstance(result, bytes):
+            return result.decode("ascii")
+        return result
 
     def jwt_login(self, *args):
         params = json.dumps(
@@ -680,8 +684,12 @@ class JWTPubKeyTestCase(unittest.HomeserverTestCase):
         self.hs.config.jwt_algorithm = "RS256"
         return self.hs
 
-    def jwt_encode(self, token, secret=jwt_privatekey):
-        return jwt.encode(token, secret, "RS256").decode("ascii")
+    def jwt_encode(self, token: str, secret: str = jwt_privatekey) -> str:
+        # PyJWT 2.0.0 changed the return type of jwt.encode from bytes to str.
+        result = jwt.encode(token, secret, "RS256")
+        if isinstance(result, bytes):
+            return result.decode("ascii")
+        return result
 
     def jwt_login(self, *args):
         params = json.dumps(


### PR DESCRIPTION
Fixes #8985.

It seems that the APIs we use in Synapse still work, but one of the APIs we use in our tests changed from returning bytes to str. This change was done on purpose by the maintainer and is expected.