### PR TITLE
Fix RoomDirectoryFederationTests and make them actually run

### DIFF
--- a/changelog.d/8998.misc
+++ b/changelog.d/8998.misc
@@ -1,0 +1,1 @@
+Fix `tests.federation.transport.RoomDirectoryFederationTests` and ensure it runs in CI.

--- a/tests/federation/transport/test_server.py
+++ b/tests/federation/transport/test_server.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 The Matrix.org Foundation C.I.C.
+# Copyright 2020 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,34 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from twisted.internet import defer
-
-from synapse.config.ratelimiting import FederationRateLimitConfig
-from synapse.federation.transport import server
-from synapse.util.ratelimitutils import FederationRateLimiter
-
 from tests import unittest
 from tests.unittest import override_config
 
 
-class RoomDirectoryFederationTests(unittest.HomeserverTestCase):
-    def prepare(self, reactor, clock, homeserver):
-        class Authenticator:
-            def authenticate_request(self, request, content):
-                return defer.succeed("otherserver.nottld")
-
-        ratelimiter = FederationRateLimiter(clock, FederationRateLimitConfig())
-        server.register_servlets(
-            homeserver, self.resource, Authenticator(), ratelimiter
-        )
-
+class RoomDirectoryFederationTests(unittest.FederatingHomeserverTestCase):
     @override_config({"allow_public_rooms_over_federation": False})
     def test_blocked_public_room_list_over_federation(self):
-        channel = self.make_request("GET", "/_matrix/federation/v1/publicRooms")
+        """Test that unauthenticated requests to the public rooms directory 403 when
+        allow_public_rooms_over_federation is False.
+        """
+        channel = self.make_request(
+            "GET",
+            "/_matrix/federation/v1/publicRooms",
+            federation_auth_origin=b"example.com",
+        )
         self.assertEquals(403, channel.code)
 
     @override_config({"allow_public_rooms_over_federation": True})
     def test_open_public_room_list_over_federation(self):
-        channel = self.make_request("GET", "/_matrix/federation/v1/publicRooms")
+        """Test that unauthenticated requests to the public rooms directory 200 when
+        allow_public_rooms_over_federation is True.
+        """
+        channel = self.make_request(
+            "GET",
+            "/_matrix/federation/v1/publicRooms",
+            federation_auth_origin=b"example.com",
+        )
         self.assertEquals(200, channel.code)


### PR DESCRIPTION
The `RoomDirectoryFederationTests` tests were not being run unless explicitly called as an `__init__.py` file was not present in `tests/federation/transport/`. Thus the folder was not a python module, and `trial` did not look inside for any test cases to run. This was found while working on #6739.

This PR adds a `__init__.py` and also fixes the test in a couple ways:

- Switch to subclassing `unittest.FederatingHomeserverTestCase` instead, which sets up federation endpoints for us.
- Supply a `federation_auth_origin` to `make_request` in order to more act like the request is coming from another server, instead of just an unauthenicated client requesting a federation endpoint.

I found that the second point makes no difference to the test passing, but felt like the right thing to do if we're testing over federation.