### PR TITLE
Account deactivation: Add info on leaving rooms

### DIFF
--- a/changelog.d/9005.doc
+++ b/changelog.d/9005.doc
@@ -1,0 +1,1 @@
+Add information on the automatic leaving of rooms when using the user deactivation admin API.

--- a/docs/admin_api/user_admin_api.rst
+++ b/docs/admin_api/user_admin_api.rst
@@ -220,8 +220,8 @@ Deactivate Account
 ==================
 
 This API deactivates an account. It removes active access tokens, resets the
-password, and deletes third-party IDs (to prevent the user requesting a
-password reset).
+password, deletes third-party IDs (to prevent the user requesting a
+password reset), and makes the user leave all rooms.
 
 It can also mark the user as GDPR-erased. This means messages sent by the
 user will still be visible by anyone that was in the room when these messages


### PR DESCRIPTION
Deactivating an account - in addition to the already listed things - also makes the user leave all rooms they are in.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Signed-off-by: FadenB <fadenb@utzutzutz.net>