### PR TITLE
Ignore date-rotated logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ _trial_temp*/
 # stuff that is likely to exist when you run a server locally
 /*.db
 /*.log
+/*.log.*
 /*.log.config
 /*.pid
 /.python-version

--- a/changelog.d/9018.misc
+++ b/changelog.d/9018.misc
@@ -1,0 +1,1 @@
+Ignore date-rotated homeserver logs saved to disk.


### PR DESCRIPTION
Ignore date-rotated logs

Ex.

 - `homeserver.log.2020-12-29`
 - `homeserver.log.2020-12-31`

```sh
$ git status
On branch 8996-fix-sqlite-object-name-reserved-for-internal-use
Your branch is up to date with 'origin/8996-fix-sqlite-object-name-reserved-for-internal-use'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        .DS_Store
        homeserver.log.2020-12-29
        homeserver.log.2020-12-31

nothing added to commit but untracked files present (use "git add" to track)
```

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
