### PR TITLE
Add a 10-minute cache to room directory query results.

### DIFF
--- a/changelog.d/9019.feature
+++ b/changelog.d/9019.feature
@@ -1,0 +1,1 @@
+Add a 10-minute cache to room directory query results.

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -44,7 +44,7 @@ class RoomListHandler(BaseHandler):
         super().__init__(hs)
         self.enable_room_list_search = hs.config.enable_room_list_search
         self.response_cache = ResponseCache(
-            hs, "room_list"
+            hs, "room_list", timeout_ms=10 * 60 * 1000
         )  # type: ResponseCache[Tuple[Optional[int], Optional[str], ThirdPartyInstanceID]]
         self.remote_response_cache = ResponseCache(
             hs, "remote_room_list", timeout_ms=30 * 1000


### PR DESCRIPTION
This is a backport of a285fe05fd7bfcca3953976e7b3356dc39b020a7 from matrix-org-hotfixes to develop; that difference annoyed me today because I had to resolve a conflict, so I'd like to resolve the difference one way or the other.

The general premise seems reasonable: cache the results of room directory lookups for 10 minutes. What I don't really know is why the change was only made on m-o-hotfixes.

I'm also not sure if it is still required: there was a bunch of optimisation work done on the room directory in summer 2019 (see #6019 and friends) which post-dates a285fe05fd7bfcca3953976e7b3356dc39b020a7, so an alternative approach might be to remove the cache on matrix-org-hotfixes.