### PR TITLE
Handle a display name / avatar URL not returned via a federation request.

### DIFF
--- a/changelog.d/9023.bugfix
+++ b/changelog.d/9023.bugfix
@@ -1,0 +1,1 @@
+Fix a longstanding issue where an internal server error would occur when requesting a profile over federation that did not include a display name / avatar URL.

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -156,7 +156,7 @@ class ProfileHandler(BaseHandler):
             except HttpResponseException as e:
                 raise e.to_synapse_error()
 
-            return result["displayname"]
+            return result.get("displayname")
 
     async def set_displayname(
         self,
@@ -246,7 +246,7 @@ class ProfileHandler(BaseHandler):
             except HttpResponseException as e:
                 raise e.to_synapse_error()
 
-            return result["avatar_url"]
+            return result.get("avatar_url")
 
     async def set_avatar_url(
         self,


### PR DESCRIPTION
The federation request for a profile does not have to include the display name / avatar, e.g. from [the spec](https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-query-profile):

> The display name of the user. May be omitted if the user does not have a display name set.
> The avatar URL for the user's avatar. May be omitted if the user does not have an avatar set.

Fixes https://sentry.matrix.org/sentry/synapse-matrixorg/issues/194164/