### PR TITLE
tox: Add a -noextras factor

### DIFF
--- a/changelog.d/9030.misc
+++ b/changelog.d/9030.misc
@@ -1,0 +1,1 @@
+Add a `-noextras` factor to `tox.ini`, to support running the tests with no optional dependencies.

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = packaging, py35, py36, py37, py38, py39, check_codestyle, check_isort
 
 [base]
-extras = test
 deps =
     python-subunit
     junitxml
@@ -25,10 +24,15 @@ deps =
     # install the "enum34" dependency of cryptography.
     pip>=10
 
+# default settings for all tox environments
 [testenv]
 deps =
     {[base]deps}
-extras = all, test
+extras =
+    # install the optional dependendencies for tox environments without
+    # '-noextras' in their name
+    !noextras: all
+    test
 
 setenv =
     # use a postgres db for tox environments with "-postgres" in the name


### PR DESCRIPTION
... for running the tests with no optional deps.

The idea here is that you can go `tox -e py36-noextras` to run with python36 and no optional dependencies.