### PR TITLE
Skip unit tests which require optional dependencies

### DIFF
--- a/changelog.d/9031.misc
+++ b/changelog.d/9031.misc
@@ -1,0 +1,1 @@
+Fix running unit tests when optional dependencies are not installed.

--- a/tests/rest/client/v1/test_login.py
+++ b/tests/rest/client/v1/test_login.py
@@ -4,7 +4,10 @@ import urllib.parse
 
 from mock import Mock
 
-import jwt
+try:
+    import jwt
+except ImportError:
+    jwt = None
 
 import synapse.rest.admin
 from synapse.appservice import ApplicationService
@@ -460,6 +463,9 @@ class CASTestCase(unittest.HomeserverTestCase):
 
 
 class JWTTestCase(unittest.HomeserverTestCase):
+    if not jwt:
+        skip = "requires jwt"
+
     servlets = [
         synapse.rest.admin.register_servlets_for_client_rest_resource,
         login.register_servlets,
@@ -628,6 +634,9 @@ class JWTTestCase(unittest.HomeserverTestCase):
 # RSS256, with a public key configured in synapse as "jwt_secret", and tokens
 # signed by the private key.
 class JWTPubKeyTestCase(unittest.HomeserverTestCase):
+    if not jwt:
+        skip = "requires jwt"
+
     servlets = [
         login.register_servlets,
     ]

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -26,8 +26,15 @@ from twisted.test.proto_helpers import AccumulatingProtocol
 from tests import unittest
 from tests.server import FakeTransport
 
+try:
+    import lxml
+except ImportError:
+    lxml = None
+
 
 class URLPreviewTests(unittest.HomeserverTestCase):
+    if not lxml:
+        skip = "url preview feature requires lxml"
 
     hijack_auth = True
     user_id = "@test:user"

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -20,8 +20,16 @@ from synapse.rest.media.v1.preview_url_resource import (
 
 from . import unittest
 
+try:
+    import lxml
+except ImportError:
+    lxml = None
+
 
 class PreviewTestCase(unittest.TestCase):
+    if not lxml:
+        skip = "url preview feature requires lxml"
+
     def test_long_summarize(self):
         example_paras = [
             """Tromsø (Norwegian pronunciation: [ˈtrʊmsœ] ( listen); Northern Sami:
@@ -137,6 +145,9 @@ class PreviewTestCase(unittest.TestCase):
 
 
 class PreviewUrlTestCase(unittest.TestCase):
+    if not lxml:
+        skip = "url preview feature requires lxml"
+
     def test_simple(self):
         html = """
         <html>

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -20,7 +20,7 @@ import hmac
 import inspect
 import logging
 import time
-from typing import Dict, Iterable, Optional, Tuple, Type, TypeVar, Union
+from typing import Callable, Dict, Iterable, Optional, Tuple, Type, TypeVar, Union
 
 from mock import Mock, patch
 
@@ -734,5 +734,31 @@ def override_config(extra_config):
     def decorator(func):
         func._extra_config = extra_config
         return func
+
+    return decorator
+
+
+TV = TypeVar("TV")
+
+
+def skip_unless(condition: bool, reason: str) -> Callable[[TV], TV]:
+    """A test decorator which will skip the decorated test unless a condition is set
+
+    For example:
+
+    class MyTestCase(TestCase):
+        @skip_unless(HAS_FOO, "Cannot test without foo")
+        def test_foo(self):
+            ...
+
+    Args:
+        condition: If true, the test will be skipped
+        reason: the reason to give for skipping the test
+    """
+
+    def decorator(f: TV) -> TV:
+        if not condition:
+            f.skip = reason  # type: ignore
+        return f
 
     return decorator


### PR DESCRIPTION
If we are lacking an optional dependency, skip the tests that rely on it.