### PR TITLE
Handle updating schema version without any deltas.

### DIFF
--- a/changelog.d/9033.misc
+++ b/changelog.d/9033.misc
@@ -1,0 +1,1 @@
+Allow bumping schema version when using split out state database.

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -489,11 +489,10 @@ def _upgrade_existing_database(
                 (v, relative_path),
             )
 
-            cur.execute("DELETE FROM schema_version")
-            cur.execute(
-                "INSERT INTO schema_version (version, upgraded) VALUES (?,?)",
-                (v, True),
-            )
+        cur.execute("DELETE FROM schema_version")
+        cur.execute(
+            "INSERT INTO schema_version (version, upgraded) VALUES (?,?)", (v, True),
+        )
 
     logger.info("Schema now up to date")
 

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -375,7 +375,16 @@ def _upgrade_existing_database(
     specific_engine_extensions = (".sqlite", ".postgres")
 
     for v in range(start_ver, SCHEMA_VERSION + 1):
-        logger.info("Applying schema deltas for v%d", v)
+        if not is_worker:
+            logger.info("Applying schema deltas for v%d", v)
+
+            cur.execute("DELETE FROM schema_version")
+            cur.execute(
+                "INSERT INTO schema_version (version, upgraded) VALUES (?,?)",
+                (v, True),
+            )
+        else:
+            logger.info("Checking schema deltas for v%d", v)
 
         # We need to search both the global and per data store schema
         # directories for schema updates.
@@ -488,11 +497,6 @@ def _upgrade_existing_database(
                 "INSERT INTO applied_schema_deltas (version, file) VALUES (?,?)",
                 (v, relative_path),
             )
-
-        cur.execute("DELETE FROM schema_version")
-        cur.execute(
-            "INSERT INTO schema_version (version, upgraded) VALUES (?,?)", (v, True),
-        )
 
     logger.info("Schema now up to date")
 


### PR DESCRIPTION
This can happen when using a split out state database and we've upgraded the schema version without there being any changes in the state schema.
