### PR TITLE
Fix error handling during insertion of client IPs

### DIFF
--- a/changelog.d/9051.bugfix
+++ b/changelog.d/9051.bugfix
@@ -1,0 +1,1 @@
+Fix error handling during insertion of client IPs into the database.


### PR DESCRIPTION
You can't continue using a transaction once an exception has been raised, so catching and dropping the error here is pointless and just causes more errors.

This PR just removes the try/except.

The errors look like:

`2021-01-08 14:00:25,524 - synapse.storage.databases.main.client_ips - 508 - ERROR - update_client_ips-1615 - Failed to insert client IP (('<user>', '<token>', '<ip>'), ('<user_agent>', '<device_id>', <ts>)): InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\n')`
