### PR TITLE
Track CPU usage of DB transactions

### DIFF
--- a/changelog.d/9056.misc
+++ b/changelog.d/9056.misc
@@ -1,0 +1,1 @@
+Add metrics to track CPU time spent in database transactions.


### PR DESCRIPTION
Some transactions have quite a lot of logic in them, so it'd be good to be able to tell if we're spending lots of time doing CPU work in them versus idly waiting for the DB to respond.

I also don't think we report these CPU metrics in the parent contexts, despite it looking like we should be picked up by `runWithConnection`:

https://github.com/matrix-org/synapse/blob/06fefe0bb19d5ef0a5873ea5697e2018ce9e6026/synapse/storage/database.py#L693

as it looks like we only ever track CPU usage in log context on the main thread:

https://github.com/matrix-org/synapse/blob/06fefe0bb19d5ef0a5873ea5697e2018ce9e6026/synapse/logging/context.py#L444-L446

However, if we did also track CPU usage from other threads then we may also pick up "harmless" CPU usage, i.e. stuff that is happening outside the GIL.