### PR TITLE
Keycloak mapping_provider example (#9037)

### DIFF
--- a/changelog.d/9057.doc
+++ b/changelog.d/9057.doc
@@ -1,0 +1,1 @@
+Added missing user_mapping_provider configuration to the Keycloak OIDC example.

--- a/changelog.d/9057.doc
+++ b/changelog.d/9057.doc
@@ -1,1 +1,1 @@
-Added missing user_mapping_provider configuration to the Keycloak OIDC example.
+Add missing user_mapping_provider configuration to the Keycloak OIDC example. Contributed by @chris-ruecker.

--- a/docs/openid.md
+++ b/docs/openid.md
@@ -158,6 +158,10 @@ oidc_config:
    client_id: "synapse"
    client_secret: "copy secret generated from above"
    scopes: ["openid", "profile"]
+   user_mapping_provider:
+     config:
+       localpart_template: "{{ user.preferred_username }}"
+       display_name_template: "{{ user.name }}"
 ```
 ### [Auth0][auth0]
 


### PR DESCRIPTION
This PR adds the missing user_mapping_provider section in [oidc.md](https://github.com/matrix-org/synapse/blob/develop/docs/openid.md#keycloak)


Signed-off-by: Christopher Rücker <chris-ruecker@protonmail.com>