### PR TITLE
Preparatory refactors of OidcHandler

### DIFF
--- a/changelog.d/9067.feature
+++ b/changelog.d/9067.feature
@@ -1,0 +1,1 @@
+Add support for multiple SSO Identity Providers.

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -349,9 +349,13 @@ class OidcHandlerTestCase(HomeserverTestCase):
         cookie = args[1]
 
         macaroon = pymacaroons.Macaroon.deserialize(cookie)
-        state = self.handler._get_value_from_macaroon(macaroon, "state")
-        nonce = self.handler._get_value_from_macaroon(macaroon, "nonce")
-        redirect = self.handler._get_value_from_macaroon(
+        state = self.handler._token_generator._get_value_from_macaroon(
+            macaroon, "state"
+        )
+        nonce = self.handler._token_generator._get_value_from_macaroon(
+            macaroon, "nonce"
+        )
+        redirect = self.handler._token_generator._get_value_from_macaroon(
             macaroon, "client_redirect_url"
         )
 
@@ -839,7 +843,7 @@ class OidcHandlerTestCase(HomeserverTestCase):
     ) -> str:
         from synapse.handlers.oidc_handler import OidcSessionData
 
-        return self.handler._generate_oidc_session_token(
+        return self.handler._token_generator.generate_oidc_session_token(
             state=state,
             session_data=OidcSessionData(
                 nonce=nonce,
@@ -980,7 +984,7 @@ async def _make_callback_with_userinfo(
     handler._fetch_userinfo = simple_async_mock(return_value=userinfo)
 
     state = "state"
-    session = handler._generate_oidc_session_token(
+    session = handler._token_generator.generate_oidc_session_token(
         state=state,
         session_data=OidcSessionData(
             nonce="nonce", client_redirect_url=client_redirect_url,


### PR DESCRIPTION
Some light refactoring of OidcHandler, in preparation for bigger things:

 * remove inheritance from deprecated BaseHandler
 * add an object to hold the things that go into a session cookie
 * factor out a separate class for manipulating said cookies