### PR TITLE
Handle bad JSON data being returned from the federation API.

### DIFF
--- a/changelog.d/9070.bugfix
+++ b/changelog.d/9070.bugfix
@@ -1,0 +1,1 @@
+Fix `JSONDecodeError` spamming the logs when sending transactions to remote servers.

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -174,6 +174,16 @@ async def _handle_json_response(
         d = timeout_deferred(d, timeout=timeout_sec, reactor=reactor)
 
         body = await make_deferred_yieldable(d)
+    except ValueError as e:
+        # The JSON content was invalid.
+        logger.warning(
+            "{%s} [%s] Failed to parse JSON response - %s %s",
+            request.txn_id,
+            request.destination,
+            request.method,
+            request.uri.decode("ascii"),
+        )
+        raise RequestSendFailed(e, can_retry=False) from e
     except defer.TimeoutError as e:
         logger.warning(
             "{%s} [%s] Timed out reading response - %s %s",

--- a/tests/http/test_fedclient.py
+++ b/tests/http/test_fedclient.py
@@ -560,4 +560,4 @@ class FederationClientTests(HomeserverTestCase):
         self.pump()
 
         f = self.failureResultOf(test_d)
-        self.assertIsInstance(f.value, ValueError)
+        self.assertIsInstance(f.value, RequestSendFailed)


### PR DESCRIPTION
This is spamming the logs on matrix.org: https://sentry.matrix.org/sentry/synapse-matrixorg/issues/194939/

I think this works OK since the server on the other end accepts the transaction OK, but returns an empty body back. The report at #9065 says that remote construct servers are doing this. We could also consider an empty body to be an empty JSON object, but that doesn't seem correct. If you're returning a response of `applicaton/json` I'd expect the body to be valid JSON.

Fixes #9065