### PR TITLE
Add very basic domain validation for `DomainSpecificString`.

### DIFF
--- a/changelog.d/9071.bugfix
+++ b/changelog.d/9071.bugfix
@@ -1,0 +1,1 @@
+Fix "Failed to send request" errors when a client provides an invalid room alias.

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -247,6 +247,14 @@ class DomainSpecificString(
 
         domain = parts[1]
 
+        # TODO The checking of a valid domain name should be made stricter.
+        if "," in domain:
+            raise SynapseError(
+                400,
+                "Invalid domain name for %s: %s" % (cls.__name__, domain),
+                Codes.INVALID_PARAM,
+            )
+
         # This code will need changing if we want to support multiple domain
         # names on one HS
         return cls(localpart=parts[0], domain=domain)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -60,13 +60,7 @@ class RoomAliasTestCase(unittest.HomeserverTestCase):
 
     def test_validate(self):
         id_string = "#test:domain,test"
-
-        try:
-            RoomAlias.from_string(id_string)
-            self.fail("Parsing '%s' should raise exception" % id_string)
-        except SynapseError as exc:
-            self.assertEqual(400, exc.code)
-            self.assertEqual("M_INVALID_PARAM", exc.errcode)
+        self.assertFalse(RoomAlias.is_valid(id_string))
 
 
 class GroupIDTestCase(unittest.TestCase):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -58,6 +58,16 @@ class RoomAliasTestCase(unittest.HomeserverTestCase):
 
         self.assertEquals(room.to_string(), "#channel:my.domain")
 
+    def test_validate(self):
+        id_string = "#test:domain,test"
+
+        try:
+            RoomAlias.from_string(id_string)
+            self.fail("Parsing '%s' should raise exception" % id_string)
+        except SynapseError as exc:
+            self.assertEqual(400, exc.code)
+            self.assertEqual("M_INVALID_PARAM", exc.errcode)
+
 
 class GroupIDTestCase(unittest.TestCase):
     def test_parse(self):


### PR DESCRIPTION
There seems to be a client attempting to join multiple rooms at once by sending a comma separated list of room aliases to the [join room API](https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-join-roomidoralias). `roomIdOrAlias` ends up being something like `#alias:test,#another:server`, which is invalid, but gets parsed as trying to join `#test` on a server named `test,#another:server`.

Something in the stack causes the error to only see the first bit before the `#`:

> RequestSendFailedsynapse: Failed to send request: ValueError: invalid hostname: test,

Anyway, these are obviously invalid domain names when we attempt to create a `RoomAlias` object and we should reject them. We could do a lot more validation here, but it is surprisingly hard to define what a "valid" domain name is (in terms of things you see on the Internet). The fix given here is very specific, but should solve the current error.

Fixes https://sentry.matrix.org/sentry/synapse-matrixorg/issues/119622/