### PR TITLE
Fix failures in Debian packaging

### DIFF
--- a/changelog.d/9079.misc
+++ b/changelog.d/9079.misc
@@ -1,0 +1,1 @@
+Fix failures when building Debian packages

--- a/changelog.d/9079.misc
+++ b/changelog.d/9079.misc
@@ -1,1 +1,0 @@
-Fix failures when building Debian packages

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+matrix-synapse-py3 (1.24.0+nmu1) UNRELEASED; urgency=medium
+
+  * Update dependencies to account for the removal of the transitional
+    dh-systemd package from Debian Bullseye.
+
+ -- Dan Callahan <danc@element.io>  Tue, 12 Jan 2021 12:08:33 +0000
+
 matrix-synapse-py3 (1.24.0) stable; urgency=medium
 
   * New synapse release 1.24.0.

--- a/debian/control
+++ b/debian/control
@@ -3,9 +3,9 @@ Section: contrib/python
 Priority: extra
 Maintainer: Synapse Packaging team <packages@matrix.org>
 # keep this list in sync with the build dependencies in docker/Dockerfile-dhvirtualenv.
+# TODO: Remove the dependency on dh-systemd after dropping support for Ubuntu xenial
 Build-Depends:
- debhelper (>= 9),
- dh-systemd,
+ debhelper (>= 9.20160709) | dh-systemd,
  dh-virtualenv (>= 1.1),
  libsystemd-dev,
  libpq-dev,

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,8 @@ Priority: extra
 Maintainer: Synapse Packaging team <packages@matrix.org>
 # keep this list in sync with the build dependencies in docker/Dockerfile-dhvirtualenv.
 # TODO: Remove the dependency on dh-systemd after dropping support for Ubuntu xenial
+#       On all other supported releases, it's merely a transitional package which
+#       does nothing but depends on debhelper (> 9.20160709)
 Build-Depends:
  debhelper (>= 9.20160709) | dh-systemd,
  dh-virtualenv (>= 1.1),

--- a/docker/Dockerfile-dhvirtualenv
+++ b/docker/Dockerfile-dhvirtualenv
@@ -54,13 +54,13 @@ ENV distro ${distro}
 #
 # NB: keep this list in sync with the list of build-deps in debian/control
 # TODO: it would be nice to do that automatically.
+# TODO: Remove the dh-systemd stanza after dropping support for Ubuntu xenial
 RUN apt-get update -qq -o Acquire::Languages=none \
     && env DEBIAN_FRONTEND=noninteractive apt-get install \
         -yqq --no-install-recommends -o Dpkg::Options::=--force-unsafe-io \
         build-essential \
         debhelper \
         devscripts \
-        dh-systemd \
         libsystemd-dev \
         lsb-release \
         pkg-config \
@@ -70,7 +70,10 @@ RUN apt-get update -qq -o Acquire::Languages=none \
         python3-venv \
         sqlite3 \
         libpq-dev \
-        xmlsec1
+        xmlsec1 \
+    && ( env DEBIAN_FRONTEND=noninteractive apt-get install \
+         -yqq --no-install-recommends -o Dpkg::Options::=--force-unsafe-io \
+         dh-systemd || true )
 
 COPY --from=builder /dh-virtualenv_1.2~dev-1_all.deb /
 

--- a/docker/Dockerfile-dhvirtualenv
+++ b/docker/Dockerfile-dhvirtualenv
@@ -50,6 +50,10 @@ FROM ${distro}
 ARG distro=""
 ENV distro ${distro}
 
+# Python < 3.7 assumes LANG="C" means ASCII-only and throws on printing unicode
+# http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
 # Install the build dependencies
 #
 # NB: keep this list in sync with the list of build-deps in debian/control

--- a/docker/Dockerfile-dhvirtualenv
+++ b/docker/Dockerfile-dhvirtualenv
@@ -59,6 +59,7 @@ ENV LANG C.UTF-8
 # NB: keep this list in sync with the list of build-deps in debian/control
 # TODO: it would be nice to do that automatically.
 # TODO: Remove the dh-systemd stanza after dropping support for Ubuntu xenial
+#       it's a transitional package on all other, more recent releases
 RUN apt-get update -qq -o Acquire::Languages=none \
     && env DEBIAN_FRONTEND=noninteractive apt-get install \
         -yqq --no-install-recommends -o Dpkg::Options::=--force-unsafe-io \


### PR DESCRIPTION
Debian package builds were failing for two reasons:

1. Python versions prior to 3.7 throw exceptions when attempting to print Unicode characters under a "C" locale.

2. We depended on `dh-systemd` which no longer exists in Debian Bullseye, but is necessary in Ubuntu Xenial.

Fixing the first issue is as easy as setting `LANG="C.UTF-8"` in the build environment. (See https://bugs.python.org/issue19846)

Fixing the second issue requires attempting to install `dh-systemd`, but ignoring failures when it does not exist.

Specifically, the `dh-systemd` package was merged with the main `debhelper` package as of debhelper (>= 9.20160709)` and a transitional package was left in its place.

That transitional package was removed in Debian Bullseye after being present in both Stretch and Buster. Thus, on the Debian side, just removing the dependency on `dh-systemd` would be sufficient.

However, Ubuntu Xenial has an old `debhelper` version, and thus actually needs `dh-systemd`. So we still try to install it on all distros, but ignore when that fails.

Once we drop support for Xenial (March 2021?) we can completely remove anything referencing `dh-systemd`.

Fixes #9073 
Fixes #9076