### PR TITLE
Fix using reactor as ip whitelist

### DIFF
--- a/changelog.d/9098.bugfix
+++ b/changelog.d/9098.bugfix
@@ -1,0 +1,1 @@
+Fix reactor being passsed as ip_whitelist to BlacklistingAgentWrapper from MatrixFederationAgent.

--- a/changelog.d/9098.bugfix
+++ b/changelog.d/9098.bugfix
@@ -1,1 +1,0 @@
-Fix reactor being passsed as ip_whitelist to BlacklistingAgentWrapper from MatrixFederationAgent.

--- a/changelog.d/9098.misc
+++ b/changelog.d/9098.misc
@@ -1,0 +1,1 @@
+Fix the wrong arguments being passed to `BlacklistingAgentWrapper` from `MatrixFederationAgent`. Contributed by Timothy Leung.

--- a/synapse/http/federation/matrix_federation_agent.py
+++ b/synapse/http/federation/matrix_federation_agent.py
@@ -102,7 +102,6 @@ class MatrixFederationAgent:
                         pool=self._pool,
                         contextFactory=tls_client_options_factory,
                     ),
-                    self._reactor,
                     ip_blacklist=ip_blacklist,
                 ),
                 user_agent=self.user_agent,


### PR DESCRIPTION
Currently the reactor in `MatrixFederationAgent` is being passed as the `ip_whitelist` in `BlacklistingAgentWrapper` ([src](https://github.com/matrix-org/synapse/blob/aa4d8c1f9aa32693412642650a7c626e164af286/synapse/http/client.py#L231-L242)). This PR removes this in keeping with how `BlacklistingAgentWrapper` is instantiated in `MatrixFederationHttpClient`:

https://github.com/matrix-org/synapse/blob/aa4d8c1f9aa32693412642650a7c626e164af286/synapse/http/matrixfederationclient.py#L254-L258

Signed-off-by: tzyl <tim95@hotmail.co.uk>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
