### PR TITLE
Reduce scope of an exception handler.

### DIFF
--- a/changelog.d/9106.misc
+++ b/changelog.d/9106.misc
@@ -1,0 +1,1 @@
+Reduce the scope of caught exceptions in `BlacklistingAgentWrapper`.


### PR DESCRIPTION
This could potentially catch more exceptions that we want, which is bad practice.

This is related to #9098, although it turns out this code will not get called in that case.