### PR TITLE
Fix get destinations to catch up query.

### DIFF
--- a/changelog.d/9114.bugfix
+++ b/changelog.d/9114.bugfix
@@ -1,0 +1,1 @@
+Fix bug in federation catchup logic that caused outbound federation to be delayed for large servers after start up. Introduced in v1.21.0.


### PR DESCRIPTION
It was doing a sequential scan on `destination_rooms`, which took
minutes.