### PR TITLE
Don't error if deleting a non-existant pusher.

### DIFF
--- a/changelog.d/9121.bugfix
+++ b/changelog.d/9121.bugfix
@@ -1,0 +1,1 @@
+Do not throw spurious errors when deleting a non-existant pusher.

--- a/changelog.d/9121.bugfix
+++ b/changelog.d/9121.bugfix
@@ -1,1 +1,1 @@
-Do not throw spurious errors when deleting a non-existant pusher.
+Fix spurious errors in logs when deleting a non-existant pusher.

--- a/synapse/storage/databases/main/pusher.py
+++ b/synapse/storage/databases/main/pusher.py
@@ -344,7 +344,9 @@ class PusherStore(PusherWorkerStore):
                 txn, self.get_if_user_has_pusher, (user_id,)
             )
 
-            self.db_pool.simple_delete_one_txn(
+            # It is expected that there is exactly one pusher to delete, but
+            # if it isn't there (or there are multiple) delete them all.
+            self.db_pool.simple_delete_txn(
                 txn,
                 "pushers",
                 {"app_id": app_id, "pushkey": pushkey, "user_name": user_id},


### PR DESCRIPTION
I believe what is happening is that the request to delete a push is occurring more than once and only one of the requests can process successfully. Other requests end up with a `StoreError 404`. I don't see any reason why we need to enforce deleting exactly one pusher here.

Fixes #5101

Fixes https://sentry.matrix.org/sentry/synapse-matrixorg/issues/194918/?query=is%3Aunresolved