### PR TITLE
Various improvements to the federation client

### DIFF
--- a/changelog.d/9129.misc
+++ b/changelog.d/9129.misc
@@ -1,0 +1,1 @@
+Various improvements to the federation client.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -718,14 +718,12 @@ class FederationClient(FederationBase):
         time_now = self._clock.time_msec()
 
         try:
-            content = await self.transport_layer.send_join_v2(
+            return await self.transport_layer.send_join_v2(
                 destination=destination,
                 room_id=pdu.room_id,
                 event_id=pdu.event_id,
                 content=pdu.get_pdu_json(time_now),
             )
-
-            return content
         except HttpResponseException as e:
             if e.code in [400, 404]:
                 err = e.to_synapse_error()
@@ -783,7 +781,7 @@ class FederationClient(FederationBase):
         time_now = self._clock.time_msec()
 
         try:
-            content = await self.transport_layer.send_invite_v2(
+            return await self.transport_layer.send_invite_v2(
                 destination=destination,
                 room_id=pdu.room_id,
                 event_id=pdu.event_id,
@@ -793,7 +791,6 @@ class FederationClient(FederationBase):
                     "invite_room_state": pdu.unsigned.get("invite_room_state", []),
                 },
             )
-            return content
         except HttpResponseException as e:
             if e.code in [400, 404]:
                 err = e.to_synapse_error()
@@ -860,14 +857,12 @@ class FederationClient(FederationBase):
         time_now = self._clock.time_msec()
 
         try:
-            content = await self.transport_layer.send_leave_v2(
+            return await self.transport_layer.send_leave_v2(
                 destination=destination,
                 room_id=pdu.room_id,
                 event_id=pdu.event_id,
                 content=pdu.get_pdu_json(time_now),
             )
-
-            return content
         except HttpResponseException as e:
             if e.code in [400, 404]:
                 err = e.to_synapse_error()
@@ -1023,10 +1018,9 @@ class FederationClient(FederationBase):
             could not fetch the complexity.
         """
         try:
-            complexity = await self.transport_layer.get_room_complexity(
+            return await self.transport_layer.get_room_complexity(
                 destination=destination, room_id=room_id
             )
-            return complexity
         except CodeMessageException as e:
             # We didn't manage to get it -- probably a 404. We are okay if other
             # servers don't give it to us.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -119,14 +119,14 @@ class FederationClient(FederationBase):
                 self.pdu_destination_tried[event_id] = destination_dict
 
     @log_function
-    def make_query(
+    async def make_query(
         self,
         destination: str,
         query_type: str,
         args: dict,
         retry_on_dns_fail: bool = False,
         ignore_backoff: bool = False,
-    ) -> Awaitable[JsonDict]:
+    ) -> JsonDict:
         """Sends a federation Query to a remote homeserver of the given type
         and arguments.
 
@@ -140,12 +140,11 @@ class FederationClient(FederationBase):
                 and try the request anyway.
 
         Returns:
-            An Awaitable which will eventually yield a JSON object from the
-            response
+            The JSON object from the response
         """
         sent_queries_counter.labels(query_type).inc()
 
-        return self.transport_layer.make_query(
+        return await self.transport_layer.make_query(
             destination,
             query_type,
             args,
@@ -154,9 +153,9 @@ class FederationClient(FederationBase):
         )
 
     @log_function
-    def query_client_keys(
+    async def query_client_keys(
         self, destination: str, content: JsonDict, timeout: int
-    ) -> Awaitable[JsonDict]:
+    ) -> JsonDict:
         """Query device keys for a device hosted on a remote server.
 
         Args:
@@ -164,26 +163,29 @@ class FederationClient(FederationBase):
             content: The query content.
 
         Returns:
-            An Awaitable which will eventually yield a JSON object from the
-            response
+            The JSON object from the response
         """
         sent_queries_counter.labels("client_device_keys").inc()
-        return self.transport_layer.query_client_keys(destination, content, timeout)
+        return await self.transport_layer.query_client_keys(
+            destination, content, timeout
+        )
 
     @log_function
-    def query_user_devices(
+    async def query_user_devices(
         self, destination: str, user_id: str, timeout: int = 30000
-    ) -> Awaitable[JsonDict]:
+    ) -> JsonDict:
         """Query the device keys for a list of user ids hosted on a remote
         server.
         """
         sent_queries_counter.labels("user_devices").inc()
-        return self.transport_layer.query_user_devices(destination, user_id, timeout)
+        return await self.transport_layer.query_user_devices(
+            destination, user_id, timeout
+        )
 
     @log_function
-    def claim_client_keys(
+    async def claim_client_keys(
         self, destination: str, content: JsonDict, timeout: int
-    ) -> Awaitable[JsonDict]:
+    ) -> JsonDict:
         """Claims one-time keys for a device hosted on a remote server.
 
         Args:
@@ -191,11 +193,12 @@ class FederationClient(FederationBase):
             content: The query content.
 
         Returns:
-            An Awaitable which will eventually yield a JSON object from the
-            response
+            The JSON object from the response
         """
         sent_queries_counter.labels("client_one_time_keys").inc()
-        return self.transport_layer.claim_client_keys(destination, content, timeout)
+        return await self.transport_layer.claim_client_keys(
+            destination, content, timeout
+        )
 
     async def backfill(
         self, dest: str, room_id: str, limit: int, extremities: Iterable[str]
@@ -890,7 +893,7 @@ class FederationClient(FederationBase):
         # content.
         return resp[1]
 
-    def get_public_rooms(
+    async def get_public_rooms(
         self,
         remote_server: str,
         limit: Optional[int] = None,
@@ -898,7 +901,7 @@ class FederationClient(FederationBase):
         search_filter: Optional[Dict] = None,
         include_all_networks: bool = False,
         third_party_instance_id: Optional[str] = None,
-    ) -> Awaitable[JsonDict]:
+    ) -> JsonDict:
         """Get the list of public rooms from a remote homeserver
 
         Args:
@@ -920,7 +923,7 @@ class FederationClient(FederationBase):
                 requests over federation
 
         """
-        return self.transport_layer.get_public_rooms(
+        return await self.transport_layer.get_public_rooms(
             remote_server,
             limit,
             since_token,


### PR DESCRIPTION
This was an old branch I had sitting around, I don't know why I started it, but it seems to have some improvements:

* Type hints for `FederationClient`.
* Using `async` functions with `await` instead of returning awaitables.
* Other minor clean-up.