### PR TITLE
Ensure the user ID is serialized in the payload during replication.

### DIFF
--- a/changelog.d/9130.feature
+++ b/changelog.d/9130.feature
@@ -1,0 +1,1 @@
+Add experimental support for handling and persistence of to-device messages to happen on worker processes.

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -163,7 +163,7 @@ class DeviceMessageHandler:
             await self.store.mark_remote_user_device_cache_as_stale(sender_user_id)
 
             # Immediately attempt a resync in the background
-            run_in_background(self._user_device_resync, sender_user_id)
+            run_in_background(self._user_device_resync, user_id=sender_user_id)
 
     async def send_device_message(
         self,


### PR DESCRIPTION
...instead of used as the instance name.

This was hinted at via https://sentry.matrix.org/sentry/synapse-matrixorg/issues/196403/ and the timeline lines up of when #9043 was done.

This is due to `ReplicationEndpoint.make_client` generating a callable which expects `instance_name` as the first argument, followed by keyword arguments to serialize.