### PR TITLE
Fedora Prerequisites are (possibly) inaccurate

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -156,9 +156,11 @@ Installing prerequisites on CentOS 8 or Fedora>26:
 ```sh
 sudo dnf install libtiff-devel libjpeg-devel libzip-devel freetype-devel \
                  libwebp-devel tk-devel redhat-rpm-config \
-                 python3-virtualenv libffi-devel openssl-devel python3-devel phycopg2 
+                 python3-virtualenv libffi-devel openssl-devel python3-devel python3-phycopg2 
 sudo dnf groupinstall "Development Tools"
 ```
+
+Signed-off-by: Joseph Arnault <computerdude90042@outlook.com>
 
 Installing prerequisites on CentOS 7 or Fedora<=25:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -156,7 +156,7 @@ Installing prerequisites on CentOS 8 or Fedora>26:
 ```sh
 sudo dnf install libtiff-devel libjpeg-devel libzip-devel freetype-devel \
                  libwebp-devel tk-devel redhat-rpm-config \
-                 python3-virtualenv libffi-devel openssl-devel
+                 python3-virtualenv libffi-devel openssl-devel python3-devel phycopg2 
 sudo dnf groupinstall "Development Tools"
 ```
 


### PR DESCRIPTION
`python3-devel` is required to build the wheel for Twisted, otherwise it'll just fail. `psycopg2` is also required for Postgresql. I don't believe these come with the "Development Tools" group, but I might be mistaken.