### PR TITLE
Enforce all replication HTTP clients calls use kwargs

### DIFF
--- a/changelog.d/9144.misc
+++ b/changelog.d/9144.misc
@@ -1,0 +1,1 @@
+Enforce that replication HTTP clients are called with keyword arguments only.

--- a/synapse/replication/http/_base.py
+++ b/synapse/replication/http/_base.py
@@ -177,7 +177,7 @@ class ReplicationEndpoint(metaclass=abc.ABCMeta):
 
         @trace(opname="outgoing_replication_request")
         @outgoing_gauge.track_inprogress()
-        async def send_request(instance_name="master", **kwargs):
+        async def send_request(*, instance_name="master", **kwargs):
             if instance_name == local_instance_name:
                 raise Exception("Trying to send HTTP request to self")
             if instance_name == "master":


### PR DESCRIPTION
Should prevent https://github.com/matrix-org/synapse/pull/9130 from happening again