### PR TITLE
Fix the Python 3.5 old-deps build.

### DIFF
--- a/changelog.d/9146.misc
+++ b/changelog.d/9146.misc
@@ -1,0 +1,1 @@
+Fix the Python 3.5 + old dependencies build in CI.

--- a/tox.ini
+++ b/tox.ini
@@ -103,6 +103,9 @@ usedevelop=true
 [testenv:py35-old]
 skip_install=True
 deps =
+    # Ensure a version of setuptools that supports Python 3.5 is installed.
+    setuptools < 51.0.0
+
     # Old automat version for Twisted
     Automat == 0.3.0
 


### PR DESCRIPTION
It seems that setuptools 51.0.0 [dropped support for Python 3.5](https://setuptools.readthedocs.io/en/latest/history.html#breaking-changes). This release actually broke support via pypa/setuptools#2518.