### PR TITLE
Quote pip install with brackets.

### DIFF
--- a/changelog.d/9151.doc
+++ b/changelog.d/9151.doc
@@ -1,0 +1,1 @@
+Quote `pip install` packages when extras are used to avoid shells interpreting bracket characters.

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -18,7 +18,7 @@ connect to a postgres database.
     virtualenv](../INSTALL.md#installing-from-source), you can install
     the library with:
 
-        ~/synapse/env/bin/pip install matrix-synapse[postgres]
+        ~/synapse/env/bin/pip install "matrix-synapse[postgres]"
 
     (substituting the path to your virtualenv for `~/synapse/env`, if
     you used a different path). You will require the postgres

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -59,7 +59,7 @@ The appropriate dependencies must also be installed for Synapse. If using a
 virtualenv, these can be installed with:
 
 ```sh
-pip install matrix-synapse[redis]
+pip install "matrix-synapse[redis]"
 ```
 
 Note that these dependencies are included when synapse is installed with `pip


### PR DESCRIPTION
We did this in some places, but not all. This should avoid shells interpreting brackets. See #9141.