### PR TITLE
Replace 'perspectives' config block with 'trusted_key_servers' in docker homeserver.yaml template

### DIFF
--- a/changelog.d/9157.misc
+++ b/changelog.d/9157.misc
@@ -1,0 +1,1 @@
+Replace the old `perspectives` option in the Synapse docker config file template with `trusted_key_servers`.

--- a/docker/conf/homeserver.yaml
+++ b/docker/conf/homeserver.yaml
@@ -198,12 +198,10 @@ old_signing_keys: {}
 key_refresh_interval: "1d" # 1 Day.
 
 # The trusted servers to download signing keys from.
-perspectives:
-  servers:
-    "matrix.org":
-      verify_keys:
-        "ed25519:auto":
-          key: "Noi6WqcDj0QmPxCNQqgezwTlBKrfqehY1u2FyWP9uYw"
+trusted_key_servers:
+  - server_name: matrix.org
+    verify_keys:
+      "ed25519:auto": "Noi6WqcDj0QmPxCNQqgezwTlBKrfqehY1u2FyWP9uYw"
 
 password_config:
    enabled: true


### PR DESCRIPTION
There is [a template](https://github.com/matrix-org/synapse/blob/ca2db5dd0c9fc430a931b4d456fea6a5300b8b42/docker/conf/homeserver.yaml) for homeserver.yaml that is used when creating a homeserver config for docker instances of Synapse. That template still contains a `perspectives` block, which has long since been deprecated and replaced by `trusted_key_servers`.

This PR switches out the old config option for the new, without changing any functionality.

The reason I'm doing this is that I would like to override (read: remove all contents of) this section in a Complement-specific docker image, and would like to override with the new option, instead of the old. (Synapse will concatenate `perspectives` and `trusted_key_servers` if it finds both).

Documentation for this option in the sample config is [here](https://github.com/matrix-org/synapse/blob/develop/docs/sample_config.yaml#L1478).