### PR TITLE
Return a 404 if no valid thumbnail can be found

### DIFF
--- a/changelog.d/9163.bugfix
+++ b/changelog.d/9163.bugfix
@@ -1,1 +1,1 @@
-Fix a longstanding bug where Synapse would return a 500 error when a thumbnail did not exist (and auto-generation of thumbnails was not enabled).
+Fix a long-standing bug where Synapse would return a 500 error when a thumbnail did not exist (and auto-generation of thumbnails was not enabled).

--- a/changelog.d/9163.bugfix
+++ b/changelog.d/9163.bugfix
@@ -1,0 +1,1 @@
+Fix a longstanding bug where Synapse would return a 500 error when a thumbnail did not exist (and auto-generation of thumbnails was not enabled).

--- a/synapse/rest/media/v1/_base.py
+++ b/synapse/rest/media/v1/_base.py
@@ -300,6 +300,7 @@ class FileInfo:
         thumbnail_height (int)
         thumbnail_method (str)
         thumbnail_type (str): Content type of thumbnail, e.g. image/png
+        thumbnail_length (int): The size of the media file, in bytes.
     """
 
     def __init__(
@@ -312,6 +313,7 @@ class FileInfo:
         thumbnail_height=None,
         thumbnail_method=None,
         thumbnail_type=None,
+        thumbnail_length=None,
     ):
         self.server_name = server_name
         self.file_id = file_id
@@ -321,6 +323,7 @@ class FileInfo:
         self.thumbnail_height = thumbnail_height
         self.thumbnail_method = thumbnail_method
         self.thumbnail_type = thumbnail_type
+        self.thumbnail_length = thumbnail_length
 
 
 def get_filename_from_headers(headers: Dict[bytes, List[bytes]]) -> Optional[str]:

--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -125,13 +125,13 @@ class ThumbnailResource(DirectServeJsonResource):
                 thumbnail_height=thumbnail_info["thumbnail_height"],
                 thumbnail_type=thumbnail_info["thumbnail_type"],
                 thumbnail_method=thumbnail_info["thumbnail_method"],
+                thumbnail_length=thumbnail_info["thumbnail_length"],
             )
 
-            t_type = file_info.thumbnail_type
-            t_length = thumbnail_info["thumbnail_length"]
-
             responder = await self.media_storage.fetch_media(file_info)
-            await respond_with_responder(request, responder, t_type, t_length)
+            await respond_with_responder(
+                request, responder, file_info.thumbnail_type, file_info.thumbnail_length
+            )
         else:
             logger.info("Couldn't find any generated thumbnails")
             respond_404(request)
@@ -298,13 +298,13 @@ class ThumbnailResource(DirectServeJsonResource):
                 thumbnail_height=thumbnail_info["thumbnail_height"],
                 thumbnail_type=thumbnail_info["thumbnail_type"],
                 thumbnail_method=thumbnail_info["thumbnail_method"],
+                thumbnail_length=thumbnail_info["thumbnail_length"],
             )
 
-            t_type = file_info.thumbnail_type
-            t_length = thumbnail_info["thumbnail_length"]
-
             responder = await self.media_storage.fetch_media(file_info)
-            await respond_with_responder(request, responder, t_type, t_length)
+            await respond_with_responder(
+                request, responder, file_info.thumbnail_type, file_info.thumbnail_length
+            )
         else:
             logger.info("Failed to find any generated thumbnails")
             respond_404(request)

--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -289,7 +289,7 @@ class ThumbnailResource(DirectServeJsonResource):
         """
         Respond to a request with an appropriate thumbnail from the previously generated thumbnails.
 
-        Params:
+        Args:
             request: The incoming request.
             desired_width: The desired width, the returned thumbnail may be larger than this.
             desired_height: The desired height, the returned thumbnail may be larger than this.
@@ -338,7 +338,7 @@ class ThumbnailResource(DirectServeJsonResource):
         """
         Choose an appropriate thumbnail from the previously generated thumbnails.
 
-        Params:
+        Args:
             desired_width: The desired width, the returned thumbnail may be larger than this.
             desired_height: The desired height, the returned thumbnail may be larger than this.
             desired_method: The desired method used to generate the thumbnail.

--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -16,7 +16,7 @@
 
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from twisted.web.http import Request
 
@@ -306,13 +306,29 @@ class ThumbnailResource(DirectServeJsonResource):
         desired_height: int,
         desired_method: str,
         desired_type: str,
-        thumbnail_infos,
+        thumbnail_infos: List[Dict[str, Any]],
     ) -> dict:
+        """
+        Choose an appropriate thumbnail from the previously generated thumbnails.
+
+        Params:
+            desired_width: The desired width, the returned thumbnail may be larger than this.
+            desired_height: The desired height, the returned thumbnail may be larger than this.
+            desired_method: The desired method used to generate the thumbnail.
+            desired_type: The desired content-type of the thumbnail.
+            thumbnail_infos: A list of dictionaries of candidate thumbnails.
+
+        Returns:
+             The thumbnail which best matches the desired parameters.
+        """
+
         d_w = desired_width
         d_h = desired_height
 
         if desired_method.lower() == "crop":
+            # Thumbnails that match equal or larger sizes of desired width/height.
             crop_info_list = []
+            # Other thumbnails.
             crop_info_list2 = []
             for info in thumbnail_infos:
                 t_w = info["thumbnail_width"]
@@ -351,7 +367,9 @@ class ThumbnailResource(DirectServeJsonResource):
             else:
                 return min(crop_info_list2)[-1]
         else:
+            # Thumbnails that match equal or larger sizes of desired width/height.
             info_list = []
+            # Other thumbnails.
             info_list2 = []
             for info in thumbnail_infos:
                 t_w = info["thumbnail_width"]

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -202,7 +202,6 @@ class MediaRepoTests(unittest.HomeserverTestCase):
 
         config = self.default_config()
         config["media_store_path"] = self.media_store_path
-        config["thumbnail_requirements"] = {}
         config["max_image_pixels"] = 2000000
 
         provider_config = {
@@ -327,6 +326,15 @@ class MediaRepoTests(unittest.HomeserverTestCase):
     def test_invalid_type(self):
         """An invalid thumbnail type is never available."""
         self._test_thumbnail("invalid", None, False)
+
+    @unittest.override_config(
+        {"thumbnail_sizes": [{"width": 32, "height": 32, "method": "crop"}]}
+    )
+    def test_no_thumbnail(self):
+        """
+        Override the config to generate only cropped thumbnails, but request a scaled one.
+        """
+        self._test_thumbnail("scale", None, False)
 
     def _test_thumbnail(self, method, expected_body, expected_found):
         params = "?width=32&height=32&method=" + method

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -328,9 +328,18 @@ class MediaRepoTests(unittest.HomeserverTestCase):
         self._test_thumbnail("invalid", None, False)
 
     @unittest.override_config(
+        {"thumbnail_sizes": [{"width": 32, "height": 32, "method": "scale"}]}
+    )
+    def test_no_thumbnail_crop(self):
+        """
+        Override the config to generate only scaled thumbnails, but request a cropped one.
+        """
+        self._test_thumbnail("crop", None, False)
+
+    @unittest.override_config(
         {"thumbnail_sizes": [{"width": 32, "height": 32, "method": "crop"}]}
     )
-    def test_no_thumbnail(self):
+    def test_no_thumbnail_scale(self):
         """
         Override the config to generate only cropped thumbnails, but request a scaled one.
         """

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -313,14 +313,20 @@ class MediaRepoTests(unittest.HomeserverTestCase):
         self.assertEqual(headers.getRawHeaders(b"Content-Disposition"), None)
 
     def test_thumbnail_crop(self):
+        """Test that a cropped remote thumbnail is available."""
         self._test_thumbnail(
             "crop", self.test_image.expected_cropped, self.test_image.expected_found
         )
 
     def test_thumbnail_scale(self):
+        """Test that a scaled remote thumbnail is available."""
         self._test_thumbnail(
             "scale", self.test_image.expected_scaled, self.test_image.expected_found
         )
+
+    def test_invalid_type(self):
+        """An invalid thumbnail type is never available."""
+        self._test_thumbnail("invalid", None, False)
 
     def _test_thumbnail(self, method, expected_body, expected_found):
         params = "?width=32&height=32&method=" + method


### PR DESCRIPTION
Currently the logic for choosing a thumbnail (among the already existing thumbnails -- so not when auto-generating thumbnails is turned on) errors if no matching thumbnail is found. This leads to a 500 error returned to the client when it is reasonable to return a 404.

This should be reviewable commit-by-commit
* The first two commits are just some setup/re-organization.
* The third commit is the "real" fix.
* The fourth and fifth commits are some abstracting (if these are controversial I'm OK backing them out).

Fixes at least https://sentry.matrix.org/sentry/synapse-matrixorg/issues/127518/