### PR TITLE
Add an admin API to get the current room state

### DIFF
--- a/changelog.d/9168.feature
+++ b/changelog.d/9168.feature
@@ -1,0 +1,1 @@
+Add an admin API for retrieving the current room state of a room.

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -367,6 +367,36 @@ Response:
 }
 ```
 
+# Room State API
+
+The Room State admin API allows server admins to get a list of all state events in a room.
+
+The response includes the following fields:
+
+* `state` - The current state of the room at the time of request.
+
+## Usage
+
+A standard request:
+
+```
+GET /_synapse/admin/v1/rooms/<room_id>/state
+
+{}
+```
+
+Response:
+
+```json
+{
+  "state": [
+    {"type": "m.room.create", "state_key": "", "etc": true},
+    {"type": "m.room.power_levels", "state_key": "", "etc": true},
+    {"type": "m.room.name", "state_key": "", "etc": true}
+  ]
+}
+```
+
 # Delete Room API
 
 The Delete Room admin API allows server admins to remove rooms from server

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -137,6 +137,7 @@ class MessageHandler:
         state_filter: StateFilter = StateFilter.all(),
         at_token: Optional[StreamToken] = None,
         is_guest: bool = False,
+        is_admin: bool = False,
     ) -> List[dict]:
         """Retrieve all state events for a given room. If the user is
         joined to the room then return the current state. If the user has
@@ -153,6 +154,7 @@ class MessageHandler:
                 stream token, we raise a 403 SynapseError. If None, returns the current
                 state based on the current_state_events table.
             is_guest: whether this user is a guest
+            is_admin: whether this user is making the request as a server admin.
         Returns:
             A list of dicts representing state events. [{}, {}, {}]
         Raises:
@@ -173,9 +175,12 @@ class MessageHandler:
             if not last_events:
                 raise NotFoundError("Can't find event for token %s" % (at_token,))
 
-            visible_events = await filter_events_for_client(
-                self.storage, user_id, last_events, filter_send_to_client=False
-            )
+            if is_admin:
+                visible_events = last_events
+            else:
+                visible_events = await filter_events_for_client(
+                    self.storage, user_id, last_events, filter_send_to_client=False,
+                )
 
             event = last_events[0]
             if visible_events:
@@ -197,7 +202,7 @@ class MessageHandler:
                 room_id, user_id, allow_departed_users=True
             )
 
-            if membership == Membership.JOIN:
+            if membership == Membership.JOIN or is_admin:
                 state_ids = await self.store.get_filtered_current_state_ids(
                     room_id, state_filter=state_filter
                 )

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -41,6 +41,7 @@ from synapse.rest.admin.rooms import (
     MakeRoomAdminRestServlet,
     RoomMembersRestServlet,
     RoomRestServlet,
+    RoomStateRestServlet,
     ShutdownRoomRestServlet,
 )
 from synapse.rest.admin.server_notice_servlet import SendServerNoticeServlet
@@ -209,6 +210,7 @@ def register_servlets(hs, http_server):
     """
     register_servlets_for_client_rest_resource(hs, http_server)
     ListRoomRestServlet(hs).register(http_server)
+    RoomStateRestServlet(hs).register(http_server)
     RoomRestServlet(hs).register(http_server)
     RoomMembersRestServlet(hs).register(http_server)
     DeleteRoomRestServlet(hs).register(http_server)

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -308,14 +308,15 @@ class RoomStateRestServlet(RestServlet):
     async def on_GET(
         self, request: SynapseRequest, room_id: str
     ) -> Tuple[int, JsonDict]:
-        await assert_requester_is_admin(self.auth, request)
+        requester = await self.auth.get_user_by_req(request)
+        await assert_user_is_admin(self.auth, requester.user)
 
         ret = await self.store.get_room(room_id)
         if not ret:
             raise NotFoundError("Room not found")
 
         room_state = await self.message_handler.get_state_events(
-            user_id=request.requester.user.to_string(),
+            user_id=requester.user.to_string(),
             room_id=room_id,
             is_admin=True,  # already verified above
         )

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1180,6 +1180,21 @@ class RoomTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.json_body["total"], 3)
 
+    def test_room_state(self):
+        """Test that room state can be requested correctly"""
+        # Create two test rooms
+        room_id = self.helper.create_room_as(self.admin_user, tok=self.admin_user_tok)
+
+        url = "/_synapse/admin/v1/rooms/%s/state" % (room_id,)
+        channel = self.make_request(
+            "GET", url.encode("ascii"), access_token=self.admin_user_tok,
+        )
+        self.assertEqual(200, channel.code, msg=channel.json_body)
+        self.assertIn("state", channel.json_body)
+        # testing that the state events match is painful and not done here. We assume that
+        # the create_room already does the right thing, so no need to verify that we got
+        # the state events it created.
+
 
 class JoinAliasRoomTestCase(unittest.HomeserverTestCase):
 


### PR DESCRIPTION
This could arguably replace the existing admin API for `/members`, however that is out of scope of this change.

This sort of endpoint is ideal for moderation use cases as well as other applications, such as needing to retrieve various bits of information about a room to perform a task (like syncing power levels between two places). This endpoint exposes nothing more than an admin would be able to access with a `select *` query on their database.

*This is for FOSDEM's Jitsi ops syncing, for now.*

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
