### PR TITLE
Speed up chain cover calculation

### DIFF
--- a/changelog.d/9176.misc
+++ b/changelog.d/9176.misc
@@ -1,0 +1,1 @@
+Speed up chain cover calculation when persisting a batch of state events at once.

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -841,6 +841,7 @@ class PersistEventsStore:
             # If we reference an auth_event_id we fetch the allocated chain ID,
             # either from the existing `chain_map` or the newly generated
             # `new_chain_tuples` map.
+            existing_chain_id = None
             if auth_event_id:
                 existing_chain_id = new_chain_tuples.get(auth_event_id)
                 if not existing_chain_id:

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -802,7 +802,6 @@ class PersistEventsStore:
         for event_id in sorted_topologically(
             events_to_calc_chain_id_for, event_to_auth_chain
         ):
-            existing_chain_id = None
             for auth_id in event_to_auth_chain.get(event_id, []):
                 if event_to_types.get(event_id) == event_to_types.get(auth_id):
                     existing_chain_id = chain_map.get(auth_id)

--- a/synapse/storage/util/sequence.py
+++ b/synapse/storage/util/sequence.py
@@ -55,6 +55,11 @@ class SequenceGenerator(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
+    def get_next_mult_txn(self, txn: Cursor, n: int) -> List[int]:
+        """Get the next `n` IDs in the sequence"""
+        ...
+
+    @abc.abstractmethod
     def check_consistency(
         self,
         db_conn: "LoggingDatabaseConnection",
@@ -173,6 +178,17 @@ class LocalSequenceGenerator(SequenceGenerator):
 
             self._current_max_id += 1
             return self._current_max_id
+
+    def get_next_mult_txn(self, txn: Cursor, n: int) -> List[int]:
+        with self._lock:
+            if self._current_max_id is None:
+                assert self._callback is not None
+                self._current_max_id = self._callback(txn)
+                self._callback = None
+
+            first_id = self._current_max_id + 1
+            self._current_max_id += n
+            return [first_id + i for i in range(n)]
 
     def check_consistency(
         self, db_conn: Connection, table: str, id_column: str, positive: bool = True


### PR DESCRIPTION
If we are persisting many state events, e.g. due to a join or from the background update, we ended up doing a lot of small queries for each state event. This PR batches up those queries.

Commits should be reviewable one by one.