### PR TITLE
Avoid a warning when using `twine check`.

### DIFF
--- a/changelog.d/9180.misc
+++ b/changelog.d/9180.misc
@@ -1,0 +1,1 @@
+Add a `long_description_type` to the package metadata.

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     python_requires="~=3.5",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This avoids a warning when using `twine check dist/*` (which we should be running in CI to avoid things like 4c37d2acd58f9cbcdc262d25a75f8b38c50ed7f9).