### PR TITLE
Align the directories linted in CI with the defaults in scripts-dev/lint.sh

### DIFF
--- a/changelog.d/9191.misc
+++ b/changelog.d/9191.misc
@@ -1,0 +1,1 @@
+Add some missing source directories to the automatic linting script.

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -80,7 +80,7 @@ else
   # then lint everything!
   if [[ -z ${files+x} ]]; then
     # Lint all source code files and directories
-    files=("synapse" "tests" "scripts-dev" "scripts" "contrib" "synctl" "setup.py" "synmark")
+    files=("synapse" "docker" "tests" "scripts-dev" "scripts" "contrib" "synctl" "setup.py" "synmark" "stubs" ".buildkite")
   fi
 fi
 

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -80,6 +80,7 @@ else
   # then lint everything!
   if [[ -z ${files+x} ]]; then
     # Lint all source code files and directories
+    # Note: this list aims the mirror the one in tox.ini
     files=("synapse" "docker" "tests" "scripts-dev" "scripts" "contrib" "synctl" "setup.py" "synmark" "stubs" ".buildkite")
   fi
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,8 @@ deps =
     # install the "enum34" dependency of cryptography.
     pip>=10
 
-# directories/files we run the linters on
+# directories/files we run the linters on.
+# if you update this list, make sure to do the same in scripts-dev/lint.sh
 lint_targets =
     setup.py
     synapse


### PR DESCRIPTION
The lists of source directories to lint between `tox.ini` and `lint.sh` became out of sync. This PR tightens them up and adds some comments reminding any future readers to keep the list in sync.

There's certainly something to be said about maintaining two lists. Perhaps in the future `tox.ini` should just call `lint.sh` instead. For now, these directories change so rarely that I don't think it's a big deal.