### PR TITLE
Do not require the CAS service URL setting (use public_baseurl instead).

### DIFF
--- a/changelog.d/9199.removal
+++ b/changelog.d/9199.removal
@@ -1,0 +1,1 @@
+The `service_url` parameter in `cas_config` is deprecated in favor of `public_baseurl`.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1878,10 +1878,6 @@ cas_config:
   #
   #server_url: "https://cas-server.com"
 
-  # The public URL of the homeserver.
-  #
-  #service_url: "https://homeserver.domain.com:8448"
-
   # The attribute of the CAS response to use as the display name.
   #
   # If unset, no displayname will be set.

--- a/synapse/config/cas.py
+++ b/synapse/config/cas.py
@@ -30,7 +30,7 @@ class CasConfig(Config):
 
         if self.cas_enabled:
             self.cas_server_url = cas_config["server_url"]
-            self.cas_service_url = cas_config["service_url"]
+            self.cas_service_url = cas_config.get("service_url") or self.public_baseurl
             self.cas_displayname_attribute = cas_config.get("displayname_attribute")
             self.cas_required_attributes = cas_config.get("required_attributes") or {}
         else:
@@ -52,10 +52,6 @@ class CasConfig(Config):
           # The URL of the CAS authorization endpoint.
           #
           #server_url: "https://cas-server.com"
-
-          # The public URL of the homeserver.
-          #
-          #service_url: "https://homeserver.domain.com:8448"
 
           # The attribute of the CAS response to use as the display name.
           #

--- a/synapse/config/cas.py
+++ b/synapse/config/cas.py
@@ -30,7 +30,13 @@ class CasConfig(Config):
 
         if self.cas_enabled:
             self.cas_server_url = cas_config["server_url"]
-            self.cas_service_url = cas_config.get("service_url") or self.public_baseurl
+            public_base_url = cas_config.get("service_url") or self.public_baseurl
+            if public_base_url[-1] != "/":
+                public_base_url += "/"
+            # TODO Update this to a _synapse URL.
+            self.cas_service_url = (
+                public_base_url + "_matrix/client/r0/login/cas/ticket"
+            )
             self.cas_displayname_attribute = cas_config.get("displayname_attribute")
             self.cas_required_attributes = cas_config.get("required_attributes") or {}
         else:

--- a/synapse/config/oidc_config.py
+++ b/synapse/config/oidc_config.py
@@ -54,8 +54,7 @@ class OIDCConfig(Config):
                     "Multiple OIDC providers have the idp_id %r." % idp_id
                 )
 
-        public_baseurl = self.public_baseurl
-        self.oidc_callback_url = public_baseurl + "_synapse/oidc/callback"
+        self.oidc_callback_url = self.public_baseurl + "_synapse/oidc/callback"
 
     @property
     def oidc_enabled(self) -> bool:

--- a/synapse/handlers/cas_handler.py
+++ b/synapse/handlers/cas_handler.py
@@ -99,11 +99,7 @@ class CasHandler:
         Returns:
             The URL to use as a "service" parameter.
         """
-        return "%s%s?%s" % (
-            self._cas_service_url,
-            "/_matrix/client/r0/login/cas/ticket",
-            urllib.parse.urlencode(args),
-        )
+        return "%s?%s" % (self._cas_service_url, urllib.parse.urlencode(args),)
 
     async def _validate_ticket(
         self, ticket: str, service_args: Dict[str, str]


### PR DESCRIPTION
Since `public_baseurl` is always defined as of #9159, it becomes easy to automatically use this for CAS if `service_url` is not defined.

By default if `service_url` is defined that will be used instead.

Fixes #7198