### PR TITLE
Update isort to v5.7.0

### DIFF
--- a/changelog.d/9222.misc
+++ b/changelog.d/9222.misc
@@ -1,0 +1,1 @@
+Update `isort` to v5.7.0 to bypass a bug where it would disagree with `black` about formatting.

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ CONDITIONAL_REQUIREMENTS["all"] = list(ALL_OPTIONAL_REQUIREMENTS)
 #
 # We pin black so that our tests don't start failing on new releases.
 CONDITIONAL_REQUIREMENTS["lint"] = [
-    "isort==5.0.3",
+    "isort==5.7.0",
     "black==19.10b0",
     "flake8-comprehensions",
     "flake8",


### PR DESCRIPTION
This new version no longer has the problem of adding/removing a blank line in `.pyi` files, which black disagrees with. This would cause `isort` to slightly modify `.pyi` files, before `black` would subsequently modify back directly afterwards:

```
+ isort synapse docker tests scripts-dev scripts contrib synctl setup.py synmark stubs .buildkite
Fixing /home/user/code/synapse/synapse/config/_base.pyi
Fixing /home/user/code/synapse/stubs/txredisapi.pyi
+ python3 -m black synapse docker tests scripts-dev scripts contrib synctl setup.py synmark stubs .buildkite
reformatted /home/user/code/synapse/stubs/txredisapi.pyi
reformatted /home/user/code/synapse/synapse/config/_base.pyi
```

Relevant `isort` issue: https://github.com/pycqa/isort/issues/1284