### PR TITLE
Check if a user is in the room before sending a PowerLevel event on their behalf

### DIFF
--- a/changelog.d/9235.bugfix
+++ b/changelog.d/9235.bugfix
@@ -1,0 +1,1 @@
+The make_room_admin admin API now checks if a user is in the room before sending a PL event on their behalf. Contributed by Pankaj Yadav.

--- a/changelog.d/9235.bugfix
+++ b/changelog.d/9235.bugfix
@@ -1,1 +1,1 @@
-The make_room_admin admin API now checks if a user is in the room before sending a PL event on their behalf. Contributed by Pankaj Yadav.
+Fix a bug in the `make_room_admin` admin API where it failed if the admin with the greatest power level was not in the room. Contributed by Pankaj Yadav.

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -431,7 +431,17 @@ class MakeRoomAdminRestServlet(RestServlet):
             if not admin_users:
                 raise SynapseError(400, "No local admin user in room")
 
-            admin_user_id = admin_users[-1]
+            admin_user_id = None
+
+            for admin_user in reversed(admin_users):
+                if room_state.get((EventTypes.Member, admin_user)):
+                    admin_user_id = admin_user
+                    break
+
+            if not admin_user_id:
+                raise SynapseError(
+                    400, "No local admin user in room",
+                )
 
             pl_content = power_levels.content
         else:


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

Signed-off-by: Pankaj Yadav <pankaj2000.fideri@gmail.com>

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Get user with the highest power level **present** in the room. Raise an error if no such user is present. ( Solves [#9175](https://github.com/matrix-org/synapse/issues/9175) )