### PR TITLE
Cache config options in SSL verification

### DIFF
--- a/changelog.d/9238.misc
+++ b/changelog.d/9238.misc
@@ -1,1 +1,0 @@
-Add ratelimited to 3PID `/requestToken` API.

--- a/changelog.d/9238.misc
+++ b/changelog.d/9238.misc
@@ -1,0 +1,1 @@
+Add ratelimited to 3PID `/requestToken` API.

--- a/changelog.d/9255.misc
+++ b/changelog.d/9255.misc
@@ -1,0 +1,1 @@
+Minor performance improvement during TLS handshake.

--- a/synapse/crypto/context_factory.py
+++ b/synapse/crypto/context_factory.py
@@ -125,19 +125,24 @@ class FederationPolicyForHTTPS:
         self._no_verify_ssl_context = _no_verify_ssl.getContext()
         self._no_verify_ssl_context.set_info_callback(_context_info_cb)
 
-    def get_options(self, host: bytes):
+        self._should_verify = self._config.federation_verify_certificates
 
+        self._federation_certificate_verification_whitelist = (
+            self._config.federation_certificate_verification_whitelist
+        )
+
+    def get_options(self, host: bytes):
         # IPolicyForHTTPS.get_options takes bytes, but we want to compare
         # against the str whitelist. The hostnames in the whitelist are already
         # IDNA-encoded like the hosts will be here.
         ascii_host = host.decode("ascii")
 
         # Check if certificate verification has been enabled
-        should_verify = self._config.federation_verify_certificates
+        should_verify = self._should_verify
 
         # Check if we've disabled certificate verification for this host
-        if should_verify:
-            for regex in self._config.federation_certificate_verification_whitelist:
+        if self._should_verify:
+            for regex in self._federation_certificate_verification_whitelist:
                 if regex.match(ascii_host):
                     should_verify = False
                     break


### PR DESCRIPTION
Reading from the config object is *slow*.