### PR TITLE
Handle empty rooms when generating email notifications.

### DIFF
--- a/changelog.d/9257.bugfix
+++ b/changelog.d/9257.bugfix
@@ -1,0 +1,1 @@
+Fix long-standing KeyError in synapse.push.mailer in get_message_vars.

--- a/changelog.d/9257.bugfix
+++ b/changelog.d/9257.bugfix
@@ -1,1 +1,1 @@
-Fix long-standing KeyError in synapse.push.mailer in get_message_vars.
+Fix long-standing bug where sending email push would fail for rooms that the server had since left.

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -495,8 +495,8 @@ class Mailer:
             return None
 
         # Get the sender's name and avatar from the room state.
-        state_key = ("m.room.member", event.sender)
-        sender_state_event_id = room_state_ids.get(state_key)
+        type_state_key = ("m.room.member", event.sender)
+        sender_state_event_id = room_state_ids.get(type_state_key)
         if sender_state_event_id:
             sender_state_event = await self.store.get_event(
                 sender_state_event_id
@@ -504,9 +504,9 @@ class Mailer:
         else:
             # Attempt to check the historical state for the room.
             historical_state = await self.state_store.get_state_for_event(
-                event.event_id, StateFilter.from_types((state_key,))
+                event.event_id, StateFilter.from_types((type_state_key,))
             )
-            sender_state_event = historical_state.get(state_key)
+            sender_state_event = historical_state.get(type_state_key)
 
         if sender_state_event:
             sender_name = name_from_member_event(sender_state_event)
@@ -750,16 +750,16 @@ class Mailer:
         member_event_ids = []
         member_events = {}
         for sender_id, event_id in sender_ids.items():
-            state_key = ("m.room.member", sender_id)
-            sender_state_event_id = room_state_ids.get(state_key)
+            type_state_key = ("m.room.member", sender_id)
+            sender_state_event_id = room_state_ids.get(type_state_key)
             if sender_state_event_id:
                 member_event_ids.append(sender_state_event_id)
             else:
                 # Attempt to check the historical state for the room.
                 historical_state = await self.state_store.get_state_for_event(
-                    event_id, StateFilter.from_types((state_key,))
+                    event_id, StateFilter.from_types((type_state_key,))
                 )
-                sender_state_event = historical_state.get(state_key)
+                sender_state_event = historical_state.get(type_state_key)
                 if sender_state_event:
                     member_events[event_id] = sender_state_event
         member_events.update(await self.store.get_events(member_event_ids))

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -443,10 +443,15 @@ class Mailer:
         if event.type != EventTypes.Message and event.type != EventTypes.Encrypted:
             return None
 
-        sender_state_event_id = room_state_ids[("m.room.member", event.sender)]
-        sender_state_event = await self.store.get_event(sender_state_event_id)
-        sender_name = name_from_member_event(sender_state_event)
-        sender_avatar_url = sender_state_event.content.get("avatar_url")
+        sender_state_event_id = room_state_ids.get(("m.room.member", event.sender))
+        if sender_state_event_id:
+            sender_state_event = await self.store.get_event(sender_state_event_id)
+            sender_name = name_from_member_event(sender_state_event)
+            sender_avatar_url = sender_state_event.content.get("avatar_url")
+        else:
+            # The sender is no longer in the room for some reason.
+            sender_name = event.sender
+            sender_avatar_url = None
 
         # 'hash' for deterministically picking default images: use
         # sender_hash % the number of default images to choose from

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -217,6 +217,25 @@ class EmailPusherTests(HomeserverTestCase):
         # We should get emailed about those messages
         self._check_for_mail()
 
+    def test_empty_room(self):
+        """All users leaving a room shouldn't cause the pusher to break."""
+        # Create a simple room with two users
+        room = self.helper.create_room_as(self.user_id, tok=self.access_token)
+        self.helper.invite(
+            room=room, src=self.user_id, tok=self.access_token, targ=self.others[0].id
+        )
+        self.helper.join(room=room, user=self.others[0].id, tok=self.others[0].token)
+
+        # The other user sends a single message.
+        self.helper.send(room, body="Hi!", tok=self.others[0].token)
+
+        # Leave the room before the message is processed.
+        self.helper.leave(room, self.user_id, tok=self.access_token)
+        self.helper.leave(room, self.others[0].id, tok=self.others[0].token)
+
+        # We should get emailed about that message
+        self._check_for_mail()
+
     def test_encrypted_message(self):
         room = self.helper.create_room_as(self.user_id, tok=self.access_token)
         self.helper.invite(

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -124,11 +124,16 @@ class EmailPusherTests(HomeserverTestCase):
         )
         self.helper.join(room=room, user=self.others[0].id, tok=self.others[0].token)
 
-        # The other user sends some messages
+        # The other user sends a single message.
+        self.helper.send(room, body="Hi!", tok=self.others[0].token)
+
+        # We should get emailed about that message
+        self._check_for_mail()
+
+        # The other user sends multiple messages.
         self.helper.send(room, body="Hi!", tok=self.others[0].token)
         self.helper.send(room, body="There!", tok=self.others[0].token)
 
-        # We should get emailed about that message
         self._check_for_mail()
 
     def test_invite_sends_email(self):
@@ -236,6 +241,26 @@ class EmailPusherTests(HomeserverTestCase):
         # We should get emailed about that message
         self._check_for_mail()
 
+    def test_empty_room_multiple_messages(self):
+        """All users leaving a room shouldn't cause the pusher to break."""
+        # Create a simple room with two users
+        room = self.helper.create_room_as(self.user_id, tok=self.access_token)
+        self.helper.invite(
+            room=room, src=self.user_id, tok=self.access_token, targ=self.others[0].id
+        )
+        self.helper.join(room=room, user=self.others[0].id, tok=self.others[0].token)
+
+        # The other user sends a single message.
+        self.helper.send(room, body="Hi!", tok=self.others[0].token)
+        self.helper.send(room, body="There!", tok=self.others[0].token)
+
+        # Leave the room before the message is processed.
+        self.helper.leave(room, self.user_id, tok=self.access_token)
+        self.helper.leave(room, self.others[0].id, tok=self.others[0].token)
+
+        # We should get emailed about that message
+        self._check_for_mail()
+
     def test_encrypted_message(self):
         room = self.helper.create_room_as(self.user_id, tok=self.access_token)
         self.helper.invite(
@@ -288,3 +313,6 @@ class EmailPusherTests(HomeserverTestCase):
         pushers = list(pushers)
         self.assertEqual(len(pushers), 1)
         self.assertTrue(pushers[0].last_stream_ordering > last_stream_ordering)
+
+        # Reset the attempts.
+        self.email_attempts = []


### PR DESCRIPTION
~~This got a bit out of hand for how I started, I can split this into separate PRs if we would like.~~ The overall goal is to fix the sentry error from #9256 where a member is no longer in the room state (for whatever reason) when generating the push notification.

This can happen in two spots which are handled separately:
1. `get_message_vars`, where the state is used to get the member's name and avatar URL, we can provide reasonable defaults by using the MXID and no avatar.
2. `make_summary_text`, where we can provide slightly more generic summaries.

~~While working on this I ended up refactoring the `make_summary_text` method, then fixing a bug in it. I can split this out to a separate PR if that is clearer.~~ This was split out into #9260.