### PR TITLE
Prevent email UIA failures from raising a LoginError

### DIFF
--- a/changelog.d/9265.bugfix
+++ b/changelog.d/9265.bugfix
@@ -1,0 +1,1 @@
+Prevent password hashes from getting dropped if a client failed threepid validation during a User Interactive Auth stage.

--- a/changelog.d/9265.bugfix
+++ b/changelog.d/9265.bugfix
@@ -1,1 +1,1 @@
-Prevent password hashes from getting dropped if a client failed threepid validation during a User Interactive Auth stage.
+Prevent password hashes from getting dropped if a client failed threepid validation during a User Interactive Auth stage. Removes a workaround for an ancient bug in Riot Web <v0.7.4.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -567,16 +567,6 @@ class AuthHandler(BaseHandler):
                         session.session_id, login_type, result
                     )
             except LoginError as e:
-                if login_type == LoginType.EMAIL_IDENTITY:
-                    # riot used to have a bug where it would request a new
-                    # validation token (thus sending a new email) each time it
-                    # got a 401 with a 'flows' field.
-                    # (https://github.com/vector-im/vector-web/issues/2447).
-                    #
-                    # Grandfather in the old behaviour for now to avoid
-                    # breaking old riot deployments.
-                    raise
-
                 # this step failed. Merge the error dict into the response
                 # so that the client can have another go.
                 errordict = e.error_dict()


### PR DESCRIPTION
Context, Fixes: https://github.com/matrix-org/synapse/issues/9263

In the past to fix an issue with old Riots re-requesting threepid validation tokens, we raised a `LoginError` during UIA instead of `InteractiveAuthIncompleteError`. This is now breaking the way Tchap logs in - which isn't standard, but also isn't disallowed by the spec.

An easy fix is just to remove the 4 year old workaround.