### PR TITLE
social login: add noopener to terms link

### DIFF
--- a/changelog.d/9300.feature
+++ b/changelog.d/9300.feature
@@ -1,0 +1,1 @@
+Further improvements to the user experience of registration via single sign-on.

--- a/synapse/res/templates/sso_new_user_consent.html
+++ b/synapse/res/templates/sso_new_user_consent.html
@@ -30,7 +30,7 @@
             <form method="post" action="{{my_url}}" id="consent_form">
                 <p>
                     <input id="accepted_version" type="checkbox" name="accepted_version" value="{{ consent_version }}" required>
-                    <label for="accepted_version">I have read and agree to the <a href="{{ terms_url }}" target="_blank">terms and conditions</a>.</label>
+                    <label for="accepted_version">I have read and agree to the <a href="{{ terms_url }}" target="_blank" rel="noopener">terms and conditions</a>.</label>
                 </p>
                 <input type="submit" class="primary-button" value="Continue"/>
             </form>


### PR DESCRIPTION
this is basically a security thing, aiui