### PR TITLE
support federation queries through http connect proxy

### DIFF
--- a/changelog.d/9306.feature
+++ b/changelog.d/9306.feature
@@ -1,0 +1,1 @@
+Add support for sending federation requests through a proxy. Contributed by @Bubu.

--- a/synapse/http/federation/matrix_federation_agent.py
+++ b/synapse/http/federation/matrix_federation_agent.py
@@ -326,7 +326,11 @@ class MatrixHostnameEndpoint:
                         )
 
                     endpoint = HTTPConnectProxyEndpoint(
-                        self._reactor, self.https_proxy_endpoint, host, port, headers=connect_headers
+                        self._reactor,
+                        self.https_proxy_endpoint,
+                        host,
+                        port,
+                        headers=connect_headers,
                     )
                 else:
                     logger.debug("Connecting to %s:%i", host.decode("ascii"), port)

--- a/synapse/http/federation/matrix_federation_agent.py
+++ b/synapse/http/federation/matrix_federation_agent.py
@@ -307,6 +307,7 @@ class MatrixHostnameEndpoint:
             host = server.host
             port = server.port
 
+            endpoint: IStreamClientEndpoint
             try:
                 if self.https_proxy_endpoint and not proxy_bypass(host.decode()):
                     logger.debug(

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -279,6 +279,7 @@ class MatrixFederationHttpClient:
             tls_client_options_factory,
             user_agent,
             hs.config.federation_ip_range_blacklist,
+            proxy_reactor=hs.get_reactor(),
         )
 
         # Use a BlacklistingAgentWrapper to prevent circumventing the IP

--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -267,7 +267,9 @@ def http_proxy_endpoint(proxy: Optional[bytes], reactor, **kwargs):
     return HostnameEndpoint(reactor, host, port, **kwargs)
 
 
-def parse_username_password(proxy: Optional[bytes]) -> Tuple[Optional[ProxyCredentials], bytes]:
+def parse_username_password(
+    proxy: Optional[bytes],
+) -> Tuple[Optional[ProxyCredentials], bytes]:
     """
     Parses the username and password from a proxy declaration e.g
     username:password@hostname:port.

--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -267,7 +267,7 @@ def http_proxy_endpoint(proxy: Optional[bytes], reactor, **kwargs):
     return HostnameEndpoint(reactor, host, port, **kwargs)
 
 
-def parse_username_password(proxy: bytes) -> Tuple[Optional[ProxyCredentials], bytes]:
+def parse_username_password(proxy: Optional[bytes]) -> Tuple[Optional[ProxyCredentials], bytes]:
     """
     Parses the username and password from a proxy declaration e.g
     username:password@hostname:port.

--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -120,11 +120,11 @@ class ProxyAgent(_AgentBase):
         # Parse credentials from https proxy connection string if present
         self.https_proxy_creds, https_proxy = parse_username_password(https_proxy)
 
-        self.http_proxy_endpoint = _http_proxy_endpoint(
+        self.http_proxy_endpoint = http_proxy_endpoint(
             http_proxy, self.proxy_reactor, **self._endpoint_kwargs
         )
 
-        self.https_proxy_endpoint = _http_proxy_endpoint(
+        self.https_proxy_endpoint = http_proxy_endpoint(
             https_proxy, self.proxy_reactor, **self._endpoint_kwargs
         )
 
@@ -243,7 +243,7 @@ class ProxyAgent(_AgentBase):
         )
 
 
-def _http_proxy_endpoint(proxy: Optional[bytes], reactor, **kwargs):
+def http_proxy_endpoint(proxy: Optional[bytes], reactor, **kwargs):
     """Parses an http proxy setting and returns an endpoint for the proxy
 
     Args:

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -16,9 +16,8 @@ import logging
 import os
 from unittest.mock import patch
 
-from mock import Mock
-
 import treq
+from mock import Mock
 from netaddr import IPSet
 from service_identity import VerificationError
 from zope.interface import implementer


### PR DESCRIPTION
Can be specified by HTTPS_PROXY env var.

pass unfiltered reactor to federation agent for proxy support

Signed-off-by: Marcus Hoffmann <bubu@bubu1.eu>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Fixes #8660