### PR TITLE
Add flake8-bugbear to the test suite, resolve resulting lint errors

### DIFF
--- a/changelog.d/9320.misc
+++ b/changelog.d/9320.misc
@@ -1,0 +1,1 @@
+Add flake8-bugbear to test suite, to enrich lint errors with probable subtle bugs.

--- a/contrib/cmdclient/console.py
+++ b/contrib/cmdclient/console.py
@@ -23,9 +23,8 @@ import shlex
 import sys
 import time
 import urllib
-from typing import Optional
-
 from http import TwistedHttpClient
+from typing import Optional
 
 import nacl.encoding
 import nacl.signing
@@ -716,7 +715,12 @@ class SynapseCmd(cmd.Cmd):
 
     @defer.inlineCallbacks
     def _run_and_pprint(
-        self, method, path, data=None, query_params: Optional[dict] = None, alt_text=None,
+        self,
+        method,
+        path,
+        data=None,
+        query_params: Optional[dict] = None,
+        alt_text=None,
     ):
         """ Runs an HTTP request and pretty prints the output.
 

--- a/contrib/cmdclient/console.py
+++ b/contrib/cmdclient/console.py
@@ -714,12 +714,7 @@ class SynapseCmd(cmd.Cmd):
 
     @defer.inlineCallbacks
     def _run_and_pprint(
-        self,
-        method,
-        path,
-        data=None,
-        query_params={"access_token": None},
-        alt_text=None,
+        self, method, path, data=None, query_params: dict = None, alt_text=None,
     ):
         """ Runs an HTTP request and pretty prints the output.
 
@@ -729,6 +724,8 @@ class SynapseCmd(cmd.Cmd):
             data: Raw JSON data if any
             query_params: dict of query parameters to add to the url
         """
+        query_params = query_params or {"access_token": None}
+
         url = self._url() + path
         if "access_token" in query_params:
             query_params["access_token"] = self._tok()

--- a/contrib/cmdclient/console.py
+++ b/contrib/cmdclient/console.py
@@ -23,6 +23,8 @@ import shlex
 import sys
 import time
 import urllib
+from typing import Optional
+
 from http import TwistedHttpClient
 
 import nacl.encoding
@@ -714,7 +716,7 @@ class SynapseCmd(cmd.Cmd):
 
     @defer.inlineCallbacks
     def _run_and_pprint(
-        self, method, path, data=None, query_params: dict = None, alt_text=None,
+        self, method, path, data=None, query_params: Optional[dict] = None, alt_text=None,
     ):
         """ Runs an HTTP request and pretty prints the output.
 

--- a/contrib/cmdclient/http.py
+++ b/contrib/cmdclient/http.py
@@ -108,7 +108,13 @@ class TwistedHttpClient(HttpClient):
 
     @defer.inlineCallbacks
     def do_request(
-        self, method, url, data=None, qparams=None, jsonreq=True, headers: Optional[dict] = None
+        self,
+        method,
+        url,
+        data=None,
+        qparams=None,
+        jsonreq=True,
+        headers: Optional[dict] = None,
     ):
         headers = headers or {}
         if qparams:
@@ -131,7 +137,9 @@ class TwistedHttpClient(HttpClient):
         defer.returnValue(json.loads(body))
 
     @defer.inlineCallbacks
-    def _create_request(self, method, url, producer=None, headers_dict: Optional[dict] = None):
+    def _create_request(
+        self, method, url, producer=None, headers_dict: Optional[dict] = None
+    ):
         """ Creates and sends a request to the given url
         """
         headers_dict = headers_dict or {}

--- a/contrib/cmdclient/http.py
+++ b/contrib/cmdclient/http.py
@@ -16,6 +16,7 @@
 import json
 import urllib
 from pprint import pformat
+from typing import Optional
 
 from twisted.internet import defer, reactor
 from twisted.web.client import Agent, readBody
@@ -86,7 +87,7 @@ class TwistedHttpClient(HttpClient):
         body = yield readBody(response)
         defer.returnValue(json.loads(body))
 
-    def _create_put_request(self, url, json_data, headers_dict: dict = None):
+    def _create_put_request(self, url, json_data, headers_dict: Optional[dict] = None):
         """ Wrapper of _create_request to issue a PUT request
         """
         headers_dict = headers_dict or {}
@@ -98,7 +99,7 @@ class TwistedHttpClient(HttpClient):
             "PUT", url, producer=_JsonProducer(json_data), headers_dict=headers_dict
         )
 
-    def _create_get_request(self, url, headers_dict: dict = None):
+    def _create_get_request(self, url, headers_dict: Optional[dict] = None):
         """ Wrapper of _create_request to issue a GET request
         """
         headers_dict = headers_dict or {}
@@ -107,7 +108,7 @@ class TwistedHttpClient(HttpClient):
 
     @defer.inlineCallbacks
     def do_request(
-        self, method, url, data=None, qparams=None, jsonreq=True, headers: dict = None
+        self, method, url, data=None, qparams=None, jsonreq=True, headers: Optional[dict] = None
     ):
         headers = headers or {}
         if qparams:
@@ -130,7 +131,7 @@ class TwistedHttpClient(HttpClient):
         defer.returnValue(json.loads(body))
 
     @defer.inlineCallbacks
-    def _create_request(self, method, url, producer=None, headers_dict: dict = None):
+    def _create_request(self, method, url, producer=None, headers_dict: Optional[dict] = None):
         """ Creates and sends a request to the given url
         """
         headers_dict = headers_dict or {}

--- a/contrib/cmdclient/http.py
+++ b/contrib/cmdclient/http.py
@@ -86,9 +86,10 @@ class TwistedHttpClient(HttpClient):
         body = yield readBody(response)
         defer.returnValue(json.loads(body))
 
-    def _create_put_request(self, url, json_data, headers_dict={}):
+    def _create_put_request(self, url, json_data, headers_dict: dict = None):
         """ Wrapper of _create_request to issue a PUT request
         """
+        headers_dict = headers_dict or {}
 
         if "Content-Type" not in headers_dict:
             raise defer.error(RuntimeError("Must include Content-Type header for PUTs"))
@@ -97,15 +98,18 @@ class TwistedHttpClient(HttpClient):
             "PUT", url, producer=_JsonProducer(json_data), headers_dict=headers_dict
         )
 
-    def _create_get_request(self, url, headers_dict={}):
+    def _create_get_request(self, url, headers_dict: dict = None):
         """ Wrapper of _create_request to issue a GET request
         """
+        headers_dict = headers_dict or {}
+
         return self._create_request("GET", url, headers_dict=headers_dict)
 
     @defer.inlineCallbacks
     def do_request(
-        self, method, url, data=None, qparams=None, jsonreq=True, headers={}
+        self, method, url, data=None, qparams=None, jsonreq=True, headers: dict = None
     ):
+        headers = headers or {}
         if qparams:
             url = "%s?%s" % (url, urllib.urlencode(qparams, True))
 
@@ -126,9 +130,11 @@ class TwistedHttpClient(HttpClient):
         defer.returnValue(json.loads(body))
 
     @defer.inlineCallbacks
-    def _create_request(self, method, url, producer=None, headers_dict={}):
+    def _create_request(self, method, url, producer=None, headers_dict: dict = None):
         """ Creates and sends a request to the given url
         """
+        headers_dict = headers_dict or {}
+
         headers_dict["User-Agent"] = ["Synapse Cmd Client"]
 
         retries_left = 5

--- a/scripts-dev/definitions.py
+++ b/scripts-dev/definitions.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
 
     definitions = {}
     for directory in args.directories:
-        for root, dirs, files in os.walk(directory):
+        for root, _, files in os.walk(directory):
             for filename in files:
                 if filename.endswith(".py"):
                     filepath = os.path.join(root, filename)

--- a/scripts-dev/list_url_patterns.py
+++ b/scripts-dev/list_url_patterns.py
@@ -48,7 +48,7 @@ args = parser.parse_args()
 
 
 for directory in args.directories:
-    for root, dirs, files in os.walk(directory):
+    for root, _, files in os.walk(directory):
         for filename in files:
             if filename.endswith(".py"):
                 filepath = os.path.join(root, filename)

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ CONDITIONAL_REQUIREMENTS["all"] = list(ALL_OPTIONAL_REQUIREMENTS)
 CONDITIONAL_REQUIREMENTS["lint"] = [
     "isort==5.7.0",
     "black==19.10b0",
+    "flake8-bugbear",
     "flake8-comprehensions",
     "flake8",
 ]

--- a/synapse/app/__init__.py
+++ b/synapse/app/__init__.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 try:
     python_dependencies.check_requirements()
 except python_dependencies.DependencyException as e:
-    sys.stderr.writelines(e.message)
+    sys.stderr.writelines(e.message)  # noqa: B306
     sys.exit(1)
 
 

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -49,7 +49,7 @@ This is all tied together by the AppServiceScheduler which DIs the required
 components.
 """
 import logging
-from typing import List
+from typing import List, Optional
 
 from synapse.appservice import ApplicationService, ApplicationServiceState
 from synapse.events import EventBase
@@ -191,7 +191,7 @@ class _TransactionController:
         self,
         service: ApplicationService,
         events: List[EventBase],
-        ephemeral: List[JsonDict] = None,
+        ephemeral: Optional[List[JsonDict]] = None,
     ):
         try:
             txn = await self.store.create_appservice_txn(

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -191,11 +191,11 @@ class _TransactionController:
         self,
         service: ApplicationService,
         events: List[EventBase],
-        ephemeral: List[JsonDict] = [],
+        ephemeral: List[JsonDict] = None,
     ):
         try:
             txn = await self.store.create_appservice_txn(
-                service=service, events=events, ephemeral=ephemeral
+                service=service, events=events, ephemeral=ephemeral or []
             )
             service_is_up = await self._is_service_up(service)
             if service_is_up:
@@ -204,8 +204,8 @@ class _TransactionController:
                     await txn.complete(self.store)
                 else:
                     run_in_background(self._on_txn_fail, service)
-        except Exception:
-            logger.exception("Error creating appservice transaction")
+        except Exception as e:
+            logger.exception("Error creating appservice transaction", exc_info=e)
             run_in_background(self._on_txn_fail, service)
 
     async def on_recovered(self, recoverer):

--- a/synapse/config/key.py
+++ b/synapse/config/key.py
@@ -404,7 +404,7 @@ def _parse_key_servers(key_servers, federation_verify_certificates):
     try:
         jsonschema.validate(key_servers, TRUSTED_KEY_SERVERS_SCHEMA)
     except jsonschema.ValidationError as e:
-        raise ConfigError("Unable to parse 'trusted_key_servers': " + e.message)
+        raise ConfigError("Unable to parse 'trusted_key_servers':") from e
 
     for server in key_servers:
         server_name = server["server_name"]

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -56,7 +56,7 @@ class MetricsConfig(Config):
             try:
                 check_requirements("sentry")
             except DependencyException as e:
-                raise ConfigError(e.message)
+                raise ConfigError(e.message) from e  # noqa: B306
 
             self.sentry_dsn = config["sentry"].get("dsn")
             if not self.sentry_dsn:

--- a/synapse/config/oidc_config.py
+++ b/synapse/config/oidc_config.py
@@ -41,7 +41,7 @@ class OIDCConfig(Config):
         try:
             check_requirements("oidc")
         except DependencyException as e:
-            raise ConfigError(e.message) from e
+            raise ConfigError(e.message) from e  # noqa: B306
 
         # check we don't have any duplicate idp_ids now. (The SSO handler will also
         # check for duplicates when the REST listeners get registered, but that happens

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -19,10 +19,9 @@ from ._base import Config
 
 class RateLimitConfig:
     def __init__(
-        self,
-        config: Dict[str, float],
-        defaults={"per_second": 0.17, "burst_count": 3.0},
+        self, config: Dict[str, float], defaults: Dict[str, float] = None,
     ):
+        defaults = defaults or {"per_second": 0.17, "burst_count": 3.0}
         self.per_second = config.get("per_second", defaults["per_second"])
         self.burst_count = int(config.get("burst_count", defaults["burst_count"]))
 

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
+from typing import Dict, Optional
 
 from ._base import Config
 
 
 class RateLimitConfig:
     def __init__(
-        self, config: Dict[str, float], defaults: Dict[str, float] = None,
+        self, config: Dict[str, float], defaults: Optional[Dict[str, float]] = None,
     ):
         defaults = defaults or {"per_second": 0.17, "burst_count": 3.0}
         self.per_second = config.get("per_second", defaults["per_second"])

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -176,7 +176,7 @@ class ContentRepositoryConfig(Config):
                 check_requirements("url_preview")
 
             except DependencyException as e:
-                raise ConfigError(e.message)
+                raise ConfigError(e.message) from e  # noqa: B306
 
             if "url_preview_ip_range_blacklist" not in config:
                 raise ConfigError(

--- a/synapse/config/saml2_config.py
+++ b/synapse/config/saml2_config.py
@@ -77,7 +77,7 @@ class SAML2Config(Config):
         try:
             check_requirements("saml2")
         except DependencyException as e:
-            raise ConfigError(e.message)
+            raise ConfigError(e.message) from e  # noqa: B306
 
         self.saml2_enabled = True
 

--- a/synapse/config/tracer.py
+++ b/synapse/config/tracer.py
@@ -39,7 +39,7 @@ class TracerConfig(Config):
         try:
             check_requirements("opentracing")
         except DependencyException as e:
-            raise ConfigError(e.message)
+            raise ConfigError(e.message) from e  # noqa: B306
 
         # The tracer is enabled so sanitize the config
 

--- a/synapse/crypto/context_factory.py
+++ b/synapse/crypto/context_factory.py
@@ -191,7 +191,7 @@ def _context_info_cb(ssl_connection, where, ret):
         # ... we further assume that SSLClientConnectionCreator has set the
         # '_synapse_tls_verifier' attribute to a ConnectionVerifier object.
         tls_protocol._synapse_tls_verifier.verify_context_info_cb(ssl_connection, where)
-    except BaseException as e:  # taken from the twisted implementation
+    except Exception as e:  # taken from the twisted implementation
         logger.exception("Error during info_callback", exc_info=e)
         f = Failure(e)
         tls_protocol.failVerification(f)

--- a/synapse/crypto/context_factory.py
+++ b/synapse/crypto/context_factory.py
@@ -191,9 +191,9 @@ def _context_info_cb(ssl_connection, where, ret):
         # ... we further assume that SSLClientConnectionCreator has set the
         # '_synapse_tls_verifier' attribute to a ConnectionVerifier object.
         tls_protocol._synapse_tls_verifier.verify_context_info_cb(ssl_connection, where)
-    except:  # noqa: E722, taken from the twisted implementation
-        logger.exception("Error during info_callback")
-        f = Failure()
+    except BaseException as e:  # taken from the twisted implementation
+        logger.exception("Error during info_callback", exc_info=e)
+        f = Failure(e)
         tls_protocol.failVerification(f)
 
 
@@ -219,7 +219,7 @@ class SSLClientConnectionCreator:
         # ... and we also gut-wrench a '_synapse_tls_verifier' attribute into the
         # tls_protocol so that the SSL context's info callback has something to
         # call to do the cert verification.
-        setattr(tls_protocol, "_synapse_tls_verifier", self._verifier)
+        tls_protocol._synapse_tls_verifier = self._verifier
         return connection
 
 

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -651,7 +651,7 @@ def _verify_third_party_invite(event: EventBase, auth_events: StateMap[EventBase
         public_key = public_key_object["public_key"]
         try:
             for server, signature_block in signed["signatures"].items():
-                for key_name, encoded_signature in signature_block.items():
+                for key_name in signature_block.keys():
                     if not key_name.startswith("ed25519:"):
                         continue
                     verify_key = decode_verify_key_bytes(

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -327,7 +327,7 @@ class FrozenEvent(EventBase):
         self,
         event_dict: JsonDict,
         room_version: RoomVersion,
-        internal_metadata_dict: JsonDict = None,
+        internal_metadata_dict: Optional[JsonDict] = None,
         rejected_reason: Optional[str] = None,
     ):
         event_dict = dict(event_dict)
@@ -383,7 +383,7 @@ class FrozenEventV2(EventBase):
         self,
         event_dict: JsonDict,
         room_version: RoomVersion,
-        internal_metadata_dict: JsonDict = None,
+        internal_metadata_dict: Optional[JsonDict] = None,
         rejected_reason: Optional[str] = None,
     ):
         event_dict = dict(event_dict)
@@ -504,7 +504,7 @@ def _event_type_from_format_version(format_version: int) -> Type[EventBase]:
 def make_event_from_dict(
     event_dict: JsonDict,
     room_version: RoomVersion = RoomVersions.V1,
-    internal_metadata_dict: JsonDict = None,
+    internal_metadata_dict: Optional[JsonDict] = None,
     rejected_reason: Optional[str] = None,
 ) -> EventBase:
     """Construct an EventBase from the given event dict"""

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -327,7 +327,7 @@ class FrozenEvent(EventBase):
         self,
         event_dict: JsonDict,
         room_version: RoomVersion,
-        internal_metadata_dict: JsonDict = {},
+        internal_metadata_dict: JsonDict = None,
         rejected_reason: Optional[str] = None,
     ):
         event_dict = dict(event_dict)
@@ -357,7 +357,7 @@ class FrozenEvent(EventBase):
             room_version=room_version,
             signatures=signatures,
             unsigned=unsigned,
-            internal_metadata_dict=internal_metadata_dict,
+            internal_metadata_dict=internal_metadata_dict or {},
             rejected_reason=rejected_reason,
         )
 
@@ -383,7 +383,7 @@ class FrozenEventV2(EventBase):
         self,
         event_dict: JsonDict,
         room_version: RoomVersion,
-        internal_metadata_dict: JsonDict = {},
+        internal_metadata_dict: JsonDict = None,
         rejected_reason: Optional[str] = None,
     ):
         event_dict = dict(event_dict)
@@ -415,7 +415,7 @@ class FrozenEventV2(EventBase):
             room_version=room_version,
             signatures=signatures,
             unsigned=unsigned,
-            internal_metadata_dict=internal_metadata_dict,
+            internal_metadata_dict=internal_metadata_dict or {},
             rejected_reason=rejected_reason,
         )
 
@@ -504,9 +504,11 @@ def _event_type_from_format_version(format_version: int) -> Type[EventBase]:
 def make_event_from_dict(
     event_dict: JsonDict,
     room_version: RoomVersion = RoomVersions.V1,
-    internal_metadata_dict: JsonDict = {},
+    internal_metadata_dict: JsonDict = None,
     rejected_reason: Optional[str] = None,
 ) -> EventBase:
     """Construct an EventBase from the given event dict"""
     event_type = _event_type_from_format_version(room_version.event_format)
-    return event_type(event_dict, room_version, internal_metadata_dict, rejected_reason)
+    return event_type(
+        event_dict, room_version, internal_metadata_dict or {}, rejected_reason
+    )

--- a/synapse/federation/send_queue.py
+++ b/synapse/federation/send_queue.py
@@ -540,10 +540,10 @@ def process_rows_for_federation(transaction_queue, rows):
             states=[state], destinations=destinations
         )
 
-    for destination, edu_map in buff.keyed_edus.items():
+    for edu_map in buff.keyed_edus.values():
         for key, edu in edu_map.items():
             transaction_queue.send_edu(edu, key)
 
-    for destination, edu_list in buff.edus.items():
+    for edu_list in buff.edus.values():
         for edu in edu_list:
             transaction_queue.send_edu(edu, None)

--- a/synapse/federation/units.py
+++ b/synapse/federation/units.py
@@ -18,6 +18,7 @@ server protocol.
 """
 
 import logging
+from typing import Optional
 
 import attr
 
@@ -98,7 +99,7 @@ class Transaction(JsonEncodedObject):
         "pdus",
     ]
 
-    def __init__(self, transaction_id=None, pdus: list = None, **kwargs):
+    def __init__(self, transaction_id=None, pdus: Optional[list] = None, **kwargs):
         """ If we include a list of pdus then we decode then as PDU's
         automatically.
         """

--- a/synapse/federation/units.py
+++ b/synapse/federation/units.py
@@ -98,7 +98,7 @@ class Transaction(JsonEncodedObject):
         "pdus",
     ]
 
-    def __init__(self, transaction_id=None, pdus=[], **kwargs):
+    def __init__(self, transaction_id=None, pdus: list = None, **kwargs):
         """ If we include a list of pdus then we decode then as PDU's
         automatically.
         """
@@ -107,7 +107,7 @@ class Transaction(JsonEncodedObject):
         if "edus" in kwargs and not kwargs["edus"]:
             del kwargs["edus"]
 
-        super().__init__(transaction_id=transaction_id, pdus=pdus, **kwargs)
+        super().__init__(transaction_id=transaction_id, pdus=pdus or [], **kwargs)
 
     @staticmethod
     def create_new(pdus, **kwargs):

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -182,7 +182,7 @@ class ApplicationServicesHandler:
         self,
         stream_key: str,
         new_token: Optional[int],
-        users: Collection[Union[str, UserID]] = None,
+        users: Optional[Collection[Union[str, UserID]]] = None,
     ):
         """This is called by the notifier in the background
         when a ephemeral event handled by the homeserver.

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -182,7 +182,7 @@ class ApplicationServicesHandler:
         self,
         stream_key: str,
         new_token: Optional[int],
-        users: Collection[Union[str, UserID]] = [],
+        users: Collection[Union[str, UserID]] = None,
     ):
         """This is called by the notifier in the background
         when a ephemeral event handled by the homeserver.
@@ -215,7 +215,7 @@ class ApplicationServicesHandler:
         # We only start a new background process if necessary rather than
         # optimistically (to cut down on overhead).
         self._notify_interested_services_ephemeral(
-            services, stream_key, new_token, users
+            services, stream_key, new_token, users or []
         )
 
     @wrap_as_background_process("notify_interested_services_ephemeral")

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1211,7 +1211,7 @@ class AuthHandler(BaseHandler):
 
         # see if any of our auth providers want to know about this
         for provider in self.password_providers:
-            for token, token_id, device_id in tokens_and_devices:
+            for token, _, device_id in tokens_and_devices:
                 await provider.on_logged_out(
                     user_id=user_id, device_id=device_id, access_token=token
                 )

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -157,7 +157,7 @@ class DeviceWorkerHandler(BaseHandler):
             # The user may have left the room
             # TODO: Check if they actually did or if we were just invited.
             if room_id not in room_ids:
-                for key, event_id in current_state_ids.items():
+                for key, _ in current_state_ids.items():
                     etype, state_key = key
                     if etype != EventTypes.Member:
                         continue
@@ -180,7 +180,7 @@ class DeviceWorkerHandler(BaseHandler):
                 log_kv(
                     {"event": "encountered empty previous state", "room_id": room_id}
                 )
-                for key, event_id in current_state_ids.items():
+                for key, _ in current_state_ids.items():
                     etype, state_key = key
                     if etype != EventTypes.Member:
                         continue
@@ -199,7 +199,7 @@ class DeviceWorkerHandler(BaseHandler):
             for state_dict in prev_state_ids.values():
                 member_event = state_dict.get((EventTypes.Member, user_id), None)
                 if not member_event or member_event != current_member_id:
-                    for key, event_id in current_state_ids.items():
+                    for key, _ in current_state_ids.items():
                         etype, state_key = key
                         if etype != EventTypes.Member:
                             continue
@@ -713,7 +713,7 @@ class DeviceListUpdater:
                 # This can happen since we batch updates
                 return
 
-            for device_id, stream_id, prev_ids, content in pending_updates:
+            for device_id, stream_id, prev_ids, _ in pending_updates:
                 logger.debug(
                     "Handling update %r/%r, ID: %r, prev: %r ",
                     user_id,
@@ -739,7 +739,7 @@ class DeviceListUpdater:
             else:
                 # Simply update the single device, since we know that is the only
                 # change (because of the single prev_id matching the current cache)
-                for device_id, stream_id, prev_ids, content in pending_updates:
+                for device_id, stream_id, _, content in pending_updates:
                     await self.store.update_remote_device_list_cache_entry(
                         user_id, device_id, content, stream_id
                     )

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -157,7 +157,7 @@ class DeviceWorkerHandler(BaseHandler):
             # The user may have left the room
             # TODO: Check if they actually did or if we were just invited.
             if room_id not in room_ids:
-                for key, _ in current_state_ids.items():
+                for key in current_state_ids.keys():
                     etype, state_key = key
                     if etype != EventTypes.Member:
                         continue
@@ -180,7 +180,7 @@ class DeviceWorkerHandler(BaseHandler):
                 log_kv(
                     {"event": "encountered empty previous state", "room_id": room_id}
                 )
-                for key, _ in current_state_ids.items():
+                for key in current_state_ids.keys():
                     etype, state_key = key
                     if etype != EventTypes.Member:
                         continue
@@ -199,7 +199,7 @@ class DeviceWorkerHandler(BaseHandler):
             for state_dict in prev_state_ids.values():
                 member_event = state_dict.get((EventTypes.Member, user_id), None)
                 if not member_event or member_event != current_member_id:
-                    for key, _ in current_state_ids.items():
+                    for key in current_state_ids.keys():
                         etype, state_key = key
                         if etype != EventTypes.Member:
                             continue

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1682,7 +1682,7 @@ class FederationHandler(BaseHandler):
         room_id: str,
         user_id: str,
         membership: str,
-        content: JsonDict = None,
+        content: Optional[JsonDict] = None,
         params: Optional[Dict[str, Union[str, Iterable[str]]]] = None,
     ) -> Tuple[str, EventBase, RoomVersion]:
         (
@@ -2814,7 +2814,7 @@ class FederationHandler(BaseHandler):
             try:
                 # for each sig on the third_party_invite block of the actual invite
                 for server, signature_block in signed["signatures"].items():
-                    for key_name, _ in signature_block.items():
+                    for key_name in signature_block.keys():
                         if not key_name.startswith("ed25519:"):
                             continue
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1682,7 +1682,7 @@ class FederationHandler(BaseHandler):
         room_id: str,
         user_id: str,
         membership: str,
-        content: JsonDict = {},
+        content: JsonDict = None,
         params: Optional[Dict[str, Union[str, Iterable[str]]]] = None,
     ) -> Tuple[str, EventBase, RoomVersion]:
         (
@@ -1690,7 +1690,7 @@ class FederationHandler(BaseHandler):
             event,
             room_version,
         ) = await self.federation_client.make_membership_event(
-            target_hosts, room_id, user_id, membership, content, params=params
+            target_hosts, room_id, user_id, membership, content or {}, params=params
         )
 
         logger.debug("Got response to make_%s: %s", membership, event)
@@ -2814,7 +2814,7 @@ class FederationHandler(BaseHandler):
             try:
                 # for each sig on the third_party_invite block of the actual invite
                 for server, signature_block in signed["signatures"].items():
-                    for key_name, encoded_signature in signature_block.items():
+                    for key_name, _ in signature_block.items():
                         if not key_name.startswith("ed25519:"):
                             continue
 

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -134,7 +134,7 @@ class MessageHandler:
         self,
         user_id: str,
         room_id: str,
-        state_filter: StateFilter = StateFilter.all(),
+        state_filter: StateFilter = None,
         at_token: Optional[StreamToken] = None,
         is_guest: bool = False,
     ) -> List[dict]:
@@ -161,6 +161,8 @@ class MessageHandler:
             AuthError (403) if the user doesn't have permission to view
             members of this room.
         """
+        state_filter = state_filter or StateFilter.all()
+
         if at_token:
             # FIXME this claims to get the state at a stream position, but
             # get_recent_events_for_room operates by topo ordering. This therefore
@@ -860,7 +862,7 @@ class EventCreationHandler:
         event: EventBase,
         context: EventContext,
         ratelimit: bool = True,
-        extra_users: List[UserID] = [],
+        extra_users: List[UserID] = None,
         ignore_shadow_ban: bool = False,
     ) -> EventBase:
         """Processes a new event.
@@ -888,6 +890,7 @@ class EventCreationHandler:
         Raises:
             ShadowBanError if the requester has been shadow-banned.
         """
+        extra_users = extra_users or []
 
         # we don't apply shadow-banning to membership events here. Invites are blocked
         # higher up the stack, and we allow shadow-banned users to send join and leave
@@ -1057,7 +1060,7 @@ class EventCreationHandler:
         event: EventBase,
         context: EventContext,
         ratelimit: bool = True,
-        extra_users: List[UserID] = [],
+        extra_users: List[UserID] = None,
     ) -> EventBase:
         """Called when we have fully built the event, have already
         calculated the push actions for the event, and checked auth.
@@ -1069,6 +1072,7 @@ class EventCreationHandler:
             it was de-duplicated (e.g. because we had already persisted an
             event with the same transaction ID.)
         """
+        extra_users = extra_users or []
         assert self.storage.persistence is not None
         assert self._events_shard_config.should_handle(
             self._instance_name, event.room_id

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -134,7 +134,7 @@ class MessageHandler:
         self,
         user_id: str,
         room_id: str,
-        state_filter: StateFilter = None,
+        state_filter: Optional[StateFilter] = None,
         at_token: Optional[StreamToken] = None,
         is_guest: bool = False,
     ) -> List[dict]:
@@ -862,7 +862,7 @@ class EventCreationHandler:
         event: EventBase,
         context: EventContext,
         ratelimit: bool = True,
-        extra_users: List[UserID] = None,
+        extra_users: Optional[List[UserID]] = None,
         ignore_shadow_ban: bool = False,
     ) -> EventBase:
         """Processes a new event.
@@ -1060,7 +1060,7 @@ class EventCreationHandler:
         event: EventBase,
         context: EventContext,
         ratelimit: bool = True,
-        extra_users: List[UserID] = None,
+        extra_users: Optional[List[UserID]] = None,
     ) -> EventBase:
         """Called when we have fully built the event, have already
         calculated the push actions for the event, and checked auth.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -153,7 +153,7 @@ class RegistrationHandler(BaseHandler):
         user_type: Optional[str] = None,
         default_display_name: Optional[str] = None,
         address: Optional[str] = None,
-        bind_emails: Iterable[str] = [],
+        bind_emails: Iterable[str] = None,
         by_admin: bool = False,
         user_agent_ips: Optional[List[Tuple[str, str]]] = None,
     ) -> str:
@@ -186,6 +186,8 @@ class RegistrationHandler(BaseHandler):
         Raises:
             SynapseError if there was a problem registering.
         """
+        bind_emails = bind_emails or []
+
         self.check_registration_ratelimit(address)
 
         result = await self.spam_checker.check_registration_for_spam(

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -153,7 +153,7 @@ class RegistrationHandler(BaseHandler):
         user_type: Optional[str] = None,
         default_display_name: Optional[str] = None,
         address: Optional[str] = None,
-        bind_emails: Iterable[str] = None,
+        bind_emails: Optional[Iterable[str]] = None,
         by_admin: bool = False,
         user_agent_ips: Optional[List[Tuple[str, str]]] = None,
     ) -> str:

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -541,7 +541,7 @@ class SyncHandler:
         )
 
     async def get_state_after_event(
-        self, event: EventBase, state_filter: StateFilter = None
+        self, event: EventBase, state_filter: Optional[StateFilter] = None
     ) -> StateMap[str]:
         """
         Get the room state after the given event
@@ -562,7 +562,7 @@ class SyncHandler:
         self,
         room_id: str,
         stream_position: StreamToken,
-        state_filter: StateFilter = None,
+        state_filter: Optional[StateFilter] = None,
     ) -> StateMap[str]:
         """ Get the room state at a particular stream position
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -575,6 +575,8 @@ class SyncHandler:
         # get_recent_events_for_room operates by topo ordering. This therefore
         # does not reliably give you the state at the given stream position.
         # (https://github.com/matrix-org/synapse/issues/3305)
+        state_filter = state_filter or StateFilter.all()
+
         last_events, _ = await self.store.get_recent_events_for_room(
             room_id, end_token=stream_position.room_key, limit=1
         )
@@ -582,7 +584,7 @@ class SyncHandler:
         if last_events:
             last_event = last_events[-1]
             state = await self.get_state_after_event(
-                last_event, state_filter=state_filter or StateFilter.all()
+                last_event, state_filter=state_filter
             )
 
         else:

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -541,7 +541,7 @@ class SyncHandler:
         )
 
     async def get_state_after_event(
-        self, event: EventBase, state_filter: StateFilter = StateFilter.all()
+        self, event: EventBase, state_filter: StateFilter = None
     ) -> StateMap[str]:
         """
         Get the room state after the given event
@@ -551,7 +551,7 @@ class SyncHandler:
             state_filter: The state filter used to fetch state from the database.
         """
         state_ids = await self.state_store.get_state_ids_for_event(
-            event.event_id, state_filter=state_filter
+            event.event_id, state_filter=state_filter or StateFilter.all()
         )
         if event.is_state():
             state_ids = dict(state_ids)
@@ -562,7 +562,7 @@ class SyncHandler:
         self,
         room_id: str,
         stream_position: StreamToken,
-        state_filter: StateFilter = StateFilter.all(),
+        state_filter: StateFilter = None,
     ) -> StateMap[str]:
         """ Get the room state at a particular stream position
 
@@ -582,7 +582,7 @@ class SyncHandler:
         if last_events:
             last_event = last_events[-1]
             state = await self.get_state_after_event(
-                last_event, state_filter=state_filter
+                last_event, state_filter=state_filter or StateFilter.all()
             )
 
         else:

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -286,7 +286,7 @@ class SimpleHttpClient:
     def __init__(
         self,
         hs: "HomeServer",
-        treq_args: Dict[str, Any] = {},
+        treq_args: Dict[str, Any] = None,
         ip_whitelist: Optional[IPSet] = None,
         ip_blacklist: Optional[IPSet] = None,
         http_proxy: Optional[bytes] = None,
@@ -307,7 +307,7 @@ class SimpleHttpClient:
 
         self._ip_whitelist = ip_whitelist
         self._ip_blacklist = ip_blacklist
-        self._extra_treq_args = treq_args
+        self._extra_treq_args = treq_args or {}
 
         self.user_agent = hs.version_string
         self.clock = hs.get_clock()

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -286,7 +286,7 @@ class SimpleHttpClient:
     def __init__(
         self,
         hs: "HomeServer",
-        treq_args: Dict[str, Any] = None,
+        treq_args: Optional[Dict[str, Any]] = None,
         ip_whitelist: Optional[IPSet] = None,
         ip_blacklist: Optional[IPSet] = None,
         http_proxy: Optional[bytes] = None,

--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import logging
 import re
+from typing import Optional
 
 from zope.interface import implementer
 
@@ -22,7 +23,7 @@ from twisted.internet.endpoints import HostnameEndpoint, wrapClientTLS
 from twisted.python.failure import Failure
 from twisted.web.client import URI, BrowserLikePolicyForHTTPS, _AgentBase
 from twisted.web.error import SchemeNotSupported
-from twisted.web.iweb import IAgent
+from twisted.web.iweb import IAgent, IPolicyForHTTPS
 
 from synapse.http.connectproxyclient import HTTPConnectProxyEndpoint
 
@@ -64,7 +65,7 @@ class ProxyAgent(_AgentBase):
         self,
         reactor,
         proxy_reactor=None,
-        contextFactory: BrowserLikePolicyForHTTPS = None,
+        contextFactory: Optional[IPolicyForHTTPS] = None,
         connectTimeout=None,
         bindAddress=None,
         pool=None,

--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -64,7 +64,7 @@ class ProxyAgent(_AgentBase):
         self,
         reactor,
         proxy_reactor=None,
-        contextFactory=BrowserLikePolicyForHTTPS(),
+        contextFactory: BrowserLikePolicyForHTTPS = None,
         connectTimeout=None,
         bindAddress=None,
         pool=None,
@@ -72,6 +72,8 @@ class ProxyAgent(_AgentBase):
         https_proxy=None,
     ):
         _AgentBase.__init__(self, reactor, pool)
+
+        contextFactory = contextFactory or BrowserLikePolicyForHTTPS()
 
         if proxy_reactor is None:
             self.proxy_reactor = reactor

--- a/synapse/logging/_remote.py
+++ b/synapse/logging/_remote.py
@@ -216,11 +216,11 @@ class RemoteHandler(logging.Handler):
         old_buffer = self._buffer
         self._buffer = deque()
 
-        for i in range(buffer_split):
+        for _ in range(buffer_split):
             self._buffer.append(old_buffer.popleft())
 
         end_buffer = []
-        for i in range(buffer_split):
+        for _ in range(buffer_split):
             end_buffer.append(old_buffer.pop())
 
         self._buffer.extend(reversed(end_buffer))

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -684,7 +684,7 @@ def run_in_background(f, *args, **kwargs):
     current = current_context()
     try:
         res = f(*args, **kwargs)
-    except BaseException as e:
+    except Exception as e:
         # the assumption here is that the caller doesn't want to be disturbed
         # by synchronous exceptions, so let's turn them into Failures.
         return defer.fail(Failure(e))

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Optional, Tuple, TypeVar, Union
 from typing_extensions import Literal
 
 from twisted.internet import defer, threads
+from twisted.python.failure import Failure
 
 if TYPE_CHECKING:
     from synapse.logging.scopecontextmanager import _LogContextScope
@@ -683,10 +684,10 @@ def run_in_background(f, *args, **kwargs):
     current = current_context()
     try:
         res = f(*args, **kwargs)
-    except:  # noqa: E722
+    except BaseException as e:
         # the assumption here is that the caller doesn't want to be disturbed
         # by synchronous exceptions, so let's turn them into Failures.
-        return defer.fail()
+        return defer.fail(Failure(e))
 
     if isinstance(res, types.CoroutineType):
         res = defer.ensureDeferred(res)

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -480,7 +480,7 @@ def start_active_span_from_request(
 def start_active_span_from_edu(
     edu_content,
     operation_name,
-    references=[],
+    references: list = None,
     tags=None,
     start_time=None,
     ignore_active_span=False,
@@ -495,6 +495,7 @@ def start_active_span_from_edu(
 
         For the other args see opentracing.tracer
     """
+    references = references or []
 
     if opentracing is None:
         return noop_context_manager()

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -480,7 +480,7 @@ def start_active_span_from_request(
 def start_active_span_from_edu(
     edu_content,
     operation_name,
-    references: list = None,
+    references: Optional[list] = None,
     tags=None,
     start_time=None,
     ignore_active_span=False,

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -118,7 +118,7 @@ class ModuleApi:
         return defer.ensureDeferred(self._auth_handler.check_user_exists(user_id))
 
     @defer.inlineCallbacks
-    def register(self, localpart, displayname=None, emails: list = None):
+    def register(self, localpart, displayname=None, emails: Optional[list] = None):
         """Registers a new user with given localpart and optional displayname, emails.
 
         Also returns an access token for the new user.
@@ -142,7 +142,7 @@ class ModuleApi:
         _, access_token = yield self.register_device(user_id)
         return user_id, access_token
 
-    def register_user(self, localpart, displayname=None, emails: list = None):
+    def register_user(self, localpart, displayname=None, emails: Optional[list] = None):
         """Registers a new user with given localpart and optional displayname, emails.
 
         Args:

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -118,7 +118,7 @@ class ModuleApi:
         return defer.ensureDeferred(self._auth_handler.check_user_exists(user_id))
 
     @defer.inlineCallbacks
-    def register(self, localpart, displayname=None, emails=[]):
+    def register(self, localpart, displayname=None, emails: list = None):
         """Registers a new user with given localpart and optional displayname, emails.
 
         Also returns an access token for the new user.
@@ -138,11 +138,11 @@ class ModuleApi:
         logger.warning(
             "Using deprecated ModuleApi.register which creates a dummy user device."
         )
-        user_id = yield self.register_user(localpart, displayname, emails)
+        user_id = yield self.register_user(localpart, displayname, emails or [])
         _, access_token = yield self.register_device(user_id)
         return user_id, access_token
 
-    def register_user(self, localpart, displayname=None, emails=[]):
+    def register_user(self, localpart, displayname=None, emails: list = None):
         """Registers a new user with given localpart and optional displayname, emails.
 
         Args:
@@ -161,7 +161,7 @@ class ModuleApi:
             self._hs.get_registration_handler().register_user(
                 localpart=localpart,
                 default_display_name=displayname,
-                bind_emails=emails,
+                bind_emails=emails or [],
             )
         )
 

--- a/synapse/notifier.py
+++ b/synapse/notifier.py
@@ -263,7 +263,7 @@ class Notifier:
         event: EventBase,
         event_pos: PersistedEventPosition,
         max_room_stream_token: RoomStreamToken,
-        extra_users: Collection[UserID] = [],
+        extra_users: Collection[UserID] = None,
     ):
         """Unwraps event and calls `on_new_room_event_args`.
         """
@@ -274,7 +274,7 @@ class Notifier:
             state_key=event.get("state_key"),
             membership=event.content.get("membership"),
             max_room_stream_token=max_room_stream_token,
-            extra_users=extra_users,
+            extra_users=extra_users or [],
         )
 
     def on_new_room_event_args(
@@ -285,7 +285,7 @@ class Notifier:
         membership: Optional[str],
         event_pos: PersistedEventPosition,
         max_room_stream_token: RoomStreamToken,
-        extra_users: Collection[UserID] = [],
+        extra_users: Collection[UserID] = None,
     ):
         """Used by handlers to inform the notifier something has happened
         in the room, room event wise.
@@ -301,7 +301,7 @@ class Notifier:
         self.pending_new_room_events.append(
             _PendingRoomEventEntry(
                 event_pos=event_pos,
-                extra_users=extra_users,
+                extra_users=extra_users or [],
                 room_id=room_id,
                 type=event_type,
                 state_key=state_key,
@@ -367,14 +367,14 @@ class Notifier:
         self,
         stream_key: str,
         new_token: Union[int, RoomStreamToken],
-        users: Collection[Union[str, UserID]] = [],
+        users: Collection[Union[str, UserID]] = None,
     ):
         try:
             stream_token = None
             if isinstance(new_token, int):
                 stream_token = new_token
             self.appservice_handler.notify_interested_services_ephemeral(
-                stream_key, stream_token, users
+                stream_key, stream_token, users or []
             )
         except Exception:
             logger.exception("Error notifying application services of event")
@@ -389,13 +389,16 @@ class Notifier:
         self,
         stream_key: str,
         new_token: Union[int, RoomStreamToken],
-        users: Collection[Union[str, UserID]] = [],
-        rooms: Collection[str] = [],
+        users: Collection[Union[str, UserID]] = None,
+        rooms: Collection[str] = None,
     ):
         """ Used to inform listeners that something has happened event wise.
 
         Will wake up all listeners for the given users and rooms.
         """
+        users = users or []
+        rooms = rooms or []
+
         with Measure(self.clock, "on_new_event"):
             user_streams = set()
 

--- a/synapse/notifier.py
+++ b/synapse/notifier.py
@@ -263,7 +263,7 @@ class Notifier:
         event: EventBase,
         event_pos: PersistedEventPosition,
         max_room_stream_token: RoomStreamToken,
-        extra_users: Collection[UserID] = None,
+        extra_users: Optional[Collection[UserID]] = None,
     ):
         """Unwraps event and calls `on_new_room_event_args`.
         """
@@ -285,7 +285,7 @@ class Notifier:
         membership: Optional[str],
         event_pos: PersistedEventPosition,
         max_room_stream_token: RoomStreamToken,
-        extra_users: Collection[UserID] = None,
+        extra_users: Optional[Collection[UserID]] = None,
     ):
         """Used by handlers to inform the notifier something has happened
         in the room, room event wise.
@@ -367,7 +367,7 @@ class Notifier:
         self,
         stream_key: str,
         new_token: Union[int, RoomStreamToken],
-        users: Collection[Union[str, UserID]] = None,
+        users: Optional[Collection[Union[str, UserID]]] = None,
     ):
         try:
             stream_token = None
@@ -389,8 +389,8 @@ class Notifier:
         self,
         stream_key: str,
         new_token: Union[int, RoomStreamToken],
-        users: Collection[Union[str, UserID]] = None,
-        rooms: Collection[str] = None,
+        users: Optional[Collection[Union[str, UserID]]] = None,
+        rooms: Optional[Collection[str]] = None,
     ):
         """ Used to inform listeners that something has happened event wise.
 

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -144,7 +144,7 @@ class RemoteKey(DirectServeJsonResource):
 
         # Note that the value is unused.
         cache_misses = {}  # type: Dict[str, Dict[str, int]]
-        for (server_name, key_id, from_server), results in cached.items():
+        for (server_name, key_id, _), results in cached.items():
             results = [(result["ts_added_ms"], result) for result in results]
 
             if not results and key_id is not None:
@@ -206,7 +206,7 @@ class RemoteKey(DirectServeJsonResource):
                 # Cast to bytes since postgresql returns a memoryview.
                 json_results.add(bytes(most_recent_result["key_json"]))
             else:
-                for ts_added, result in results:
+                for _, result in results:
                     # Cast to bytes since postgresql returns a memoryview.
                     json_results.add(bytes(result["key_json"]))
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -671,7 +671,7 @@ class DatabasePool:
 
             for after_callback, after_args, after_kwargs in after_callbacks:
                 after_callback(*after_args, **after_kwargs)
-        except BaseException as e:  # we re-raise the exception, this is fine.
+        except Exception as e:  # we re-raise the exception, this is fine.
             for after_callback, after_args, after_kwargs in exception_callbacks:
                 after_callback(*after_args, **after_kwargs)
             raise e
@@ -900,7 +900,7 @@ class DatabasePool:
         table: str,
         keyvalues: Dict[str, Any],
         values: Dict[str, Any],
-        insertion_values: Dict[str, Any] = None,
+        insertion_values: Optional[Dict[str, Any]] = None,
         desc: str = "simple_upsert",
         lock: bool = True,
     ) -> Optional[bool]:
@@ -966,7 +966,7 @@ class DatabasePool:
         table: str,
         keyvalues: Dict[str, Any],
         values: Dict[str, Any],
-        insertion_values: Dict[str, Any] = None,
+        insertion_values: Optional[Dict[str, Any]] = None,
         lock: bool = True,
     ) -> Optional[bool]:
         """
@@ -1007,7 +1007,7 @@ class DatabasePool:
         table: str,
         keyvalues: Dict[str, Any],
         values: Dict[str, Any],
-        insertion_values: Dict[str, Any] = None,
+        insertion_values: Optional[Dict[str, Any]] = None,
         lock: bool = True,
     ) -> bool:
         """
@@ -1083,7 +1083,7 @@ class DatabasePool:
         table: str,
         keyvalues: Dict[str, Any],
         values: Dict[str, Any],
-        insertion_values: Dict[str, Any] = None,
+        insertion_values: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Use the native UPSERT functionality in recent PostgreSQL versions.
@@ -1516,7 +1516,7 @@ class DatabasePool:
         column: str,
         iterable: Iterable[Any],
         retcols: Iterable[str],
-        keyvalues: Dict[str, Any] = None,
+        keyvalues: Optional[Dict[str, Any]] = None,
         desc: str = "simple_select_many_batch",
         batch_size: int = 100,
     ) -> List[Any]:

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -671,10 +671,10 @@ class DatabasePool:
 
             for after_callback, after_args, after_kwargs in after_callbacks:
                 after_callback(*after_args, **after_kwargs)
-        except:  # noqa: E722, as we reraise the exception this is fine.
+        except BaseException as e:  # we re-raise the exception, this is fine.
             for after_callback, after_args, after_kwargs in exception_callbacks:
                 after_callback(*after_args, **after_kwargs)
-            raise
+            raise e
 
         return cast(R, result)
 
@@ -900,7 +900,7 @@ class DatabasePool:
         table: str,
         keyvalues: Dict[str, Any],
         values: Dict[str, Any],
-        insertion_values: Dict[str, Any] = {},
+        insertion_values: Dict[str, Any] = None,
         desc: str = "simple_upsert",
         lock: bool = True,
     ) -> Optional[bool]:
@@ -927,6 +927,8 @@ class DatabasePool:
             Native upserts always return None. Emulated upserts return True if a
             new entry was created, False if an existing one was updated.
         """
+        insertion_values = insertion_values or {}
+
         attempts = 0
         while True:
             try:
@@ -964,7 +966,7 @@ class DatabasePool:
         table: str,
         keyvalues: Dict[str, Any],
         values: Dict[str, Any],
-        insertion_values: Dict[str, Any] = {},
+        insertion_values: Dict[str, Any] = None,
         lock: bool = True,
     ) -> Optional[bool]:
         """
@@ -982,6 +984,8 @@ class DatabasePool:
             Native upserts always return None. Emulated upserts return True if a
             new entry was created, False if an existing one was updated.
         """
+        insertion_values = insertion_values or {}
+
         if self.engine.can_native_upsert and table not in self._unsafe_to_upsert_tables:
             self.simple_upsert_txn_native_upsert(
                 txn, table, keyvalues, values, insertion_values=insertion_values
@@ -1003,7 +1007,7 @@ class DatabasePool:
         table: str,
         keyvalues: Dict[str, Any],
         values: Dict[str, Any],
-        insertion_values: Dict[str, Any] = {},
+        insertion_values: Dict[str, Any] = None,
         lock: bool = True,
     ) -> bool:
         """
@@ -1017,6 +1021,8 @@ class DatabasePool:
             Returns True if a new entry was created, False if an existing
             one was updated.
         """
+        insertion_values = insertion_values or {}
+
         # We need to lock the table :(, unless we're *really* careful
         if lock:
             self.engine.lock_table(txn, table)
@@ -1077,7 +1083,7 @@ class DatabasePool:
         table: str,
         keyvalues: Dict[str, Any],
         values: Dict[str, Any],
-        insertion_values: Dict[str, Any] = {},
+        insertion_values: Dict[str, Any] = None,
     ) -> None:
         """
         Use the native UPSERT functionality in recent PostgreSQL versions.
@@ -1090,7 +1096,7 @@ class DatabasePool:
         """
         allvalues = {}  # type: Dict[str, Any]
         allvalues.update(keyvalues)
-        allvalues.update(insertion_values)
+        allvalues.update(insertion_values or {})
 
         if not values:
             latter = "NOTHING"
@@ -1510,7 +1516,7 @@ class DatabasePool:
         column: str,
         iterable: Iterable[Any],
         retcols: Iterable[str],
-        keyvalues: Dict[str, Any] = {},
+        keyvalues: Dict[str, Any] = None,
         desc: str = "simple_select_many_batch",
         batch_size: int = 100,
     ) -> List[Any]:
@@ -1528,6 +1534,7 @@ class DatabasePool:
             desc: description of the transaction, for logging and metrics
             batch_size: the number of rows for each select query
         """
+        keyvalues = keyvalues or {}
         results = []  # type: List[Dict[str, Any]]
 
         if not iterable:

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -165,7 +165,7 @@ class PersistEventsStore:
             )
 
         async with stream_ordering_manager as stream_orderings:
-            for (event, context), stream in zip(events_and_contexts, stream_orderings):
+            for (event, _), stream in zip(events_and_contexts, stream_orderings):
                 event.internal_metadata.stream_ordering = stream
 
             await self.db_pool.runInteraction(
@@ -292,7 +292,7 @@ class PersistEventsStore:
                 txn.execute(sql + clause, args)
                 to_recursively_check = []
 
-                for event_id, prev_event_id, metadata, rejected in txn:
+                for _, prev_event_id, metadata, rejected in txn:
                     if prev_event_id in existing_prevs:
                         continue
 
@@ -314,8 +314,8 @@ class PersistEventsStore:
         txn: LoggingTransaction,
         events_and_contexts: List[Tuple[EventBase, EventContext]],
         backfilled: bool,
-        state_delta_for_room: Dict[str, DeltaState] = {},
-        new_forward_extremeties: Dict[str, List[str]] = {},
+        state_delta_for_room: Dict[str, DeltaState] = None,
+        new_forward_extremeties: Dict[str, List[str]] = None,
     ):
         """Insert some number of room events into the necessary database tables.
 
@@ -336,6 +336,9 @@ class PersistEventsStore:
                 extremities.
 
         """
+        state_delta_for_room = state_delta_for_room or {}
+        new_forward_extremeties = new_forward_extremeties or {}
+
         all_events_and_contexts = events_and_contexts
 
         min_stream_order = events_and_contexts[0][0].internal_metadata.stream_ordering
@@ -1100,7 +1103,7 @@ class PersistEventsStore:
     def _update_forward_extremities_txn(
         self, txn, new_forward_extremities, max_stream_order
     ):
-        for room_id, new_extrem in new_forward_extremities.items():
+        for room_id in new_forward_extremities.keys():
             self.db_pool.simple_delete_txn(
                 txn, table="event_forward_extremities", keyvalues={"room_id": room_id}
             )
@@ -1353,7 +1356,7 @@ class PersistEventsStore:
         ]
 
         state_values = []
-        for event, context in state_events_and_contexts:
+        for event, _ in state_events_and_contexts:
             vals = {
                 "event_id": event.event_id,
                 "room_id": event.room_id,
@@ -1396,7 +1399,11 @@ class PersistEventsStore:
         return [ec for ec in events_and_contexts if ec[0] not in to_remove]
 
     def _update_metadata_tables_txn(
-        self, txn, events_and_contexts, all_events_and_contexts, backfilled
+        self,
+        txn,
+        events_and_contexts: List[Tuple[EventBase, EventContext]],
+        all_events_and_contexts,
+        backfilled,
     ):
         """Update all the miscellaneous tables for new events
 
@@ -1422,7 +1429,7 @@ class PersistEventsStore:
             # nothing to do here
             return
 
-        for event, context in events_and_contexts:
+        for event, _ in events_and_contexts:
             if event.type == EventTypes.Redaction and event.redacts is not None:
                 # Remove the entries in the event_push_actions table for the
                 # redacted event.

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -314,8 +314,8 @@ class PersistEventsStore:
         txn: LoggingTransaction,
         events_and_contexts: List[Tuple[EventBase, EventContext]],
         backfilled: bool,
-        state_delta_for_room: Dict[str, DeltaState] = None,
-        new_forward_extremeties: Dict[str, List[str]] = None,
+        state_delta_for_room: Optional[Dict[str, DeltaState]] = None,
+        new_forward_extremeties: Optional[Dict[str, List[str]]] = None,
     ):
         """Insert some number of room events into the necessary database tables.
 

--- a/synapse/storage/databases/main/group_server.py
+++ b/synapse/storage/databases/main/group_server.py
@@ -1171,7 +1171,7 @@ class GroupServerStore(GroupServerWorkerStore):
         user_id: str,
         membership: str,
         is_admin: bool = False,
-        content: JsonDict = {},
+        content: JsonDict = None,
         local_attestation: Optional[dict] = None,
         remote_attestation: Optional[dict] = None,
         is_publicised: bool = False,
@@ -1191,6 +1191,7 @@ class GroupServerStore(GroupServerWorkerStore):
                 attestation from the group, else None.
             is_publicised: Whether this should be publicised.
         """
+        content = content or []
 
         def _register_user_group_membership_txn(txn, next_id):
             # TODO: Upsert?

--- a/synapse/storage/databases/main/group_server.py
+++ b/synapse/storage/databases/main/group_server.py
@@ -1171,7 +1171,7 @@ class GroupServerStore(GroupServerWorkerStore):
         user_id: str,
         membership: str,
         is_admin: bool = False,
-        content: JsonDict = None,
+        content: Optional[JsonDict] = None,
         local_attestation: Optional[dict] = None,
         remote_attestation: Optional[dict] = None,
         is_publicised: bool = False,

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -205,10 +205,9 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
         Returns:
             Map from type/state_key to event ID.
         """
+        state_filter = state_filter or StateFilter.all()
 
-        where_clause, where_args = (
-            state_filter or StateFilter.all()
-        ).make_sql_filter_clause()
+        where_clause, where_args = state_filter.make_sql_filter_clause()
 
         if not where_clause:
             # We delegate to the cached version

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -191,7 +191,7 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
 
     # FIXME: how should this be cached?
     async def get_filtered_current_state_ids(
-        self, room_id: str, state_filter: StateFilter = None
+        self, room_id: str, state_filter: Optional[StateFilter] = None
     ) -> StateMap[str]:
         """Get the current state event of a given type for a room based on the
         current_state_events table.  This may not be as up-to-date as the result

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -191,7 +191,7 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
 
     # FIXME: how should this be cached?
     async def get_filtered_current_state_ids(
-        self, room_id: str, state_filter: StateFilter = StateFilter.all()
+        self, room_id: str, state_filter: StateFilter = None
     ) -> StateMap[str]:
         """Get the current state event of a given type for a room based on the
         current_state_events table.  This may not be as up-to-date as the result
@@ -206,7 +206,9 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
             Map from type/state_key to event ID.
         """
 
-        where_clause, where_args = state_filter.make_sql_filter_clause()
+        where_clause, where_args = (
+            state_filter or StateFilter.all()
+        ).make_sql_filter_clause()
 
         if not where_clause:
             # We delegate to the cached version

--- a/synapse/storage/databases/state/bg_updates.py
+++ b/synapse/storage/databases/state/bg_updates.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import logging
+from typing import Optional
 
 from synapse.storage._base import SQLBaseStore
 from synapse.storage.database import DatabasePool
@@ -73,7 +74,7 @@ class StateGroupBackgroundUpdateStore(SQLBaseStore):
             return count
 
     def _get_state_groups_from_groups_txn(
-        self, txn, groups, state_filter: StateFilter = None
+        self, txn, groups, state_filter: Optional[StateFilter] = None
     ):
         state_filter = state_filter or StateFilter.all()
 

--- a/synapse/storage/databases/state/bg_updates.py
+++ b/synapse/storage/databases/state/bg_updates.py
@@ -75,11 +75,11 @@ class StateGroupBackgroundUpdateStore(SQLBaseStore):
     def _get_state_groups_from_groups_txn(
         self, txn, groups, state_filter: StateFilter = None
     ):
+        state_filter = state_filter or StateFilter.all()
+
         results = {group: {} for group in groups}
 
-        where_clause, where_args = (
-            state_filter or StateFilter.all()
-        ).make_sql_filter_clause()
+        where_clause, where_args = state_filter.make_sql_filter_clause()
 
         # Unless the filter clause is empty, we're going to append it after an
         # existing where clause

--- a/synapse/storage/databases/state/bg_updates.py
+++ b/synapse/storage/databases/state/bg_updates.py
@@ -73,11 +73,13 @@ class StateGroupBackgroundUpdateStore(SQLBaseStore):
             return count
 
     def _get_state_groups_from_groups_txn(
-        self, txn, groups, state_filter=StateFilter.all()
+        self, txn, groups, state_filter: StateFilter = None
     ):
         results = {group: {} for group in groups}
 
-        where_clause, where_args = state_filter.make_sql_filter_clause()
+        where_clause, where_args = (
+            state_filter or StateFilter.all()
+        ).make_sql_filter_clause()
 
         # Unless the filter clause is empty, we're going to append it after an
         # existing where clause

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -15,7 +15,7 @@
 
 import logging
 from collections import namedtuple
-from typing import Dict, Iterable, List, Set, Tuple, Optional
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from synapse.api.constants import EventTypes
 from synapse.storage._base import SQLBaseStore

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -15,7 +15,7 @@
 
 import logging
 from collections import namedtuple
-from typing import Dict, Iterable, List, Set, Tuple
+from typing import Dict, Iterable, List, Set, Tuple, Optional
 
 from synapse.api.constants import EventTypes
 from synapse.storage._base import SQLBaseStore
@@ -207,7 +207,7 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
         return state_filter.filter_state(state_dict_ids), not missing_types
 
     async def _get_state_for_groups(
-        self, groups: Iterable[int], state_filter: StateFilter = None
+        self, groups: Iterable[int], state_filter: Optional[StateFilter] = None
     ) -> Dict[int, MutableStateMap[str]]:
         """Gets the state at each of a list of state groups, optionally
         filtering by type/state_key

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -207,7 +207,7 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
         return state_filter.filter_state(state_dict_ids), not missing_types
 
     async def _get_state_for_groups(
-        self, groups: Iterable[int], state_filter: StateFilter = StateFilter.all()
+        self, groups: Iterable[int], state_filter: StateFilter = None
     ) -> Dict[int, MutableStateMap[str]]:
         """Gets the state at each of a list of state groups, optionally
         filtering by type/state_key
@@ -221,7 +221,9 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
             Dict of state group to state map.
         """
 
-        member_filter, non_member_filter = state_filter.get_member_split()
+        member_filter, non_member_filter = (
+            state_filter or StateFilter.all()
+        ).get_member_split()
 
         # Now we look them up in the member and non-member caches
         (

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -220,10 +220,9 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
         Returns:
             Dict of state group to state map.
         """
+        state_filter = state_filter or StateFilter.all()
 
-        member_filter, non_member_filter = (
-            state_filter or StateFilter.all()
-        ).get_member_split()
+        member_filter, non_member_filter = state_filter.get_member_split()
 
         # Now we look them up in the member and non-member caches
         (

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -450,7 +450,7 @@ class StateGroupStorage:
         return self.stores.state._get_state_groups_from_groups(groups, state_filter)
 
     async def get_state_for_events(
-        self, event_ids: List[str], state_filter: StateFilter = StateFilter.all()
+        self, event_ids: List[str], state_filter: StateFilter = None
     ) -> Dict[str, StateMap[EventBase]]:
         """Given a list of event_ids and type tuples, return a list of state
         dicts for each event.
@@ -462,6 +462,8 @@ class StateGroupStorage:
         Returns:
             A dict of (event_id) -> (type, state_key) -> [state_events]
         """
+        state_filter = state_filter or StateFilter.all()
+
         event_to_groups = await self.stores.main._get_state_group_for_events(event_ids)
 
         groups = set(event_to_groups.values())
@@ -486,7 +488,7 @@ class StateGroupStorage:
         return {event: event_to_state[event] for event in event_ids}
 
     async def get_state_ids_for_events(
-        self, event_ids: List[str], state_filter: StateFilter = StateFilter.all()
+        self, event_ids: List[str], state_filter: StateFilter = None
     ) -> Dict[str, StateMap[str]]:
         """
         Get the state dicts corresponding to a list of events, containing the event_ids
@@ -499,6 +501,8 @@ class StateGroupStorage:
         Returns:
             A dict from event_id -> (type, state_key) -> event_id
         """
+        state_filter = state_filter or StateFilter.all()
+
         event_to_groups = await self.stores.main._get_state_group_for_events(event_ids)
 
         groups = set(event_to_groups.values())
@@ -514,7 +518,7 @@ class StateGroupStorage:
         return {event: event_to_state[event] for event in event_ids}
 
     async def get_state_for_event(
-        self, event_id: str, state_filter: StateFilter = StateFilter.all()
+        self, event_id: str, state_filter: StateFilter = None
     ) -> StateMap[EventBase]:
         """
         Get the state dict corresponding to a particular event
@@ -526,11 +530,13 @@ class StateGroupStorage:
         Returns:
             A dict from (type, state_key) -> state_event
         """
-        state_map = await self.get_state_for_events([event_id], state_filter)
+        state_map = await self.get_state_for_events(
+            [event_id], state_filter or StateFilter.all()
+        )
         return state_map[event_id]
 
     async def get_state_ids_for_event(
-        self, event_id: str, state_filter: StateFilter = StateFilter.all()
+        self, event_id: str, state_filter: StateFilter = None
     ) -> StateMap[str]:
         """
         Get the state dict corresponding to a particular event
@@ -542,11 +548,13 @@ class StateGroupStorage:
         Returns:
             A dict from (type, state_key) -> state_event
         """
-        state_map = await self.get_state_ids_for_events([event_id], state_filter)
+        state_map = await self.get_state_ids_for_events(
+            [event_id], state_filter or StateFilter.all()
+        )
         return state_map[event_id]
 
     def _get_state_for_groups(
-        self, groups: Iterable[int], state_filter: StateFilter = StateFilter.all()
+        self, groups: Iterable[int], state_filter: StateFilter = None
     ) -> Awaitable[Dict[int, MutableStateMap[str]]]:
         """Gets the state at each of a list of state groups, optionally
         filtering by type/state_key
@@ -559,7 +567,9 @@ class StateGroupStorage:
         Returns:
             Dict of state group to state map.
         """
-        return self.stores.state._get_state_for_groups(groups, state_filter)
+        return self.stores.state._get_state_for_groups(
+            groups, state_filter or StateFilter.all()
+        )
 
     async def store_state_group(
         self,

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -450,7 +450,7 @@ class StateGroupStorage:
         return self.stores.state._get_state_groups_from_groups(groups, state_filter)
 
     async def get_state_for_events(
-        self, event_ids: List[str], state_filter: StateFilter = None
+        self, event_ids: List[str], state_filter: Optional[StateFilter] = None
     ) -> Dict[str, StateMap[EventBase]]:
         """Given a list of event_ids and type tuples, return a list of state
         dicts for each event.
@@ -488,7 +488,7 @@ class StateGroupStorage:
         return {event: event_to_state[event] for event in event_ids}
 
     async def get_state_ids_for_events(
-        self, event_ids: List[str], state_filter: StateFilter = None
+        self, event_ids: List[str], state_filter: Optional[StateFilter] = None
     ) -> Dict[str, StateMap[str]]:
         """
         Get the state dicts corresponding to a list of events, containing the event_ids
@@ -518,7 +518,7 @@ class StateGroupStorage:
         return {event: event_to_state[event] for event in event_ids}
 
     async def get_state_for_event(
-        self, event_id: str, state_filter: StateFilter = None
+        self, event_id: str, state_filter: Optional[StateFilter] = None
     ) -> StateMap[EventBase]:
         """
         Get the state dict corresponding to a particular event
@@ -536,7 +536,7 @@ class StateGroupStorage:
         return state_map[event_id]
 
     async def get_state_ids_for_event(
-        self, event_id: str, state_filter: StateFilter = None
+        self, event_id: str, state_filter: Optional[StateFilter] = None
     ) -> StateMap[str]:
         """
         Get the state dict corresponding to a particular event
@@ -554,7 +554,7 @@ class StateGroupStorage:
         return state_map[event_id]
 
     def _get_state_for_groups(
-        self, groups: Iterable[int], state_filter: StateFilter = None
+        self, groups: Iterable[int], state_filter: Optional[StateFilter] = None
     ) -> Awaitable[Dict[int, MutableStateMap[str]]]:
         """Gets the state at each of a list of state groups, optionally
         filtering by type/state_key

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -91,7 +91,9 @@ class StreamIdGenerator:
             # ... persist event ...
     """
 
-    def __init__(self, db_conn, table, column, extra_tables: Optional[list] = None, step=1):
+    def __init__(
+        self, db_conn, table, column, extra_tables: Optional[list] = None, step=1
+    ):
         assert step != 0
         self._lock = threading.Lock()
         self._step = step

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -91,12 +91,12 @@ class StreamIdGenerator:
             # ... persist event ...
     """
 
-    def __init__(self, db_conn, table, column, extra_tables=[], step=1):
+    def __init__(self, db_conn, table, column, extra_tables: list = None, step=1):
         assert step != 0
         self._lock = threading.Lock()
         self._step = step
         self._current = _load_current_id(db_conn, table, column, step)
-        for table, column in extra_tables:
+        for table, column in extra_tables or []:
             self._current = (max if step > 0 else min)(
                 self._current, _load_current_id(db_conn, table, column, step)
             )

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -91,7 +91,7 @@ class StreamIdGenerator:
             # ... persist event ...
     """
 
-    def __init__(self, db_conn, table, column, extra_tables: list = None, step=1):
+    def __init__(self, db_conn, table, column, extra_tables: Optional[list] = None, step=1):
         assert step != 0
         self._lock = threading.Lock()
         self._step = step

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -485,7 +485,7 @@ def timeout_deferred(
 
         try:
             deferred.cancel()
-        except BaseException as e:  # if we throw any exception it'll break time outs
+        except Exception as e:  # if we throw any exception it'll break time outs
             logger.exception("Canceller failed during timeout", exc_info=e)
 
         # the cancel() call should have set off a chain of errbacks which

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -485,8 +485,8 @@ def timeout_deferred(
 
         try:
             deferred.cancel()
-        except:  # noqa: E722, if we throw any exception it'll break time outs
-            logger.exception("Canceller failed during timeout")
+        except BaseException as e:  # if we throw any exception it'll break time outs
+            logger.exception("Canceller failed during timeout", exc_info=e)
 
         # the cancel() call should have set off a chain of errbacks which
         # will have errbacked new_d, but in case it hasn't, errback it now.

--- a/synapse/util/caches/__init__.py
+++ b/synapse/util/caches/__init__.py
@@ -115,8 +115,7 @@ def register_cache(
         CacheMetric: an object which provides inc_{hits,misses,evictions} methods
     """
     if resizable:
-        if not resize_callback:
-            resize_callback = getattr(cache, "set_cache_factor")
+        resize_callback = resize_callback or cache.set_cache_factor  # type: ignore
         add_resizable_cache(cache_name, resize_callback)
 
     metric = CacheMetric(cache, cache_type, cache_name, collect_callback)

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -57,7 +57,9 @@ def enumerate_leaves(node, depth):
 class _Node:
     __slots__ = ["prev_node", "next_node", "key", "value", "callbacks"]
 
-    def __init__(self, prev_node, next_node, key, value, callbacks: Optional[set] = None):
+    def __init__(
+        self, prev_node, next_node, key, value, callbacks: Optional[set] = None
+    ):
         self.prev_node = prev_node
         self.next_node = next_node
         self.key = key

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -57,7 +57,7 @@ def enumerate_leaves(node, depth):
 class _Node:
     __slots__ = ["prev_node", "next_node", "key", "value", "callbacks"]
 
-    def __init__(self, prev_node, next_node, key, value, callbacks: set = None):
+    def __init__(self, prev_node, next_node, key, value, callbacks: Optional[set] = None):
         self.prev_node = prev_node
         self.next_node = next_node
         self.key = key
@@ -176,7 +176,7 @@ class LruCache(Generic[KT, VT]):
 
         self.len = synchronized(cache_len)
 
-        def add_node(key, value, callbacks: set = None):
+        def add_node(key, value, callbacks: Optional[set] = None):
             prev_node = list_root
             next_node = prev_node.next_node
             node = _Node(prev_node, next_node, key, value, callbacks or set())
@@ -237,7 +237,7 @@ class LruCache(Generic[KT, VT]):
         def cache_get(
             key: KT,
             default: Optional[T] = None,
-            callbacks: Iterable[Callable[[], None]] = None,
+            callbacks: Optional[Iterable[Callable[[], None]]] = None,
             update_metrics: bool = True,
         ):
             node = cache.get(key, None)
@@ -254,7 +254,7 @@ class LruCache(Generic[KT, VT]):
 
         @synchronized
         def cache_set(
-            key: KT, value: VT, callbacks: Iterable[Callable[[], None]] = None
+            key: KT, value: VT, callbacks: Optional[Iterable[Callable[[], None]]] = None
         ):
             callbacks = callbacks or []
 

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -223,7 +223,7 @@ class FederationTestCase(unittest.HomeserverTestCase):
                 room_version,
             )
 
-        for i in range(3):
+        for _ in range(3):
             event = create_invite()
             self.get_success(
                 self.handler.on_invite_request(other_server, event, event.room_version,)

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -181,7 +181,11 @@ class MatrixFederationAgentTests(unittest.TestCase):
                 _check_logcontext(context)
 
     def _handle_well_known_connection(
-        self, client_factory, expected_sni, content, response_headers: Optional[dict] = None
+        self,
+        client_factory,
+        expected_sni,
+        content,
+        response_headers: Optional[dict] = None,
     ):
         """Handle an outgoing HTTPs connection: wire it up to a server, check that the
         request is for a .well-known, and send the response.
@@ -208,7 +212,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self._send_well_known_response(request, content, headers=response_headers)
         return well_known_server
 
-    def _send_well_known_response(self, request, content, headers: Optional[dict] = None):
+    def _send_well_known_response(
+        self, request, content, headers: Optional[dict] = None
+    ):
         """Check that an incoming request looks like a valid .well-known request, and
         send back the response.
         """

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from typing import Optional
 
 from mock import Mock
 
@@ -180,7 +181,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
                 _check_logcontext(context)
 
     def _handle_well_known_connection(
-        self, client_factory, expected_sni, content, response_headers: dict = None
+        self, client_factory, expected_sni, content, response_headers: Optional[dict] = None
     ):
         """Handle an outgoing HTTPs connection: wire it up to a server, check that the
         request is for a .well-known, and send the response.
@@ -207,7 +208,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self._send_well_known_response(request, content, headers=response_headers)
         return well_known_server
 
-    def _send_well_known_response(self, request, content, headers: dict = None):
+    def _send_well_known_response(self, request, content, headers: Optional[dict] = None):
         """Check that an incoming request looks like a valid .well-known request, and
         send back the response.
         """

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -180,7 +180,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
                 _check_logcontext(context)
 
     def _handle_well_known_connection(
-        self, client_factory, expected_sni, content, response_headers={}
+        self, client_factory, expected_sni, content, response_headers: dict = None
     ):
         """Handle an outgoing HTTPs connection: wire it up to a server, check that the
         request is for a .well-known, and send the response.
@@ -192,6 +192,8 @@ class MatrixFederationAgentTests(unittest.TestCase):
         Returns:
             HTTPChannel: server impl
         """
+        response_headers = response_headers or {}
+
         # make the connection for .well-known
         well_known_server = self._make_connection(
             client_factory, expected_sni=expected_sni
@@ -205,10 +207,12 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self._send_well_known_response(request, content, headers=response_headers)
         return well_known_server
 
-    def _send_well_known_response(self, request, content, headers={}):
+    def _send_well_known_response(self, request, content, headers: dict = None):
         """Check that an incoming request looks like a valid .well-known request, and
         send back the response.
         """
+        headers = headers or {}
+
         self.assertEqual(request.method, b"GET")
         self.assertEqual(request.path, b"/.well-known/matrix/server")
         self.assertEqual(request.requestHeaders.getRawHeaders(b"host"), [b"testserv"])

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -260,7 +260,7 @@ class BaseMultiWorkerStreamTestCase(unittest.HomeserverTestCase):
         return resource
 
     def make_worker_hs(
-        self, worker_app: str, extra_config: dict = {}, **kwargs
+        self, worker_app: str, extra_config: dict = None, **kwargs
     ) -> HomeServer:
         """Make a new worker HS instance, correctly connecting replcation
         stream to the master HS.
@@ -277,7 +277,7 @@ class BaseMultiWorkerStreamTestCase(unittest.HomeserverTestCase):
 
         config = self._get_worker_hs_config()
         config["worker_app"] = worker_app
-        config.update(extra_config)
+        config.update(extra_config or {})
 
         worker_hs = self.setup_test_homeserver(
             homeserver_to_use=GenericWorkerServer,

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -260,7 +260,7 @@ class BaseMultiWorkerStreamTestCase(unittest.HomeserverTestCase):
         return resource
 
     def make_worker_hs(
-        self, worker_app: str, extra_config: dict = None, **kwargs
+        self, worker_app: str, extra_config: Optional[dict] = None, **kwargs
     ) -> HomeServer:
         """Make a new worker HS instance, correctly connecting replcation
         stream to the master HS.

--- a/tests/replication/slave/storage/test_events.py
+++ b/tests/replication/slave/storage/test_events.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from typing import Optional
 
 from canonicaljson import encode_canonical_json
 
@@ -329,13 +330,13 @@ class SlavedEventStoreTestCase(BaseSlavedStoreTestCase):
         room_id=ROOM_ID,
         type="m.room.message",
         key=None,
-        internal: dict = None,
+        internal: Optional[dict] = None,
         depth=None,
-        prev_events: list = None,
-        auth_events: list = None,
-        prev_state: list = None,
+        prev_events: Optional[list] = None,
+        auth_events: Optional[list] = None,
+        prev_state: Optional[list] = None,
         redacts=None,
-        push_actions: list = None,
+        push_actions: Optional[list] = None,
         **content
     ):
         internal = internal or {}

--- a/tests/replication/slave/storage/test_events.py
+++ b/tests/replication/slave/storage/test_events.py
@@ -329,15 +329,20 @@ class SlavedEventStoreTestCase(BaseSlavedStoreTestCase):
         room_id=ROOM_ID,
         type="m.room.message",
         key=None,
-        internal={},
+        internal: dict = None,
         depth=None,
-        prev_events=[],
-        auth_events=[],
-        prev_state=[],
+        prev_events: list = None,
+        auth_events: list = None,
+        prev_state: list = None,
         redacts=None,
-        push_actions=[],
+        push_actions: list = None,
         **content
     ):
+        internal = internal or {}
+        prev_events = prev_events or []
+        auth_events = auth_events or []
+        prev_state = prev_state or []
+        push_actions = push_actions or []
 
         if depth is None:
             depth = self.event_id

--- a/tests/replication/tcp/streams/test_events.py
+++ b/tests/replication/tcp/streams/test_events.py
@@ -237,7 +237,7 @@ class EventsStreamTestCase(BaseStreamTestCase):
 
         # the state rows are unsorted
         state_rows = []  # type: List[EventsStreamCurrentStateRow]
-        for stream_name, token, row in received_rows:
+        for stream_name, _, row in received_rows:
             self.assertEqual("events", stream_name)
             self.assertIsInstance(row, EventsStreamRow)
             self.assertEqual(row.type, "state")
@@ -352,7 +352,7 @@ class EventsStreamTestCase(BaseStreamTestCase):
 
             # the state rows are unsorted
             state_rows = []  # type: List[EventsStreamCurrentStateRow]
-            for j in range(STATES_PER_USER + 1):
+            for _ in range(STATES_PER_USER + 1):
                 stream_name, token, row = received_rows.pop(0)
                 self.assertEqual("events", stream_name)
                 self.assertIsInstance(row, EventsStreamRow)

--- a/tests/rest/admin/test_device.py
+++ b/tests/rest/admin/test_device.py
@@ -351,7 +351,7 @@ class DevicesRestTestCase(unittest.HomeserverTestCase):
         """
         # Create devices
         number_devices = 5
-        for n in range(number_devices):
+        for _ in range(number_devices):
             self.login("user", "pass")
 
         # Get devices
@@ -452,7 +452,7 @@ class DeleteDevicesRestTestCase(unittest.HomeserverTestCase):
 
         # Create devices
         number_devices = 5
-        for n in range(number_devices):
+        for _ in range(number_devices):
             self.login("user", "pass")
 
         # Get devices

--- a/tests/rest/admin/test_event_reports.py
+++ b/tests/rest/admin/test_event_reports.py
@@ -49,19 +49,19 @@ class EventReportsTestCase(unittest.HomeserverTestCase):
         self.helper.join(self.room_id2, user=self.admin_user, tok=self.admin_user_tok)
 
         # Two rooms and two users. Every user sends and reports every room event
-        for i in range(5):
+        for _ in range(5):
             self._create_event_and_report(
                 room_id=self.room_id1, user_tok=self.other_user_tok,
             )
-        for i in range(5):
+        for _ in range(5):
             self._create_event_and_report(
                 room_id=self.room_id2, user_tok=self.other_user_tok,
             )
-        for i in range(5):
+        for _ in range(5):
             self._create_event_and_report(
                 room_id=self.room_id1, user_tok=self.admin_user_tok,
             )
-        for i in range(5):
+        for _ in range(5):
             self._create_event_and_report(
                 room_id=self.room_id2, user_tok=self.admin_user_tok,
             )

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -614,7 +614,7 @@ class RoomTestCase(unittest.HomeserverTestCase):
         # Create 3 test rooms
         total_rooms = 3
         room_ids = []
-        for x in range(total_rooms):
+        for _ in range(total_rooms):
             room_id = self.helper.create_room_as(
                 self.admin_user, tok=self.admin_user_tok
             )
@@ -676,7 +676,7 @@ class RoomTestCase(unittest.HomeserverTestCase):
         # Create 5 test rooms
         total_rooms = 5
         room_ids = []
-        for x in range(total_rooms):
+        for _ in range(total_rooms):
             room_id = self.helper.create_room_as(
                 self.admin_user, tok=self.admin_user_tok
             )

--- a/tests/rest/admin/test_statistics.py
+++ b/tests/rest/admin/test_statistics.py
@@ -401,7 +401,7 @@ class UserMediaStatisticsTestCase(unittest.HomeserverTestCase):
             number_media: Number of media to be created for the user
         """
         upload_resource = self.media_repo.children[b"upload"]
-        for i in range(number_media):
+        for _ in range(number_media):
             # file size is 67 Byte
             image_data = unhexlify(
                 b"89504e470d0a1a0a0000000d4948445200000001000000010806"

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -1664,7 +1664,7 @@ class UserMembershipRestTestCase(unittest.HomeserverTestCase):
         # Create rooms and join
         other_user_tok = self.login("user", "pass")
         number_rooms = 5
-        for n in range(number_rooms):
+        for _ in range(number_rooms):
             self.helper.create_room_as(self.other_user, tok=other_user_tok)
 
         # Get rooms
@@ -2054,7 +2054,7 @@ class UserMediaRestTestCase(unittest.HomeserverTestCase):
         Create a number of media for a specific user
         """
         upload_resource = self.media_repo.children[b"upload"]
-        for i in range(number_media):
+        for _ in range(number_media):
             # file size is 67 Byte
             image_data = unhexlify(
                 b"89504e470d0a1a0a0000000d4948445200000001000000010806"

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -205,7 +205,7 @@ class RoomPermissionsTestCase(RoomBase):
         )
         self.assertEquals(403, channel.code, msg=channel.result["body"])
 
-    def _test_get_membership(self, room=None, members: list = None, expect_code=None):
+    def _test_get_membership(self, room=None, members: Optional[list] = None, expect_code=None):
         for member in members or []:
             path = "/rooms/%s/state/m.room.member/%s" % (room, member)
             channel = self.make_request("GET", path)

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -205,8 +205,8 @@ class RoomPermissionsTestCase(RoomBase):
         )
         self.assertEquals(403, channel.code, msg=channel.result["body"])
 
-    def _test_get_membership(self, room=None, members=[], expect_code=None):
-        for member in members:
+    def _test_get_membership(self, room=None, members: list = None, expect_code=None):
+        for member in members or []:
             path = "/rooms/%s/state/m.room.member/%s" % (room, member)
             channel = self.make_request("GET", path)
             self.assertEquals(expect_code, channel.code)
@@ -643,7 +643,7 @@ class RoomInviteRatelimitTestCase(RoomBase):
     def test_invites_by_users_ratelimit(self):
         """Tests that invites to a specific user are actually rate-limited."""
 
-        for i in range(3):
+        for _ in range(3):
             room_id = self.helper.create_room_as(self.user_id)
             self.helper.invite(room_id, self.user_id, "@other-users:red")
 
@@ -665,7 +665,7 @@ class RoomJoinRatelimitTestCase(RoomBase):
     )
     def test_join_local_ratelimit(self):
         """Tests that local joins are actually rate-limited."""
-        for i in range(3):
+        for _ in range(3):
             self.helper.create_room_as(self.user_id)
 
         self.helper.create_room_as(self.user_id, expect_code=429)
@@ -730,7 +730,7 @@ class RoomJoinRatelimitTestCase(RoomBase):
         for path in paths_to_test:
             # Make sure we send more requests than the rate-limiting config would allow
             # if all of these requests ended up joining the user to a room.
-            for i in range(4):
+            for _ in range(4):
                 channel = self.make_request("POST", path % room_id, {})
                 self.assertEquals(channel.code, 200)
 

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -19,6 +19,7 @@
 """Tests REST events for /rooms paths."""
 
 import json
+from typing import Optional
 from urllib import parse as urlparse
 
 from mock import Mock
@@ -205,7 +206,9 @@ class RoomPermissionsTestCase(RoomBase):
         )
         self.assertEquals(403, channel.code, msg=channel.result["body"])
 
-    def _test_get_membership(self, room=None, members: Optional[list] = None, expect_code=None):
+    def _test_get_membership(
+        self, room=None, members: Optional[list] = None, expect_code=None
+    ):
         for member in members or []:
             path = "/rooms/%s/state/m.room.member/%s" % (room, member)
             channel = self.make_request("GET", path)

--- a/tests/rest/client/v1/utils.py
+++ b/tests/rest/client/v1/utils.py
@@ -132,7 +132,7 @@ class RestHelper:
         src: str,
         targ: str,
         membership: str,
-        extra_data: dict = None,
+        extra_data: Optional[dict] = None,
         tok: Optional[str] = None,
         expect_code: int = 200,
     ) -> None:
@@ -187,7 +187,7 @@ class RestHelper:
         self,
         room_id,
         type,
-        content: dict = None,
+        content: Optional[dict] = None,
         txn_id=None,
         tok=None,
         expect_code=200,

--- a/tests/rest/client/v1/utils.py
+++ b/tests/rest/client/v1/utils.py
@@ -132,7 +132,7 @@ class RestHelper:
         src: str,
         targ: str,
         membership: str,
-        extra_data: dict = {},
+        extra_data: dict = None,
         tok: Optional[str] = None,
         expect_code: int = 200,
     ) -> None:
@@ -156,7 +156,7 @@ class RestHelper:
             path = path + "?access_token=%s" % tok
 
         data = {"membership": membership}
-        data.update(extra_data)
+        data.update(extra_data or {})
 
         channel = make_request(
             self.hs.get_reactor(),
@@ -184,7 +184,13 @@ class RestHelper:
         )
 
     def send_event(
-        self, room_id, type, content={}, txn_id=None, tok=None, expect_code=200
+        self,
+        room_id,
+        type,
+        content: Optional[dict] = None,
+        txn_id=None,
+        tok=None,
+        expect_code=200,
     ):
         if txn_id is None:
             txn_id = "m%s" % (str(time.time()))
@@ -198,7 +204,7 @@ class RestHelper:
             self.site,
             "PUT",
             path,
-            json.dumps(content).encode("utf8"),
+            json.dumps(content or {}).encode("utf8"),
         )
 
         assert int(channel.result["code"]) == expect_code, (

--- a/tests/rest/client/v1/utils.py
+++ b/tests/rest/client/v1/utils.py
@@ -187,7 +187,7 @@ class RestHelper:
         self,
         room_id,
         type,
-        content: Optional[dict] = None,
+        content: dict = None,
         txn_id=None,
         tok=None,
         expect_code=200,

--- a/tests/rest/client/v2_alpha/test_relations.py
+++ b/tests/rest/client/v2_alpha/test_relations.py
@@ -16,6 +16,7 @@
 import itertools
 import json
 import urllib
+from typing import Optional
 
 from synapse.api.constants import EventTypes, RelationTypes
 from synapse.rest import admin
@@ -628,7 +629,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         relation_type,
         event_type,
         key=None,
-        content={},
+        content: Optional[dict] = None,
         access_token=None,
         parent_id=None,
     ):

--- a/tests/rest/client/v2_alpha/test_relations.py
+++ b/tests/rest/client/v2_alpha/test_relations.py
@@ -629,7 +629,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         relation_type,
         event_type,
         key=None,
-        content: Optional[dict] = None,
+        content: dict = None,
         access_token=None,
         parent_id=None,
     ):
@@ -648,6 +648,8 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         Returns:
             FakeChannel
         """
+        content = content or {}
+
         if not access_token:
             access_token = self.user_token
 

--- a/tests/rest/client/v2_alpha/test_relations.py
+++ b/tests/rest/client/v2_alpha/test_relations.py
@@ -16,6 +16,7 @@
 import itertools
 import json
 import urllib
+from typing import Optional
 
 from synapse.api.constants import EventTypes, RelationTypes
 from synapse.rest import admin
@@ -628,7 +629,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         relation_type,
         event_type,
         key=None,
-        content: dict = None,
+        content: Optional[dict] = None,
         access_token=None,
         parent_id=None,
     ):

--- a/tests/rest/client/v2_alpha/test_relations.py
+++ b/tests/rest/client/v2_alpha/test_relations.py
@@ -16,7 +16,6 @@
 import itertools
 import json
 import urllib
-from typing import Optional
 
 from synapse.api.constants import EventTypes, RelationTypes
 from synapse.rest import admin

--- a/tests/server.py
+++ b/tests/server.py
@@ -588,7 +588,7 @@ class FakeTransport:
         if self.disconnected:
             return
 
-        if getattr(self.other, "transport") is None:
+        if getattr(self.other, "transport", None) is None:
             # the other has no transport yet; reschedule
             if self.autoflush:
                 self._reactor.callLater(0.0, self.flush)

--- a/tests/storage/test_event_metrics.py
+++ b/tests/storage/test_event_metrics.py
@@ -39,12 +39,12 @@ class ExtremStatisticsTestCase(HomeserverTestCase):
             last_event = None
 
             # Make a real event chain
-            for i in range(event_count):
+            for _ in range(event_count):
                 ev = self.create_and_send_event(room_id, user, False, last_event)
                 last_event = [ev]
 
             # Sprinkle in some extremities
-            for i in range(extrems):
+            for _ in range(extrems):
                 ev = self.create_and_send_event(room_id, user, False, last_event)
 
         # Let it run for a while, then pull out the statistics from the

--- a/tests/storage/test_id_generators.py
+++ b/tests/storage/test_id_generators.py
@@ -43,8 +43,10 @@ class MultiWriterIdGeneratorTestCase(HomeserverTestCase):
         )
 
     def _create_id_generator(
-        self, instance_name="master", writers=["master"]
+        self, instance_name="master", writers: list = None
     ) -> MultiWriterIdGenerator:
+        writers = writers or ["master"]
+
         def _create(conn):
             return MultiWriterIdGenerator(
                 conn,
@@ -477,8 +479,10 @@ class BackwardsMultiWriterIdGeneratorTestCase(HomeserverTestCase):
         )
 
     def _create_id_generator(
-        self, instance_name="master", writers=["master"]
+        self, instance_name="master", writers: list = None
     ) -> MultiWriterIdGenerator:
+        writers = writers or ["master"]
+
         def _create(conn):
             return MultiWriterIdGenerator(
                 conn,
@@ -610,8 +614,10 @@ class MultiTableMultiWriterIdGeneratorTestCase(HomeserverTestCase):
         )
 
     def _create_id_generator(
-        self, instance_name="master", writers=["master"]
+        self, instance_name="master", writers: list = None
     ) -> MultiWriterIdGenerator:
+        writers = writers or ["master"]
+
         def _create(conn):
             return MultiWriterIdGenerator(
                 conn,

--- a/tests/storage/test_id_generators.py
+++ b/tests/storage/test_id_generators.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+
 from synapse.storage.database import DatabasePool
 from synapse.storage.engines import IncorrectDatabaseSetup
 from synapse.storage.util.id_generators import MultiWriterIdGenerator
@@ -43,7 +45,7 @@ class MultiWriterIdGeneratorTestCase(HomeserverTestCase):
         )
 
     def _create_id_generator(
-        self, instance_name="master", writers: list = None
+        self, instance_name="master", writers: Optional[list] = None
     ) -> MultiWriterIdGenerator:
         writers = writers or ["master"]
 
@@ -479,7 +481,7 @@ class BackwardsMultiWriterIdGeneratorTestCase(HomeserverTestCase):
         )
 
     def _create_id_generator(
-        self, instance_name="master", writers: list = None
+        self, instance_name="master", writers: Optional[list] = None
     ) -> MultiWriterIdGenerator:
         writers = writers or ["master"]
 
@@ -614,7 +616,7 @@ class MultiTableMultiWriterIdGeneratorTestCase(HomeserverTestCase):
         )
 
     def _create_id_generator(
-        self, instance_name="master", writers: list = None
+        self, instance_name="master", writers: Optional[list] = None
     ) -> MultiWriterIdGenerator:
         writers = writers or ["master"]
 

--- a/tests/storage/test_redaction.py
+++ b/tests/storage/test_redaction.py
@@ -51,7 +51,12 @@ class RedactionTestCase(unittest.HomeserverTestCase):
         self.depth = 1
 
     def inject_room_member(
-        self, room, user, membership, replaces_state=None, extra_content: Optional[dict] = None
+        self,
+        room,
+        user,
+        membership,
+        replaces_state=None,
+        extra_content: Optional[dict] = None,
     ):
         content = {"membership": membership}
         content.update(extra_content or {})

--- a/tests/storage/test_redaction.py
+++ b/tests/storage/test_redaction.py
@@ -50,10 +50,10 @@ class RedactionTestCase(unittest.HomeserverTestCase):
         self.depth = 1
 
     def inject_room_member(
-        self, room, user, membership, replaces_state=None, extra_content={}
+        self, room, user, membership, replaces_state=None, extra_content: dict = None
     ):
         content = {"membership": membership}
-        content.update(extra_content)
+        content.update(extra_content or {})
         builder = self.event_builder_factory.for_room_version(
             RoomVersions.V1,
             {

--- a/tests/storage/test_redaction.py
+++ b/tests/storage/test_redaction.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
 
 from canonicaljson import json
 
@@ -50,7 +51,7 @@ class RedactionTestCase(unittest.HomeserverTestCase):
         self.depth = 1
 
     def inject_room_member(
-        self, room, user, membership, replaces_state=None, extra_content: dict = None
+        self, room, user, membership, replaces_state=None, extra_content: Optional[dict] = None
     ):
         content = {"membership": membership}
         content.update(extra_content or {})

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
 
 from mock import Mock
 
@@ -37,7 +38,7 @@ def create_event(
     state_key=None,
     depth=2,
     event_id=None,
-    prev_events: list = None,
+    prev_events: Optional[list] = None,
     **kwargs
 ):
     prev_events = prev_events or []

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -37,9 +37,10 @@ def create_event(
     state_key=None,
     depth=2,
     event_id=None,
-    prev_events=[],
+    prev_events: list = None,
     **kwargs
 ):
+    prev_events = prev_events or []
     global _next_event_id
 
     if not event_id:

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from typing import Optional
 
 from mock import Mock
 
@@ -148,7 +149,7 @@ class FilterEventsForServerTestCase(tests.unittest.TestCase):
 
     @defer.inlineCallbacks
     def inject_room_member(
-        self, user_id, membership="join", extra_content: dict = None
+        self, user_id, membership="join", extra_content: Optional[dict] = None
     ):
         content = {"membership": membership}
         content.update(extra_content or {})

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -147,9 +147,11 @@ class FilterEventsForServerTestCase(tests.unittest.TestCase):
         return event
 
     @defer.inlineCallbacks
-    def inject_room_member(self, user_id, membership="join", extra_content={}):
+    def inject_room_member(
+        self, user_id, membership="join", extra_content: dict = None
+    ):
         content = {"membership": membership}
-        content.update(extra_content)
+        content.update(extra_content or {})
         builder = self.event_builder_factory.for_room_version(
             RoomVersions.V1,
             {

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -134,13 +134,13 @@ class TestCase(unittest.TestCase):
     def assertObjectHasAttributes(self, attrs, obj):
         """Asserts that the given object has each of the attributes given, and
         that the value of each matches according to assertEquals."""
-        for (key, value) in attrs.items():
+        for key in attrs.keys():
             if not hasattr(obj, key):
                 raise AssertionError("Expected obj to have a '.%s'" % key)
             try:
                 self.assertEquals(attrs[key], getattr(obj, key))
             except AssertionError as e:
-                raise (type(e))(e.message + " for '.%s'" % key)
+                raise ((type(e))("{!s} for '.{}'".format(type(e), key))) from e
 
     def assert_dict(self, required, actual):
         """Does a partial assert of a dict.

--- a/tests/util/test_logcontext.py
+++ b/tests/util/test_logcontext.py
@@ -75,7 +75,7 @@ class LoggingContextTestCase(unittest.TestCase):
             try:
                 self.assertIs(current_context(), sentinel_context)
                 d2.callback(None)
-            except BaseException as e:
+            except Exception as e:
                 d2.errback(twisted.python.failure.Failure(e))
 
         reactor.callLater(0.01, check_logcontext)

--- a/tests/util/test_logcontext.py
+++ b/tests/util/test_logcontext.py
@@ -75,8 +75,8 @@ class LoggingContextTestCase(unittest.TestCase):
             try:
                 self.assertIs(current_context(), sentinel_context)
                 d2.callback(None)
-            except BaseException:
-                d2.errback(twisted.python.failure.Failure())
+            except BaseException as e:
+                d2.errback(twisted.python.failure.Failure(e))
 
         reactor.callLater(0.01, check_logcontext)
 

--- a/tests/util/test_ratelimitutils.py
+++ b/tests/util/test_ratelimitutils.py
@@ -89,9 +89,9 @@ def _await_resolution(reactor, d):
     return (reactor.seconds() - start_time) * 1000
 
 
-def build_rc_config(settings={}):
+def build_rc_config(settings: dict = None):
     config_dict = default_config("test")
-    config_dict.update(settings)
+    config_dict.update(settings or {})
     config = HomeServerConfig()
     config.parse_config_dict(config_dict, "", "")
     return config.rc_federation

--- a/tests/util/test_ratelimitutils.py
+++ b/tests/util/test_ratelimitutils.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+
 from synapse.config.homeserver import HomeServerConfig
 from synapse.util.ratelimitutils import FederationRateLimiter
 
@@ -89,7 +91,7 @@ def _await_resolution(reactor, d):
     return (reactor.seconds() - start_time) * 1000
 
 
-def build_rc_config(settings: dict = None):
+def build_rc_config(settings: Optional[dict] = None):
     config_dict = default_config("test")
     config_dict.update(settings or {})
     config = HomeServerConfig()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -303,7 +303,7 @@ def setup_test_homeserver(
             # database for a few more seconds due to flakiness, preventing
             # us from dropping it when the test is over. If we can't drop
             # it, warn and move on.
-            for x in range(5):
+            for _ in range(5):
                 try:
                     cur.execute("DROP DATABASE IF EXISTS %s;" % (test_db,))
                     db_conn.commit()


### PR DESCRIPTION
The scope of this PR is the following;
- adding `flake8-bugbear` to the `lint` extras
- fixing all resulting `flake8` errors
- adding various small fixes in the name of explicitness; (discussed in #9318)
  - `raise X from e`
  - `Failure(e)`

PR contains some comments on areas where wider intention isn't (as) clear.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Closes #9279

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`