### PR TITLE
Fix #8518 (sync requests being cached wrongly on timeout)

### DIFF
--- a/changelog.d/9358.misc
+++ b/changelog.d/9358.misc
@@ -1,0 +1,1 @@
+Added a fix that invalidates cache for empty timed-out sync responses.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -331,7 +331,8 @@ class SyncHandler:
                 lazy_loaded = "false"
             non_empty_sync_counter.labels(sync_type, lazy_loaded).inc()
 
-        # hack: sanity check to invalidate cache, prevent a loop
+        # fixme hack: sanity check to invalidate cache, prevent a self-referral loop
+        #  replace with contextvars approach once it gets working on twisted (twisted/twisted#1262)
         if since_token == result.next_batch:
             result = NoTimedCache(result)  # type: ignore # because it is unwrapped in ResponseCache.set.<remove>()
 

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -114,7 +114,7 @@ class ResponseCache(Generic[T]):
                 )
             else:
                 self.pending_result_cache.pop(key, None)
-            return r
+            return r.obj if isinstance(r, NoTimedCache) else r
 
         result.addBoth(remove)
         return result.observe()

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -15,6 +15,8 @@
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Optional, TypeVar
 
+import attr
+
 from twisted.internet import defer
 
 from synapse.logging.context import make_deferred_yieldable, run_in_background
@@ -27,6 +29,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+@attr.s(slots=True, frozen=True)
+class NoTimedCache(Generic[T]):
+    obj = attr.ib()
 
 
 class ResponseCache(Generic[T]):
@@ -101,7 +108,7 @@ class ResponseCache(Generic[T]):
         self.pending_result_cache[key] = result
 
         def remove(r):
-            if self.timeout_sec:
+            if self.timeout_sec and not isinstance(r, NoTimedCache):
                 self.clock.call_later(
                     self.timeout_sec, self.pending_result_cache.pop, key, None
                 )

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -32,7 +32,7 @@ T = TypeVar("T")
 
 
 @attr.s(slots=True, frozen=True)
-class NoTimedCache(Generic[T]):
+class NoTimedCache:
     obj = attr.ib()
 
 

--- a/synapse/util/caches/response_cache.py
+++ b/synapse/util/caches/response_cache.py
@@ -131,9 +131,10 @@ class ResponseCache(Generic[T]):
         """The same as wrap(), but adds a conditional to the final execution.
 
         When the final execution completes, *all* conditionals need to return True for it to properly cache,
-        else it'll not be cached in a timed fashion."""
+        else it'll not be cached in a timed fashion.
+        """
 
-        # See if there's already a result on this key that hasn't yet completed, due to the single-threaded nature of
+        # See if there's already a result on this key that hasn't yet completed. Due to the single-threaded nature of
         # python, adding a key immediately in the same execution thread will not cause a race condition.
         result = self.get(key)
         if not result or isinstance(result, defer.Deferred) and not result.called:


### PR DESCRIPTION
This fixes #8518 by adding a conditional check on `SyncResult` in a function when `prev_stream_token == current_stream_token`, as a sanity check. In `CachedResponse.set.<remove>()`, the result is immediately popped from the cache if the conditional function returns "false".

This prevents the caching of a timed-out `SyncResult` (that has `next_key` as the stream key that produced that `SyncResult`). The cache is prevented from returning a `SyncResult` that makes the client request the same stream key over and over again, effectively making it stuck in a loop of requesting and getting a response immediately for as long as the cache keeps those values.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`

Fixes #8518