### PR TITLE
Remove unneeded type constraints on 3rd party protocol lookup responses

### DIFF
--- a/changelog.d/9361.bugfix
+++ b/changelog.d/9361.bugfix
@@ -1,0 +1,1 @@
+Fix a bug causing Synapse to impose the wrong type constraints on fields when processing responses from appservices to `/_matrix/app/v1/thirdparty/user/{protocol}`.

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -76,9 +76,6 @@ def _is_valid_3pe_result(r, field):
     fields = r["fields"]
     if not isinstance(fields, dict):
         return False
-    for k in fields.keys():
-        if not isinstance(fields[k], str):
-            return False
 
     return True
 


### PR DESCRIPTION
Synapse checks that the `fields` object in 3rd party protocol lookup responses from app services only includes string values, but [the spec](https://matrix.org/docs/spec/application_service/r0.1.2#get-matrix-app-v1-thirdparty-user-protocol) says there's no such constraint.