### PR TITLE
Add a config option to prioritise local users in user directory search results

### DIFF
--- a/changelog.d/9383.feature
+++ b/changelog.d/9383.feature
@@ -1,0 +1,1 @@
+Add a configuration option, `user_directory.prefer_local_users`, which when enabled will make it more likely for users on the same server as you to appear above other users.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2542,9 +2542,14 @@ spam_checker:
 # rebuild the user_directory search indexes, see
 # https://github.com/matrix-org/synapse/blob/master/docs/user_directory.md
 #
+# 'prioritise_local_users' defines whether to prioritise local users in
+# search query results. If True, local users are more likely to appear above
+# remote users when searching the user directory. Defaults to false.
+#
 #user_directory:
 #  enabled: true
 #  search_all_users: false
+#  prioritise_local_users: false
 
 
 # User Consent configuration

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2542,14 +2542,14 @@ spam_checker:
 # rebuild the user_directory search indexes, see
 # https://github.com/matrix-org/synapse/blob/master/docs/user_directory.md
 #
-# 'prioritise_local_users' defines whether to prioritise local users in
+# 'prefer_local_users' defines whether to prioritise local users in
 # search query results. If True, local users are more likely to appear above
 # remote users when searching the user directory. Defaults to false.
 #
 #user_directory:
 #  enabled: true
 #  search_all_users: false
-#  prioritise_local_users: false
+#  prefer_local_users: false
 
 
 # User Consent configuration

--- a/synapse/config/user_directory.py
+++ b/synapse/config/user_directory.py
@@ -26,7 +26,7 @@ class UserDirectoryConfig(Config):
     def read_config(self, config, **kwargs):
         self.user_directory_search_enabled = True
         self.user_directory_search_all_users = False
-        self.user_directory_search_prioritise_local_users = False
+        self.user_directory_search_prefer_local_users = False
         user_directory_config = config.get("user_directory", None)
         if user_directory_config:
             self.user_directory_search_enabled = user_directory_config.get(
@@ -35,8 +35,8 @@ class UserDirectoryConfig(Config):
             self.user_directory_search_all_users = user_directory_config.get(
                 "search_all_users", False
             )
-            self.user_directory_search_prioritise_local_users = user_directory_config.get(
-                "prioritise_local_users", False
+            self.user_directory_search_prefer_local_users = user_directory_config.get(
+                "prefer_local_users", False
             )
 
     def generate_config_section(self, config_dir_path, server_name, **kwargs):
@@ -53,12 +53,12 @@ class UserDirectoryConfig(Config):
         # rebuild the user_directory search indexes, see
         # https://github.com/matrix-org/synapse/blob/master/docs/user_directory.md
         #
-        # 'prioritise_local_users' defines whether to prioritise local users in
+        # 'prefer_local_users' defines whether to prioritise local users in
         # search query results. If True, local users are more likely to appear above
         # remote users when searching the user directory. Defaults to false.
         #
         #user_directory:
         #  enabled: true
         #  search_all_users: false
-        #  prioritise_local_users: false
+        #  prefer_local_users: false
         """

--- a/synapse/config/user_directory.py
+++ b/synapse/config/user_directory.py
@@ -26,6 +26,7 @@ class UserDirectoryConfig(Config):
     def read_config(self, config, **kwargs):
         self.user_directory_search_enabled = True
         self.user_directory_search_all_users = False
+        self.user_directory_search_prioritise_local_users = False
         user_directory_config = config.get("user_directory", None)
         if user_directory_config:
             self.user_directory_search_enabled = user_directory_config.get(
@@ -33,6 +34,9 @@ class UserDirectoryConfig(Config):
             )
             self.user_directory_search_all_users = user_directory_config.get(
                 "search_all_users", False
+            )
+            self.user_directory_search_prioritise_local_users = user_directory_config.get(
+                "prioritise_local_users", False
             )
 
     def generate_config_section(self, config_dir_path, server_name, **kwargs):
@@ -49,7 +53,12 @@ class UserDirectoryConfig(Config):
         # rebuild the user_directory search indexes, see
         # https://github.com/matrix-org/synapse/blob/master/docs/user_directory.md
         #
+        # 'prioritise_local_users' defines whether to prioritise local users in
+        # search query results. If True, local users are more likely to appear above
+        # remote users when searching the user directory. Defaults to false.
+        #
         #user_directory:
         #  enabled: true
         #  search_all_users: false
+        #  prioritise_local_users: false
         """

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -558,8 +558,8 @@ class UserDirectoryStore(UserDirectoryBackgroundUpdateStore):
     def __init__(self, database: DatabasePool, db_conn, hs):
         super().__init__(database, db_conn, hs)
 
-        self._prioritise_local_users_in_search = (
-            hs.config.user_directory_search_prioritise_local_users
+        self._prefer_local_users_in_search = (
+            hs.config.user_directory_search_prefer_local_users
         )
         self._server_name = hs.config.server_name
 
@@ -762,7 +762,7 @@ class UserDirectoryStore(UserDirectoryBackgroundUpdateStore):
 
         # If enabled, this config option will rank local users higher than those on
         # remote instances.
-        if self._prioritise_local_users_in_search:
+        if self._prefer_local_users_in_search:
             # The statement checks whether a given user's user ID contains a domain name
             # that matches the local server
             if isinstance(self.database_engine, PostgresEngine):

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -766,17 +766,17 @@ class UserDirectoryStore(UserDirectoryBackgroundUpdateStore):
             # The statement checks whether a given user's user ID contains a domain name
             # that matches the local server
             if isinstance(self.database_engine, PostgresEngine):
-                statement = "* (CASE WHEN user_id LIKE '%:' || ? THEN 2.0 ELSE 1.0 END)"
+                statement = "* (CASE WHEN user_id LIKE ? THEN 2.0 ELSE 1.0 END)"
             elif isinstance(self.database_engine, Sqlite3Engine):
                 # Note that we need to include a comma at the end for valid SQL
-                statement = "user_id LIKE '%:' || ? DESC,"
+                statement = "user_id LIKE ? DESC,"
             else:
                 # This should be unreachable.
                 raise Exception("Unrecognized database engine")
             additional_ordering_statements.append(statement)
 
             # Append the local server name as an argument to the final query
-            ordering_arguments += (self._server_name,)
+            ordering_arguments += ("%:" + self._server_name,)
 
         if isinstance(self.database_engine, PostgresEngine):
             full_query, exact_query, prefix_query = _parse_query_postgres(search_term)

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -549,13 +549,13 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
             "user_directory": {
                 "enabled": True,
                 "search_all_users": True,
-                "prioritise_local_users": True,
+                "prefer_local_users": True,
             }
         }
     )
-    def test_prioritise_local_users(self):
+    def test_prefer_local_users(self):
         """Tests that local users are shown higher in search results when
-        user_directory.prioritise_local_users is True.
+        user_directory.prefer_local_users is True.
         """
         # Create a room and few users to test the directory with
         searching_user = self.register_user("searcher", "password")

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -18,6 +18,7 @@ from twisted.internet import defer
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes, RoomEncryptionAlgorithms, UserTypes
+from synapse.api.room_versions import RoomVersion, RoomVersions
 from synapse.rest.client.v1 import login, room
 from synapse.rest.client.v2_alpha import user_directory
 from synapse.storage.roommember import ProfileInfo
@@ -46,6 +47,8 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
     def prepare(self, reactor, clock, hs):
         self.store = hs.get_datastore()
         self.handler = hs.get_user_directory_handler()
+        self.event_builder_factory = self.hs.get_event_builder_factory()
+        self.event_creation_handler = self.hs.get_event_creation_handler()
 
     def test_handle_local_profile_change_with_support_user(self):
         support_user_id = "@support:test"
@@ -540,6 +543,97 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         u4 = self.register_user("user4", "pass")
         s = self.get_success(self.handler.search_users(u1, u4, 10))
         self.assertEqual(len(s["results"]), 1)
+
+    @override_config(
+        {
+            "user_directory": {
+                "enabled": True,
+                "search_all_users": True,
+                "prioritise_local_users": True,
+            }
+        }
+    )
+    def test_prioritise_local_users(self):
+        """Tests that local users are shown higher in search results when
+        user_directory.prioritise_local_users is True.
+        """
+        # Create a room and few users to test the directory with
+        searching_user = self.register_user("searcher", "password")
+        searching_user_tok = self.login("searcher", "password")
+
+        room_id = self.helper.create_room_as(
+            searching_user,
+            room_version=RoomVersions.V1.identifier,
+            tok=searching_user_tok,
+        )
+
+        # Create a few local users and join them to the room
+        local_user_1 = self.register_user("user_xxxxx", "password")
+        local_user_2 = self.register_user("user_bbbbb", "password")
+        local_user_3 = self.register_user("user_zzzzz", "password")
+
+        self._add_user_to_room(room_id, RoomVersions.V1, local_user_1)
+        self._add_user_to_room(room_id, RoomVersions.V1, local_user_2)
+        self._add_user_to_room(room_id, RoomVersions.V1, local_user_3)
+
+        # Create a few "remote" users and join them to the room
+        remote_user_1 = "@user_aaaaa:remote_server"
+        remote_user_2 = "@user_yyyyy:remote_server"
+        remote_user_3 = "@user_ccccc:remote_server"
+        self._add_user_to_room(room_id, RoomVersions.V1, remote_user_1)
+        self._add_user_to_room(room_id, RoomVersions.V1, remote_user_2)
+        self._add_user_to_room(room_id, RoomVersions.V1, remote_user_3)
+
+        local_users = [local_user_1, local_user_2, local_user_3]
+        remote_users = [remote_user_1, remote_user_2, remote_user_3]
+
+        # Populate the user directory via background update
+        self._add_background_updates()
+        while not self.get_success(
+            self.store.db_pool.updates.has_completed_background_updates()
+        ):
+            self.get_success(
+                self.store.db_pool.updates.do_next_background_update(100), by=0.1
+            )
+
+        # The local searching user searches for the term "user", which other users have
+        # in their user id
+        results = self.get_success(
+            self.handler.search_users(searching_user, "user", 20)
+        )["results"]
+        received_user_id_ordering = [result["user_id"] for result in results]
+
+        # Typically we'd expect Synapse to return users in lexicographical order,
+        # assuming they have similar User IDs/display names, and profile information.
+
+        # Check that the order of returned results using our module is as we expect,
+        # i.e our local users show up first, despite all users having lexographically mixed
+        # user IDs.
+        [self.assertIn(user, local_users) for user in received_user_id_ordering[:3]]
+        [self.assertIn(user, remote_users) for user in received_user_id_ordering[3:]]
+
+    def _add_user_to_room(
+        self, room_id: str, room_version: RoomVersion, user_id: str,
+    ):
+        # Add a user to the room.
+        builder = self.event_builder_factory.for_room_version(
+            room_version,
+            {
+                "type": "m.room.member",
+                "sender": user_id,
+                "state_key": user_id,
+                "room_id": room_id,
+                "content": {"membership": "join"},
+            },
+        )
+
+        event, context = self.get_success(
+            self.event_creation_handler.create_new_client_event(builder)
+        )
+
+        self.get_success(
+            self.hs.get_storage().persistence.persist_event(event, context)
+        )
 
 
 class TestUserDirSearchDisabled(unittest.HomeserverTestCase):


### PR DESCRIPTION
This PR adds a homeserver config option, `user_directory.prefer_local_users`, that when enabled will show local users higher in user directory search results than remote users. This option is off by default.

Note that turning this on doesn't necessarily mean that remote users will always be put below local users, but they should be assuming all other ranking factors (search query match, profile information present etc) are identical.

This is useful for, say, University networks that are openly federating, but want to prioritise local students and staff in the user directory over other random users.

Reviewable commit-by-commit.