### PR TITLE
Remove dead handled_events set in invite_join

### DIFF
--- a/changelog.d/9394.misc
+++ b/changelog.d/9394.misc
@@ -1,0 +1,1 @@
+Remove some dead code from the acceptance of room invites path.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1354,8 +1354,6 @@ class FederationHandler(BaseHandler):
 
         await self._clean_room_for_join(room_id)
 
-        handled_events = set()
-
         try:
             # Try the host we successfully got a response to /make_join/
             # request first.
@@ -1374,10 +1372,6 @@ class FederationHandler(BaseHandler):
             state = ret["state"]
             auth_chain = ret["auth_chain"]
             auth_chain.sort(key=lambda e: e.depth)
-
-            handled_events.update([s.event_id for s in state])
-            handled_events.update([a.event_id for a in auth_chain])
-            handled_events.add(event.event_id)
 
             logger.debug("do_invite_join auth_chain: %s", auth_chain)
             logger.debug("do_invite_join state: %s", state)


### PR DESCRIPTION
This PR removes a set that was created and [initially used](https://github.com/matrix-org/synapse/commit/1d2a0040cff8d04cdc7d7d09d8f04a5d628fa9dd#diff-0bc92da3d703202f5b9be2d3f845e375f5b1a6bc6ba61705a8af9be1121f5e42R435-R436), but is no longer today.

May help cut down a bit on the time it takes to accept invites.