### PR TITLE
Some speedups for presence

### DIFF
--- a/changelog.d/9399.misc
+++ b/changelog.d/9399.misc
@@ -1,0 +1,1 @@
+Optimise some code behind the user presence feature.

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -472,7 +472,7 @@ class FederationSender:
             self._processing_pending_presence = False
 
     def send_presence_to_destinations(
-        self, states: List[UserPresenceState], destinations: List[str]
+        self, states: List[UserPresenceState], destinations: Iterable[str]
     ) -> None:
         """Send the given presence states to the given destinations.
             destinations (list[str])

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -1114,14 +1114,12 @@ class PresenceEventSource:
         """Returns the set of users that the given user should see presence
         updates for
         """
-        user_id = user.to_string()
-        users_interested_in = set()
-        users_interested_in.add(user_id)  # So that we receive our own presence
+        user_id = user.to_string
 
-        users_who_share_room = await self.store.get_users_who_share_room_with_user(
-            user_id, on_invalidate=cache_context.invalidate
+        users_interested_in = await self.store.get_users_who_share_room_with_user(
+            user_id,
         )
-        users_interested_in.update(users_who_share_room)
+        users_interested_in.update(user_id)  # So that we receive our own presence
 
         if explicit_room_id:
             user_ids = await self.store.get_users_in_room(

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -909,9 +909,6 @@ class PresenceHandler(BasePresenceHandler):
             state = await self.current_state_for_user(user_id)
             hosts = await self.state.get_current_hosts_in_room(room_id)
 
-            # Filter out ourselves.
-            hosts = {host for host in hosts if host != self.server_name}
-
             self.federation.send_presence_to_destinations(
                 states=[state], destinations=hosts
             )
@@ -1114,7 +1111,7 @@ class PresenceEventSource:
         """Returns the set of users that the given user should see presence
         updates for
         """
-        user_id = user.to_string
+        user_id = user.to_string()
 
         users_interested_in = await self.store.get_users_who_share_room_with_user(
             user_id,

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -1114,9 +1114,9 @@ class PresenceEventSource:
         user_id = user.to_string()
 
         users_interested_in = await self.store.get_users_who_share_room_with_user(
-            user_id,
+            user_id, on_invalidate=cache_context.invalidate
         )
-        users_interested_in.update(user_id)  # So that we receive our own presence
+        users_interested_in.add(user_id)  # So that we receive our own presence
 
         if explicit_room_id:
             user_ids = await self.store.get_users_in_room(

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -496,9 +496,10 @@ class RoomMemberWorkerStore(EventsWorkerStore):
                 FROM users_in_public_rooms as p1
                 INNER JOIN users_in_public_rooms as p2
                     ON p1.room_id = p2.room_id
+                    AND p1.user_id != p2.user_id
                     AND p1.user_id = ?
-                UNION
-                SELECT DISTINCT user_id
+                UNION ALL
+                SELECT DISTINCT other_user_id
                 FROM users_who_share_private_rooms
                 WHERE
                     user_id = ?
@@ -512,7 +513,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             "get_users_who_share_room_with_user", _get_users_who_share_room_with_user
         )
 
-        return {row["user_id"] for row in rows}
+        return {row.get("user_id") or row.get("other_user_id") for row in rows}
 
     async def get_joined_users_from_context(
         self, event: EventBase, context: EventContext

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -585,7 +585,11 @@ class PresenceJoinTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(expected_state.state, PresenceState.ONLINE)
         self.federation_sender.send_presence_to_destinations.assert_called_once_with(
-            destinations={"server2", "server3"}, states=[expected_state]
+            # server1 is included here as it appears when getting the current hosts for
+            # the room. send_presence_to_destinations will remove the host server before
+            # sending out presence.
+            destinations=frozenset({"server1", "server2", "server3"}),
+            states=[expected_state],
         )
 
     def _add_new_user(self, room_id, user_id):

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -585,10 +585,10 @@ class PresenceJoinTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(expected_state.state, PresenceState.ONLINE)
         self.federation_sender.send_presence_to_destinations.assert_called_once_with(
-            # server1 is included here as it appears when getting the current hosts for
+            # "server" is included here as it appears when getting the current hosts for
             # the room. send_presence_to_destinations will remove the host server before
             # sending out presence.
-            destinations=frozenset({"server1", "server2", "server3"}),
+            destinations=frozenset({"server", "server2", "server3"}),
             states=[expected_state],
         )
 


### PR DESCRIPTION
This PR speeds up presence a bit in two ways:

* First commit switches out some code run during every presence update that did the following in Python:
 
   - For every local user on the server
      - For every room they're in
        - For every user in those rooms
            - deduplicate and return that user
  
  for SQL that gets the union of 1. all distinct users who share a private room 2. all distinct users that share a public room. Which should hopefully be a bit less insane.

* Second commit is a small one that just prevents us from iterating over the list of hosts in a room twice sequentially when joining that room.