### PR TITLE
Remove dead notify_for_states presence method

### DIFF
--- a/changelog.d/9408.misc
+++ b/changelog.d/9408.misc
@@ -1,0 +1,1 @@
+Clean up an unused method in the presence handler code.

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -658,17 +658,6 @@ class PresenceHandler(BasePresenceHandler):
 
         self._push_to_remotes(states)
 
-    async def notify_for_states(self, state, stream_id):
-        parties = await get_interested_parties(self.store, [state])
-        room_ids_to_states, users_to_states = parties
-
-        self.notifier.on_new_event(
-            "presence_key",
-            stream_id,
-            rooms=room_ids_to_states.keys(),
-            users=[UserID.from_string(u) for u in users_to_states],
-        )
-
     def _push_to_remotes(self, states):
         """Sends state updates to remote servers.
 


### PR DESCRIPTION
This PR removes a dead method that was found while working on presence performance. It seems like the commit that added this method (https://github.com/matrix-org/synapse/commit/4e1cebd56f9688d49a51929264c095356005f9a3) didn't call it from anywhere at the time either?