### PR TITLE
Reduce the memory usage of previewing media files

### DIFF
--- a/changelog.d/9421.bugfix
+++ b/changelog.d/9421.bugfix
@@ -1,0 +1,1 @@
+Reduce the amount of memory used when generating the URL preview of a file that is larger than the `max_spider_size`.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -56,7 +56,7 @@ from twisted.web.client import (
 )
 from twisted.web.http import PotentialDataLoss
 from twisted.web.http_headers import Headers
-from twisted.web.iweb import IAgent, IBodyProducer, IResponse
+from twisted.web.iweb import UNKNOWN_LENGTH, IAgent, IBodyProducer, IResponse
 
 from synapse.api.errors import Codes, HttpResponseException, SynapseError
 from synapse.http import QuieterFileBodyProducer, RequestTimedOutError, redact_uri
@@ -801,9 +801,8 @@ def read_body_with_max_size(
     """
     # If the Content-Length header gives a size larger than the maximum allowed
     # size, do not bother downloading the body.
-    if max_size is not None:
-        content_length_headers = response.headers.getRawHeaders(b"Content-Length", None)
-        if content_length_headers and int(content_length_headers[0]) > max_size:
+    if max_size is not None and response.length != UNKNOWN_LENGTH:
+        if response.length > max_size:
             return defer.fail(BodyExceededMaxSize())
 
     d = defer.Deferred()

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -768,7 +768,9 @@ class _ReadBodyWithMaxSizeProtocol(protocol.Protocol):
         # in the meantime.
         if self.max_size is not None and self.length >= self.max_size:
             self.deferred.errback(BodyExceededMaxSize())
-            self.transport.loseConnection()
+            # Close the connection (forcefully) since all the data will get
+            # discarded anyway.
+            self.transport.abortConnection()
 
     def connectionLost(self, reason: Failure) -> None:
         # If the maximum size was already exceeded, there's nothing to do.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -407,6 +407,9 @@ class SimpleHttpClient:
                     agent=self.agent,
                     data=body_producer,
                     headers=headers,
+                    # Avoid buffering the body in treq since we do not reuse
+                    # response bodies.
+                    unbuffered=True,
                     **self._extra_treq_args,
                 )  # type: defer.Deferred
 

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -18,6 +18,7 @@ from mock import Mock
 
 from twisted.python.failure import Failure
 from twisted.web.client import ResponseDone
+from twisted.web.iweb import UNKNOWN_LENGTH
 
 from synapse.http.client import BodyExceededMaxSize, read_body_with_max_size
 
@@ -27,12 +28,12 @@ from tests.unittest import TestCase
 class ReadBodyWithMaxSizeTests(TestCase):
     def setUp(self):
         """Start reading the body, returns the response, result and proto"""
-        self.response = Mock()
+        response = Mock(length=UNKNOWN_LENGTH)
         self.result = BytesIO()
-        self.deferred = read_body_with_max_size(self.response, self.result, 6)
+        self.deferred = read_body_with_max_size(response, self.result, 6)
 
         # Fish the protocol out of the response.
-        self.protocol = self.response.deliverBody.call_args[0][0]
+        self.protocol = response.deliverBody.call_args[0][0]
         self.protocol.transport = Mock()
 
     def _cleanup_error(self):

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -89,7 +89,7 @@ class ReadBodyWithMaxSizeTests(TestCase):
         self.protocol.dataReceived(b"1234567890")
         self.assertIsInstance(self.deferred.result, Failure)
         self.assertIsInstance(self.deferred.result.value, BodyExceededMaxSize)
-        self.protocol.transport.loseConnection.assert_called_once()
+        self.protocol.transport.abortConnection.assert_called_once()
 
         # More data might have come in.
         self.protocol.dataReceived(b"1234567890")


### PR DESCRIPTION
I'm hoping this will help with #9365. There's a few tangentially related fixes in here:

* Always check the `Content-Length` header before attempting to load the body. (This was only being done in 1 of the 3 callers.)
* Do not buffer responses in treq, this feature seems to exist to allow you to read a response multiple times, but we never do that so this avoids saving bodies in two places.
* Forcefully disconnect when the maximum body size is reached. See [`abortConnection`](https://twistedmatrix.com/documents/19.2.0/api/twisted.internet.interfaces.ITCPTransport.html#abortConnection) vs. [`loseConnection`](https://twistedmatrix.com/documents/19.2.0/api/twisted.internet.interfaces.ITransport.html#loseConnection):
    > Discards any buffered data, stops any registered producer, and, if possible, notifies the other end of the unclean closure.

    vs.

    > Note that if there is a registered producer on a transport it will not be closed until the producer has been unregistered.

    ... so we were still being streamed all the data and wasting CPU cycles getting data that was dropped on the floor.
