### PR TITLE
Fix arm docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,4 +79,6 @@ commands:
         type: string
     steps:
       - run: docker buildx build -f docker/Dockerfile-cargo-cache --push -t 127.0.0.1:5000/cargo_cache --platform << parameters.platforms >> --progress=plain .
-      - run: docker buildx build -f docker/Dockerfile --push --platform << parameters.platforms >> --label gitsha1=${CIRCLE_SHA1} << parameters.tag >> --build-arg BASE_IMAGE=127.0.0.1:5000/cargo_cache --build-arg CARGO_NET_OFFLINE=true --progress=plain  .
+      - run:
+          command: docker buildx build -f docker/Dockerfile --push --platform << parameters.platforms >> --label gitsha1=${CIRCLE_SHA1} << parameters.tag >> --build-arg BASE_IMAGE=127.0.0.1:5000/cargo_cache --build-arg CARGO_NET_OFFLINE=true --progress=plain  .
+          no_output_timeout: 30m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,9 @@ commands:
         default: "v0.4.1"
     steps:
       - setup_remote_docker:
-          # 19.03.13 was the most recent available on circleci at the time of
+          # 20.10.2 was the most recent available on circleci at the time of
           # writing.
-          version: 19.03.13
+          version: 20.10.2
       - run: apk add --no-cache curl
       - run: mkdir -vp ~/.docker/cli-plugins/ ~/dockercache
       - run: curl --silent -L "https://github.com/docker/buildx/releases/download/<< parameters.buildx_version >>/buildx-<< parameters.buildx_version >>.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
@@ -64,7 +64,10 @@ commands:
       # create a context named `builder` for the builds
       - run: docker context create builder
       # create a buildx builder using the new context, and set it as the default
-      - run: docker buildx create builder --use
+      - run: docker buildx create --driver docker-container --driver-opt network=host builder --use
+      # Start a registry so that have somewhere to store our temporary docker
+      # images (as multi arch builds don't work with stand local docker store)
+      - run: docker run -d -p 127.0.0.1:5000:5000 --name registry registry:2
 
   docker_build:
     description: Builds and pushed images to dockerhub using buildx
@@ -75,4 +78,5 @@ commands:
       tag:
         type: string
     steps:
-      - run: docker buildx build -f docker/Dockerfile --push --platform << parameters.platforms >> --label gitsha1=${CIRCLE_SHA1} << parameters.tag >> --progress=plain .
+      - run: docker buildx build -f docker/Dockerfile-cargo-cache --push -t 127.0.0.1:5000/cargo_cache --platform << parameters.platforms >> --progress=plain .
+      - run: docker buildx build -f docker/Dockerfile --push --platform << parameters.platforms >> --label gitsha1=${CIRCLE_SHA1} << parameters.tag >> --build-arg BASE_IMAGE=127.0.0.1:5000/cargo_cache --build-arg CARGO_NET_OFFLINE=true --progress=plain  .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ jobs:
     steps:
       - checkout
       - docker_prepare
-      - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
+      # - run: docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
       # for `latest`, we don't want the arm images to disappear, so don't update the tag
       # until all of the platforms are built.
       - docker_build:
-          tag: -t matrixdotorg/synapse:latest
+          tag: -t 127.0.0.1:5000/synapse:erikj-test
           platforms: linux/amd64,linux/arm/v7,linux/arm64
 
 workflows:
@@ -41,7 +41,7 @@ workflows:
       - dockerhubuploadlatest:
           filters:
             branches:
-              only: master
+              only: erikj/arm_docker_cache
 
 commands:
   docker_prepare:

--- a/changelog.d/9423.bugfix
+++ b/changelog.d/9423.bugfix
@@ -1,0 +1,1 @@
+Fix building docker images for 32-bit ARM.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,9 @@ ENV CARGO_NET_OFFLINE=${CARGO_NET_OFFLINE}
 
 # Build dependencies that are not available as wheels, to speed up rebuilds
 RUN pip install --prefix="/install" --no-warn-script-location \
+        lxml
+
+RUN pip install --prefix="/install" --no-warn-script-location \
         cryptography
 
 RUN pip install --prefix="/install" --no-warn-script-location \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,11 +12,13 @@
 #
 
 ARG PYTHON_VERSION=3.8
+ARG BASE_IMAGE=docker.io/python:${PYTHON_VERSION}-slim
+ARG CARGO_NET_OFFLINE=false
 
 ###
 ### Stage 0: builder
 ###
-FROM docker.io/python:${PYTHON_VERSION}-slim as builder
+FROM ${BASE_IMAGE} as builder
 
 # install the OS build deps
 RUN apt-get update && apt-get install -y \
@@ -31,6 +33,8 @@ RUN apt-get update && apt-get install -y \
     rustc \
     zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
+
+ENV CARGO_NET_OFFLINE=${CARGO_NET_OFFLINE}
 
 # Build dependencies that are not available as wheels, to speed up rebuilds
 RUN pip install --prefix="/install" --no-warn-script-location \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,9 @@ ENV CARGO_NET_OFFLINE=${CARGO_NET_OFFLINE}
 
 # Build dependencies that are not available as wheels, to speed up rebuilds
 RUN pip install --prefix="/install" --no-warn-script-location \
-        cryptography \
+        cryptography
+
+RUN pip install --prefix="/install" --no-warn-script-location \
         frozendict \
         jaeger-client \
         opentracing \

--- a/docker/Dockerfile-cargo-cache
+++ b/docker/Dockerfile-cargo-cache
@@ -1,0 +1,21 @@
+# A docker file that caches the cargo index for the cryptography deps. This is
+# mainly useful for multi-arch builds where fetching the index from the internet
+# fails for 32bit archs built on 64 bit platforms.
+
+ARG PYTHON_VERSION=3.8
+
+FROM --platform=$BUILDPLATFORM docker.io/python:${PYTHON_VERSION}-slim as builder
+
+RUN apt-get update && apt-get install -y \
+    rustc \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip download --no-binary cryptography --no-deps cryptography
+
+RUN tar -xf cryptography*.tar.gz --wildcards cryptography*/src/rust/
+
+RUN cd cryptography*/src/rust && cargo fetch
+
+FROM docker.io/python:${PYTHON_VERSION}-slim
+
+COPY --from=builder /root/.cargo /root/.cargo


### PR DESCRIPTION
c.f. https://github.com/matrix-org/synapse/issues/9403

Basically building the `cryptography` package now requires rust to build, which fetches packages from crates.io. Fetching packages breaks when building for 32bit arch on 64bit platforms, so we create a base image that has the packages already downloaded. This allowis us to run rustc/cargo in offline mode, which doesn't break.

We don't want to do this by default however, as cryptography ships wheels for most platforms and so the extra steps are entirely unnecessary.

Does anyone know of a good way of testing this works on circle CI? I have tested locally