### PR TITLE
Fix only handling the last presence state for each user

### DIFF
--- a/changelog.d/9425.bugfix
+++ b/changelog.d/9425.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug in the deduplication of old presence, resulting in no deduplication.

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -349,10 +349,13 @@ class PresenceHandler(BasePresenceHandler):
                 [self.user_to_current_state[user_id] for user_id in unpersisted]
             )
 
-    async def _update_states(self, new_states):
+    async def _update_states(self, new_states: Iterable[UserPresenceState]):
         """Updates presence of users. Sets the appropriate timeouts. Pokes
         the notifier and federation if and only if the changed presence state
         should be sent to clients/servers.
+
+        Args:
+            new_states: The new user presence state updates to process.
         """
         now = self.clock.time_msec()
 

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -349,7 +349,7 @@ class PresenceHandler(BasePresenceHandler):
                 [self.user_to_current_state[user_id] for user_id in unpersisted]
             )
 
-    async def _update_states(self, new_states: Iterable[UserPresenceState]):
+    async def _update_states(self, new_states: Iterable[UserPresenceState]) -> None:
         """Updates presence of users. Sets the appropriate timeouts. Pokes
         the notifier and federation if and only if the changed presence state
         should be sent to clients/servers.

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -368,7 +368,7 @@ class PresenceHandler(BasePresenceHandler):
             new_states_dict = {}
             for new_state in new_states:
                 new_states_dict[new_state.user_id] = new_state
-            new_state = new_states_dict.values()
+            new_states = new_states_dict.values()
 
             for new_state in new_states:
                 user_id = new_state.user_id


### PR DESCRIPTION
This is a small bug that I noticed while working on #8956.

We have a for-loop which attempts to strip all presence changes for each user except for the final one, as we don't really care about older presence:

https://github.com/matrix-org/synapse/blob/9e19c6aab4b5a99039f2ddc7d3120dd3b26c274b/synapse/handlers/presence.py#L368-L371

`new_states_dict` stores this stripped copy of latest presence state for each user, before it is... put into a new variable `new_state`, which is just overridden by the subsequent for loop.

I believe this was instead meant to override `new_states`. Without doing so, it effectively meant:

1. The for loop had no effect.
2. We were still processing old presence state for users.