### PR TITLE
Add back the guard against the user directory stream position being unset

### DIFF
--- a/changelog.d/9428.bugfix
+++ b/changelog.d/9428.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.27.0: "TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType." related to the user directory.

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -143,6 +143,10 @@ class UserDirectoryHandler(StateDeltasHandler):
         if self.pos is None:
             self.pos = await self.store.get_user_directory_stream_pos()
 
+        # If still None then the initial background update hasn't happened yet.
+        if self.pos is None:
+            return None
+
         # Loop round handling deltas until we're up to date
         while True:
             with Measure(self.clock, "user_dir_delta"):

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -707,7 +707,13 @@ class UserDirectoryStore(UserDirectoryBackgroundUpdateStore):
 
         return {row["room_id"] for row in rows}
 
-    async def get_user_directory_stream_pos(self) -> int:
+    async def get_user_directory_stream_pos(self) -> Optional[int]:
+        """
+        Get the stream ID of the user directory stream.
+
+        Returns:
+            The stream token or None if the initial background update hasn't happened yet.
+        """
         return await self.db_pool.simple_select_one_onecol(
             table="user_directory_stream_pos",
             keyvalues={},


### PR DESCRIPTION
This adds back the code removed in https://github.com/matrix-org/synapse/pull/9223/files#r564010797.

That comment is incorrect -- the call to `get_user_directory_stream_pos` will raise an error if there's no row in `get_user_directory_stream_pos`, but row itself can have a `null` value for `stream_id`.

Fixes #9420