### PR TITLE
Deprecate old admin API `GET /_synapse/admin/v1/users/<user_id>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,20 @@
+Synapse 1.xx.0 (2021-xx-xx)
+===========================
+
+Removal warning
+---------------
+
+The old List Accounts API is deprecated and will be removed in a future release. They will be replaced by the
+[List Accounts API](https://github.com/matrix-org/synapse/blob/master/docs/admin_api/user_admin_api.rst#list-accounts).
+
+The new API is available since Synapse 1.7.0 (2019-12-13).
+
+The old API has no documentation and unit tests. It is misleading.
+It expects user_id and returns a list of all users.
+
+`GET /_synapse/admin/v2/users` replaces `GET /_synapse/admin/v1/users/<user_id>`.
+
+
 Synapse 1.27.0 (2021-02-16)
 ===========================
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ This API was undocumented and misleading. It can be replaced by the
 [v2 list accounts API](https://github.com/matrix-org/synapse/blob/master/docs/admin_api/user_admin_api.rst#list-accounts),
 which has been available since Synapse 1.7.0 (2019-12-13).
 
-Please check any scripts you might have for the admin API and replace
+Please check if you're using any scripts which use the admin API and replace
 `GET /_synapse/admin/v1/users/<user_id>` with `GET /_synapse/admin/v2/users`.
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,15 +4,13 @@ Synapse 1.xx.0 (2021-xx-xx)
 Removal warning
 ---------------
 
-The old List Accounts API is deprecated and will be removed in a future release. They will be replaced by the
-[List Accounts API](https://github.com/matrix-org/synapse/blob/master/docs/admin_api/user_admin_api.rst#list-accounts).
+The v1 list accounts API is deprecated and will be removed in a future release.
+This API was undocumented and misleading. It can be replaced by the
+[v2 list accounts API](https://github.com/matrix-org/synapse/blob/master/docs/admin_api/user_admin_api.rst#list-accounts),
+which has been available since Synapse 1.7.0 (2019-12-13).
 
-The new API is available since Synapse 1.7.0 (2019-12-13).
-
-The old API has no documentation and unit tests. It is misleading.
-It expects user_id and returns a list of all users.
-
-`GET /_synapse/admin/v2/users` replaces `GET /_synapse/admin/v1/users/<user_id>`.
+Please check any scripts you might have for the admin API and replace
+`GET /_synapse/admin/v1/users/<user_id>` with `GET /_synapse/admin/v2/users`.
 
 
 Synapse 1.27.0 (2021-02-16)

--- a/changelog.d/9429.removal
+++ b/changelog.d/9429.removal
@@ -1,0 +1,1 @@
+Deprecate old admin API `GET /_synapse/admin/v1/users/<user_id>`.


### PR DESCRIPTION
Related: #9401, #8334

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Signed-off-by: Dirk Klimpel dirk@klimpel.org