### PR TITLE
example systemd config: propagate reloads to units

### DIFF
--- a/changelog.d/9463.doc
+++ b/changelog.d/9463.doc
@@ -1,0 +1,1 @@
+Update the example systemd config to propagate reloads to individual units.

--- a/docs/systemd-with-workers/system/matrix-synapse-worker@.service
+++ b/docs/systemd-with-workers/system/matrix-synapse-worker@.service
@@ -4,6 +4,7 @@ AssertPathExists=/etc/matrix-synapse/workers/%i.yaml
 
 # This service should be restarted when the synapse target is restarted.
 PartOf=matrix-synapse.target
+ReloadPropagatedFrom=synapse.target
 
 # if this is started at the same time as the main, let the main process start
 # first, to initialise the database schema.

--- a/docs/systemd-with-workers/system/matrix-synapse-worker@.service
+++ b/docs/systemd-with-workers/system/matrix-synapse-worker@.service
@@ -4,7 +4,7 @@ AssertPathExists=/etc/matrix-synapse/workers/%i.yaml
 
 # This service should be restarted when the synapse target is restarted.
 PartOf=matrix-synapse.target
-ReloadPropagatedFrom=synapse.target
+ReloadPropagatedFrom=matrix-synapse.target
 
 # if this is started at the same time as the main, let the main process start
 # first, to initialise the database schema.

--- a/docs/systemd-with-workers/system/matrix-synapse.service
+++ b/docs/systemd-with-workers/system/matrix-synapse.service
@@ -3,6 +3,7 @@ Description=Synapse master
 
 # This service should be restarted when the synapse target is restarted.
 PartOf=matrix-synapse.target
+ReloadPropagatedFrom=synapse.target
 
 [Service]
 Type=notify

--- a/docs/systemd-with-workers/system/matrix-synapse.service
+++ b/docs/systemd-with-workers/system/matrix-synapse.service
@@ -3,7 +3,7 @@ Description=Synapse master
 
 # This service should be restarted when the synapse target is restarted.
 PartOf=matrix-synapse.target
-ReloadPropagatedFrom=synapse.target
+ReloadPropagatedFrom=matrix-synapse.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
It should be possible to reload `synapse.target` to have the reload propagate to all the synapse units.