### PR TITLE
Add back the deprecated SAML endpoint.

### DIFF
--- a/changelog.d/9474.misc
+++ b/changelog.d/9474.misc
@@ -1,0 +1,1 @@
+Revert change in v1.28.0rc1 to remove the deprecated SAML endpoint.

--- a/synapse/rest/synapse/client/__init__.py
+++ b/synapse/rest/synapse/client/__init__.py
@@ -54,7 +54,12 @@ def build_synapse_client_resource_tree(hs: "HomeServer") -> Mapping[str, Resourc
     if hs.config.saml2_enabled:
         from synapse.rest.synapse.client.saml2 import SAML2Resource
 
-        resources["/_synapse/client/saml2"] = SAML2Resource(hs)
+        res = SAML2Resource(hs)
+        resources["/_synapse/client/saml2"] = res
+
+        # This is also mounted under '/_matrix' for backwards-compatibility.
+        # To be removed in Synapse v1.32.0.
+        resources["/_matrix/saml2"] = res
 
     return resources
 


### PR DESCRIPTION
Partially reverts #9434, fixes #9452.

This can be removed in a future version.