### PR TITLE
Add SQL delta for deleting stale pushers

### DIFF
--- a/changelog.d/9479.bugfix
+++ b/changelog.d/9479.bugfix
@@ -1,0 +1,1 @@
+Fix deleting pushers when using sharded pushers.

--- a/synapse/storage/databases/main/schema/delta/59/08delete_stale_pushers.sql
+++ b/synapse/storage/databases/main/schema/delta/59/08delete_stale_pushers.sql
@@ -1,0 +1,19 @@
+/* Copyright 2021 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+-- Delete all pushers associated with deleted devices. This is to clear up after
+-- a bug where they weren't correctly deleted when using workers.
+DELETE FROM pushers WHERE access_token NOT IN (SELECT id FROM access_tokens);


### PR DESCRIPTION
The select for this took ~8s on matrix.org. I think we could turn this into a background job, but I'm not sure it's worth it.

This a clean up after the fix in https://github.com/matrix-org/synapse/pull/9465