### PR TITLE
Add option for timed /sync cache

### DIFF
--- a/changelog.d/9484.bugfix
+++ b/changelog.d/9484.bugfix
@@ -1,0 +1,1 @@
+Add experimental config feature for timed `/sync` cache, fixes #3880.

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -29,4 +29,6 @@ class ExperimentalConfig(Config):
         self.msc2858_enabled = experimental.get("msc2858_enabled", False)  # type: bool
 
         # Timeout value (in milliseconds) on sync Response Cache
-        self.sync_cache_timeout_ms = experimental.get("sync_cache_timeout_ms", 0)  # type: int
+        self.sync_cache_timeout_ms = experimental.get(
+            "sync_cache_timeout_ms", 0
+        )  # type: int

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -27,3 +27,6 @@ class ExperimentalConfig(Config):
 
         # MSC2858 (multiple SSO identity providers)
         self.msc2858_enabled = experimental.get("msc2858_enabled", False)  # type: bool
+
+        # Timeout value (in milliseconds) on sync Response Cache
+        self.sync_cache_timeout_ms = experimental.get("sync_cache_timeout_ms", 0)  # type: int

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -244,7 +244,7 @@ class SyncHandler:
         self.event_sources = hs.get_event_sources()
         self.clock = hs.get_clock()
         self.response_cache = ResponseCache(
-            hs, "sync"
+            hs, "sync", timeout_ms=hs.config.experimental.sync_cache_timeout_ms
         )  # type: ResponseCache[Tuple[Any, ...]]
         self.state = hs.get_state_handler()
         self.auth = hs.get_auth()


### PR DESCRIPTION
This adds the `experimental_features.sync_cache_timeout_ms` config value. Thus this fixes #3880.

Stabilisation for general recommended use is left for a future PR or decision, after this has been tested enough (in my opinion).

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`