### PR TITLE
Prometheus metrics for logins and registrations

### DIFF
--- a/changelog.d/9511.feature
+++ b/changelog.d/9511.feature
@@ -1,0 +1,1 @@
+Add prometheus metrics for number of users successfully registering and logging in.

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -606,6 +606,7 @@ class SsoHandler:
             default_display_name=attributes.display_name,
             bind_emails=attributes.emails,
             user_agent_ips=[(user_agent, ip_address)],
+            auth_provider_id=auth_provider_id,
         )
 
         await self._store.record_user_external_id(


### PR DESCRIPTION
Add prom metrics for number of users successfully registering and logging in, by SSO provider. 

Fixes #9431.

Based on #9510.