### PR TITLE
Update nginx reverse-proxy docs

### DIFF
--- a/changelog.d/9512.feature
+++ b/changelog.d/9512.feature
@@ -1,0 +1,1 @@
+Add support for `X-Forwarded-Proto` header when using a reverse proxy.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -53,6 +53,8 @@ server {
         proxy_pass http://localhost:8008;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+
         # Nginx by default only allows file uploads up to 1M in size
         # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
         client_max_body_size 50M;


### PR DESCRIPTION
Turns out nginx overwrites the Host header by default.