### PR TITLE
Fix 'rejected_events_metadata' background update

### DIFF
--- a/changelog.d/9537.bugfix
+++ b/changelog.d/9537.bugfix
@@ -1,0 +1,1 @@
+Fix rare edge case that caused a background update to fail if the server had rejected an event that had duplicate auth events.

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -696,7 +696,9 @@ class EventsBackgroundUpdatesStore(SQLBaseStore):
                 )
 
             if not has_event_auth:
-                for auth_id in event.auth_event_ids():
+                # Old, dodgy, events may have duplicate auth events, which we
+                # need to deduplicate as we have a unique constraint.
+                for auth_id in set(event.auth_event_ids()):
                     auth_events.append(
                         {
                             "room_id": event.room_id,


### PR DESCRIPTION
Turns out matrix.org has an event that has duplicate auth events (which really isn't supposed to happen, but here we are). This caused the background update to fail due to `UniqueViolation`.

This was added in v1.28.0, but we only just noticed on matrix.org due to #9503.

Sentry link: https://sentry.matrix.org/sentry/synapse-matrixorg/issues/200948/