### PR TITLE
Add a basic test for purging rooms

### DIFF
--- a/changelog.d/9541.bugfix
+++ b/changelog.d/9541.bugfix
@@ -1,1 +1,0 @@
-Properly purge the event chain cover index when purging history.

--- a/changelog.d/9541.bugfix
+++ b/changelog.d/9541.bugfix
@@ -1,0 +1,1 @@
+Properly purge the event chain cover index when purging history.

--- a/changelog.d/9541.misc
+++ b/changelog.d/9541.misc
@@ -1,0 +1,1 @@
+Add an additional test for purging a room.

--- a/tests/storage/test_purge.py
+++ b/tests/storage/test_purge.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.internet import defer
-
-from synapse.api.errors import NotFoundError
+from synapse.api.errors import NotFoundError, SynapseError
 from synapse.rest.client.v1 import room
 
 from tests.unittest import HomeserverTestCase
@@ -33,9 +31,12 @@ class PurgeTests(HomeserverTestCase):
     def prepare(self, reactor, clock, hs):
         self.room_id = self.helper.create_room_as(self.user_id)
 
-    def test_purge(self):
+        self.store = hs.get_datastore()
+        self.storage = self.hs.get_storage()
+
+    def test_purge_history(self):
         """
-        Purging a room will delete everything before the topological point.
+        Purging a room history will delete everything before the topological point.
         """
         # Send four messages to the room
         first = self.helper.send(self.room_id, body="test1")
@@ -43,30 +44,27 @@ class PurgeTests(HomeserverTestCase):
         third = self.helper.send(self.room_id, body="test3")
         last = self.helper.send(self.room_id, body="test4")
 
-        store = self.hs.get_datastore()
-        storage = self.hs.get_storage()
-
         # Get the topological token
         token = self.get_success(
-            store.get_topological_token_for_event(last["event_id"])
+            self.store.get_topological_token_for_event(last["event_id"])
         )
         token_str = self.get_success(token.to_string(self.hs.get_datastore()))
 
         # Purge everything before this topological token
         self.get_success(
-            storage.purge_events.purge_history(self.room_id, token_str, True)
+            self.storage.purge_events.purge_history(self.room_id, token_str, True)
         )
 
         # 1-3 should fail and last will succeed, meaning that 1-3 are deleted
         # and last is not.
-        self.get_failure(store.get_event(first["event_id"]), NotFoundError)
-        self.get_failure(store.get_event(second["event_id"]), NotFoundError)
-        self.get_failure(store.get_event(third["event_id"]), NotFoundError)
-        self.get_success(store.get_event(last["event_id"]))
+        self.get_failure(self.store.get_event(first["event_id"]), NotFoundError)
+        self.get_failure(self.store.get_event(second["event_id"]), NotFoundError)
+        self.get_failure(self.store.get_event(third["event_id"]), NotFoundError)
+        self.get_success(self.store.get_event(last["event_id"]))
 
-    def test_purge_wont_delete_extrems(self):
+    def test_purge_history_wont_delete_extrems(self):
         """
-        Purging a room will delete everything before the topological point.
+        Purging a room history will delete everything before the topological point.
         """
         # Send four messages to the room
         first = self.helper.send(self.room_id, body="test1")
@@ -74,22 +72,21 @@ class PurgeTests(HomeserverTestCase):
         third = self.helper.send(self.room_id, body="test3")
         last = self.helper.send(self.room_id, body="test4")
 
-        storage = self.hs.get_datastore()
-
         # Set the topological token higher than it should be
         token = self.get_success(
-            storage.get_topological_token_for_event(last["event_id"])
+            self.store.get_topological_token_for_event(last["event_id"])
         )
         event = "t{}-{}".format(token.topological + 1, token.stream + 1)
 
         # Purge everything before this topological token
-        purge = defer.ensureDeferred(storage.purge_history(self.room_id, event, True))
-        self.pump()
-        f = self.failureResultOf(purge)
+        f = self.get_failure(
+            self.storage.purge_events.purge_history(self.room_id, event, True),
+            SynapseError
+        )
         self.assertIn("greater than forward", f.value.args[0])
 
         # Try and get the events
-        self.get_success(storage.get_event(first["event_id"]))
-        self.get_success(storage.get_event(second["event_id"]))
-        self.get_success(storage.get_event(third["event_id"]))
-        self.get_success(storage.get_event(last["event_id"]))
+        self.get_success(self.store.get_event(first["event_id"]))
+        self.get_success(self.store.get_event(second["event_id"]))
+        self.get_success(self.store.get_event(third["event_id"]))
+        self.get_success(self.store.get_event(last["event_id"]))

--- a/tests/storage/test_purge.py
+++ b/tests/storage/test_purge.py
@@ -81,7 +81,7 @@ class PurgeTests(HomeserverTestCase):
         # Purge everything before this topological token
         f = self.get_failure(
             self.storage.purge_events.purge_history(self.room_id, event, True),
-            SynapseError
+            SynapseError,
         )
         self.assertIn("greater than forward", f.value.args[0])
 

--- a/tests/storage/test_purge.py
+++ b/tests/storage/test_purge.py
@@ -104,9 +104,6 @@ class PurgeTests(HomeserverTestCase):
             state_handler.get_current_state(self.room_id, "m.room.create", "")
         )
         self.assertIsNotNone(create_event)
-        create_context = self.get_success(
-            state_handler.compute_event_context(create_event)
-        )
 
         # Purge everything before this topological token
         self.get_success(self.storage.purge_events.purge_room(self.room_id))


### PR DESCRIPTION
This adds a basic storage layer test for purging rooms, doesn't offer too much more than the ones using the admin API, but I find it quite a bit clearer.

Related to #9498 / #9481.