### PR TITLE
Add a list of hashes to ignore during git blame.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Black reformatting (#5482).
+32e7c9e7f20b57dd081023ac42d6931a8da9b3a3
+
+# Target Python 3.5 with black (#8664).
+aff1eb7c671b0a3813407321d2702ec46c71fa56
+
+# Update black to 20.8b1 (#9381).
+0a00b7ff14890987f09112a2ae696c61001e6cf1


### PR DESCRIPTION
This adds a file which lists revs which should be ignored when doing a `git blame`, this is useful for mass reformatting, etc. You can configure git to use it automatically via `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

Note that we only want to include changes in here which we are highly confident won't change behavior (e.g. we don't want to include things like the async/await conversation).

I suspect we should also document running `git config`. Maybe in CONTRIBUTING, but I like keeping that simple... Any thoughts?
