### PR TITLE
Fix spam checker modules documentation example

### DIFF
--- a/changelog.d/9580.doc
+++ b/changelog.d/9580.doc
@@ -1,1 +1,1 @@
-Fix spam checker modules documentation example to clarify parse_config is a required method.
+Clarify the spam checker modules documentation example to mention that `parse_config` is a required method.

--- a/changelog.d/9580.doc
+++ b/changelog.d/9580.doc
@@ -1,0 +1,1 @@
+Fix spam checker modules documentation example to clarify parse_config is a required method.

--- a/docs/spam_checker.md
+++ b/docs/spam_checker.md
@@ -14,7 +14,7 @@ The Python class is instantiated with two objects:
 * An instance of `synapse.module_api.ModuleApi`.
 
 It then implements methods which return a boolean to alter behavior in Synapse.
-All the methods are mandatory to be defined.
+All the methods are must be defined.
 
 There's a generic method for checking every event (`check_event_for_spam`), as
 well as some specific methods:
@@ -33,8 +33,8 @@ The `ModuleApi` class provides a way for the custom spam checker class to
 call back into the homeserver internals.
 
 Additionally, a `parse_config` method is mandatory and receives the plugin config
-dictionary. After possible sanitizing, It must return a dictionary which
-will be passed to `__init__` later.
+dictionary. After parsing, It must return an object which will be
+passed to `__init__` later.
 
 ### Example
 

--- a/docs/spam_checker.md
+++ b/docs/spam_checker.md
@@ -25,6 +25,7 @@ well as some specific methods:
 * `user_may_publish_room`
 * `check_username_for_spam`
 * `check_registration_for_spam`
+* `check_media_file_for_spam`
 
 The details of each of these methods (as well as their inputs and outputs)
 are documented in the `synapse.events.spamcheck.SpamChecker` class.

--- a/docs/spam_checker.md
+++ b/docs/spam_checker.md
@@ -14,6 +14,7 @@ The Python class is instantiated with two objects:
 * An instance of `synapse.module_api.ModuleApi`.
 
 It then implements methods which return a boolean to alter behavior in Synapse.
+All the methods are mandatory to be defined.
 
 There's a generic method for checking every event (`check_event_for_spam`), as
 well as some specific methods:
@@ -31,6 +32,10 @@ are documented in the `synapse.events.spamcheck.SpamChecker` class.
 The `ModuleApi` class provides a way for the custom spam checker class to
 call back into the homeserver internals.
 
+Additionally, a `parse_config` method is mandatory and receives the plugin config
+dictionary. After possible sanitizing, It must return a dictionary which
+will be passed to `__init__` later.
+
 ### Example
 
 ```python
@@ -41,6 +46,10 @@ class ExampleSpamChecker:
         self.config = config
         self.api = api
 
+    @staticmethod
+    def parse_config(config):
+        return config
+        
     async def check_event_for_spam(self, foo):
         return False  # allow all events
 

--- a/docs/spam_checker.md
+++ b/docs/spam_checker.md
@@ -14,7 +14,7 @@ The Python class is instantiated with two objects:
 * An instance of `synapse.module_api.ModuleApi`.
 
 It then implements methods which return a boolean to alter behavior in Synapse.
-All the methods are must be defined.
+All the methods must be defined.
 
 There's a generic method for checking every event (`check_event_for_spam`), as
 well as some specific methods:


### PR DESCRIPTION
A parse_config method is mandatory on spam checked modules.

This relates to #8944 as well.

Signed-off-by: Jason Robinson <jasonr@matrix.org>