### PR TITLE
Fix a bug in the background task for purging chain cover

### DIFF
--- a/changelog.d/9583.bugfix
+++ b/changelog.d/9583.bugfix
@@ -1,0 +1,1 @@
+Purge chain cover indexes for events that were purged prior to Synapse v1.29.0.

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -969,7 +969,7 @@ class EventsBackgroundUpdatesStore(SQLBaseStore):
             event_id = ""
             for event_id, chain_id, sequence_number, has_event in rows:
                 if not has_event:
-                    unreferenced_event_ids.append(event_id)
+                    unreferenced_event_ids.append((event_id,))
                     unreferenced_chain_id_tuples.append((chain_id, sequence_number))
 
             # Delete the unreferenced auth chains from event_auth_chain_links and


### PR DESCRIPTION
One of my refactors slightly broke #9542. We need to pass a list of tuples, not just a list to `executemany`.