### PR TITLE
Return m.change_password.enabled=false if local database is disabled

### DIFF
--- a/changelog.d/9588.bugfix
+++ b/changelog.d/9588.bugfix
@@ -1,1 +1,1 @@
-Return `m.change_password` `enabled:false` if local database not used for authentication.
+Fix the `/capabilities` endpoint to return `m.change_password` as disabled if the local password database is not used for authentication. Contributed by @dklimpel.

--- a/changelog.d/9588.bugfix
+++ b/changelog.d/9588.bugfix
@@ -1,0 +1,1 @@
+Return `m.change_password` `enabled:false` if local database not used for authentication.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -215,6 +215,10 @@ class AuthHandler(BaseHandler):
         self._password_enabled = hs.config.password_enabled
         self._password_localdb_enabled = hs.config.password_localdb_enabled
 
+        self._change_password = (
+            self._password_enabled and self._password_localdb_enabled
+        )
+
         # start out by assuming PASSWORD is enabled; we will remove it later if not.
         login_types = set()
         if self._password_localdb_enabled:
@@ -884,6 +888,18 @@ class AuthHandler(BaseHandler):
                 user_infos.keys(),
             )
         return result
+
+    def get_allow_change_password(self) -> bool:
+        """Get status if users on this server are allowed to change or set a password.
+        Both `config.password_enabled` and `config.password_localdb_enabled`
+        must be true.
+        It is allowed that people add a password to their account even if they created
+        that account with SSO if it is not explicitly prohibited.
+
+        Returns:
+            Whether users on this server are allowed to change or set a password
+        """
+        return self._change_password
 
     def get_supported_login_types(self) -> Iterable[str]:
         """Get a the login types supported for the /login API

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -215,10 +215,6 @@ class AuthHandler(BaseHandler):
         self._password_enabled = hs.config.password_enabled
         self._password_localdb_enabled = hs.config.password_localdb_enabled
 
-        self._change_password = (
-            self._password_enabled and self._password_localdb_enabled
-        )
-
         # start out by assuming PASSWORD is enabled; we will remove it later if not.
         login_types = set()
         if self._password_localdb_enabled:
@@ -889,17 +885,18 @@ class AuthHandler(BaseHandler):
             )
         return result
 
-    def get_allow_change_password(self) -> bool:
-        """Get status if users on this server are allowed to change or set a password.
-        Both `config.password_enabled` and `config.password_localdb_enabled`
-        must be true.
-        It is allowed that people add a password to their account even if they created
-        that account with SSO if it is not explicitly prohibited.
+    def can_change_password(self) -> bool:
+        """Get whether users on this server are allowed to change or set a password.
+
+        Both `config.password_enabled` and `config.password_localdb_enabled` must be true.
+
+        Note that any account (even SSO accounts) are allowed to add passwords if the above
+        is true.
 
         Returns:
             Whether users on this server are allowed to change or set a password
         """
-        return self._change_password
+        return self._password_enabled and self._password_localdb_enabled
 
     def get_supported_login_types(self) -> Iterable[str]:
         """Get a the login types supported for the /login API

--- a/synapse/rest/client/v2_alpha/capabilities.py
+++ b/synapse/rest/client/v2_alpha/capabilities.py
@@ -42,7 +42,7 @@ class CapabilitiesRestServlet(RestServlet):
 
     async def on_GET(self, request: SynapseRequest) -> Tuple[int, JsonDict]:
         await self.auth.get_user_by_req(request, allow_guest=True)
-        change_password = self.auth_handler.get_allow_change_password()
+        change_password = self.auth_handler.can_change_password()
 
         response = {
             "capabilities": {

--- a/synapse/rest/client/v2_alpha/capabilities.py
+++ b/synapse/rest/client/v2_alpha/capabilities.py
@@ -15,7 +15,6 @@
 import logging
 from typing import TYPE_CHECKING, Tuple
 
-from synapse.api.constants import LoginType
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
 from synapse.http.servlet import RestServlet
 from synapse.http.site import SynapseRequest
@@ -42,14 +41,8 @@ class CapabilitiesRestServlet(RestServlet):
         self.auth_handler = hs.get_auth_handler()
 
     async def on_GET(self, request: SynapseRequest) -> Tuple[int, JsonDict]:
-        requester = await self.auth.get_user_by_req(request, allow_guest=True)
-        supported_ui_auth_types = await self.auth_handler._get_available_ui_auth_types(
-            requester.user
-        )
-        if LoginType.PASSWORD in supported_ui_auth_types:
-            change_password = True
-        else:
-            change_password = False
+        await self.auth.get_user_by_req(request, allow_guest=True)
+        change_password = self.auth_handler.get_allow_change_password()
 
         response = {
             "capabilities": {

--- a/tests/rest/client/v2_alpha/test_capabilities.py
+++ b/tests/rest/client/v2_alpha/test_capabilities.py
@@ -18,6 +18,7 @@ from synapse.rest.client.v1 import login
 from synapse.rest.client.v2_alpha import capabilities
 
 from tests import unittest
+from tests.unittest import override_config
 
 
 class CapabilitiesTestCase(unittest.HomeserverTestCase):
@@ -33,6 +34,7 @@ class CapabilitiesTestCase(unittest.HomeserverTestCase):
         hs = self.setup_test_homeserver()
         self.store = hs.get_datastore()
         self.config = hs.config
+        self.auth_handler = hs.get_auth_handler()
         return hs
 
     def test_check_auth_required(self):
@@ -56,7 +58,7 @@ class CapabilitiesTestCase(unittest.HomeserverTestCase):
             capabilities["m.room_versions"]["default"],
         )
 
-    def test_get_change_password_capabilities(self):
+    def test_get_change_password_capabilities_password_login(self):
         localpart = "user"
         password = "pass"
         user = self.register_user(localpart, password)
@@ -67,3 +69,37 @@ class CapabilitiesTestCase(unittest.HomeserverTestCase):
 
         self.assertEqual(channel.code, 200)
         self.assertTrue(capabilities["m.change_password"]["enabled"])
+
+    @override_config({"password_config": {"localdb_enabled": False}})
+    def test_get_change_password_capabilities_localdb_disabled(self):
+        localpart = "user"
+        password = "pass"
+        user = self.register_user(localpart, password)
+        access_token = self.get_success(
+            self.auth_handler.get_access_token_for_user_id(
+                user, device_id=None, valid_until_ms=None
+            )
+        )
+
+        channel = self.make_request("GET", self.url, access_token=access_token)
+        capabilities = channel.json_body["capabilities"]
+
+        self.assertEqual(channel.code, 200)
+        self.assertFalse(capabilities["m.change_password"]["enabled"])
+
+    @override_config({"password_config": {"enabled": False}})
+    def test_get_change_password_capabilities_password_disabled(self):
+        localpart = "user"
+        password = "pass"
+        user = self.register_user(localpart, password)
+        access_token = self.get_success(
+            self.auth_handler.get_access_token_for_user_id(
+                user, device_id=None, valid_until_ms=None
+            )
+        )
+
+        channel = self.make_request("GET", self.url, access_token=access_token)
+        capabilities = channel.json_body["capabilities"]
+
+        self.assertEqual(channel.code, 200)
+        self.assertFalse(capabilities["m.change_password"]["enabled"])

--- a/tests/rest/client/v2_alpha/test_capabilities.py
+++ b/tests/rest/client/v2_alpha/test_capabilities.py
@@ -66,12 +66,4 @@ class CapabilitiesTestCase(unittest.HomeserverTestCase):
         capabilities = channel.json_body["capabilities"]
 
         self.assertEqual(channel.code, 200)
-
-        # Test case where password is handled outside of Synapse
         self.assertTrue(capabilities["m.change_password"]["enabled"])
-        self.get_success(self.store.user_set_password_hash(user, None))
-        channel = self.make_request("GET", self.url, access_token=access_token)
-        capabilities = channel.json_body["capabilities"]
-
-        self.assertEqual(channel.code, 200)
-        self.assertFalse(capabilities["m.change_password"]["enabled"])


### PR DESCRIPTION
Return `m.change_password` `enabled:false` if local database not used for authentication
Fixes: #9456

I had to remove a part of the test. Because I do not know how to create an `access_token` for an user who uses SSO.

What is the best config switch for this situation? `password_config.enabled` or `password_config.localdb_enabled`?
https://github.com/matrix-org/synapse/blob/1baab2035265cf2543fe3c0ef5412c1ac0740c7e/synapse/handlers/set_password.py#L37-L45
`set_password` uses `password_config.localdb_enabled`

https://github.com/matrix-org/synapse/blob/a7a379006651ea219c2618c0a47e8f4053a9e769/docs/sample_config.yaml#L2211-L2220
The documentation says that `localdb_enabled` is ignored if `password_config.enabled` is `false`. But I can not find the code where `localdb_enabled` becomes unset or set to `false` if `localdb_enabled` is `false`.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Signed-off-by: Dirk Klimpel dirk@klimpel.org