### PR TITLE
Add logging for redis connection setup

### DIFF
--- a/changelog.d/9590.misc
+++ b/changelog.d/9590.misc
@@ -1,0 +1,1 @@
+Add logging for redis connection setup.

--- a/stubs/txredisapi.pyi
+++ b/stubs/txredisapi.pyi
@@ -17,6 +17,8 @@
 """
 from typing import Any, List, Optional, Type, Union
 
+from twisted.internet import protocol
+
 class RedisProtocol:
     def publish(self, channel: str, message: bytes): ...
     async def ping(self) -> None: ...
@@ -52,7 +54,7 @@ def lazyConnection(
 
 class ConnectionHandler: ...
 
-class RedisFactory:
+class RedisFactory(protocol.ReconnectingClientFactory):
     continueTrying: bool
     handler: RedisProtocol
     pool: List[RedisProtocol]

--- a/synapse/replication/tcp/redis.py
+++ b/synapse/replication/tcp/redis.py
@@ -264,7 +264,7 @@ class SynapseRedisFactory(txredisapi.RedisFactory):
         logger.info(
             "Connecting to redis server %s", format_address(connector.getDestination())
         )
-        super().startedConnecting(connector)
+        super().startedConnecting(connector)  # type: ignore  # mypy is confused
 
     def clientConnectionFailed(self, connector: IConnector, reason: Failure):
         logger.info(
@@ -272,7 +272,7 @@ class SynapseRedisFactory(txredisapi.RedisFactory):
             format_address(connector.getDestination()),
             reason.value,
         )
-        super().clientConnectionFailed(connector, reason)
+        super().clientConnectionFailed(connector, reason)  # type: ignore  # mypy is confused
 
     def clientConnectionLost(self, connector: IConnector, reason: Failure):
         logger.info(
@@ -280,7 +280,7 @@ class SynapseRedisFactory(txredisapi.RedisFactory):
             format_address(connector.getDestination()),
             reason.value,
         )
-        super().clientConnectionLost(connector, reason)
+        super().clientConnectionLost(connector, reason)  # type: ignore  # mypy is confused
 
 
 def format_address(address: IAddress) -> str:

--- a/synapse/replication/tcp/redis.py
+++ b/synapse/replication/tcp/redis.py
@@ -264,7 +264,7 @@ class SynapseRedisFactory(txredisapi.RedisFactory):
         logger.info(
             "Connecting to redis server %s", format_address(connector.getDestination())
         )
-        super().startedConnecting(connector)  # type: ignore  # mypy is confused
+        super().startedConnecting(connector)
 
     def clientConnectionFailed(self, connector: IConnector, reason: Failure):
         logger.info(
@@ -272,7 +272,7 @@ class SynapseRedisFactory(txredisapi.RedisFactory):
             format_address(connector.getDestination()),
             reason.value,
         )
-        super().clientConnectionFailed(connector, reason)  # type: ignore  # mypy is confused
+        super().clientConnectionFailed(connector, reason)
 
     def clientConnectionLost(self, connector: IConnector, reason: Failure):
         logger.info(
@@ -280,7 +280,7 @@ class SynapseRedisFactory(txredisapi.RedisFactory):
             format_address(connector.getDestination()),
             reason.value,
         )
-        super().clientConnectionLost(connector, reason)  # type: ignore  # mypy is confused
+        super().clientConnectionLost(connector, reason)
 
 
 def format_address(address: IAddress) -> str:


### PR DESCRIPTION
This makes it write logs like:

```
2021-03-11 12:29:02,800 - synapse.replication.tcp.redis - 264 - INFO - None - Connecting to redis server localhost:6379
2021-03-11 12:29:02,802 - synapse.replication.tcp.redis - 270 - INFO - None - Connection to redis server localhost:6379 failed: Connection was refused by other side: 111: Connection refused.
```

It's an attempt to get more insight into what is happening with redis connections, as well as mitigating the issue where requests mysteriously block when the redis server is down.