### PR TITLE
Reject concurrent transactions

### DIFF
--- a/changelog.d/9597.bugfix
+++ b/changelog.d/9597.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.20 which caused incoming federation transactions to stack up, causing slow recovery from outages.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -206,7 +206,7 @@ class FederationServer(FederationBase):
         # CRITICAL SECTION: the first thing we must do (before awaiting) is
         # add an entry to _active_transactions.
         assert origin not in self._active_transactions
-        self._active_transactions[origin] = transaction.transaction_id
+        self._active_transactions[origin] = transaction.transaction_id  # type: ignore
 
         try:
             result = await self._handle_incoming_transaction(


### PR DESCRIPTION
If more transactions arrive from an origin while we're still processing the first one, reject them.

Hopefully fixes #9489