### PR TITLE
Remove state events from /admin/v1/rooms/<room_id>/context/<event_id>

### DIFF
--- a/changelog.d/9615.removal
+++ b/changelog.d/9615.removal
@@ -1,0 +1,1 @@
+Remove state events from /_synapse/admin/v1/rooms/<room_id>/context/<event_id> for performance reasons.

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -606,6 +606,8 @@ GET /_synapse/admin/v1/rooms/<room_id>/context/<event_id>
 
 This API mimmicks [GET /_matrix/client/r0/rooms/{roomId}/context/{eventId}](https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-context-eventid). Please refer to the link for all details on parameters and reseponse.
 
+The main difference is that this call does NOT return state events, for performance reasons.
+
 Example response:
 
 ```json
@@ -673,43 +675,5 @@ Example response:
     }
   ],
   "start": "t27-54_2_0_2",
-  "state": [
-    {
-      "content": {
-        "creator": "@example:example.org",
-        "room_version": "1",
-        "m.federate": true,
-        "predecessor": {
-          "event_id": "$something:example.org",
-          "room_id": "!oldroom:example.org"
-        }
-      },
-      "type": "m.room.create",
-      "event_id": "$143273582443PhrSn:example.org",
-      "room_id": "!636q39766251:example.com",
-      "sender": "@example:example.org",
-      "origin_server_ts": 1432735824653,
-      "unsigned": {
-        "age": 1234
-      },
-      "state_key": ""
-    },
-    {
-      "content": {
-        "membership": "join",
-        "avatar_url": "mxc://example.org/SEsfnsuifSDFSSEF",
-        "displayname": "Alice Margatroid"
-      },
-      "type": "m.room.member",
-      "event_id": "$143273582443PhrSn:example.org",
-      "room_id": "!636q39766251:example.com",
-      "sender": "@example:example.org",
-      "origin_server_ts": 1432735824653,
-      "unsigned": {
-        "age": 1234
-      },
-      "state_key": "@alice:example.org"
-    }
-  ]
 }
 ```

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -684,8 +684,5 @@ class RoomEventContextServlet(RestServlet):
         results["events_after"] = await self._event_serializer.serialize_events(
             results["events_after"], time_now
         )
-        results["state"] = await self._event_serializer.serialize_events(
-            results["state"], time_now
-        )
 
         return 200, results


### PR DESCRIPTION
Real-world tests show that this API is too slow (and timeouts) because serialization
of state events can be extremely slow when there are too many state events, e.g.
in irc rooms.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
