### PR TITLE
Prevent bundling aggregations for state events

### DIFF
--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -685,7 +685,10 @@ class RoomEventContextServlet(RestServlet):
             results["events_after"], time_now
         )
         results["state"] = await self._event_serializer.serialize_events(
-            results["state"], time_now
+            results["state"],
+            time_now,
+            # No need to bundle aggregations for state events
+            bundle_aggregations=False,
         )
 
         return 200, results


### PR DESCRIPTION
We're trying this out on hotfixes to see whether it helps address
performance issues. There's no need to do aggregation bundling for
state events anyways.

Note: mypy CI failure is unrelated.