### PR TITLE
Revert requiring a specific version of Twisted for mypy checks.

### DIFF
--- a/changelog.d/9618.misc
+++ b/changelog.d/9618.misc
@@ -1,0 +1,1 @@
+Fix incorrect type hints.

--- a/tox.ini
+++ b/tox.ini
@@ -189,7 +189,5 @@ commands=
 [testenv:mypy]
 deps =
     {[base]deps}
-    # Type hints are broken with Twisted > 20.3.0, see https://github.com/matrix-org/synapse/issues/9513
-    twisted==20.3.0
 extras = all,mypy
 commands = mypy


### PR DESCRIPTION
This removes the pin on Twisted in the tox mypy check (originally added in #9515.