### PR TITLE
Handle an empty cookie as an invalid macaroon.

### DIFF
--- a/changelog.d/9620.bugfix
+++ b/changelog.d/9620.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.28.0 where the OpenID Connect callback endpoint could error with a `MacaroonInitException`.

--- a/synapse/handlers/oidc_handler.py
+++ b/synapse/handlers/oidc_handler.py
@@ -29,6 +29,7 @@ from authlib.oidc.discovery import OpenIDProviderMetadata, get_well_known_url
 from jinja2 import Environment, Template
 from pymacaroons.exceptions import (
     MacaroonDeserializationException,
+    MacaroonInitException,
     MacaroonInvalidSignatureException,
 )
 from typing_extensions import TypedDict
@@ -217,7 +218,7 @@ class OidcHandler:
             session_data = self._token_generator.verify_oidc_session_token(
                 session, state
             )
-        except (MacaroonDeserializationException, KeyError) as e:
+        except (MacaroonInitException, MacaroonDeserializationException, KeyError) as e:
             logger.exception("Invalid session for OIDC callback")
             self._sso_handler.render_error(request, "invalid_session", str(e))
             return


### PR DESCRIPTION
Fixes https://sentry.matrix.org/sentry/synapse-matrixorg/issues/199800/

It seems that the cookie retrieved is empty, causing the pymacaroon library to raise a different exception than we expect.