### PR TITLE
Only send catch up events if they're the latest in the room

### DIFF
--- a/changelog.d/9621.misc
+++ b/changelog.d/9621.misc
@@ -1,0 +1,1 @@
+Only send catch up events if they're the latest in the room, reducing the number of events a server receives after recovering from downtime.

--- a/synapse/storage/databases/main/transactions.py
+++ b/synapse/storage/databases/main/transactions.py
@@ -428,7 +428,8 @@ class TransactionStore(TransactionWorkerStore):
     ) -> List[str]:
         q = """
                 SELECT event_id FROM destination_rooms
-                 JOIN events USING (stream_ordering)
+                 INNER JOIN events USING (stream_ordering)
+                 INNER JOIN event_forward_extremities USING (event_id)
                 WHERE destination = ?
                   AND stream_ordering > ?
                 ORDER BY stream_ordering


### PR DESCRIPTION
This is a bit of a hack to help mitigate #9492. One of the problems there is that in a busy with lots of servers, each server will send the last event *they* sent, which results in the server that has come back online getting a smattering of events rather than just the latest event its missed. The flip side is that it relies on whatever server that did send the last event in the room actually sending that to the newly up server.

I'm not really sure if this is what we want to do. Other thing we could do is add more metadata to the sent event to help the remote Do The Right Thing, or simply send the current forward extremities of the room to them (though currently servers drop events they get via `/send` from other servers).

Thoughts?