### PR TITLE
only save remote cross-signing keys if they're different from the current ones

### DIFF
--- a/changelog.d/9634.misc
+++ b/changelog.d/9634.misc
@@ -1,2 +1,1 @@
-Only save remote cross-signing and device keys if they're different from the
-current ones.
+Only save remote cross-signing and device keys if they're different from the current ones.

--- a/changelog.d/9634.misc
+++ b/changelog.d/9634.misc
@@ -1,1 +1,2 @@
-Only save remote cross-signing keys if they're different from the current ones.
+Only save remote cross-signing and device keys if they're different from the
+current ones.

--- a/changelog.d/9634.misc
+++ b/changelog.d/9634.misc
@@ -1,0 +1,1 @@
+Only save remote cross-signing keys if they're different from the current ones.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -973,14 +973,17 @@ class DeviceListUpdater:
         """
         device_ids = []
 
-        if master_key:
+        current_keys = await self.store.get_e2e_cross_signing_keys_bulk([user_id])
+        current_keys = current_keys.get(user_id)
+
+        if master_key and master_key != current_keys.get("master"):
             await self.store.set_e2e_cross_signing_key(user_id, "master", master_key)
             _, verify_key = get_verify_key_from_cross_signing_key(master_key)
             # verify_key is a VerifyKey from signedjson, which uses
             # .version to denote the portion of the key ID after the
             # algorithm and colon, which is the device ID
             device_ids.append(verify_key.version)
-        if self_signing_key:
+        if self_signing_key and self_signing_key != current_keys.get("self_signing"):
             await self.store.set_e2e_cross_signing_key(
                 user_id, "self_signing", self_signing_key
             )

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -973,8 +973,8 @@ class DeviceListUpdater:
         """
         device_ids = []
 
-        current_keys = await self.store.get_e2e_cross_signing_keys_bulk([user_id])
-        current_keys = current_keys.get(user_id)
+        current_keys_map = await self.store.get_e2e_cross_signing_keys_bulk([user_id])
+        current_keys = current_keys_map.get(user_id) or {}
 
         if master_key and master_key != current_keys.get("master"):
             await self.store.set_e2e_cross_signing_key(user_id, "master", master_key)

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -929,7 +929,7 @@ class DeviceListUpdater:
             ignore_devices = True
         else:
             cached_devices = await self.store.get_cached_devices_for_user(user_id)
-            if cached_devices == {d["device_id"]:d for d in devices}:
+            if cached_devices == {d["device_id"]: d for d in devices}:
                 devices = []
                 ignore_devices = True
 
@@ -942,7 +942,9 @@ class DeviceListUpdater:
             )
 
         if not ignore_devices:
-            await self.store.update_remote_device_list_cache(user_id, devices, stream_id)
+            await self.store.update_remote_device_list_cache(
+                user_id, devices, stream_id
+            )
         device_ids = [device["device_id"] for device in devices]
 
         # Handle cross-signing keys.


### PR DESCRIPTION
There seems to be a feedback loop where, if a remote user has a master signing key but no self-signing key, synapse will try to re-fetch that user's keys, which it will blindly treat as a device update, which will notify local users about the device change, which will cause them to fetch the remote user's keys, which will cause synapse to notice that they have a master key but no self-signing key, and will try to re-fetch again.  This change will only update the local cached keys after refetching the remote user's keys if anything actually changed, which breaks the loop.