### PR TITLE
Fix federation stall on concurrent access errors

### DIFF
--- a/changelog.d/9639.bugfix
+++ b/changelog.d/9639.bugfix
@@ -1,0 +1,1 @@
+Fixes #9635, and optimizes federation sending.

--- a/changelog.d/9639.bugfix
+++ b/changelog.d/9639.bugfix
@@ -1,1 +1,1 @@
-Fixes #9635, and optimizes federation sending.
+Fixes #9635.

--- a/changelog.d/9639.bugfix
+++ b/changelog.d/9639.bugfix
@@ -1,1 +1,1 @@
-Fixes #9635.
+Fix bug where federation sending can stall due to `concurrent access` database exceptions when it falls behind.

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, Hashable, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Dict, Hashable, Iterable, List, Optional, Set, Tuple
 
 from prometheus_client import Counter
 
@@ -189,9 +189,7 @@ class FederationSender:
                 if not events and next_token >= self._last_poked_id:
                     break
 
-                async def handle_event(
-                    event: EventBase, flush_destination_rooms: bool = True
-                ) -> None:
+                async def handle_event(event: EventBase) -> None:
                     # Only send events for this server.
                     send_on_behalf_of = event.internal_metadata.get_send_on_behalf_of()
                     is_mine = self.is_mine_id(event.sender)
@@ -253,9 +251,7 @@ class FederationSender:
                     logger.debug("Sending %s to %r", event, destinations)
 
                     if destinations:
-                        await self._send_pdu(
-                            event, destinations, flush_destination_rooms
-                        )
+                        await self._send_pdu(event, destinations)
 
                         now = self.clock.time_msec()
                         ts = await self.store.get_received_ts(event.event_id)
@@ -264,11 +260,10 @@ class FederationSender:
                             "federation_sender"
                         ).observe((now - ts) / 1000)
 
-                async def handle_room_events(events: Sequence[EventBase]) -> None:
+                async def handle_room_events(events: Iterable[EventBase]) -> None:
                     with Measure(self.clock, "handle_room_events"):
-                        evs_len = len(events)
-                        for pos, event in enumerate(events, start=1):
-                            await handle_event(event, pos == evs_len)
+                        for event in events:
+                            await handle_event(event)
 
                 events_by_room = {}  # type: Dict[str, List[EventBase]]
                 for event in events:
@@ -312,12 +307,7 @@ class FederationSender:
         finally:
             self._is_processing = False
 
-    async def _send_pdu(
-        self,
-        pdu: EventBase,
-        destinations: Iterable[str],
-        flush_destination_rooms: bool = True,
-    ) -> None:
+    async def _send_pdu(self, pdu: EventBase, destinations: Iterable[str]) -> None:
         # We loop through all destinations to see whether we already have
         # a transaction in progress. If we do, stick it in the pending_pdus
         # table and we'll get back to it later.
@@ -334,15 +324,14 @@ class FederationSender:
 
         assert pdu.internal_metadata.stream_ordering
 
-        if flush_destination_rooms:
-            # track the fact that we have a PDU for these destinations,
-            # to allow us to perform catch-up later on if the remote is unreachable
-            # for a while.
-            await self.store.store_destination_rooms_entries(
-                destinations,
-                pdu.room_id,
-                pdu.internal_metadata.stream_ordering,
-            )
+        # track the fact that we have a PDU for these destinations,
+        # to allow us to perform catch-up later on if the remote is unreachable
+        # for a while.
+        await self.store.store_destination_rooms_entries(
+            destinations,
+            pdu.room_id,
+            pdu.internal_metadata.stream_ordering,
+        )
 
         for destination in destinations:
             self._get_per_destination_queue(destination).send_pdu(pdu)

--- a/synapse/storage/databases/main/transactions.py
+++ b/synapse/storage/databases/main/transactions.py
@@ -22,7 +22,6 @@ from canonicaljson import encode_canonical_json
 from synapse.metrics.background_process_metrics import wrap_as_background_process
 from synapse.storage._base import SQLBaseStore, db_to_json
 from synapse.storage.database import DatabasePool, LoggingTransaction
-from synapse.storage.engines import PostgresEngine, Sqlite3Engine
 from synapse.types import JsonDict
 from synapse.util.caches.expiringcache import ExpiringCache
 

--- a/synapse/storage/databases/main/transactions.py
+++ b/synapse/storage/databases/main/transactions.py
@@ -25,14 +25,6 @@ from synapse.storage.database import DatabasePool, LoggingTransaction
 from synapse.types import JsonDict
 from synapse.util.caches.expiringcache import ExpiringCache
 
-try:
-    from psycopg2.errors import SerializationFailure
-except ImportError:
-    # No postgres, no harm in making it a dummy class.
-    class SerializationFailure(Exception):
-        ...
-
-
 db_binary_type = memoryview
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This PR fixes #9635 by ensuring that the `store_destination_rooms_entries` db interaction gets retried indefinitely when it fails with `psycopg2.errors.SerializationFailure`.

This is fine, as this failure is simply a [rollback of the transaction if another transaction had changed the view of the table concurrently](https://www.postgresql.org/docs/10/transaction-iso.html#XACT-SERIALIZABLE), which means the "other" transaction has succeeded, and this one has failed, thus, this is infinitely retry-able until this transaction "succeeds" while the other "loses". In the very worst case, this blocks until the `destinations` table is less congested.

~~And to relieve some of that congestion, the second fix this PR gives is making sure every `handle_room_events` background task only instructs it's (eventual) `_send_pdu` calls to *only* call `self.store.store_destination_rooms_entries` when it is handling the final event in the (per-room) event list.~~

~~Again, this is fine, as `destinations_rooms` is used to calculate which events need to be caught-up with, and in the worst case (when the federation sender shuts down or aborts in the middle of a `handle_room_events` task), it'll cause the catch-up to notify more events (likely 1 more event) some servers, but it wont drop any to send.~~

~~This'll also cause federation to deliver to large rooms such as `#matrix:matrix.org` more efficiently, as the `store_destination_rooms_entries` call is only done *once* on the last event that is being caught up with, meaning that if that call is expensive, and federation events start "backing up", it'll be able to keep pace by calling this only once per room in the batch of 100 events that're submitted to per-destination queues. This'll increase performance substantially on smaller servers.~~

Edit: Some of the principles this PR was made on (for `destination_rooms`) were likely to be false, this PR will only be about the fix, and the optimisation will be tried in another PR.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`