### PR TITLE
Implement MSC3026: busy presence state

### DIFF
--- a/changelog.d/9644.feature
+++ b/changelog.d/9644.feature
@@ -1,0 +1,1 @@
+Implement the busy presence state as described in [MSC3026](https://github.com/matrix-org/matrix-doc/pull/3026).

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -51,6 +51,7 @@ class PresenceState:
     OFFLINE = "offline"
     UNAVAILABLE = "unavailable"
     ONLINE = "online"
+    BUSY = "org.matrix.msc3026.busy"
 
 
 class JoinRules:

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -441,12 +441,12 @@ class GenericWorkerPresence(BasePresenceHandler):
             PresenceState.ONLINE,
             PresenceState.UNAVAILABLE,
             PresenceState.OFFLINE,
+            PresenceState.BUSY,
         )
 
-        if self._busy_presence_enabled:
-            valid_presence += (PresenceState.BUSY,)
-
-        if presence not in valid_presence:
+        if presence not in valid_presence or (
+            presence == PresenceState.BUSY and not self._busy_presence_enabled
+        ):
             raise SynapseError(400, "Invalid presence state")
 
         user_id = target_user.to_string()

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -439,6 +439,7 @@ class GenericWorkerPresence(BasePresenceHandler):
             PresenceState.ONLINE,
             PresenceState.UNAVAILABLE,
             PresenceState.OFFLINE,
+            PresenceState.BUSY,
         )
         if presence not in valid_presence:
             raise SynapseError(400, "Invalid presence state")

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -302,6 +302,8 @@ class GenericWorkerPresence(BasePresenceHandler):
             self.send_stop_syncing, UPDATE_SYNCING_USERS_MS
         )
 
+        self._busy_presence_enabled = hs.config.experimental.msc3026_enabled
+
         hs.get_reactor().addSystemEventTrigger(
             "before",
             "shutdown",
@@ -439,8 +441,11 @@ class GenericWorkerPresence(BasePresenceHandler):
             PresenceState.ONLINE,
             PresenceState.UNAVAILABLE,
             PresenceState.OFFLINE,
-            PresenceState.BUSY,
         )
+
+        if self._busy_presence_enabled:
+            valid_presence += (PresenceState.BUSY,)
+
         if presence not in valid_presence:
             raise SynapseError(400, "Invalid presence state")
 

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -27,3 +27,5 @@ class ExperimentalConfig(Config):
 
         # MSC2858 (multiple SSO identity providers)
         self.msc2858_enabled = experimental.get("msc2858_enabled", False)  # type: bool
+        # MSC3026 (busy presence state)
+        self.msc3026_enabled = experimental.get("msc3026_enabled", False)  # type: bool

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -751,7 +751,7 @@ class PresenceHandler(BasePresenceHandler):
             new_fields["status_msg"] = msg
 
         if presence == PresenceState.ONLINE or (
-            self._busy_presence_enabled and presence == PresenceState.BUSY
+            presence == PresenceState.BUSY and self._busy_presence_enabled
         ):
             new_fields["last_active_ts"] = self.clock.time_msec()
 

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -730,6 +730,7 @@ class PresenceHandler(BasePresenceHandler):
             PresenceState.ONLINE,
             PresenceState.UNAVAILABLE,
             PresenceState.OFFLINE,
+            PresenceState.BUSY,
         )
         if presence not in valid_presence:
             raise SynapseError(400, "Invalid presence state")
@@ -744,7 +745,7 @@ class PresenceHandler(BasePresenceHandler):
             msg = status_msg if presence != PresenceState.OFFLINE else None
             new_fields["status_msg"] = msg
 
-        if presence == PresenceState.ONLINE:
+        if presence == PresenceState.ONLINE or presence == PresenceState.BUSY:
             new_fields["last_active_ts"] = self.clock.time_msec()
 
         await self._update_states([prev_state.copy_and_replace(**new_fields)])

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -104,6 +104,8 @@ class BasePresenceHandler(abc.ABC):
         self.clock = hs.get_clock()
         self.store = hs.get_datastore()
 
+        self._busy_presence_enabled = hs.config.experimental.msc3026_enabled
+
         active_presence = self.store.take_presence_startup_info()
         self.user_to_current_state = {state.user_id: state for state in active_presence}
 
@@ -730,8 +732,11 @@ class PresenceHandler(BasePresenceHandler):
             PresenceState.ONLINE,
             PresenceState.UNAVAILABLE,
             PresenceState.OFFLINE,
-            PresenceState.BUSY,
         )
+
+        if self._busy_presence_enabled:
+            valid_presence += (PresenceState.BUSY,)
+
         if presence not in valid_presence:
             raise SynapseError(400, "Invalid presence state")
 
@@ -745,7 +750,10 @@ class PresenceHandler(BasePresenceHandler):
             msg = status_msg if presence != PresenceState.OFFLINE else None
             new_fields["status_msg"] = msg
 
-        if presence == PresenceState.ONLINE or presence == PresenceState.BUSY:
+        if (
+            presence == PresenceState.ONLINE or
+            (self._busy_presence_enabled and presence == PresenceState.BUSY)
+        ):
             new_fields["last_active_ts"] = self.clock.time_msec()
 
         await self._update_states([prev_state.copy_and_replace(**new_fields)])

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -732,12 +732,12 @@ class PresenceHandler(BasePresenceHandler):
             PresenceState.ONLINE,
             PresenceState.UNAVAILABLE,
             PresenceState.OFFLINE,
+            PresenceState.BUSY,
         )
 
-        if self._busy_presence_enabled:
-            valid_presence += (PresenceState.BUSY,)
-
-        if presence not in valid_presence:
+        if presence not in valid_presence or (
+            presence == PresenceState.BUSY and not self._busy_presence_enabled
+        ):
             raise SynapseError(400, "Invalid presence state")
 
         user_id = target_user.to_string()
@@ -750,9 +750,8 @@ class PresenceHandler(BasePresenceHandler):
             msg = status_msg if presence != PresenceState.OFFLINE else None
             new_fields["status_msg"] = msg
 
-        if (
-            presence == PresenceState.ONLINE or
-            (self._busy_presence_enabled and presence == PresenceState.BUSY)
+        if presence == PresenceState.ONLINE or (
+            self._busy_presence_enabled and presence == PresenceState.BUSY
         ):
             new_fields["last_active_ts"] = self.clock.time_msec()
 

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -82,7 +82,7 @@ class VersionsRestServlet(RestServlet):
                     "io.element.e2ee_forced.private": self.e2ee_forced_private,
                     "io.element.e2ee_forced.trusted_private": self.e2ee_forced_trusted_private,
                     # Supports the busy presence state described in MSC3026.
-                    "org.matrix.msc3026.busy_presence": True,
+                    "org.matrix.msc3026.busy_presence": self.config.experimental.msc3026_enabled,
                 },
             },
         )

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -81,6 +81,8 @@ class VersionsRestServlet(RestServlet):
                     "io.element.e2ee_forced.public": self.e2ee_forced_public,
                     "io.element.e2ee_forced.private": self.e2ee_forced_private,
                     "io.element.e2ee_forced.trusted_private": self.e2ee_forced_trusted_private,
+                    # Supports the busy presence state described in MSC3026.
+                    "org.matrix.msc3026.busy_presence": True,
                 },
             },
         )

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -310,6 +310,26 @@ class PresenceTimeoutTestCase(unittest.TestCase):
         self.assertIsNotNone(new_state)
         self.assertEquals(new_state.state, PresenceState.UNAVAILABLE)
 
+    def test_busy_no_idle(self):
+        """
+        Tests that a user setting their presence to busy but idling doesn't turn their
+        presence state into unavailable.
+        """
+        user_id = "@foo:bar"
+        now = 5000000
+
+        state = UserPresenceState.default(user_id)
+        state = state.copy_and_replace(
+            state=PresenceState.BUSY,
+            last_active_ts=now - IDLE_TIMER - 1,
+            last_user_sync_ts=now,
+        )
+
+        new_state = handle_timeout(state, is_mine=True, syncing_user_ids=set(), now=now)
+
+        self.assertIsNotNone(new_state)
+        self.assertEquals(new_state.state, PresenceState.BUSY)
+
     def test_sync_timeout(self):
         user_id = "@foo:bar"
         now = 5000000


### PR DESCRIPTION
This PR implements [MSC3026](https://github.com/matrix-org/matrix-doc/pull/3026), which introduces a busy presence state. This state means that the user is online and active in the app, but might not generate new presence events (e.g. the user is in a call and the window's not in focus) and therefore shouldn't get their presence changed to unavailable if no new event have been received in some time.