### PR TITLE
federation_client: stop adding URL prefix

### DIFF
--- a/changelog.d/9645.misc
+++ b/changelog.d/9645.misc
@@ -1,0 +1,1 @@
+In the `federation_client` commandline client, stop automatically adding the URL prefix, so that servlets on other prefixes can be tested.

--- a/scripts-dev/federation_client.py
+++ b/scripts-dev/federation_client.py
@@ -223,7 +223,7 @@ def main():
     parser.add_argument("--body", help="Data to send as the body of the HTTP request")
 
     parser.add_argument(
-        "path", help="request path. We will add '/_matrix/federation/v1/' to this."
+        "path", help="request path, including the '/_matrix/federation/...' prefix."
     )
 
     args = parser.parse_args()
@@ -239,7 +239,7 @@ def main():
         args.server_name,
         key,
         args.destination,
-        "/_matrix/federation/v1/" + args.path,
+        args.path,
         content=args.body,
     )
 


### PR DESCRIPTION
this is just a dev script so I don't think we need to announce the change particularly.