### PR TITLE
Record more information into structured logs

### DIFF
--- a/changelog.d/9654.feature
+++ b/changelog.d/9654.feature
@@ -1,0 +1,1 @@
+Include request information in structured logging output.

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -132,7 +132,7 @@ class SynapseRequest(Request):
 
         # create a LogContext for this request
         request_id = self.get_request_id()
-        self.logcontext = LoggingContext(request_id, request_id=request_id)
+        self.logcontext = LoggingContext(request_id, request=self)
 
         # override the Server header which is set by twisted
         self.setHeader("Server", self.site.server_version_string)
@@ -333,6 +333,9 @@ class SynapseRequest(Request):
             self.request_metrics.stop(self.finish_time, self.code, self.sentLength)
         except Exception as e:
             logger.warning("Failed to stop metrics: %r", e)
+
+        # Break the cycle between SynapseRequest and LoggingContext.
+        self.logcontext = None
 
     def _should_log_request(self) -> bool:
         """Whether we should log at INFO that we processed the request."""

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -115,9 +115,12 @@ class SynapseRequest(Request):
         assert self.logcontext.request is not None
 
         (
-            self.logcontext.request.requester,
-            self.logcontext.request.authenticated_entity,
+            requester,
+            authenticated_entity,
         ) = self.get_authenticated_entity()
+        self.logcontext.request.requester = requester
+        # If there's no authenticated entity, it was the requester.
+        self.logcontext.request.authenticated_entity = authenticated_entity or requester
 
     def get_request_id(self):
         return "%s-%i" % (self.get_method(), self.request_seq)

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -132,7 +132,7 @@ class SynapseRequest(Request):
 
         # create a LogContext for this request
         request_id = self.get_request_id()
-        self.logcontext = LoggingContext(request_id, request=request_id)
+        self.logcontext = LoggingContext(request_id, request_id=request_id)
 
         # override the Server header which is set by twisted
         self.setHeader("Server", self.site.server_version_string)

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -197,16 +197,16 @@ class SynapseRequest(Request):
         self.logcontext = LoggingContext(
             request_id,
             request=ContextRequest(
-                self.get_request_id(),
-                self.getClientIP(),
-                self.site.site_tag,
+                request_id=request_id,
+                ip_address=self.getClientIP(),
+                site_tag=self.site.site_tag,
                 # The requester is going to be unknown at this point.
-                None,
-                None,
-                self.get_method(),
-                self.get_redacted_uri(),
-                self.clientproto.decode("ascii", errors="replace"),
-                get_request_user_agent(self),
+                requester=None,
+                authenticated_entity=None,
+                method=self.get_method(),
+                url=self.get_redacted_uri(),
+                protocol=self.clientproto.decode("ascii", errors="replace"),
+                user_agent=get_request_user_agent(self),
             ),
         )
 

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -323,7 +323,7 @@ class LoggingContext:
             self.scope = self.parent_context.scope
 
         if request is not None:
-            # the request_id param overrides the request_id from the parent context
+            # the request param overrides the request from the parent context
             self.request = request
 
     def __str__(self) -> str:

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -606,7 +606,7 @@ class LoggingContextFilter(logging.Filter):
 
             record.ip_address = request.ip_address  # type: ignore
             record.site_tag = request.site_tag  # type: ignore
-            record.requester = request.requester
+            record.requester = request.requester  # type: ignore
             record.authenticated_entity = request.authenticated_entity  # type: ignore
             record.method = request.method  # type: ignore
             record.url = request.url  # type: ignore

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -574,7 +574,7 @@ class LoggingContextFilter(logging.Filter):
 
             record.ip_address = request.getClientIP()  # type: ignore
             record.site_tag = request.site.site_tag  # type: ignore
-            record.authenticated_entity = request.get_authenticated_entity()  # type: ignore
+            record.requester, record.authenticated_entity = request.get_authenticated_entity()  # type: ignore
             record.method = request.get_method()  # type: ignore
             record.url = request.get_redacted_uri()  # type: ignore
             record.protocol = request.clientproto.decode("ascii", errors="replace")  # type: ignore

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -192,6 +192,7 @@ class ContextRequest:
     * Be a single variable that can be passed from parent LoggingContexts to
       their children.
     """
+
     request_id = attr.ib(type=str)
     ip_address = attr.ib(type=str)
     site_tag = attr.ib(type=str)

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -183,6 +183,15 @@ class ContextResourceUsage:
 
 @attr.s(slots=True)
 class ContextRequest:
+    """
+    A bundle of attributes from the SynapseRequest object.
+
+    This exists to:
+
+    * Avoid a cycle between LoggingContext and SynapseRequest.
+    * Be a single variable that can be passed from parent LoggingContexts to
+      their children.
+    """
     request_id = attr.ib(type=str)
     ip_address = attr.ib(type=str)
     site_tag = attr.ib(type=str)

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -564,6 +564,22 @@ class LoggingContextFilter(logging.Filter):
             # compatibility this is stored as the "request" on the record.
             record.request = str(context)  # type: ignore
 
+            # Add some data from the HTTP request.
+            request = context.request
+            if request is None:
+                return True
+
+            # Avoid a circular import.
+            from synapse.http import get_request_user_agent
+
+            record.ip_address = request.getClientIP()  # type: ignore
+            record.site_tag = request.site.site_tag  # type: ignore
+            record.authenticated_entity = request.get_authenticated_entity()  # type: ignore
+            record.method = request.get_method()  # type: ignore
+            record.url = request.get_redacted_uri()  # type: ignore
+            record.protocol = request.clientproto.decode("ascii", errors="replace")  # type: ignore
+            record.user_agent = get_request_user_agent(request)  # type: ignore
+
         return True
 
 

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -684,8 +684,8 @@ def set_current_context(context: LoggingContextOrSentinel) -> LoggingContextOrSe
 def nested_logging_context(suffix: str) -> LoggingContext:
     """Creates a new logging context as a child of another.
 
-    The nested logging context will have a 'request_id' made up of the parent context's
-    request_id, plus the given suffix.
+    The nested logging context will have a 'name' made up of the parent context's
+    name, plus the given suffix.
 
     CPU/db usage stats will be added to the parent context's on exit.
 
@@ -695,7 +695,7 @@ def nested_logging_context(suffix: str) -> LoggingContext:
             # ... do stuff
 
     Args:
-        suffix: suffix to add to the parent context's 'request_id'.
+        suffix: suffix to add to the parent context's 'name'.
 
     Returns:
         LoggingContext: new logging context.

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -29,6 +29,7 @@ import types
 import warnings
 from typing import TYPE_CHECKING, Optional, Tuple, TypeVar, Union
 
+import attr
 from typing_extensions import Literal
 
 from twisted.internet import defer, threads
@@ -180,40 +181,17 @@ class ContextResourceUsage:
         return res
 
 
+@attr.s(slots=True)
 class ContextRequest:
-    __slots__ = [
-        "request_id",
-        "ip_address",
-        "site_tag",
-        "requester",
-        "authenticated_entity",
-        "method",
-        "url",
-        "protocol",
-        "user_agent",
-    ]
-
-    def __init__(
-        self,
-        request_id,
-        ip_address,
-        site_tag,
-        requester,
-        authenticated_entity,
-        method,
-        url,
-        protocol,
-        user_agent,
-    ):
-        self.request_id = request_id
-        self.ip_address = ip_address
-        self.site_tag = site_tag
-        self.requester = requester
-        self.authenticated_entity = authenticated_entity
-        self.method = method
-        self.url = url
-        self.protocol = protocol
-        self.user_agent = user_agent
+    request_id = attr.ib(type=str)
+    ip_address = attr.ib(type=str)
+    site_tag = attr.ib(type=str)
+    requester = attr.ib(type=Optional[str])
+    authenticated_entity = attr.ib(type=Optional[str])
+    method = attr.ib(type=str)
+    url = attr.ib(type=str)
+    protocol = attr.ib(type=str)
+    user_agent = attr.ib(type=str)
 
 
 LoggingContextOrSentinel = Union["LoggingContext", "_Sentinel"]

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -203,7 +203,7 @@ def run_as_background_process(desc: str, func, *args, bg_start_span=True, **kwar
             try:
                 ctx = noop_context_manager()
                 if bg_start_span:
-                    ctx = start_active_span(desc, tags={"request_id": context.request})
+                    ctx = start_active_span(desc, tags={"request_id": context.request_id})
                 with ctx:
                     return await maybe_awaitable(func(*args, **kwargs))
             except Exception:
@@ -244,8 +244,8 @@ class BackgroundProcessLoggingContext(LoggingContext):
 
     __slots__ = ["_proc"]
 
-    def __init__(self, name: str, request: Optional[str] = None):
-        super().__init__(name, request=request)
+    def __init__(self, name: str, request_id: Optional[str] = None):
+        super().__init__(name, request_id=request_id)
 
         self._proc = _BackgroundProcess(name, self)
 

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -16,7 +16,7 @@
 import logging
 import threading
 from functools import wraps
-from typing import TYPE_CHECKING, Dict, Optional, Set
+from typing import TYPE_CHECKING, Dict, Optional, Set, Union
 
 from prometheus_client.core import REGISTRY, Counter, Gauge
 
@@ -199,11 +199,11 @@ def run_as_background_process(desc: str, func, *args, bg_start_span=True, **kwar
         _background_process_start_count.labels(desc).inc()
         _background_process_in_flight_count.labels(desc).inc()
 
-        with BackgroundProcessLoggingContext(desc, "%s-%i" % (desc, count)) as context:
+        with BackgroundProcessLoggingContext(desc, count) as context:
             try:
                 ctx = noop_context_manager()
                 if bg_start_span:
-                    ctx = start_active_span(desc, tags={"request_id": context.request_id})
+                    ctx = start_active_span(desc, tags={"request_id": str(context)})
                 with ctx:
                     return await maybe_awaitable(func(*args, **kwargs))
             except Exception:
@@ -242,12 +242,18 @@ class BackgroundProcessLoggingContext(LoggingContext):
     processes.
     """
 
-    __slots__ = ["_proc"]
+    __slots__ = ["_id", "_proc"]
 
-    def __init__(self, name: str, request_id: Optional[str] = None):
-        super().__init__(name, request_id=request_id)
+    def __init__(self, name: str, id: Optional[Union[int, str]] = None):
+        super().__init__(name)
+        self._id = id
 
         self._proc = _BackgroundProcess(name, self)
+
+    def __str__(self) -> str:
+        if self._id is not None:
+            return "%s-%s" % (self.name, self._id)
+        return "%s@%x" % (self.name, id(self))
 
     def start(self, rusage: "Optional[resource._RUsage]"):
         """Log context has started running (again)."""

--- a/synapse/replication/tcp/protocol.py
+++ b/synapse/replication/tcp/protocol.py
@@ -184,8 +184,9 @@ class BaseReplicationStreamProtocol(LineOnlyReceiver):
 
         # a logcontext which we use for processing incoming commands. We declare it as a
         # background process so that the CPU stats get reported to prometheus.
-        ctx_name = "replication-conn-%s" % self.conn_id
-        self._logging_context = BackgroundProcessLoggingContext(ctx_name, ctx_name)
+        self._logging_context = BackgroundProcessLoggingContext(
+            "replication-conn", self.conn_id
+        )
 
     def connectionMade(self):
         logger.info("[%s] Connection established", self.id())

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -71,7 +71,7 @@ class MockPerspectiveServer:
 @logcontext_clean
 class KeyringTestCase(unittest.HomeserverTestCase):
     def check_context(self, val, expected):
-        self.assertEquals(getattr(current_context(), "request", None), expected)
+        self.assertEquals(getattr(current_context(), "request_id", None), expected)
         return val
 
     def test_verify_json_objects_for_server_awaits_previous_requests(self):
@@ -89,7 +89,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
         first_lookup_deferred = Deferred()
 
         async def first_lookup_fetch(keys_to_fetch):
-            self.assertEquals(current_context().request, "context_11")
+            self.assertEquals(current_context().request_id, "context_11")
             self.assertEqual(keys_to_fetch, {"server10": {get_key_id(key1): 0}})
 
             await make_deferred_yieldable(first_lookup_deferred)
@@ -103,7 +103,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
 
         async def first_lookup():
             with LoggingContext("context_11") as context_11:
-                context_11.request = "context_11"
+                context_11.request_id = "context_11"
 
                 res_deferreds = kr.verify_json_objects_for_server(
                     [("server10", json1, 0, "test10"), ("server11", {}, 0, "test11")]
@@ -130,7 +130,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
         # should block rather than start a second call
 
         async def second_lookup_fetch(keys_to_fetch):
-            self.assertEquals(current_context().request, "context_12")
+            self.assertEquals(current_context().request_id, "context_12")
             return {
                 "server10": {
                     get_key_id(key1): FetchKeyResult(get_verify_key(key1), 100)
@@ -143,7 +143,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
 
         async def second_lookup():
             with LoggingContext("context_12") as context_12:
-                context_12.request = "context_12"
+                context_12.request_id = "context_12"
 
                 res_deferreds_2 = kr.verify_json_objects_for_server(
                     [("server10", json1, 0, "test")]
@@ -592,7 +592,7 @@ def run_in_context(f, *args, **kwargs):
     with LoggingContext("testctx") as ctx:
         # we set the "request" prop to make it easier to follow what's going on in the
         # logs.
-        ctx.request = "testctx"
+        ctx.request_id = "testctx"
         rv = yield f(*args, **kwargs)
     return rv
 

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -16,6 +16,7 @@ import time
 
 from mock import Mock
 
+import attr
 import canonicaljson
 import signedjson.key
 import signedjson.sign
@@ -68,10 +69,15 @@ class MockPerspectiveServer:
         signedjson.sign.sign_json(res, self.server_name, self.key)
 
 
+@attr.s(slots=True)
+class FakeRequest:
+    id = attr.ib()
+
+
 @logcontext_clean
 class KeyringTestCase(unittest.HomeserverTestCase):
     def check_context(self, val, expected):
-        self.assertEquals(getattr(current_context(), "request_id", None), expected)
+        self.assertEquals(getattr(current_context(), "request", None), expected)
         return val
 
     def test_verify_json_objects_for_server_awaits_previous_requests(self):
@@ -89,7 +95,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
         first_lookup_deferred = Deferred()
 
         async def first_lookup_fetch(keys_to_fetch):
-            self.assertEquals(current_context().request_id, "context_11")
+            self.assertEquals(current_context().request.id, "context_11")
             self.assertEqual(keys_to_fetch, {"server10": {get_key_id(key1): 0}})
 
             await make_deferred_yieldable(first_lookup_deferred)
@@ -102,9 +108,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
         mock_fetcher.get_keys.side_effect = first_lookup_fetch
 
         async def first_lookup():
-            with LoggingContext("context_11") as context_11:
-                context_11.request_id = "context_11"
-
+            with LoggingContext("context_11", request=FakeRequest("context_11")):
                 res_deferreds = kr.verify_json_objects_for_server(
                     [("server10", json1, 0, "test10"), ("server11", {}, 0, "test11")]
                 )
@@ -130,7 +134,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
         # should block rather than start a second call
 
         async def second_lookup_fetch(keys_to_fetch):
-            self.assertEquals(current_context().request_id, "context_12")
+            self.assertEquals(current_context().request.id, "context_12")
             return {
                 "server10": {
                     get_key_id(key1): FetchKeyResult(get_verify_key(key1), 100)
@@ -142,9 +146,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
         second_lookup_state = [0]
 
         async def second_lookup():
-            with LoggingContext("context_12") as context_12:
-                context_12.request_id = "context_12"
-
+            with LoggingContext("context_12", request=FakeRequest("context_12")):
                 res_deferreds_2 = kr.verify_json_objects_for_server(
                     [("server10", json1, 0, "test")]
                 )
@@ -589,10 +591,7 @@ def get_key_id(key):
 
 @defer.inlineCallbacks
 def run_in_context(f, *args, **kwargs):
-    with LoggingContext("testctx") as ctx:
-        # we set the "request" prop to make it easier to follow what's going on in the
-        # logs.
-        ctx.request_id = "testctx"
+    with LoggingContext("testctx"):
         rv = yield f(*args, **kwargs)
     return rv
 

--- a/tests/logging/test_terse_json.py
+++ b/tests/logging/test_terse_json.py
@@ -16,9 +16,9 @@ import json
 import logging
 from io import BytesIO, StringIO
 
-from twisted.web.server import Request
-
 from mock import Mock, patch
+
+from twisted.web.server import Request
 
 from synapse.http.site import SynapseRequest
 from synapse.logging._terse_json import JsonFormatter, TerseJsonFormatter
@@ -192,7 +192,7 @@ class TerseJsonTestCase(LoggerCleanupMixin, TestCase):
         self.assertEqual(log["ip_address"], "127.0.0.1")
         self.assertEqual(log["site_tag"], "test-site")
         self.assertEqual(log["requester"], "@foo:test")
-        self.assertIsNone(log["authenticated_entity"])
+        self.assertEqual(log["authenticated_entity"], "@foo:test")
         self.assertEqual(log["method"], "POST")
         self.assertEqual(log["url"], "/_matrix/client/versions")
         self.assertEqual(log["protocol"], "1.1")

--- a/tests/logging/test_terse_json.py
+++ b/tests/logging/test_terse_json.py
@@ -170,6 +170,7 @@ class TerseJsonTestCase(LoggerCleanupMixin, TestCase):
             "request",
             "ip_address",
             "site_tag",
+            "requester",
             "authenticated_entity",
             "method",
             "url",
@@ -181,6 +182,7 @@ class TerseJsonTestCase(LoggerCleanupMixin, TestCase):
         self.assertTrue(log["request"].startswith("POST-"))
         self.assertEqual(log["ip_address"], "127.0.0.1")
         self.assertEqual(log["site_tag"], "test-site")
+        self.assertIsNone(log["requester"])
         self.assertIsNone(log["authenticated_entity"])
         self.assertEqual(log["method"], "POST")
         self.assertEqual(log["url"], "/_matrix/client/versions")

--- a/tests/logging/test_terse_json.py
+++ b/tests/logging/test_terse_json.py
@@ -120,7 +120,7 @@ class TerseJsonTestCase(LoggerCleanupMixin, TestCase):
         handler.addFilter(LoggingContextFilter())
         logger = self.get_logger(handler)
 
-        with LoggingContext(request="test"):
+        with LoggingContext(request_id="test"):
             logger.info("Hello there, %s!", "wally")
 
         log = self.get_log_line()

--- a/tests/logging/test_terse_json.py
+++ b/tests/logging/test_terse_json.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import json
 import logging
 from io import BytesIO, StringIO
@@ -163,13 +162,27 @@ class TerseJsonTestCase(LoggerCleanupMixin, TestCase):
 
         log = self.get_log_line()
 
-        # The terse logger should give us these keys.
+        # The terse logger includes additional request information, if possible.
         expected_log_keys = [
             "log",
             "level",
             "namespace",
             "request",
+            "ip_address",
+            "site_tag",
+            "authenticated_entity",
+            "method",
+            "url",
+            "protocol",
+            "user_agent",
         ]
         self.assertCountEqual(log.keys(), expected_log_keys)
         self.assertEqual(log["log"], "Hello there, wally!")
         self.assertTrue(log["request"].startswith("POST-"))
+        self.assertEqual(log["ip_address"], "127.0.0.1")
+        self.assertEqual(log["site_tag"], "test-site")
+        self.assertIsNone(log["authenticated_entity"])
+        self.assertEqual(log["method"], "POST")
+        self.assertEqual(log["url"], "/_matrix/client/versions")
+        self.assertEqual(log["protocol"], "1.1")
+        self.assertEqual(log["user_agent"], "")

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -471,7 +471,7 @@ class HomeserverTestCase(TestCase):
         kwargs["config"] = config_obj
 
         async def run_bg_updates():
-            with LoggingContext("run_bg_updates", request_id="run_bg_updates-1"):
+            with LoggingContext("run_bg_updates"):
                 while not await stor.db_pool.updates.has_completed_background_updates():
                     await stor.db_pool.updates.do_next_background_update(1)
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -471,7 +471,7 @@ class HomeserverTestCase(TestCase):
         kwargs["config"] = config_obj
 
         async def run_bg_updates():
-            with LoggingContext("run_bg_updates", request="run_bg_updates-1"):
+            with LoggingContext("run_bg_updates", request_id="run_bg_updates-1"):
                 while not await stor.db_pool.updates.has_completed_background_updates():
                     await stor.db_pool.updates.do_next_background_update(1)
 

--- a/tests/util/caches/test_descriptors.py
+++ b/tests/util/caches/test_descriptors.py
@@ -661,14 +661,14 @@ class CachedListDescriptorTestCase(unittest.TestCase):
 
             @descriptors.cachedList("fn", "args1")
             async def list_fn(self, args1, arg2):
-                assert current_context().request == "c1"
+                assert current_context().request_id == "c1"
                 # we want this to behave like an asynchronous function
                 await run_on_reactor()
-                assert current_context().request == "c1"
+                assert current_context().request_id == "c1"
                 return self.mock(args1, arg2)
 
         with LoggingContext() as c1:
-            c1.request = "c1"
+            c1.request_id = "c1"
             obj = Cls()
             obj.mock.return_value = {10: "fish", 20: "chips"}
             d1 = obj.list_fn([10, 20], 2)

--- a/tests/util/caches/test_descriptors.py
+++ b/tests/util/caches/test_descriptors.py
@@ -661,14 +661,13 @@ class CachedListDescriptorTestCase(unittest.TestCase):
 
             @descriptors.cachedList("fn", "args1")
             async def list_fn(self, args1, arg2):
-                assert current_context().request_id == "c1"
+                assert current_context().name == "c1"
                 # we want this to behave like an asynchronous function
                 await run_on_reactor()
-                assert current_context().request_id == "c1"
+                assert current_context().name == "c1"
                 return self.mock(args1, arg2)
 
-        with LoggingContext() as c1:
-            c1.request_id = "c1"
+        with LoggingContext("c1") as c1:
             obj = Cls()
             obj.mock.return_value = {10: "fish", 20: "chips"}
             d1 = obj.list_fn([10, 20], 2)

--- a/tests/util/test_logcontext.py
+++ b/tests/util/test_logcontext.py
@@ -17,11 +17,11 @@ from .. import unittest
 
 class LoggingContextTestCase(unittest.TestCase):
     def _check_test_key(self, value):
-        self.assertEquals(current_context().request, value)
+        self.assertEquals(current_context().request_id, value)
 
     def test_with_context(self):
         with LoggingContext() as context_one:
-            context_one.request = "test"
+            context_one.request_id = "test"
             self._check_test_key("test")
 
     @defer.inlineCallbacks
@@ -31,14 +31,14 @@ class LoggingContextTestCase(unittest.TestCase):
         @defer.inlineCallbacks
         def competing_callback():
             with LoggingContext() as competing_context:
-                competing_context.request = "competing"
+                competing_context.request_id = "competing"
                 yield clock.sleep(0)
                 self._check_test_key("competing")
 
         reactor.callLater(0, competing_callback)
 
         with LoggingContext() as context_one:
-            context_one.request = "one"
+            context_one.request_id = "one"
             yield clock.sleep(0)
             self._check_test_key("one")
 
@@ -48,7 +48,7 @@ class LoggingContextTestCase(unittest.TestCase):
         callback_completed = [False]
 
         with LoggingContext() as context_one:
-            context_one.request = "one"
+            context_one.request_id = "one"
 
             # fire off function, but don't wait on it.
             d2 = run_in_background(function)
@@ -134,7 +134,7 @@ class LoggingContextTestCase(unittest.TestCase):
         sentinel_context = current_context()
 
         with LoggingContext() as context_one:
-            context_one.request = "one"
+            context_one.request_id = "one"
 
             d1 = make_deferred_yieldable(blocking_function())
             # make sure that the context was reset by make_deferred_yieldable
@@ -150,7 +150,7 @@ class LoggingContextTestCase(unittest.TestCase):
         sentinel_context = current_context()
 
         with LoggingContext() as context_one:
-            context_one.request = "one"
+            context_one.request_id = "one"
 
             d1 = make_deferred_yieldable(_chained_deferred_function())
             # make sure that the context was reset by make_deferred_yieldable
@@ -167,7 +167,7 @@ class LoggingContextTestCase(unittest.TestCase):
         argument isn't actually a deferred"""
 
         with LoggingContext() as context_one:
-            context_one.request = "one"
+            context_one.request_id = "one"
 
             d1 = make_deferred_yieldable("bum")
             self._check_test_key("one")
@@ -177,9 +177,9 @@ class LoggingContextTestCase(unittest.TestCase):
             self._check_test_key("one")
 
     def test_nested_logging_context(self):
-        with LoggingContext(request="foo"):
+        with LoggingContext(request_id="foo"):
             nested_context = nested_logging_context(suffix="bar")
-            self.assertEqual(nested_context.request, "foo-bar")
+            self.assertEqual(nested_context.request_id, "foo-bar")
 
     @defer.inlineCallbacks
     def test_make_deferred_yieldable_with_await(self):
@@ -194,7 +194,7 @@ class LoggingContextTestCase(unittest.TestCase):
         sentinel_context = current_context()
 
         with LoggingContext() as context_one:
-            context_one.request = "one"
+            context_one.request_id = "one"
 
             d1 = make_deferred_yieldable(blocking_function())
             # make sure that the context was reset by make_deferred_yieldable

--- a/tests/util/test_logcontext.py
+++ b/tests/util/test_logcontext.py
@@ -17,11 +17,10 @@ from .. import unittest
 
 class LoggingContextTestCase(unittest.TestCase):
     def _check_test_key(self, value):
-        self.assertEquals(current_context().request_id, value)
+        self.assertEquals(current_context().name, value)
 
     def test_with_context(self):
-        with LoggingContext() as context_one:
-            context_one.request_id = "test"
+        with LoggingContext("test"):
             self._check_test_key("test")
 
     @defer.inlineCallbacks
@@ -30,15 +29,13 @@ class LoggingContextTestCase(unittest.TestCase):
 
         @defer.inlineCallbacks
         def competing_callback():
-            with LoggingContext() as competing_context:
-                competing_context.request_id = "competing"
+            with LoggingContext("competing"):
                 yield clock.sleep(0)
                 self._check_test_key("competing")
 
         reactor.callLater(0, competing_callback)
 
-        with LoggingContext() as context_one:
-            context_one.request_id = "one"
+        with LoggingContext("one"):
             yield clock.sleep(0)
             self._check_test_key("one")
 
@@ -47,9 +44,7 @@ class LoggingContextTestCase(unittest.TestCase):
 
         callback_completed = [False]
 
-        with LoggingContext() as context_one:
-            context_one.request_id = "one"
-
+        with LoggingContext("one"):
             # fire off function, but don't wait on it.
             d2 = run_in_background(function)
 
@@ -133,9 +128,7 @@ class LoggingContextTestCase(unittest.TestCase):
 
         sentinel_context = current_context()
 
-        with LoggingContext() as context_one:
-            context_one.request_id = "one"
-
+        with LoggingContext("one"):
             d1 = make_deferred_yieldable(blocking_function())
             # make sure that the context was reset by make_deferred_yieldable
             self.assertIs(current_context(), sentinel_context)
@@ -149,9 +142,7 @@ class LoggingContextTestCase(unittest.TestCase):
     def test_make_deferred_yieldable_with_chained_deferreds(self):
         sentinel_context = current_context()
 
-        with LoggingContext() as context_one:
-            context_one.request_id = "one"
-
+        with LoggingContext("one"):
             d1 = make_deferred_yieldable(_chained_deferred_function())
             # make sure that the context was reset by make_deferred_yieldable
             self.assertIs(current_context(), sentinel_context)
@@ -166,9 +157,7 @@ class LoggingContextTestCase(unittest.TestCase):
         """Check that make_deferred_yieldable does the right thing when its
         argument isn't actually a deferred"""
 
-        with LoggingContext() as context_one:
-            context_one.request_id = "one"
-
+        with LoggingContext("one"):
             d1 = make_deferred_yieldable("bum")
             self._check_test_key("one")
 
@@ -177,9 +166,9 @@ class LoggingContextTestCase(unittest.TestCase):
             self._check_test_key("one")
 
     def test_nested_logging_context(self):
-        with LoggingContext(request_id="foo"):
+        with LoggingContext("foo"):
             nested_context = nested_logging_context(suffix="bar")
-            self.assertEqual(nested_context.request_id, "foo-bar")
+            self.assertEqual(nested_context.name, "foo-bar")
 
     @defer.inlineCallbacks
     def test_make_deferred_yieldable_with_await(self):
@@ -193,9 +182,7 @@ class LoggingContextTestCase(unittest.TestCase):
 
         sentinel_context = current_context()
 
-        with LoggingContext() as context_one:
-            context_one.request_id = "one"
-
+        with LoggingContext("one"):
             d1 = make_deferred_yieldable(blocking_function())
             # make sure that the context was reset by make_deferred_yieldable
             self.assertIs(current_context(), sentinel_context)


### PR DESCRIPTION
This was some work I had going towards #8683, it adds some basic request information to the structured logs (similar to information available in the [processed log lines](https://github.com/matrix-org/synapse/wiki#what-do-all-those-fields-in-the-processed-line-mean)).

In particular this should allow pivoting on things like IP address or user ID in structured logs.

In order to do this there was a bit of refactoring necessary to `LoggingContext`. Each commit should be separately reviewable.