### PR TITLE
Revert "Patch to temporarily drop cross-user m.key_share_requests (#8675)"

### DIFF
--- a/changelog.d/8675.misc
+++ b/changelog.d/8675.misc
@@ -1,1 +1,0 @@
-Temporarily drop cross-user m.room_key_request to_device messages over performance concerns.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -955,10 +955,6 @@ class FederationHandlerRegistry:
         ):
             return
 
-        # Temporary patch to drop cross-user key share requests
-        if edu_type == "m.room_key_request":
-            return
-
         # Check if we have a handler on this instance
         handler = self.edu_handlers.get(edu_type)
         if handler:


### PR DESCRIPTION
We patched `matrix-org-hotfixes` a little while ago in #8675 to drop any cross-user key share requests while they were being accidentally spammed by a client. This was a temporary fix until we had some rate-limiting in place.

Rate-limiting landed in https://github.com/matrix-org/synapse/pull/8957. Note that the rate-limit can't be configured, but has what appear to be [sensible defaults](https://github.com/matrix-org/synapse/blob/db2efa9c50569adbfab102b1f447f5a8312b95f3/synapse/config/ratelimiting.py#L105-L113).

Note that the original patch was already actually overridden partially when the rate-limit PR landed, as they conflicted. So we've already lifted the restriction between local devices on matrix.org, but requests were still blocked from being sent over federation. This PR cleans up the remaining bits.

This reverts commit d60af9305a07fadcf0270d1887c5b7d063834967.

