### PR TITLE
Bump mypy-zope to 0.2.13.

### DIFF
--- a/changelog.d/9678.misc
+++ b/changelog.d/9678.misc
@@ -1,0 +1,1 @@
+Bump mypy-zope to 0.2.13 to fix "Cannot determine consistent method resolution order (MRO)" errors when running mypy a second time.

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ CONDITIONAL_REQUIREMENTS["lint"] = [
     "flake8",
 ]
 
-CONDITIONAL_REQUIREMENTS["mypy"] = ["mypy==0.812", "mypy-zope==0.2.11"]
+CONDITIONAL_REQUIREMENTS["mypy"] = ["mypy==0.812", "mypy-zope==0.2.13"]
 
 # Dependencies which are exclusively required by unit test code. This is
 # NOT a list of all modules that are necessary to run the unit tests.


### PR DESCRIPTION
This fixes the "Cannot determine consistent method resolution order (MRO)" error when running mypy a second time with Twisted 21.2.0.