### PR TITLE
docs: fallback/web endpoint does not appear to be mounted on workers

### DIFF
--- a/changelog.d/9679.doc
+++ b/changelog.d/9679.doc
@@ -1,0 +1,1 @@
+Improve worker documentation for fallback/web auth endpoints.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -232,7 +232,6 @@ expressions:
     # Registration/login requests
     ^/_matrix/client/(api/v1|r0|unstable)/login$
     ^/_matrix/client/(r0|unstable)/register$
-    ^/_matrix/client/(r0|unstable)/auth/.*/fallback/web$
 
     # Event sending requests
     ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/redact
@@ -276,7 +275,7 @@ using):
 
 Ensure that all SSO logins go to a single process.
 For multiple workers not handling the SSO endpoints properly, see
-[#7530](https://github.com/matrix-org/synapse/issues/7530) and 
+[#7530](https://github.com/matrix-org/synapse/issues/7530) and
 [#9427](https://github.com/matrix-org/synapse/issues/9427).
 
 Note that a HTTP listener with `client` and `federation` resources must be


### PR DESCRIPTION
I tried routing `^/_matrix/client/(r0|unstable)/auth/.*/fallback/web$` to a generic worker as per the current worker docs, but when attempting to remove devices on a SAML configure instance I got 400 `M_UNRECOGNISED` to `/_matrix/client/r0/auth/m.login.sso/fallback/web`

There is some discussion in https://github.com/matrix-org/synapse/issues/7530#issuecomment-718990782 about routing this to a single worker, but I believe the problem is that `synapse.rest.client.v2_alpha.auth.AuthRestServlet` isn't mounted on workers (and so won't work for any stage type not just `m.login.sso`). I don't feel qualified to say whether it could be mounted on worker(s), so the best I can do is to make the docs reflect what I think the situation is

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
