### PR TITLE
Add type hints to for the federation sender.

### DIFF
--- a/changelog.d/9681.misc
+++ b/changelog.d/9681.misc
@@ -1,0 +1,1 @@
+Add additional type hints to the Homeserver object.

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -792,13 +792,6 @@ class FederationSenderHandler:
 
         self._fed_position_linearizer = Linearizer(name="_fed_position_linearizer")
 
-    def on_start(self):
-        # There may be some events that are persisted but haven't been sent,
-        # so send them now.
-        self.federation_sender.notify_new_events(
-            self.store.get_room_max_stream_ordering()
-        )
-
     def wake_destination(self, server: str):
         self.federation_sender.wake_destination(server)
 

--- a/synapse/federation/send_queue.py
+++ b/synapse/federation/send_queue.py
@@ -49,7 +49,7 @@ from synapse.api.presence import UserPresenceState
 from synapse.federation.sender import AbstractFederationSender, FederationSender
 from synapse.metrics import LaterGauge
 from synapse.replication.tcp.streams.federation import FederationStream
-from synapse.types import JsonDict, ReadReceipt
+from synapse.types import JsonDict, ReadReceipt, RoomStreamToken
 from synapse.util.metrics import Measure
 
 from .units import Edu
@@ -202,10 +202,12 @@ class FederationRemoteSendQueue(AbstractFederationSender):
             for key in keys[:i]:
                 del self.edus[key]
 
-    def notify_new_events(self, max_token: int) -> None:
+    def notify_new_events(self, max_token: RoomStreamToken) -> None:
         """As per FederationSender"""
-        # We don't need to replicate this as it gets sent down a different
-        # stream.
+        # This should never get called.
+        raise NotImplementedError(
+            "FederationRemoteSendQueue unexpectedly received a call to notify_new_events."
+        )
 
     def build_and_send_edu(
         self,

--- a/synapse/federation/send_queue.py
+++ b/synapse/federation/send_queue.py
@@ -205,9 +205,7 @@ class FederationRemoteSendQueue(AbstractFederationSender):
     def notify_new_events(self, max_token: RoomStreamToken) -> None:
         """As per FederationSender"""
         # This should never get called.
-        raise NotImplementedError(
-            "FederationRemoteSendQueue unexpectedly received a call to notify_new_events."
-        )
+        raise NotImplementedError()
 
     def build_and_send_edu(
         self,

--- a/synapse/federation/send_queue.py
+++ b/synapse/federation/send_queue.py
@@ -31,17 +31,23 @@ Events are replicated via a separate events stream.
 
 import logging
 from collections import namedtuple
-from typing import Dict, List, Tuple, Type
+from typing import TYPE_CHECKING, Dict, List, Optional, Sized, Tuple, Type
 
 from sortedcontainers import SortedDict
 
 from twisted.internet import defer
 
 from synapse.api.presence import UserPresenceState
+from synapse.federation.sender import FederationSender
 from synapse.metrics import LaterGauge
+from synapse.replication.tcp.streams.federation import FederationStream
+from synapse.types import JsonDict, ReadReceipt
 from synapse.util.metrics import Measure
 
 from .units import Edu
+
+if TYPE_CHECKING:
+    from synapse.server import HomeServer
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +55,7 @@ logger = logging.getLogger(__name__)
 class FederationRemoteSendQueue:
     """A drop in replacement for FederationSender"""
 
-    def __init__(self, hs):
+    def __init__(self, hs: "HomeServer"):
         self.server_name = hs.hostname
         self.clock = hs.get_clock()
         self.notifier = hs.get_notifier()
@@ -58,7 +64,7 @@ class FederationRemoteSendQueue:
         # We may have multiple federation sender instances, so we need to track
         # their positions separately.
         self._sender_instances = hs.config.worker.federation_shard_config.instances
-        self._sender_positions = {}
+        self._sender_positions = {}  # type: Dict[str, int]
 
         # Pending presence map user_id -> UserPresenceState
         self.presence_map = {}  # type: Dict[str, UserPresenceState]
@@ -94,7 +100,7 @@ class FederationRemoteSendQueue:
         # we make a new function, so we need to make a new function so the inner
         # lambda binds to the queue rather than to the name of the queue which
         # changes. ARGH.
-        def register(name, queue):
+        def register(name: str, queue: Sized) -> None:
             LaterGauge(
                 "synapse_federation_send_queue_%s_size" % (queue_name,),
                 "",
@@ -115,13 +121,13 @@ class FederationRemoteSendQueue:
 
         self.clock.looping_call(self._clear_queue, 30 * 1000)
 
-    def _next_pos(self):
+    def _next_pos(self) -> int:
         pos = self.pos
         self.pos += 1
         self.pos_time[self.clock.time_msec()] = pos
         return pos
 
-    def _clear_queue(self):
+    def _clear_queue(self) -> None:
         """Clear the queues for anything older than N minutes"""
 
         FIVE_MINUTES_AGO = 5 * 60 * 1000
@@ -138,7 +144,7 @@ class FederationRemoteSendQueue:
 
         self._clear_queue_before_pos(position_to_delete)
 
-    def _clear_queue_before_pos(self, position_to_delete):
+    def _clear_queue_before_pos(self, position_to_delete: int) -> None:
         """Clear all the queues from before a given position"""
         with Measure(self.clock, "send_queue._clear"):
             # Delete things out of presence maps
@@ -188,13 +194,18 @@ class FederationRemoteSendQueue:
             for key in keys[:i]:
                 del self.edus[key]
 
-    def notify_new_events(self, max_token):
+    def notify_new_events(self, max_token: int) -> None:
         """As per FederationSender"""
         # We don't need to replicate this as it gets sent down a different
         # stream.
-        pass
 
-    def build_and_send_edu(self, destination, edu_type, content, key=None):
+    def build_and_send_edu(
+        self,
+        destination: str,
+        edu_type: str,
+        content: JsonDict,
+        key: Optional[tuple] = None,
+    ) -> None:
         """As per FederationSender"""
         if destination == self.server_name:
             logger.info("Not sending EDU to ourselves")
@@ -218,38 +229,40 @@ class FederationRemoteSendQueue:
 
         self.notifier.on_new_replication_data()
 
-    def send_read_receipt(self, receipt):
+    def send_read_receipt(self, receipt: ReadReceipt) -> defer.Deferred:
         """As per FederationSender
 
         Args:
-            receipt (synapse.types.ReadReceipt):
+            receipt:
         """
         # nothing to do here: the replication listener will handle it.
         return defer.succeed(None)
 
-    def send_presence(self, states):
+    def send_presence(self, states: List[UserPresenceState]) -> None:
         """As per FederationSender
 
         Args:
-            states (list(UserPresenceState))
+            states
         """
         pos = self._next_pos()
 
         # We only want to send presence for our own users, so lets always just
         # filter here just in case.
-        local_states = list(filter(lambda s: self.is_mine_id(s.user_id), states))
+        local_states = [s for s in states if self.is_mine_id(s.user_id)]
 
         self.presence_map.update({state.user_id: state for state in local_states})
         self.presence_changed[pos] = [state.user_id for state in local_states]
 
         self.notifier.on_new_replication_data()
 
-    def send_presence_to_destinations(self, states, destinations):
+    def send_presence_to_destinations(
+        self, states: List[UserPresenceState], destinations: List[str]
+    ) -> None:
         """As per FederationSender
 
         Args:
-            states (list[UserPresenceState])
-            destinations (list[str])
+            states
+            destinations
         """
         for state in states:
             pos = self._next_pos()
@@ -258,15 +271,15 @@ class FederationRemoteSendQueue:
 
         self.notifier.on_new_replication_data()
 
-    def send_device_messages(self, destination):
+    def send_device_messages(self, destination: str) -> None:
         """As per FederationSender"""
         # We don't need to replicate this as it gets sent down a different
         # stream.
 
-    def get_current_token(self):
+    def get_current_token(self) -> int:
         return self.pos - 1
 
-    def federation_ack(self, instance_name, token):
+    def federation_ack(self, instance_name: str, token: int) -> None:
         if self._sender_instances:
             # If we have configured multiple federation sender instances we need
             # to track their positions separately, and only clear the queue up
@@ -504,13 +517,16 @@ ParsedFederationStreamData = namedtuple(
 )
 
 
-def process_rows_for_federation(transaction_queue, rows):
+def process_rows_for_federation(
+    transaction_queue: FederationSender,
+    rows: List[FederationStream.FederationStreamRow],
+) -> None:
     """Parse a list of rows from the federation stream and put them in the
     transaction queue ready for sending to the relevant homeservers.
 
     Args:
-        transaction_queue (FederationSender)
-        rows (list(synapse.replication.tcp.streams.federation.FederationStream.FederationStreamRow))
+        transaction_queue
+        rows
     """
 
     # The federation stream contains a bunch of different types of

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -74,6 +74,7 @@ class AbstractFederationSender(metaclass=abc.ABCMeta):
         """This gets called when we have some new events we might want to
         send out to other servers.
         """
+        raise NotImplementedError()
 
     @abc.abstractmethod
     async def send_read_receipt(self, receipt: ReadReceipt) -> None:
@@ -82,6 +83,7 @@ class AbstractFederationSender(metaclass=abc.ABCMeta):
         Args:
             receipt: receipt to be sent
         """
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def send_presence(self, states: List[UserPresenceState]) -> None:
@@ -90,6 +92,7 @@ class AbstractFederationSender(metaclass=abc.ABCMeta):
         This actually queues up the presence states ready for sending and
         triggers a background task to process them and send out the transactions.
         """
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def send_presence_to_destinations(
@@ -100,6 +103,7 @@ class AbstractFederationSender(metaclass=abc.ABCMeta):
         Args:
             destinations:
         """
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def build_and_send_edu(
@@ -117,10 +121,11 @@ class AbstractFederationSender(metaclass=abc.ABCMeta):
             content: content of EDU
             key: clobbering key for this edu
         """
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def send_device_messages(self, destination: str) -> None:
-        pass
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def wake_destination(self, destination: str) -> None:
@@ -129,20 +134,21 @@ class AbstractFederationSender(metaclass=abc.ABCMeta):
         This is mainly useful if the remote server has been down and we think it
         might have come back.
         """
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def get_current_token(self) -> int:
-        pass
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def federation_ack(self, instance_name: str, token: int) -> None:
-        pass
+        raise NotImplementedError()
 
     @abc.abstractmethod
     async def get_replication_rows(
         self, instance_name: str, from_token: int, to_token: int, target_row_count: int
     ) -> Tuple[List[Tuple[int, Tuple]], int, bool]:
-        pass
+        raise NotImplementedError()
 
 
 class FederationSender(AbstractFederationSender):

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -132,17 +132,17 @@ class AbstractFederationSender(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_current_token(self) -> int:
-        # Dummy implementation for case where federation sender isn't offloaded
-        # to a worker.
-        return 0
+        pass
+
+    @abc.abstractmethod
+    def federation_ack(self, instance_name: str, token: int) -> None:
+        pass
 
     @abc.abstractmethod
     async def get_replication_rows(
         self, instance_name: str, from_token: int, to_token: int, target_row_count: int
     ) -> Tuple[List[Tuple[int, Tuple]], int, bool]:
-        # Dummy implementation for case where federation sender isn't offloaded
-        # to a worker.
-        return [], 0, False
+        pass
 
 
 class FederationSender(AbstractFederationSender):
@@ -678,6 +678,10 @@ class FederationSender(AbstractFederationSender):
         # Dummy implementation for case where federation sender isn't offloaded
         # to a worker.
         return 0
+
+    def federation_ack(self, instance_name: str, token: int) -> None:
+        # It is not expected that this gets called on FederationSender.
+        raise NotImplementedError()
 
     @staticmethod
     async def get_replication_rows(

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -312,16 +312,16 @@ class FederationAckCommand(Command):
 
     NAME = "FEDERATION_ACK"
 
-    def __init__(self, instance_name, token):
+    def __init__(self, instance_name: str, token: int):
         self.instance_name = instance_name
         self.token = token
 
     @classmethod
-    def from_line(cls, line):
+    def from_line(cls, line: str) -> "FederationAckCommand":
         instance_name, token = line.split(" ")
         return cls(instance_name, int(token))
 
-    def to_line(self):
+    def to_line(self) -> str:
         return "%s %s" % (self.instance_name, self.token)
 
 

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -34,6 +34,7 @@ from typing_extensions import Deque
 
 from twisted.internet.protocol import ReconnectingClientFactory
 
+from synapse.federation.send_queue import FederationRemoteSendQueue
 from synapse.metrics import LaterGauge
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.replication.tcp.client import DirectTcpReplicationClientFactory
@@ -213,7 +214,9 @@ class ReplicationCommandHandler:
 
         self._federation_sender = None
         if self._is_master and not hs.config.send_federation:
-            self._federation_sender = hs.get_federation_sender()
+            federation_sender = hs.get_federation_sender()
+            assert isinstance(federation_sender, FederationRemoteSendQueue)
+            self._federation_sender = federation_sender
 
         self._server_notices_sender = None
         if self._is_master:

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -34,7 +34,6 @@ from typing_extensions import Deque
 
 from twisted.internet.protocol import ReconnectingClientFactory
 
-from synapse.federation.send_queue import FederationRemoteSendQueue
 from synapse.metrics import LaterGauge
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.replication.tcp.client import DirectTcpReplicationClientFactory
@@ -214,9 +213,7 @@ class ReplicationCommandHandler:
 
         self._federation_sender = None
         if self._is_master and not hs.config.send_federation:
-            federation_sender = hs.get_federation_sender()
-            assert isinstance(federation_sender, FederationRemoteSendQueue)
-            self._federation_sender = federation_sender
+            self._federation_sender = hs.get_federation_sender()
 
         self._server_notices_sender = None
         if self._is_master:

--- a/synapse/replication/tcp/streams/federation.py
+++ b/synapse/replication/tcp/streams/federation.py
@@ -16,7 +16,6 @@
 from collections import namedtuple
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Tuple
 
-from synapse.federation.sender import FederationSender
 from synapse.replication.tcp.streams._base import (
     Stream,
     current_token_without_instance,
@@ -50,7 +49,6 @@ class FederationStream(Stream):
             # will be a real FederationSender, which has stubs for current_token and
             # get_replication_rows.)
             federation_sender = hs.get_federation_sender()
-            assert isinstance(federation_sender, FederationSender)
             current_token = current_token_without_instance(
                 federation_sender.get_current_token
             )

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -60,7 +60,7 @@ from synapse.federation.federation_server import (
     FederationServer,
 )
 from synapse.federation.send_queue import FederationRemoteSendQueue
-from synapse.federation.sender import FederationSender
+from synapse.federation.sender import AbstractFederationSender, FederationSender
 from synapse.federation.transport.client import TransportLayerClient
 from synapse.groups.attestations import GroupAttestationSigning, GroupAttestionRenewer
 from synapse.groups.groups_server import GroupsServerHandler, GroupsServerWorkerHandler
@@ -571,7 +571,7 @@ class HomeServer(metaclass=abc.ABCMeta):
         return TransportLayerClient(self)
 
     @cache_in_self
-    def get_federation_sender(self):
+    def get_federation_sender(self) -> AbstractFederationSender:
         if self.should_send_federation():
             return FederationSender(self)
         elif not self.config.worker_app:


### PR DESCRIPTION
This adds an abstract-class for the `FederationSender` and `FederationRemoteSendQueue` to ensure they implement the same interface, we then return this interface from the `HomeServer` object.

Split out of #9374