### PR TITLE
Rewrite complement.sh

### DIFF
--- a/changelog.d/9685.misc
+++ b/changelog.d/9685.misc
@@ -1,0 +1,1 @@
+Update `scripts-dev/complement.sh` to use a local checkout of Complement, allow running a subset of tests and have it use Synapse's Complement test blacklist.

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -1,4 +1,4 @@
-#! /bin/bash -e
+#!/usr/bin/env bash
 # This script is designed for developers who want to test their code
 # against Complement.
 #
@@ -15,6 +15,10 @@
 #
 # ./complement.sh "TestOutboundFederation(Profile|Send)"
 #
+
+# Exit if a line returns a non-zero exit code
+set -e
+
 COMPLEMENT_DIR="${COMPLEMENT_DIR:-$(dirname $0)/../../complement}"
 
 cd "$(dirname $0)/.."

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -37,4 +37,4 @@ if [[ -n $1 ]]; then
 fi
 
 # Run the tests!
-COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist $EXTRA_COMPLEMENT_ARGS ./tests
+COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist -count=1 $EXTRA_COMPLEMENT_ARGS ./tests

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -1,22 +1,35 @@
-#! /bin/bash -eu
+#! /bin/bash -e
 # This script is designed for developers who want to test their code
 # against Complement.
 #
 # It makes a Synapse image which represents the current checkout,
-# then downloads Complement and runs it with that image.
+# builds a synapse-complement image on top, then runs tests with it.
+#
+# By default the script assumes that a Complement checkout exists next to
+# the current Synapse checkout directory. This can be overridden by setting
+# the COMPLEMENT_DIR env var to the path to your Complement checkout.
+#
+# A regular expression of test method names can be supplied as the first
+# argument to the script. Complement will then only run those tests. If
+# no regex is supplied, all tests are run. Ex.
+#
+# ./complement.sh "TestOutboundFederation(Profile|Send)"
+#
+COMPLEMENT_DIR="${COMPLEMENT_DIR:-$(dirname $0)/../../complement}"
 
 cd "$(dirname $0)/.."
 
 # Build the base Synapse image from the local checkout
-docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile .
+docker build -t matrixdotorg/synapse -f docker/Dockerfile .
+# Build the Synapse monolith image from Complement, based on the above image we just built
+docker build -t complement-synapse -f "$COMPLEMENT_DIR/dockerfiles/Synapse.Dockerfile" "$COMPLEMENT_DIR/dockerfiles"
 
-# Download Complement
-wget -N https://github.com/matrix-org/complement/archive/master.tar.gz
-tar -xzf master.tar.gz
-cd complement-master
-
-# Build the Synapse image from Complement, based on the above image we just built
-docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile ./dockerfiles
+cd "$COMPLEMENT_DIR"
 
 # Run the tests on the resulting image!
-COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -count=1 ./tests
+if [[ -z $1 ]]; then
+  # No test name regex is set, run all tests
+  COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist ./tests
+else
+  COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist -run "$1" ./tests
+fi

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -30,10 +30,11 @@ docker build -t complement-synapse -f "$COMPLEMENT_DIR/dockerfiles/Synapse.Docke
 
 cd "$COMPLEMENT_DIR"
 
-# Run the tests on the resulting image!
-if [[ -z $1 ]]; then
-  # No test name regex is set, run all tests
-  COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist ./tests
-else
-  COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist -run "$1" ./tests
+EXTRA_COMPLEMENT_ARGS=""
+if [[ -n $1 ]]; then
+  # A test name regex has been set, supply it to Complement
+  EXTRA_COMPLEMENT_ARGS+="-run $1 "
 fi
+
+# Run the tests!
+COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist $EXTRA_COMPLEMENT_ARGS ./tests


### PR DESCRIPTION
This PR rewrites the original complement.sh script with a number of improvements:

* We now use a local checkout of Complement (configurable with `COMPLEMENT_DIR`), instead of downloading the master branch.
* You can now specify a regex of test names to run, or just run all tests.
* We now use the Synapse test blacklist tag (so all tests will pass).