### PR TITLE
In delegation guide, document public_baseurl

### DIFF
--- a/changelog.d/9693.doc
+++ b/changelog.d/9693.doc
@@ -1,0 +1,1 @@
+Update delegation guide to mention setting public_baseurl as required by matrix-react-sdk based clients.

--- a/docs/delegate.md
+++ b/docs/delegate.md
@@ -51,6 +51,18 @@ However, if you really need it, you can find some documentation on how such a
 record should look like and how Synapse will use it in [the Matrix
 specification](https://matrix.org/docs/spec/server_server/latest#resolving-server-names).
 
+## public_baseurl configuration
+
+You will also need to set public_baseurl in homeserver.yaml to the address of your actual
+synapse server (or a reverse proxy that points to synapse).
+
+```yaml
+public_baseurl: https://synapse.example.com/
+```
+
+otherwise certain clients such as element.io will attempt to reach your homeserver via the
+top level via `https://example.com/`.
+
 ## Delegation FAQ
 
 ### When do I need delegation?


### PR DESCRIPTION
Clients using matrix-react-sdk use the `well_known.homeserver` value from the login
response, which default to server_name, when trying to communicate to the homeserver.

https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-login

https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/Login.ts#L222

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
