### PR TITLE
Explicitly upgrade openssl in docker file and enforce new version of cryptography

### DIFF
--- a/changelog.d/9697.docker
+++ b/changelog.d/9697.docker
@@ -1,0 +1,1 @@
+Ensure that the docker container has up to date versions of openssl.

--- a/changelog.d/9697.misc
+++ b/changelog.d/9697.misc
@@ -1,0 +1,1 @@
+Enforce that `cryptography` dependency is up to date to ensure it has the most recent openssl patches.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && apt-get install -y \
         libffi-dev \
         libjpeg-dev \
         libpq-dev \
-        libssl \
         libssl-dev \
         libwebp-dev \
         libxml++2.6-dev \
@@ -72,7 +71,6 @@ RUN apt-get update && apt-get install -y \
         libwebp6 \
         xmlsec1 \
         libjemalloc2 \
-        libssl \
         libssl-dev \
         openssl \
         && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,10 +24,12 @@ RUN apt-get update && apt-get install -y \
         libffi-dev \
         libjpeg-dev \
         libpq-dev \
+        libssl \
         libssl-dev \
         libwebp-dev \
         libxml++2.6-dev \
         libxslt1-dev \
+        openssl \
         rustc \
         zlib1g-dev \
         && rm -rf /var/lib/apt/lists/*
@@ -70,6 +72,9 @@ RUN apt-get update && apt-get install -y \
         libwebp6 \
         xmlsec1 \
         libjemalloc2 \
+        libssl \
+        libssl-dev \
+        openssl \
         && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,17 +20,17 @@ FROM docker.io/python:${PYTHON_VERSION}-slim as builder
 
 # install the OS build deps
 RUN apt-get update && apt-get install -y \
-    build-essential \
-    libffi-dev \
-    libjpeg-dev \
-    libpq-dev \
-    libssl-dev \
-    libwebp-dev \
-    libxml++2.6-dev \
-    libxslt1-dev \
-    rustc \
-    zlib1g-dev \
- && rm -rf /var/lib/apt/lists/*
+        build-essential \
+        libffi-dev \
+        libjpeg-dev \
+        libpq-dev \
+        libssl-dev \
+        libwebp-dev \
+        libxml++2.6-dev \
+        libxslt1-dev \
+        rustc \
+        zlib1g-dev \
+        && rm -rf /var/lib/apt/lists/*
 
 # Build dependencies that are not available as wheels, to speed up rebuilds
 RUN pip install --prefix="/install" --no-warn-script-location \
@@ -63,14 +63,14 @@ RUN pip install --prefix="/install" --no-warn-script-location \
 FROM docker.io/python:${PYTHON_VERSION}-slim
 
 RUN apt-get update && apt-get install -y \
-    curl \
-    gosu \
-    libjpeg62-turbo \
-    libpq5 \
-    libwebp6 \
-    xmlsec1 \
-    libjemalloc2 \
- && rm -rf /var/lib/apt/lists/*
+        curl \
+        gosu \
+        libjpeg62-turbo \
+        libpq5 \
+        libwebp6 \
+        xmlsec1 \
+        libjemalloc2 \
+        && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local
 COPY ./docker/start.py /start.py
@@ -83,4 +83,4 @@ EXPOSE 8008/tcp 8009/tcp 8448/tcp
 ENTRYPOINT ["/start.py"]
 
 HEALTHCHECK --interval=1m --timeout=5s \
-  CMD curl -fSs http://localhost:8008/health || exit 1
+        CMD curl -fSs http://localhost:8008/health || exit 1

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -84,7 +84,7 @@ REQUIREMENTS = [
     "typing-extensions>=3.7.4",
     # We enforce that we have a `cryptography` version that bundles an `openssl`
     # with the latest security patches.
-    "cryptography>=3.4.7",
+    "cryptography>=3.4.7;python_version>='3.6'",
 ]
 
 CONDITIONAL_REQUIREMENTS = {

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -82,6 +82,9 @@ REQUIREMENTS = [
     "Jinja2>=2.9",
     "bleach>=1.4.3",
     "typing-extensions>=3.7.4",
+    # We enforce that we have a `cryptography` version that bundles an `openssl`
+    # with the latest security patches.
+    "cryptography>=3.4.7",
 ]
 
 CONDITIONAL_REQUIREMENTS = {


### PR DESCRIPTION
This is to ensure that we have an `openssl` version with the latest security patches.

(Apologies for the reformatting, but vscode *really* wants to reformat the dockerfile)