### PR TITLE
Fix the suggested pip incantation for cryptography

### DIFF
--- a/changelog.d/9699.bugfix
+++ b/changelog.d/9699.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.30.1 which meant the suggested `pip` incantation to install an updated `cryptography` was incorrect.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import logging
 from typing import List, Set
 
@@ -101,7 +102,7 @@ CONDITIONAL_REQUIREMENTS = {
         "txacme>=0.9.2",
         # txacme depends on eliot. Eliot 1.8.0 is incompatible with
         # python 3.5.2, as per https://github.com/itamarst/eliot/issues/418
-        'eliot<1.8.0;python_version<"3.5.3"',
+        "eliot<1.8.0;python_version<'3.5.3'",
     ],
     "saml2": [
         # pysaml2 6.4.0 is incompatible with Python 3.5 (see https://github.com/IdentityPython/pysaml2/issues/749)
@@ -131,6 +132,18 @@ for name, optional_deps in CONDITIONAL_REQUIREMENTS.items():
         ALL_OPTIONAL_REQUIREMENTS = set(optional_deps) | ALL_OPTIONAL_REQUIREMENTS
 
 
+# ensure there are no double-quote characters in any of the deps (otherwise the
+# 'pip install' incantation in DependencyException will break)
+for dep in itertools.chain(
+    REQUIREMENTS,
+    *CONDITIONAL_REQUIREMENTS.values(),
+):
+    if '"' in dep:
+        raise Exception(
+            "Dependency `%s` contains double-quote; use single-quotes instead" % (dep,)
+        )
+
+
 def list_requirements():
     return list(set(REQUIREMENTS) | ALL_OPTIONAL_REQUIREMENTS)
 
@@ -150,7 +163,7 @@ class DependencyException(Exception):
     @property
     def dependencies(self):
         for i in self.args[0]:
-            yield "'" + i + "'"
+            yield '"' + i + '"'
 
 
 def check_requirements(for_feature=None):


### PR DESCRIPTION
If you have the wrong version of `cryptography` installed, synapse suggests:

```
To install run:
    pip install --upgrade --force 'cryptography>=3.4.7;python_version>='3.6''
```

However, the use of ' inside '...' doesn't work, so when you run this, you get
an error.