### PR TITLE
Use 'dmypy run' in lint.sh instead of 'mypy'

### DIFF
--- a/changelog.d/9701.misc
+++ b/changelog.d/9701.misc
@@ -1,0 +1,1 @@
+Use `dmypy run` in lint script for improved performance in type-checking while developing.

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -95,4 +95,4 @@ isort "${files[@]}"
 python3 -m black "${files[@]}"
 ./scripts-dev/config-lint.sh
 flake8 "${files[@]}"
-mypy
+dmypy run


### PR DESCRIPTION
For it's obvious performance benefits. `dmypy` support landed in #9692 (~~although it appear that it doesn't actually work on develop atm...~~ Twisted just needed an upgrade :)