### PR TITLE
Fix mypy error on 3.6

### DIFF
--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -169,7 +169,7 @@ import inspect
 import logging
 import re
 from functools import wraps
-from typing import TYPE_CHECKING, Dict, Optional, Type
+from typing import TYPE_CHECKING, Dict, Optional, Pattern, Type
 
 import attr
 
@@ -262,7 +262,7 @@ logger = logging.getLogger(__name__)
 # Block everything by default
 # A regex which matches the server_names to expose traces for.
 # None means 'block everything'.
-_homeserver_whitelist = None  # type: Optional[re.Pattern[str]]
+_homeserver_whitelist = None  # type: Optional[Pattern[str]]
 
 # Util methods
 


### PR DESCRIPTION
When using `mypy` on 3.6, it will fail on the following;

```
synapse/logging/opentracing.py:265: error: Name 're.Pattern' is not defined  [name-defined]
Found 1 error in 1 file (checked 389 source files)
```

This isn't caught in CI cuz the mypy CI check runs on python 3.7, this PR fixes it by getting it from `typing` instead of `re`, `re.Pattern` is only valid in Python >=3.7

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`