### PR TITLE
Fix CI by ignore type for None module import

### DIFF
--- a/changelog.d/9709.misc
+++ b/changelog.d/9709.misc
@@ -1,0 +1,1 @@
+Fix type-checking CI on develop.

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -44,7 +44,7 @@ from tests.server import FakeTransport
 try:
     import hiredis
 except ImportError:
-    hiredis = None
+    hiredis = None  # type: ignore
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Looks like this is the workaround(?) we use in other places where we need to test whether a module exists.

Why this only broke now, I couldn't tell you. Perhaps we configured mypy to only start checking this file recently?