### PR TITLE
Revert "Use 'dmypy run' in lint.sh instead of 'mypy' (#9701)"

### DIFF
--- a/changelog.d/9720.misc
+++ b/changelog.d/9720.misc
@@ -1,0 +1,1 @@
+Revert using `dmypy run` in lint script.

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -95,4 +95,4 @@ isort "${files[@]}"
 python3 -m black "${files[@]}"
 ./scripts-dev/config-lint.sh
 flake8 "${files[@]}"
-dmypy run
+mypy


### PR DESCRIPTION
This reverts commit f380bb77d19e7dd4ee6f61cd489e240ee4aa8fc2.

Reverting since it gives errors that running `mypy` directly doesn't give. So the `lint.sh` script fails for me every time.

I can merge this across branches after it merges.