### PR TITLE
Fix version for bugbear

### DIFF
--- a/changelog.d/9734.misc
+++ b/changelog.d/9734.misc
@@ -1,0 +1,1 @@
+Pin flake8-bugbear's version.

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ CONDITIONAL_REQUIREMENTS["lint"] = [
     "isort==5.7.0",
     "black==20.8b1",
     "flake8-comprehensions",
-    "flake8-bugbear",
+    "flake8-bugbear==21.3.2",
     "flake8",
 ]
 


### PR DESCRIPTION
Bugbear [added new checks](https://github.com/PyCQA/flake8-bugbear/releases/tag/21.4.1), however, because we're both not actively ignoring new checks (to a degree) or fixing the bugbear version, these got auto-updated in CI, breaking it because `flake8` is now disapproving of the codebase.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`