### PR TITLE
Check for proper membership during a local join of restricted rooms.

### DIFF
--- a/changelog.d/9735.feature
+++ b/changelog.d/9735.feature
@@ -1,0 +1,1 @@
+Add experimental support for [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083): restricting room access via group membership.

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -46,4 +46,4 @@ if [[ -n "$1" ]]; then
 fi
 
 # Run the tests!
-COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist -count=1 $EXTRA_COMPLEMENT_ARGS ./tests
+COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist,msc3083 -count=1 $EXTRA_COMPLEMENT_ARGS ./tests

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -295,8 +295,8 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 newly_joined = prev_member_event.membership != Membership.JOIN
                 is_invite = prev_member_event.membership == Membership.INVITE
 
-            # If the member is not already in the room, check if they should be
-            # allowed access via membership in a space.
+            # If the member is not already in the room and is not accepting an invite,
+            # check if they should be allowed access via membership in a space.
             if (
                 newly_joined
                 and not is_invite

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -289,14 +289,20 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
 
         if event.membership == Membership.JOIN:
             newly_joined = True
+            is_invite = False
             if prev_member_event_id:
                 prev_member_event = await self.store.get_event(prev_member_event_id)
                 newly_joined = prev_member_event.membership != Membership.JOIN
+                is_invite = prev_member_event.membership == Membership.INVITE
 
             # If the member is not already in the room, check if they should be
             # allowed access via membership in a space.
-            if newly_joined and not await self._can_join_restricted_room(
-                prev_state_ids, room_id, user_id
+            if (
+                newly_joined
+                and not is_invite
+                and not await self._can_join_restricted_room(
+                    prev_state_ids, room_id, user_id
+                )
             ):
                 raise AuthError(
                     403,

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -210,7 +210,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         if join_rules_event.content.get("join_rule") != JoinRules.MSC3083_RESTRICTED:
             return True
 
-        # If allowed is of the wrong form, then only allows invites.
+        # If allowed is of the wrong form, then only allow invited users.
         allowed_spaces = join_rules_event.content.get("allow", [])
         if not isinstance(allowed_spaces, list):
             return False

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -179,11 +179,14 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
 
         await self._invites_per_user_limiter.ratelimit(requester, invitee_user_id)
 
-    async def _can_join_restricted_room(
+    async def _can_join_without_invite(
         self, state_ids: StateMap[str], room_version: RoomVersion, user_id: str
     ) -> bool:
         """
-        Check whether a user can join a restricted room.
+        Check whether a user can join a room without an invite.
+
+        When joining a room with restricted joined rules (as defined in MSC3083),
+        the membership of spaces must be checked during join.
 
         Args:
             state_ids: The state of the room as it currently is.
@@ -300,7 +303,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             if (
                 newly_joined
                 and not user_is_invited
-                and not await self._can_join_restricted_room(
+                and not await self._can_join_without_invite(
                     prev_state_ids, event.room_version, user_id
                 )
             ):

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -187,7 +187,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
 
         Args:
             state_ids: The state of the room as it currently is.
-            room_id: The room being joined.
+            room_version: The room version of the room being joined.
             user_id: The user joining the room.
 
         Returns:

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -220,13 +220,13 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             if not isinstance(space, dict):
                 continue
 
-            soace_id = space.get("space")
-            if not isinstance(soace_id, str):
+            space_id = space.get("space")
+            if not isinstance(space_id, str):
                 continue
 
             # The user was joined to one of the spaces specified, they can join
             # this room!
-            if soace_id in joined_rooms:
+            if space_id in joined_rooms:
                 return True
 
         # The user was not in any of the required spaces.
@@ -289,17 +289,17 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
 
         if event.membership == Membership.JOIN:
             newly_joined = True
-            is_invite = False
+            user_is_invited = False
             if prev_member_event_id:
                 prev_member_event = await self.store.get_event(prev_member_event_id)
                 newly_joined = prev_member_event.membership != Membership.JOIN
-                is_invite = prev_member_event.membership == Membership.INVITE
+                user_is_invited = prev_member_event.membership == Membership.INVITE
 
             # If the member is not already in the room and is not accepting an invite,
             # check if they should be allowed access via membership in a space.
             if (
                 newly_joined
-                and not is_invite
+                and not user_is_invited
                 and not await self._can_join_restricted_room(
                     prev_state_ids, event.room_version, user_id
                 )

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -210,10 +210,10 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         if join_rules_event.content.get("join_rule") != JoinRules.MSC3083_RESTRICTED:
             return True
 
-        # If allowed is of the wrong form, then ignore it (and treat the room as public).
+        # If allowed is of the wrong form, then only allows invites.
         allowed_spaces = join_rules_event.content.get("allow", [])
         if not isinstance(allowed_spaces, list):
-            return True
+            return False
 
         # Get the list of joined rooms and see if there's an overlap.
         joined_rooms = await self.store.get_rooms_for_user(user_id)


### PR DESCRIPTION
Expands the support for [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083) by checking membership in a space when joining a restricted room.

Fixes #9714