### PR TITLE
Fix reported bugbear: too broad exception assertion

### DIFF
--- a/changelog.d/9753.misc
+++ b/changelog.d/9753.misc
@@ -1,0 +1,1 @@
+Check that a `ConfigError` is raised, rather than simply `Exception`, when appropriate in homeserver config file generation tests.

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -20,6 +20,7 @@ from io import StringIO
 
 import yaml
 
+from synapse.config import ConfigError
 from synapse.config.homeserver import HomeServerConfig
 
 from tests import unittest
@@ -35,9 +36,9 @@ class ConfigLoadingTestCase(unittest.TestCase):
 
     def test_load_fails_if_server_name_missing(self):
         self.generate_config_and_remove_lines_containing("server_name")
-        with self.assertRaises(Exception):
+        with self.assertRaises(ConfigError):
             HomeServerConfig.load_config("", ["-c", self.file])
-        with self.assertRaises(Exception):
+        with self.assertRaises(ConfigError):
             HomeServerConfig.load_or_generate_config("", ["-c", self.file])
 
     def test_generates_and_loads_macaroon_secret_key(self):


### PR DESCRIPTION
This reported issue was breaking develop for me. And to be fair, it's a valid issue to fix. The issue is well-described in the error:

>tests/config/test_load.py:40:9: B017 assertRaises(Exception): should be considered evil. It can lead to your test passing even if the code being tested is never executed due to a typo. Either assert for a more specific exception (builtin or custom), use assertRaisesRegex, or use the context manager form of assertRaises.

This issue was blocking #6739's CI from passing.