### PR TITLE
Fix incompatibility with bionic

### DIFF
--- a/.buildkite/scripts/test_old_deps.sh
+++ b/.buildkite/scripts/test_old_deps.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 # this script is run by buildkite in a plain `xenial` container; it installs the
-# minimal requirements for tox and hands over to the py35-old tox environment.
+# minimal requirements for tox and hands over to the py3-old tox environment.
 
 set -ex
 
 apt-get update
-apt-get install -y python3.5 python3.5-dev python3-pip libxml2-dev libxslt-dev xmlsec1 zlib1g-dev tox
+apt-get install -y python3 python3-dev python3-pip libxml2-dev libxslt-dev xmlsec1 zlib1g-dev tox
 
 export LANG="C.UTF-8"
 
 # Prevent virtualenv from auto-updating pip to an incompatible version
 export VIRTUALENV_NO_DOWNLOAD=1
 
-exec tox -e py35-old,combine
+exec tox -e py3-old,combine

--- a/changelog.d/9769.misc
+++ b/changelog.d/9769.misc
@@ -1,0 +1,1 @@
+Fix incompatibility with `tox` 2.5.

--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,8 @@ usedevelop=true
 # A test suite for the oldest supported versions of Python libraries, to catch
 # any uses of APIs not available in them.
 [testenv:py35-old]
-skip_install=True
+skip_install = true
+usedevelop = false
 deps =
     # Old automat version for Twisted
     Automat == 0.3.0
@@ -136,7 +137,8 @@ commands =
     python -m synmark {posargs:}
 
 [testenv:packaging]
-skip_install=True
+skip_install = true
+usedevelop = false
 deps =
     check-manifest
 commands =
@@ -154,7 +156,8 @@ extras = lint
 commands = isort -c --df --sp setup.cfg {[base]lint_targets}
 
 [testenv:check-newsfragment]
-skip_install = True
+skip_install = true
+usedevelop = false
 deps = towncrier>=18.6.0rc1
 commands =
    python -m towncrier.check --compare-with=origin/develop
@@ -163,7 +166,8 @@ commands =
 commands = {toxinidir}/scripts-dev/generate_sample_config --check
 
 [testenv:combine]
-skip_install = True
+skip_install = true
+usedevelop = false
 deps =
     coverage
     pip>=10 ; python_version >= '3.6'
@@ -173,14 +177,16 @@ commands=
     coverage report
 
 [testenv:cov-erase]
-skip_install = True
+skip_install = true
+usedevelop = false
 deps =
     coverage
 commands=
     coverage erase
 
 [testenv:cov-html]
-skip_install = True
+skip_install = true
+usedevelop = false
 deps =
     coverage
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ commands =
     # we use "env" rather than putting a value in `setenv` so that it is not
     # inherited by other tox environments.
     #
-    # keep this in sync with the copy in `testenv:py35-old`.
+    # keep this in sync with the copy in `testenv:py3-old`.
     #
     /usr/bin/env COVERAGE_PROCESS_START={toxinidir}/.coveragerc "{envbindir}/trial" {env:TRIAL_FLAGS:} {posargs:tests} {env:TOXSUFFIX:}
 
@@ -103,7 +103,7 @@ usedevelop=true
 
 # A test suite for the oldest supported versions of Python libraries, to catch
 # any uses of APIs not available in them.
-[testenv:py35-old]
+[testenv:py3-old]
 skip_install = true
 usedevelop = false
 deps =


### PR DESCRIPTION
These are the changes needed to be able to run the `olddeps` build on bionic instead of xenial:

 * tweak the script and tox env names so that it will run on whatever version of python3 is available, rather than 3.5 specifically.
 * bionic has tox 2.5 (instead of 2.3), and apparently on tox 2.5, `usedevelop` overrides `skip_install`, so we end up trying to install the full dependencies even for the `-old` environment..
