### PR TITLE
Enable complement tests for MSC2946.

### DIFF
--- a/changelog.d/9771.misc
+++ b/changelog.d/9771.misc
@@ -1,0 +1,1 @@
+Enable Complement tests for [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946): Spaces Summary API.

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -46,4 +46,4 @@ if [[ -n "$1" ]]; then
 fi
 
 # Run the tests!
-COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist,msc3083 -count=1 $EXTRA_COMPLEMENT_ARGS ./tests
+COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags synapse_blacklist,msc2946,msc3083 -count=1 $EXTRA_COMPLEMENT_ARGS ./tests


### PR DESCRIPTION
Fixes #9756 by providing the additional tag. This depends on matrix-org/complement#101 and will need a corresponding pipelines PR.