### PR TITLE
Use mock from the stdlib.

### DIFF
--- a/changelog.d/9772.misc
+++ b/changelog.d/9772.misc
@@ -1,0 +1,1 @@
+Use mock from the standard library instead of a separate package.

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,10 @@ ignore=W503,W504,E203,E731,E501,B007
 
 [isort]
 line_length = 88
-sections=FUTURE,STDLIB,COMPAT,THIRDPARTY,TWISTED,FIRSTPARTY,TESTS,LOCALFOLDER
+sections=FUTURE,STDLIB,THIRDPARTY,TWISTED,FIRSTPARTY,TESTS,LOCALFOLDER
 default_section=THIRDPARTY
 known_first_party = synapse
 known_tests=tests
-known_compat = mock
 known_twisted=twisted,OpenSSL
 multi_line_output=3
 include_trailing_comma=true

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ CONDITIONAL_REQUIREMENTS["mypy"] = ["mypy==0.812", "mypy-zope==0.2.13"]
 # Tests assume that all optional dependencies are installed.
 #
 # parameterized_class decorator was introduced in parameterized 0.7.0
-CONDITIONAL_REQUIREMENTS["test"] = ["mock>=2.0", "parameterized>=0.7.0"]
+CONDITIONAL_REQUIREMENTS["test"] = ["parameterized>=0.7.0"]
 
 setup(
     name="matrix-synapse",

--- a/synmark/suites/logging.py
+++ b/synmark/suites/logging.py
@@ -16,7 +16,6 @@
 import logging
 import warnings
 from io import StringIO
-
 from unittest.mock import Mock
 
 from pyperf import perf_counter

--- a/synmark/suites/logging.py
+++ b/synmark/suites/logging.py
@@ -17,7 +17,7 @@ import logging
 import warnings
 from io import StringIO
 
-from mock import Mock
+from unittest.mock import Mock
 
 from pyperf import perf_counter
 

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 import pymacaroons
 

--- a/tests/app/test_openid_listener.py
+++ b/tests/app/test_openid_listener.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from parameterized import parameterized
 

--- a/tests/appservice/test_appservice.py
+++ b/tests/appservice/test_appservice.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
-
 from unittest.mock import Mock
 
 from twisted.internet import defer

--- a/tests/appservice/test_appservice.py
+++ b/tests/appservice/test_appservice.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import re
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/appservice/test_scheduler.py
+++ b/tests/appservice/test_scheduler.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import time
-
 from unittest.mock import Mock
 
 import attr

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import time
 
-from mock import Mock
+from unittest.mock import Mock
 
 import attr
 import canonicaljson

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
-from mock import Mock
+from unittest.mock import Mock
 
 import attr
 

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
-
 from unittest.mock import Mock
 
 import attr

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -313,7 +313,8 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
             self.hs.get_federation_transport_client().send_transaction.call_args_list
         )
         for call in calls:
-            federation_transaction = call.args[0]  # type: Transaction
+            call_args = call[0]
+            federation_transaction = call_args[0]  # type: Transaction
 
             # Get the sent EDUs in this transaction
             edus = federation_transaction.get_dict()["edus"]

--- a/tests/federation/test_complexity.py
+++ b/tests/federation/test_complexity.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.api.errors import Codes, SynapseError
 from synapse.rest import admin

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.api.constants import EventTypes
 from synapse.events import EventBase

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -1,5 +1,4 @@
 from typing import List, Tuple
-
 from unittest.mock import Mock
 
 from synapse.api.constants import EventTypes

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from typing import Optional
 
-from mock import Mock
+from unittest.mock import Mock
 
 from signedjson import key, sign
 from signedjson.types import BaseKey, SigningKey

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Optional
-
 from unittest.mock import Mock
 
 from signedjson import key, sign

--- a/tests/handlers/test_admin.py
+++ b/tests/handlers/test_admin.py
@@ -15,7 +15,7 @@
 
 from collections import Counter
 
-from mock import Mock
+from unittest.mock import Mock
 
 import synapse.api.errors
 import synapse.handlers.admin

--- a/tests/handlers/test_admin.py
+++ b/tests/handlers/test_admin.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from collections import Counter
-
 from unittest.mock import Mock
 
 import synapse.api.errors

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 import pymacaroons
 

--- a/tests/handlers/test_cas.py
+++ b/tests/handlers/test_cas.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.handlers.cas_handler import CasResponse
 

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-from mock import Mock
+from unittest.mock import Mock
 
 import synapse
 import synapse.api.errors

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -14,7 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import mock
+from unittest import mock
 
 from signedjson import key as key, sign as sign
 

--- a/tests/handlers/test_e2e_room_keys.py
+++ b/tests/handlers/test_e2e_room_keys.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 import copy
-
 from unittest import mock
 
 from synapse.api.errors import SynapseError

--- a/tests/handlers/test_e2e_room_keys.py
+++ b/tests/handlers/test_e2e_room_keys.py
@@ -17,7 +17,7 @@
 
 import copy
 
-import mock
+from unittest import mock
 
 from synapse.api.errors import SynapseError
 

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -16,7 +16,7 @@ import json
 import os
 from urllib.parse import parse_qs, urlparse
 
-from mock import ANY, Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pymacaroons
 

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 import json
 import os
-from urllib.parse import parse_qs, urlparse
-
 from unittest.mock import ANY, Mock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pymacaroons
 

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -17,7 +17,7 @@
 
 from typing import Any, Type, Union
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -16,7 +16,6 @@
 """Tests for the password_auth_provider interface"""
 
 from typing import Any, Type, Union
-
 from unittest.mock import Mock
 
 from twisted.internet import defer

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 from signedjson.key import generate_signing_key
 

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 import synapse.types
 from synapse.api.errors import AuthError, SynapseError

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.api.auth import Auth
 from synapse.api.constants import UserTypes

--- a/tests/handlers/test_saml.py
+++ b/tests/handlers/test_saml.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from typing import Optional
-
 from unittest.mock import Mock
 
 import attr

--- a/tests/handlers/test_saml.py
+++ b/tests/handlers/test_saml.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from mock import Mock
+from unittest.mock import Mock
 
 import attr
 

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -17,7 +17,7 @@
 import json
 from typing import Dict
 
-from mock import ANY, Mock, call
+from unittest.mock import ANY, Mock, call
 
 from twisted.internet import defer
 from twisted.web.resource import Resource

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -16,7 +16,6 @@
 
 import json
 from typing import Dict
-
 from unittest.mock import ANY, Mock, call
 
 from twisted.internet import defer

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import logging
 from typing import Optional
-
 from unittest.mock import Mock
 
 import treq

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -15,7 +15,7 @@
 import logging
 from typing import Optional
 
-from mock import Mock
+from unittest.mock import Mock
 
 import treq
 from netaddr import IPSet

--- a/tests/http/federation/test_srv_resolver.py
+++ b/tests/http/federation/test_srv_resolver.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 from twisted.internet.defer import Deferred

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -14,7 +14,7 @@
 
 from io import BytesIO
 
-from mock import Mock
+from unittest.mock import Mock
 
 from netaddr import IPSet
 

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from io import BytesIO
-
 from unittest.mock import Mock
 
 from netaddr import IPSet

--- a/tests/http/test_fedclient.py
+++ b/tests/http/test_fedclient.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from netaddr import IPSet
 from parameterized import parameterized

--- a/tests/http/test_servlet.py
+++ b/tests/http/test_servlet.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import json
 from io import BytesIO
-
 from unittest.mock import Mock
 
 from synapse.api.errors import SynapseError

--- a/tests/http/test_servlet.py
+++ b/tests/http/test_servlet.py
@@ -15,7 +15,7 @@
 import json
 from io import BytesIO
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.api.errors import SynapseError
 from synapse.http.servlet import (

--- a/tests/http/test_simple_client.py
+++ b/tests/http/test_simple_client.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from netaddr import IPSet
 

--- a/tests/logging/test_terse_json.py
+++ b/tests/logging/test_terse_json.py
@@ -16,7 +16,7 @@ import json
 import logging
 from io import BytesIO, StringIO
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from twisted.web.server import Request
 

--- a/tests/logging/test_terse_json.py
+++ b/tests/logging/test_terse_json.py
@@ -15,7 +15,6 @@
 import json
 import logging
 from io import BytesIO, StringIO
-
 from unittest.mock import Mock, patch
 
 from twisted.web.server import Request

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.api.constants import EduTypes
 from synapse.events import EventBase

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -358,7 +358,8 @@ class ModuleApiTestCase(FederatingHomeserverTestCase):
             self.hs.get_federation_transport_client().send_transaction.call_args_list
         )
         for call in calls:
-            federation_transaction = call.args[0]  # type: Transaction
+            call_args = call[0]
+            federation_transaction = call_args[0]  # type: Transaction
 
             # Get the sent EDUs in this transaction
             edus = federation_transaction.get_dict()["edus"]

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet.defer import Deferred
 

--- a/tests/replication/slave/storage/_base.py
+++ b/tests/replication/slave/storage/_base.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from tests.replication._base import BaseStreamTestCase
 

--- a/tests/replication/tcp/streams/test_receipts.py
+++ b/tests/replication/tcp/streams/test_receipts.py
@@ -15,7 +15,7 @@
 
 # type: ignore
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.replication.tcp.streams._base import ReceiptsStream
 

--- a/tests/replication/tcp/streams/test_typing.py
+++ b/tests/replication/tcp/streams/test_typing.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.handlers.typing import RoomMember
 from synapse.replication.tcp.streams import TypingStream

--- a/tests/replication/test_federation_ack.py
+++ b/tests/replication/test_federation_ack.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 
 from synapse.app.generic_worker import GenericWorkerServer
 from synapse.replication.tcp.commands import FederationAckCommand

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-
 from unittest.mock import Mock
 
 from synapse.api.constants import EventTypes, Membership

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import logging
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.api.constants import EventTypes, Membership
 from synapse.events.builder import EventBuilderFactory

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import logging
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-
 from unittest.mock import Mock
 
 from twisted.internet import defer

--- a/tests/replication/test_sharded_event_persister.py
+++ b/tests/replication/test_sharded_event_persister.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import logging
 
-from mock import patch
+from unittest.mock import patch
 
 from synapse.api.room_versions import RoomVersion
 from synapse.rest import admin

--- a/tests/replication/test_sharded_event_persister.py
+++ b/tests/replication/test_sharded_event_persister.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-
 from unittest.mock import patch
 
 from synapse.api.room_versions import RoomVersion

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -17,7 +17,6 @@ import json
 import os
 import urllib.parse
 from binascii import unhexlify
-
 from unittest.mock import Mock
 
 from twisted.internet.defer import Deferred

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -18,7 +18,7 @@ import os
 import urllib.parse
 from binascii import unhexlify
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet.defer import Deferred
 

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -17,7 +17,7 @@ import json
 import urllib.parse
 from typing import List, Optional
 
-from mock import Mock
+from unittest.mock import Mock
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes, Membership

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -16,7 +16,6 @@
 import json
 import urllib.parse
 from typing import List, Optional
-
 from unittest.mock import Mock
 
 import synapse.rest.admin

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -20,7 +20,7 @@ import urllib.parse
 from binascii import unhexlify
 from typing import List, Optional
 
-from mock import Mock
+from unittest.mock import Mock
 
 import synapse.rest.admin
 from synapse.api.constants import UserTypes

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -19,7 +19,6 @@ import json
 import urllib.parse
 from binascii import unhexlify
 from typing import List, Optional
-
 from unittest.mock import Mock
 
 import synapse.rest.admin

--- a/tests/rest/client/test_retention.py
+++ b/tests/rest/client/test_retention.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.api.constants import EventTypes
 from synapse.rest import admin

--- a/tests/rest/client/test_shadow_banned.py
+++ b/tests/rest/client/test_shadow_banned.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -15,7 +15,7 @@
 import threading
 from typing import Dict
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.events import EventBase
 from synapse.module_api import ModuleApi

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import threading
 from typing import Dict
-
 from unittest.mock import Mock
 
 from synapse.events import EventBase

--- a/tests/rest/client/test_transactions.py
+++ b/tests/rest/client/test_transactions.py
@@ -1,4 +1,4 @@
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 from twisted.internet import defer, reactor
 

--- a/tests/rest/client/v1/test_events.py
+++ b/tests/rest/client/v1/test_events.py
@@ -15,7 +15,7 @@
 
 """ Tests REST events for /events paths."""
 
-from mock import Mock
+from unittest.mock import Mock
 
 import synapse.rest.admin
 from synapse.rest.client.v1 import events, login, room

--- a/tests/rest/client/v1/test_login.py
+++ b/tests/rest/client/v1/test_login.py
@@ -16,9 +16,8 @@
 import time
 import urllib.parse
 from typing import Any, Dict, List, Optional, Union
-from urllib.parse import urlencode
-
 from unittest.mock import Mock
+from urllib.parse import urlencode
 
 import pymacaroons
 

--- a/tests/rest/client/v1/test_login.py
+++ b/tests/rest/client/v1/test_login.py
@@ -18,7 +18,7 @@ import urllib.parse
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlencode
 
-from mock import Mock
+from unittest.mock import Mock
 
 import pymacaroons
 

--- a/tests/rest/client/v1/test_presence.py
+++ b/tests/rest/client/v1/test_presence.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -20,9 +20,8 @@
 
 import json
 from typing import Iterable
-from urllib import parse as urlparse
-
 from unittest.mock import Mock
+from urllib import parse as urlparse
 
 import synapse.rest.admin
 from synapse.api.constants import EventContentFields, EventTypes, Membership

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -22,7 +22,7 @@ import json
 from typing import Iterable
 from urllib import parse as urlparse
 
-from mock import Mock
+from unittest.mock import Mock
 
 import synapse.rest.admin
 from synapse.api.constants import EventContentFields, EventTypes, Membership

--- a/tests/rest/client/v1/test_typing.py
+++ b/tests/rest/client/v1/test_typing.py
@@ -16,7 +16,7 @@
 
 """Tests REST events for /rooms paths."""
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.rest.client.v1 import room
 from synapse.types import UserID

--- a/tests/rest/client/v1/utils.py
+++ b/tests/rest/client/v1/utils.py
@@ -22,7 +22,7 @@ import time
 import urllib.parse
 from typing import Any, Dict, Mapping, MutableMapping, Optional
 
-from mock import patch
+from unittest.mock import patch
 
 import attr
 

--- a/tests/rest/client/v1/utils.py
+++ b/tests/rest/client/v1/utils.py
@@ -21,7 +21,6 @@ import re
 import time
 import urllib.parse
 from typing import Any, Dict, Mapping, MutableMapping, Optional
-
 from unittest.mock import patch
 
 import attr

--- a/tests/rest/key/v2/test_remote_key_resource.py
+++ b/tests/rest/key/v2/test_remote_key_resource.py
@@ -15,7 +15,7 @@
 import urllib.parse
 from io import BytesIO, StringIO
 
-from mock import Mock
+from unittest.mock import Mock
 
 import signedjson.key
 from canonicaljson import encode_canonical_json

--- a/tests/rest/key/v2/test_remote_key_resource.py
+++ b/tests/rest/key/v2/test_remote_key_resource.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import urllib.parse
 from io import BytesIO, StringIO
-
 from unittest.mock import Mock
 
 import signedjson.key

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -20,7 +20,7 @@ from io import BytesIO
 from typing import Optional
 from urllib import parse
 
-from mock import Mock
+from unittest.mock import Mock
 
 import attr
 from parameterized import parameterized_class

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -18,9 +18,8 @@ import tempfile
 from binascii import unhexlify
 from io import BytesIO
 from typing import Optional
-from urllib import parse
-
 from unittest.mock import Mock
+from urllib import parse
 
 import attr
 from parameterized import parameterized_class

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -16,7 +16,7 @@ import json
 import os
 import re
 
-from mock import patch
+from unittest.mock import patch
 
 from twisted.internet._resolver import HostResolution
 from twisted.internet.address import IPv4Address, IPv6Address

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -15,7 +15,6 @@
 import json
 import os
 import re
-
 from unittest.mock import patch
 
 from twisted.internet._resolver import HostResolution

--- a/tests/scripts/test_new_matrix_user.py
+++ b/tests/scripts/test_new_matrix_user.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse._scripts.register_new_matrix_user import request_registration
 

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/storage/test_appservice.py
+++ b/tests/storage/test_appservice.py
@@ -15,7 +15,6 @@
 import json
 import os
 import tempfile
-
 from unittest.mock import Mock
 
 import yaml

--- a/tests/storage/test_appservice.py
+++ b/tests/storage/test_appservice.py
@@ -16,7 +16,7 @@ import json
 import os
 import tempfile
 
-from mock import Mock
+from unittest.mock import Mock
 
 import yaml
 

--- a/tests/storage/test_background_update.py
+++ b/tests/storage/test_background_update.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.storage.background_updates import BackgroundUpdater
 

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -15,7 +15,6 @@
 
 
 from collections import OrderedDict
-
 from unittest.mock import Mock
 
 from twisted.internet import defer

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -16,7 +16,7 @@
 
 from collections import OrderedDict
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/storage/test_cleanup_extrems.py
+++ b/tests/storage/test_cleanup_extrems.py
@@ -16,7 +16,7 @@
 import os.path
 from unittest.mock import patch
 
-from mock import Mock
+from unittest.mock import Mock
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes

--- a/tests/storage/test_cleanup_extrems.py
+++ b/tests/storage/test_cleanup_extrems.py
@@ -14,9 +14,7 @@
 # limitations under the License.
 
 import os.path
-from unittest.mock import patch
-
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import synapse.rest.admin
 from synapse.api.constants import EventTypes

--- a/tests/storage/test_client_ips.py
+++ b/tests/storage/test_client_ips.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 import synapse.rest.admin
 from synapse.http.site import XForwardedForRequest

--- a/tests/storage/test_event_push_actions.py
+++ b/tests/storage/test_event_push_actions.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/storage/test_monthly_active_users.py
+++ b/tests/storage/test_monthly_active_users.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/test_distributor.py
+++ b/tests/test_distributor.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from synapse.util.distributor import Distributor
 

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet.defer import succeed
 

--- a/tests/test_phone_home.py
+++ b/tests/test_phone_home.py
@@ -15,7 +15,7 @@
 
 import resource
 
-import mock
+from unittest import mock
 
 from synapse.app.phone_stats_home import phone_stats_home
 

--- a/tests/test_phone_home.py
+++ b/tests/test_phone_home.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import resource
-
 from unittest import mock
 
 from synapse.app.phone_stats_home import phone_stats_home

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List, Optional
-
 from unittest.mock import Mock
 
 from twisted.internet import defer

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from typing import List, Optional
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -14,7 +14,7 @@
 
 import json
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.test.proto_helpers import MemoryReactorClock
 

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-
 from unittest.mock import Mock
 
 from twisted.test.proto_helpers import MemoryReactorClock

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -22,7 +22,7 @@ import warnings
 from asyncio import Future
 from typing import Any, Awaitable, Callable, TypeVar
 
-from mock import Mock
+from unittest.mock import Mock
 
 import attr
 

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -21,7 +21,6 @@ import sys
 import warnings
 from asyncio import Future
 from typing import Any, Awaitable, Callable, TypeVar
-
 from unittest.mock import Mock
 
 import attr

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -15,7 +15,7 @@
 import logging
 from typing import Optional
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.internet import defer
 from twisted.internet.defer import succeed

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import logging
 from typing import Optional
-
 from unittest.mock import Mock
 
 from twisted.internet import defer

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -22,7 +22,7 @@ import logging
 import time
 from typing import Callable, Dict, Iterable, Optional, Tuple, Type, TypeVar, Union
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from canonicaljson import json
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -21,7 +21,6 @@ import inspect
 import logging
 import time
 from typing import Callable, Dict, Iterable, Optional, Tuple, Type, TypeVar, Union
-
 from unittest.mock import Mock, patch
 
 from canonicaljson import json

--- a/tests/util/caches/test_descriptors.py
+++ b/tests/util/caches/test_descriptors.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 import logging
 from typing import Set
-
 from unittest import mock
 
 from twisted.internet import defer, reactor

--- a/tests/util/caches/test_descriptors.py
+++ b/tests/util/caches/test_descriptors.py
@@ -16,7 +16,7 @@
 import logging
 from typing import Set
 
-import mock
+from unittest import mock
 
 from twisted.internet import defer, reactor
 

--- a/tests/util/caches/test_ttlcache.py
+++ b/tests/util/caches/test_ttlcache.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.util.caches.ttlcache import TTLCache
 

--- a/tests/util/test_file_consumer.py
+++ b/tests/util/test_file_consumer.py
@@ -17,7 +17,7 @@
 import threading
 from io import StringIO
 
-from mock import NonCallableMock
+from unittest.mock import NonCallableMock
 
 from twisted.internet import defer, reactor
 

--- a/tests/util/test_file_consumer.py
+++ b/tests/util/test_file_consumer.py
@@ -16,7 +16,6 @@
 
 import threading
 from io import StringIO
-
 from unittest.mock import NonCallableMock
 
 from twisted.internet import defer, reactor

--- a/tests/util/test_lrucache.py
+++ b/tests/util/test_lrucache.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-from mock import Mock
+from unittest.mock import Mock
 
 from synapse.util.caches.lrucache import LruCache
 from synapse.util.caches.treecache import TreeCache

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,9 +21,8 @@ import time
 import uuid
 import warnings
 from typing import Type
-from urllib import parse as urlparse
-
 from unittest.mock import Mock, patch
+from urllib import parse as urlparse
 
 from twisted.internet import defer
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,7 +23,7 @@ import warnings
 from typing import Type
 from urllib import parse as urlparse
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from twisted.internet import defer
 


### PR DESCRIPTION
This is a redo of #7709, which I still had on my computer. Switches from using the mock package to the one in the standard library since we've now dropped Python 3.5.

Done with some sed magic + running isort.

* Switches from importing `mock`, to importing it as a submodule of `unittest`.
* Stop installing the `mock` package.
* Updates the isort config to consider `mock` a stdlib package.
* Runs isort.

This affects test only code so should be fine if unit tests pass. Should be reviewable commit-by-commit. I separated the automated steps from the steps where I manually changed things.