### PR TITLE
Allow homeserver admins to remove appservice-initiated rooms from the public room directory

### DIFF
--- a/changelog.d/9773.feature
+++ b/changelog.d/9773.feature
@@ -1,0 +1,1 @@
+Allow homeserver admins to remove appservice rooms from the public room directory.

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -529,6 +529,21 @@ You will have to manually handle, if you so choose, the following:
 * Removal of the Content Violation room if desired.
 
 
+# Delist Room From Public Directory API
+
+Allows delisting a room from both the public room directory and any application service-specific
+room lists. The room will still exist, but not be publicly visible. Note that this **does not**
+prevent room owners or application services from adding the room to public room lists again
+afterwards.
+
+```
+    DELETE /_synapse/admin/v1/rooms/directory/<room_id_or_alias>
+```
+
+The room will be removed from both the public directory and any application service
+directories. The response body for a successful request is empty.
+
+
 # Make Room Admin API
 
 Grants another user the highest power available to a local user who is in the room.

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -468,23 +468,37 @@ class DirectoryHandler(BaseHandler):
 
         await self.store.set_room_is_public(room_id, making_public)
 
-    async def edit_published_appservice_room_list(
-        self, appservice_id: str, network_id: str, room_id: str, visibility: str
-    ):
-        """Add or remove a room from the appservice/network specific public
-        room list.
+    async def add_room_to_published_appservice_room_list(
+        self, room_id: str, appservice_id: str, network_id: str
+    ) -> None:
+        """Add a room to the appservice/network specific public room list.
 
         Args:
-            appservice_id: ID of the appservice that owns the list
-            network_id: The ID of the network the list is associated with
-            room_id
-            visibility: either "public" or "private"
+            room_id: The ID of the room to add to the directory.
+            appservice_id: The ID of the appservice that owns the list.
+            network_id: The ID of the network the list is associated with.
         """
-        if visibility not in ["public", "private"]:
-            raise SynapseError(400, "Invalid visibility setting")
-
         await self.store.set_room_is_public_appservice(
-            room_id, appservice_id, network_id, visibility == "public"
+            room_id, appservice_id, network_id, True
+        )
+
+    async def remove_room_from_published_appservice_room_list(
+        self,
+        room_id: str,
+        appservice_id: Optional[str] = None,
+        network_id: Optional[str] = None,
+    ) -> None:
+        """Remove a room from the appservice/network specific public room list.
+
+        Args:
+            room_id: The ID of the room to remove from the directory.
+            appservice_id: The ID of the appservice that owns the list. If None, this function
+                will attempt to remove the room from all appservice lists.
+            network_id: The ID of the network the list is associated with. If None, this function
+                will attempt to remove the room from all appservice network lists.
+        """
+        await self.store.set_room_is_public_appservice(
+            room_id, appservice_id, network_id, False
         )
 
     async def get_aliases_for_room(

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -38,6 +38,7 @@ from synapse.rest.admin.media import ListMediaInRoom, register_servlets_for_medi
 from synapse.rest.admin.purge_room_servlet import PurgeRoomServlet
 from synapse.rest.admin.rooms import (
     DeleteRoomRestServlet,
+    DelistRoomFromDirectoryRestServlet,
     ForwardExtremitiesRestServlet,
     JoinRoomAliasServlet,
     ListRoomRestServlet,
@@ -214,6 +215,7 @@ def register_servlets(hs, http_server):
     Register all the admin servlets.
     """
     register_servlets_for_client_rest_resource(hs, http_server)
+    DelistRoomFromDirectoryRestServlet(hs).register(http_server)
     ListRoomRestServlet(hs).register(http_server)
     RoomStateRestServlet(hs).register(http_server)
     RoomRestServlet(hs).register(http_server)

--- a/synapse/rest/client/v1/directory.py
+++ b/synapse/rest/client/v1/directory.py
@@ -179,8 +179,17 @@ class ClientAppserviceDirectoryListServer(RestServlet):
                 403, "Only appservices can edit the appservice published room list"
             )
 
-        await self.directory_handler.edit_published_appservice_room_list(
-            requester.app_service.id, network_id, room_id, visibility
-        )
+        if visibility == "public":
+            await self.directory_handler.add_room_to_published_appservice_room_list(
+                room_id, requester.app_service.id, network_id
+            )
+        elif visibility == "private":
+            await self.directory_handler.remove_room_from_published_appservice_room_list(
+                room_id, requester.app_service.id, network_id
+            )
+        else:
+            raise SynapseError(
+                400, "Invalid visibility setting", errcode=Codes.INVALID_PARAM
+            )
 
         return 200, {}

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1396,8 +1396,6 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore, SearchStore):
                     txn,
                     table="appservice_room_list",
                     keyvalues={
-                        "appservice_id": appservice_id,
-                        "network_id": network_id,
                         "room_id": room_id,
                     },
                 )

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -559,28 +559,6 @@ class TestAppserviceRoomDirectoryList(unittest.HomeserverTestCase):
         # Check that the room is no longer in the public room directory
         self.assertFalse(self._is_room_in_public_room_directory(self.room_id))
 
-    def test_admin_remove_from_appservice_room_directory(self):
-        """Tests that a homeserver admin can remove a room from the appservice-specific room directory"""
-        # Check that the room is not currently in the public room directory
-        self.assertFalse(self._is_room_in_public_room_directory(self.room_id))
-
-        # Attempt to list the room as an appservice
-        self._set_visibility_of_appservice_room(
-            self.room_id,
-            visible=True,
-        )
-
-        # Check that the room is currently in the public room directory
-        self.assertTrue(self._is_room_in_public_room_directory(self.room_id))
-
-        # Attempt to remove the room as a homeserver admin
-        self._set_visibility_of_appservice_room(
-            self.room_id, visible=False, access_token=self.admin_tok
-        )
-
-        # Check that the room is no longer in the public room directory
-        self.assertFalse(self._is_room_in_public_room_directory(self.room_id))
-
     def _set_visibility_of_appservice_room(
         self,
         room_id: str,


### PR DESCRIPTION
Homeserver admins can already delist rooms from the public room directory by calling [`/directory/list/room/{roomId}`](https://matrix.org/docs/spec/client_server/r0.6.1#put-matrix-client-r0-directory-list-room-roomid) with an admin access token.

However, application services can also list rooms, which will appear when supplying a `third_party_instance_id` or even just setting `include_all_networks: true` when calling [`POST /publicRooms`](https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-publicrooms).

Application services can list and delist rooms via the [`PUT /directory/list/appservice/{networkId}/{roomId}`](https://matrix.org/docs/spec/application_service/r0.1.2#put-matrix-client-r0-directory-list-appservice-networkid-roomid) endpoint.

This PR allows homeserver admins to also delist appservice rooms via this endpoint. It also adds tests for that, as well as the happy paths of appservices (we didn't seem to have any) and the sad path of a normal user trying to call the endpoint.