### PR TITLE
Add timeout for resolve_service

### DIFF
--- a/changelog.d/9776.bugfix
+++ b/changelog.d/9776.bugfix
@@ -1,0 +1,1 @@
+Clarify SRV record DNS timeouts. (#9774)

--- a/changelog.d/9776.bugfix
+++ b/changelog.d/9776.bugfix
@@ -1,1 +1,1 @@
-Clarify SRV record DNS timeouts. (#9774)
+Clarify SRV record DNS timeouts (#9774).


### PR DESCRIPTION
Fixes #9774

Adds a stricter timeout to `resolve_service` that returns in 50s (smaller than the previous 60s, and the overarching 60s of timeout a federation transaction has)

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`