### PR TITLE
Fix duplicate logging of exceptions in transaction processing

### DIFF
--- a/changelog.d/9780.bugfix
+++ b/changelog.d/9780.bugfix
@@ -1,0 +1,1 @@
+Fix duplicate logging of exceptions thrown during federation transaction processing.

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -425,13 +425,9 @@ class FederationSendServlet(BaseFederationServlet):
             logger.exception(e)
             return 400, {"error": "Invalid transaction"}
 
-        try:
-            code, response = await self.handler.on_incoming_transaction(
-                origin, transaction_data
-            )
-        except Exception:
-            logger.exception("on_incoming_transaction failed")
-            raise
+        code, response = await self.handler.on_incoming_transaction(
+            origin, transaction_data
+        )
 
         return code, response
 


### PR DESCRIPTION
There's no point logging this twice.