### PR TITLE
More robust handling of the Content-Type header for thumbnail generation

### DIFF
--- a/changelog.d/9788.bugfix
+++ b/changelog.d/9788.bugfix
@@ -1,1 +1,1 @@
-Fix thumbnail generation for some sites with non-standard content types.
+Fix thumbnail generation for some sites with non-standard content types. Contributed by @rkfg.

--- a/changelog.d/9788.bugfix
+++ b/changelog.d/9788.bugfix
@@ -1,0 +1,1 @@
+Fix thumbnail generation for some sites with non-standard content types.

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -71,6 +71,7 @@ def parse_thumbnail_requirements(thumbnail_sizes):
         jpeg_thumbnail = ThumbnailRequirement(width, height, method, "image/jpeg")
         png_thumbnail = ThumbnailRequirement(width, height, method, "image/png")
         requirements.setdefault("image/jpeg", []).append(jpeg_thumbnail)
+        requirements.setdefault("image/jpg", []).append(jpeg_thumbnail)
         requirements.setdefault("image/webp", []).append(jpeg_thumbnail)
         requirements.setdefault("image/gif", []).append(png_thumbnail)
         requirements.setdefault("image/png", []).append(png_thumbnail)

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -468,6 +468,9 @@ class MediaRepository:
         return media_info
 
     def _get_thumbnail_requirements(self, media_type):
+        scpos = media_type.find(";")
+        if scpos > 0:
+            media_type = media_type[:scpos]
         return self.thumbnail_requirements.get(media_type, ())
 
     def _generate_thumbnail(

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -513,10 +513,6 @@ class PreviewUrlResource(DirectServeJsonResource):
 
                 if b"Content-Type" in headers:
                     media_type = headers[b"Content-Type"][0].decode("ascii")
-                    if media_type.startswith("image/"):
-                        scpos = media_type.find(";")
-                        if scpos > 0:
-                            media_type = media_type[:scpos]
                 else:
                     media_type = "application/octet-stream"
 

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -513,6 +513,10 @@ class PreviewUrlResource(DirectServeJsonResource):
 
                 if b"Content-Type" in headers:
                     media_type = headers[b"Content-Type"][0].decode("ascii")
+                    if media_type.startswith("image/"):
+                        scpos = media_type.find(";")
+                        if scpos > 0:
+                            media_type = media_type[:scpos]
                 else:
                     media_type = "application/octet-stream"
 


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

This PR solves thumbnail generation in previews for some sites that use not quite standard Content-Type headers as described in #2853.