### PR TITLE
Experimental Sync Speedup

### DIFF
--- a/changelog.d/9798.misc
+++ b/changelog.d/9798.misc
@@ -1,0 +1,1 @@
+Speed up `/sync` by ignoring non-encrypted rooms when updating devicelists.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -127,7 +127,7 @@ class DeviceWorkerHandler(BaseHandler):
         # First we check if any devices have changed for users that we share
         # rooms with.
         users_who_share_room = await self.store.get_users_who_share_room_with_user(
-            user_id
+            user_id, True
         )
 
         tracked_users = set(users_who_share_room)
@@ -454,7 +454,7 @@ class DeviceHandler(DeviceWorkerHandler):
             return
 
         users_who_share_room = await self.store.get_users_who_share_room_with_user(
-            user_id
+            user_id, True
         )
 
         hosts = set()  # type: Set[str]

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -1322,7 +1322,7 @@ class PresenceEventSource:
 
         # Find the users who share a room with this user
         users_who_share_room = await self.store.get_users_who_share_room_with_user(
-            user_id, on_invalidate=cache_context.invalidate
+            user_id, False, on_invalidate=cache_context.invalidate
         )
         users_interested_in.update(users_who_share_room)
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1163,7 +1163,7 @@ class SyncHandler:
             # that were in a room we've left.
 
             users_who_share_room = await self.store.get_users_who_share_room_with_user(
-                user_id
+                user_id, True
             )
 
             # Always tell the user about their own devices. We check as the user

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -174,7 +174,7 @@ class FederationSenderDevicesTestCases(HomeserverTestCase):
     def prepare(self, reactor, clock, hs):
         # stub out get_users_who_share_room_with_user so that it claims that
         # `@user2:host2` is in the room
-        def get_users_who_share_room_with_user(user_id):
+        def get_users_who_share_room_with_user(user_id, encrypted_only):
             return defer.succeed({"@user2:host2"})
 
         hs.get_datastore().get_users_who_share_room_with_user = (


### PR DESCRIPTION
This PR adds a speedup to `/sync` when the user is in many rooms with many members, the devicelist checking part of these sync requests can take up a while (1 second flat per sync) on single-user homeservers / lower-end setups.

This PR makes it so that `/sync` will only check for devicelist changes for users in encrypted rooms, thus this fixes #7524.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`