### PR TITLE
Add note to docker docs explaining platform support

### DIFF
--- a/changelog.d/9801.doc
+++ b/changelog.d/9801.doc
@@ -1,0 +1,1 @@
+Add a note to the docker docs mentioning that we mirror upstream's supported Docker platforms.

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,9 +4,10 @@ This Docker image will run Synapse as a single process. By default it uses a
 sqlite database; for production use you should connect it to a separate
 postgres database. The image also does *not* provide a TURN server.
 
-Running this image is supported on all platforms that are supported by Docker upstream.
-Note that as such, Docker's experimental WS1-backend Linux Containers on Windows
-platform is [not supported](https://github.com/docker/for-win/issues/6470).
+This image should work on all platforms that are supported by Docker upstream.
+Note that Docker's WS1-backend Linux Containers on Windows
+platform is [experimental](https://github.com/docker/for-win/issues/6470) and
+is not supported by this image.
 
 ## Volumes
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,9 +2,11 @@
 
 This Docker image will run Synapse as a single process. By default it uses a
 sqlite database; for production use you should connect it to a separate
-postgres database.
+postgres database. The image also does *not* provide a TURN server.
 
-The image also does *not* provide a TURN server.
+Running this image is supported on all platforms that are supported by Docker upstream.
+Note that as such, Docker's experimental WS1-backend Linux Containers on Windows
+platform is [not supported](https://github.com/docker/for-win/issues/6470).
 
 ## Volumes
 


### PR DESCRIPTION
Context is in https://github.com/matrix-org/synapse/issues/9764#issuecomment-818615894.

I struggled to find a more official link for this. The problem occurs when using WSL1 instead of WSL2, which some Windows platforms (at least Server 2019) still don't have. Docker have updated their documentation to paint a much happier picture now given WSL2's support.

The last sentence here can probably be removed once WSL1 is no longer around... though that will likely not be for a very long time.