### PR TITLE
Add support for static server name to hostname resolution

### DIFF
--- a/synapse/config/federation.py
+++ b/synapse/config/federation.py
@@ -45,6 +45,12 @@ class FederationConfig(Config):
             "allow_profile_lookup_over_federation", True
         )
 
+        static_server_name_resolution_map = config.get("static_server_name_resolution_map", {})
+        if type(static_server_name_resolution_map) is dict:
+            self.static_server_name_resolution_map = {
+                server_name.encode("ascii"): hostname.encode("ascii") for server_name, hostname in static_server_name_resolution_map.items()
+            }
+
     def generate_config_section(self, config_dir_path, server_name, **kwargs):
         return """\
         ## Federation ##
@@ -76,6 +82,14 @@ class FederationConfig(Config):
         # on this homeserver. Defaults to 'true'.
         #
         #allow_profile_lookup_over_federation: false
+
+        # Static server name to hostname resolution
+        # Use this map from “stored server name” to “current hostname” when your
+        # hostname can change and consequently can't be used as homeserver name.
+        # This map is looked up just before "well known" delegation.
+        # If not specified, defaults to empty, no static resolution is applied.
+        #static_server_name_resolution_map:
+        #  "123456789.mycompany.com": "example.com"
         """
 
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -249,6 +249,7 @@ class MatrixFederationHttpClient:
             tls_client_options_factory,
             user_agent,
             hs.config.federation_ip_range_blacklist,
+            hs.config.static_server_name_resolution_map,
         )
 
         # Use a BlacklistingAgentWrapper to prevent circumventing the IP


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Other todos:
- run `generate_sample_config`
- fix tests: all `MatrixFederationAgentTests` are failing (`__init__() missing 1 required positional argument: 'static_server_name_resolution_map'`)
I currently have these changes on a branch that I'll try to push to synapse repo if possible, just so that it's available in the future if needed.