### PR TITLE
remove `HomeServer.get_config`

### DIFF
--- a/changelog.d/9815.misc
+++ b/changelog.d/9815.misc
@@ -1,0 +1,1 @@
+Replace `HomeServer.get_config()` with inline references.

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -643,7 +643,7 @@ class GenericWorkerServer(HomeServer):
                     listener.bind_addresses, listener.port, manhole_globals={"hs": self}
                 )
             elif listener.type == "metrics":
-                if not self.get_config().enable_metrics:
+                if not self.config.enable_metrics:
                     logger.warning(
                         (
                             "Metrics listener configured, but "

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -191,7 +191,7 @@ class SynapseHomeServer(HomeServer):
                 }
             )
 
-            if self.get_config().threepid_behaviour_email == ThreepidBehaviour.LOCAL:
+            if self.config.threepid_behaviour_email == ThreepidBehaviour.LOCAL:
                 from synapse.rest.synapse.client.password_reset import (
                     PasswordResetSubmitTokenResource,
                 )
@@ -230,7 +230,7 @@ class SynapseHomeServer(HomeServer):
             )
 
         if name in ["media", "federation", "client"]:
-            if self.get_config().enable_media_repo:
+            if self.config.enable_media_repo:
                 media_repo = self.get_media_repository_resource()
                 resources.update(
                     {MEDIA_PREFIX: media_repo, LEGACY_MEDIA_PREFIX: media_repo}
@@ -244,7 +244,7 @@ class SynapseHomeServer(HomeServer):
             resources[SERVER_KEY_V2_PREFIX] = KeyApiV2Resource(self)
 
         if name == "webclient":
-            webclient_loc = self.get_config().web_client_location
+            webclient_loc = self.config.web_client_location
 
             if webclient_loc is None:
                 logger.warning(
@@ -265,7 +265,7 @@ class SynapseHomeServer(HomeServer):
                 # https://twistedmatrix.com/trac/ticket/7678
                 resources[WEB_CLIENT_PREFIX] = File(webclient_loc)
 
-        if name == "metrics" and self.get_config().enable_metrics:
+        if name == "metrics" and self.config.enable_metrics:
             resources[METRICS_PREFIX] = MetricsResource(RegistryProxy)
 
         if name == "replication":
@@ -274,9 +274,7 @@ class SynapseHomeServer(HomeServer):
         return resources
 
     def start_listening(self, listeners: Iterable[ListenerConfig]):
-        config = self.get_config()
-
-        if config.redis_enabled:
+        if self.config.redis_enabled:
             # If redis is enabled we connect via the replication command handler
             # in the same way as the workers (since we're effectively a client
             # rather than a server).
@@ -284,7 +282,9 @@ class SynapseHomeServer(HomeServer):
 
         for listener in listeners:
             if listener.type == "http":
-                self._listening_services.extend(self._listener_http(config, listener))
+                self._listening_services.extend(
+                    self._listener_http(self.config, listener)
+                )
             elif listener.type == "manhole":
                 _base.listen_manhole(
                     listener.bind_addresses, listener.port, manhole_globals={"hs": self}
@@ -298,7 +298,7 @@ class SynapseHomeServer(HomeServer):
                 for s in services:
                     reactor.addSystemEventTrigger("before", "shutdown", s.stopListening)
             elif listener.type == "metrics":
-                if not self.get_config().enable_metrics:
+                if not self.config.enable_metrics:
                     logger.warning(
                         (
                             "Metrics listener configured, but "

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -501,7 +501,7 @@ class StoreKeyFetcher(KeyFetcher):
 class BaseV2KeyFetcher(KeyFetcher):
     def __init__(self, hs: "HomeServer"):
         self.store = hs.get_datastore()
-        self.config = hs.get_config()
+        self.config = hs.config
 
     async def process_v2_response(
         self, from_server: str, response_json: JsonDict, time_added_ms: int

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -136,7 +136,7 @@ class FederationServer(FederationBase):
         )  # type: ResponseCache[Tuple[str, str]]
 
         self._federation_metrics_domains = (
-            hs.get_config().federation.federation_metrics_domains
+            hs.config.federation.federation_metrics_domains
         )
 
     async def on_backfill_request(

--- a/synapse/federation/sender/transaction_manager.py
+++ b/synapse/federation/sender/transaction_manager.py
@@ -56,7 +56,7 @@ class TransactionManager:
         self._transport_layer = hs.get_federation_transport_client()
 
         self._federation_metrics_domains = (
-            hs.get_config().federation.federation_metrics_domains
+            hs.config.federation.federation_metrics_domains
         )
 
         # HACK to get unique tx id

--- a/synapse/rest/media/v1/config_resource.py
+++ b/synapse/rest/media/v1/config_resource.py
@@ -30,7 +30,7 @@ class MediaConfigResource(DirectServeJsonResource):
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
-        config = hs.get_config()
+        config = hs.config
         self.clock = hs.get_clock()
         self.auth = hs.get_auth()
         self.limits_dict = {"m.upload.size": config.max_upload_size}

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -319,9 +319,6 @@ class HomeServer(metaclass=abc.ABCMeta):
 
         return self.datastores
 
-    def get_config(self) -> HomeServerConfig:
-        return self.config
-
     @cache_in_self
     def get_distributor(self) -> Distributor:
         return Distributor()

--- a/tests/app/test_openid_listener.py
+++ b/tests/app/test_openid_listener.py
@@ -109,7 +109,7 @@ class SynapseHomeserverOpenIDListenerTests(HomeserverTestCase):
         }
 
         # Listen with the config
-        self.hs._listener_http(self.hs.get_config(), parse_listener_def(config))
+        self.hs._listener_http(self.hs.config, parse_listener_def(config))
 
         # Grab the resource from the site that was told to listen
         site = self.reactor.tcpServers[0][1]


### PR DESCRIPTION
Every single time I want to access the config object, I have to remember
whether or not we use `get_config`. Let's just get rid of it.