### PR TITLE
Add Application Service registration type requirement + py35, pg95 deprecation notices to v1.32.0 upgrade notes

### DIFF
--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -106,8 +106,8 @@ has been available since Synapse 1.7.0 (2019-12-13), and is accessible under ``G
 
 The deprecation of the old endpoint was announced with Synapse 1.28.0 (released on 2021-02-25).
 
-Application Services must use type ``m.login.application`` when registering users
----------------------------------------------------------------------------------
+Application Services must use type ``m.login.application_service`` when registering users
+-----------------------------------------------------------------------------------------
 
 In compliance with the
 `Application Service spec <https://matrix.org/docs/spec/application_service/r0.1.2#server-admin-style-permissions>`_,

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -91,7 +91,7 @@ Upgrading to v1.32.0
 Dropping support for end-of-life Python, Postgres and SQLite versions
 ---------------------------------------------------------------------
 
-In line with our `deprecation policy <https://github.com/matrix-org/synapse/blob/v1.32.0rc1/docs/deprecation_policy.md>`_,
+In line with our `deprecation policy <https://github.com/matrix-org/synapse/blob/release-v1.32.0/docs/deprecation_policy.md>`_,
 we've dropped support for Python 3.5 and PostgreSQL 9.5, as they are no longer supported upstream.
 
 This release of Synapse requires Python 3.6+ and PostgresSQL 9.6+ or SQLite 3.22+.

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -112,7 +112,7 @@ Application Services must use type ``m.login.application`` when registering user
 In compliance with the
 `Application Service spec <https://matrix.org/docs/spec/application_service/r0.1.2#server-admin-style-permissions>`_,
 Application Services are now required to use the ``m.login.application_service`` type when registering users via the
-``/_matrix/client/r0/register`` endpoint.
+``/_matrix/client/r0/register`` endpoint. This behaviour was deprecated in Synapse v1.30.0.
 
 Please ensure your Application Services are up to date.
 

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -88,6 +88,14 @@ for example:
 Upgrading to v1.32.0
 ====================
 
+Dropping support for end-of-life Python, Postgres and SQLite versions
+---------------------------------------------------------------------
+
+In line with our `deprecation policy <https://github.com/matrix-org/synapse/blob/v1.32.0rc1/docs/deprecation_policy.md>`_,
+we've dropped support for Python 3.5 and PostgreSQL 9.5, as they are no longer supported upstream.
+
+This release of Synapse requires Python 3.6+ and PostgresSQL 9.6+ or SQLite 3.22+.
+
 Removal of old List Accounts Admin API
 --------------------------------------
 
@@ -97,6 +105,16 @@ The `v2 list accounts API <https://github.com/matrix-org/synapse/blob/master/doc
 has been available since Synapse 1.7.0 (2019-12-13), and is accessible under ``GET /_synapse/admin/v2/users``.
 
 The deprecation of the old endpoint was announced with Synapse 1.28.0 (released on 2021-02-25).
+
+Application Services must use type ``m.login.application`` when registering users
+---------------------------------------------------------------------------------
+
+In compliance with the
+`Application Service spec <https://matrix.org/docs/spec/application_service/r0.1.2#server-admin-style-permissions>`_,
+Application Services are now required to use the ``m.login.application_service`` type when registering users via the
+``/_matrix/client/r0/register`` endpoint.
+
+Please ensure your Application Services are up to date.
 
 Upgrading to v1.29.0
 ====================

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -88,8 +88,8 @@ for example:
 Upgrading to v1.32.0
 ====================
 
-Dropping support for end-of-life Python, Postgres and SQLite versions
----------------------------------------------------------------------
+Dropping support for old Python, Postgres and SQLite versions
+-------------------------------------------------------------
 
 In line with our `deprecation policy <https://github.com/matrix-org/synapse/blob/release-v1.32.0/docs/deprecation_policy.md>`_,
 we've dropped support for Python 3.5 and PostgreSQL 9.5, as they are no longer supported upstream.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/9846.

Adds important removal information from the top of https://github.com/matrix-org/synapse/releases/tag/v1.32.0rc1 into UPGRADE.rst.