### PR TITLE
Fix bug where we sent remote presence states to remote servers

### DIFF
--- a/changelog.d/9850.feature
+++ b/changelog.d/9850.feature
@@ -1,0 +1,1 @@
+Add experimental support for handling presence on a worker.

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -539,6 +539,10 @@ class FederationSender(AbstractFederationSender):
             # No-op if presence is disabled.
             return
 
+        # Ensure we only send out presence states for local users.
+        for state in states:
+            assert self.is_mine_id(state.user_id)
+
         for destination in destinations:
             if destination == self.server_name:
                 continue


### PR DESCRIPTION
Broke in #9828.

The reason for filtering the presence state in `maybe_send_presence_to_interested_destinations` is that otherwise we'd do it at each call site.