### PR TITLE
Make LoggingContext's name optional

### DIFF
--- a/changelog.d/9857.bugfix
+++ b/changelog.d/9857.bugfix
@@ -1,0 +1,1 @@
+Fix a regression in Synapse v1.32.1 which caused `LoggingContext` errors in plugins.

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -258,7 +258,8 @@ class LoggingContext:
           child to the parent
 
     Args:
-        name (str): Name for the context for debugging.
+        name: Name for the context for logging. If this is omitted, it is
+           inherited from the parent context.
         parent_context (LoggingContext|None): The parent of the new context
     """
 
@@ -277,12 +278,11 @@ class LoggingContext:
 
     def __init__(
         self,
-        name: str,
+        name: Optional[str] = None,
         parent_context: "Optional[LoggingContext]" = None,
         request: Optional[ContextRequest] = None,
     ) -> None:
         self.previous_context = current_context()
-        self.name = name
 
         # track the resources used by this context so far
         self._resource_usage = ContextResourceUsage()
@@ -313,6 +313,15 @@ class LoggingContext:
         if request is not None:
             # the request param overrides the request from the parent context
             self.request = request
+
+        # if we don't have a `name`, but do have a parent context, use its name.
+        if self.parent_context and not name:
+            name = str(self.parent_context)
+        if not name:
+            raise ValueError(
+                "LoggingContext must be given either a name or a parent context"
+            )
+        self.name = name
 
     def __str__(self) -> str:
         return self.name

--- a/synapse/logging/context.py
+++ b/synapse/logging/context.py
@@ -315,9 +315,9 @@ class LoggingContext:
             self.request = request
 
         # if we don't have a `name`, but do have a parent context, use its name.
-        if self.parent_context and not name:
+        if self.parent_context and name is None:
             name = str(self.parent_context)
-        if not name:
+        if name is None:
             raise ValueError(
                 "LoggingContext must be given either a name or a parent context"
             )


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse-s3-storage-provider/issues/55