### PR TITLE
Note LoggingContext signature change incompatibility in 1.32.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,11 @@ Synapse 1.32.0 (2021-04-20)
 that can overwhelm connected Prometheus instances. This issue was not present in
 1.32.0rc1, and is fixed in 1.32.1. See the changelog for 1.32.1 above for more information.
 
+**Note:** This release also introduces a change that may affected Synapse modules that
+import `synapse.logging.context.LoggingContext`, such as
+[synapse-s3-storage-provider](https://github.com/matrix-org/synapse-s3-storage-provider).
+This will be fixed in a later Synapse version.
+
 **Note:** This release requires Python 3.6+ and Postgres 9.6+ or SQLite 3.22+.
 
 This release removes the deprecated `GET /_synapse/admin/v1/users/<user_id>` admin API. Please use the [v2 API](https://github.com/matrix-org/synapse/blob/develop/docs/admin_api/user_admin_api.rst#query-user-account) instead, which has improved capabilities.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,8 +20,8 @@ Synapse 1.32.0 (2021-04-20)
 that can overwhelm connected Prometheus instances. This issue was not present in
 1.32.0rc1, and is fixed in 1.32.1. See the changelog for 1.32.1 above for more information.
 
-**Note:** This release also introduces a change that may affected Synapse modules that
-import `synapse.logging.context.LoggingContext`, such as
+**Note:** This release also mistakenly included a change that may affected Synapse 
+modules that import `synapse.logging.context.LoggingContext`, such as
 [synapse-s3-storage-provider](https://github.com/matrix-org/synapse-s3-storage-provider).
 This will be fixed in a later Synapse version.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Synapse 1.32.0 (2021-04-20)
 
 **Note:** This release introduces [a regression](https://github.com/matrix-org/synapse/issues/9853)
 that can overwhelm connected Prometheus instances. This issue was not present in
-1.32.0rc1. If affeected, it is recommended to downgrade to 1.31.0 in the meantime, and 
+1.32.0rc1. If affected, it is recommended to downgrade to 1.31.0 in the meantime, and 
 follow [these instructions](https://github.com/matrix-org/synapse/pull/9854#issuecomment-823472183)
 to clean up any excess writeahead logs.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,10 @@ Synapse 1.32.1 (2021-04-21)
 ===========================
 
 This release fixes [a regression](https://github.com/matrix-org/synapse/issues/9853)
-in Synapse 1.32.0 that caused connected Prometheus instances to become unstable. If you
-ran Synapse 1.32.0 with Prometheus metrics, first upgrade to Synapse 1.32.1 and follow
-[these instructions](https://github.com/matrix-org/synapse/pull/9854#issuecomment-823472183)
-to clean up any excess writeahead logs.
+in Synapse 1.32.0 that caused connected Prometheus instances to become unstable. 
+
+However, as this release is still subject to the `LoggingContext` change in 1.32.0,
+it is recommended to remain on or downgrade to 1.31.0.
 
 Bugfixes
 --------
@@ -18,7 +18,9 @@ Synapse 1.32.0 (2021-04-20)
 
 **Note:** This release introduces [a regression](https://github.com/matrix-org/synapse/issues/9853)
 that can overwhelm connected Prometheus instances. This issue was not present in
-1.32.0rc1, and is fixed in 1.32.1. See the changelog for 1.32.1 above for more information.
+1.32.0rc1. If affeected, it is recommended to downgrade to 1.31.0 in the meantime, and 
+follow [these instructions](https://github.com/matrix-org/synapse/pull/9854#issuecomment-823472183)
+to clean up any excess writeahead logs.
 
 **Note:** This release also mistakenly included a change that may affected Synapse 
 modules that import `synapse.logging.context.LoggingContext`, such as

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -88,15 +88,6 @@ for example:
 Upgrading to v1.32.0
 ====================
 
-Changes to synapse.logging.context.LoggingContext affecting some Synapse modules
---------------------------------------------------------------------------------
-
-This release is incompatible with the current version (commit hash ``3c3fafd``) of
-`synapse-s3-storage-provider <https://github.com/matrix-org/synapse-s3-storage-provider/>`_. The
-module makes use of ``synapse.logging.context.LoggingContext``, which changed its signature in this release.
-
-A future release will provide backwards compatibility for this usage.
-
 Regression causing connected Prometheus instances to become overwhelmed
 -----------------------------------------------------------------------
 

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -88,6 +88,15 @@ for example:
 Upgrading to v1.32.0
 ====================
 
+Changes to synapse.logging.context.LoggingContext affecting some Synapse modules
+--------------------------------------------------------------------------------
+
+This release is incompatible with the current version (commit hash ``3c3fafd``) of
+`synapse-s3-storage-provider <https://github.com/matrix-org/synapse-s3-storage-provider/>`_. The
+module makes use of ``synapse.logging.context.LoggingContext``, which changed its signature in this release.
+
+A future release will provide backwards compatibility for this usage.
+
 Regression causing connected Prometheus instances to become overwhelmed
 -----------------------------------------------------------------------
 

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -93,11 +93,11 @@ Regression causing connected Prometheus instances to become overwhelmed
 
 This release introduces `a regression <https://github.com/matrix-org/synapse/issues/9853>`_
 that can overwhelm connected Prometheus instances. This issue is not present in
-Synapse v1.32.0rc1, and is fixed in Synapse v1.32.1.
+Synapse v1.32.0rc1.
 
-If you have been affected, please first upgrade to a more recent Synapse version.
-You then may need to remove excess writeahead logs in order for Prometheus to recover.
-Instructions for doing so are provided
+If you have been affected, please downgrade to 1.31.0. You then may need to
+remove excess writeahead logs in order for Prometheus to recover. Instructions
+for doing so are provided
 `here <https://github.com/matrix-org/synapse/pull/9854#issuecomment-823472183>`_.
 
 Dropping support for old Python, Postgres and SQLite versions


### PR DESCRIPTION
1.32.0 also introduced an incompatibility with Synapse modules that make use of `synapse.logging.context.LoggingContext`, such as [synapse-s3-storage-provider](https://github.com/matrix-org/synapse-s3-storage-provider).

This PR adds a note to the 1.32.0 changelog and upgrade notes about it.