### PR TITLE
Remove room and user invite ratelimits in default unit test config

### DIFF
--- a/changelog.d/9871.misc
+++ b/changelog.d/9871.misc
@@ -1,0 +1,1 @@
+Disable invite rate-limiting by default when running the unit tests.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -153,6 +153,10 @@ def default_config(name, parse=False):
             "local": {"per_second": 10000, "burst_count": 10000},
             "remote": {"per_second": 10000, "burst_count": 10000},
         },
+        "rc_invites": {
+            "per_room": {"per_second": 10000, "burst_count": 10000},
+            "per_user": {"per_second": 10000, "burst_count": 10000},
+        },
         "rc_3pid_validation": {"per_second": 10000, "burst_count": 10000},
         "saml2_enabled": False,
         "public_baseurl": None,


### PR DESCRIPTION
I was hitting room invite rate limits in [this test](https://github.com/matrix-org/synapse-dinsic/blob/0060eb332c307887ca0a911f91940de0cea2bdef/tests/rest/client/test_room_access_rules.py#L851-L977). With the `prepare` statement and the invites in the test itself I was finding 429's failing the test.

I think it may just be a matter of time before we run into a similar issue in a future unit test. So raising the rate limit for tests by default seemed like the thing to do.