### PR TITLE
pass a reactor into SynapseSite

### DIFF
--- a/changelog.d/9874.misc
+++ b/changelog.d/9874.misc
@@ -1,0 +1,1 @@
+Pass a reactor into `SynapseSite` to make testing easier.

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -390,6 +390,7 @@ class GenericWorkerServer(HomeServer):
                 listener_config,
                 root_resource,
                 self.version_string,
+                reactor=self.get_reactor(),
             ),
             reactor=self.get_reactor(),
         )

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -126,19 +126,20 @@ class SynapseHomeServer(HomeServer):
         else:
             root_resource = OptionsResource()
 
-        root_resource = create_resource_tree(resources, root_resource)
+        site = SynapseSite(
+            "synapse.access.%s.%s" % ("https" if tls else "http", site_tag),
+            site_tag,
+            listener_config,
+            create_resource_tree(resources, root_resource),
+            self.version_string,
+            reactor=self.get_reactor(),
+        )
 
         if tls:
             ports = listen_ssl(
                 bind_addresses,
                 port,
-                SynapseSite(
-                    "synapse.access.https.%s" % (site_tag,),
-                    site_tag,
-                    listener_config,
-                    root_resource,
-                    self.version_string,
-                ),
+                site,
                 self.tls_server_context_factory,
                 reactor=self.get_reactor(),
             )
@@ -148,13 +149,7 @@ class SynapseHomeServer(HomeServer):
             ports = listen_tcp(
                 bind_addresses,
                 port,
-                SynapseSite(
-                    "synapse.access.http.%s" % (site_tag,),
-                    site_tag,
-                    listener_config,
-                    root_resource,
-                    self.version_string,
-                ),
+                site,
                 reactor=self.get_reactor(),
             )
             logger.info("Synapse now listening on TCP port %d", port)

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -349,6 +349,7 @@ class BaseMultiWorkerStreamTestCase(unittest.HomeserverTestCase):
             config=worker_hs.config.server.listeners[0],
             resource=resource,
             server_version_string="1",
+            reactor=self.reactor,
         )
 
         if worker_hs.config.redis.redis_enabled:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -202,6 +202,7 @@ class OptionsResourceTests(unittest.TestCase):
             parse_listener_def({"type": "http", "port": 0}),
             self.resource,
             "1.0",
+            reactor=self.reactor,
         )
 
         # render the request and return the channel

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -247,6 +247,7 @@ class HomeserverTestCase(TestCase):
             config=self.hs.config.server.listeners[0],
             resource=self.resource,
             server_version_string="1",
+            reactor=self.reactor,
         )
 
         from tests.rest.client.v1.utils import RestHelper


### PR DESCRIPTION
It turns out that `Site` takes a `reactor` argument. Then it attaches that reactor's `callLater` to any `HTTPChannel`s that the site creates (via a bit of hackery in [`HTTPFactory.buildProtocol`](https://github.com/twisted/twisted/blob/fc76fcbeb9e8b96eed30761a5bfca6e9be115f5c/src/twisted/web/http.py#L3167)).

This is particularly important to get right in test code, because otherwise `HTTPChannel` ends up setting timeouts on the *default* reactor, which then makes trial complain about a dirty reactor; but since some tests use the homeserver's default site, we need to get it right for that code too.

