### PR TITLE
Use current state table for `presence.get_interested_remotes`

### DIFF
--- a/changelog.d/9887.misc
+++ b/changelog.d/9887.misc
@@ -1,0 +1,1 @@
+Small performance improvement around handling new local presence updates.


### PR DESCRIPTION
This should be a lot quicker than asking the state handler.