### PR TITLE
Remove usage of deprecated attrs cmp argument

### DIFF
--- a/changelog.d/9892.misc
+++ b/changelog.d/9892.misc
@@ -1,0 +1,1 @@
+Remove usage of deprecated `cmp` argument in the `attr.s` decorator.

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@attr.s(slots=True, cmp=False)
+@attr.s(slots=True, eq=False, order=False)
 class VerifyJsonRequest:
     """
     A request to verify a JSON object.

--- a/synapse/events/builder.py
+++ b/synapse/events/builder.py
@@ -34,7 +34,7 @@ from synapse.util import Clock
 from synapse.util.stringutils import random_string
 
 
-@attr.s(slots=True, cmp=False, frozen=True)
+@attr.s(slots=True, eq=False, order=False, frozen=True)
 class EventBuilder:
     """A format independent event builder used to build up the event content
     before signing the event.

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -404,7 +404,7 @@ def map_username_to_mxid_localpart(
     return username.decode("ascii")
 
 
-@attr.s(frozen=True, slots=True, cmp=False)
+@attr.s(frozen=True, slots=True, eq=False, order=False)
 class RoomStreamToken:
     """Tokens are positions between events. The token "s1" comes after event 1.
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -479,7 +479,7 @@ def get_clock():
 
 
 @implementer(ITransport)
-@attr.s(cmp=False)
+@attr.s(eq=False, order=False)
 class FakeTransport:
     """
     A twisted.internet.interfaces.ITransport implementation which sends all its data


### PR DESCRIPTION
The `cmp` argument to the `attr.s` decorator [is deprecated](https://www.attrs.org/en/stable/api.html#attr.s).
This replaces it with `eq` and `order` as suggested in the attrs docs.

Fixes: #9641
Signed-off-by: Ulrich Petri <github@ulo.pe>

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
