### PR TITLE
Use the parent's logging context name for runWithConnection.

### DIFF
--- a/changelog.d/9895.bugfix
+++ b/changelog.d/9895.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.32.0 where the associated connection was improperly logged for SQL logging statements.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -718,7 +718,9 @@ class DatabasePool:
             # pool).
             assert not self.engine.in_transaction(conn)
 
-            with LoggingContext("runWithConnection", parent_context) as context:
+            with LoggingContext(
+                str(curr_context), parent_context=parent_context
+            ) as context:
                 sched_duration_sec = monotonic_time() - start_time
                 sql_scheduling_timer.observe(sched_duration_sec)
                 context.add_database_scheduled(sched_duration_sec)


### PR DESCRIPTION
Fixes #9893 hopefully. This should now log the connection ID for log lines.

I audited places where we create `LoggingContext` (again), but the rest seemed OK? Would appreciate a double checking though.