### PR TITLE
Don't set the external cache if its been done recently

### DIFF
--- a/changelog.d/9905.feature
+++ b/changelog.d/9905.feature
@@ -1,0 +1,1 @@
+Improve performance of sending events for worker-based deployments using Redis.

--- a/changelog.d/9905.misc
+++ b/changelog.d/9905.misc
@@ -1,0 +1,1 @@
+Don't set the external cache for "joined hosts" if its been done recently.

--- a/changelog.d/9905.misc
+++ b/changelog.d/9905.misc
@@ -1,1 +1,0 @@
-Don't set the external cache for "joined hosts" if its been done recently.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2446,7 +2446,9 @@ class FederationHandler(BaseHandler):
         # If we are going to send this event over federation we precaclculate
         # the joined hosts.
         if event.internal_metadata.get_send_on_behalf_of():
-            await self.event_creation_handler.cache_joined_hosts_for_event(event)
+            await self.event_creation_handler.cache_joined_hosts_for_event(
+                event, context
+            )
 
         return context
 

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1022,6 +1022,9 @@ class EventCreationHandler:
         if not self._external_cache.is_enabled():
             return
 
+        # If external cache is enabled we should always have this.
+        assert self._external_cache_joined_hosts_updates
+
         # We actually store two mappings, event ID -> prev state group,
         # state group -> joined hosts, which is much more space efficient
         # than event ID -> joined hosts.
@@ -1037,9 +1040,8 @@ class EventCreationHandler:
         )
 
         if state_entry.state_group:
-            if self._external_cache_joined_hosts_updates:
-                if state_entry.state_group in self._external_cache_joined_hosts_updates:
-                    return
+            if state_entry.state_group in self._external_cache_joined_hosts_updates:
+                return
 
             joined_hosts = await self.store.get_joined_hosts(event.room_id, state_entry)
 
@@ -1058,8 +1060,7 @@ class EventCreationHandler:
                 expiry_ms=60 * 60 * 1000,
             )
 
-            if self._external_cache_joined_hosts_updates:
-                self._external_cache_joined_hosts_updates[context.prev_group] = None
+            self._external_cache_joined_hosts_updates[state_entry.state_group] = None
 
     async def _validate_canonical_alias(
         self, directory_handler, room_alias_str: str, expected_room_id: str

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1023,7 +1023,7 @@ class EventCreationHandler:
             return
 
         # If external cache is enabled we should always have this.
-        assert self._external_cache_joined_hosts_updates
+        assert self._external_cache_joined_hosts_updates is not None
 
         # We actually store two mappings, event ID -> prev state group,
         # state group -> joined hosts, which is much more space efficient


### PR DESCRIPTION
This may shave some time off event sending and make Redis less busy.