### PR TITLE
Support stable MSC1772 spaces identifiers.

### DIFF
--- a/changelog.d/9915.feature
+++ b/changelog.d/9915.feature
@@ -1,0 +1,1 @@
+Support stable identifiers from [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772).

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -110,6 +110,8 @@ class EventTypes:
 
     Dummy = "org.matrix.dummy_event"
 
+    SpaceChild = "m.space.child"
+    SpaceParent = "m.space.parent"
     MSC1772_SPACE_CHILD = "org.matrix.msc1772.space.child"
     MSC1772_SPACE_PARENT = "org.matrix.msc1772.space.parent"
 

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -176,6 +176,7 @@ class EventContentFields:
     SELF_DESTRUCT_AFTER = "org.matrix.self_destruct_after"
 
     # cf https://github.com/matrix-org/matrix-doc/pull/1772
+    ROOM_TYPE = "m.type"
     MSC1772_ROOM_TYPE = "org.matrix.msc1772.type"
 
 

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -332,7 +332,9 @@ class SpaceSummaryHandler:
         )
 
         # TODO: update once MSC1772 lands
-        room_type = create_event.content.get(EventContentFields.MSC1772_ROOM_TYPE)
+        room_type = create_event.content.get(EventContentFields.ROOM_TYPE)
+        if not room_type:
+            room_type = create_event.content.get(EventContentFields.MSC1772_ROOM_TYPE)
 
         entry = {
             "room_id": stats["room_id"],

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -288,6 +288,7 @@ class SpaceSummaryHandler:
             ev.data
             for ev in res.events
             if ev.event_type == EventTypes.MSC1772_SPACE_CHILD
+            or ev.event_type == EventTypes.SpaceChild
         )
 
     async def _is_room_accessible(self, room_id: str, requester: Optional[str]) -> bool:
@@ -360,8 +361,9 @@ class SpaceSummaryHandler:
             [
                 event_id
                 for key, event_id in current_state_ids.items()
-                # TODO: update once MSC1772 lands
+                # TODO: update once MSC1772 has been FCP for a period of time.
                 if key[0] == EventTypes.MSC1772_SPACE_CHILD
+                or key[0] == EventTypes.SpaceChild
             ]
         )
 


### PR DESCRIPTION
Blocked on FCP matrix-org/matrix-doc#1772.

Also see matrix-org/matrix-js-sdk#1679, matrix-org/complement#107.