### PR TITLE
Leave out optional keys from /sync

### DIFF
--- a/changelog.d/9919.feature
+++ b/changelog.d/9919.feature
@@ -1,0 +1,1 @@
+Strip empty objects and list from the `/sync` response.

--- a/changelog.d/9919.feature
+++ b/changelog.d/9919.feature
@@ -1,1 +1,1 @@
-Strip empty objects and list from the `/sync` response.
+Omit empty fields from the `/sync` response.  Contributed by @deepbluev7.

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -235,15 +235,10 @@ class SyncRestServlet(RestServlet):
         response["next_batch"] = await sync_result.next_batch.to_string(self.store)
         response.update(
             {
-                "account_data": {"events": sync_result.account_data},
-                "to_device": {"events": sync_result.to_device},
                 "device_lists": {
                     "changed": list(sync_result.device_lists.changed),
                     "left": list(sync_result.device_lists.left),
                 },
-                "presence": SyncRestServlet.encode_presence(
-                    sync_result.presence, time_now
-                ),
                 "rooms": {"join": joined, "invite": invited, "leave": archived},
                 "groups": {
                     "join": sync_result.groups.join,
@@ -254,6 +249,16 @@ class SyncRestServlet(RestServlet):
                 "org.matrix.msc2732.device_unused_fallback_key_types": sync_result.device_unused_fallback_key_types,
             }
         )
+
+        if sync_result.account_data:
+            response["account_data"] = {"events": sync_result.account_data}
+        if sync_result.presence:
+            response["presence"] = SyncRestServlet.encode_presence(
+                sync_result.presence, time_now
+            )
+
+        if sync_result.to_device:
+            response["to_device"] = {"events": sync_result.to_device}
 
         return response
 

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -239,7 +239,6 @@ class SyncRestServlet(RestServlet):
                     "changed": list(sync_result.device_lists.changed),
                     "left": list(sync_result.device_lists.left),
                 },
-                "rooms": {"join": joined, "invite": invited, "leave": archived},
                 "groups": {
                     "join": sync_result.groups.join,
                     "invite": sync_result.groups.invite,
@@ -259,6 +258,13 @@ class SyncRestServlet(RestServlet):
 
         if sync_result.to_device:
             response["to_device"] = {"events": sync_result.to_device}
+
+        if joined:
+            response["rooms"]["join"] = joined
+        if invited:
+            response["rooms"]["invite"] = invited
+        if archived:
+            response["rooms"]["leave"] = archived
 
         return response
 

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -235,10 +235,6 @@ class SyncRestServlet(RestServlet):
         response["next_batch"] = await sync_result.next_batch.to_string(self.store)
         response.update(
             {
-                "device_lists": {
-                    "changed": list(sync_result.device_lists.changed),
-                    "left": list(sync_result.device_lists.left),
-                },
                 "device_one_time_keys_count": sync_result.device_one_time_keys_count,
                 "org.matrix.msc2732.device_unused_fallback_key_types": sync_result.device_unused_fallback_key_types,
             }
@@ -253,6 +249,11 @@ class SyncRestServlet(RestServlet):
 
         if sync_result.to_device:
             response["to_device"] = {"events": sync_result.to_device}
+
+        if sync_result.device_lists.changed:
+            response["device_lists"]["changed"] = list(sync_result.device_lists.changed)
+        if sync_result.device_lists.left:
+            response["device_lists"]["left"] = list(sync_result.device_lists.left)
 
         if joined:
             response["rooms"]["join"] = joined

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -239,11 +239,6 @@ class SyncRestServlet(RestServlet):
                     "changed": list(sync_result.device_lists.changed),
                     "left": list(sync_result.device_lists.left),
                 },
-                "groups": {
-                    "join": sync_result.groups.join,
-                    "invite": sync_result.groups.invite,
-                    "leave": sync_result.groups.leave,
-                },
                 "device_one_time_keys_count": sync_result.device_one_time_keys_count,
                 "org.matrix.msc2732.device_unused_fallback_key_types": sync_result.device_unused_fallback_key_types,
             }
@@ -265,6 +260,13 @@ class SyncRestServlet(RestServlet):
             response["rooms"]["invite"] = invited
         if archived:
             response["rooms"]["leave"] = archived
+
+        if sync_result.groups.join:
+            response["groups"]["join"] = sync_result.groups.join
+        if sync_result.groups.invite:
+            response["groups"]["invite"] = sync_result.groups.invite
+        if sync_result.groups.leave:
+            response["groups"]["leave"] = sync_result.groups.leave
 
         return response
 

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -233,12 +233,6 @@ class SyncRestServlet(RestServlet):
 
         response: dict = defaultdict(dict)
         response["next_batch"] = await sync_result.next_batch.to_string(self.store)
-        response.update(
-            {
-                "device_one_time_keys_count": sync_result.device_one_time_keys_count,
-                "org.matrix.msc2732.device_unused_fallback_key_types": sync_result.device_unused_fallback_key_types,
-            }
-        )
 
         if sync_result.account_data:
             response["account_data"] = {"events": sync_result.account_data}
@@ -254,6 +248,15 @@ class SyncRestServlet(RestServlet):
             response["device_lists"]["changed"] = list(sync_result.device_lists.changed)
         if sync_result.device_lists.left:
             response["device_lists"]["left"] = list(sync_result.device_lists.left)
+
+        if sync_result.device_one_time_keys_count:
+            response[
+                "device_one_time_keys_count"
+            ] = sync_result.device_one_time_keys_count
+        if sync_result.device_unused_fallback_key_types:
+            response[
+                "org.matrix.msc2732.device_unused_fallback_key_types"
+            ] = sync_result.device_unused_fallback_key_types
 
         if joined:
             response["rooms"]["join"] = joined

--- a/tests/rest/client/v2_alpha/test_sync.py
+++ b/tests/rest/client/v2_alpha/test_sync.py
@@ -37,26 +37,7 @@ class FilterTestCase(unittest.HomeserverTestCase):
         channel = self.make_request("GET", "/sync")
 
         self.assertEqual(channel.code, 200)
-        self.assertTrue(
-            {
-                "next_batch",
-            }.issubset(set(channel.json_body.keys()))
-        )
-
-    def test_sync_presence_disabled(self):
-        """
-        When presence is disabled, the key does not appear in /sync.
-        """
-        self.hs.config.use_presence = False
-
-        channel = self.make_request("GET", "/sync")
-
-        self.assertEqual(channel.code, 200)
-        self.assertTrue(
-            {
-                "next_batch",
-            }.issubset(set(channel.json_body.keys()))
-        )
+        self.assertIn("next_batch", channel.json_body)
 
 
 class SyncFilterTestCase(unittest.HomeserverTestCase):

--- a/tests/rest/client/v2_alpha/test_sync.py
+++ b/tests/rest/client/v2_alpha/test_sync.py
@@ -40,11 +40,6 @@ class FilterTestCase(unittest.HomeserverTestCase):
         self.assertTrue(
             {
                 "next_batch",
-                "rooms",
-                "presence",
-                "account_data",
-                "to_device",
-                "device_lists",
             }.issubset(set(channel.json_body.keys()))
         )
 
@@ -60,10 +55,6 @@ class FilterTestCase(unittest.HomeserverTestCase):
         self.assertTrue(
             {
                 "next_batch",
-                "rooms",
-                "account_data",
-                "to_device",
-                "device_lists",
             }.issubset(set(channel.json_body.keys()))
         )
 

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -306,8 +306,9 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
 
         channel = self.make_request("GET", "/sync?timeout=0", access_token=tok)
 
-        invites = channel.json_body["rooms"]["invite"]
-        self.assertEqual(len(invites), 0, invites)
+        self.assertFalse(
+            "rooms" in channel.json_body, "Got invites without server notice"
+        )
 
     def test_invite_with_notice(self):
         """Tests that, if the MAU limit is hit, the server notices user invites each user
@@ -364,7 +365,8 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
             # We could also pick another user and sync with it, which would return an
             # invite to a system notices room, but it doesn't matter which user we're
             # using so we use the last one because it saves us an extra sync.
-            invites = channel.json_body["rooms"]["invite"]
+            if "rooms" in channel.json_body:
+                invites = channel.json_body["rooms"]["invite"]
 
         # Make sure we have an invite to process.
         self.assertEqual(len(invites), 1, invites)

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -306,8 +306,8 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
 
         channel = self.make_request("GET", "/sync?timeout=0", access_token=tok)
 
-        self.assertFalse(
-            "rooms" in channel.json_body, "Got invites without server notice"
+        self.assertNotIn(
+            "rooms", channel.json_body, "Got invites without server notice"
         )
 
     def test_invite_with_notice(self):


### PR DESCRIPTION
This leaves out all optional keys from /sync. This should be fine for all clients tested against conduit already, but it may break some clients, as such we should check, that at least most of them don't break horribly and maybe back out some of the individual changes. (We can probably always leave out groups for example, while the others may cause more issues.)

Clients I have tested:

- [x] Nheko
- [x] Element (slightly outdated version)
- [x] FluffyChat (old version)

This also needs an updated sytest, see https://github.com/matrix-org/sytest/pull/1040

In my testing this decreases the sync json response to about half, which saves about 30% of data on every /sync. It also makes debugging a lot easier, since the response json is easier to read. :3

Tell me if the news entry is descriptive enough, since some people may want to be aware of this change, if they are client developers or so. Also, my python skills suck, I'm sure there is a tidier way to do this. Also, no idea how to run against the newer sytest version? Is that automatic, after it is merged?


### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))



Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>

