### PR TITLE
Include the origin_server_ts of the create event in Spaces Summary.

### DIFF
--- a/changelog.d/9928.bugfix
+++ b/changelog.d/9928.bugfix
@@ -1,0 +1,1 @@
+Include the `origin_server_ts` property in the experimental [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946) support to allow clients to properly sort rooms.

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -344,7 +344,7 @@ class SpaceSummaryHandler:
                 stats["history_visibility"] == HistoryVisibility.WORLD_READABLE
             ),
             "guest_can_join": stats["guest_access"] == "can_join",
-            "origin_server_ts": create_event.origin_server_ts,
+            "creation_ts": create_event.origin_server_ts,
             "room_type": room_type,
         }
 

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -344,6 +344,7 @@ class SpaceSummaryHandler:
                 stats["history_visibility"] == HistoryVisibility.WORLD_READABLE
             ),
             "guest_can_join": stats["guest_access"] == "can_join",
+            "origin_server_ts": create_event.origin_server_ts,
             "room_type": room_type,
         }
 


### PR DESCRIPTION
Per updates the [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946), this is necessary for clients to sort rooms (as specified in MSC1772).