### PR TITLE
Ensure we only have one copy of an event in memory at a time

### DIFF
--- a/changelog.d/9939.misc
+++ b/changelog.d/9939.misc
@@ -1,0 +1,1 @@
+Ensure we only have one copy of an event in memory at a time.

--- a/synapse/storage/databases/main/censor_events.py
+++ b/synapse/storage/databases/main/censor_events.py
@@ -181,7 +181,7 @@ class CensorEventsStore(EventsWorkerStore, CacheInvalidationWorkerStore, SQLBase
             # changed its content in the database. We can't call
             # self._invalidate_cache_and_stream because self.get_event_cache isn't of the
             # right type.
-            txn.call_after(self._get_event_cache.invalidate, (event.event_id,))
+            txn.call_after(self._invalidate_get_event_cache, event.event_id)
             # Send that invalidation to replication so that other workers also invalidate
             # the event cache.
             self._send_invalidation_to_replication(

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -742,6 +742,8 @@ class EventsWorkerStore(SQLBaseStore):
             # that would require a larger refactor).
             cached_entry = self._in_memory_events.get(event_id)
             if cached_entry is not None:
+                # We need to add to the event_map as we read from it to fetch redactions.
+                event_map[event_id] = cached_entry.event
                 result_map[event_id] = cached_entry
                 self._get_event_cache.set((event_id,), cached_entry)
                 continue


### PR DESCRIPTION
This ensures that if the get event cache overflows we don't end up with
multiple copies of the event in RAM at the same time (which could lead
to memory bloat).

My hunch is that this would help with the federation readers on matrix.org using tonnes of memory due to them having undersized caches. But that is just a hunch with a tiny bit of circumstantial evidence to back it up.