### PR TITLE
Revert "Leave out optional keys from /sync (#9919)"

### DIFF
--- a/changelog.d/9919.feature
+++ b/changelog.d/9919.feature
@@ -1,1 +1,0 @@
-Omit empty fields from the `/sync` response.  Contributed by @deepbluev7.

--- a/tests/rest/client/v2_alpha/test_sync.py
+++ b/tests/rest/client/v2_alpha/test_sync.py
@@ -37,7 +37,35 @@ class FilterTestCase(unittest.HomeserverTestCase):
         channel = self.make_request("GET", "/sync")
 
         self.assertEqual(channel.code, 200)
-        self.assertIn("next_batch", channel.json_body)
+        self.assertTrue(
+            {
+                "next_batch",
+                "rooms",
+                "presence",
+                "account_data",
+                "to_device",
+                "device_lists",
+            }.issubset(set(channel.json_body.keys()))
+        )
+
+    def test_sync_presence_disabled(self):
+        """
+        When presence is disabled, the key does not appear in /sync.
+        """
+        self.hs.config.use_presence = False
+
+        channel = self.make_request("GET", "/sync")
+
+        self.assertEqual(channel.code, 200)
+        self.assertTrue(
+            {
+                "next_batch",
+                "rooms",
+                "account_data",
+                "to_device",
+                "device_lists",
+            }.issubset(set(channel.json_body.keys()))
+        )
 
 
 class SyncFilterTestCase(unittest.HomeserverTestCase):

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -306,9 +306,8 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
 
         channel = self.make_request("GET", "/sync?timeout=0", access_token=tok)
 
-        self.assertNotIn(
-            "rooms", channel.json_body, "Got invites without server notice"
-        )
+        invites = channel.json_body["rooms"]["invite"]
+        self.assertEqual(len(invites), 0, invites)
 
     def test_invite_with_notice(self):
         """Tests that, if the MAU limit is hit, the server notices user invites each user
@@ -365,8 +364,7 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
             # We could also pick another user and sync with it, which would return an
             # invite to a system notices room, but it doesn't matter which user we're
             # using so we use the last one because it saves us an extra sync.
-            if "rooms" in channel.json_body:
-                invites = channel.json_body["rooms"]["invite"]
+            invites = channel.json_body["rooms"]["invite"]
 
         # Make sure we have an invite to process.
         self.assertEqual(len(invites), 1, invites)


### PR DESCRIPTION
This reverts commit e9eb3549d32a6f93d07de8dbd5e1ebe54c8d8278 / #9919

The PR breaks Element iOS push, as its handling expects some of the keys to be there. We revert while they fix it and put out a new release.