### PR TITLE
Add room members admin API with power levels

### DIFF
--- a/changelog.d/9949.feature
+++ b/changelog.d/9949.feature
@@ -1,0 +1,1 @@
+Add room members admin API with membership and power levels. Contributed by Awesome Technologies Innovationslabor GmbH.

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -43,6 +43,8 @@ from synapse.rest.admin.rooms import (
     MakeRoomAdminRestServlet,
     RoomEventContextServlet,
     RoomMembersRestServlet,
+    RoomMembersRestServletV2,
+    RoomPowerLevelsRestServlet,
     RoomRestServlet,
     RoomStateRestServlet,
     ShutdownRoomRestServlet,
@@ -217,6 +219,8 @@ def register_servlets(hs, http_server):
     RoomStateRestServlet(hs).register(http_server)
     RoomRestServlet(hs).register(http_server)
     RoomMembersRestServlet(hs).register(http_server)
+    RoomMembersRestServletV2(hs).register(http_server)
+    RoomPowerLevelsRestServlet(hs).register(http_server)
     DeleteRoomRestServlet(hs).register(http_server)
     JoinRoomAliasServlet(hs).register(http_server)
     PurgeRoomServlet(hs).register(http_server)

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -359,6 +359,9 @@ class RoomMembersRestServletV2(RestServlet):
         room_data = await self.state.get_current_state(
             room_id=room_id, event_type=EventTypes.PowerLevels
         )
+        if not room_data:
+            return 200, members
+
         power_levels = room_data.get("content")
         power_level_users = power_levels["users"] if "users" in power_levels else {}
         default_power_level = (
@@ -411,6 +414,8 @@ class RoomPowerLevelsRestServlet(RestServlet):
         room_data = await self.state.get_current_state(
             room_id=room_id, event_type=EventTypes.PowerLevels, state_key=""
         )
+        if not room_data:
+            return 204, {}
 
         return 200, room_data.get("content")
 

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -222,9 +222,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         )
 
     @cached(max_entries=100000, iterable=True)
-    async def get_users_in_room_with_state(
-        self, room_id: str
-    ) -> List[Dict]:
+    async def get_users_in_room_with_state(self, room_id: str) -> List[Dict]:
         """Get a mapping from user ID to membership for all users in a given room.
 
         Args:

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1212,7 +1212,9 @@ class RoomTestCase(unittest.HomeserverTestCase):
 
         # Have another user join the room
         user_3 = self.register_user("foobar", "pass")
-        self.helper.invite(room_id_2, src=self.admin_user, targ=user_3, tok=self.admin_user_tok)
+        self.helper.invite(
+            room_id_2, src=self.admin_user, targ=user_3, tok=self.admin_user_tok
+        )
 
         url = "/_synapse/admin/v1/rooms/%s/members" % (room_id_1,)
         channel = self.make_request(


### PR DESCRIPTION
This commit adds two new endpoints to get power_levels for room members.
One is a V2 of the current room members endpoint, adding `membership` and `power_level` attributes for each user.
The other one exposes all power level attributes of the room using a new endpoint.
Both are missing pagination right now. Is this required for very large rooms?

Please comment how you would like to see such an API. @dklimpel @anoadragon453 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
