### PR TITLE
Use ijson to parse the response to `/send_join`, reducing memory usage.

### DIFF
--- a/changelog.d/9958.feature
+++ b/changelog.d/9958.feature
@@ -1,0 +1,1 @@
+Reduce memory usage when joining very large rooms over federation.

--- a/mypy.ini
+++ b/mypy.ini
@@ -174,3 +174,6 @@ ignore_missing_imports = True
 
 [mypy-pympler.*]
 ignore_missing_imports = True
+
+[mypy-ijson.*]
+ignore_missing_imports = True

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -17,13 +17,19 @@ import logging
 import urllib
 from typing import Any, Dict, List, Optional
 
+import attr
+import ijson
+
 from synapse.api.constants import Membership
 from synapse.api.errors import Codes, HttpResponseException, SynapseError
+from synapse.api.room_versions import RoomVersion
 from synapse.api.urls import (
     FEDERATION_UNSTABLE_PREFIX,
     FEDERATION_V1_PREFIX,
     FEDERATION_V2_PREFIX,
 )
+from synapse.events import EventBase, make_event_from_dict
+from synapse.http.matrixfederationclient import ByteParser
 from synapse.logging.utils import log_function
 from synapse.types import JsonDict
 
@@ -240,21 +246,36 @@ class TransportLayerClient:
         return content
 
     @log_function
-    async def send_join_v1(self, destination, room_id, event_id, content):
+    async def send_join_v1(
+        self,
+        room_version,
+        destination,
+        room_id,
+        event_id,
+        content,
+    ) -> "SendJoinResponse":
         path = _create_v1_path("/send_join/%s/%s", room_id, event_id)
 
         response = await self.client.put_json(
-            destination=destination, path=path, data=content
+            destination=destination,
+            path=path,
+            data=content,
+            parser=SendJoinParser(room_version, v1_api=True),
         )
 
         return response
 
     @log_function
-    async def send_join_v2(self, destination, room_id, event_id, content):
+    async def send_join_v2(
+        self, room_version, destination, room_id, event_id, content
+    ) -> "SendJoinResponse":
         path = _create_v2_path("/send_join/%s/%s", room_id, event_id)
 
         response = await self.client.put_json(
-            destination=destination, path=path, data=content
+            destination=destination,
+            path=path,
+            data=content,
+            parser=SendJoinParser(room_version, v1_api=False),
         )
 
         return response
@@ -1052,3 +1073,67 @@ def _create_v2_path(path, *args):
         str
     """
     return _create_path(FEDERATION_V2_PREFIX, path, *args)
+
+
+@attr.s(slots=True, auto_attribs=True)
+class SendJoinResponse:
+    """The parsed response of a `/send_join` request."""
+
+    auth_events: List[EventBase]
+    state: List[EventBase]
+
+
+@ijson.coroutine
+def _event_list_parser(room_version: RoomVersion, events: List[EventBase]):
+    """Helper function for use with `ijson.items_coro` to parse an array of
+    events and add them to the given list.
+    """
+
+    while True:
+        obj = yield
+        event = make_event_from_dict(obj, room_version)
+        events.append(event)
+
+
+class SendJoinParser(ByteParser[SendJoinResponse]):
+    """A parser for the response to `/send_join` requests.
+
+    Args:
+        room_version: The version of the room.
+        v1_api: Whether the response is in the v1 format.
+    """
+
+    CONTENT_TYPE = "application/json"
+
+    def __init__(self, room_version: RoomVersion, v1_api: bool):
+        self._response = SendJoinResponse([], [])
+
+        if v1_api:
+            # The V1 API has the shape of `[200, {...}]`, which we handle by
+            # prefixing with `item.*`.
+            self._coro_state = ijson.items_coro(
+                _event_list_parser(room_version, self._response.state),
+                "item.state.item",
+            )
+            self._coro_auth = ijson.items_coro(
+                _event_list_parser(room_version, self._response.auth_events),
+                "item.auth_chain.item",
+            )
+        else:
+            self._coro_state = ijson.items_coro(
+                _event_list_parser(room_version, self._response.state),
+                "state.item",
+            )
+            self._coro_auth = ijson.items_coro(
+                _event_list_parser(room_version, self._response.auth_events),
+                "auth_chain.item",
+            )
+
+    def write(self, data: bytes) -> int:
+        self._coro_state.send(data)
+        self._coro_auth.send(data)
+
+        return len(data)
+
+    def finish(self) -> SendJoinResponse:
+        return self._response

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -1111,7 +1111,7 @@ class SendJoinParser(ByteParser[SendJoinResponse]):
         # The V1 API has the shape of `[200, {...}]`, which we handle by
         # prefixing with `item.*`.
         prefix = "item." if v1_api else ""
-            
+
         self._coro_state = ijson.items_coro(
             _event_list_parser(room_version, self._response.state),
             prefix + "state.item",

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -813,7 +813,12 @@ class _ReadBodyWithMaxSizeProtocol(protocol.Protocol):
         if self.deferred.called:
             return
 
-        self.stream.write(data)
+        try:
+            self.stream.write(data)
+        except Exception:
+            self.deferred.errback()
+            return
+
         self.length += len(data)
         # The first time the maximum size is exceeded, error and cancel the
         # connection. dataReceived might be called again if data was received

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -180,7 +180,7 @@ class MatrixFederationRequest:
 
 
 class JsonParser(ByteParser[Union[JsonDict, list]]):
-    """A parser that buffers the response and tries and parses it as JSON."""
+    """A parser that buffers the response and tries to parse it as JSON."""
 
     CONTENT_TYPE = "application/json"
 
@@ -229,7 +229,7 @@ async def _handle_response(
     parser: ByteParser[T],
 ) -> T:
     """
-    Reads the JSON body of a response, with a timeout
+    Reads the body of a response with a timeout and sends it to a parser
 
     Args:
         reactor: twisted reactor, for the timeout

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -198,31 +198,6 @@ class JsonParser(ByteParser[Union[JsonDict, list]]):
         return json_decoder.decode(self._buffer.getvalue())
 
 
-async def _handle_json_response(
-    reactor: IReactorTime,
-    timeout_sec: float,
-    request: MatrixFederationRequest,
-    response: IResponse,
-    start_ms: int,
-) -> Union[JsonDict, list]:
-    """
-    Reads the JSON body of a response, with a timeout
-
-    Args:
-        reactor: twisted reactor, for the timeout
-        timeout_sec: number of seconds to wait for response to complete
-        request: the request that triggered the response
-        response: response to the request
-        start_ms: Timestamp when request was made
-
-    Returns:
-        The parsed JSON response
-    """
-    return await _handle_response(
-        reactor, timeout_sec, request, response, start_ms, JsonParser()
-    )
-
-
 async def _handle_response(
     reactor: IReactorTime,
     timeout_sec: float,
@@ -950,12 +925,8 @@ class MatrixFederationHttpClient:
         else:
             _sec_timeout = self.default_timeout
 
-        body = await _handle_json_response(
-            self.reactor,
-            _sec_timeout,
-            request,
-            response,
-            start_ms,
+        body = await _handle_response(
+            self.reactor, _sec_timeout, request, response, start_ms, parser=JsonParser()
         )
         return body
 
@@ -1027,8 +998,8 @@ class MatrixFederationHttpClient:
         else:
             _sec_timeout = self.default_timeout
 
-        body = await _handle_json_response(
-            self.reactor, _sec_timeout, request, response, start_ms
+        body = await _handle_response(
+            self.reactor, _sec_timeout, request, response, start_ms, parser=JsonParser()
         )
 
         return body
@@ -1095,8 +1066,8 @@ class MatrixFederationHttpClient:
         else:
             _sec_timeout = self.default_timeout
 
-        body = await _handle_json_response(
-            self.reactor, _sec_timeout, request, response, start_ms
+        body = await _handle_response(
+            self.reactor, _sec_timeout, request, response, start_ms, parser=JsonParser()
         )
         return body
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -773,7 +773,7 @@ class MatrixFederationHttpClient:
         ignore_backoff: bool = False,
         backoff_on_404: bool = False,
         try_trailing_slash_on_400: bool = False,
-        parser: Optional[Type[ByteParser[T]]] = None,
+        parser: Optional[ByteParser[T]] = None,
     ) -> T:
         ...
 
@@ -789,7 +789,7 @@ class MatrixFederationHttpClient:
         ignore_backoff: bool = False,
         backoff_on_404: bool = False,
         try_trailing_slash_on_400: bool = False,
-        parser: Optional[Type[ByteParser]] = None,
+        parser: Optional[ByteParser] = None,
     ):
         """Sends the specified json data using PUT
 
@@ -864,7 +864,7 @@ class MatrixFederationHttpClient:
             _sec_timeout = self.default_timeout
 
         if parser is None:
-            parser = JsonParser
+            parser = JsonParser()
 
         body = await _handle_response(
             self.reactor,
@@ -872,7 +872,7 @@ class MatrixFederationHttpClient:
             request,
             response,
             start_ms,
-            parser=parser(),
+            parser=parser,
         )
 
         return body

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -104,12 +104,15 @@ QueryArgs = Dict[str, Union[str, List[str]]]
 T = TypeVar("T")
 
 
-class ByteParser(ByteWriteable, Generic[T]):
+class ByteParser(ByteWriteable, Generic[T], abc.ABC):
     """A `ByteWriteable` that has an additional `finish` function that returns
     the parsed data.
     """
 
     CONTENT_TYPE = abc.abstractproperty()  # type: str  # type: ignore
+    """The expected content type of the response, e.g. `application/json`. If
+    the content type doesn't match we fail the request.
+    """
 
     @abc.abstractmethod
     def finish(self) -> T:
@@ -823,6 +826,8 @@ class MatrixFederationHttpClient:
                 of the request. Workaround for #3622 in Synapse <= v0.99.3. This
                 will be attempted before backing off if backing off has been
                 enabled.
+            parser: The parser to use to decode the response. Defaults to
+                parsing as JSON.
 
         Returns:
             Succeeds when we get a 2xx HTTP response. The

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -87,6 +87,7 @@ REQUIREMENTS = [
     # We enforce that we have a `cryptography` version that bundles an `openssl`
     # with the latest security patches.
     "cryptography>=3.4.7",
+    "ijson>=3.0",
 ]
 
 CONDITIONAL_REQUIREMENTS = {


### PR DESCRIPTION
Instead of parsing the full response to `/send_join` into Python objects (which can be huge for large rooms) and *then* parsing that into events, we instead use ijson to stream parse the response directly into `EventBase` objects.

Question: Do we want to make this an optional dependency? It should be easy (just a case of adding a `JsonParser` subclass), though does mean we have more things to test