### PR TITLE
Support enabling opentracing by user

### DIFF
--- a/changelog.d/9978.feature
+++ b/changelog.d/9978.feature
@@ -1,0 +1,1 @@
+Add a configuration option which allows enabling opentracing by user id.

--- a/docs/opentracing.md
+++ b/docs/opentracing.md
@@ -42,17 +42,17 @@ To receive OpenTracing spans, start up a Jaeger server. This can be done
 using docker like so:
 
 ```sh
-docker run -d --name jaeger
+docker run -d --name jaeger \
   -p 6831:6831/udp \
   -p 6832:6832/udp \
   -p 5778:5778 \
   -p 16686:16686 \
   -p 14268:14268 \
-  jaegertracing/all-in-one:1.13
+  jaegertracing/all-in-one:1
 ```
 
 Latest documentation is probably at
-<https://www.jaegertracing.io/docs/1.13/getting-started/>
+https://www.jaegertracing.io/docs/latest/getting-started.
 
 ## Enable OpenTracing in Synapse
 
@@ -62,7 +62,7 @@ as shown in the [sample config](./sample_config.yaml). For example:
 
 ```yaml
 opentracing:
-  tracer_enabled: true
+  enabled: true
   homeserver_whitelist:
     - "mytrustedhomeserver.org"
     - "*.myotherhomeservers.com"
@@ -90,4 +90,4 @@ to two problems, namely:
 ## Configuring Jaeger
 
 Sampling strategies can be set as in this document:
-<https://www.jaegertracing.io/docs/1.13/sampling/>
+<https://www.jaegertracing.io/docs/latest/sampling/>.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2855,12 +2855,12 @@ opentracing:
     #homeserver_whitelist:
     #  - ".*"
 
-    # A list of the matrix IDs of users whose requests will always be traced, 
+    # A list of the matrix IDs of users whose requests will always be traced,
     # even if the tracing system would otherwise drop the traces due to
     # probabilistic sampling.
     #
     # By default, the list is empty.
-    # 
+    #
     #force_tracing_for_users:
     #  - "@user1:server_name"
     #  - "@user2:server_name"

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2845,7 +2845,8 @@ opentracing:
     #enabled: true
 
     # The list of homeservers we wish to send and receive span contexts and span baggage.
-    # See docs/opentracing.rst
+    # See docs/opentracing.rst.
+    #
     # This is a list of regexes which are matched against the server_name of the
     # homeserver.
     #
@@ -2854,19 +2855,26 @@ opentracing:
     #homeserver_whitelist:
     #  - ".*"
 
+    # A list of the matrix IDs of users whose requests will always be traced, 
+    # even if the tracing system would otherwise drop the traces due to
+    # probabilistic sampling.
+    #
+    # By default, the list is empty.
+    # 
+    #force_tracing_for_users:
+    #  - "@user1:server_name"
+    #  - "@user2:server_name"
+
     # Jaeger can be configured to sample traces at different rates.
     # All configuration options provided by Jaeger can be set here.
-    # Jaeger's configuration mostly related to trace sampling which
+    # Jaeger's configuration is mostly related to trace sampling which
     # is documented here:
-    # https://www.jaegertracing.io/docs/1.13/sampling/.
+    # https://www.jaegertracing.io/docs/latest/sampling/.
     #
     #jaeger_config:
     #  sampler:
     #    type: const
     #    param: 1
-
-    #  Logging whether spans were started and reported
-    #
     #  logging:
     #    false
 

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -265,12 +265,7 @@ class Auth:
             if device_id:
                 opentracing.set_tag("device_id", device_id)
             if user_info.token_owner in self._force_tracing_for_users:
-                logger.info("enabling tracing for %s", user_info.token_owner)
                 opentracing.set_tag(opentracing.tags.SAMPLING_PRIORITY, 1)
-            else:
-                logger.info(
-                    "%s not in %s", user_info.token_owner, self._force_tracing_for_users
-                )
 
             return requester
         except KeyError:

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -87,7 +87,6 @@ class Auth:
         )
         self._track_appservice_user_ips = hs.config.track_appservice_user_ips
         self._macaroon_secret_key = hs.config.macaroon_secret_key
-
         self._force_tracing_for_users = hs.config.tracing.force_tracing_for_users
 
     async def check_from_context(

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -88,6 +88,8 @@ class Auth:
         self._track_appservice_user_ips = hs.config.track_appservice_user_ips
         self._macaroon_secret_key = hs.config.macaroon_secret_key
 
+        self._force_tracing_for_users = hs.config.tracing.force_tracing_for_users
+
     async def check_from_context(
         self, room_version: str, event, context, do_sig_check=True
     ) -> None:
@@ -208,6 +210,8 @@ class Auth:
                 opentracing.set_tag("authenticated_entity", user_id)
                 opentracing.set_tag("user_id", user_id)
                 opentracing.set_tag("appservice_id", app_service.id)
+                if user_id in self._force_tracing_for_users:
+                    opentracing.set_tag(opentracing.tags.SAMPLING_PRIORITY, 1)
 
                 return requester
 
@@ -260,6 +264,13 @@ class Auth:
             opentracing.set_tag("user_id", user_info.user_id)
             if device_id:
                 opentracing.set_tag("device_id", device_id)
+            if user_info.token_owner in self._force_tracing_for_users:
+                logger.info("enabling tracing for %s", user_info.token_owner)
+                opentracing.set_tag(opentracing.tags.SAMPLING_PRIORITY, 1)
+            else:
+                logger.info(
+                    "%s not in %s", user_info.token_owner, self._force_tracing_for_users
+                )
 
             return requester
         except KeyError:

--- a/synapse/config/tracer.py
+++ b/synapse/config/tracer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Set
+
 from synapse.python_dependencies import DependencyException, check_requirements
 
 from ._base import Config, ConfigError
@@ -32,6 +34,8 @@ class TracerConfig(Config):
             {"sampler": {"type": "const", "param": 1}, "logging": False},
         )
 
+        self.force_tracing_for_users: Set[str] = set()
+
         if not self.opentracer_enabled:
             return
 
@@ -47,6 +51,19 @@ class TracerConfig(Config):
         self.opentracer_whitelist = opentracing_config.get("homeserver_whitelist", [])
         if not isinstance(self.opentracer_whitelist, list):
             raise ConfigError("Tracer homeserver_whitelist config is malformed")
+
+        force_tracing_for_users = opentracing_config.get("force_tracing_for_users", [])
+        if not isinstance(force_tracing_for_users, list):
+            raise ConfigError(
+                "Expected a list", ("opentracing", "force_tracing_for_users")
+            )
+        for i, u in enumerate(force_tracing_for_users):
+            if not isinstance(u, str):
+                raise ConfigError(
+                    "Expected a string",
+                    ("opentracing", "force_tracing_for_users", f"index {i}"),
+                )
+            self.force_tracing_for_users.add(u)
 
     def generate_config_section(cls, **kwargs):
         return """\
@@ -64,7 +81,8 @@ class TracerConfig(Config):
             #enabled: true
 
             # The list of homeservers we wish to send and receive span contexts and span baggage.
-            # See docs/opentracing.rst
+            # See docs/opentracing.rst.
+            #
             # This is a list of regexes which are matched against the server_name of the
             # homeserver.
             #
@@ -72,20 +90,27 @@ class TracerConfig(Config):
             #
             #homeserver_whitelist:
             #  - ".*"
-
+            
+            # A list of the matrix IDs of users whose requests will always be traced, 
+            # even if the tracing system would otherwise drop the traces due to
+            # probabilistic sampling.
+            #
+            # By default, the list is empty.
+            # 
+            #force_tracing_for_users:
+            #  - "@user1:server_name"
+            #  - "@user2:server_name"
+            
             # Jaeger can be configured to sample traces at different rates.
             # All configuration options provided by Jaeger can be set here.
-            # Jaeger's configuration mostly related to trace sampling which
+            # Jaeger's configuration is mostly related to trace sampling which
             # is documented here:
-            # https://www.jaegertracing.io/docs/1.13/sampling/.
+            # https://www.jaegertracing.io/docs/latest/sampling/.
             #
             #jaeger_config:
             #  sampler:
             #    type: const
             #    param: 1
-
-            #  Logging whether spans were started and reported
-            #
             #  logging:
             #    false
         """

--- a/synapse/config/tracer.py
+++ b/synapse/config/tracer.py
@@ -90,17 +90,17 @@ class TracerConfig(Config):
             #
             #homeserver_whitelist:
             #  - ".*"
-            
-            # A list of the matrix IDs of users whose requests will always be traced, 
+
+            # A list of the matrix IDs of users whose requests will always be traced,
             # even if the tracing system would otherwise drop the traces due to
             # probabilistic sampling.
             #
             # By default, the list is empty.
-            # 
+            #
             #force_tracing_for_users:
             #  - "@user1:server_name"
             #  - "@user2:server_name"
-            
+
             # Jaeger can be configured to sample traces at different rates.
             # All configuration options provided by Jaeger can be set here.
             # Jaeger's configuration is mostly related to trace sampling which


### PR DESCRIPTION
Add a config option which allows enabling opentracing by user id, eg for
debugging requests made by a test user.