### PR TITLE
Fix the allowed range of valid ordering characters for spaces.

### DIFF
--- a/changelog.d/10002.bugfix
+++ b/changelog.d/10002.bugfix
@@ -1,0 +1,1 @@
+Fix a validation bug introduced in v1.34.0 in the ordering of spaces in the space summary API.

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -430,8 +430,8 @@ def _is_suggested_child_event(edge_event: EventBase) -> bool:
     return False
 
 
-# Order may only contain characters in the range of \x20 (space) to \x7F (~).
-_INVALID_ORDER_CHARS_RE = re.compile(r"[^\x20-\x7F]")
+# Order may only contain characters in the range of \x20 (space) to \x7E (~).
+_INVALID_ORDER_CHARS_RE = re.compile(r"[^\x20-\x7E]")
 
 
 def _child_events_comparison_key(child: EventBase) -> Tuple[bool, Optional[str], str]:

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -430,7 +430,7 @@ def _is_suggested_child_event(edge_event: EventBase) -> bool:
     return False
 
 
-# Order may only contain characters in the range of \x20 (space) to \x7E (~).
+# Order may only contain characters in the range of \x20 (space) to \x7E (~) inclusive.
 _INVALID_ORDER_CHARS_RE = re.compile(r"[^\x20-\x7E]")
 
 


### PR DESCRIPTION
Per matrix-org/matrix-doc#3195.