### PR TITLE
Enable spaces by default.

### DIFF
--- a/changelog.d/10011.feature
+++ b/changelog.d/10011.feature
@@ -1,1 +1,1 @@
-Enable experimental support for [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946): Spaces Summary by default.
+Enable experimental support for [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946) (spaces summary API) and [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083) (restricted join rules) by default.

--- a/changelog.d/10011.feature
+++ b/changelog.d/10011.feature
@@ -1,0 +1,1 @@
+Enable experimental support for [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946): Spaces Summary by default.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -546,6 +546,21 @@ retention:
 #next_link_domain_whitelist: ["matrix.org"]
 
 
+# Enable experimental features in Synapse.
+#
+# Experimental features might break or be removed without a deprecation
+# period.
+#
+experimental_features:
+  # Support for Spaces (MSC1772), it enables the following:
+  #
+  # * The Spaces Summary API (MSC2946).
+  # * Restricting room membership based on space membership (MSC3083).
+  #
+  # Uncomment to disable support for Spaces.
+  #spaces_enabled: False
+
+
 ## TLS ##
 
 # PEM-encoded X509 certificate for TLS.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -558,7 +558,7 @@ experimental_features:
   # * Restricting room membership based on space membership (MSC3083).
   #
   # Uncomment to disable support for Spaces.
-  #spaces_enabled: False
+  #spaces_enabled: false
 
 
 ## TLS ##

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -546,21 +546,6 @@ retention:
 #next_link_domain_whitelist: ["matrix.org"]
 
 
-# Enable experimental features in Synapse.
-#
-# Experimental features might break or be removed without a deprecation
-# period.
-#
-experimental_features:
-  # Support for Spaces (MSC1772), it enables the following:
-  #
-  # * The Spaces Summary API (MSC2946).
-  # * Restricting room membership based on space membership (MSC3083).
-  #
-  # Uncomment to disable support for Spaces.
-  #spaces_enabled: false
-
-
 ## TLS ##
 
 # PEM-encoded X509 certificate for TLS.
@@ -2958,3 +2943,18 @@ redis:
   # Optional password if configured on the Redis instance
   #
   #password: <secret_password>
+
+
+# Enable experimental features in Synapse.
+#
+# Experimental features might break or be removed without a deprecation
+# period.
+#
+experimental_features:
+  # Support for Spaces (MSC1772), it enables the following:
+  #
+  # * The Spaces Summary API (MSC2946).
+  # * Restricting room membership based on space membership (MSC3083).
+  #
+  # Uncomment to disable support for Spaces.
+  #spaces_enabled: false

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -29,7 +29,7 @@ class ExperimentalConfig(Config):
         self.msc2858_enabled = experimental.get("msc2858_enabled", False)  # type: bool
 
         # Spaces (MSC1772, MSC2946, MSC3083, etc)
-        self.spaces_enabled = experimental.get("spaces_enabled", False)  # type: bool
+        self.spaces_enabled = experimental.get("spaces_enabled", True)  # type: bool
         if self.spaces_enabled:
             KNOWN_ROOM_VERSIONS[RoomVersions.MSC3083.identifier] = RoomVersions.MSC3083
 

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -50,5 +50,5 @@ class ExperimentalConfig(Config):
           # * Restricting room membership based on space membership (MSC3083).
           #
           # Uncomment to disable support for Spaces.
-          #spaces_enabled: False
+          #spaces_enabled: false
         """

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -35,3 +35,20 @@ class ExperimentalConfig(Config):
 
         # MSC3026 (busy presence state)
         self.msc3026_enabled = experimental.get("msc3026_enabled", False)  # type: bool
+
+    def generate_config_section(self, **kwargs):
+        return """\
+        # Enable experimental features in Synapse.
+        #
+        # Experimental features might break or be removed without a deprecation
+        # period.
+        #
+        experimental_features:
+          # Support for Spaces (MSC1772), it enables the following:
+          #
+          # * The Spaces Summary API (MSC2946).
+          # * Restricting room membership based on space membership (MSC3083).
+          #
+          # Uncomment to disable support for Spaces.
+          #spaces_enabled: False
+        """

--- a/synapse/config/homeserver.py
+++ b/synapse/config/homeserver.py
@@ -57,7 +57,6 @@ class HomeServerConfig(RootConfig):
 
     config_classes = [
         ServerConfig,
-        ExperimentalConfig,
         TlsConfig,
         FederationConfig,
         CacheConfig,
@@ -94,4 +93,5 @@ class HomeServerConfig(RootConfig):
         TracerConfig,
         WorkerConfig,
         RedisConfig,
+        ExperimentalConfig,
     ]


### PR DESCRIPTION
This enables the experimental spaces flag by default.

## Questions

* Do we want to do this for the multi-SSO providers and busy presence?
* Are there things we want to move behind a different flag (maybe the restricted rooms parts)?