### PR TITLE
Fixed removal of new presence stream states

### DIFF
--- a/changelog.d/10014.bugfix
+++ b/changelog.d/10014.bugfix
@@ -1,1 +1,1 @@
-Fixed deletion of new presense stream states from database. 
+Fixed deletion of new presence stream states from database. 

--- a/changelog.d/10014.bugfix
+++ b/changelog.d/10014.bugfix
@@ -1,0 +1,1 @@
+Fixed deletion of new presense stream states from database. 


### PR DESCRIPTION
Signed-off-by: Marek Matys <themarcq@gmail.com>

https://github.com/matrix-org/synapse/issues/9962

This is a fix for above problem.

I fixed it by swaping the order of insertion of new records and deletion of old ones. This ensures that we don't delete fresh database records as we do deletes before inserts.
