### PR TITLE
Remove unused properties on SpaceSummaryHandler

### DIFF
--- a/changelog.d/10038.feature
+++ b/changelog.d/10038.feature
@@ -1,0 +1,1 @@
+Experimental support to allow a user who could join a restricted room to view it in the spaces summary.

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -50,8 +50,6 @@ class SpaceSummaryHandler:
     def __init__(self, hs: "HomeServer"):
         self._clock = hs.get_clock()
         self._auth = hs.get_auth()
-        self._room_list_handler = hs.get_room_list_handler()
-        self._state_handler = hs.get_state_handler()
         self._event_auth_handler = hs.get_event_auth_handler()
         self._store = hs.get_datastore()
         self._event_serializer = hs.get_event_client_serializer()


### PR DESCRIPTION
Follow-up to #9922 to remove (now) unused properties on the handler.