### PR TITLE
Run complement with Synapse workers manually.

### DIFF
--- a/changelog.d/10039.misc
+++ b/changelog.d/10039.misc
@@ -1,0 +1,1 @@
+Fix running complement tests with Synapse workers.

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -193,9 +193,9 @@ NGINX_LOCATION_CONFIG_BLOCK = """
 """
 
 NGINX_UPSTREAM_CONFIG_BLOCK = """
-upstream {upstream_worker_type} {
+upstream {upstream_worker_type} {{
 {body}
-}
+}}
 """
 
 

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -184,12 +184,12 @@ stderr_logfile_maxbytes=0
 """
 
 NGINX_LOCATION_CONFIG_BLOCK = """
-    location ~* {endpoint} {
+    location ~* {endpoint} {{
         proxy_pass {upstream};
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $host;
-    }
+    }}
 """
 
 NGINX_UPSTREAM_CONFIG_BLOCK = """

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -10,6 +10,9 @@
 # checkout by setting the COMPLEMENT_DIR environment variable to the
 # filepath of a local Complement checkout.
 #
+# By default Synapse is run in monolith mode. This can be overridden by
+# setting the WORKERS environment variable.
+#
 # A regular expression of test method names can be supplied as the first
 # argument to the script. Complement will then only run those tests. If
 # no regex is supplied, all tests are run. For example;


### PR DESCRIPTION
This attempts to be able to run complement with Synapse worker mode via the `complement.sh` script. Adding a `WORKERS=1` will cause them to be used.

It also fixes a couple of minor things necessary to get this to work.

Corresponding complement PR: matrix-org/complement#116.