### PR TITLE
Fix docker image to not log at `/homeserver.log`

### DIFF
--- a/changelog.d/10045.docker
+++ b/changelog.d/10045.docker
@@ -1,0 +1,1 @@
+Fixed server not having access to `homeserver.log` by moving the default path to `/data/homeserver.log`. Contributed by Sergio Miguéns Iglesias.

--- a/changelog.d/10045.docker
+++ b/changelog.d/10045.docker
@@ -1,1 +1,1 @@
-Fixed server not having access to `homeserver.log` by moving the default path to `/data/homeserver.log`. Contributed by Sergio Miguéns Iglesias.
+Fix bug introduced in Synapse 1.33.0 which caused a `Permission denied: '/homeserver.log'` error when starting Synapse with the generated log configuration. Contributed by Sergio Miguéns Iglesias.

--- a/docker/conf/log.config
+++ b/docker/conf/log.config
@@ -9,10 +9,11 @@ formatters:
 {% endif %}
 
 handlers:
+{% if LOG_FILE_PATH %}
   file:
     class: logging.handlers.TimedRotatingFileHandler
     formatter: precise
-    filename: {{ LOG_FILE_PATH or "/data/homeserver.log" }}
+    filename: {{ LOG_FILE_PATH }}
     when: "midnight"
     backupCount: 6  # Does not include the current log file.
     encoding: utf8
@@ -29,6 +30,7 @@ handlers:
     # be written to disk.
     capacity: 10
     flushLevel: 30  # Flush for WARNING logs as well
+{% endif %}
 
   console:
     class: logging.StreamHandler

--- a/docker/conf/log.config
+++ b/docker/conf/log.config
@@ -12,7 +12,7 @@ handlers:
   file:
     class: logging.handlers.TimedRotatingFileHandler
     formatter: precise
-    filename: {{ LOG_FILE_PATH or "homeserver.log" }}
+    filename: {{ LOG_FILE_PATH or "/data/homeserver.log" }}
     when: "midnight"
     backupCount: 6  # Does not include the current log file.
     encoding: utf8


### PR DESCRIPTION
Fixes #9970 

Signed-off-by: Sergio Miguéns Iglesias <lonyelon@lony.xyz>