### PR TITLE
Fix `get_state_ids_for_event` return type typo to match what the function actually does

### DIFF
--- a/changelog.d/10050.misc
+++ b/changelog.d/10050.misc
@@ -1,0 +1,1 @@
+Fix `get_state_ids_for_event` return type typo to match what the function actually does.

--- a/changelog.d/10050.misc
+++ b/changelog.d/10050.misc
@@ -1,1 +1,1 @@
-Fix `get_state_ids_for_event` return type typo to match what the function actually does.
+Fix typo in `get_state_ids_for_event` docstring where the return type was incorrect.

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -540,7 +540,7 @@ class StateGroupStorage:
             state_filter: The state filter used to fetch state from the database.
 
         Returns:
-            A dict from (type, state_key) -> state_event
+            A dict from (type, state_key) -> state_event_id
         """
         state_map = await self.get_state_ids_for_events(
             [event_id], state_filter or StateFilter.all()


### PR DESCRIPTION
Fix `get_state_ids_for_event` return type typo to match what the function actually does

Split out from https://github.com/matrix-org/synapse/pull/9247

It looks like a typo copy/paste from `get_state_for_event` above.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
