### PR TITLE
Fix docker permission error when generating config with the current synapse:latest image

### DIFF
--- a/changelog.d/10053.bugfix
+++ b/changelog.d/10053.bugfix
@@ -1,0 +1,2 @@
+fixed a bug that made the default docker image setup to display a permission
+error after generating a fresh config file and running the container.

--- a/docker/README.md
+++ b/docker/README.md
@@ -66,6 +66,7 @@ The following environment variables are supported in `generate` mode:
   such as the database and media store. Defaults to `/data`.
 * `UID`, `GID`: the user id and group id to use for creating the data
   directories. Defaults to `991`, `991`.
+* `LOG_FILE_PATH`: where the homeserver.log file will be stored.
 
 ## Running synapse
 
@@ -186,7 +187,7 @@ point to another Dockerfile.
 ## Disabling the healthcheck
 
 If you are using a non-standard port or tls inside docker you can disable the healthcheck
-whilst running the above `docker run` commands. 
+whilst running the above `docker run` commands.
 
 ```
    --no-healthcheck
@@ -212,7 +213,7 @@ If you wish to point the healthcheck at a different port with docker command, ad
 ## Setting the healthcheck in docker-compose file
 
 You can add the following to set a custom healthcheck in a docker compose file.
-You will need docker-compose version >2.1 for this to work. 
+You will need docker-compose version >2.1 for this to work.
 
 ```
 healthcheck:

--- a/docker/conf/log.config
+++ b/docker/conf/log.config
@@ -12,7 +12,7 @@ handlers:
   file:
     class: logging.handlers.TimedRotatingFileHandler
     formatter: precise
-    filename: {{ LOG_FILE_PATH or "homeserver.log" }}
+    filename: {{ LOG_FILE_PATH or "/data/homeserver.log" }}
     when: "midnight"
     backupCount: 6  # Does not include the current log file.
     encoding: utf8

--- a/docker/test-this-pr/gen-conf.sh
+++ b/docker/test-this-pr/gen-conf.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Author: Pierre Dahmani
+# Created: 23.05.2021
+#
+# Description: tests generation of config files for matrix.
+
+DEFAULT_VOLUME_PATH=/var/lib/docker/volumes/synapse-data/_data/my.matrix.host.log.config
+check_filename_correct(){
+# checks if the filename was set to /data/homeserver.log.
+if $(grep -q "filename: /data/homeserver.log" $DEFAULT_VOLUME_PATH); then
+    echo "success."
+    echo "Filename is now set to /data/homeserver.log"
+else
+    echo "failure."
+    echo "Filename is NOT set to /data/homeserver.log"
+fi
+}
+# builds the docker image with the files that are given in this repo / merge
+# request.
+# (expects you to start this from the directory the script is located at)
+cd ../.. || (echo "../../ did not exist?" && exit 1)
+docker build -f docker/Dockerfile  -t pierrefha:matrix-test .
+
+# removes the default docker volume from the example
+docker volume rm synapse-data
+
+echo -e "generating config with the current public matrix image...\n"
+# generates configuration files
+docker run -it --rm \
+    --mount type=volume,src=synapse-data,dst=/data \
+    -e SYNAPSE_SERVER_NAME=my.matrix.host \
+    -e SYNAPSE_REPORT_STATS=yes \
+    matrixdotorg/synapse:latest generate
+
+echo -e "\nrunning test..."
+check_filename_correct
+
+# removes the just created volume. try again with the fixed version.
+echo "removing the volume we just created..."
+docker volume rm synapse-data
+
+echo -e "generating config with the changes.\n"
+# generates configuration files with the image we just built
+docker run -it --rm \
+    --mount type=volume,src=synapse-data,dst=/data \
+    -e SYNAPSE_SERVER_NAME=my.matrix.host \
+    -e SYNAPSE_REPORT_STATS=yes \
+    pierrefha:matrix-test generate
+
+echo -e "\nrunning test..."
+check_filename_correct

--- a/docker/test-this-pr/start-synapse.sh
+++ b/docker/test-this-pr/start-synapse.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Author: Pierre Dahmani
+# Created: 23.05.2021
+#
+# Description: test script to start synapse. requires gen-conf.sh to be ran
+# before.
+
+docker run -d --name synapse \
+    --mount type=volume,src=synapse-data,dst=/data \
+    -p 8008:8008 \
+    matrixdotorg/synapse:latest
+
+# tail log of latest container to see if we were successfull
+docker container logs -f "$(docker ps -ql)"


### PR DESCRIPTION
# Fixes small config error.

Currently if we are creating a fresh configuration for matrix (based on the :latest docker image and the suggested commands) and then run the image with the suggested commands, we get a permission error.
```
PermissionError: [Errno 13] Permission denied: '/homeserver.log'.
```
# issues:
[10023](https://github.com/matrix-org/synapse/issues/10023)
[9970](https://github.com/matrix-org/synapse/issues/9970)

# What changed?
- added the LOG_FILE_PATH env to the readme.md for the docker installation (documentation).
- changed the default path from /homeserver.log to /data/homeserver.log (configuration)
- I added a folder for you to easier test this issue. Be aware that running the script will delete the default volume that is described in the docker readme ("synapse-data").. I will remove this folder afterwards, if you think the change is okay.