### PR TITLE
Pass the origin when calculating the spaces summary over GET.

### DIFF
--- a/changelog.d/10079.bugfix
+++ b/changelog.d/10079.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.35.0rc1 when calling the spaces summary API via a GET request.

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -1398,7 +1398,7 @@ class FederationSpaceSummaryServlet(BaseFederationServlet):
                 )
 
         return 200, await self.handler.federation_space_summary(
-            room_id, suggested_only, max_rooms_per_space, exclude_rooms
+            origin, room_id, suggested_only, max_rooms_per_space, exclude_rooms
         )
 
     # TODO When switching to the stable endpoint, remove the POST handler.


### PR DESCRIPTION
This fixes a bug caused by the combination of #9922 and #9947 merging separately. The former added an additional parameter to `federation_space_summary` while the latter added an additional call to `federation_space_summary`. 😢 

I found this while brushing off a branch to add some type hints to the `synapse/federation/transport/server.py`, but those were too invasive to put into a release branch.