### PR TITLE
Do not show invite-only rooms in spaces summary (unless joined/invited).

### DIFF
--- a/changelog.d/10109.bugfix
+++ b/changelog.d/10109.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.35.0 where invite-only rooms would be shown to users in a space who were not invited.


### PR DESCRIPTION
This fixes #10104 to not show invite-only rooms to everyone in a space.

This was due to a bug in the refactoring done in #9922 where we called a method expecting an exception to be raised, but the function bailed early if the restricted join rules weren't used. To fix it, I called some lower-level functions which seems clearer.