### PR TITLE
Don't try and backfill the same room in parallel.

### DIFF
--- a/changelog.d/10116.bugfix
+++ b/changelog.d/10116.bugfix
@@ -1,0 +1,1 @@
+Fix bug where the server would attempt to fetch the same history in the room from a remote server multiple times in parallel.


### PR DESCRIPTION
If backfilling is slow then the client may time out and retry, causing Synapse to start a new `/backfill` before the existing backfill has finished, duplicating work.