### PR TITLE
Improve event caching code

### DIFF
--- a/changelog.d/10119.misc
+++ b/changelog.d/10119.misc
@@ -1,0 +1,1 @@
+Try and ensure we only have one copy of an event in memory at a time.

--- a/changelog.d/10119.misc
+++ b/changelog.d/10119.misc
@@ -1,1 +1,1 @@
-Try and ensure we only have one copy of an event in memory at a time.
+Improve event caching mechanism to avoid having multiple copies of an event in memory at a time.

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -97,7 +97,7 @@ class DefaultDictProperty(DictProperty):
 
 
 class _EventInternalMetadata:
-    __slots__ = ["_dict", "stream_ordering", "outlier", "redacted_by"]
+    __slots__ = ["_dict", "stream_ordering", "outlier"]
 
     def __init__(self, internal_metadata_dict: JsonDict):
         # we have to copy the dict, because it turns out that the same dict is
@@ -110,10 +110,6 @@ class _EventInternalMetadata:
         # whether this event is an outlier (ie, whether we have the state at that point
         # in the DAG)
         self.outlier = False
-
-        # Whether this event has a valid redaction event pointing at it (i.e.
-        # whether it should be redacted before giving to clients).
-        self.redacted_by: Optional[str] = None
 
     out_of_band_membership: bool = DictProperty("out_of_band_membership")
     send_on_behalf_of: str = DictProperty("send_on_behalf_of")

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -97,7 +97,7 @@ class DefaultDictProperty(DictProperty):
 
 
 class _EventInternalMetadata:
-    __slots__ = ["_dict", "stream_ordering", "outlier"]
+    __slots__ = ["_dict", "stream_ordering", "outlier", "redacted_by"]
 
     def __init__(self, internal_metadata_dict: JsonDict):
         # we have to copy the dict, because it turns out that the same dict is
@@ -110,6 +110,10 @@ class _EventInternalMetadata:
         # whether this event is an outlier (ie, whether we have the state at that point
         # in the DAG)
         self.outlier = False
+
+        # Whether this event has a valid redaction event pointing at it (i.e.
+        # whether it should be redacted before giving to clients).
+        self.redacted_by: Optional[str] = None
 
     out_of_band_membership: bool = DictProperty("out_of_band_membership")
     send_on_behalf_of: str = DictProperty("send_on_behalf_of")

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -592,7 +592,7 @@ class EventsWorkerStore(SQLBaseStore):
     def _get_events_from_cache(
         self, events: Iterable[str], update_metrics: bool = True
     ) -> Dict[str, _EventCacheEntry]:
-        """Fetch events from the caches
+        """Fetch events from the caches, may return rejected events.
 
         Args:
             events: list of event_ids to fetch
@@ -737,7 +737,8 @@ class EventsWorkerStore(SQLBaseStore):
     async def _get_events_from_db(
         self, event_ids: Iterable[str]
     ) -> Dict[str, _EventCacheEntry]:
-        """Fetch a bunch of events from the database.
+        """Fetch a bunch of events from the database, may return rejected
+        events.
 
         Returned events will be added to the cache for future lookups.
 

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -553,14 +553,16 @@ class EventsWorkerStore(SQLBaseStore):
 
                 event_entry_map.update(missing_events)
             except Exception as e:
-                fetching_deferred.errback(e)
+                with PreserveLoggingContext():
+                    fetching_deferred.errback(e)
                 raise e
             finally:
                 # Ensure that we mark these events as no longer being fetched.
                 for event_id in missing_events_ids:
                     self._current_event_fetches.pop(event_id, None)
 
-            fetching_deferred.callback(missing_events)
+            with PreserveLoggingContext():
+                fetching_deferred.callback(missing_events)
 
         if already_fetching:
             # Wait for the other event requests to finish and add their results

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -14,6 +14,7 @@
 
 import logging
 import threading
+import weakref
 from typing import (
     Collection,
     Container,
@@ -173,6 +174,10 @@ class EventsWorkerStore(SQLBaseStore):
         # Map from event ID to a deferred that will result in an
         # Dict[str, _EventCacheEntry].
         self._current_event_fetches: Dict[str, ObservableDeferred] = {}
+
+        # We keep track of the events we have currently loaded in memory so that
+        # we can reuse them even if they've been evicted from the cache.
+        self._event_ref: Dict[str, EventBase] = weakref.WeakValueDictionary()
 
         self._event_fetch_lock = threading.Condition()
         self._event_fetch_list = []
@@ -588,6 +593,8 @@ class EventsWorkerStore(SQLBaseStore):
 
     def _invalidate_get_event_cache(self, event_id):
         self._get_event_cache.invalidate((event_id,))
+        self._event_ref.pop(event_id, None)
+        self._current_event_fetches.pop(event_id, None)
 
     def _get_events_from_cache(
         self, events: Iterable[str], update_metrics: bool = True
@@ -601,13 +608,34 @@ class EventsWorkerStore(SQLBaseStore):
         event_map = {}
 
         for event_id in events:
+            # First check if its in the event cache
             ret = self._get_event_cache.get(
                 (event_id,), None, update_metrics=update_metrics
             )
-            if not ret:
-                continue
+            if ret:
+                event_map[event_id] = ret
 
-            event_map[event_id] = ret
+            # Otherwise check if we still have the event in memory.
+            event = self._event_ref.get(event_id)
+            if event:
+                redacted_event = None
+                if event.internal_metadata.redacted_by is not None:
+                    # The event has been redacted, so we generate a redacted
+                    # version.
+                    redacted_event = prune_event(event)
+                    redacted_event.unsigned[
+                        "redacted_by"
+                    ] = event.internal_metadata.redacted_by
+
+                cache_entry = _EventCacheEntry(
+                    event=event,
+                    redacted_event=redacted_event,
+                )
+                event_map[event_id] = cache_entry
+
+                # We add the entry back into the cache as we want to keep
+                # recently queried events in the cache.
+                self._get_event_cache.set((event_id,), cache_entry)
 
         return event_map
 
@@ -877,12 +905,19 @@ class EventsWorkerStore(SQLBaseStore):
                 original_ev, redactions, event_map
             )
 
+            if redacted_event:
+                original_ev.internal_metadata.redacted_by = redacted_event.unsigned[
+                    "redacted_by"
+                ]
+
             cache_entry = _EventCacheEntry(
                 event=original_ev, redacted_event=redacted_event
             )
 
             self._get_event_cache.set((event_id,), cache_entry)
             result_map[event_id] = cache_entry
+
+            self._event_ref[event_id] = original_ev
 
         return result_map
 

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -598,7 +598,7 @@ class EventsWorkerStore(SQLBaseStore):
         self, events: Iterable[str], update_metrics: bool = True
     ) -> Dict[str, _EventCacheEntry]:
         """Fetch events from the caches.
-        
+
         May return rejected events.
 
         Args:
@@ -745,7 +745,7 @@ class EventsWorkerStore(SQLBaseStore):
         self, event_ids: Iterable[str]
     ) -> Dict[str, _EventCacheEntry]:
         """Fetch a bunch of events from the database.
-        
+
         May return rejected events.
 
         Returned events will be added to the cache for future lookups.

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -529,7 +529,7 @@ class EventsWorkerStore(SQLBaseStore):
         for event_id in missing_events_ids:
             deferred = self._current_event_fetches.get(event_id)
             if deferred is not None:
-                # We're already pulling the event out of the DB, ad the deferred
+                # We're already pulling the event out of the DB. Add the deferred
                 # to the collection of deferreds to wait on.
                 already_fetching[event_id] = deferred.observe()
             else:

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -14,7 +14,6 @@
 
 import logging
 import threading
-import weakref
 from typing import (
     Collection,
     Container,
@@ -174,10 +173,6 @@ class EventsWorkerStore(SQLBaseStore):
         # Map from event ID to a deferred that will result in an
         # Dict[str, _EventCacheEntry].
         self._current_event_fetches: Dict[str, ObservableDeferred] = {}
-
-        # We keep track of the events we have currently loaded in memory so that
-        # we can reuse them even if they've been evicted from the cache.
-        self._event_ref: Dict[str, EventBase] = weakref.WeakValueDictionary()
 
         self._event_fetch_lock = threading.Condition()
         self._event_fetch_list = []
@@ -593,8 +588,6 @@ class EventsWorkerStore(SQLBaseStore):
 
     def _invalidate_get_event_cache(self, event_id):
         self._get_event_cache.invalidate((event_id,))
-        self._event_ref.pop(event_id, None)
-        self._current_event_fetches.pop(event_id, None)
 
     def _get_events_from_cache(
         self, events: Iterable[str], update_metrics: bool = True
@@ -608,34 +601,13 @@ class EventsWorkerStore(SQLBaseStore):
         event_map = {}
 
         for event_id in events:
-            # First check if its in the event cache
             ret = self._get_event_cache.get(
                 (event_id,), None, update_metrics=update_metrics
             )
-            if ret:
-                event_map[event_id] = ret
+            if not ret:
+                continue
 
-            # Otherwise check if we still have the event in memory.
-            event = self._event_ref.get(event_id)
-            if event:
-                redacted_event = None
-                if event.internal_metadata.redacted_by is not None:
-                    # The event has been redacted, so we generate a redacted
-                    # version.
-                    redacted_event = prune_event(event)
-                    redacted_event.unsigned[
-                        "redacted_by"
-                    ] = event.internal_metadata.redacted_by
-
-                cache_entry = _EventCacheEntry(
-                    event=event,
-                    redacted_event=redacted_event,
-                )
-                event_map[event_id] = cache_entry
-
-                # We add the entry back into the cache as we want to keep
-                # recently queried events in the cache.
-                self._get_event_cache.set((event_id,), cache_entry)
+            event_map[event_id] = ret
 
         return event_map
 
@@ -905,19 +877,12 @@ class EventsWorkerStore(SQLBaseStore):
                 original_ev, redactions, event_map
             )
 
-            if redacted_event:
-                original_ev.internal_metadata.redacted_by = redacted_event.unsigned[
-                    "redacted_by"
-                ]
-
             cache_entry = _EventCacheEntry(
                 event=original_ev, redacted_event=redacted_event
             )
 
             self._get_event_cache.set((event_id,), cache_entry)
             result_map[event_id] = cache_entry
-
-            self._event_ref[event_id] = original_ev
 
         return result_map
 

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -597,7 +597,9 @@ class EventsWorkerStore(SQLBaseStore):
     def _get_events_from_cache(
         self, events: Iterable[str], update_metrics: bool = True
     ) -> Dict[str, _EventCacheEntry]:
-        """Fetch events from the caches, may return rejected events.
+        """Fetch events from the caches.
+        
+        May return rejected events.
 
         Args:
             events: list of event_ids to fetch
@@ -742,8 +744,9 @@ class EventsWorkerStore(SQLBaseStore):
     async def _get_events_from_db(
         self, event_ids: Iterable[str]
     ) -> Dict[str, _EventCacheEntry]:
-        """Fetch a bunch of events from the database, may return rejected
-        events.
+        """Fetch a bunch of events from the database.
+        
+        May return rejected events.
 
         Returned events will be added to the cache for future lookups.
 

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -629,14 +629,12 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         # We don't update the event cache hit ratio as it completely throws off
         # the hit ratio counts. After all, we don't populate the cache if we
         # miss it here
-        event_map = self._get_events_from_cache(
-            member_event_ids, allow_rejected=False, update_metrics=False
-        )
+        event_map = self._get_events_from_cache(member_event_ids, update_metrics=False)
 
         missing_member_event_ids = []
         for event_id in member_event_ids:
             ev_entry = event_map.get(event_id)
-            if ev_entry:
+            if ev_entry and not ev_entry.event.rejected_reason:
                 if ev_entry.event.membership == Membership.JOIN:
                     users_in_room[ev_entry.event.state_key] = ProfileInfo(
                         display_name=ev_entry.event.content.get("displayname", None),

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -131,31 +131,6 @@ class EventCacheTestCase(unittest.HomeserverTestCase):
             # We should have fetched the event from the DB
             self.assertEqual(ctx.get_resource_usage().evt_db_fetch_count, 1)
 
-    def test_event_ref(self):
-        """Test that we reuse events that are still in memory but have fallen
-        out of the cache, rather than requesting them from the DB.
-        """
-
-        # Reset the event cache
-        self.store._get_event_cache.clear()
-
-        with LoggingContext("test") as ctx:
-            # We keep hold of the event event though we never use it.
-            event = self.get_success(self.store.get_event(self.event_id))  # noqa: F841
-
-            # We should have fetched the event from the DB
-            self.assertEqual(ctx.get_resource_usage().evt_db_fetch_count, 1)
-
-        # Reset the event cache
-        self.store._get_event_cache.clear()
-
-        with LoggingContext("test") as ctx:
-            self.get_success(self.store.get_event(self.event_id))
-
-            # Since the event is still in memory we shouldn't have fetched it
-            # from the DB
-            self.assertEqual(ctx.get_resource_usage().evt_db_fetch_count, 0)
-
     def test_dedupe(self):
         """Test that if we request the same event multiple times we only pull it
         out once.


### PR DESCRIPTION
This PR mainly does two things:
1. Ensure we only load an event from the DB once when the same event is requested multiple times at once.
2. Ensure that there is only one copy of any given event in memory at a time by using weak references.