### PR TITLE
Delete delivered to-device messages earlier in /sync

### DIFF
--- a/changelog.d/10124.misc
+++ b/changelog.d/10124.misc
@@ -1,0 +1,1 @@
+Work to improve the responsiveness of `/sync` requests.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -315,6 +315,17 @@ class SyncHandler:
         if context:
             context.tag = sync_type
 
+        # if we have a since token, delete any to-device messages before that token
+        # (since we now know that the device has received them)
+        if since_token is not None:
+            since_stream_id = since_token.to_device_key
+            deleted = await self.store.delete_messages_for_device(
+                sync_config.user.to_string(), sync_config.device_id, since_stream_id
+            )
+            logger.debug(
+                "Deleted %d to-device messages up to %d", deleted, since_stream_id
+            )
+
         if timeout == 0 or since_token is None or full_state:
             # we are going to return immediately, so don't bother calling
             # notifier.wait_for_events.
@@ -1230,16 +1241,6 @@ class SyncHandler:
             since_stream_id = int(sync_result_builder.since_token.to_device_key)
 
         if since_stream_id != int(now_token.to_device_key):
-            # We only delete messages when a new message comes in, but that's
-            # fine so long as we delete them at some point.
-
-            deleted = await self.store.delete_messages_for_device(
-                user_id, device_id, since_stream_id
-            )
-            logger.debug(
-                "Deleted %d to-device messages up to %d", deleted, since_stream_id
-            )
-
             messages, stream_id = await self.store.get_new_messages_for_device(
                 user_id, device_id, since_stream_id, now_token.to_device_key
             )


### PR DESCRIPTION
I hope this will improve #9564.

The current impl doesn't seem optimal. Here's what happens:

 * sync arrives, we wait for a wakeup
 * we get woken up by something random
 * we run the to-device deletion.
 * we ultimately decide it's not time to return yet
 * we wait for another wakeup
 * a to-device message arrives, which wakes us up
 * we run the to-device deletion *again*.
   * There cannot be anything to delete which we haven't already deleted, but the `last_deleted_stream_id` magic in `delete_messages_for_device` is confused by the new to-device message
   * so we run a DELETE operation which will do nothing, but is surprisingly slow (something something handwave postgres deleted rows)

Hopefully, by doing the deletion right at the start, rather than after we get woken up, we can improve the latency between wakeup and response.