### PR TITLE
Fix broken link to README at root of repo

### DIFF
--- a/changelog.d/10132.doc
+++ b/changelog.d/10132.doc
@@ -1,1 +1,1 @@
-Fix broken link in Docker docs
+Fix broken link in Docker docs.

--- a/changelog.d/10132.doc
+++ b/changelog.d/10132.doc
@@ -1,0 +1,1 @@
+Fix broken link in Docker docs

--- a/docker/README.md
+++ b/docker/README.md
@@ -226,4 +226,4 @@ healthcheck:
 ## Using jemalloc
 
 Jemalloc is embedded in the image and will be used instead of the default allocator.
-You can read about jemalloc by reading the Synapse [README](../README.md).
+You can read about jemalloc by reading the Synapse [README](../README.rst).


### PR DESCRIPTION
Looks like the README filename changed from `README.md` to `README.rst`

Or should the link go to this specific section of the README?

https://github.com/matrix-org/synapse/blob/develop/README.rst#help-synapse-is-slow-and-eats-all-my-ram-cpu

Signed-off-by: Chris Castle <chris@crc.io>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

I receive the following error when I run the linter on `docker/README.md`

```
$ ./scripts-dev/lint.sh docker/README.md 
Linting these paths: docker/README.md

+ isort docker/README.md
+ python3 -m black docker/README.md
error: cannot format docker/README.md: Cannot parse: 3:5: This Docker image will run Synapse as a single process. By default it uses a
Oh no! 💥 💔 💥
1 file failed to reformat.
```

