### PR TITLE
Make opentracing trace into event persistence

### DIFF
--- a/changelog.d/10134.misc
+++ b/changelog.d/10134.misc
@@ -1,0 +1,1 @@
+Improve OpenTracing for event persistence.

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -207,7 +207,7 @@ class Auth:
 
                 request.requester = user_id
                 if user_id in self._force_tracing_for_users:
-                    opentracing.set_tag(opentracing.tags.SAMPLING_PRIORITY, 1)
+                    opentracing.force_tracing()
                 opentracing.set_tag("authenticated_entity", user_id)
                 opentracing.set_tag("user_id", user_id)
                 opentracing.set_tag("appservice_id", app_service.id)
@@ -260,7 +260,7 @@ class Auth:
 
             request.requester = requester
             if user_info.token_owner in self._force_tracing_for_users:
-                opentracing.set_tag(opentracing.tags.SAMPLING_PRIORITY, 1)
+                opentracing.force_tracing()
             opentracing.set_tag("authenticated_entity", user_info.token_owner)
             opentracing.set_tag("user_id", user_info.user_id)
             if device_id:

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -551,6 +551,10 @@ def start_active_span_from_edu(
 
 
 # Opentracing setters for tags, logs, etc
+@only_if_tracing
+def active_span():
+    """Get the currently active span, if any"""
+    return opentracing.tracer.active_span
 
 
 @ensure_active_span("set a tag")


### PR DESCRIPTION
Previously, because events were persisted by a separate background process, we wouldn't be able to see what was happening when we traced an event send request.

~~ Let's treat the persist operation as a child of the send request~~

~~There are a couple of preparatory refactors here: suggest reviewing commit-by-commit.~~ 
~~Now based on #10145.~~

Use the span references feature to link from the persist operation to the request, and back again.