### PR TITLE
opentracing: use a consistent name for background processes

### DIFF
--- a/changelog.d/10135.misc
+++ b/changelog.d/10135.misc
@@ -1,0 +1,1 @@
+OpenTracing: use a consistent name for background processes.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -337,6 +337,7 @@ def ensure_active_span(message, ret=None):
 @contextlib.contextmanager
 def noop_context_manager(*args, **kwargs):
     """Does exactly what it says on the tin"""
+    # TODO: replace with contextlib.nullcontext once we drop support for Python 3.6
     yield
 
 

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -204,11 +204,12 @@ def run_as_background_process(desc: str, func, *args, bg_start_span=True, **kwar
 
         with BackgroundProcessLoggingContext(desc, count) as context:
             try:
-                ctx = noop_context_manager()
                 if bg_start_span:
                     ctx = start_active_span(
-                        desc, tags={SynapseTags.REQUEST_ID: str(context)}
+                        f"bgproc.{desc}", tags={SynapseTags.REQUEST_ID: str(context)}
                     )
+                else:
+                    ctx = noop_context_manager()
                 with ctx:
                     return await maybe_awaitable(func(*args, **kwargs))
             except Exception:


### PR DESCRIPTION
... otherwise we tend to get a namespace clash between the bg process and the functions that it calls.