### PR TITLE
Correct type hints for parse_string(s)_from_args.

### DIFF
--- a/changelog.d/10137.misc
+++ b/changelog.d/10137.misc
@@ -1,0 +1,1 @@
+Add `parse_strings_from_args` for parsing an array from query parameters.

--- a/mypy.ini
+++ b/mypy.ini
@@ -32,6 +32,7 @@ files =
   synapse/http/federation/matrix_federation_agent.py,
   synapse/http/federation/well_known_resolver.py,
   synapse/http/matrixfederationclient.py,
+  synapse/http/servlet.py,
   synapse/http/server.py,
   synapse/http/site.py,
   synapse/logging,

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -253,11 +253,10 @@ def parse_strings_from_args(
         args: the twisted HTTP request.args list.
         name: the name of the query parameter.
         default: value to use if the parameter is absent, defaults to None.
-        required : whether to raise a 400 SynapseError if the
+        required: whether to raise a 400 SynapseError if the
             parameter is absent, defaults to False.
-        allowed_values (list[bytes|unicode]): List of allowed values for the
-            string, or None if any value is allowed, defaults to None. Must be
-            the same type as name, if given.
+        allowed_values: List of allowed values for the
+            string, or None if any value is allowed, defaults to None.
         encoding: The encoding to decode the string content with.
 
     Returns:
@@ -281,12 +280,8 @@ def parse_strings_from_args(
         if required:
             message = "Missing string query parameter %r" % (name,)
             raise SynapseError(400, message, errcode=Codes.MISSING_PARAM)
-        else:
 
-            if isinstance(default, bytes):
-                return default.decode(encoding)
-
-            return default
+        return default
 
 
 def parse_string_from_args(
@@ -326,11 +321,14 @@ def parse_string_from_args(
     strings = parse_strings_from_args(
         args,
         name,
-        default=[default],
+        default=[default] if default is not None else None,
         required=required,
         allowed_values=allowed_values,
         encoding=encoding,
     )
+
+    if strings is None:
+        return None
 
     return strings[0]
 

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -197,8 +197,9 @@ def parse_string(
             parameter is present, must be one of a list of allowed values and
             is not one of those allowed values.
     """
+    args = request.args  # type: Dict[bytes, List[bytes]]  # type: ignore
     return parse_string_from_args(
-        request.args, name, default, required, allowed_values, encoding
+        args, name, default, required, allowed_values, encoding
     )
 
 
@@ -422,9 +423,8 @@ class RestServlet:
 
     def register(self, http_server):
         """ Register this servlet with the given HTTP server. """
-        if hasattr(self, "PATTERNS"):
-            patterns = self.PATTERNS
-
+        patterns = getattr(self, "PATTERNS", None)
+        if patterns:
             for method in ("GET", "PUT", "POST", "DELETE"):
                 if hasattr(self, "on_%s" % (method,)):
                     servlet_classname = self.__class__.__name__

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -111,8 +111,8 @@ def parse_boolean_from_args(args, name, default=None, required=False):
 
 
 @overload
-def parse_bytes(
-    request: Request,
+def parse_bytes_from_args(
+    args: Dict[bytes, List[bytes]],
     name: str,
     default: Literal[None] = None,
     required: Literal[True] = True,
@@ -121,8 +121,8 @@ def parse_bytes(
 
 
 @overload
-def parse_bytes(
-    request: Request,
+def parse_bytes_from_args(
+    args: Dict[bytes, List[bytes]],
     name: str,
     default: Optional[bytes] = None,
     required: bool = False,
@@ -130,8 +130,8 @@ def parse_bytes(
     ...
 
 
-def parse_bytes(
-    request: Request,
+def parse_bytes_from_args(
+    args: Dict[bytes, List[bytes]],
     name: str,
     default: Optional[bytes] = None,
     required: bool = False,
@@ -140,7 +140,7 @@ def parse_bytes(
     Parse a string parameter as bytes from the request query string.
 
     Args:
-        request: the twisted HTTP request.
+        args: A mapping of request args as bytes to a list of bytes (e.g. request.args).
         name: the name of the query parameter.
         default: value to use if the parameter is absent,
             defaults to None. Must be bytes if encoding is None.
@@ -152,7 +152,6 @@ def parse_bytes(
     Raises:
         SynapseError if the parameter is absent and required.
     """
-    args = request.args  # type: Dict[bytes, List[bytes]]  # type: ignore
     name_bytes = name.encode("ascii")
 
     if name_bytes in args:
@@ -262,7 +261,7 @@ def parse_strings_from_args(
     The content of the query param will be decoded to Unicode using the encoding.
 
     Args:
-        args: the twisted HTTP request.args list.
+        args: A mapping of request args as bytes to a list of bytes (e.g. request.args).
         name: the name of the query parameter.
         default: value to use if the parameter is absent, defaults to None.
         required: whether to raise a 400 SynapseError if the
@@ -311,7 +310,7 @@ def parse_string_from_args(
     The content of the query param will be decoded to Unicode using the encoding.
 
     Args:
-        args: the twisted HTTP request.args list.
+        args: A mapping of request args as bytes to a list of bytes (e.g. request.args).
         name: the name of the query parameter.
         default: value to use if the parameter is absent, defaults to None.
         required: whether to raise a 400 SynapseError if the

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -15,7 +15,7 @@
 """ This module contains base REST classes for constructing REST servlets. """
 
 import logging
-from typing import Dict, Iterable, List, Optional, Union, overload
+from typing import Dict, Iterable, List, Optional, overload
 
 from typing_extensions import Literal
 
@@ -166,7 +166,7 @@ def parse_bytes(
 
 def parse_string(
     request: Request,
-    name: Union[bytes, str],
+    name: str,
     default: Optional[str] = None,
     required: bool = False,
     allowed_values: Optional[Iterable[str]] = None,
@@ -226,7 +226,7 @@ def _parse_string_value(
 @overload
 def parse_strings_from_args(
     args: Dict[bytes, List[bytes]],
-    name: Union[bytes, str],
+    name: str,
     default: Optional[List[str]] = None,
     required: bool = False,
     allowed_values: Optional[Iterable[str]] = None,
@@ -237,7 +237,7 @@ def parse_strings_from_args(
 
 def parse_strings_from_args(
     args: Dict[bytes, List[bytes]],
-    name: Union[bytes, str],
+    name: str,
     default: Optional[List[str]] = None,
     required: bool = False,
     allowed_values: Optional[Iterable[str]] = None,
@@ -267,12 +267,10 @@ def parse_strings_from_args(
             parameter is present, must be one of a list of allowed values and
             is not one of those allowed values.
     """
+    name_bytes = name.encode("ascii")
 
-    if not isinstance(name, bytes):
-        name = name.encode("ascii")
-
-    if name in args:
-        values = args[name]
+    if name_bytes in args:
+        values = args[name_bytes]
 
         return [
             _parse_string_value(value, allowed_values, name=name, encoding=encoding)
@@ -292,7 +290,7 @@ def parse_strings_from_args(
 
 def parse_string_from_args(
     args: Dict[bytes, List[bytes]],
-    name: Union[bytes, str],
+    name: str,
     default: Optional[str] = None,
     required: bool = False,
     allowed_values: Optional[Iterable[str]] = None,

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -229,6 +229,18 @@ def parse_strings_from_args(
     args: Dict[bytes, List[bytes]],
     name: str,
     default: Optional[List[str]] = None,
+    required: Literal[True] = True,
+    allowed_values: Optional[Iterable[str]] = None,
+    encoding: str = "ascii",
+) -> List[str]:
+    ...
+
+
+@overload
+def parse_strings_from_args(
+    args: Dict[bytes, List[bytes]],
+    name: str,
+    default: Optional[List[str]] = None,
     required: bool = False,
     allowed_values: Optional[Iterable[str]] = None,
     encoding: str = "ascii",

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -170,7 +170,7 @@ def parse_string(
     default: Optional[str] = None,
     required: bool = False,
     allowed_values: Optional[Iterable[str]] = None,
-    encoding: Optional[str] = "ascii",
+    encoding: str = "ascii",
 ):
     """
     Parse a string parameter from the request query string.
@@ -181,17 +181,16 @@ def parse_string(
     Args:
         request: the twisted HTTP request.
         name: the name of the query parameter.
-        default: value to use if the parameter is absent,
-            defaults to None. Must be bytes if encoding is None.
+        default: value to use if the parameter is absent, defaults to None.
         required: whether to raise a 400 SynapseError if the
             parameter is absent, defaults to False.
         allowed_values: List of allowed values for the
             string, or None if any value is allowed, defaults to None. Must be
             the same type as name, if given.
-        encoding : The encoding to decode the string content with.
+        encoding: The encoding to decode the string content with.
+
     Returns:
-        A string value or the default. Unicode if encoding
-        was given, bytes otherwise.
+        A string value or the default.
 
     Raises:
         SynapseError if the parameter is absent and required, or if the
@@ -204,37 +203,24 @@ def parse_string(
 
 
 def _parse_string_value(
-    value: Union[str, bytes],
+    value: bytes,
     allowed_values: Optional[Iterable[str]],
     name: str,
-    encoding: Optional[str],
-) -> Union[str, bytes]:
-    if encoding:
-        try:
-            value = value.decode(encoding)
-        except ValueError:
-            raise SynapseError(400, "Query parameter %r must be %s" % (name, encoding))
+    encoding: str,
+) -> str:
+    try:
+        value_str = value.decode(encoding)
+    except ValueError:
+        raise SynapseError(400, "Query parameter %r must be %s" % (name, encoding))
 
-    if allowed_values is not None and value not in allowed_values:
+    if allowed_values is not None and value_str not in allowed_values:
         message = "Query parameter %r must be one of [%s]" % (
             name,
             ", ".join(repr(v) for v in allowed_values),
         )
         raise SynapseError(400, message)
     else:
-        return value
-
-
-@overload
-def parse_strings_from_args(
-    args: List[str],
-    name: Union[bytes, str],
-    default: Optional[List[str]] = None,
-    required: bool = False,
-    allowed_values: Optional[Iterable[str]] = None,
-    encoding: Literal[None] = None,
-) -> Optional[List[bytes]]:
-    ...
+        return value_str
 
 
 @overload
@@ -255,19 +241,17 @@ def parse_strings_from_args(
     default: Optional[List[str]] = None,
     required: bool = False,
     allowed_values: Optional[Iterable[str]] = None,
-    encoding: Optional[str] = "ascii",
-) -> Optional[List[Union[bytes, str]]]:
+    encoding: str = "ascii",
+) -> Optional[List[str]]:
     """
     Parse a string parameter from the request query string list.
 
-    If encoding is not None, the content of the query param will be
-    decoded to Unicode using the encoding, otherwise it will be encoded
+    The content of the query param will be decoded to Unicode using the encoding.
 
     Args:
         args: the twisted HTTP request.args list.
         name: the name of the query parameter.
-        default: value to use if the parameter is absent,
-            defaults to None. Must be bytes if encoding is None.
+        default: value to use if the parameter is absent, defaults to None.
         required : whether to raise a 400 SynapseError if the
             parameter is absent, defaults to False.
         allowed_values (list[bytes|unicode]): List of allowed values for the
@@ -276,8 +260,7 @@ def parse_strings_from_args(
         encoding: The encoding to decode the string content with.
 
     Returns:
-        A string value or the default. Unicode if encoding
-        was given, bytes otherwise.
+        A string value or the default.
 
     Raises:
         SynapseError if the parameter is absent and required, or if the
@@ -297,11 +280,11 @@ def parse_strings_from_args(
         ]
     else:
         if required:
-            message = "Missing string query parameter %r" % (name)
+            message = "Missing string query parameter %r" % (name,)
             raise SynapseError(400, message, errcode=Codes.MISSING_PARAM)
         else:
 
-            if encoding and isinstance(default, bytes):
+            if isinstance(default, bytes):
                 return default.decode(encoding)
 
             return default
@@ -313,20 +296,18 @@ def parse_string_from_args(
     default: Optional[str] = None,
     required: bool = False,
     allowed_values: Optional[Iterable[str]] = None,
-    encoding: Optional[str] = "ascii",
-) -> Optional[Union[bytes, str]]:
+    encoding: str = "ascii",
+) -> Optional[str]:
     """
     Parse the string parameter from the request query string list
     and return the first result.
 
-    If encoding is not None, the content of the query param will be
-    decoded to Unicode using the encoding, otherwise it will be encoded
+    The content of the query param will be decoded to Unicode using the encoding.
 
     Args:
         args: the twisted HTTP request.args list.
         name: the name of the query parameter.
-        default: value to use if the parameter is absent,
-            defaults to None. Must be bytes if encoding is None.
+        default: value to use if the parameter is absent, defaults to None.
         required: whether to raise a 400 SynapseError if the
             parameter is absent, defaults to False.
         allowed_values: List of allowed values for the
@@ -335,8 +316,7 @@ def parse_string_from_args(
         encoding: The encoding to decode the string content with.
 
     Returns:
-        A string value or the default. Unicode if encoding
-        was given, bytes otherwise.
+        A string value or the default.
 
     Raises:
         SynapseError if the parameter is absent and required, or if the

--- a/synapse/http/servlet.py
+++ b/synapse/http/servlet.py
@@ -165,7 +165,7 @@ def parse_bytes(
 
 
 def parse_string(
-    request,
+    request: Request,
     name: Union[bytes, str],
     default: Optional[str] = None,
     required: bool = False,
@@ -225,7 +225,7 @@ def _parse_string_value(
 
 @overload
 def parse_strings_from_args(
-    args: List[str],
+    args: Dict[bytes, List[bytes]],
     name: Union[bytes, str],
     default: Optional[List[str]] = None,
     required: bool = False,
@@ -236,7 +236,7 @@ def parse_strings_from_args(
 
 
 def parse_strings_from_args(
-    args: List[str],
+    args: Dict[bytes, List[bytes]],
     name: Union[bytes, str],
     default: Optional[List[str]] = None,
     required: bool = False,
@@ -291,7 +291,7 @@ def parse_strings_from_args(
 
 
 def parse_string_from_args(
-    args: List[str],
+    args: Dict[bytes, List[bytes]],
     name: Union[bytes, str],
     default: Optional[str] = None,
     required: bool = False,

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -649,7 +649,7 @@ class RoomEventContextServlet(RestServlet):
         limit = parse_integer(request, "limit", default=10)
 
         # picking the API shape for symmetry with /messages
-        filter_str = parse_string(request, b"filter", encoding="utf-8")
+        filter_str = parse_string(request, "filter", encoding="utf-8")
         if filter_str:
             filter_json = urlparse.unquote(filter_str)
             event_filter = Filter(

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -25,6 +25,7 @@ from synapse.http import get_request_uri
 from synapse.http.server import HttpServer, finish_request
 from synapse.http.servlet import (
     RestServlet,
+    parse_bytes,
     parse_json_object_from_request,
     parse_string,
 )
@@ -437,9 +438,7 @@ class SsoRedirectServlet(RestServlet):
             finish_request(request)
             return
 
-        client_redirect_url = parse_string(
-            request, "redirectUrl", required=True, encoding=None
-        )
+        client_redirect_url = parse_bytes(request, "redirectUrl", required=True)
         sso_url = await self._sso_handler.handle_redirect_request(
             request,
             client_redirect_url,

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -14,7 +14,7 @@
 
 import logging
 import re
-from typing import TYPE_CHECKING, Awaitable, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Awaitable, Callable, Dict, List, Optional
 
 from synapse.api.errors import Codes, LoginError, SynapseError
 from synapse.api.ratelimiting import Ratelimiter
@@ -25,7 +25,7 @@ from synapse.http import get_request_uri
 from synapse.http.server import HttpServer, finish_request
 from synapse.http.servlet import (
     RestServlet,
-    parse_bytes,
+    parse_bytes_from_args,
     parse_json_object_from_request,
     parse_string,
 )
@@ -438,7 +438,8 @@ class SsoRedirectServlet(RestServlet):
             finish_request(request)
             return
 
-        client_redirect_url = parse_bytes(request, "redirectUrl", required=True)
+        args = request.args  # type: Dict[bytes, List[bytes]]  # type: ignore
+        client_redirect_url = parse_bytes_from_args(args, "redirectUrl", required=True)
         sso_url = await self._sso_handler.handle_redirect_request(
             request,
             client_redirect_url,

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -537,7 +537,7 @@ class RoomMessageListRestServlet(RestServlet):
             self.store, request, default_limit=10
         )
         as_client_event = b"raw" not in request.args
-        filter_str = parse_string(request, b"filter", encoding="utf-8")
+        filter_str = parse_string(request, "filter", encoding="utf-8")
         if filter_str:
             filter_json = urlparse.unquote(filter_str)
             event_filter = Filter(
@@ -652,7 +652,7 @@ class RoomEventContextServlet(RestServlet):
         limit = parse_integer(request, "limit", default=10)
 
         # picking the API shape for symmetry with /messages
-        filter_str = parse_string(request, b"filter", encoding="utf-8")
+        filter_str = parse_string(request, "filter", encoding="utf-8")
         if filter_str:
             filter_json = urlparse.unquote(filter_str)
             event_filter = Filter(

--- a/synapse/rest/consent/consent_resource.py
+++ b/synapse/rest/consent/consent_resource.py
@@ -17,6 +17,7 @@ import logging
 from hashlib import sha256
 from http import HTTPStatus
 from os import path
+from typing import Dict, List
 
 import jinja2
 from jinja2 import TemplateNotFound
@@ -24,7 +25,7 @@ from jinja2 import TemplateNotFound
 from synapse.api.errors import NotFoundError, StoreError, SynapseError
 from synapse.config import ConfigError
 from synapse.http.server import DirectServeHtmlResource, respond_with_html
-from synapse.http.servlet import parse_bytes, parse_string
+from synapse.http.servlet import parse_bytes_from_args, parse_string
 from synapse.types import UserID
 
 # language to use for the templates. TODO: figure this out from Accept-Language
@@ -116,7 +117,8 @@ class ConsentResource(DirectServeHtmlResource):
         has_consented = False
         public_version = username == ""
         if not public_version:
-            userhmac_bytes = parse_bytes(request, "h", required=True)
+            args = request.args  # type: Dict[bytes, List[bytes]]
+            userhmac_bytes = parse_bytes_from_args(args, "h", required=True)
 
             self._check_hash(username, userhmac_bytes)
 
@@ -152,7 +154,8 @@ class ConsentResource(DirectServeHtmlResource):
         """
         version = parse_string(request, "v", required=True)
         username = parse_string(request, "u", required=True)
-        userhmac = parse_bytes(request, "h", required=True)
+        args = request.args  # type: Dict[bytes, List[bytes]]
+        userhmac = parse_bytes_from_args(args, "h", required=True)
 
         self._check_hash(username, userhmac)
 

--- a/synapse/rest/consent/consent_resource.py
+++ b/synapse/rest/consent/consent_resource.py
@@ -24,7 +24,7 @@ from jinja2 import TemplateNotFound
 from synapse.api.errors import NotFoundError, StoreError, SynapseError
 from synapse.config import ConfigError
 from synapse.http.server import DirectServeHtmlResource, respond_with_html
-from synapse.http.servlet import parse_string
+from synapse.http.servlet import parse_bytes, parse_string
 from synapse.types import UserID
 
 # language to use for the templates. TODO: figure this out from Accept-Language
@@ -116,7 +116,7 @@ class ConsentResource(DirectServeHtmlResource):
         has_consented = False
         public_version = username == ""
         if not public_version:
-            userhmac_bytes = parse_string(request, "h", required=True, encoding=None)
+            userhmac_bytes = parse_bytes(request, "h", required=True)
 
             self._check_hash(username, userhmac_bytes)
 
@@ -152,7 +152,7 @@ class ConsentResource(DirectServeHtmlResource):
         """
         version = parse_string(request, "v", required=True)
         username = parse_string(request, "u", required=True)
-        userhmac = parse_string(request, "h", required=True, encoding=None)
+        userhmac = parse_bytes(request, "h", required=True)
 
         self._check_hash(username, userhmac)
 

--- a/synapse/rest/media/v1/upload_resource.py
+++ b/synapse/rest/media/v1/upload_resource.py
@@ -14,13 +14,13 @@
 # limitations under the License.
 
 import logging
-from typing import IO, TYPE_CHECKING, Optional
+from typing import IO, TYPE_CHECKING, Dict, List, Optional
 
 from twisted.web.server import Request
 
 from synapse.api.errors import Codes, SynapseError
 from synapse.http.server import DirectServeJsonResource, respond_with_json
-from synapse.http.servlet import parse_bytes
+from synapse.http.servlet import parse_bytes_from_args
 from synapse.http.site import SynapseRequest
 from synapse.rest.media.v1.media_storage import SpamMediaException
 
@@ -61,7 +61,8 @@ class UploadResource(DirectServeJsonResource):
                 errcode=Codes.TOO_LARGE,
             )
 
-        upload_name_bytes = parse_bytes(request, "filename")
+        args = request.args  # type: Dict[bytes, List[bytes]]  # type: ignore
+        upload_name_bytes = parse_bytes_from_args(args, "filename")
         if upload_name_bytes:
             try:
                 upload_name = upload_name_bytes.decode("utf8")  # type: Optional[str]

--- a/synapse/rest/media/v1/upload_resource.py
+++ b/synapse/rest/media/v1/upload_resource.py
@@ -14,13 +14,13 @@
 # limitations under the License.
 
 import logging
-from typing import IO, TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Optional
 
 from twisted.web.server import Request
 
 from synapse.api.errors import Codes, SynapseError
 from synapse.http.server import DirectServeJsonResource, respond_with_json
-from synapse.http.servlet import parse_string
+from synapse.http.servlet import parse_bytes
 from synapse.http.site import SynapseRequest
 from synapse.rest.media.v1.media_storage import SpamMediaException
 
@@ -61,10 +61,10 @@ class UploadResource(DirectServeJsonResource):
                 errcode=Codes.TOO_LARGE,
             )
 
-        upload_name = parse_string(request, b"filename", encoding=None)
-        if upload_name:
+        upload_name_bytes = parse_bytes(request, "filename")
+        if upload_name_bytes:
             try:
-                upload_name = upload_name.decode("utf8")
+                upload_name = upload_name_bytes.decode("utf8")  # type: Optional[str]
             except UnicodeDecodeError:
                 raise SynapseError(
                     msg="Invalid UTF-8 filename parameter: %r" % (upload_name), code=400


### PR DESCRIPTION
Does a few things:

* Fixes the type hints added in #10048 which were incorrect in some situations.
* Adds a seperate `parse_bytes` method (which simplifies the above type hints dramatically).
* Enables mypy for the `servlet` file (which would have found the issues with #10048).

Each commit should be reviewable separately.

This is blocking #10080, as the type hints that are currently there conflict with that PR.