### PR TITLE
Avoid sending lots of federation transactions all at once due to presence.

### DIFF
--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -251,7 +251,7 @@ class PerDestinationQueue:
                 await self._transaction_transmission_loop()
 
         if delay:
-            self._clock.call_later(_start, random.uniform(0, 5000))
+            self._clock.call_later(random.uniform(0, 5000), _start)
         else:
             _start()
 

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -251,7 +251,7 @@ class PerDestinationQueue:
                 await self._transaction_transmission_loop()
 
         if delay:
-            self._clock.call_later(random.uniform(0, 5000), _start)
+            self._clock.call_later(random.uniform(0, 5), _start)
         else:
             _start()
 

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -179,7 +179,7 @@ class PerDestinationQueue:
             states: presence to send
         """
         self._pending_presence.update({state.user_id: state for state in states})
-        self.attempt_new_transaction()
+        self.attempt_new_transaction(delay=True)
 
     def queue_read_receipt(self, receipt: ReadReceipt) -> None:
         """Add a RR to the list to be sent. Doesn't start the transmission loop yet

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -32,9 +32,7 @@ from synapse.handlers.presence import format_user_presence_state
 from synapse.logging import issue9533_logger
 from synapse.logging.opentracing import SynapseTags, set_tag
 from synapse.metrics import sent_transactions_counter
-from synapse.metrics.background_process_metrics import (
-    wrap_as_background_process,
-)
+from synapse.metrics.background_process_metrics import wrap_as_background_process
 from synapse.types import ReadReceipt
 from synapse.util.retryutils import NotRetryingDestination, get_retry_limiter
 


### PR DESCRIPTION
One of the really annoying things with presence is that every time your state changes it will send a transaction to all servers you share a room with all at once. This can cause huge spikes in CPU (and I think memory), so ideally we'd avoid that.

This PR adds a random delay between 0 and 5s before poking the PerDestinationQueue to start sending transactions. The idea here is that a) a 5s delay to presence is fine most of the time, and b) we mainly care about presence being fast when a user is already interacting with a room, e.g. they've started typing, at which point we'll already be sending transactions to those servers which will pull in the relevant presence updates.

The PR needs clean up, but I mostly want to check whether this seems like a sane thing to do? It has made things noticeably better on jki.re.