### PR TITLE
Clean up a broken import in admin_cmd.py

### DIFF
--- a/changelog.d/10154.bugfix
+++ b/changelog.d/10154.bugfix
@@ -1,0 +1,1 @@
+Remove a broken import line in Synapse's admin_cmd worker. Broke in 1.33.0.

--- a/synapse/app/admin_cmd.py
+++ b/synapse/app/admin_cmd.py
@@ -36,7 +36,6 @@ from synapse.replication.slave.storage.devices import SlavedDeviceStore
 from synapse.replication.slave.storage.events import SlavedEventStore
 from synapse.replication.slave.storage.filtering import SlavedFilteringStore
 from synapse.replication.slave.storage.groups import SlavedGroupServerStore
-from synapse.replication.slave.storage.presence import SlavedPresenceStore
 from synapse.replication.slave.storage.push_rule import SlavedPushRuleStore
 from synapse.replication.slave.storage.receipts import SlavedReceiptsStore
 from synapse.replication.slave.storage.registration import SlavedRegistrationStore
@@ -54,7 +53,6 @@ class AdminCmdSlavedStore(
     SlavedApplicationServiceStore,
     SlavedRegistrationStore,
     SlavedFilteringStore,
-    SlavedPresenceStore,
     SlavedGroupServerStore,
     SlavedDeviceInboxStore,
     SlavedDeviceStore,


### PR DESCRIPTION
Fixes: https://github.com/matrix-org/synapse/issues/10128

This PR fixes an import in `synapse/app/admin_cmd.py` that broke in #9820. Interestingly none of our linting caught this, even though our linting tools pass over this file. I'm not quite sure why, but my thought is that as this file is technically a new entrypoint to the codebase, `flake8` (which would be the tool to catch this), isn't able to check `synapse.replication.slave.storage.presence.SlavedPresenceStore` actually exists.

While this PR does remove the import, nowhere do I see in `admin_cmd.py` nor in `hs.get_admin_handler().export_user_data()`, which this function calls, the usage of any methods from `SlavedPresenceStore`, now `PresenceStore`. So I'm not sure if it's necessary to replace the import with anything.

I'm also not really sure how to use this tool in general. I got as far as running `python -m synapse.app.admin_cmd export-data "@userid:localhost"`, though it seems that this spins up a worker and requires a worker config file to be available.

We also don't use this tool internally either at matrix.org, so it's also worth asking whether anyone actually uses this tool...