### PR TITLE
Update Complement run with Synapse-supported MSC-related build tags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -322,7 +322,7 @@ jobs:
         working-directory: complement/dockerfiles
 
       # Run Complement
-      - run: go test -v -tags synapse_blacklist ./tests
+      - run: go test -v -tags synapse_blacklist,msc2946,msc3083,msc2403 ./tests
         env:
           COMPLEMENT_BASE_IMAGE: complement-synapse:latest
         working-directory: complement

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -322,7 +322,7 @@ jobs:
         working-directory: complement/dockerfiles
 
       # Run Complement
-      - run: go test -v -tags synapse_blacklist,msc2946,msc3083,msc2403 ./tests
+      - run: go test -v -tags synapse_blacklist,msc2403,msc2946,msc3083 ./tests
         env:
           COMPLEMENT_BASE_IMAGE: complement-synapse:latest
         working-directory: complement

--- a/changelog.d/10155.misc
+++ b/changelog.d/10155.misc
@@ -1,0 +1,1 @@
+Update the Complement build tags in GitHub Actions to test currently experimental features.


### PR DESCRIPTION
This PR updates the build tags that we perform Complement runs with to match our [buildkite pipeline](https://github.com/matrix-org/pipelines/blob/618b3e90bcae8efd1a71502ae95b7913e6e24665/synapse/pipeline.yml#L570), as well as adding `msc2403` (as it will be required once #9359 is merged). Build tags are what we use to determine which tests to run in Complement (really it determines which test files are compiled into the final binary).

I haven't put in a comment about updating the buildkite side here, as we've decided to migrate fully to GitHub Actions anyhow.

Requires: https://github.com/matrix-org/synapse/pull/9359