### PR TITLE
Add metrics to track how often events are `soft_failed`

### DIFF
--- a/changelog.d/10156.misc
+++ b/changelog.d/10156.misc
@@ -1,0 +1,1 @@
+Add `synapse_handlers_federation_soft_failed_event` metric to track how often events are `soft_failed`.

--- a/changelog.d/10156.misc
+++ b/changelog.d/10156.misc
@@ -1,1 +1,1 @@
-Add `synapse_federation_soft_failed_events_total` metric to track how often events are `soft_failed`.
+Add `synapse_federation_soft_failed_events_total` metric to track how often events are soft failed.

--- a/changelog.d/10156.misc
+++ b/changelog.d/10156.misc
@@ -1,1 +1,1 @@
-Add `synapse_handlers_federation_soft_failed_event` metric to track how often events are `soft_failed`.
+Add `synapse_federation_soft_failed_events_total` metric to track how often events are `soft_failed`.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -33,6 +33,7 @@ from typing import (
 )
 
 import attr
+from prometheus_client import Counter
 from signedjson.key import decode_verify_key_bytes
 from signedjson.sign import verify_signed_json
 from unpaddedbase64 import decode_base64
@@ -100,6 +101,8 @@ if TYPE_CHECKING:
     from synapse.server import HomeServer
 
 logger = logging.getLogger(__name__)
+
+soft_failed_event_counter = Counter("synapse_handlers_federation_soft_failed_event", "")
 
 
 @attr.s(slots=True)
@@ -2498,6 +2501,7 @@ class FederationHandler(BaseHandler):
             event_auth.check(room_version_obj, event, auth_events=current_auth_events)
         except AuthError as e:
             logger.warning("Soft-failing %r because %s", event, e)
+            soft_failed_event_counter.inc()
             event.internal_metadata.soft_failed = True
 
     async def on_get_missing_events(

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -102,7 +102,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-soft_failed_event_counter = Counter("synapse_federation_soft_failed_events_total", "")
+soft_failed_event_counter = Counter(
+    "synapse_federation_soft_failed_events_total",
+    "Events received over federation that we marked as soft_failed",
+)
 
 
 @attr.s(slots=True)

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -102,7 +102,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-soft_failed_event_counter = Counter("synapse_handlers_federation_soft_failed_event", "")
+soft_failed_event_counter = Counter("synapse_federation_soft_failed_events_total", "")
 
 
 @attr.s(slots=True)


### PR DESCRIPTION
Add metrics to track how often events are `soft_failed`

Spawned from missing messages we were seeing on `matrix.org` from a
federated Gitter bridged room, https://gitlab.com/gitterHQ/webapp/-/issues/2770.
The underlying issue in Synapse is tracked by https://github.com/matrix-org/synapse/issues/10066
where the message and join event race and the message is `soft_failed` before the
`join` event reaches the remote federated server.

Less soft_failed events = better and usually this should only trigger for events
where people are doing bad things and trying to fuzz and fake everything.

This metric does not track what situation causes the event to be `soft_failed` but could be used to know how many people roughly are potentially running into https://github.com/matrix-org/synapse/issues/10066.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)~~
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
