### PR TITLE
Ensure that we do not cache empty sync responses after a timeout

### DIFF
--- a/changelog.d/10157.bugfix
+++ b/changelog.d/10157.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.21.0 which could cause `/sync` to return immediately with an empty response.

--- a/changelog.d/10157.misc
+++ b/changelog.d/10157.misc
@@ -1,1 +1,0 @@
-Extend `ResponseCache` to pass a context object into the callback.

--- a/changelog.d/10158.bugfix
+++ b/changelog.d/10158.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.21.0 which could cause `/sync` to return immediately with an empty response.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -75,11 +75,9 @@ REQUIREMENTS = [
     "phonenumbers>=8.2.0",
     # we use GaugeHistogramMetric, which was added in prom-client 0.4.0.
     "prometheus_client>=0.4.0",
-    # we use attr.validators.deep_iterable, which arrived in 19.1.0 (Note:
-    # Fedora 31 only has 19.1, so if we want to upgrade we should wait until 33
-    # is out in November.)
+    # we use `order`, which arrived in attrs 19.2.0.
     # Note: 21.1.0 broke `/sync`, see #9936
-    "attrs>=19.1.0,!=21.1.0",
+    "attrs>=19.2.0,!=21.1.0",
     "netaddr>=0.7.18",
     "Jinja2>=2.9",
     "bleach>=1.4.3",

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -404,7 +404,7 @@ def map_username_to_mxid_localpart(
     return username.decode("ascii")
 
 
-@attr.s(frozen=True, slots=True, cmp=False)
+@attr.s(frozen=True, slots=True, order=False)
 class RoomStreamToken:
     """Tokens are positions between events. The token "s1" comes after event 1.
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -138,21 +138,19 @@ class FakeChannel:
     def transport(self):
         return self
 
-    def await_result(self, timeout: int = 100) -> None:
+    def await_result(self, timeout_ms: int = 1000) -> None:
         """
         Wait until the request is finished.
         """
+        end_time = self._reactor.seconds() + timeout_ms / 1000.0
         self._reactor.run()
-        x = 0
 
         while not self.is_finished():
             # If there's a producer, tell it to resume producing so we get content
             if self._producer:
                 self._producer.resumeProducing()
 
-            x += 1
-
-            if x > timeout:
+            if self._reactor.seconds() > end_time:
                 raise TimedOutException("Timed out waiting for request to finish.")
 
             self._reactor.advance(0.1)


### PR DESCRIPTION
Fixes #8518 by telling the `ResponseCache` not to cache the `/sync` response if the next_batch param is the same as the `since` token.

~~Based on #10157.~~

Note that actually enabling the sync cache timeout (ie, #3880) is left for a future task.