### PR TITLE
Manually pull the complement branch matching the current branch name.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -326,7 +326,7 @@ jobs:
               continue
             fi
 
-            (wget -O - https://github.com/matrix-org/complement/archive/$BRANCH_NAME.tar.gz | tar -xz --strip-components=1 -C complement) && break
+            (wget -O - "https://github.com/matrix-org/complement/archive/$BRANCH_NAME.tar.gz" | tar -xz --strip-components=1 -C complement) && break
           done
 
       # Build initial Synapse image

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -308,9 +308,16 @@ jobs:
       # Attempt to check out the same branch of Complement as the PR. If it
       # doesn't exist, fallback to master.
       - name: Checkout complement
+        shell: bash
         run: |
+          # For pull requests we want to use GITHUB_HEAD_REF (the pull request
+          # head branch). Otherwise, we use GITHUB_REF (refs/heads/<branch>).
+          BRANCH_NAME="$GITHUB_HEAD_REF"
+          if [[ -z "$BRANCH_NAME" ]]; then
+            BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          fi
           mkdir -p complement
-          (wget -O - https://github.com/matrix-org/complement/archive/$GITHUB_HEAD_REF.tar.gz || wget -O - https://github.com/matrix-org/complement/archive/master.tar.gz) | tar -xz --strip-components=1 -C complement
+          (wget -O - https://github.com/matrix-org/complement/archive/$BRANCH_NAME.tar.gz || wget -O - https://github.com/matrix-org/complement/archive/master.tar.gz) | tar -xz --strip-components=1 -C complement
 
       # Build initial Synapse image
       - run: docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -310,14 +310,24 @@ jobs:
       - name: Checkout complement
         shell: bash
         run: |
-          # For pull requests we want to use GITHUB_HEAD_REF (the pull request
-          # head branch). Otherwise, we use GITHUB_REF (refs/heads/<branch>).
-          BRANCH_NAME="$GITHUB_HEAD_REF"
-          if [[ -z "$BRANCH_NAME" ]]; then
-            BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-          fi
           mkdir -p complement
-          (wget -O - https://github.com/matrix-org/complement/archive/$BRANCH_NAME.tar.gz || wget -O - https://github.com/matrix-org/complement/archive/master.tar.gz) | tar -xz --strip-components=1 -C complement
+          # Attempt to use the version of complement which best matches the current
+          # build. Depending on whether this is a PR or release, etc. we need to
+          # use different fallbacks.
+          #
+          # 1. First check if there's a similarly named branch (GITHUB_HEAD_REF
+          #    for pull requests, otherwise GITHUB_REF).
+          # 2. Attempt to use the base branch, e.g. when merging into release-vX.Y
+          #    (GITHUB_BASE_REF for pull requests).
+          # 3. Use the default complement branch ("master").
+          for BRANCH_NAME in "$GITHUB_HEAD_REF" "$GITHUB_BASE_REF" "${GITHUB_REF#refs/heads/}" "master"; do
+            # Skip empty branch names and merge commits.
+            if [[ -z "$BRANCH_NAME" || $BRANCH_NAME =~ ^refs/pull/.* ]]; then
+              continue
+            fi
+
+            (wget -O - https://github.com/matrix-org/complement/archive/$BRANCH_NAME.tar.gz | tar -xz --strip-components=1 -C complement) && break
+          done
 
       # Build initial Synapse image
       - run: docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -305,11 +305,12 @@ jobs:
         with:
           path: synapse
 
-      - name: Run actions/checkout@v2 for complement
-        uses: actions/checkout@v2
-        with:
-          repository: "matrix-org/complement"
-          path: complement
+      # Attempt to check out the same branch of Complement as the PR. If it
+      # doesn't exist, fallback to master.
+      - name: Checkout complement
+        run: |
+          mkdir -p complement
+          (wget -O - https://github.com/matrix-org/complement/archive/$GITHUB_HEAD_REF.tar.gz || wget -O - https://github.com/matrix-org/complement/archive/master.tar.gz) | tar -xz --strip-components=1 -C complement
 
       # Build initial Synapse image
       - run: docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile .

--- a/changelog.d/10160.misc
+++ b/changelog.d/10160.misc
@@ -1,0 +1,1 @@
+Fetch the corresponding complement branch when performing CI.


### PR DESCRIPTION
This is akin to matrix-org/pipelines#157, but using GitHub Actions.