### PR TITLE
Remove support for unstable MSC1772 prefixes.

### DIFF
--- a/changelog.d/10161.removal
+++ b/changelog.d/10161.removal
@@ -1,0 +1,1 @@
+Stop supporting the unstable spaces prefixes from MSC1772.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -112,8 +112,6 @@ class EventTypes:
 
     SpaceChild = "m.space.child"
     SpaceParent = "m.space.parent"
-    MSC1772_SPACE_CHILD = "org.matrix.msc1772.space.child"
-    MSC1772_SPACE_PARENT = "org.matrix.msc1772.space.parent"
 
 
 class ToDeviceEventTypes:
@@ -180,7 +178,6 @@ class EventContentFields:
 
     # cf https://github.com/matrix-org/matrix-doc/pull/1772
     ROOM_TYPE = "type"
-    MSC1772_ROOM_TYPE = "org.matrix.msc1772.type"
 
 
 class RoomEncryptionAlgorithms:

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -402,10 +402,7 @@ class SpaceSummaryHandler:
             return (), ()
 
         return res.rooms, tuple(
-            ev.data
-            for ev in res.events
-            if ev.event_type == EventTypes.MSC1772_SPACE_CHILD
-            or ev.event_type == EventTypes.SpaceChild
+            ev.data for ev in res.events if ev.event_type == EventTypes.SpaceChild
         )
 
     async def _is_room_accessible(
@@ -514,11 +511,6 @@ class SpaceSummaryHandler:
             current_state_ids[(EventTypes.Create, "")]
         )
 
-        # TODO: update once MSC1772 lands
-        room_type = create_event.content.get(EventContentFields.ROOM_TYPE)
-        if not room_type:
-            room_type = create_event.content.get(EventContentFields.MSC1772_ROOM_TYPE)
-
         room_version = await self._store.get_room_version(room_id)
         allowed_spaces = None
         if await self._event_auth_handler.has_restricted_join_rules(
@@ -540,7 +532,7 @@ class SpaceSummaryHandler:
             ),
             "guest_can_join": stats["guest_access"] == "can_join",
             "creation_ts": create_event.origin_server_ts,
-            "room_type": room_type,
+            "room_type": create_event.content.get(EventContentFields.ROOM_TYPE),
             "allowed_spaces": allowed_spaces,
         }
 
@@ -569,9 +561,7 @@ class SpaceSummaryHandler:
             [
                 event_id
                 for key, event_id in current_state_ids.items()
-                # TODO: update once MSC1772 has been FCP for a period of time.
-                if key[0] == EventTypes.MSC1772_SPACE_CHILD
-                or key[0] == EventTypes.SpaceChild
+                if key[0] == EventTypes.SpaceChild
             ]
         )
 


### PR DESCRIPTION
This drops support for unstable prefixes for MSC1772 (`org.org.matrix.msc1772.space.*`). This will change to only support the `m.space.*` versions.

I think this is fine since current Element clients (which I believe are the only things to support spaces) only use the stable prefixes and we said very loudly from the beginning that the unstable prefixes would break.

The reality of this is that you would not be able to use the spaces summary on those anymore, but current Elements treat them as normal rooms anyway so it shouldn't matter.

Fixes #9929