### PR TITLE
Fix sending presence over federation when using workers

### DIFF
--- a/changelog.d/10163.bugfix
+++ b/changelog.d/10163.bugfix
@@ -1,0 +1,1 @@
+Fix a bug when using federation sender worker where it would send out more presence updates than necessary, leading to high resource usage. Broke in v1.33.0.


### PR DESCRIPTION
When using a federation sender we'd send out all local presence updates over
federation even when they shouldn't be.

Fixes #10153.

Introduced in #9819