### PR TITLE
Only send a presence state to a destination once

### DIFF
--- a/changelog.d/10165.bugfix
+++ b/changelog.d/10165.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where Synapse could send the same presence update to a remote twice.


### PR DESCRIPTION
It turns out that we were sending the same presence state to a remote potentially multiple times.

In practice this is probably isn't causing too many issues, as each federation destination queue will dedupe presence updates. However, depending on caching, it is possible that we'd start a new transaction the first time the destination queue gets told about an update. This would cause us to send the presence update twice. 