### PR TITLE
Add fields to better debug where events are being `soft_failed`

### DIFF
--- a/changelog.d/10168.misc
+++ b/changelog.d/10168.misc
@@ -1,0 +1,1 @@
+Add extra logging fields to better debug where events are being soft failed.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2425,7 +2425,11 @@ class FederationHandler(BaseHandler):
         )
 
     async def _check_for_soft_fail(
-        self, event: EventBase, state: Optional[Iterable[EventBase]], backfilled: bool
+        self,
+        event: EventBase,
+        state: Optional[Iterable[EventBase]],
+        backfilled: bool,
+        origin: str,
     ) -> None:
         """Checks if we should soft fail the event; if so, marks the event as
         such.
@@ -2434,6 +2438,7 @@ class FederationHandler(BaseHandler):
             event
             state: The state at the event if we don't have all the event's prev events
             backfilled: Whether the event is from backfill
+            origin: The host the event originates from.
         """
         # For new (non-backfilled and non-outlier) events we check if the event
         # passes auth based on the current state. If it doesn't then we
@@ -2503,7 +2508,17 @@ class FederationHandler(BaseHandler):
         try:
             event_auth.check(room_version_obj, event, auth_events=current_auth_events)
         except AuthError as e:
-            logger.warning("Soft-failing %r because %s", event, e)
+            logger.warning(
+                "Soft-failing %r (from %s) because %s",
+                event,
+                e,
+                origin,
+                extra={
+                    "room_id": event.room_id,
+                    "mxid": event.sender,
+                    "hs": origin,
+                },
+            )
             soft_failed_event_counter.inc()
             event.internal_metadata.soft_failed = True
 
@@ -2616,7 +2631,7 @@ class FederationHandler(BaseHandler):
             context.rejected = RejectedReason.AUTH_ERROR
 
         if not context.rejected:
-            await self._check_for_soft_fail(event, state, backfilled)
+            await self._check_for_soft_fail(event, state, backfilled, origin=origin)
 
         if event.type == EventTypes.GuestAccess and not context.rejected:
             await self.maybe_kick_guest_users(event)


### PR DESCRIPTION
Add `room_id`, `mxid`, and `hs` fields to better debug where and who events are being `soft_failed`. We can do aggregations with Elasticsearch and Kibana on these fields.

Follow-up to https://github.com/matrix-org/synapse/pull/10156#discussion_r650292223


### Testing strategy

 1. Enable structured logging in the Sytest Synapse homeserver config,
 1. In the `formatters` property, add a `structured` key (this key could be named anything) that points to the `synapse.logging.TerseJsonFormatter` class, [`lib/SyTest/Homeserver.pm#L220-L224`)(https://github.com/matrix-org/sytest/blob/eedac420ae8c810f48200e7a4ba6a3bc85958f35/lib/SyTest/Homeserver.pm#L220-L224)
    ```diff
      formatters => {
         precise => {
            format => "%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(request)s - %(message)s"
         },
    +    structured => {
    +       class => "synapse.logging.TerseJsonFormatter"
    +    }
      },
    ```
 1. In the `handlers` property, adjust file handler `formatter` to point to your `structured` formatter:
    ```diff
      handlers => {
         file => {
            class => "logging.FileHandler",
    +       formatter => "structured",
            filename => "$hs_dir/$log_type.log",
            filters => ["context"],
            encoding => "utf8"
         }
      },
    ```
 1. Modify [`synapse/handlers/federation.py`](https://github.com/matrix-org/synapse/blob/13577aa55ebe6087e8b813c0643bbb53148e9510/synapse/handlers/federation.py#L2503-L2505) to always soft-fail messages
    ```diff
      try:
          event_auth.check(room_version_obj, event, auth_events=current_auth_events)
    +     raise AuthError(403, "Fake Auth failure")
      except AuthError as e:
          ...
    ```
 1. `./run-tests.pl tests/50federation/34room-backfill.pl --server-log --stop-on-fail`
 1. Notice `Soft-failing` structured log objects with the `room_id`, `mxid`, `hs` properties 🎉 
    ```
    {"log":"Soft-failing <FrozenEventV3 event_id='$dhqyh6kWWYCzVsc3k4Xh951oiK25va81l5gFB64798w', type='m.room.message', state_key=None> (from 403: Fake Auth failure) because localhost:51321","namespace":"synapse.handlers.federation","level":"WARNING","time":1623484246.69,"request":"PUT-45-!qCOYGPEywmWeSYLrPJ:localhost:8800-$dhqyh6kWWYCzVsc3k4Xh951oiK25va81l5gFB64798w","ip_address":"127.0.0.1","site_tag":"8800","requester":"localhost:51321","authenticated_entity":"localhost:51321","method":"PUT","url":"/_matrix/federation/v1/send/1623484246656","protocol":"HTTP/1.1","user_agent":"Perl + Net::Async::HTTP/0.47","server_name":"localhost:8800","room_id":"!qCOYGPEywmWeSYLrPJ:localhost:8800","mxid":"@__ANON__-3:localhost:51321","hs":"localhost:51321"}
    ```

### Dev notes


#### How to enable structured logging

 1. In your `homeserver.yaml`, find where your `log_config` is located
 1. Open your log config file you found from your `homeserver.yaml` in the last step (probably looks something like `*.log.config`)
 1. In the `formatters` property, add a `structured` key (this key could be named anything) that points to the `synapse.logging.TerseJsonFormatter` class
    ```diff
    formatters:
        precise:
            format: '%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(request)s - %(message)s'
    +    structured:
    +        class: synapse.logging.TerseJsonFormatter
    ```
 1. In the `handlers` property, adjust file handler `formatter` to point to your `structured` formatter:
    ```diff
    handlers:
        file:
            class: logging.handlers.TimedRotatingFileHandler
    +        formatter: structured
            filename: /Users/eric/Documents/github/element/synapse/homeserver.log
            when: midnight
            backupCount: 3  # Does not include the current log file.
            encoding: utf8
    ```
 1. Run the app to generate some logs, `python -m synapse.app.homeserver --config-path homeserver.yaml`
 1. Open the log file and observe the structured logging (a bunch of json objects)



#### Background and notes behind structured logging

> > For the future:
> > If we want to dig deeper into what rooms are soft_failing messages, we could use the Elasticsearch logs and some aggregations (Kibana or raw ES queries). We can add a few fields to the Elasticsearch mapping, `room_id`, `mxid`, `event_id` which should handle the high cardinality(lots of different values) just fine.
> > It looks like we use [Logstash](https://github.com/matrix-org/matrix-ansible-private/tree/main/roles/logstash) or [Filebeat](https://github.com/matrix-org/matrix-ansible-private/tree/main/roles/filebeat) and I assume there is a way we can parse another field out besides `message`? Maybe https://stackoverflow.com/q/40460830/796832
> > _-- [#10156 (comment)](https://github.com/matrix-org/synapse/pull/10156#issuecomment-859287143)_
> 
> To document my additional findings here;
> 
> We can already use `logger.info('foo', extra={ "foo": "bar"})` as shown in [`tests/logging/test_terse_json.py#L64-L74`](https://github.com/matrix-org/synapse/blob/13577aa55ebe6087e8b813c0643bbb53148e9510/tests/logging/test_terse_json.py#L64-L74) to add extra fields to the structured logging.
> 
> * Docs on structured logging in Synapse: https://github.com/matrix-org/synapse/blob/develop/docs/structured_logging.md
> * Improve structured logging: #8683
>   
>   * Record more information into structured logs: #9654
> * Use structured logging for EMS: [matrix-org/matrix-hosted#1229](https://github.com/matrix-org/matrix-hosted/issues/1229)
> * Use structured logging for `matrix.org`: [matrix-org/internal-config#889](https://github.com/matrix-org/internal-config/issues/889)
> * [Allow simultaneously enabling structured logging and "standard" logging](https://github.com/matrix-org/synapse/issues/8588) which was implemented in #8607
> * List of issues with the `z-logging` label: https://github.com/matrix-org/synapse/labels/z-logging
>
> *-- https://github.com/matrix-org/synapse/pull/10156#discussion_r650292223*

 - "The fourth keyword argument is `extra` which can be used to pass a dictionary which is used to populate the `__dict__` of the `LogRecord`", https://docs.python.org/3/library/logging.html#logging.Logger.debug
 - Defines which properties of the `LogRecord` are being copied into the structured log JSON, [`synapse/logging/_terse_json.py#L23-L48`](https://github.com/matrix-org/synapse/blob/13577aa55ebe6087e8b813c0643bbb53148e9510/synapse/logging/_terse_json.py#L23-L48)



#### Unused testing commands

 1. Start the app, `python -m synapse.app.homeserver --config-path homeserver.yaml`
 1. `register_new_matrix_user -c ./homeserver.yaml http://localhost:8008` (`test-user1`, `my-password`, not admin)
 1. To get an access token for the user you just created, do a login request (note the `access_token` in the response):
    ```
    curl -X POST "http://localhost:8008/_matrix/client/r0/login" \
      -H $'Content-Type: application/json' \
      --data-binary @- << EOF
      {
        "type": "m.login.password",
        "identifier": {
          "type": "m.id.user",
          "user": "test-user1"
        },
        "password": "my-password"
      }
    EOF
    ```
 1. Create a room to post in (note the `room_id` in the response)
    ```
    curl -X POST "http://localhost:8008/_matrix/client/r0/createRoom" \
      -H $'Authorization: Bearer <your_access_token>' \
      -H $'Content-Type: application/json' \
      --data-binary @- << EOF
      {
        "preset": "public_chat",
        "room_alias_name": "thepub",
        "name": "The Grand Duke Pub",
        "topic": "All about happy hour"
      }
    EOF
    ```
 1. Send a message to the room
    ```
    curl -X PUT "http://localhost:8008/_matrix/client/r0/rooms/\!kzVUpZOLnmGsiRAsBD:my.synapse.server/send/m.room.message/$(openssl rand -base64 12)"\
      -H $'Authorization: Bearer <your_access_token>' \
      -H $'Content-Type: application/json' \
      --data-binary @- << EOF
      {
        "msgtype": "m.text",
        "body": "asdf"
      }
    EOF
    ```
 1. Get the messages
    ```
    curl -X GET \
      -H $'Authorization: Bearer <your_access_token>' \
      "http://localhost:8008/_matrix/client/r0/rooms/\!kzVUpZOLnmGsiRAsBD:my.synapse.server/messages?dir=b&limit=100"
    ```






### Todo

 - [x] Turn on structured logging and see if the new properties are in the logs



### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)~~
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
