### PR TITLE
Fix requestOpenIdToken response: integer expires_in

### DIFF
--- a/changelog.d/10175.bugfix
+++ b/changelog.d/10175.bugfix
@@ -1,1 +1,1 @@
-Return an integer `expires_in` in requestOpenIdToken response.
+Fix a minor bug in the response to `/_matrix/client/r0/user/{user}/openid/request_token`. Contributed by @lukaslihotzki.

--- a/changelog.d/10175.bugfix
+++ b/changelog.d/10175.bugfix
@@ -1,0 +1,1 @@
+Return an integer `expires_in` in requestOpenIdToken response.

--- a/synapse/rest/client/v2_alpha/openid.py
+++ b/synapse/rest/client/v2_alpha/openid.py
@@ -85,7 +85,7 @@ class IdTokenServlet(RestServlet):
                 "access_token": token,
                 "token_type": "Bearer",
                 "matrix_server_name": self.server_name,
-                "expires_in": self.EXPIRES_MS / 1000,
+                "expires_in": self.EXPIRES_MS // 1000,
             },
         )
 


### PR DESCRIPTION
`expires_in` must be an integer according to the OpenAPI spec:
https://github.com/matrix-org/matrix-doc/blob/master/data/api/client-server/definitions/openid_token.yaml#L32

True division (`/`) returns a float instead (`"expires_in": 3600.0`).
Floor division (`//`) returns an integer, so the response is spec compliant.