### PR TITLE
Only allow skipping UI auth for certain actions.

### DIFF
--- a/changelog.d/10184.bugfix
+++ b/changelog.d/10184.bugfix
@@ -1,1 +1,1 @@
-Do not apply the `ui_auth.session_timeout` to dangerous operations: deactivating an account, modifying an account password, and adding 3PIDs.
+Always require users to re-authenticate for dangerous operations: deactivating an account, modifying an account password, and adding 3PIDs.

--- a/changelog.d/10184.bugfix
+++ b/changelog.d/10184.bugfix
@@ -1,0 +1,1 @@
+Do not apply the `ui_auth.session_timeout` to dangerous operations: deactivating an account, modifying an account password, and adding 3PIDs.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2318,6 +2318,10 @@ ui_auth:
     # the user-interactive authentication process, by allowing for multiple
     # (and potentially different) operations to use the same validation session.
     #
+    # This is ignored for potentially "dangerous" operations (including
+    # deactivating an account, modifying an account password, and
+    # adding a 3PID).
+    #
     # Uncomment below to allow for credential validation to last for 15
     # seconds.
     #

--- a/synapse/config/auth.py
+++ b/synapse/config/auth.py
@@ -103,6 +103,10 @@ class AuthConfig(Config):
             # the user-interactive authentication process, by allowing for multiple
             # (and potentially different) operations to use the same validation session.
             #
+            # This is ignored for potentially "dangerous" operations (including
+            # deactivating an account, modifying an account password, and
+            # adding a 3PID).
+            #
             # Uncomment below to allow for credential validation to last for 15
             # seconds.
             #

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -302,6 +302,7 @@ class AuthHandler(BaseHandler):
         request: SynapseRequest,
         request_body: Dict[str, Any],
         description: str,
+        can_skip_ui_auth: bool = False,
     ) -> Tuple[dict, Optional[str]]:
         """
         Checks that the user is who they claim to be, via a UI auth.
@@ -319,6 +320,10 @@ class AuthHandler(BaseHandler):
 
             description: A human readable string to be displayed to the user that
                          describes the operation happening on their account.
+
+            can_skip_ui_auth: True if the UI auth session timeout applies this
+                              action. Should be set to False for any "dangerous"
+                              actions (e.g. deactivating an account).
 
         Returns:
             A tuple of (params, session_id).
@@ -343,7 +348,7 @@ class AuthHandler(BaseHandler):
         """
         if not requester.access_token_id:
             raise ValueError("Cannot validate a user without an access token")
-        if self._ui_auth_session_timeout:
+        if can_skip_ui_auth and self._ui_auth_session_timeout:
             last_validated = await self.store.get_access_token_last_validated(
                 requester.access_token_id
             )

--- a/synapse/rest/client/v2_alpha/devices.py
+++ b/synapse/rest/client/v2_alpha/devices.py
@@ -86,6 +86,10 @@ class DeleteDevicesRestServlet(RestServlet):
             request,
             body,
             "remove device(s) from your account",
+            # It is frequently that users might want to call this multiple times
+            # in a row while cleaning up devices, so allow a single UI auth
+            # session to be re-used.
+            can_skip_ui_auth=True,
         )
 
         await self.device_handler.delete_devices(
@@ -135,6 +139,10 @@ class DeviceRestServlet(RestServlet):
             request,
             body,
             "remove a device from your account",
+            # It is frequently that users might want to call this multiple times
+            # in a row while cleaning up devices, so allow a single UI auth
+            # session to be re-used.
+            can_skip_ui_auth=True,
         )
 
         await self.device_handler.delete_device(requester.user.to_string(), device_id)

--- a/synapse/rest/client/v2_alpha/devices.py
+++ b/synapse/rest/client/v2_alpha/devices.py
@@ -86,9 +86,8 @@ class DeleteDevicesRestServlet(RestServlet):
             request,
             body,
             "remove device(s) from your account",
-            # It is frequently that users might want to call this multiple times
-            # in a row while cleaning up devices, so allow a single UI auth
-            # session to be re-used.
+            # Users might call this multiple times in a row while cleaning up
+            # devices, allow a single UI auth session to be re-used.
             can_skip_ui_auth=True,
         )
 
@@ -139,9 +138,8 @@ class DeviceRestServlet(RestServlet):
             request,
             body,
             "remove a device from your account",
-            # It is frequently that users might want to call this multiple times
-            # in a row while cleaning up devices, so allow a single UI auth
-            # session to be re-used.
+            # Users might call this multiple times in a row while cleaning up
+            # devices, allow a single UI auth session to be re-used.
             can_skip_ui_auth=True,
         )
 

--- a/synapse/rest/client/v2_alpha/keys.py
+++ b/synapse/rest/client/v2_alpha/keys.py
@@ -277,6 +277,9 @@ class SigningKeyUploadServlet(RestServlet):
             request,
             body,
             "add a device signing key to your account",
+            # Allow skipping of UI auth since this is frequently called directly
+            # after login and it is silly to ask users to re-auth immediately.
+            can_skip_ui_auth=True,
         )
 
         result = await self.e2e_keys_handler.upload_signing_keys_for_user(user_id, body)


### PR DESCRIPTION
This limits the UI auth grace period to:

* Deleting devices
* Uploading cross-signing keys

So it stops using it for (and thus always requires UI auth):

* Deactivating accounts
* Resetting passwords
* Adding 3PIDs

It should be easy to change the above list if people want to bikeshed it. (In particular adding 3PIDs I went back and forth on.)

This modifies behavior added in #8970 in a backwards-incompatible manner, but I think it is likely OK in this case as the security added outweighs backwards compatibility concerns.

Fixes #9754