### PR TITLE
Ensure that errors during startup are written to the logs and the console.

### DIFF
--- a/changelog.d/10191.feature
+++ b/changelog.d/10191.feature
@@ -1,0 +1,1 @@
+Ensure that errors during startup are written to the logs and the console.

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -143,12 +143,21 @@ def start_reactor(
 
 def quit_with_error(error_string: str) -> NoReturn:
     message_lines = error_string.split("\n")
-    line_length = max(len(line) for line in message_lines if len(line) < 80) + 2
+    line_length = min(max(len(line) for line in message_lines), 80) + 2
     sys.stderr.write("*" * line_length + "\n")
     for line in message_lines:
         sys.stderr.write(" %s\n" % (line.rstrip(),))
     sys.stderr.write("*" * line_length + "\n")
     sys.exit(1)
+
+
+def handle_startup_exception(e: Exception) -> NoReturn:
+    # Exceptions that occur between setting up the logging and forking or starting
+    # the reactor are written to the logs, followed by a summary to stderr.
+    logger.exception("Exception during startup")
+    quit_with_error(
+        f"Error during initialisation:\n   {e}\nThere may be more information in the logs."
+    )
 
 
 def redirect_stdio_to_logs() -> None:

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -33,6 +33,7 @@ from synapse.api.urls import (
 )
 from synapse.app import _base
 from synapse.app._base import (
+    handle_startup_exception,
     max_request_body_size,
     redirect_stdio_to_logs,
     register_start,
@@ -469,11 +470,14 @@ def start(config_options):
 
     setup_logging(hs, config, use_worker_options=True)
 
-    hs.setup()
+    try:
+        hs.setup()
 
-    # Ensure the replication streamer is always started in case we write to any
-    # streams. Will no-op if no streams can be written to by this worker.
-    hs.get_replication_streamer()
+        # Ensure the replication streamer is always started in case we write to any
+        # streams. Will no-op if no streams can be written to by this worker.
+        hs.get_replication_streamer()
+    except Exception as e:
+        handle_startup_exception(e)
 
     register_start(_base.start, hs)
 

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -32,7 +32,11 @@ from synapse.api.urls import (
     SERVER_KEY_V2_PREFIX,
 )
 from synapse.app import _base
-from synapse.app._base import max_request_body_size, register_start
+from synapse.app._base import (
+    max_request_body_size,
+    redirect_stdio_to_logs,
+    register_start,
+)
 from synapse.config._base import ConfigError
 from synapse.config.homeserver import HomeServerConfig
 from synapse.config.logger import setup_logging
@@ -472,6 +476,10 @@ def start(config_options):
     hs.get_replication_streamer()
 
     register_start(_base.start, hs)
+
+    # redirect stdio to the logs, if configured.
+    if not hs.config.no_redirect_stdio:
+        redirect_stdio_to_logs()
 
     _base.start_worker_reactor("synapse-generic-worker", config)
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -41,6 +41,7 @@ from synapse.app._base import (
     listen_tcp,
     max_request_body_size,
     quit_with_error,
+    redirect_stdio_to_logs,
     register_start,
 )
 from synapse.config._base import ConfigError
@@ -500,6 +501,11 @@ def main():
         # check base requirements
         check_requirements()
         hs = setup(sys.argv[1:])
+
+        # redirect stdio to the logs, if configured.
+        if not hs.config.no_redirect_stdio:
+            redirect_stdio_to_logs()
+
         run(hs)
 
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -37,10 +37,10 @@ from synapse.api.urls import (
 )
 from synapse.app import _base
 from synapse.app._base import (
+    handle_startup_exception,
     listen_ssl,
     listen_tcp,
     max_request_body_size,
-    quit_with_error,
     redirect_stdio_to_logs,
     register_start,
 )
@@ -70,8 +70,6 @@ from synapse.rest.synapse.client import build_synapse_client_resource_tree
 from synapse.rest.well_known import WellKnownResource
 from synapse.server import HomeServer
 from synapse.storage import DataStore
-from synapse.storage.engines import IncorrectDatabaseSetup
-from synapse.storage.prepare_database import UpgradeDatabaseException
 from synapse.util.httpresourcetree import create_resource_tree
 from synapse.util.module_loader import load_module
 from synapse.util.versionstring import get_version_string
@@ -359,10 +357,8 @@ def setup(config_options):
 
     try:
         hs.setup()
-    except IncorrectDatabaseSetup as e:
-        quit_with_error(str(e))
-    except UpgradeDatabaseException as e:
-        quit_with_error("Failed to upgrade database: %s" % (e,))
+    except Exception as e:
+        handle_startup_exception(e)
 
     async def do_acme() -> bool:
         """

--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -259,9 +259,7 @@ def _setup_stdlib_logging(config, log_config_path, logBeginner: LogBeginner) -> 
         finally:
             threadlocal.active = False
 
-    logBeginner.beginLoggingTo([_log], redirectStandardIO=not config.no_redirect_stdio)
-    if not config.no_redirect_stdio:
-        print("Redirected stdout/stderr to logs")
+    logBeginner.beginLoggingTo([_log], redirectStandardIO=False)
 
 
 def _load_logging_config(log_config_path: str) -> None:


### PR DESCRIPTION
There is a class of exception that happens *after* setting up the logs, but *before* we start up the reactor (which has its own exception handling).

These end up hitting `sys.stderr`, and then one of two things happens:

 * If stderr has been redirected to the logs, the error is written to the logs (one line at a time, which messes up structured logging and sentry), and nothing is written to the console (which is super misleading when running from a shell).
 * If stdio redirection is disabled, the error is written to the console, and nothing is written to the logs. This is confusing when running synapse under a process supervisor (eg systemd), where it ies expected that all errors end up in the log (see also #1781).

It seems like the ideal would be for the errors to end up in *both* places; however, this gets a bit messy if the logging is set up to go to the console (as is the default under docker, for example): a naive implementation would end up with two copies of the exception being printed on the console.

After some consideration, it seems best that we write the full exception to the logs (whereever they are going), and then write a summary to the console. This might still lead to a bit of duplication, but it's not too bad.

To make this work, we delay the redirection of stdio until we are about to fork/start the reactor.