### PR TITLE
doc: add django-oauth-toolkit to oidc doc

### DIFF
--- a/changelog.d/10192.doc
+++ b/changelog.d/10192.doc
@@ -1,0 +1,1 @@
+Add documentation on how to connect Django with synapse using oidc and django-oauth-toolkit. Contributed by @HugoDelval.

--- a/docs/openid.md
+++ b/docs/openid.md
@@ -454,13 +454,13 @@ Django application providing out of the box all the endpoints, data and logic
 needed to add OAuth2 capabilities to your Django projects. It supports
 [OpenID Connect too](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html).
 
-**Configuration on Django's side:**
+Configuration on Django's side:
 
 1. Add an application: https://example.com/admin/oauth2_provider/application/add/ and choose parameters like this:
-  * `Redirect uris`: https://synapse.example.com/_synapse/client/oidc/callback
-  * `Client type`: `Confidential`
-  * `Authorization grant type`: `Authorization code`
-  * `Algorithm`: `HMAC with SHA-2 256`
+* `Redirect uris`: https://synapse.example.com/_synapse/client/oidc/callback
+* `Client type`: `Confidential`
+* `Authorization grant type`: `Authorization code`
+* `Algorithm`: `HMAC with SHA-2 256`
 2. You can [customize the claims](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#customizing-the-oidc-responses) Django gives to synapse (optional):
    <details>
     <summary>Code sample</summary>
@@ -476,8 +476,8 @@ needed to add OAuth2 capabilities to your Django projects. It supports
                 "last_name": request.user.last_name,
             }
     ```
-  </details>
-3. Your synapse config is then:
+   </details>
+Your synapse config is then:
 
 ```yaml
 oidc_providers:

--- a/docs/openid.md
+++ b/docs/openid.md
@@ -446,3 +446,51 @@ The synapse config will look like this:
       config:
         email_template: "{{ user.email }}"
 ```
+
+## Django OAuth Toolkit
+
+[django-oauth-toolkit](https://github.com/jazzband/django-oauth-toolkit) is a
+Django application providing out of the box all the endpoints, data and logic
+needed to add OAuth2 capabilities to your Django projects. It supports
+[OpenID Connect too](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html).
+
+**Configuration on Django's side:**
+
+1. Add an application: https://example.com/admin/oauth2_provider/application/add/ and choose parameters like this:
+  * `Redirect uris`: https://synapse.example.com/_synapse/client/oidc/callback
+  * `Client type`: `Confidential`
+  * `Authorization grant type`: `Authorization code`
+  * `Algorithm`: `HMAC with SHA-2 256`
+2. You can [customize the claims](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#customizing-the-oidc-responses) Django gives to synapse (optional):
+   <details>
+    <summary>Code sample</summary>
+
+    ```python
+    class CustomOAuth2Validator(OAuth2Validator):
+
+        def get_additional_claims(self, request):
+            return {
+                "sub": request.user.email,
+                "email": request.user.email,
+                "first_name": request.user.first_name,
+                "last_name": request.user.last_name,
+            }
+    ```
+  </details>
+3. Your synapse config is then:
+
+```yaml
+oidc_providers:
+  - idp_id: django_example
+    idp_name: "Django Example"
+    issuer: "https://example.com/o/"
+    client_id: "your-client-id"  # CHANGE ME
+    client_secret: "your-client-secret"  # CHANGE ME
+    scopes: ["openid"]
+    user_profile_method: "userinfo_endpoint"  # needed because oauth-toolkit does not include user information in the authorization response
+    user_mapping_provider:
+      config:
+        localpart_template: "{{ user.email.split('@')[0] }}"
+        display_name_template: "{{ user.first_name }} {{ user.last_name }}"
+        email_template: "{{ user.email }}"
+```


### PR DESCRIPTION
This PR adds an entry to the examples of OpenID providers.

It's possible to use synapse with users coming from a django's database using this module : https://github.com/jazzband/django-oauth-toolkit

I've tested it and it worked well but I've come across some issues with the configuration so I wanted to help future people wanting to do the same thing.

This is my first PR on the repo so please tell me if I'm missing something


### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))


