### PR TITLE
Fix persist_events to stop leaking opentracing contexts

### DIFF
--- a/changelog.d/10193.misc
+++ b/changelog.d/10193.misc
@@ -1,0 +1,1 @@
+Improve OpenTracing for event persistence.

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -111,7 +111,7 @@ class _EventPersistQueueItem:
     backfilled: bool
     deferred: ObservableDeferred
 
-    parent_opentracing_span_contexts: List = []
+    parent_opentracing_span_contexts: List = attr.ib(factory=list)
     """A list of opentracing spans waiting for this batch"""
 
     opentracing_span_context: Any = None


### PR DESCRIPTION
Fixes a leak introduced in #10134.