### PR TITLE
Deploy a documentation version for each new Synapse release

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,7 +3,10 @@ name: Deploy the documentation
 on:
   push:
     branches:
+      # For bleeding-edge documentation
       - develop
+      # For documentation specific to a release
+      - 'release-v*'
 
   workflow_dispatch:
 
@@ -22,6 +25,7 @@ jobs:
       - name: Build the documentation
         run: mdbook build
 
+      # Deploy to the latest documentation directories
       - name: Deploy latest documentation
         uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # v3.8.0
         with:
@@ -29,3 +33,26 @@ jobs:
           keep_files: true
           publish_dir: ./book
           destination_dir: ./develop
+
+      - name: Get the current Synapse version
+        id: vars
+        # The $GITHUB_REF value for a branch looks like `refs/heads/release-v1.2`. We do some
+        # bash magic to remove the "refs/heads/release-v" bit from this, to end up with
+        # "1.2" - our major/minor version number.
+        run: echo ::set-output name=synapse-version::${GITHUB_REF#refs/heads/release-v}
+
+      # Deploy to the version-specific directory
+      - name: Deploy release-specific documentation
+        # We only carry out this step if we're running on a release branch,
+        # and the current Synapse version does not have "rc" in the name.
+        #
+        # The result is that only full releases are deployed, but can be
+        # updated if the release branch gets retroactive fixes.
+        if: ${{ startsWith( github.ref, 'refs/heads/release-v' ) && !contains( steps.vars.outputs.synapse-version, 'rc') }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          keep_files: true
+          publish_dir: ./book
+          # The resulting documentation will end up in a directory named `vX.Y`.
+          destination_dir: ./v${{ steps.vars.outputs.synapse-version }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,9 +37,15 @@ jobs:
       - name: Get the current Synapse version
         id: vars
         # The $GITHUB_REF value for a branch looks like `refs/heads/release-v1.2`. We do some
-        # bash magic to remove the "refs/heads/release-v" bit from this, to end up with
-        # "1.2" - our major/minor version number.
-        run: echo ::set-output name=synapse-version::${GITHUB_REF#refs/heads/release-v}
+        # bash magic to remove the "refs/heads/release-v" bit from this, to end up with "1.2",
+        # our major/minor version number, and set this to a var called `branch-version`.
+        #
+        # We then use some python to get Synapse's full version string, which may look
+        # like "1.2.3rc4". We set this to a var called `synapse-version`. We use this
+        # to determine if this release is still an RC, and if so block deployment.
+        run: |
+          echo ::set-output name=branch-version::${GITHUB_REF#refs/heads/release-v}
+          echo ::set-output name=synapse-version::`python3 -c 'import synapse; print(synapse.__version__)'`
 
       # Deploy to the version-specific directory
       - name: Deploy release-specific documentation
@@ -55,4 +61,4 @@ jobs:
           keep_files: true
           publish_dir: ./book
           # The resulting documentation will end up in a directory named `vX.Y`.
-          destination_dir: ./v${{ steps.vars.outputs.synapse-version }}
+          destination_dir: ./v${{ steps.vars.outputs.branch-version }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Get the current Synapse version
         id: vars
         # The $GITHUB_REF value for a branch looks like `refs/heads/release-v1.2`. We do some
-        # bash magic to remove the "refs/heads/release-v" bit from this, to end up with "1.2",
+        # shell magic to remove the "refs/heads/release-v" bit from this, to end up with "1.2",
         # our major/minor version number, and set this to a var called `branch-version`.
         #
         # We then use some python to get Synapse's full version string, which may look

--- a/changelog.d/10198.doc
+++ b/changelog.d/10198.doc
@@ -1,0 +1,1 @@
+Deploy a snapshot of the documentation website upon each new Synapse release.


### PR DESCRIPTION
This PR will run a new "Deploy release-specific documentation" job whenever a push to a branch name matching `release-v*` occurs. Doing so will create/add to a folder named `vX.Y` on the `gh-pages` branch. Doing so will allow us to build up `major.minor` releases of the docs as we release Synapse.

This is especially useful for having a mechanism for keeping around documentation of old/removed features (for those running older versions of Synapse), without needing to clutter the latest copy of the docs.

After a [discussion](https://matrix.to/#/!XaqDhxuTIlvldquJaV:matrix.org/$rKmkBmQle8OwTlGcoyu0BkcWXdnHW3_oap8BMgclwIY?via=matrix.org&via=vector.modular.im&via=envs.net) in #synapse-dev, we wanted to use tags to trigger the documentation deployments, which I agreed with. However, I soon realised that the bash-foo required to turn a tag of `v1.2.3rc1` into `1.2` was a lot more complex than the branch's `release-v1.2`. So, I've gone with the latter for simplicity.

In the future we'll have some UI on the website to switch between versions, but for now you can simply just change 'develop' to 'v1.2' in the URL.

You can see the workflow in action here: https://github.com/anoadragon453/synapse/runs/2850612850