### PR TITLE
Warn users trying to use the deprecated spam checker interface

### DIFF
--- a/changelog.d/10210.removal
+++ b/changelog.d/10210.removal
@@ -1,0 +1,1 @@
+The current spam checker interface is deprecated in favour of a new generic modules system. See the [upgrade notes](https://github.com/matrix-org/synapse/blob/master/UPGRADE.rst#deprecation-of-the-current-spam-checker-interface) for more information on how to update to the new system.

--- a/synapse/config/spam_checker.py
+++ b/synapse/config/spam_checker.py
@@ -12,12 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Any, Dict, List, Tuple
 
 from synapse.config import ConfigError
 from synapse.util.module_loader import load_module
 
 from ._base import Config
+
+logger = logging.getLogger(__name__)
+
+LEGACY_SPAM_CHECKER_WARNING = """
+This server is using a spam checker module that is implementing the deprecated spam
+checker interface. Please check with the module's maintainer to see if a new version
+supporting Synapse's generic modules system is available.
+For more information, please see https://matrix-org.github.io/synapse/develop/modules.html
+---------------------------------------------------------------------------------------"""
 
 
 class SpamCheckerConfig(Config):
@@ -42,3 +52,8 @@ class SpamCheckerConfig(Config):
                 self.spam_checkers.append(load_module(spam_checker, config_path))
         else:
             raise ConfigError("spam_checker syntax is incorrect")
+
+        # If this configuration is being used in any way, warn the admin that it is going
+        # away soon.
+        if self.spam_checkers:
+            logger.warning(LEGACY_SPAM_CHECKER_WARNING)


### PR DESCRIPTION
I forgot to do that in #10062 

So admins aren't surprised if things break when we remove this code in a couple of months.