### PR TITLE
Check third party rules before persisting knocks over federation

### DIFF
--- a/changelog.d/10212.feature
+++ b/changelog.d/10212.feature
@@ -1,0 +1,1 @@
+Implement "room knocking" as per [MSC2403](https://github.com/matrix-org/matrix-doc/pull/2403). Contributed by Sorunome and anoa.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2086,8 +2086,6 @@ class FederationHandler(BaseHandler):
 
         context = await self.state_handler.compute_event_context(event)
 
-        await self._auth_and_persist_event(origin, event, context)
-
         event_allowed = await self.third_party_event_rules.check_event_allowed(
             event, context
         )
@@ -2096,6 +2094,8 @@ class FederationHandler(BaseHandler):
             raise SynapseError(
                 403, "This event is not allowed in this context", Codes.FORBIDDEN
             )
+
+        await self._auth_and_persist_event(origin, event, context)
 
         return context
 


### PR DESCRIPTION
An accidental mis-ordering of operations during #6739 technically allowed an incoming knock event over federation in before checking it against any configured Third Party Access Rules modules.

This PR corrects that by performing the TPAR check *before* persisting the event.

Thanks to @richvdh for catching it.

Uses the same changelog as #6739 as that has not yet been included in a release.