### PR TITLE
Re-introduce "Leave out optional keys from /sync" change

### DIFF
--- a/changelog.d/10214.feature
+++ b/changelog.d/10214.feature
@@ -1,0 +1,1 @@
+Omit empty fields from the `/sync` response. Contributed by @deepbluev7.

--- a/changelog.d/9919.feature
+++ b/changelog.d/9919.feature
@@ -1,1 +1,0 @@
-Omit empty fields from the `/sync` response.  Contributed by @deepbluev7.

--- a/changelog.d/9919.feature
+++ b/changelog.d/9919.feature
@@ -1,0 +1,1 @@
+Omit empty fields from the `/sync` response.  Contributed by @deepbluev7.

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -262,20 +262,20 @@ class SyncRestServlet(RestServlet):
             ] = sync_result.device_unused_fallback_key_types
 
         if joined:
-            response["rooms"]["join"] = joined
+            response["rooms"][Membership.JOIN] = joined
         if invited:
-            response["rooms"]["invite"] = invited
+            response["rooms"][Membership.INVITE] = invited
         if knocked:
-            response["rooms"]["knock"] = knocked
+            response["rooms"][Membership.KNOCK] = knocked
         if archived:
-            response["rooms"]["leave"] = archived
+            response["rooms"][Membership.LEAVE] = archived
 
         if sync_result.groups.join:
-            response["groups"]["join"] = sync_result.groups.join
+            response["groups"][Membership.JOIN] = sync_result.groups.join
         if sync_result.groups.invite:
-            response["groups"]["invite"] = sync_result.groups.invite
+            response["groups"][Membership.INVITE] = sync_result.groups.invite
         if sync_result.groups.leave:
-            response["groups"]["leave"] = sync_result.groups.leave
+            response["groups"][Membership.LEAVE] = sync_result.groups.leave
 
         return response
 

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -265,6 +265,8 @@ class SyncRestServlet(RestServlet):
             response["rooms"]["join"] = joined
         if invited:
             response["rooms"]["invite"] = invited
+        if knocked:
+            response["rooms"]["knock"] = knocked
         if archived:
             response["rooms"]["leave"] = archived
 

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import itertools
 import logging
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple
 
 from synapse.api.constants import Membership, PresenceState
@@ -232,29 +233,49 @@ class SyncRestServlet(RestServlet):
         )
 
         logger.debug("building sync response dict")
-        return {
-            "account_data": {"events": sync_result.account_data},
-            "to_device": {"events": sync_result.to_device},
-            "device_lists": {
-                "changed": list(sync_result.device_lists.changed),
-                "left": list(sync_result.device_lists.left),
-            },
-            "presence": SyncRestServlet.encode_presence(sync_result.presence, time_now),
-            "rooms": {
-                Membership.JOIN: joined,
-                Membership.INVITE: invited,
-                Membership.KNOCK: knocked,
-                Membership.LEAVE: archived,
-            },
-            "groups": {
-                Membership.JOIN: sync_result.groups.join,
-                Membership.INVITE: sync_result.groups.invite,
-                Membership.LEAVE: sync_result.groups.leave,
-            },
-            "device_one_time_keys_count": sync_result.device_one_time_keys_count,
-            "org.matrix.msc2732.device_unused_fallback_key_types": sync_result.device_unused_fallback_key_types,
-            "next_batch": await sync_result.next_batch.to_string(self.store),
-        }
+
+        response: dict = defaultdict(dict)
+        response["next_batch"] = await sync_result.next_batch.to_string(self.store)
+
+        if sync_result.account_data:
+            response["account_data"] = {"events": sync_result.account_data}
+        if sync_result.presence:
+            response["presence"] = SyncRestServlet.encode_presence(
+                sync_result.presence, time_now
+            )
+
+        if sync_result.to_device:
+            response["to_device"] = {"events": sync_result.to_device}
+
+        if sync_result.device_lists.changed:
+            response["device_lists"]["changed"] = list(sync_result.device_lists.changed)
+        if sync_result.device_lists.left:
+            response["device_lists"]["left"] = list(sync_result.device_lists.left)
+
+        if sync_result.device_one_time_keys_count:
+            response[
+                "device_one_time_keys_count"
+            ] = sync_result.device_one_time_keys_count
+        if sync_result.device_unused_fallback_key_types:
+            response[
+                "org.matrix.msc2732.device_unused_fallback_key_types"
+            ] = sync_result.device_unused_fallback_key_types
+
+        if joined:
+            response["rooms"]["join"] = joined
+        if invited:
+            response["rooms"]["invite"] = invited
+        if archived:
+            response["rooms"]["leave"] = archived
+
+        if sync_result.groups.join:
+            response["groups"]["join"] = sync_result.groups.join
+        if sync_result.groups.invite:
+            response["groups"]["invite"] = sync_result.groups.invite
+        if sync_result.groups.leave:
+            response["groups"]["leave"] = sync_result.groups.leave
+
+        return response
 
     @staticmethod
     def encode_presence(events, time_now):

--- a/tests/rest/client/v2_alpha/test_sync.py
+++ b/tests/rest/client/v2_alpha/test_sync.py
@@ -41,35 +41,7 @@ class FilterTestCase(unittest.HomeserverTestCase):
         channel = self.make_request("GET", "/sync")
 
         self.assertEqual(channel.code, 200)
-        self.assertTrue(
-            {
-                "next_batch",
-                "rooms",
-                "presence",
-                "account_data",
-                "to_device",
-                "device_lists",
-            }.issubset(set(channel.json_body.keys()))
-        )
-
-    def test_sync_presence_disabled(self):
-        """
-        When presence is disabled, the key does not appear in /sync.
-        """
-        self.hs.config.use_presence = False
-
-        channel = self.make_request("GET", "/sync")
-
-        self.assertEqual(channel.code, 200)
-        self.assertTrue(
-            {
-                "next_batch",
-                "rooms",
-                "account_data",
-                "to_device",
-                "device_lists",
-            }.issubset(set(channel.json_body.keys()))
-        )
+        self.assertIn("next_batch", channel.json_body)
 
 
 class SyncFilterTestCase(unittest.HomeserverTestCase):

--- a/tests/rest/client/v2_alpha/test_sync.py
+++ b/tests/rest/client/v2_alpha/test_sync.py
@@ -15,12 +15,7 @@
 import json
 
 import synapse.rest.admin
-from synapse.api.constants import (
-    EventContentFields,
-    EventTypes,
-    Membership,
-    RelationTypes,
-)
+from synapse.api.constants import EventContentFields, EventTypes, RelationTypes
 from synapse.rest.client.v1 import login, room
 from synapse.rest.client.v2_alpha import knock, read_marker, sync
 
@@ -348,7 +343,7 @@ class SyncKnockTestCase(
 
         # We expect to see the knock event in the stripped room state later
         self.expected_room_state[EventTypes.Member] = {
-            "content": {"membership": Membership.KNOCK, "displayname": "knocker"},
+            "content": {"membership": "knock", "displayname": "knocker"},
             "state_key": "@knocker:test",
         }
 
@@ -361,7 +356,7 @@ class SyncKnockTestCase(
         self.assertEqual(channel.code, 200, channel.json_body)
 
         # Extract the stripped room state events from /sync
-        knock_entry = channel.json_body["rooms"][Membership.KNOCK]
+        knock_entry = channel.json_body["rooms"]["knock"]
         room_state_events = knock_entry[self.room_id]["knock_state"]["events"]
 
         # Validate that the knock membership event came last

--- a/tests/rest/client/v2_alpha/test_sync.py
+++ b/tests/rest/client/v2_alpha/test_sync.py
@@ -15,7 +15,12 @@
 import json
 
 import synapse.rest.admin
-from synapse.api.constants import EventContentFields, EventTypes, RelationTypes
+from synapse.api.constants import (
+    EventContentFields,
+    EventTypes,
+    Membership,
+    RelationTypes,
+)
 from synapse.rest.client.v1 import login, room
 from synapse.rest.client.v2_alpha import knock, read_marker, sync
 
@@ -343,7 +348,7 @@ class SyncKnockTestCase(
 
         # We expect to see the knock event in the stripped room state later
         self.expected_room_state[EventTypes.Member] = {
-            "content": {"membership": "knock", "displayname": "knocker"},
+            "content": {"membership": Membership.KNOCK, "displayname": "knocker"},
             "state_key": "@knocker:test",
         }
 
@@ -356,7 +361,7 @@ class SyncKnockTestCase(
         self.assertEqual(channel.code, 200, channel.json_body)
 
         # Extract the stripped room state events from /sync
-        knock_entry = channel.json_body["rooms"]["knock"]
+        knock_entry = channel.json_body["rooms"][Membership.KNOCK]
         room_state_events = knock_entry[self.room_id]["knock_state"]["events"]
 
         # Validate that the knock membership event came last

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -306,8 +306,9 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
 
         channel = self.make_request("GET", "/sync?timeout=0", access_token=tok)
 
-        invites = channel.json_body["rooms"]["invite"]
-        self.assertEqual(len(invites), 0, invites)
+        self.assertNotIn(
+            "rooms", channel.json_body, "Got invites without server notice"
+        )
 
     def test_invite_with_notice(self):
         """Tests that, if the MAU limit is hit, the server notices user invites each user
@@ -364,7 +365,8 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
             # We could also pick another user and sync with it, which would return an
             # invite to a system notices room, but it doesn't matter which user we're
             # using so we use the last one because it saves us an extra sync.
-            invites = channel.json_body["rooms"]["invite"]
+            if "rooms" in channel.json_body:
+                invites = channel.json_body["rooms"]["invite"]
 
         # Make sure we have an invite to process.
         self.assertEqual(len(invites), 1, invites)

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -16,7 +16,12 @@ from unittest.mock import Mock
 
 from twisted.internet import defer
 
-from synapse.api.constants import EventTypes, LimitBlockingTypes, ServerNoticeMsgType
+from synapse.api.constants import (
+    EventTypes,
+    LimitBlockingTypes,
+    Membership,
+    ServerNoticeMsgType,
+)
 from synapse.api.errors import ResourceLimitError
 from synapse.rest import admin
 from synapse.rest.client.v1 import login, room
@@ -322,7 +327,9 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
 
         # Scan the events in the room to search for a message from the server notices
         # user.
-        events = channel.json_body["rooms"]["join"][room_id]["timeline"]["events"]
+        events = channel.json_body["rooms"][Membership.JOIN][room_id]["timeline"][
+            "events"
+        ]
         notice_in_room = False
         for event in events:
             if (
@@ -366,7 +373,7 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
             # invite to a system notices room, but it doesn't matter which user we're
             # using so we use the last one because it saves us an extra sync.
             if "rooms" in channel.json_body:
-                invites = channel.json_body["rooms"]["invite"]
+                invites = channel.json_body["rooms"][Membership.INVITE]
 
         # Make sure we have an invite to process.
         self.assertEqual(len(invites), 1, invites)

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -16,12 +16,7 @@ from unittest.mock import Mock
 
 from twisted.internet import defer
 
-from synapse.api.constants import (
-    EventTypes,
-    LimitBlockingTypes,
-    Membership,
-    ServerNoticeMsgType,
-)
+from synapse.api.constants import EventTypes, LimitBlockingTypes, ServerNoticeMsgType
 from synapse.api.errors import ResourceLimitError
 from synapse.rest import admin
 from synapse.rest.client.v1 import login, room
@@ -327,9 +322,7 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
 
         # Scan the events in the room to search for a message from the server notices
         # user.
-        events = channel.json_body["rooms"][Membership.JOIN][room_id]["timeline"][
-            "events"
-        ]
+        events = channel.json_body["rooms"]["join"][room_id]["timeline"]["events"]
         notice_in_room = False
         for event in events:
             if (
@@ -373,7 +366,7 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
             # invite to a system notices room, but it doesn't matter which user we're
             # using so we use the last one because it saves us an extra sync.
             if "rooms" in channel.json_body:
-                invites = channel.json_body["rooms"][Membership.INVITE]
+                invites = channel.json_body["rooms"]["invite"]
 
         # Make sure we have an invite to process.
         self.assertEqual(len(invites), 1, invites)


### PR DESCRIPTION
Closes: https://github.com/matrix-org/synapse/issues/9941

Required some fixes due to merge conflicts with #6739, but nothing too hairy. The first commit is the same as the original (after merge conflict resolution) then two more for compatibility with the latest sync code.

cc @callahad 