### PR TITLE
Fix performance of responding to user key requests over federation

### DIFF
--- a/changelog.d/10221.bugfix
+++ b/changelog.d/10221.bugfix
@@ -1,1 +1,1 @@
-Fix performance of responding to user key requests over federation. Introduced in v1.34.0.
+Fix performance of responding to user key requests over federation. Introduced in v1.34.0rc1.

--- a/changelog.d/10221.bugfix
+++ b/changelog.d/10221.bugfix
@@ -1,1 +1,1 @@
-Fix performance of responding to user key requests over federation.
+Fix performance of responding to user key requests over federation. Introduced in v1.34.0.

--- a/changelog.d/10221.bugfix
+++ b/changelog.d/10221.bugfix
@@ -1,1 +1,1 @@
-Fix performance of responding to user key requests over federation. Introduced in v1.34.0rc1.
+Fix performance regression in responding to user key requests over federation. Introduced in v1.34.0rc1.

--- a/changelog.d/10221.bugfix
+++ b/changelog.d/10221.bugfix
@@ -1,0 +1,1 @@
+Fix performance of responding to user key requests over federation.

--- a/synapse/config/_base.pyi
+++ b/synapse/config/_base.pyi
@@ -11,6 +11,7 @@ from synapse.config import (
     database,
     emailconfig,
     experimental,
+    federation,
     groups,
     jwt,
     key,
@@ -87,6 +88,7 @@ class RootConfig:
     tracer: tracer.TracerConfig
     redis: redis.RedisConfig
     modules: modules.ModulesConfig
+    federation: federation.FederationConfig
 
     config_classes: List = ...
     def __init__(self) -> None: ...

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -62,6 +62,13 @@ class EndToEndKeyBackgroundStore(SQLBaseStore):
 
 
 class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore):
+    def __init__(self, database: DatabasePool, db_conn: Connection, hs: "HomeServer"):
+        super().__init__(database, db_conn, hs)
+
+        self._allow_device_name_lookup_over_federation = (
+            self.hs.config.federation.allow_device_name_lookup_over_federation
+        )
+
     async def get_e2e_device_keys_for_federation_query(
         self, user_id: str
     ) -> Tuple[int, List[JsonDict]]:
@@ -85,7 +92,7 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore):
                     result["keys"] = keys
 
                 device_display_name = None
-                if self.hs.config.allow_device_name_lookup_over_federation:
+                if self._allow_device_name_lookup_over_federation:
                     device_display_name = device.display_name
                 if device_display_name:
                     result["device_display_name"] = device_display_name


### PR DESCRIPTION
We were repeatedly looking up a config option in a loop (using the
unclassed config style), which is expensive enough that it can cause
large CPU usage.