### PR TITLE
Send out invite rejections and knocks over federation

### DIFF
--- a/changelog.d/10223.bugfix
+++ b/changelog.d/10223.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug which meant that invite rejections were not sent out over federation in a timely manner.

--- a/changelog.d/10223.bugfix
+++ b/changelog.d/10223.bugfix
@@ -1,1 +1,1 @@
-Fix a long-standing bug which meant that invite rejections were not sent out over federation in a timely manner.
+Fix a long-standing bug which meant that invite rejections and knocks were not sent out over federation in a timely manner.

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -65,4 +65,4 @@ if [[ -n "$1" ]]; then
 fi
 
 # Run the tests!
-go test -v -tags synapse_blacklist,msc2946,msc3083 -count=1 $EXTRA_COMPLEMENT_ARGS ./tests
+go test -v -tags synapse_blacklist,msc2946,msc3083,msc2403 -count=1 $EXTRA_COMPLEMENT_ARGS ./tests

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1980,6 +1980,13 @@ class FederationHandler(BaseHandler):
 
         event.internal_metadata.outlier = False
 
+        # Send this event on behalf of the other server.
+        #
+        # The remote server isn't a full participant in the room at this point, so
+        # may not have an up-to-date list of the other homeservers participating in
+        # the room, so we send it on their behalf.
+        event.internal_metadata.send_on_behalf_of = origin
+
         context = await self.state_handler.compute_event_context(event)
         await self._auth_and_persist_event(origin, event, context)
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2091,6 +2091,13 @@ class FederationHandler(BaseHandler):
 
         event.internal_metadata.outlier = False
 
+        # Send this event on behalf of the other server.
+        #
+        # The remote server isn't a full participant in the room at this point, so
+        # may not have an up-to-date list of the other homeservers participating in
+        # the room, so we send it on their behalf.
+        event.internal_metadata.send_on_behalf_of = origin
+
         context = await self.state_handler.compute_event_context(event)
 
         event_allowed = await self.third_party_event_rules.check_event_allowed(


### PR DESCRIPTION
ensure that events sent via `send_leave` and `send_knock` are sent on to the rest of the federation.

Fixes #10222.