### PR TITLE
Fix schema delta to not take as long on large servers

### DIFF
--- a/changelog.d/10227.feature
+++ b/changelog.d/10227.feature
@@ -1,0 +1,1 @@
+Implement "room knocking" as per [MSC2403](https://github.com/matrix-org/matrix-doc/pull/2403). Contributed by Sorunome and anoa.

--- a/synapse/storage/schema/main/delta/59/11add_knock_members_to_stats.sql
+++ b/synapse/storage/schema/main/delta/59/11add_knock_members_to_stats.sql
@@ -13,5 +13,8 @@
  * limitations under the License.
  */
 
-ALTER TABLE room_stats_current ADD COLUMN knocked_members INT NOT NULL DEFAULT '0';
-ALTER TABLE room_stats_historical ADD COLUMN knocked_members BIGINT NOT NULL DEFAULT '0';
+-- Existing rows will default to NULL, so anything reading from these tables
+-- needs to interpret NULL as 0. This is fine here as no existing rooms can have
+-- any knocked members.
+ALTER TABLE room_stats_current ADD COLUMN knocked_members INT;
+ALTER TABLE room_stats_historical ADD COLUMN knocked_members BIGINT;


### PR DESCRIPTION
Introduced in #6739

Fixes #10226

It doesn't look like anything is reading from these tables currently that care about `knocked_members`.