### PR TITLE
Fixes to the release script

### DIFF
--- a/changelog.d/10239.misc
+++ b/changelog.d/10239.misc
@@ -1,0 +1,1 @@
+Fixes to the release script.

--- a/changelog.d/10239.misc
+++ b/changelog.d/10239.misc
@@ -1,1 +1,1 @@
-Fixes to the release script.
+Update the release script to use the semver terminology and determine the release branch based on the next version.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -83,12 +83,6 @@ def run():
     if current_version.pre:
         # If the current version is an RC we don't need to bump any of the
         # version numbers (other than the RC number).
-        base_version = "{}.{}.{}".format(
-            current_version.major,
-            current_version.minor,
-            current_version.micro,
-        )
-
         if rc:
             new_version = "{}.{}.{}rc{}".format(
                 current_version.major,
@@ -97,38 +91,43 @@ def run():
                 current_version.pre[1] + 1,
             )
         else:
-            new_version = base_version
+            new_version = "{}.{}.{}".format(
+                current_version.major,
+                current_version.minor,
+                current_version.micro,
+            )
     else:
         # If this is a new release cycle then we need to know if its a major
         # version bump or a hotfix.
         release_type = click.prompt(
             "Release type",
-            type=click.Choice(("major", "hotfix")),
+            type=click.Choice(("minor", "patch")),
             show_choices=True,
-            default="major",
+            default="minor",
         )
 
-        if release_type == "major":
-            base_version = new_version = "{}.{}.{}".format(
-                current_version.major,
-                current_version.minor + 1,
-                0,
-            )
+        if release_type == "minor":
             if rc:
                 new_version = "{}.{}.{}rc1".format(
                     current_version.major,
                     current_version.minor + 1,
                     0,
                 )
-
+            else:
+                new_version = "{}.{}.{}".format(
+                    current_version.major,
+                    current_version.minor + 1,
+                    0,
+                )
         else:
-            base_version = new_version = "{}.{}.{}".format(
-                current_version.major,
-                current_version.minor,
-                current_version.micro + 1,
-            )
             if rc:
                 new_version = "{}.{}.{}rc1".format(
+                    current_version.major,
+                    current_version.minor,
+                    current_version.micro + 1,
+                )
+            else:
+                new_version = "{}.{}.{}".format(
                     current_version.major,
                     current_version.minor,
                     current_version.micro + 1,
@@ -139,7 +138,10 @@ def run():
         click.get_current_context().abort()
 
     # Switch to the release branch.
-    release_branch_name = f"release-v{current_version.major}.{current_version.minor}"
+    parsed_new_version = version.parse(new_version)
+    release_branch_name = (
+        f"release-v{parsed_new_version.major}.{parsed_new_version.minor}"
+    )
     release_branch = find_ref(repo, release_branch_name)
     if release_branch:
         if release_branch.is_remote():
@@ -153,7 +155,7 @@ def run():
         # release type.
         if current_version.is_prerelease:
             default = release_branch_name
-        elif release_type == "major":
+        elif release_type == "minor":
             default = "develop"
         else:
             default = "master"

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -97,8 +97,8 @@ def run():
                 current_version.micro,
             )
     else:
-        # If this is a new release cycle then we need to know if its a major
-        # version bump or a hotfix.
+        # If this is a new release cycle then we need to know if it's a minor
+        # or a patch version bump.
         release_type = click.prompt(
             "Release type",
             type=click.Choice(("minor", "patch")),


### PR DESCRIPTION
* rename major/minor into the right semver terminology minor/patch (since this was something that got me very confused the first couple of times I've used the script)
* name the release branch based on the new version, not the previous one