### PR TITLE
Modify docs root redirect to develop/index.html instead of a specific page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <title> Synapse Documentation </title>
-<meta http-equiv="Refresh" content="0; url='https://matrix-org.github.io/synapse/develop/welcome_and_overview.html'" />
+<meta http-equiv="Refresh" content="0; url='https://matrix-org.github.io/synapse/develop" />
 <p>
     Redirecting you to the latest documentation.
-        If you are not redirected, please <a href="https://matrix-org.github.io/synapse/develop/welcome_and_overview.html">click here</a>.
+        If you are not redirected, please <a href="https://matrix-org.github.io/synapse/develop">click here</a>.
 </p>


### PR DESCRIPTION
Context: https://github.com/matrix-org/synapse/pull/10242

`index.html` will still be the welcome page (for now), but if we ever decide to change that in the future, we won't need to update this redirect page again.

Note that CI is not expected to pass.