### PR TITLE
Create an index.html file when generating a docs build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,7 +23,12 @@ jobs:
           mdbook-version: '0.4.9'
 
       - name: Build the documentation
-        run: mdbook build
+        # mdbook will only create an index.html if we're including docs/README.md in SUMMARY.md.
+        # However, we're using docs/README.md for other purposes and need to pick a new page
+        # as the default. Let's opt for the welcome page instead.
+        run: |
+          mdbook build
+          cp book/welcome_and_overview.html book/index.html
 
       # Deploy to the latest documentation directories
       - name: Deploy latest documentation

--- a/changelog.d/10242.doc
+++ b/changelog.d/10242.doc
@@ -1,0 +1,1 @@
+Choose Welcome & Overview as the default page for synapse documentation website.


### PR DESCRIPTION
Currently when a new build of the docs is created, an `index.html` file does not exist. Typically this would be generated from a`docs/README.md` file - which we have - however we're currently using [docs/README.md](https://github.com/matrix-org/synapse/blob/394673055db4df49bfd58c2f6118834a6d928563/docs/README.md) to explain the docs and point to the website. It is not part of the content of the website. So we end up not having an `index.html` file, which will result in a 404 page if one tries to navigate to `https://matrix-org.github.io/synapse/<docs_version>/index.html`.

This isn't a really problem for the default version of the documentation (currently `develop`), as [navigating to the top-level root](https://matrix-org.github.io/synapse/) of the website (without specifying a version) will [redirect](https://github.com/matrix-org/synapse/blob/a77e6925f26597958eccf0ef9956cb13c536e57e/index.html#L2) you to the Welcome and Overview page of the `develop` docs version.

However, ideally once we add a GUI for switching between versions, we'll want to send the user to `matrix-org.github.io/synapse/<version>/index.html`, which currently isn't generated.

This PR modifies the CI that builds the docs to simply copy the rendered [Welcome & Overview page](https://matrix-org.github.io/synapse/develop/welcome_and_overview.html) to `index.html`.

**This PR is paired with https://github.com/matrix-org/synapse/pull/10241**, which modifies the current redirect in the `gh-pages` branch to point to `develop/index.html` instead of `develop/welcome_and_overview.html`. Therefore if we ever want to change the default page of the docs, all we'd need to do is update the `cp` call in the CI.

I'm aware that this isn't the most *elegant* solution. Ideally I'd like an option in mdbook's [index preprocessor](https://rust-lang.github.io/mdBook/format/configuration/preprocessors.html) to specify a separate file from `docs/README.md` that should turn into `index.html`. However, it's a slight edge-case, and I can see why it's not an available option.

The workflow has been tested over on my copy of synapse. [An index.html](https://github.com/anoadragon453/synapse/blob/gh-pages/v1.9999/index.html) was generated properly -> https://anoadragon453.github.io/synapse/latest/index.html