### PR TITLE
Soft-fail spammy events received over federation

### DIFF
--- a/changelog.d/10263.feature
+++ b/changelog.d/10263.feature
@@ -1,0 +1,1 @@
+Mark events received over federation which fail a spam check as "soft-failed".

--- a/synapse/federation/federation_base.py
+++ b/synapse/federation/federation_base.py
@@ -90,11 +90,11 @@ class FederationBase:
 
         if result:
             logger.warning(
-                "Event contains spam, redacting %s: %s",
+                "Event contains spam, soft-failing %s: %s",
                 pdu.event_id,
                 pdu.get_pdu_json(),
             )
-            return prune_event(pdu)
+            pdu.internal_metadata.soft_failed = True
 
         return pdu
 

--- a/synapse/federation/federation_base.py
+++ b/synapse/federation/federation_base.py
@@ -89,12 +89,12 @@ class FederationBase:
         result = await self.spam_checker.check_event_for_spam(pdu)
 
         if result:
-            logger.warning(
-                "Event contains spam, soft-failing %s: %s",
-                pdu.event_id,
-                pdu.get_pdu_json(),
-            )
-            pdu.internal_metadata.soft_failed = True
+            logger.warning("Event contains spam, soft-failing %s", pdu.event_id)
+            # we redact (to save disk space) as well as soft-failing (to stop
+            # using the event in prev_events).
+            redacted_event = prune_event(pdu)
+            redacted_event.internal_metadata.soft_failed = True
+            return redacted_event
 
         return pdu
 


### PR DESCRIPTION
Soft-failing spam which arrives over federation achieves two things:
 * the content will not be served to the clients of local users
 * spam events will not be used as prev-events for future events we generate.

The second point is useful in the following situation. Suppose we have three servers in a room: `spammy.com`, `speedy.com` and `slow.com`. `spammy` creates thousands of events and sends them out to the other servers. `speedy` accepts them all (possibly redacting them or similar measures) and starts generating its own events (possibly including things like server ACLs). `slow.com` can't keep up with the traffic from `spammy.com` so when it sees events from `speedy.com` it sees unknown events which it needs to backfill, so traffic from `speedy.com` to `slow.com` is severely impacted too.

On the other hand, if `speedy.com` soft-fails the spam, `slow.com` will be able to better handle later events from `speedy.com`.