### PR TITLE
Fix `populate_stream_ordering2` background job

### DIFF
--- a/changelog.d/10267.bugfix
+++ b/changelog.d/10267.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where Synapse would return errors after 2<sup>31</sup> events were handled by the server.

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -1068,6 +1068,8 @@ class EventsBackgroundUpdatesStore(SQLBaseStore):
                 (last_stream, batch_size),
             )
             row_count = txn.rowcount
+            if row_count == 0:
+                return 0
             last_stream = max(row[0] for row in txn)
             logger.info("populated stream_ordering2 up to %i", last_stream)
 

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -1069,6 +1069,7 @@ class EventsBackgroundUpdatesStore(SQLBaseStore):
             )
             row_count = txn.rowcount
             last_stream = max(row[0] for row in txn)
+            logger.info("populated stream_ordering2 up to %i", last_stream)
 
             self.db_pool.updates._background_update_progress_txn(
                 txn,

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -1060,7 +1060,7 @@ class EventsBackgroundUpdatesStore(SQLBaseStore):
                 """
                 UPDATE events SET stream_ordering2=stream_ordering
                 WHERE stream_ordering IN (
-                   SELECT stream_ordering from events WHERE stream_ordering > ?
+                   SELECT stream_ordering FROM events WHERE stream_ordering > ?
                    ORDER BY stream_ordering LIMIT ?
                 )
                 RETURNING stream_ordering;


### PR DESCRIPTION
It was possible for us not to find any rows in a batch, and hence conclude that
we had finished. Let's not do that.