### PR TITLE
Fix the homeserver config example in presence router docs

### DIFF
--- a/changelog.d/10288.doc
+++ b/changelog.d/10288.doc
@@ -1,0 +1,1 @@
+Fix homeserver config option name in presence router documentation.

--- a/docs/presence_router_module.md
+++ b/docs/presence_router_module.md
@@ -222,7 +222,9 @@ Synapse, amend your homeserver config file with the following.
 
 ```yaml
 presence:
-  routing_module:
+  enabled: true
+
+  presence_router:
     module: my_module.ExamplePresenceRouter
     config:
       # Any configuration options for your module. The below is an example.


### PR DESCRIPTION
The presence router docs include some sample homeserver config. At some point we changed the name of the [config option](https://github.com/matrix-org/synapse/blob/859dc05b3692a3672c1a0db8deaaa9274b6aa6f5/docs/sample_config.yaml#L104-L113), but forgot to update the docs.

I've also added `presence.enabled: true` to the example, as that's the new way to enable presence (the `presence_enabled` option has been deprecated).