### PR TITLE
fix ordering of bg update

### DIFF
--- a/changelog.d/10291.bugfix
+++ b/changelog.d/10291.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where Synapse would return errors after 2<sup>31</sup> events were handled by the server.

--- a/synapse/storage/schema/main/delta/60/01recreate_stream_ordering.sql.postgres
+++ b/synapse/storage/schema/main/delta/60/01recreate_stream_ordering.sql.postgres
@@ -42,4 +42,4 @@ INSERT INTO background_updates (ordering, update_name, progress_json, depends_on
 
 -- ... and another to do the switcheroo
 INSERT INTO background_updates (ordering, update_name, progress_json, depends_on) VALUES
-  (6003, 'replace_stream_ordering_column', '{}', 'index_stream_ordering2_ts');
+  (6001, 'replace_stream_ordering_column', '{}', 'index_stream_ordering2_ts');


### PR DESCRIPTION
this was a typo introduced in #10282. We don't want to end up doing the
`replace_stream_ordering_column` update after anything that comes up in
migration 60/03.