### PR TITLE
Reenable 'Backfilled events whose prev_events...' sytest

### DIFF
--- a/changelog.d/10292.misc
+++ b/changelog.d/10292.misc
@@ -1,0 +1,1 @@
+Reenable a SyTest after it has been fixed.

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -45,5 +45,4 @@ Peeked rooms only turn up in the sync for the device who peeked them
 
 # Blacklisted due to changes made in #10272
 Outbound federation will ignore a missing event with bad JSON for room version 6
-Backfilled events whose prev_events are in a different room do not allow cross-room back-pagination
 Federation rejects inbound events where the prev_events cannot be found


### PR DESCRIPTION
Now that we've fixed it in https://github.com/matrix-org/sytest/pull/1059