### PR TITLE
Rebuild event auth when rebuilding an event after a call to a `ThirdPartyEventRules` module

### DIFF
--- a/changelog.d/10316.misc
+++ b/changelog.d/10316.misc
@@ -1,0 +1,1 @@
+Rebuild event context and auth when processing specific results from `ThirdPartyEventRules` modules.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1594,11 +1594,13 @@ class EventCreationHandler:
         for k, v in original_event.internal_metadata.get_dict().items():
             setattr(builder.internal_metadata, k, v)
 
-        # the event type hasn't changed, so there's no point in re-calculating the
-        # auth events.
+        # modules can send new state events, so we re-calculate the auth events just in
+        # case.
+        prev_event_ids = await self.store.get_prev_events_for_room(builder.room_id)
+
         event = await builder.build(
-            prev_event_ids=original_event.prev_event_ids(),
-            auth_event_ids=original_event.auth_event_ids(),
+            prev_event_ids=prev_event_ids,
+            auth_event_ids=None,
         )
 
         # we rebuild the event context, to be on the safe side. If nothing else,


### PR DESCRIPTION
Because modules might send extra state events when processing an event (e.g. https://github.com/matrix-org/synapse-dinsic/pull/100), and in some cases these extra events might get dropped if we don't recalculate the initial event's auth.