### PR TITLE
build the docs for master

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,40 +27,28 @@ jobs:
       - name: Build the documentation
         run: mdbook build
 
-      # Deploy to the latest documentation directories
-      - name: Deploy latest documentation
+      # Figure out the target directory.
+      #
+      # The target directory is normally the same as the branch name, but we
+      # strip 'release-' from the name for release branches.
+      #
+      - name: Get the target directory name
+        id: vars
+        run: |
+          # first strip the 'refs/heads/' prefix with some shell foo
+          branch="${GITHUB_REF#refs/heads/}"
+
+          # now strip 'release-'
+          branch="${branch#release-}"
+
+          # finally, set the 'branch-version' var.
+          echo "::set-output name=branch-version::$branch"
+          
+      # Deploy to the target directory.
+      - name: Deploy to gh pages
         uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           keep_files: true
           publish_dir: ./book
-          destination_dir: ./develop
-
-      - name: Get the current Synapse version
-        id: vars
-        # The $GITHUB_REF value for a branch looks like `refs/heads/release-v1.2`. We do some
-        # shell magic to remove the "refs/heads/release-v" bit from this, to end up with "1.2",
-        # our major/minor version number, and set this to a var called `branch-version`.
-        #
-        # We then use some python to get Synapse's full version string, which may look
-        # like "1.2.3rc4". We set this to a var called `synapse-version`. We use this
-        # to determine if this release is still an RC, and if so block deployment.
-        run: |
-          echo ::set-output name=branch-version::${GITHUB_REF#refs/heads/release-v}
-          echo ::set-output name=synapse-version::`python3 -c 'import synapse; print(synapse.__version__)'`
-
-      # Deploy to the version-specific directory
-      - name: Deploy release-specific documentation
-        # We only carry out this step if we're running on a release branch,
-        # and the current Synapse version does not have "rc" in the name.
-        #
-        # The result is that only full releases are deployed, but can be
-        # updated if the release branch gets retroactive fixes.
-        if: ${{ startsWith( github.ref, 'refs/heads/release-v' ) && !contains( steps.vars.outputs.synapse-version, 'rc') }}
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          keep_files: true
-          publish_dir: ./book
-          # The resulting documentation will end up in a directory named `vX.Y`.
-          destination_dir: ./v${{ steps.vars.outputs.branch-version }}
+          destination_dir: ./${{ steps.vars.outputs.branch-version }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,8 @@ on:
       - develop
       # For documentation specific to a release
       - 'release-v*'
+      # stable docs
+      - master
 
   workflow_dispatch:
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,8 +29,7 @@ jobs:
 
       # Figure out the target directory.
       #
-      # The target directory is normally the same as the branch name, but we
-      # strip 'release-' from the name for release branches.
+      # The target directory depends on the name of the branch
       #
       - name: Get the target directory name
         id: vars
@@ -38,8 +37,16 @@ jobs:
           # first strip the 'refs/heads/' prefix with some shell foo
           branch="${GITHUB_REF#refs/heads/}"
 
-          # now strip 'release-'
-          branch="${branch#release-}"
+          case $branch in
+              release-*)
+                  # strip 'release-' from the name for release branches.
+                  branch="${branch#release-}"
+                  ;;
+              master)
+                  # deploy to "latest" for the master branch.
+                  branch="latest"
+                  ;;
+          esac
 
           # finally, set the 'branch-version' var.
           echo "::set-output name=branch-version::$branch"


### PR DESCRIPTION
as well as running the job for master, I've reworked the logic for where we deploy to.

Firstly, we shouldn't deploy to `develop` unless we're actually building `develop` (as otherwise we can end up rewinding the develop docs to a release build).

Secondly, I've ripped out the RC logic. I wasn't at all convinced it was helpful. Consider a release cycle:
 1. fork the release branch
 2. land a release-blocking bugfix or two
 3. cut an RC: bump the synapse version
 4. cut the final release: bump the synapse version

It is odd to me that we will deploy the docs for the release branch ant steps 1, 2 and 4 but not step 3.