### PR TITLE
Minor changes to `user_daily_visits`

### DIFF
--- a/changelog.d/10324.misc
+++ b/changelog.d/10324.misc
@@ -1,0 +1,1 @@
+Minor change to the code that populates `user_daily_visits`.

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -352,7 +352,7 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                     ) udv
                     ON u.user_id = udv.user_id AND u.device_id=udv.device_id
                     INNER JOIN users ON users.name=u.user_id
-                    WHERE last_seen > ? AND last_seen <= ?
+                    WHERE ? <= last_seen AND last_seen < ?
                     AND udv.timestamp IS NULL AND users.is_guest=0
                     AND users.appservice_id IS NULL
                     GROUP BY u.user_id, u.device_id

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -320,7 +320,7 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
         """
         Returns millisecond unixtime for start of UTC day.
         """
-        now = time.gmtime(self.hs.get_clock().time())
+        now = time.gmtime(self._clock.time())
         today_start = calendar.timegm((now.tm_year, now.tm_mon, now.tm_mday, 0, 0, 0))
         return today_start * 1000
 

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -320,7 +320,7 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
         """
         Returns millisecond unixtime for start of UTC day.
         """
-        now = time.gmtime()
+        now = time.gmtime(self.hs.get_clock().time())
         today_start = calendar.timegm((now.tm_year, now.tm_mon, now.tm_mday, 0, 0, 0))
         return today_start * 1000
 


### PR DESCRIPTION
Change 1: we use the clock as the source of time in _get_start_of_day, because otherwise in (WIP) tests, we end up in a situation where we're searching (real time) < ... <= (fake time), which typically yields no results, as real time is much bigger than fake time.

Change 2: Use `? <= last_seen AND last_seen < ?` instead of `? < last_seen AND last_seen <= ?`, because the latter ignores changes that occur in the same millisecond after the query is run (which is probably a bit pedantic for real life, but in tests, causes trouble).