### PR TITLE
Add a new version of the R30 phone-home metric, which removes a false impression of retention given by the old R30 metric

### DIFF
--- a/changelog.d/10332.feature
+++ b/changelog.d/10332.feature
@@ -1,0 +1,1 @@
+Add a new version of the R30 phone-home metric, which removes a false impression of retention given by the old R30 metric.

--- a/synapse/app/phone_stats_home.py
+++ b/synapse/app/phone_stats_home.py
@@ -107,6 +107,10 @@ async def phone_stats_home(hs, stats, stats_process=_stats_process):
     for name, count in r30_results.items():
         stats["r30_users_" + name] = count
 
+    r30v2_results = await hs.get_datastore().count_r30_users()
+    for name, count in r30v2_results.items():
+        stats["r30v2_users_" + name] = count
+
     stats["cache_factor"] = hs.config.caches.global_factor
     stats["event_cache_size"] = hs.config.caches.event_cache_size
 

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -404,19 +404,20 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
 
             # This is the 'all users' count.
             sql = """
-                SELECT
-                    DISTINCT COUNT(*) OVER ()
-                FROM
-                    user_daily_visits
-                WHERE
-                    timestamp > (? * 1000)
-                    AND
-                    timestamp < (? * 1000)
-                GROUP BY
-                    user_id
-                HAVING
-                    max(timestamp) - min(timestamp) > (? * 1000)
-                ;
+                SELECT COUNT(*) FROM (
+                    SELECT
+                        1
+                    FROM
+                        user_daily_visits
+                    WHERE
+                        timestamp > (? * 1000)
+                        AND
+                        timestamp < (? * 1000)
+                    GROUP BY
+                        user_id
+                    HAVING
+                        max(timestamp) - min(timestamp) > (? * 1000)
+                )
             """
 
             txn.execute(

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -373,14 +373,14 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                         FROM
                             user_daily_visits
                         WHERE
-                            timestamp > (? * 1000)
+                            timestamp > (CAST(? AS BIGINT) * 1000)
                             AND
-                            timestamp < (? * 1000)
+                            timestamp < (CAST(? AS BIGINT) * 1000)
                         GROUP BY
                             user_id,
                             client_type
                         HAVING
-                            max(timestamp) - min(timestamp) > (? * 1000)
+                            max(timestamp) - min(timestamp) > (CAST(? AS BIGINT) * 1000)
                     ) AS temp
                 GROUP BY
                     client_type
@@ -410,13 +410,13 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                     FROM
                         user_daily_visits
                     WHERE
-                        timestamp > (? * 1000)
+                        timestamp > (CAST(? AS BIGINT) * 1000)
                         AND
-                        timestamp < (? * 1000)
+                        timestamp < (CAST(? AS BIGINT) * 1000)
                     GROUP BY
                         user_id
                     HAVING
-                        max(timestamp) - min(timestamp) > (? * 1000)
+                        max(timestamp) - min(timestamp) > (CAST(? AS BIGINT) * 1000)
                 )
             """
 

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -389,9 +389,9 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                 ;
             """
 
-            # REVIEW: do we want to initialise the counts to zero so that we
-            # get an explicit zero for clients that don't appear in our tables?
-            results = {}
+            # We initialise all the client types to zero, so we get an explicit
+            # zero if they don't appear in the query results
+            results = {"ios": 0, "android": 0, "web": 0, "electron": 0}
             txn.execute(
                 sql,
                 (sixty_days_ago_in_secs, one_day_from_now_in_secs, thirty_days_in_secs),

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -417,7 +417,7 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                         user_id
                     HAVING
                         max(timestamp) - min(timestamp) > (CAST(? AS BIGINT) * 1000)
-                )
+                ) AS r30_users
             """
 
             txn.execute(

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -376,14 +376,14 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                         FROM
                             user_daily_visits
                         WHERE
-                            timestamp > (CAST(? AS BIGINT) * 1000)
+                            timestamp > ?
                             AND
-                            timestamp < (CAST(? AS BIGINT) * 1000)
+                            timestamp < ?
                         GROUP BY
                             user_id,
                             client_type
                         HAVING
-                            max(timestamp) - min(timestamp) > (CAST(? AS BIGINT) * 1000)
+                            max(timestamp) - min(timestamp) > ?
                     ) AS temp
                 GROUP BY
                     client_type
@@ -395,7 +395,11 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
             results = {"ios": 0, "android": 0, "web": 0, "electron": 0}
             txn.execute(
                 sql,
-                (sixty_days_ago_in_secs, one_day_from_now_in_secs, thirty_days_in_secs),
+                (
+                    sixty_days_ago_in_secs * 1000,
+                    one_day_from_now_in_secs * 1000,
+                    thirty_days_in_secs * 1000,
+                ),
             )
 
             for row in txn:
@@ -411,13 +415,13 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                     FROM
                         user_daily_visits
                     WHERE
-                        timestamp > CAST(? AS BIGINT)
+                        timestamp > ?
                         AND
-                        timestamp < CAST(? AS BIGINT)
+                        timestamp < ?
                     GROUP BY
                         user_id
                     HAVING
-                        max(timestamp) - min(timestamp) > CAST(? AS BIGINT)
+                        max(timestamp) - min(timestamp) > ?
                 ) AS r30_users
             """
 

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -326,7 +326,14 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
         (This is the second version of this metric, hence R30'v2')
 
         Returns:
-             A mapping of counts globally as well as broken out by platform.
+             A mapping from client type to the number of 30-day retained users for that client.
+
+             The dict keys are:
+              - "all" (a combined number of users across any and all clients)
+              - "android" (Element Android)
+              - "ios" (Element iOS)
+              - "electron" (Element Desktop)
+              - "web" (any web application -- it's not possible to distinguish Element Web here)
         """
 
         def _count_r30v2_users(txn):

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -384,8 +384,6 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                     ) AS temp
                 GROUP BY
                     client_type
-                ORDER BY
-                    client_type
                 ;
             """
 

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -346,10 +346,6 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                             user_id,
                             CASE
                                 WHEN
-                                    user_agent IS NULL OR
-                                    user_agent = ''
-                                    THEN 'unknown'
-                                WHEN
                                     LOWER(user_agent) LIKE '%%riot%%' OR
                                     LOWER(user_agent) LIKE '%%element%%'
                                     THEN CASE

--- a/synapse/storage/databases/main/metrics.py
+++ b/synapse/storage/databases/main/metrics.py
@@ -410,19 +410,23 @@ class ServerMetricsStore(EventPushActionsWorkerStore, SQLBaseStore):
                     FROM
                         user_daily_visits
                     WHERE
-                        timestamp > (CAST(? AS BIGINT) * 1000)
+                        timestamp > CAST(? AS BIGINT)
                         AND
-                        timestamp < (CAST(? AS BIGINT) * 1000)
+                        timestamp < CAST(? AS BIGINT)
                     GROUP BY
                         user_id
                     HAVING
-                        max(timestamp) - min(timestamp) > (CAST(? AS BIGINT) * 1000)
+                        max(timestamp) - min(timestamp) > CAST(? AS BIGINT)
                 ) AS r30_users
             """
 
             txn.execute(
                 sql,
-                (sixty_days_ago_in_secs, one_day_from_now_in_secs, thirty_days_in_secs),
+                (
+                    sixty_days_ago_in_secs * 1000,
+                    one_day_from_now_in_secs * 1000,
+                    thirty_days_in_secs * 1000,
+                ),
             )
             row = txn.fetchone()
             if row is None:

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -347,16 +347,18 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         # (user_daily_visits is updated every 5 minutes using a looping call.)
         self.reactor.advance(FIVE_MINUTES_IN_SECONDS)
 
+        store = self.hs.get_datastore()
+
         # Check that the user does not contribute to R30v2, even though it's been
         # more than 30 days since registration.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
         )
 
         # Check that this is a situation where old R30 differs:
         # old R30 DOES count this as 'retained'.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30_users())
+        r30_results = self.get_success(store.count_r30_users())
         self.assertEqual(r30_results, {"all": 1, "ios": 1})
 
         # Now we want to check that the user will still be able to appear in
@@ -369,7 +371,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.reactor.advance(FIVE_MINUTES_IN_SECONDS)
 
         # Check the user now satisfies the requirements to appear in R30v2.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 1, "ios": 1, "android": 0, "electron": 0, "web": 0}
         )
@@ -378,7 +380,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.reactor.advance(27.5 * ONE_DAY_IN_SECONDS)
 
         # Check the user still appears in R30v2.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 1, "ios": 1, "android": 0, "electron": 0, "web": 0}
         )
@@ -387,7 +389,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.reactor.advance(ONE_DAY_IN_SECONDS)
 
         # Check the user no longer appears in R30v2.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
         )

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -192,7 +192,8 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.helper.send(room_id, "message", tok=access_token)
         first_post_at = self.hs.get_clock().time()
 
-        # (give time for user_daily_visits table to be updated)
+        # Give time for user_daily_visits table to be updated.
+        # (user_daily_visits is updated every 5 minutes using a looping call.)
         self.reactor.advance(FIVE_MINUTES_IN_SECONDS)
 
         store = self.hs.get_datastore()
@@ -270,7 +271,8 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         )
         self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
 
-        # give time for user_daily_visits to update
+        # Give time for user_daily_visits table to be updated.
+        # (user_daily_visits is updated every 5 minutes using a looping call.)
         self.reactor.advance(FIVE_MINUTES_IN_SECONDS)
 
         store = self.hs.get_datastore()
@@ -341,7 +343,8 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         # the user returns for one day, perhaps just to check out a new feature
         self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
 
-        # (give time for tables to update)
+        # Give time for user_daily_visits table to be updated.
+        # (user_daily_visits is updated every 5 minutes using a looping call.)
         self.reactor.advance(FIVE_MINUTES_IN_SECONDS)
 
         # Check that the user does not contribute to R30v2, even though it's been

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -175,8 +175,6 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # This starts the needed data collection that we rely on to calculate
         # R30v2 metrics.
-        # REVIEW: would I be better off just starting the looping call for
-        # populating user_daily_visits itself?
         start_phone_stats_home(hs)
         return hs
 

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -1,4 +1,5 @@
 import synapse
+from synapse.app.phone_stats_home import start_phone_stats_home
 from synapse.rest.client.v1 import login, room
 
 from tests import unittest
@@ -152,6 +153,33 @@ class PhoneHomeTestCase(HomeserverTestCase):
         r30_results = self.get_success(self.hs.get_datastore().count_r30_users())
         self.assertEqual(r30_results, {"all": 1, "unknown": 1})
 
+
+class PhoneHomeR30V2TestCase(HomeserverTestCase):
+    servlets = [
+        synapse.rest.admin.register_servlets_for_client_rest_resource,
+        room.register_servlets,
+        login.register_servlets,
+    ]
+
+    def _advance_to(self, desired_time: float):
+        now = self.hs.get_clock().time()
+        assert now < desired_time
+        self.reactor.advance(desired_time - now)
+
+    def make_homeserver(self, reactor, clock):
+        hs = super(PhoneHomeR30V2TestCase, self).make_homeserver(reactor, clock)
+
+        # We don't want our tests to actually report statistics, so check
+        # that it's not enabled
+        assert not hs.config.report_stats
+
+        # This starts the needed data collection that we rely on to calculate
+        # R30v2 metrics.
+        # REVIEW: would I be better off just starting the looping call for
+        # populating user_daily_visits itself?
+        start_phone_stats_home(hs)
+        return hs
+
     def test_r30v2_minimum_usage(self):
         """
         Tests the minimum amount of interaction necessary for the R30v2 metric
@@ -163,14 +191,24 @@ class PhoneHomeTestCase(HomeserverTestCase):
         access_token = self.login("u1", "secret!")
         room_id = self.helper.create_room_as(room_creator=user_id, tok=access_token)
         self.helper.send(room_id, "message", tok=access_token)
+        first_post_at = self.hs.get_clock().time()
+
+        # (give time for tables to be updated)
+        self.reactor.advance(300)
+        self.reactor.advance(300)
 
         # Check the R30 results do not count that user.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
         self.assertEqual(r30_results, {"all": 0})
 
-        # Advance 30 days (+ 1 second, because strict inequality causes issues if we are
-        # bang on 30 days later).
-        self.reactor.advance(30 * DAY + 1)
+        # Advance 31 days.
+        # (R30v2 includes users with **more** than 30 days between the two visits,
+        #  and user_daily_visits records the timestamp as the start of the day.)
+        # REVIEW: is >=31 days really what was intended? Need to ask.
+        self.reactor.advance(31 * DAY)
+        # Also advance 10 minutes to let another user_daily_visits update occur
+        self.reactor.advance(600)
+        self.reactor.advance(1)
 
         # (Make sure the user isn't somehow counted by this point.)
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
@@ -179,25 +217,27 @@ class PhoneHomeTestCase(HomeserverTestCase):
         # Send a message (this counts as activity)
         self.helper.send(room_id, "message2", tok=access_token)
 
-        # We have to wait up to 5 seconds for _update_client_ips_batch to get
-        # called and update the user_ips table in a batch.
-        self.reactor.advance(5.1)
+        # We have to wait up a few minutes for the user_daily_visits table to
+        # be updated by a background process.
+        self.reactor.advance(300)
+        self.reactor.advance(1)
 
         # *Now* the user is counted.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 1, "unknown": 1})
+        self.assertEqual(r30_results, {"all": 1})
 
-        # Advance 29 days. The user has now not posted for 29 days.
-        self.reactor.advance(29 * DAY)
+        # Advance to JUST under 60 days after the user's first post
+        self._advance_to(first_post_at + 60 * DAY - 5)
+        self.reactor.advance(1)
 
-        # The user is still counted.
+        # Check the user is still counted.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 1, "unknown": 1})
+        self.assertEqual(r30_results, {"all": 1})
 
-        # Advance another day. The user has now not posted for 30 days.
-        self.reactor.advance(DAY)
+        # Advance into the next day. The user's first activity is now more than 60 days old.
+        self._advance_to(first_post_at + 60 * DAY + 5)
 
-        # The user is now no longer counted in R30.
+        # Check the user is now no longer counted in R30.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
         self.assertEqual(r30_results, {"all": 0})
 
@@ -207,11 +247,24 @@ class PhoneHomeTestCase(HomeserverTestCase):
         before appearing in the R30v2 statistic, even if they post every day
         during that time!
         """
+        # set a custom user-agent to impersonate Element/Android.
+        headers = (
+            (
+                "User-Agent",
+                "Element/1.1 (Linux; U; Android 9; MatrixAndroidSDK_X 0.0.1)",
+            ),
+        )
+
         # Register a user and send a message
         user_id = self.register_user("u1", "secret!")
-        access_token = self.login("u1", "secret!")
-        room_id = self.helper.create_room_as(room_creator=user_id, tok=access_token)
-        self.helper.send(room_id, "message", tok=access_token)
+        access_token = self.login("u1", "secret!", custom_headers=headers)
+        room_id = self.helper.create_room_as(
+            room_creator=user_id, tok=access_token, custom_headers=headers
+        )
+        self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
+
+        self.reactor.advance(399)
+        self.reactor.advance(1)
 
         # Check the user does not contribute to R30 yet.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
@@ -219,16 +272,103 @@ class PhoneHomeTestCase(HomeserverTestCase):
 
         for _ in range(30):
             # This loop posts a message every day for 30 days
-            self.reactor.advance(DAY)
-            self.helper.send(room_id, "I'm still here", tok=access_token)
+            self.reactor.advance(DAY - 401)
+            self.reactor.advance(1)
+            self.helper.send(
+                room_id, "I'm still here", tok=access_token, custom_headers=headers
+            )
+
+            self.reactor.advance(399)
+            self.reactor.advance(1)
 
             # Notice that the user *still* does not contribute to R30!
             r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
             self.assertEqual(r30_results, {"all": 0})
 
-        self.reactor.advance(DAY)
-        self.helper.send(room_id, "Still here!", tok=access_token)
+        # (This advance needs to be split up into multiple advances
+        #  because otherwise strict inequality hits.)
+        self.reactor.advance(DAY - 1)
+        self.reactor.advance(1)
+        self.helper.send(
+            room_id, "Still here!", tok=access_token, custom_headers=headers
+        )
+
+        self.reactor.advance(399)
+        self.reactor.advance(1)
 
         # *Now* the user appears in R30.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 1, "unknown": 1})
+        self.assertEqual(r30_results, {"all": 1, "android": 1})
+
+    def test_r30v2_returning_dormant_users_not_counted(self):
+        """
+        Tests that dormant users (users inactive for a long time) do not
+        contribute to R30v2 when they return for just a single day.
+        This is a key difference between R30 and R30v2.
+        """
+
+        # set a custom user-agent to impersonate Element/iOS.
+        headers = (
+            (
+                "User-Agent",
+                "Riot/1.4 (iPhone; iOS 13; Scale/4.00)",
+            ),
+        )
+
+        # Register a user and send a message
+        user_id = self.register_user("u1", "secret!")
+        access_token = self.login("u1", "secret!", custom_headers=headers)
+        room_id = self.helper.create_room_as(
+            room_creator=user_id, tok=access_token, custom_headers=headers
+        )
+        self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
+
+        # the user goes inactive for 2 months
+        self.reactor.advance(60 * DAY)
+
+        # the user returns for one day, perhaps just to check out a new feature
+        self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
+
+        # (give time for tables to update)
+        self.reactor.advance(300)
+        self.reactor.advance(300)
+        self.reactor.advance(300)
+
+        # Check that the user does not contribute to R30v2, even though it's been
+        # more than 30 days since registration.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 0})
+
+        # Check that this is a situation where old R30 differs:
+        # old R30 DOES count this as 'retained'.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30_users())
+        self.assertEqual(r30_results, {"all": 1, "ios": 1})
+
+        # Now we want to check that the user will still be able to appear in
+        # R30v2 as long as the user performs some other activity between
+        # 30 and 60 days later.
+        self.reactor.advance(32 * DAY)
+        self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
+
+        # (give time for tables to update)
+        self.reactor.advance(300)
+        self.reactor.advance(300)
+        self.reactor.advance(300)
+
+        # Check the user now satisfies the requirements to appear in R30v2.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 1, "ios": 1})
+
+        # Advance to 59.5 days after the user's first R30v2-eligible activity.
+        self.reactor.advance(27.5 * DAY)
+
+        # Check the user still appears in R30v2.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 1, "ios": 1})
+
+        # Advance to 60.5 days after the user's first R30v2-eligible activity.
+        self.reactor.advance(DAY)
+
+        # Check the user no longer appears in R30v2.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 0})

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -151,3 +151,84 @@ class PhoneHomeTestCase(HomeserverTestCase):
         # *Now* the user appears in R30.
         r30_results = self.get_success(self.hs.get_datastore().count_r30_users())
         self.assertEqual(r30_results, {"all": 1, "unknown": 1})
+
+    def test_r30v2_minimum_usage(self):
+        """
+        Tests the minimum amount of interaction necessary for the R30v2 metric
+        to consider a user 'retained'.
+        """
+
+        # Register a user, log it in, create a room and send a message
+        user_id = self.register_user("u1", "secret!")
+        access_token = self.login("u1", "secret!")
+        room_id = self.helper.create_room_as(room_creator=user_id, tok=access_token)
+        self.helper.send(room_id, "message", tok=access_token)
+
+        # Check the R30 results do not count that user.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 0})
+
+        # Advance 30 days (+ 1 second, because strict inequality causes issues if we are
+        # bang on 30 days later).
+        self.reactor.advance(30 * DAY + 1)
+
+        # (Make sure the user isn't somehow counted by this point.)
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 0})
+
+        # Send a message (this counts as activity)
+        self.helper.send(room_id, "message2", tok=access_token)
+
+        # We have to wait up to 5 seconds for _update_client_ips_batch to get
+        # called and update the user_ips table in a batch.
+        self.reactor.advance(5.1)
+
+        # *Now* the user is counted.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 1, "unknown": 1})
+
+        # Advance 29 days. The user has now not posted for 29 days.
+        self.reactor.advance(29 * DAY)
+
+        # The user is still counted.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 1, "unknown": 1})
+
+        # Advance another day. The user has now not posted for 30 days.
+        self.reactor.advance(DAY)
+
+        # The user is now no longer counted in R30.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 0})
+
+    def test_r30v2_user_must_be_retained_for_at_least_a_month(self):
+        """
+        Tests that a newly-registered user must be retained for a whole month
+        before appearing in the R30v2 statistic, even if they post every day
+        during that time!
+        """
+        # Register a user and send a message
+        user_id = self.register_user("u1", "secret!")
+        access_token = self.login("u1", "secret!")
+        room_id = self.helper.create_room_as(room_creator=user_id, tok=access_token)
+        self.helper.send(room_id, "message", tok=access_token)
+
+        # Check the user does not contribute to R30 yet.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 0})
+
+        for _ in range(30):
+            # This loop posts a message every day for 30 days
+            self.reactor.advance(DAY)
+            self.helper.send(room_id, "I'm still here", tok=access_token)
+
+            # Notice that the user *still* does not contribute to R30!
+            r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+            self.assertEqual(r30_results, {"all": 0})
+
+        self.reactor.advance(DAY)
+        self.helper.send(room_id, "Still here!", tok=access_token)
+
+        # *Now* the user appears in R30.
+        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        self.assertEqual(r30_results, {"all": 1, "unknown": 1})

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -205,7 +205,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         # Advance 31 days.
         # (R30v2 includes users with **more** than 30 days between the two visits,
         #  and user_daily_visits records the timestamp as the start of the day.)
-        self.reactor.advance(31 * DAY)
+        self.reactor.advance(31 * ONE_DAY_IN_SECONDS)
         # Also advance 10 minutes to let another user_daily_visits update occur
         self.reactor.advance(600)
 
@@ -229,7 +229,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         )
 
         # Advance to JUST under 60 days after the user's first post
-        self._advance_to(first_post_at + 60 * DAY - 5)
+        self._advance_to(first_post_at + 60 * ONE_DAY_IN_SECONDS - 5)
         self.reactor.advance(1)
 
         # Check the user is still counted.
@@ -239,7 +239,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         )
 
         # Advance into the next day. The user's first activity is now more than 60 days old.
-        self._advance_to(first_post_at + 60 * DAY + 5)
+        self._advance_to(first_post_at + 60 * ONE_DAY_IN_SECONDS + 5)
 
         # Check the user is now no longer counted in R30.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
@@ -279,7 +279,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         for _ in range(30):
             # This loop posts a message every day for 30 days
-            self.reactor.advance(DAY - 400)
+            self.reactor.advance(ONE_DAY_IN_SECONDS - 400)
             self.helper.send(
                 room_id, "I'm still here", tok=access_token, custom_headers=headers
             )
@@ -294,7 +294,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # (This advance needs to be split up into multiple advances
         #  because otherwise strict inequality hits.)
-        self.reactor.advance(DAY)
+        self.reactor.advance(ONE_DAY_IN_SECONDS)
         self.helper.send(
             room_id, "Still here!", tok=access_token, custom_headers=headers
         )
@@ -331,7 +331,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
 
         # the user goes inactive for 2 months
-        self.reactor.advance(60 * DAY)
+        self.reactor.advance(60 * ONE_DAY_IN_SECONDS)
 
         # the user returns for one day, perhaps just to check out a new feature
         self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
@@ -354,7 +354,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         # Now we want to check that the user will still be able to appear in
         # R30v2 as long as the user performs some other activity between
         # 30 and 60 days later.
-        self.reactor.advance(32 * DAY)
+        self.reactor.advance(32 * ONE_DAY_IN_SECONDS)
         self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
 
         # (give time for tables to update)
@@ -367,7 +367,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         )
 
         # Advance to 59.5 days after the user's first R30v2-eligible activity.
-        self.reactor.advance(27.5 * DAY)
+        self.reactor.advance(27.5 * ONE_DAY_IN_SECONDS)
 
         # Check the user still appears in R30v2.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
@@ -376,7 +376,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         )
 
         # Advance to 60.5 days after the user's first R30v2-eligible activity.
-        self.reactor.advance(DAY)
+        self.reactor.advance(ONE_DAY_IN_SECONDS)
 
         # Check the user no longer appears in R30v2.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -194,8 +194,10 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         # (give time for tables to be updated)
         self.reactor.advance(300)
 
+        store = self.hs.get_datastore()
+
         # Check the R30 results do not count that user.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
         )
@@ -208,7 +210,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.reactor.advance(600)
 
         # (Make sure the user isn't somehow counted by this point.)
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
         )
@@ -221,7 +223,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.reactor.advance(300)
 
         # *Now* the user is counted.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 1, "android": 0, "electron": 0, "ios": 0, "web": 0}
         )
@@ -231,7 +233,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.reactor.advance(1)
 
         # Check the user is still counted.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 1, "android": 0, "electron": 0, "ios": 0, "web": 0}
         )
@@ -240,7 +242,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self._advance_to(first_post_at + 60 * ONE_DAY_IN_SECONDS + 5)
 
         # Check the user is now no longer counted in R30.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
         )
@@ -269,8 +271,10 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         self.reactor.advance(400)
 
+        store = self.hs.get_datastore()
+
         # Check the user does not contribute to R30 yet.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
         )
@@ -285,7 +289,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
             self.reactor.advance(400)
 
             # Notice that the user *still* does not contribute to R30!
-            r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+            r30_results = self.get_success(store.count_r30v2_users())
             self.assertEqual(
                 r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
             )
@@ -300,7 +304,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.reactor.advance(400)
 
         # *Now* the user appears in R30.
-        r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
+        r30_results = self.get_success(store.count_r30v2_users())
         self.assertEqual(
             r30_results, {"all": 1, "android": 1, "electron": 0, "ios": 0, "web": 0}
         )

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -161,10 +161,10 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         login.register_servlets,
     ]
 
-    def _advance_to(self, desired_time: float):
+    def _advance_to(self, desired_time_secs: float):
         now = self.hs.get_clock().time()
-        assert now < desired_time
-        self.reactor.advance(desired_time - now)
+        assert now < desired_time_secs
+        self.reactor.advance(desired_time_secs - now)
 
     def make_homeserver(self, reactor, clock):
         hs = super(PhoneHomeR30V2TestCase, self).make_homeserver(reactor, clock)

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -195,7 +195,6 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # (give time for tables to be updated)
         self.reactor.advance(300)
-        self.reactor.advance(300)
 
         # Check the R30 results do not count that user.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
@@ -209,7 +208,6 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.reactor.advance(31 * DAY)
         # Also advance 10 minutes to let another user_daily_visits update occur
         self.reactor.advance(600)
-        self.reactor.advance(1)
 
         # (Make sure the user isn't somehow counted by this point.)
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
@@ -223,7 +221,6 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         # We have to wait up a few minutes for the user_daily_visits table to
         # be updated by a background process.
         self.reactor.advance(300)
-        self.reactor.advance(1)
 
         # *Now* the user is counted.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
@@ -272,8 +269,7 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         )
         self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
 
-        self.reactor.advance(399)
-        self.reactor.advance(1)
+        self.reactor.advance(400)
 
         # Check the user does not contribute to R30 yet.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
@@ -283,14 +279,12 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         for _ in range(30):
             # This loop posts a message every day for 30 days
-            self.reactor.advance(DAY - 401)
-            self.reactor.advance(1)
+            self.reactor.advance(DAY - 400)
             self.helper.send(
                 room_id, "I'm still here", tok=access_token, custom_headers=headers
             )
 
-            self.reactor.advance(399)
-            self.reactor.advance(1)
+            self.reactor.advance(400)
 
             # Notice that the user *still* does not contribute to R30!
             r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
@@ -300,14 +294,12 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # (This advance needs to be split up into multiple advances
         #  because otherwise strict inequality hits.)
-        self.reactor.advance(DAY - 1)
-        self.reactor.advance(1)
+        self.reactor.advance(DAY)
         self.helper.send(
             room_id, "Still here!", tok=access_token, custom_headers=headers
         )
 
-        self.reactor.advance(399)
-        self.reactor.advance(1)
+        self.reactor.advance(400)
 
         # *Now* the user appears in R30.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
@@ -346,8 +338,6 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # (give time for tables to update)
         self.reactor.advance(300)
-        self.reactor.advance(300)
-        self.reactor.advance(300)
 
         # Check that the user does not contribute to R30v2, even though it's been
         # more than 30 days since registration.
@@ -368,8 +358,6 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         self.helper.send(room_id, "message", tok=access_token, custom_headers=headers)
 
         # (give time for tables to update)
-        self.reactor.advance(300)
-        self.reactor.advance(300)
         self.reactor.advance(300)
 
         # Check the user now satisfies the requirements to appear in R30v2.

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -199,7 +199,9 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # Check the R30 results do not count that user.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 0})
+        self.assertEqual(
+            r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
+        )
 
         # Advance 31 days.
         # (R30v2 includes users with **more** than 30 days between the two visits,
@@ -212,7 +214,9 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # (Make sure the user isn't somehow counted by this point.)
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 0})
+        self.assertEqual(
+            r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
+        )
 
         # Send a message (this counts as activity)
         self.helper.send(room_id, "message2", tok=access_token)
@@ -224,7 +228,9 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # *Now* the user is counted.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 1})
+        self.assertEqual(
+            r30_results, {"all": 1, "android": 0, "electron": 0, "ios": 0, "web": 0}
+        )
 
         # Advance to JUST under 60 days after the user's first post
         self._advance_to(first_post_at + 60 * DAY - 5)
@@ -232,14 +238,18 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # Check the user is still counted.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 1})
+        self.assertEqual(
+            r30_results, {"all": 1, "android": 0, "electron": 0, "ios": 0, "web": 0}
+        )
 
         # Advance into the next day. The user's first activity is now more than 60 days old.
         self._advance_to(first_post_at + 60 * DAY + 5)
 
         # Check the user is now no longer counted in R30.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 0})
+        self.assertEqual(
+            r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
+        )
 
     def test_r30v2_user_must_be_retained_for_at_least_a_month(self):
         """
@@ -268,7 +278,9 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # Check the user does not contribute to R30 yet.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 0})
+        self.assertEqual(
+            r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
+        )
 
         for _ in range(30):
             # This loop posts a message every day for 30 days
@@ -283,7 +295,9 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
             # Notice that the user *still* does not contribute to R30!
             r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-            self.assertEqual(r30_results, {"all": 0})
+            self.assertEqual(
+                r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
+            )
 
         # (This advance needs to be split up into multiple advances
         #  because otherwise strict inequality hits.)
@@ -298,7 +312,9 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # *Now* the user appears in R30.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 1, "android": 1})
+        self.assertEqual(
+            r30_results, {"all": 1, "android": 1, "electron": 0, "ios": 0, "web": 0}
+        )
 
     def test_r30v2_returning_dormant_users_not_counted(self):
         """
@@ -337,7 +353,9 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         # Check that the user does not contribute to R30v2, even though it's been
         # more than 30 days since registration.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 0})
+        self.assertEqual(
+            r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
+        )
 
         # Check that this is a situation where old R30 differs:
         # old R30 DOES count this as 'retained'.
@@ -357,18 +375,24 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
 
         # Check the user now satisfies the requirements to appear in R30v2.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 1, "ios": 1})
+        self.assertEqual(
+            r30_results, {"all": 1, "ios": 1, "android": 0, "electron": 0, "web": 0}
+        )
 
         # Advance to 59.5 days after the user's first R30v2-eligible activity.
         self.reactor.advance(27.5 * DAY)
 
         # Check the user still appears in R30v2.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 1, "ios": 1})
+        self.assertEqual(
+            r30_results, {"all": 1, "ios": 1, "android": 0, "electron": 0, "web": 0}
+        )
 
         # Advance to 60.5 days after the user's first R30v2-eligible activity.
         self.reactor.advance(DAY)
 
         # Check the user no longer appears in R30v2.
         r30_results = self.get_success(self.hs.get_datastore().count_r30v2_users())
-        self.assertEqual(r30_results, {"all": 0})
+        self.assertEqual(
+            r30_results, {"all": 0, "android": 0, "electron": 0, "ios": 0, "web": 0}
+        )

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -206,7 +206,6 @@ class PhoneHomeR30V2TestCase(HomeserverTestCase):
         # Advance 31 days.
         # (R30v2 includes users with **more** than 30 days between the two visits,
         #  and user_daily_visits records the timestamp as the start of the day.)
-        # REVIEW: is >=31 days really what was intended? Need to ask.
         self.reactor.advance(31 * DAY)
         # Also advance 10 minutes to let another user_daily_visits update occur
         self.reactor.advance(600)

--- a/tests/rest/client/v1/utils.py
+++ b/tests/rest/client/v1/utils.py
@@ -19,7 +19,7 @@ import json
 import re
 import time
 import urllib.parse
-from typing import Any, Dict, Mapping, MutableMapping, Optional
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Tuple, Union
 from unittest.mock import patch
 
 import attr
@@ -53,6 +53,9 @@ class RestHelper:
         tok: str = None,
         expect_code: int = 200,
         extra_content: Optional[Dict] = None,
+        custom_headers: Optional[
+            Iterable[Tuple[Union[bytes, str], Union[bytes, str]]]
+        ] = None,
     ) -> str:
         """
         Create a room.
@@ -87,6 +90,7 @@ class RestHelper:
             "POST",
             path,
             json.dumps(content).encode("utf8"),
+            custom_headers=custom_headers,
         )
 
         assert channel.result["code"] == b"%d" % expect_code, channel.result
@@ -175,14 +179,30 @@ class RestHelper:
 
         self.auth_user_id = temp_id
 
-    def send(self, room_id, body=None, txn_id=None, tok=None, expect_code=200):
+    def send(
+        self,
+        room_id,
+        body=None,
+        txn_id=None,
+        tok=None,
+        expect_code=200,
+        custom_headers: Optional[
+            Iterable[Tuple[Union[bytes, str], Union[bytes, str]]]
+        ] = None,
+    ):
         if body is None:
             body = "body_text_here"
 
         content = {"msgtype": "m.text", "body": body}
 
         return self.send_event(
-            room_id, "m.room.message", content, txn_id, tok, expect_code
+            room_id,
+            "m.room.message",
+            content,
+            txn_id,
+            tok,
+            expect_code,
+            custom_headers=custom_headers,
         )
 
     def send_event(
@@ -193,6 +213,9 @@ class RestHelper:
         txn_id=None,
         tok=None,
         expect_code=200,
+        custom_headers: Optional[
+            Iterable[Tuple[Union[bytes, str], Union[bytes, str]]]
+        ] = None,
     ):
         if txn_id is None:
             txn_id = "m%s" % (str(time.time()))
@@ -207,6 +230,7 @@ class RestHelper:
             "PUT",
             path,
             json.dumps(content or {}).encode("utf8"),
+            custom_headers=custom_headers,
         )
 
         assert (

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -594,7 +594,15 @@ class HomeserverTestCase(TestCase):
         user_id = channel.json_body["user_id"]
         return user_id
 
-    def login(self, username, password, device_id=None):
+    def login(
+        self,
+        username,
+        password,
+        device_id=None,
+        custom_headers: Optional[
+            Iterable[Tuple[Union[bytes, str], Union[bytes, str]]]
+        ] = None,
+    ):
         """
         Log in a user, and get an access token. Requires the Login API be
         registered.
@@ -605,7 +613,10 @@ class HomeserverTestCase(TestCase):
             body["device_id"] = device_id
 
         channel = self.make_request(
-            "POST", "/_matrix/client/r0/login", json.dumps(body).encode("utf8")
+            "POST",
+            "/_matrix/client/r0/login",
+            json.dumps(body).encode("utf8"),
+            custom_headers=custom_headers,
         )
         self.assertEqual(channel.code, 200, channel.result)
 


### PR DESCRIPTION
The old R30 metric can be tricked into thinking a user is 'retained' if, any point after 30 days of registration, they return even for just one 'day'. That said, a user which has been inactive for (e.g.) 6 months and opens up (e.g.) Element briefly (e.g. to check a new feature they heard about) can hardly be called 'retained'.

R30v2 instead counts users which have had at least 2 active days in the past 60 days, and where the earliest of these is at least 30 days earlier than the last. This more closely matches a sensible definition of 30-day retention.


This PR adds the R30v2 metric, some tests which characterise it, and plugs it into the phone-home statistics (which will be received by Panopticon).