### PR TITLE
Ensure we always drop the federation inbound lock

### DIFF
--- a/changelog.d/10336.bugfix
+++ b/changelog.d/10336.bugfix
@@ -1,0 +1,1 @@
+Fix bug where inbound federation in a room could be delayed due to not correctly dropping a lock. Introduced in v1.37.1.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -949,10 +949,8 @@ class FederationServer(FederationBase):
                 room_id, room_version
             )
             if not next:
-                # We need to ensure that we always use the lock, so that it gets
-                # correctly dropped.
-                async with lock:
-                    return
+                await lock.release()
+                return
 
             origin, event = next
         else:

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -949,7 +949,10 @@ class FederationServer(FederationBase):
                 room_id, room_version
             )
             if not next:
-                return
+                # We need to ensure that we always use the lock, so that it gets
+                # correctly dropped.
+                async with lock:
+                    return
 
             origin, event = next
         else:

--- a/synapse/storage/databases/main/lock.py
+++ b/synapse/storage/databases/main/lock.py
@@ -310,13 +310,24 @@ class Lock:
         _excinst: Optional[BaseException],
         _exctb: Optional[TracebackType],
     ) -> bool:
+        await self.release()
+
+        return False
+
+    async def release(self) -> None:
+        """Release the lock.
+
+        This is automatically called when using the lock as a context manager.
+        """
+
+        if self._dropped:
+            return
+
         if self._looping_call.running:
             self._looping_call.stop()
 
         await self._store._drop_lock(self._lock_name, self._lock_key, self._token)
         self._dropped = True
-
-        return False
 
     def __del__(self) -> None:
         if not self._dropped:


### PR DESCRIPTION
Hopefully fixes errors like: `Lock for (federation_inbound_pdu, <room_id>) dropped without being released`

(Sentry link: https://sentry.matrix.org/sentry/synapse-matrixorg/issues/224832/)