### PR TITLE
Update unpaddedbase64 to >=2.1.0

### DIFF
--- a/changelog.d/10351.misc
+++ b/changelog.d/10351.misc
@@ -1,0 +1,1 @@
+Update unpaddedbase64 to >=2.1.0.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 REQUIREMENTS = [
     "jsonschema>=2.5.1",
     "frozendict>=1",
-    "unpaddedbase64>=1.1.0",
+    "unpaddedbase64>=2.1.0",
     "canonicaljson>=1.4.0",
     # we use the type definitions added in signedjson 1.1.
     "signedjson>=1.1.0",


### PR DESCRIPTION
Completes a task in #9131 (@ PR reviewer, please tick it off after merge)

> Update the minimum version of unpaddedbase64 to 2.1.0 and remove its ignore_missing_imports line from mypy.ini

The line was already removed from `mypy.ini`, but the minimum version wasn't updated.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

---

Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>
