### PR TITLE
Fix federation inbound age metric.

### DIFF
--- a/changelog.d/10355.bugfix
+++ b/changelog.d/10355.bugfix
@@ -1,0 +1,1 @@
+Fix newly added `synapse_federation_server_oldest_inbound_pdu_in_staging` prometheus metric to measure age rather than timestamp.

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1230,7 +1230,9 @@ class EventFederationWorkerStore(EventsWorkerStore, SignatureWorkerStore, SQLBas
                 "SELECT coalesce(min(received_ts), 0) FROM federation_inbound_events_staging"
             )
 
-            (age,) = txn.fetchone()
+            (received_ts,) = txn.fetchone()
+
+            age = self._clock.time_msec() - received_ts
 
             return count, age
 


### PR DESCRIPTION
We should be reporting the age rather than absolute timestamp.

The metric as it stands is a bit useless, as it defaults to a timestamp of `0`, which makes the graphs and alerting rules complicated.

Introduced in #10284.