### PR TITLE
Warn about letsencrypt certificates errors

### DIFF
--- a/docs/turn-howto.md
+++ b/docs/turn-howto.md
@@ -114,6 +114,8 @@ This will install and start a systemd service called `coturn`.
 
     We recommend that you only try to set up TLS/DTLS once you have set up a
     basic installation and got it working.
+    
+    Please note that letsencrypt authority is currently not supported by element-andoid.
 
 1.  Ensure your firewall allows traffic into the TURN server on the ports
     you've configured it to listen on (By default: 3478 and 5349 for TURN


### PR DESCRIPTION
Connections from android to a turn server with letsencrypt certificates fail with error:
TLSv1.2 Record Layer: Alert (Level: Fatal, Description: Unknown CA)

This is the same issue than https://github.com/jitsi/jitsi-meet/issues/5589

This remark will hopefully save some trouble to other people.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
