### PR TITLE
Allow providing credentials to `http_proxy`

### DIFF
--- a/changelog.d/10360.feature
+++ b/changelog.d/10360.feature
@@ -1,0 +1,1 @@
+Allow providing credentials to `http_proxy`.

--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -198,7 +198,7 @@ class ProxyAgent(_AgentBase):
                     b"Proxy-Authorization",
                     self.http_proxy_creds.as_proxy_authorization_value(),
                 )
-                # if authentification is requierd, use tunnel instead of transparent mode
+                # if authentication is required, use tunnel instead of transparent mode
                 endpoint = HTTPConnectProxyEndpoint(
                     self.proxy_reactor,
                     self.http_proxy_endpoint,

--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -193,25 +193,17 @@ class ProxyAgent(_AgentBase):
             # Determine whether we need to set Proxy-Authorization headers
             if self.http_proxy_creds:
                 # Set a Proxy-Authorization header
-                connect_headers = Headers()
-                connect_headers.addRawHeader(
+                if headers is None:
+                    headers = Headers()
+                headers.addRawHeader(
                     b"Proxy-Authorization",
                     self.http_proxy_creds.as_proxy_authorization_value(),
                 )
-                # if authentication is required, use tunnel instead of transparent mode
-                endpoint = HTTPConnectProxyEndpoint(
-                    self.proxy_reactor,
-                    self.http_proxy_endpoint,
-                    parsed_uri.host,
-                    parsed_uri.port,
-                    headers=connect_headers,
-                )
-            else:
-                # Cache *all* connections under the same key, since we are only
-                # connecting to a single destination, the proxy:
-                pool_key = ("http-proxy", self.http_proxy_endpoint)
-                endpoint = self.http_proxy_endpoint
-                request_path = uri
+            # Cache *all* connections under the same key, since we are only
+            # connecting to a single destination, the proxy:
+            pool_key = ("http-proxy", self.http_proxy_endpoint)
+            endpoint = self.http_proxy_endpoint
+            request_path = uri
         elif (
             parsed_uri.scheme == b"https"
             and self.https_proxy_endpoint

--- a/tests/http/test_proxyagent.py
+++ b/tests/http/test_proxyagent.py
@@ -305,18 +305,11 @@ class MatrixFederationAgentTests(TestCase):
         # request.setHeader(b"Content-Length", b"0")
         request.finish()
 
-        """
-        here need to wrap the http request, but not with ssl
-        
-        # now we can replace the proxy channel with a new, SSL-wrapped HTTP channel
-        ssl_factory = _wrap_server_factory_for_tls(_get_test_protocol_factory())
-        ssl_protocol = ssl_factory.buildProtocol(None)
-        http_server = ssl_protocol.wrappedProtocol
-
-        ssl_protocol.makeConnection(
-            FakeTransport(client_protocol, self.reactor, ssl_protocol)
+        http_server = _get_test_protocol_factory().buildProtocol(None)
+        http_server.makeConnection(
+            FakeTransport(client_protocol, self.reactor, http_server)
         )
-        c2s_transport.other = ssl_protocol
+        c2s_transport.other = http_server
 
         self.reactor.advance(0)
 
@@ -342,7 +335,6 @@ class MatrixFederationAgentTests(TestCase):
         resp = self.successResultOf(d)
         body = self.successResultOf(treq.content(resp))
         self.assertEqual(body, b"result")
-        """
 
     @patch.dict(os.environ, {"https_proxy": "proxy.com", "no_proxy": "unused.com"})
     def test_https_request_via_proxy(self):

--- a/tests/http/test_proxyagent.py
+++ b/tests/http/test_proxyagent.py
@@ -206,8 +206,39 @@ class MatrixFederationAgentTests(TestCase):
     @patch.dict(os.environ, {"http_proxy": "proxy.com:8888", "no_proxy": "unused.com"})
     def test_http_request_via_proxy(self):
         """
-        Tests that requests can be made through a proxy
-        This use transparent proxy.
+        Tests that requests can be made through a proxy.
+        """
+        self._do_http_request_via_proxy(auth_credentials=None)
+
+    @patch.dict(
+        os.environ,
+        {"http_proxy": "bob:pinkponies@proxy.com:8888", "no_proxy": "unused.com"},
+    )
+    def test_http_request_via_proxy_with_auth(self):
+        """
+        Tests that authenticated requests can be made through a proxy.
+        """
+        self._do_http_request_via_proxy(auth_credentials="bob:pinkponies")
+
+    @patch.dict(os.environ, {"https_proxy": "proxy.com", "no_proxy": "unused.com"})
+    def test_https_request_via_proxy(self):
+        """Tests that TLS-encrypted requests can be made through a proxy"""
+        self._do_https_request_via_proxy(auth_credentials=None)
+
+    @patch.dict(
+        os.environ,
+        {"https_proxy": "bob:pinkponies@proxy.com", "no_proxy": "unused.com"},
+    )
+    def test_https_request_via_proxy_with_auth(self):
+        """Tests that authenticated, TLS-encrypted requests can be made through a proxy"""
+        self._do_https_request_via_proxy(auth_credentials="bob:pinkponies")
+
+    def _do_http_request_via_proxy(
+        self,
+        auth_credentials: Optional[str] = None,
+    ):
+        """
+        Tests that requests can be made through a proxy.
         """
         agent = ProxyAgent(self.reactor, use_proxy=True)
 
@@ -234,6 +265,22 @@ class MatrixFederationAgentTests(TestCase):
 
         request = http_server.requests[0]
 
+        # Check whether auth credentials have been supplied to the proxy
+        proxy_auth_header_values = request.requestHeaders.getRawHeaders(
+            b"Proxy-Authorization"
+        )
+
+        if auth_credentials is not None:
+            # Compute the correct header value for Proxy-Authorization
+            encoded_credentials = base64.b64encode(b"bob:pinkponies")
+            expected_header_value = b"Basic " + encoded_credentials
+
+            # Validate the header's value
+            self.assertIn(expected_header_value, proxy_auth_header_values)
+        else:
+            # Check that the Proxy-Authorization header has not been supplied to the proxy
+            self.assertIsNone(proxy_auth_header_values)
+
         self.assertEqual(request.method, b"GET")
         self.assertEqual(request.path, b"http://test.com")
         self.assertEqual(request.requestHeaders.getRawHeaders(b"host"), [b"test.com"])
@@ -245,109 +292,6 @@ class MatrixFederationAgentTests(TestCase):
         resp = self.successResultOf(d)
         body = self.successResultOf(treq.content(resp))
         self.assertEqual(body, b"result")
-
-    @patch.dict(
-        os.environ,
-        {"http_proxy": "bob:pinkponies@proxy.com:8888", "no_proxy": "unused.com"},
-    )
-    def test_http_request_via_proxy_with_auth(self):
-        """
-        Tests that authenticated requests can be made through a proxy
-        This use a proxy tunnel via CONNECT method similar to https.
-        """
-        agent = ProxyAgent(self.reactor, use_proxy=True)
-
-        self.reactor.lookups["proxy.com"] = "1.2.3.5"
-        d = agent.request(b"GET", b"http://test.com/abc")
-
-        # there should be a pending TCP connection
-        clients = self.reactor.tcpClients
-        self.assertEqual(len(clients), 1)
-        (host, port, client_factory, _timeout, _bindAddress) = clients[0]
-        self.assertEqual(host, "1.2.3.5")
-        self.assertEqual(port, 8888)
-
-        # make a test HTTP server, and wire up the client
-        proxy_server = self._make_connection(
-            client_factory, _get_test_protocol_factory()
-        )
-
-        # fish the transports back out so that we can do the old switcheroo
-        s2c_transport = proxy_server.transport
-        client_protocol = s2c_transport.other
-        c2s_transport = client_protocol.transport
-
-        # the FakeTransport is async, so we need to pump the reactor
-        self.reactor.advance(0)
-
-        # now there should be a pending CONNECT request
-        self.assertEqual(len(proxy_server.requests), 1)
-
-        request = proxy_server.requests[0]
-        self.assertEqual(request.method, b"CONNECT")
-        self.assertEqual(request.path, b"test.com:80")
-
-        # Check whether auth credentials have been supplied to the proxy
-        proxy_auth_header_values = request.requestHeaders.getRawHeaders(
-            b"Proxy-Authorization"
-        )
-        # Compute the correct header value for Proxy-Authorization
-        encoded_credentials = base64.b64encode(b"bob:pinkponies")
-        expected_header_value = b"Basic " + encoded_credentials
-
-        # Validate the header's value
-        self.assertIn(expected_header_value, proxy_auth_header_values)
-
-        # tell the proxy server not to close the connection
-        proxy_server.persistent = True
-
-        # this just stops the http Request trying to do a chunked response
-        # request.setHeader(b"Content-Length", b"0")
-        request.finish()
-
-        http_server = _get_test_protocol_factory().buildProtocol(None)
-        http_server.makeConnection(
-            FakeTransport(client_protocol, self.reactor, http_server)
-        )
-        c2s_transport.other = http_server
-
-        self.reactor.advance(0)
-
-        # now there should be a pending request
-        self.assertEqual(len(http_server.requests), 1)
-
-        request = http_server.requests[0]
-        self.assertEqual(request.method, b"GET")
-        self.assertEqual(request.path, b"/abc")
-        self.assertEqual(request.requestHeaders.getRawHeaders(b"host"), [b"test.com"])
-
-        # Check that the destination server DID NOT receive proxy credentials
-        proxy_auth_header_values = request.requestHeaders.getRawHeaders(
-            b"Proxy-Authorization"
-        )
-        self.assertIsNone(proxy_auth_header_values)
-
-        request.write(b"result")
-        request.finish()
-
-        self.reactor.advance(0)
-
-        resp = self.successResultOf(d)
-        body = self.successResultOf(treq.content(resp))
-        self.assertEqual(body, b"result")
-
-    @patch.dict(os.environ, {"https_proxy": "proxy.com", "no_proxy": "unused.com"})
-    def test_https_request_via_proxy(self):
-        """Tests that TLS-encrypted requests can be made through a proxy"""
-        self._do_https_request_via_proxy(auth_credentials=None)
-
-    @patch.dict(
-        os.environ,
-        {"https_proxy": "bob:pinkponies@proxy.com", "no_proxy": "unused.com"},
-    )
-    def test_https_request_via_proxy_with_auth(self):
-        """Tests that authenticated, TLS-encrypted requests can be made through a proxy"""
-        self._do_https_request_via_proxy(auth_credentials="bob:pinkponies")
 
     def _do_https_request_via_proxy(
         self,

--- a/tests/http/test_proxyagent.py
+++ b/tests/http/test_proxyagent.py
@@ -305,7 +305,7 @@ class MatrixFederationAgentTests(TestCase):
         # request.setHeader(b"Content-Length", b"0")
         request.finish()
 
-        '''
+        """
         here need to wrap the http request, but not with ssl
         
         # now we can replace the proxy channel with a new, SSL-wrapped HTTP channel
@@ -342,7 +342,7 @@ class MatrixFederationAgentTests(TestCase):
         resp = self.successResultOf(d)
         body = self.successResultOf(treq.content(resp))
         self.assertEqual(body, b"result")
-        '''
+        """
 
     @patch.dict(os.environ, {"https_proxy": "proxy.com", "no_proxy": "unused.com"})
     def test_https_request_via_proxy(self):


### PR DESCRIPTION
Add support for http proxy authentication via `http_proxy`

Fixes: #9000 
Follow up: #9657
Related to: #9119

~~I am need some help.
I do not know how to create the test case.
The missing part is to wrap the HTTP request into the proxy tunnel.~~
https://github.com/matrix-org/synapse/blob/25c9e4c0b11d0480e4cd07f7bc1316eae05c3397/tests/http/test_proxyagent.py#L311-L319

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Signed-off-by: Dirk Klimpel dirk@klimpel.org