### PR TITLE
doc: Add delegation example to the caddy reverse proxy section

### DIFF
--- a/changelog.d/10368.doc
+++ b/changelog.d/10368.doc
@@ -1,0 +1,1 @@
+Add delegation example for caddy in the reverse proxy documentation. Contributed by @moritzdietz.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -116,7 +116,7 @@ example.com {
 
     handle /.well-known/matrix/client {
         import matrix-well-known-header
-        respond `{"m.homeserver":{"base_url":"https://matrix.example.com"},"m.identity_server":{"base_url":"https://identity.example.com}}`
+        respond `{"m.homeserver":{"base_url":"https://matrix.example.com"},"m.identity_server":{"base_url":"https://identity.example.com"}}`
     }
 }
 

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -98,6 +98,37 @@ example.com:8448 {
   reverse_proxy http://localhost:8008
 }
 ```
+[Delegation](delegate.md) example:
+```
+(matrix-well-known-header) {
+    # Headers
+    header Access-Control-Allow-Origin "*"
+    header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
+    header Access-Control-Allow-Headers "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+    header Content-Type "application/json"
+}
+
+example.com {
+    handle /.well-known/matrix/server {
+        import matrix-well-known-header
+        respond `{"m.server":"matrix.example.com:8448"}`
+    }
+
+    handle /.well-known/matrix/client {
+        import matrix-well-known-header
+        respond `{"m.homeserver":{"base_url":"https://matrix.example.com"},"m.identity_server":{"base_url":"https://identity.example.com}}`
+    }
+}
+
+matrix.example.com {
+    reverse_proxy /_matrix/* http://localhost:8008
+    reverse_proxy /_synapse/client/* http://localhost:8008
+}
+
+matrix.example.com:8448 {
+    reverse_proxy http://localhost:8008
+}
+```
 
 ### Apache
 

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -111,7 +111,7 @@ example.com:8448 {
 example.com {
     handle /.well-known/matrix/server {
         import matrix-well-known-header
-        respond `{"m.server":"matrix.example.com:8448"}`
+        respond `{"m.server":"matrix.example.com:443"}`
     }
 
     handle /.well-known/matrix/client {
@@ -123,10 +123,6 @@ example.com {
 matrix.example.com {
     reverse_proxy /_matrix/* http://localhost:8008
     reverse_proxy /_synapse/client/* http://localhost:8008
-}
-
-matrix.example.com:8448 {
-    reverse_proxy http://localhost:8008
 }
 ```
 


### PR DESCRIPTION
This PR can be seen as a mere suggestion. I can see the documentation getting a bit out of hand if one adds full examples of all of the reverse proxies out there. Dedicated guides on how to set up a specific reverse proxy could be better maybe.
But I also thought that it couldn't hurt to expand the bit of documentation and give admins looking into getting all information from one source the opportunity to not just choose nginx because it's _just_ all there for it already.

Perhaps there is a better place within the repository to document full example of a specific reverse proxy flavor which?

The documentation consists of information I gathered from these sources:

- CORS headers: https://matrix.org/docs/spec/client_server/latest#cors
- `Content-Type "application/json"`: https://matrix.org/docs/spec/server_server/r0.1.4#get-well-known-matrix-server
- Caddy: [concpets/addresses](https://caddyserver.com/docs/caddyfile/concepts#addresses)
- Caddy: [concepts/snippets](https://caddyserver.com/docs/caddyfile/concepts#snippets)
- Caddy: [concepts/tokens-and-quotes](https://caddyserver.com/docs/caddyfile/concepts#tokens-and-quotes)
- Caddy: [directives/handle](https://caddyserver.com/docs/caddyfile/directives/handle)
- Caddy: [directives/header](https://caddyserver.com/docs/caddyfile/directives/header)
- Caddy: [directives/respond](https://caddyserver.com/docs/caddyfile/directives/respond)
- Caddy: [directives/reverse_proxy](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy)

I used a flattened JSON body for the respond body, as Caddy will throw a format error for the Caddyfile configuration file otherwise.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

Signed-off-by: Moritz Dietz moritz@moritzdietz.com