### PR TITLE
Make GHA config more efficient

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           # if we're running from a tag, get the full list of distros; otherwise just use debian:sid
           dists='["debian:sid"]'
-          if [[ $GITHUB_REF == "refs/tags/*" ]]; then
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
               dists=$(scripts-dev/build_debian_packages --show-dists-json)
           fi
           echo "::set-output name=distros::$dists"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -3,21 +3,23 @@
 name: Build release artifacts
 
 on:
+  # we build on PRs and develop to (hopefully) get early warning
+  # of things breaking (but only build one set of debs)
+  pull_request:
   push:
-    # we build on develop and release branches to (hopefully) get early warning
-    # of things breaking
-    branches: ["develop", "release-*"]
+    branches: ["develop"]
 
-    # we also rebuild on tags, so that we can be sure of picking the artifacts
-    # from the right tag.
+    # we do the full build on tags.
     tags: ["v*"]
 
 permissions:
   contents: write
 
 jobs:
-  # first get the list of distros to build for.
+  # if we're running from a tag, get the full list of distros
   get-distros:
+    name: "Calculate list of debian distros"
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -33,10 +35,15 @@ jobs:
   build-debs:
     needs: get-distros
     name: "Build .deb packages"
+    # build even if get-distros didn't run
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         distro: ${{ fromJson(needs.get-distros.outputs.distros) }}
+        # always build for sid
+        include:
+          - distro: debian:sid
 
     steps:
       - uses: actions/checkout@v2
@@ -66,7 +73,7 @@ jobs:
   # if it's a tag, create a release and attach the artifacts to it
   attach-assets:
     name: "Attach assets to release"
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/') }}
     needs:
       - build-debs
       - build-sdist

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -16,17 +16,20 @@ permissions:
   contents: write
 
 jobs:
-  # if we're running from a tag, get the full list of distros
   get-distros:
     name: "Calculate list of debian distros"
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - id: set-distros
         run: |
-          echo "::set-output name=distros::$(scripts-dev/build_debian_packages --show-dists-json)"
+          # if we're running from a tag, get the full list of distros; otherwise just use debian:sid
+          dists='["debian:sid"]'
+          if [[ $GITHUB_REF == "refs/tags/*" ]]; then
+              dists=$(scripts-dev/build_debian_packages --show-dists-json)
+          fi
+          echo "::set-output name=distros::$dists"
     # map the step outputs to job outputs
     outputs:
       distros: ${{ steps.set-distros.outputs.distros }}
@@ -35,15 +38,10 @@ jobs:
   build-debs:
     needs: get-distros
     name: "Build .deb packages"
-    # build even if get-distros didn't run
-    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         distro: ${{ fromJson(needs.get-distros.outputs.distros) }}
-        # always build for sid
-        include:
-          - distro: debian:sid
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,14 +65,14 @@ jobs:
 
   # Dummy step to gate other tests on without repeating the whole list
   linting-done:
-    if: ${{ always() }} # Run this even if prior jobs were skipped
+    if: ${{ !cancelled() }} # Run this even if prior jobs were skipped
     needs: [lint, lint-crlf, lint-newsfile, lint-sdist]
     runs-on: ubuntu-latest
     steps:
       - run: "true"
 
   trial:
-    if: ${{ !failure() }} # Allow previous steps to be skipped, but not fail
+    if: ${{ !cancelled() && !failure() }} # Allow previous steps to be skipped, but not fail
     needs: linting-done
     runs-on: ubuntu-latest
     strategy:
@@ -131,7 +131,7 @@ jobs:
           || true
 
   trial-olddeps:
-    if: ${{ !failure() }} # Allow previous steps to be skipped, but not fail
+    if: ${{ !cancelled && !failure() }} # Allow previous steps to be skipped, but not fail
     needs: linting-done
     runs-on: ubuntu-latest
     steps:
@@ -156,7 +156,7 @@ jobs:
 
   trial-pypy:
     # Very slow; only run if the branch name includes 'pypy'
-    if: ${{ contains(github.ref, 'pypy') && !failure() }}
+    if: ${{ contains(github.ref, 'pypy') && !failure() && !cancelled() }}
     needs: linting-done
     runs-on: ubuntu-latest
     strategy:
@@ -185,7 +185,7 @@ jobs:
           || true
 
   sytest:
-    if: ${{ !failure() }}
+    if: ${{ !failure() && !cancelled() }}
     needs: linting-done
     runs-on: ubuntu-latest
     container:
@@ -245,7 +245,7 @@ jobs:
             /logs/**/*.log*
 
   portdb:
-    if: ${{ !failure() }} # Allow previous steps to be skipped, but not fail
+    if: ${{ !failure() && !cancelled() }} # Allow previous steps to be skipped, but not fail
     needs: linting-done
     runs-on: ubuntu-latest
     strategy:
@@ -286,7 +286,7 @@ jobs:
       - run: .buildkite/scripts/test_synapse_port_db.sh
 
   complement:
-    if: ${{ !failure() }}
+    if: ${{ !failure() && !cancelled() }}
     needs: linting-done
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,7 @@ jobs:
           || true
 
   trial-olddeps:
-    if: ${{ !cancelled && !failure() }} # Allow previous steps to be skipped, but not fail
+    if: ${{ !cancelled() && !failure() }} # Allow previous steps to be skipped, but not fail
     needs: linting-done
     runs-on: ubuntu-latest
     steps:

--- a/changelog.d/10383.misc
+++ b/changelog.d/10383.misc
@@ -1,0 +1,1 @@
+Make the Github Actions workflow configuration more efficient.


### PR DESCRIPTION
A few things here:
 * Build the debs for single distro for each PR, so that we can see if it breaks. Do the same for `develop`. Building all the debs ties up the GHA workers for *ages*.
 * Stop building the debs for `release` branches. Again, it takes ages, and I don't think anyone is actually going to stop and look at them. We'll know they are working when we make an RC.
 * Change the configs so that if we manually cancel a workflow, it actually does something.