### PR TITLE
Set section for prerelease debs

### DIFF
--- a/changelog.d/10391.misc
+++ b/changelog.d/10391.misc
@@ -1,0 +1,1 @@
+When building Debian packages for prerelease versions, set the Section accordingly.

--- a/docker/build_debian.sh
+++ b/docker/build_debian.sh
@@ -15,6 +15,20 @@ cd /synapse/build
 dch -M -l "+$DIST" "build for $DIST"
 dch -M -r "" --force-distribution --distribution "$DIST"
 
+# if this is a prerelease, set the Section accordingly.
+#
+# When the package is later added to the package repo, reprepro will use the
+# Section to determine which "component" it should go into (see
+# https://manpages.debian.org/stretch/reprepro/reprepro.1.en.html#GUESSING)
+
+DEB_VERSION=`dpkg-parsechangelog -SVersion`
+case $DEB_VERSION in
+    *rc*|*a*|*b*|*c*)
+        sed -ie '/^Section:/c\Section: prerelease' debian/control
+        ;;
+esac
+
+
 dpkg-buildpackage -us -uc
 
 ls -l ..


### PR DESCRIPTION
This is part of fixing https://github.com/matrix-org/synapse/issues/6116: we want to put RC debs into a different place than release debs, so reprepro has to be able to tell them apart.