### PR TITLE
Make oEmbed globs configurable and extract more info from the response

### DIFF
--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -206,6 +206,8 @@ class ContentRepositoryConfig(Config):
                 "url_preview_accept_language"
             ) or ["en"]
 
+            self.oembed_globs = config.get("oembed_globs", {})
+
     def generate_config_section(self, data_dir_path, **kwargs):
         media_store = os.path.join(data_dir_path, "media_store")
 
@@ -366,6 +368,24 @@ class ContentRepositoryConfig(Config):
         #
         url_preview_accept_language:
         #   - en
+        
+        # TODO
+        # oembed_globs:
+        #   "https://publish.twitter.com/oembed":
+        #       - https://twitter.com/*/status/*
+        #       - https://*.twitter.com/*/status/*
+        #       - https://twitter.com/*/moments/*
+        #       - https://*.twitter.com/*/moments/*
+        #       # Include the HTTP versions too.
+        #       - http://twitter.com/*/status/*
+        #       - http://*.twitter.com/*/status/*
+        #       - http://twitter.com/*/moments/*
+        #       - http://*.twitter.com/*/moments/*
+        #   "https://www.youtube.com/oembed":
+        #       - https://*.youtube.com/watch*
+        #       - https://*.youtube.com/v/*
+        #       - https://youtu.be/*
+        #       - https://*.youtube.com/playlist?list=*
         """
             % locals()
         )


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/9733

Needs moar tests, some refactoring to tidy up the code, to load the providers.json from upstream automagically

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
