### PR TITLE
Make deprecation notice of the spam checker doc more obvious

### DIFF
--- a/changelog.d/10395.doc
+++ b/changelog.d/10395.doc
@@ -1,0 +1,1 @@
+Make deprecation notice of the spam checker doc more obvious.

--- a/docs/spam_checker.md
+++ b/docs/spam_checker.md
@@ -1,7 +1,7 @@
 <h2 style="color:red">
 This page of the Synapse documentation is now deprecated. For up to date
 documentation on setting up or writing a spam checker module, please see
-<a href="https://matrix-org.github.io/synapse/develop/modules.html">this page</a>.
+<a href="modules.md">this page</a>.
 </h2>
 
 # Handling spam in Synapse

--- a/docs/spam_checker.md
+++ b/docs/spam_checker.md
@@ -1,6 +1,8 @@
-**Note: this page of the Synapse documentation is now deprecated. For up to date
+<h2 style="color:red">
+This page of the Synapse documentation is now deprecated. For up to date
 documentation on setting up or writing a spam checker module, please see
-[this page](https://matrix-org.github.io/synapse/develop/modules.html).**
+<a href="https://matrix-org.github.io/synapse/develop/modules.html">this page</a>.
+</h2>
 
 # Handling spam in Synapse
 


### PR DESCRIPTION
Old:

![image](https://user-images.githubusercontent.com/5547783/125640661-6b80ca8a-f9a6-4fe4-b3e8-75e7290191b9.png)

New:

![image](https://user-images.githubusercontent.com/5547783/125640685-cc0f4cae-588e-409a-be42-509e50bc38de.png)

Fixes #10333 