### PR TITLE
Stagger send presence to remotes

### DIFF
--- a/changelog.d/10398.misc
+++ b/changelog.d/10398.misc
@@ -1,0 +1,1 @@
+Stagger sending of presence update to remote servers, reducing CPU spikes caused by starting many connections to remote servers at once.

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -163,7 +163,7 @@ class _PresenceQueue:
 
     sender: "FederationSender" = attr.ib()
     clock: Clock = attr.ib()
-    queue: "OrderedDict[str, Literal[None]]" = attr.ib(factory=OrderedDict)
+    queue: OrderedDict[str, Literal[None]] = attr.ib(factory=OrderedDict)
     processing: bool = attr.ib(default=False)
 
     def add_to_queue(self, destination: str) -> None:
@@ -185,7 +185,7 @@ class _PresenceQueue:
         self.processing = True
 
         try:
-            # We start with a delay that should drain queue quickly enough that
+            # We start with a delay that should drain the queue quickly enough that
             # we process all destinations in the queue in _MAX_TIME_IN_QUEUE
             # seconds.
             #
@@ -213,7 +213,7 @@ class _PresenceQueue:
 
                 # More destinations may have been added to the queue, so we may
                 # need to reduce the delay to ensure everything gets processed
-                # with _MAX_TIME_IN_QUEUE seconds.
+                # within _MAX_TIME_IN_QUEUE seconds.
                 current_sleep_seconds = min(
                     current_sleep_seconds, self._MAX_TIME_IN_QUEUE / len(self.queue)
                 )

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import abc
-import collections
 import logging
-import typing
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Dict, Hashable, Iterable, List, Optional, Set, Tuple
 
 import attr
@@ -164,9 +163,7 @@ class _PresenceQueue:
 
     sender: "FederationSender" = attr.ib()
     clock: Clock = attr.ib()
-    queue: typing.OrderedDict[str, Literal[None]] = attr.ib(
-        factory=collections.OrderedDict
-    )
+    queue: "OrderedDict[str, Literal[None]]" = attr.ib(factory=OrderedDict)
     processing: bool = attr.ib(default=False)
 
     def add_to_queue(self, destination: str) -> None:

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -163,7 +163,7 @@ class _PresenceQueue:
 
     sender: "FederationSender" = attr.ib()
     clock: Clock = attr.ib()
-    queue: OrderedDict[str, Literal[None]] = attr.ib(factory=OrderedDict)
+    queue: "OrderedDict[str, Literal[None]]" = attr.ib(factory=OrderedDict)
     processing: bool = attr.ib(default=False)
 
     def add_to_queue(self, destination: str) -> None:

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -171,14 +171,24 @@ class PerDestinationQueue:
 
         self.attempt_new_transaction()
 
-    def send_presence(self, states: Iterable[UserPresenceState]) -> None:
-        """Add presence updates to the queue. Start the transmission loop if necessary.
+    def send_presence(
+        self, states: Iterable[UserPresenceState], start_loop: bool = True
+    ) -> None:
+        """Add presence updates to the queue.
+
+        Args:
+            states: Presence updates to send
+            start_loop: Whether to start the transmission loop if not already
+                running.
 
         Args:
             states: presence to send
         """
         self._pending_presence.update({state.user_id: state for state in states})
-        self.attempt_new_transaction()
+        self._new_data_to_send = True
+
+        if start_loop:
+            self.attempt_new_transaction()
 
     def queue_read_receipt(self, receipt: ReadReceipt) -> None:
         """Add a RR to the list to be sent. Doesn't start the transmission loop yet

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -285,6 +285,10 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
         presence_updates, _ = sync_presence(self, self.presence_receiving_user_two_id)
         self.assertEqual(len(presence_updates), 3)
 
+        # We stagger sending of presence, so we need to wait a bit for them to
+        # get sent out.
+        self.reactor.advance(60)
+
         # Test that sending to a remote user works
         remote_user_id = "@far_away_person:island"
 
@@ -300,6 +304,10 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
         self.get_success(
             self.module_api.send_local_online_presence_to([remote_user_id])
         )
+
+        # We stagger sending of presence, so we need to wait a bit for them to
+        # get sent out.
+        self.reactor.advance(60)
 
         # Check that the expected presence updates were sent
         # We explicitly compare using sets as we expect that calling


### PR DESCRIPTION
This is to help with performance, where trying to connect to thousands of hosts at once can consume a lot of CPU (due to TLS etc).
