### PR TITLE
Do not include signatures/hashes in make_{join,leave,knock} responses.

### DIFF
--- a/changelog.d/10404.bugfix
+++ b/changelog.d/10404.bugfix
@@ -1,0 +1,1 @@
+Responses from `/make_{join,leave,knock}` no longer include signatures, which will turn out to be invalid after events are returned to `/send_{join,leave,knock}`.

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -291,6 +291,20 @@ class EventBase(metaclass=abc.ABCMeta):
 
         return pdu_json
 
+    def get_templated_pdu_json(self) -> JsonDict:
+        """
+        Return a JSON object suitable for a templated event, as used in the
+        make_{join,leave,knock} workflow.
+        """
+        # By using _dict directly we don't pull in signatures/unsigned.
+        template_json = dict(self._dict)
+        # The hashes (similar to the signature) need to be recalculated by the
+        # joining/leaving/knocking server after (potentially) modifying the
+        # event.
+        template_json.pop("hashes")
+
+        return template_json
+
     def __set__(self, instance, value):
         raise AttributeError("Unrecognized attribute %s" % (instance,))
 

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -562,8 +562,7 @@ class FederationServer(FederationBase):
             raise IncompatibleRoomVersionError(room_version=room_version)
 
         pdu = await self.handler.on_make_join_request(origin, room_id, user_id)
-        time_now = self._clock.time_msec()
-        return {"event": pdu.get_pdu_json(time_now), "room_version": room_version}
+        return {"event": pdu.get_templated_pdu_json(), "room_version": room_version}
 
     async def on_invite_request(
         self, origin: str, content: JsonDict, room_version_id: str
@@ -611,8 +610,7 @@ class FederationServer(FederationBase):
 
         room_version = await self.store.get_room_version_id(room_id)
 
-        time_now = self._clock.time_msec()
-        return {"event": pdu.get_pdu_json(time_now), "room_version": room_version}
+        return {"event": pdu.get_templated_pdu_json(), "room_version": room_version}
 
     async def on_send_leave_request(
         self, origin: str, content: JsonDict, room_id: str
@@ -659,9 +657,8 @@ class FederationServer(FederationBase):
             )
 
         pdu = await self.handler.on_make_knock_request(origin, room_id, user_id)
-        time_now = self._clock.time_msec()
         return {
-            "event": pdu.get_pdu_json(time_now),
+            "event": pdu.get_templated_pdu_json(),
             "room_version": room_version.identifier,
         }
 


### PR DESCRIPTION
Currently the responses to `/make_{join,leave,knock}` requests include the `signatures` and `hashes` keys, these will become invalid once the joining/leaving/knocking server modifies the event (before calling `/send_{join,leave,knock}`).

In order to avoid invalid signatures being added to events, we should not return them. This seems to match the [concept of templated events in the spec](https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-make-join-roomid-userid), although the examples show a much smaller subset of returned fields.

I originally tried to have the `EventBuilder` know about whether the event is a "full" event or not, but then you cannot properly instantiate an `EventBase` object. It seemed simpler to strip out the unnecessary fields at the end, although they'll still be calculated.