### PR TITLE
Don’t have Scripts in Modules

### DIFF
--- a/changelog.d/10415.misc
+++ b/changelog.d/10415.misc
@@ -1,0 +1,1 @@
+Remove shebang line from module files.

--- a/synapse/_scripts/review_recent_signups.py
+++ b/synapse/_scripts/review_recent_signups.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2021 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/admin_cmd.py
+++ b/synapse/app/admin_cmd.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2019 Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/appservice.py
+++ b/synapse/app/appservice.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/client_reader.py
+++ b/synapse/app/client_reader.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/event_creator.py
+++ b/synapse/app/event_creator.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2018 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/federation_reader.py
+++ b/synapse/app/federation_reader.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/federation_sender.py
+++ b/synapse/app/federation_sender.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/frontend_proxy.py
+++ b/synapse/app/frontend_proxy.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016 OpenMarket Ltd
 # Copyright 2020 The Matrix.org Foundation C.I.C.
 #

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2014-2016 OpenMarket Ltd
 # Copyright 2019 New Vector Ltd
 #

--- a/synapse/app/media_repository.py
+++ b/synapse/app/media_repository.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/pusher.py
+++ b/synapse/app/pusher.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/synchrotron.py
+++ b/synapse/app/synchrotron.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/app/user_dir.py
+++ b/synapse/app/user_dir.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2017 Vector Creations Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/push/pusherpool.py
+++ b/synapse/push/pusherpool.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2015, 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/synapse/util/versionstring.py
+++ b/synapse/util/versionstring.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
*This exists because rpmlint complained while packaging Synapse for Fedora.*

This PR removes the shebang lines from all files belonging to Python modules.

Afaict this does not remove functionality:
- For the files under `_script` the shebang can be removed as they are wrapped by a *real* script (with shebang).
- The files under `app` are actually meant to be called directly, but should not occur as cli tools. Without a shebang, they can still be called by their module name, e.g. `python3 -m synapse.app.homeserver`.

Tangential Suggestion: After reading into Python and scripts, using `entry_point` in `setup.py` would make those wrappers scripts unnecessary.


### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
