### PR TITLE
One last inline type hint (for the whole repo)

### DIFF
--- a/changelog.d/10418.misc
+++ b/changelog.d/10418.misc
@@ -1,0 +1,1 @@
+Convert internal type variable syntax to reflect wider ecosystem use.

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -89,7 +89,7 @@ class ModuleApi:
         self._server_name = hs.hostname
         self._presence_stream = hs.get_event_sources().sources["presence"]
         self._state = hs.get_state_handler()
-        self._clock = hs.get_clock()  # type: Clock
+        self._clock: Clock = hs.get_clock()
         self._send_email_handler = hs.get_send_email_handler()
 
         try:


### PR DESCRIPTION
I thought this change would be a lot bigger, related to #8351, the last of com2ann conversions, this one is simply;

```
python3.8 -m com2ann -v 6 ./
```

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))

---

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`
