### PR TITLE
Improve failover logic for MSC3083 restricted rooms

### DIFF
--- a/changelog.d/10447.feature
+++ b/changelog.d/10447.feature
@@ -1,0 +1,1 @@
+Update support for [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083) to consider changes in the MSC around which servers can issue join events.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -536,7 +536,7 @@ class FederationClient(FederationBase):
                 suppressed if the exception is an InvalidResponseError.
 
             failover_errcodes: Error codes (specific to this endpoint) which should
-                cause a failover.
+                cause a failover when received as part of an HTTP 400 error.
 
             failover_on_unknown_endpoint: if True, we will try other servers if it looks
                 like a server doesn't support the endpoint. This is typically useful


### PR DESCRIPTION
Based on the error handling in [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083).

~~Based on #10254.~~

This improves the failover logic for `/make_join` and `/send_join` such that errors of type `M_UNABLE_TO_AUTHORISE_JOIN` and `M_UNABLE_TO_GRANT_JOIN` cause trying another server instead of erroring back to the client.

See complement tests: matrix-org/complement#172.