### PR TITLE
Support MSC3289: Room version 8

### DIFF
--- a/changelog.d/10449.bugfix
+++ b/changelog.d/10449.bugfix
@@ -1,0 +1,1 @@
+Mark the experimental room version from [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) as unstable.

--- a/changelog.d/10449.feature
+++ b/changelog.d/10449.feature
@@ -1,0 +1,1 @@
+Support [MSC3289: room version 8](https://github.com/matrix-org/matrix-doc/pull/3289).

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -62,7 +62,7 @@ class JoinRules:
     INVITE = "invite"
     PRIVATE = "private"
     # As defined for MSC3083.
-    MSC3083_RESTRICTED = "restricted"
+    RESTRICTED = "restricted"
 
 
 class RestrictedJoinRuleTypes:

--- a/synapse/api/room_versions.py
+++ b/synapse/api/room_versions.py
@@ -276,12 +276,12 @@ MSC3244_CAPABILITIES = {
     for cap in (
         RoomVersionCapability(
             "knock",
-            RoomVersions.V8,
+            RoomVersions.V7,
             lambda room_version: room_version.msc2403_knocking,
         ),
         RoomVersionCapability(
             "restricted",
-            RoomVersions.V8,
+            None,
             lambda room_version: room_version.msc3083_join_rules,
         ),
     )

--- a/synapse/api/room_versions.py
+++ b/synapse/api/room_versions.py
@@ -193,7 +193,7 @@ class RoomVersions:
     )
     MSC2716 = RoomVersion(
         "org.matrix.msc2716",
-        RoomDisposition.STABLE,
+        RoomDisposition.UNSTABLE,
         EventFormatVersions.V3,
         StateResolutionVersions.V2,
         enforce_key_validity=True,

--- a/synapse/api/room_versions.py
+++ b/synapse/api/room_versions.py
@@ -219,6 +219,20 @@ class RoomVersions:
         msc2403_knocking=True,
         msc2716_historical=True,
     )
+    V8 = RoomVersion(
+        "8",
+        RoomDisposition.STABLE,
+        EventFormatVersions.V3,
+        StateResolutionVersions.V2,
+        enforce_key_validity=True,
+        special_case_aliases_auth=False,
+        strict_canonicaljson=True,
+        limit_notifications_power_levels=True,
+        msc2176_redaction_rules=False,
+        msc3083_join_rules=True,
+        msc2403_knocking=True,
+        msc2716_historical=False,
+    )
 
 
 KNOWN_ROOM_VERSIONS: Dict[str, RoomVersion] = {
@@ -234,6 +248,7 @@ KNOWN_ROOM_VERSIONS: Dict[str, RoomVersion] = {
         RoomVersions.MSC3083,
         RoomVersions.V7,
         RoomVersions.MSC2716,
+        RoomVersions.V8,
     )
 }
 
@@ -261,12 +276,12 @@ MSC3244_CAPABILITIES = {
     for cap in (
         RoomVersionCapability(
             "knock",
-            RoomVersions.V7,
+            RoomVersions.V8,
             lambda room_version: room_version.msc2403_knocking,
         ),
         RoomVersionCapability(
             "restricted",
-            None,
+            RoomVersions.V8,
             lambda room_version: room_version.msc3083_join_rules,
         ),
     )

--- a/synapse/api/room_versions.py
+++ b/synapse/api/room_versions.py
@@ -177,20 +177,6 @@ class RoomVersions:
         msc2403_knocking=False,
         msc2716_historical=False,
     )
-    MSC3083 = RoomVersion(
-        "org.matrix.msc3083.v2",
-        RoomDisposition.UNSTABLE,
-        EventFormatVersions.V3,
-        StateResolutionVersions.V2,
-        enforce_key_validity=True,
-        special_case_aliases_auth=False,
-        strict_canonicaljson=True,
-        limit_notifications_power_levels=True,
-        msc2176_redaction_rules=False,
-        msc3083_join_rules=True,
-        msc2403_knocking=False,
-        msc2716_historical=False,
-    )
     V7 = RoomVersion(
         "7",
         RoomDisposition.STABLE,
@@ -245,7 +231,6 @@ KNOWN_ROOM_VERSIONS: Dict[str, RoomVersion] = {
         RoomVersions.V5,
         RoomVersions.V6,
         RoomVersions.MSC2176,
-        RoomVersions.MSC3083,
         RoomVersions.V7,
         RoomVersions.MSC2716,
         RoomVersions.V8,

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -370,10 +370,7 @@ def _is_membership_change_allowed(
             raise AuthError(403, "You are banned from this room")
         elif join_rule == JoinRules.PUBLIC:
             pass
-        elif (
-            room_version.msc3083_join_rules
-            and join_rule == JoinRules.MSC3083_RESTRICTED
-        ):
+        elif room_version.msc3083_join_rules and join_rule == JoinRules.RESTRICTED:
             # This is the same as public, but the event must contain a reference
             # to the server who authorised the join. If the event does not contain
             # the proper content it is rejected.

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -240,7 +240,7 @@ class EventAuthHandler:
 
         # If the join rule is not restricted, this doesn't apply.
         join_rules_event = await self._store.get_event(join_rules_event_id)
-        return join_rules_event.content.get("join_rule") == JoinRules.MSC3083_RESTRICTED
+        return join_rules_event.content.get("join_rule") == JoinRules.RESTRICTED
 
     async def get_rooms_that_allow_join(
         self, state_ids: StateMap[str]

--- a/tests/events/test_utils.py
+++ b/tests/events/test_utils.py
@@ -341,7 +341,7 @@ class PruneEventTestCase(unittest.TestCase):
                 "signatures": {},
                 "unsigned": {},
             },
-            room_version=RoomVersions.MSC3083,
+            room_version=RoomVersions.V8,
         )
 
 

--- a/tests/handlers/test_space_summary.py
+++ b/tests/handlers/test_space_summary.py
@@ -232,12 +232,12 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
         self.helper.invite(invited_room, targ=user2, tok=self.token)
         restricted_room = self._create_room_with_join_rule(
             JoinRules.MSC3083_RESTRICTED,
-            room_version=RoomVersions.MSC3083.identifier,
+            room_version=RoomVersions.V8.identifier,
             allow=[],
         )
         restricted_accessible_room = self._create_room_with_join_rule(
             JoinRules.MSC3083_RESTRICTED,
-            room_version=RoomVersions.MSC3083.identifier,
+            room_version=RoomVersions.V8.identifier,
             allow=[
                 {
                     "type": RestrictedJoinRuleTypes.ROOM_MEMBERSHIP,

--- a/tests/handlers/test_space_summary.py
+++ b/tests/handlers/test_space_summary.py
@@ -231,12 +231,12 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
         invited_room = self._create_room_with_join_rule(JoinRules.INVITE)
         self.helper.invite(invited_room, targ=user2, tok=self.token)
         restricted_room = self._create_room_with_join_rule(
-            JoinRules.MSC3083_RESTRICTED,
+            JoinRules.RESTRICTED,
             room_version=RoomVersions.V8.identifier,
             allow=[],
         )
         restricted_accessible_room = self._create_room_with_join_rule(
-            JoinRules.MSC3083_RESTRICTED,
+            JoinRules.RESTRICTED,
             room_version=RoomVersions.V8.identifier,
             allow=[
                 {
@@ -459,13 +459,13 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
                 {
                     "room_id": restricted_room,
                     "world_readable": False,
-                    "join_rules": JoinRules.MSC3083_RESTRICTED,
+                    "join_rules": JoinRules.RESTRICTED,
                     "allowed_spaces": [],
                 },
                 {
                     "room_id": restricted_accessible_room,
                     "world_readable": False,
-                    "join_rules": JoinRules.MSC3083_RESTRICTED,
+                    "join_rules": JoinRules.RESTRICTED,
                     "allowed_spaces": [self.room],
                 },
                 {

--- a/tests/test_event_auth.py
+++ b/tests/test_event_auth.py
@@ -384,7 +384,7 @@ class EventAuthTestCase(unittest.TestCase):
             },
         )
         event_auth.check(
-            RoomVersions.MSC3083,
+            RoomVersions.V8,
             authorised_join_event,
             auth_events,
             do_sig_check=False,
@@ -400,7 +400,7 @@ class EventAuthTestCase(unittest.TestCase):
             "@inviter:foo.test"
         )
         event_auth.check(
-            RoomVersions.MSC3083,
+            RoomVersions.V8,
             _join_event(
                 pleb,
                 additional_content={
@@ -414,7 +414,7 @@ class EventAuthTestCase(unittest.TestCase):
         # A join which is missing an authorised server is rejected.
         with self.assertRaises(AuthError):
             event_auth.check(
-                RoomVersions.MSC3083,
+                RoomVersions.V8,
                 _join_event(pleb),
                 auth_events,
                 do_sig_check=False,
@@ -427,7 +427,7 @@ class EventAuthTestCase(unittest.TestCase):
         )
         with self.assertRaises(AuthError):
             event_auth.check(
-                RoomVersions.MSC3083,
+                RoomVersions.V8,
                 _join_event(
                     pleb,
                     additional_content={
@@ -442,7 +442,7 @@ class EventAuthTestCase(unittest.TestCase):
         # *would* be valid, but is sent be a different user.)
         with self.assertRaises(AuthError):
             event_auth.check(
-                RoomVersions.MSC3083,
+                RoomVersions.V8,
                 _member_event(
                     pleb,
                     "join",
@@ -459,7 +459,7 @@ class EventAuthTestCase(unittest.TestCase):
         auth_events[("m.room.member", pleb)] = _member_event(pleb, "ban")
         with self.assertRaises(AuthError):
             event_auth.check(
-                RoomVersions.MSC3083,
+                RoomVersions.V8,
                 authorised_join_event,
                 auth_events,
                 do_sig_check=False,
@@ -468,7 +468,7 @@ class EventAuthTestCase(unittest.TestCase):
         # A user who left can re-join.
         auth_events[("m.room.member", pleb)] = _member_event(pleb, "leave")
         event_auth.check(
-            RoomVersions.MSC3083,
+            RoomVersions.V8,
             authorised_join_event,
             auth_events,
             do_sig_check=False,
@@ -478,7 +478,7 @@ class EventAuthTestCase(unittest.TestCase):
         # be authorised since the user is already joined.)
         auth_events[("m.room.member", pleb)] = _member_event(pleb, "join")
         event_auth.check(
-            RoomVersions.MSC3083,
+            RoomVersions.V8,
             _join_event(pleb),
             auth_events,
             do_sig_check=False,
@@ -490,7 +490,7 @@ class EventAuthTestCase(unittest.TestCase):
             pleb, "invite", sender=creator
         )
         event_auth.check(
-            RoomVersions.MSC3083,
+            RoomVersions.V8,
             _join_event(pleb),
             auth_events,
             do_sig_check=False,


### PR DESCRIPTION
This adds support for [MSC3289](https://github.com/matrix-org/matrix-doc/pull/3289): room version 8. This is room version 7 + [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083).

~~Based on #10447. (Hence the draft.)~~

This should not be merged until MSC3289 is merged.

Also see matrix-org/sytest#1100 and matrix-org/complement#181.