### PR TITLE
Cancel redundant GHA workflows

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -12,6 +12,10 @@ on:
     # we do the full build on tags.
     tags: ["v*"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 permissions:
   contents: write
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
     branches: ["develop", "release-*"]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/changelog.d/10451.misc
+++ b/changelog.d/10451.misc
@@ -1,0 +1,1 @@
+Cancel redundant GHA workflows when a new commit is pushed.


### PR DESCRIPTION
The idea here is that we only need the most recent `tests` or `release artifacts` workflow for each branch, and all the rest are just sucking up GHA worker time redundantly, so we may as well cancel them.

(docs at https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency)