### PR TITLE
Change release script to update debian changelog for RCs

### DIFF
--- a/changelog.d/10465.misc
+++ b/changelog.d/10465.misc
@@ -1,0 +1,1 @@
+Fix release script to correctly version debian changelog when doing RCs.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -190,12 +190,24 @@ def run():
     # Generate changelogs
     subprocess.run("python3 -m towncrier", shell=True)
 
-    # Generate debian changelogs if its not an RC.
-    if not rc:
-        subprocess.run(
-            f'dch -M -v {new_version} "New synapse release {new_version}."', shell=True
-        )
-        subprocess.run('dch -M -r -D stable ""', shell=True)
+    # Generate debian changelogs
+    assert not parsed_new_version.is_devrelease
+    assert not parsed_new_version.is_postrelease
+
+    if parsed_new_version.pre is not None:
+        # If this is an RC then we need to coerce the version string to match
+        # Debian norms, e.g. 1.39.0rc2 gets converted to 1.39.0~rc2.
+        base_ver = parsed_new_version.base_version
+        pre_type, pre_num = parsed_new_version.pre
+        debian_version = f"{base_ver}~{pre_type}{pre_num}"
+    else:
+        debian_version = new_version
+
+    subprocess.run(
+        f'dch -M -v {debian_version} "New synapse release {debian_version}."',
+        shell=True,
+    )
+    subprocess.run('dch -M -r -D stable ""', shell=True)
 
     # Show the user the changes and ask if they want to edit the change log.
     repo.git.add("-u")

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -139,6 +139,11 @@ def run():
 
     # Switch to the release branch.
     parsed_new_version = version.parse(new_version)
+
+    # We assume for debian changelogs that we only do RCs or full releases.
+    assert not parsed_new_version.is_devrelease
+    assert not parsed_new_version.is_postrelease
+
     release_branch_name = (
         f"release-v{parsed_new_version.major}.{parsed_new_version.minor}"
     )
@@ -191,9 +196,6 @@ def run():
     subprocess.run("python3 -m towncrier", shell=True)
 
     # Generate debian changelogs
-    assert not parsed_new_version.is_devrelease
-    assert not parsed_new_version.is_postrelease
-
     if parsed_new_version.pre is not None:
         # If this is an RC then we need to coerce the version string to match
         # Debian norms, e.g. 1.39.0rc2 gets converted to 1.39.0~rc2.


### PR DESCRIPTION
We used to only do debs for full releases, but we're now doing them for RCs too, so we need to update the changelog.