### PR TITLE
Fix saml.DefaultSamlMappingProvider import

### DIFF
--- a/changelog.d/10477.bugfix
+++ b/changelog.d/10477.bugfix
@@ -1,1 +1,1 @@
-Fix circular import with the default SAML mapping handler.
+Fix bug introduced in Synapse 1.38 which caused an exception at startup when SAML authentication was enabled.

--- a/changelog.d/10477.bugfix
+++ b/changelog.d/10477.bugfix
@@ -1,0 +1,1 @@
+Fix circular import with the default SAML mapping handler.

--- a/synapse/handlers/_base.py
+++ b/synapse/handlers/_base.py
@@ -15,8 +15,6 @@
 import logging
 from typing import TYPE_CHECKING, Optional
 
-import synapse.state
-import synapse.storage
 import synapse.types
 from synapse.api.constants import EventTypes, Membership
 from synapse.api.ratelimiting import Ratelimiter


### PR DESCRIPTION
Not sure from when, but trying to import the default configured SAML mapping provider crashes with circular imports.

Removed the imports `synapse.state` and `synapse.storage` which were caising the circular, and seem to have only been used for type hints, which were removed in https://github.com/matrix-org/synapse/commit/98aec1cc9da2bd6b8e34ffb282c85abf9b8b42ca

Signed-off-by: Jason Robinson <jasonr@matrix.org>
