### PR TITLE
Fix typo that causes R30v2 to actually be old R30

### DIFF
--- a/changelog.d/10486.bugfix
+++ b/changelog.d/10486.bugfix
@@ -1,0 +1,1 @@
+Fix reporting old R30 stats as R30v2 stats.

--- a/synapse/app/phone_stats_home.py
+++ b/synapse/app/phone_stats_home.py
@@ -109,7 +109,7 @@ async def phone_stats_home(hs, stats, stats_process=_stats_process):
     for name, count in r30_results.items():
         stats["r30_users_" + name] = count
 
-    r30v2_results = await store.count_r30_users()
+    r30v2_results = await store.count_r30v2_users()
     for name, count in r30v2_results.items():
         stats["r30v2_users_" + name] = count
 


### PR DESCRIPTION
Signed-off-by: Olivier Wilkinson (reivilibre) <olivier@librepush.net>
