### PR TITLE
Remove the deprecation notice for the Third-Party Rules module interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,6 @@ Bugfixes
 Synapse 1.39.0rc1 (2021-07-20)
 ==============================
 
-The Third-Party Event Rules module interface has been deprecated in favour of the generic module interface introduced in Synapse v1.37.0. Support for the old interface is planned to be removed in September 2021. See the [upgrade notes](https://matrix-org.github.io/synapse/latest/upgrade.html#upgrading-to-v1390) for more information.
 
 Features
 --------
@@ -86,7 +85,6 @@ Deprecations and Removals
 -------------------------
 
 - Remove functionality associated with the unused `room_stats_historical` and `user_stats_historical` tables. Contributed by @xmunoz. ([\#9721](https://github.com/matrix-org/synapse/issues/9721))
-- The third-party event rules module interface is deprecated in favour of the generic module interface introduced in Synapse v1.37.0. See the [upgrade notes](https://matrix-org.github.io/synapse/latest/upgrade.html#upgrading-to-v1390) for more information. ([\#10386](https://github.com/matrix-org/synapse/issues/10386))
 
 
 Internal Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,7 @@ Features
 - The spaces summary API now returns any joinable rooms, not only rooms which are world-readable. ([\#10298](https://github.com/matrix-org/synapse/issues/10298), [\#10305](https://github.com/matrix-org/synapse/issues/10305))
 - Add a new version of the R30 phone-home metric, which removes a false impression of retention given by the old R30 metric. ([\#10332](https://github.com/matrix-org/synapse/issues/10332), [\#10427](https://github.com/matrix-org/synapse/issues/10427))
 - Allow providing credentials to `http_proxy`. ([\#10360](https://github.com/matrix-org/synapse/issues/10360))
+- Add support for `ThirdPartyRules` callbacks to the new module interface added in v1.37.0. ([\#10386](https://github.com/matrix-org/synapse/issues/10386))
 
 
 Bugfixes

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -86,19 +86,6 @@ process, for example:
     ```
 
 
-# Upgrading to v1.39.0
-
-## Deprecation of the current third-party rules module interface
-
-The current third-party rules module interface is deprecated in favour of the new generic
-modules system introduced in Synapse v1.37.0. Authors of third-party rules modules can refer
-to [this documentation](modules.md#porting-an-existing-module-that-uses-the-old-interface)
-to update their modules. Synapse administrators can refer to [this documentation](modules.md#using-modules)
-to update their configuration once the modules they are using have been updated.
-
-We plan to remove support for the current third-party rules interface in September 2021.
-
-
 # Upgrading to v1.38.0
 
 ## Re-indexing of `events` table on Postgres databases


### PR DESCRIPTION
As per https://github.com/matrix-org/synapse/issues/10469#issuecomment-888213232, we don't want to deprecate/remove interfaces one by one anymore, but rather deprecate and remove them all at once.

CI failing is expected since this PR is missing a changelog entry on purpose.