### PR TITLE
Extend the release script to tag and create the releases.

### DIFF
--- a/changelog.d/10496.misc
+++ b/changelog.d/10496.misc
@@ -1,0 +1,1 @@
+Extend release script to also tag and create GitHub releases.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -27,16 +27,21 @@ from packaging import version
 from redbaron import RedBaron
 
 
-@click.command()
-def run():
-    """An interactive script to walk through the initial stages of creating a
-    release, including creating release branch, updating changelog and pushing to
-    GitHub.
+@click.group()
+def cli():
+    """An interactive script to walk through the parts of creating a release.
 
     Requires the dev dependencies be installed, which can be done via:
 
         pip install -e .[dev]
 
+    """
+
+
+@cli.command()
+def prepare():
+    """Do the initial stages of creating a release, including creating release
+    branch, updating changelog and pushing to GitHub.
     """
 
     # Make sure we're in a git repo.
@@ -257,4 +262,4 @@ def update_branch(repo: git.Repo):
 
 
 if __name__ == "__main__":
-    run()
+    cli()

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -358,7 +358,7 @@ def publish(gh_token: str):
 
 
 @cli.command()
-def upload(gh_token: Optional[str]):
+def upload():
     """Upload release to pypi."""
 
     current_version, _, _ = parse_version_from_module()

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -33,7 +33,6 @@ import redbaron
 from click.exceptions import ClickException
 from github import Github
 from packaging import version
-from redbaron import RedBaron
 
 
 @click.group()
@@ -378,11 +377,13 @@ def publish(gh_token: Optional[str]):
     )
 
 
-def parse_version_from_module() -> Tuple[version.Version, RedBaron, redbaron.Node]:
+def parse_version_from_module() -> Tuple[
+    version.Version, redbaron.RedBaron, redbaron.Node
+]:
     # Parse the AST and load the `__version__` node so that we can edit it
     # later.
     with open("synapse/__init__.py") as f:
-        red = RedBaron(f.read())
+        red = redbaron.RedBaron(f.read())
 
     version_node = None
     for node in red:

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -267,7 +267,7 @@ def tag(gh_token: Optional[str]):
 
     # Check we haven't released this version.
     if tag_name in repo.tags:
-        raise click.ClickException(f"Tag already exists for {current_version}!\n")
+        raise click.ClickException(f"Tag {tag_name} already exists!\n")
 
     # Get the appropriate changelogs and tag.
     changes = get_changes_for_version(current_version)
@@ -334,7 +334,7 @@ def publish(gh_token: Optional[str]):
         return
 
     if gh_token:
-        # Create a new draft release
+        # Publish the draft release
         gh = Github(gh_token)
         gh_repo = gh.get_repo("matrix-org/synapse")
         for release in gh_repo.get_releases():

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -54,6 +54,7 @@ def cli():
         # ... wait for asssets to build ...
 
         ./scripts-dev/release.py publish
+        ./scripts-dev/release.py upload
 
     If the env var GH_TOKEN (or GITHUB_TOKEN) is set, or passed into the
     `tag`/`publish` command, then a new draft release will be created/published.
@@ -315,7 +316,7 @@ def tag(gh_token: Optional[str]):
 @cli.command()
 @click.option("--gh-token", envvar=["GH_TOKEN", "GITHUB_TOKEN"])
 def publish(gh_token: Optional[str]):
-    """Publish release and upload to PyPI."""
+    """Publish release."""
 
     # Make sure we're in a git repo.
     try:
@@ -355,6 +356,14 @@ def publish(gh_token: Optional[str]):
                 prerelease=release.prerelease,
                 draft=False,
             )
+
+
+@cli.command()
+def upload(gh_token: Optional[str]):
+    """Upload release to pypi."""
+
+    current_version, _, _ = parse_version_from_module()
+    tag_name = f"v{current_version}"
 
     pypi_asset_names = [
         f"matrix_synapse-{current_version}-py3-none-any.whl",

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -345,16 +345,16 @@ def publish(gh_token: str):
     assert release.title == tag_name
 
     if not release.draft:
-        if not click.confirm("Release already published. Continue?", default=True):
-            return
-    else:
-        release = release.update_release(
-            name=release.title,
-            message=release.body,
-            tag_name=release.tag_name,
-            prerelease=release.prerelease,
-            draft=False,
-        )
+        click.echo("Release already published.")
+        return
+
+    release = release.update_release(
+        name=release.title,
+        message=release.body,
+        tag_name=release.tag_name,
+        prerelease=release.prerelease,
+        draft=False,
+    )
 
 
 @cli.command()

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -314,8 +314,8 @@ def tag(gh_token: Optional[str]):
 
 
 @cli.command()
-@click.option("--gh-token", envvar=["GH_TOKEN", "GITHUB_TOKEN"])
-def publish(gh_token: Optional[str]):
+@click.option("--gh-token", envvar=["GH_TOKEN", "GITHUB_TOKEN"], required=True)
+def publish(gh_token: str):
     """Publish release."""
 
     # Make sure we're in a git repo.
@@ -333,29 +333,28 @@ def publish(gh_token: Optional[str]):
     if not click.confirm(f"Publish {tag_name}?", default=True):
         return
 
-    if gh_token:
-        # Publish the draft release
-        gh = Github(gh_token)
-        gh_repo = gh.get_repo("matrix-org/synapse")
-        for release in gh_repo.get_releases():
-            if release.title == tag_name:
-                break
-        else:
-            raise ClickException(f"Failed to find GitHub release for {tag_name}")
+    # Publish the draft release
+    gh = Github(gh_token)
+    gh_repo = gh.get_repo("matrix-org/synapse")
+    for release in gh_repo.get_releases():
+        if release.title == tag_name:
+            break
+    else:
+        raise ClickException(f"Failed to find GitHub release for {tag_name}")
 
-        assert release.title == tag_name
+    assert release.title == tag_name
 
-        if not release.draft:
-            if not click.confirm("Release already published. Continue?", default=True):
-                return
-        else:
-            release = release.update_release(
-                name=release.title,
-                message=release.body,
-                tag_name=release.tag_name,
-                prerelease=release.prerelease,
-                draft=False,
-            )
+    if not release.draft:
+        if not click.confirm("Release already published. Continue?", default=True):
+            return
+    else:
+        release = release.update_release(
+            name=release.title,
+            message=release.body,
+            tag_name=release.tag_name,
+            prerelease=release.prerelease,
+            draft=False,
+        )
 
 
 @cli.command()

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,8 @@ CONDITIONAL_REQUIREMENTS["dev"] = CONDITIONAL_REQUIREMENTS["lint"] + [
     "click==7.1.2",
     "redbaron==0.9.2",
     "GitPython==3.1.14",
+    "commonmark==0.9.1",
+    "pygithub==1.55",
 ]
 
 CONDITIONAL_REQUIREMENTS["mypy"] = ["mypy==0.812", "mypy-zope==0.2.13"]


### PR DESCRIPTION
This splits the release script into three subcommands:

```
./scripts-dev/release.py prepare

# ... ask others to look at the changelog ...

./scripts-dev/release.py tag

# ... wait for asssets to build ...

./scripts-dev/release.py publish
```

Reviewable commit by commit.