### PR TITLE
Fix deb build script to set prerelease flag correctly

### DIFF
--- a/changelog.d/10500.misc
+++ b/changelog.d/10500.misc
@@ -1,0 +1,1 @@
+Fix a bug which caused production debian packages to be incorrectly marked as 'prerelease'.

--- a/docker/build_debian.sh
+++ b/docker/build_debian.sh
@@ -11,10 +11,6 @@ DIST=`cut -d ':' -f2 <<< $distro`
 cp -aT /synapse/source /synapse/build
 cd /synapse/build
 
-# add an entry to the changelog for this distribution
-dch -M -l "+$DIST" "build for $DIST"
-dch -M -r "" --force-distribution --distribution "$DIST"
-
 # if this is a prerelease, set the Section accordingly.
 #
 # When the package is later added to the package repo, reprepro will use the
@@ -23,11 +19,14 @@ dch -M -r "" --force-distribution --distribution "$DIST"
 
 DEB_VERSION=`dpkg-parsechangelog -SVersion`
 case $DEB_VERSION in
-    *rc*|*a*|*b*|*c*)
+    *~rc*|*~a*|*~b*|*~c*)
         sed -ie '/^Section:/c\Section: prerelease' debian/control
         ;;
 esac
 
+# add an entry to the changelog for this distribution
+dch -M -l "+$DIST" "build for $DIST"
+dch -M -r "" --force-distribution --distribution "$DIST"
 
 dpkg-buildpackage -us -uc
 


### PR DESCRIPTION
if we end up doing a 1.39.1, we'll want to make sure this lands on the release branch first.