### PR TITLE
Fix PeriodicallyFlushingMemoryHandler inhibiting application shutdown

### DIFF
--- a/changelog.d/10517.bugfix
+++ b/changelog.d/10517.bugfix
@@ -1,0 +1,1 @@
+Fix the `PeriodicallyFlushingMemoryHandler` inhibiting application shutdown because of its background thread.

--- a/synapse/logging/handlers.py
+++ b/synapse/logging/handlers.py
@@ -45,6 +45,7 @@ class PeriodicallyFlushingMemoryHandler(MemoryHandler):
         self._flushing_thread: Thread = Thread(
             name="PeriodicallyFlushingMemoryHandler flushing thread",
             target=self._flush_periodically,
+            daemon=True,
         )
         self._flushing_thread.start()
 


### PR DESCRIPTION
not tested (not immediately sure how to -- `synctl stop` used to already work)