### PR TITLE
Make `PeriodicallyFlushingMemoryHandler` (buffered logging handler which periodically flushes itself) the default logging handler.

### DIFF
--- a/changelog.d/10518.feature
+++ b/changelog.d/10518.feature
@@ -1,0 +1,1 @@
+Make `PeriodicallyFlushingMemoryHandler` (buffered logging handler which periodically flushes itself) the default logging handler.

--- a/changelog.d/10518.feature
+++ b/changelog.d/10518.feature
@@ -1,1 +1,1 @@
-Make `PeriodicallyFlushingMemoryHandler` (buffered logging handler which periodically flushes itself) the default logging handler.
+The default logging handler for new installations is now `PeriodicallyFlushingMemoryHandler`, a buffered logging handler which periodically flushes itself.

--- a/docker/conf/log.config
+++ b/docker/conf/log.config
@@ -25,19 +25,23 @@ handlers:
   buffer:
     class: synapse.logging.handlers.PeriodicallyFlushingMemoryHandler
     target: file
+
     # The capacity is the maximum number of log lines that are buffered
     # before being written to disk. Increasing this will lead to better
     # performance, at the expensive of it taking longer for log lines to
     # be written to disk.
     # This parameter is required.
     capacity: 10
+
     # Logs with a level at or above the flush level will cause the buffer to
     # be flushed immediately.
     # Default value: 40 (ERROR)
     # Other values: 50 (CRITICAL), 30 (WARNING), 20 (INFO), 10 (DEBUG)
     flushLevel: 30  # Flush immediately for WARNING logs and higher
+
     # The period of time, in seconds, between forced flushes.
     # Messages will not be delayed for longer than this time.
+    # Default value: 5 seconds
     period: 5
 {% endif %}
 

--- a/docker/conf/log.config
+++ b/docker/conf/log.config
@@ -22,7 +22,7 @@ handlers:
   # there will be a delay for INFO/DEBUG logs to get written, but WARNING/ERROR
   # logs will still be flushed immediately.
   buffer:
-    class: logging.handlers.MemoryHandler
+    class: synapse.logging.handlers.PeriodicallyFlushingMemoryHandler
     target: file
     # The capacity is the number of log lines that are buffered before
     # being written to disk. Increasing this will lead to better
@@ -30,6 +30,9 @@ handlers:
     # be written to disk.
     capacity: 10
     flushLevel: 30  # Flush for WARNING logs as well
+    # The period of time, in seconds, between forced flushes.
+    # Messages will not be delayed for longer than this time.
+    period: 5
 {% endif %}
 
   console:

--- a/docker/conf/log.config
+++ b/docker/conf/log.config
@@ -18,18 +18,24 @@ handlers:
     backupCount: 6  # Does not include the current log file.
     encoding: utf8
 
-  # Default to buffering writes to log file for efficiency. This means that
-  # there will be a delay for INFO/DEBUG logs to get written, but WARNING/ERROR
-  # logs will still be flushed immediately.
+  # Default to buffering writes to log file for efficiency.
+  # WARNING/ERROR logs will still be flushed immediately, but there will be a
+  # delay (of up to `period` seconds, or until the buffer is full with
+  # `capacity` messages) before INFO/DEBUG logs get written.
   buffer:
     class: synapse.logging.handlers.PeriodicallyFlushingMemoryHandler
     target: file
-    # The capacity is the number of log lines that are buffered before
-    # being written to disk. Increasing this will lead to better
+    # The capacity is the maximum number of log lines that are buffered
+    # before being written to disk. Increasing this will lead to better
     # performance, at the expensive of it taking longer for log lines to
     # be written to disk.
+    # This parameter is required.
     capacity: 10
-    flushLevel: 30  # Flush for WARNING logs as well
+    # Logs with a level at or above the flush level will cause the buffer to
+    # be flushed immediately.
+    # Default value: 40 (ERROR)
+    # Other values: 50 (CRITICAL), 30 (WARNING), 20 (INFO), 10 (DEBUG)
+    flushLevel: 30  # Flush immediately for WARNING logs and higher
     # The period of time, in seconds, between forced flushes.
     # Messages will not be delayed for longer than this time.
     period: 5

--- a/docs/sample_log_config.yaml
+++ b/docs/sample_log_config.yaml
@@ -31,19 +31,23 @@ handlers:
     buffer:
         class: synapse.logging.handlers.PeriodicallyFlushingMemoryHandler
         target: file
+
         # The capacity is the maximum number of log lines that are buffered
         # before being written to disk. Increasing this will lead to better
         # performance, at the expensive of it taking longer for log lines to
         # be written to disk.
         # This parameter is required.
         capacity: 10
+
         # Logs with a level at or above the flush level will cause the buffer to
         # be flushed immediately.
         # Default value: 40 (ERROR)
         # Other values: 50 (CRITICAL), 30 (WARNING), 20 (INFO), 10 (DEBUG)
         flushLevel: 30  # Flush immediately for WARNING logs and higher
+
         # The period of time, in seconds, between forced flushes.
         # Messages will not be delayed for longer than this time.
+        # Default value: 5 seconds
         period: 5
 
     # A handler that writes logs to stderr. Unused by default, but can be used

--- a/docs/sample_log_config.yaml
+++ b/docs/sample_log_config.yaml
@@ -28,7 +28,7 @@ handlers:
     # will be a delay for INFO/DEBUG logs to get written, but WARNING/ERROR
     # logs will still be flushed immediately.
     buffer:
-        class: logging.handlers.MemoryHandler
+        class: synapse.logging.handlers.PeriodicallyFlushingMemoryHandler
         target: file
         # The capacity is the number of log lines that are buffered before
         # being written to disk. Increasing this will lead to better
@@ -36,6 +36,9 @@ handlers:
         # be written to disk.
         capacity: 10
         flushLevel: 30  # Flush for WARNING logs as well
+        # The period of time, in seconds, between forced flushes.
+        # Messages will not be delayed for longer than this time.
+        period: 5
 
     # A handler that writes logs to stderr. Unused by default, but can be used
     # instead of "buffer" and "file" in the logger handlers.

--- a/docs/sample_log_config.yaml
+++ b/docs/sample_log_config.yaml
@@ -24,18 +24,24 @@ handlers:
         backupCount: 3  # Does not include the current log file.
         encoding: utf8
 
-    # Default to buffering writes to log file for efficiency. This means that
-    # will be a delay for INFO/DEBUG logs to get written, but WARNING/ERROR
-    # logs will still be flushed immediately.
+    # Default to buffering writes to log file for efficiency.
+    # WARNING/ERROR logs will still be flushed immediately, but there will be a
+    # delay (of up to `period` seconds, or until the buffer is full with
+    # `capacity` messages) before INFO/DEBUG logs get written.
     buffer:
         class: synapse.logging.handlers.PeriodicallyFlushingMemoryHandler
         target: file
-        # The capacity is the number of log lines that are buffered before
-        # being written to disk. Increasing this will lead to better
+        # The capacity is the maximum number of log lines that are buffered
+        # before being written to disk. Increasing this will lead to better
         # performance, at the expensive of it taking longer for log lines to
         # be written to disk.
+        # This parameter is required.
         capacity: 10
-        flushLevel: 30  # Flush for WARNING logs as well
+        # Logs with a level at or above the flush level will cause the buffer to
+        # be flushed immediately.
+        # Default value: 40 (ERROR)
+        # Other values: 50 (CRITICAL), 30 (WARNING), 20 (INFO), 10 (DEBUG)
+        flushLevel: 30  # Flush immediately for WARNING logs and higher
         # The period of time, in seconds, between forced flushes.
         # Messages will not be delayed for longer than this time.
         period: 5

--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -67,18 +67,24 @@ handlers:
         backupCount: 3  # Does not include the current log file.
         encoding: utf8
 
-    # Default to buffering writes to log file for efficiency. This means that
-    # will be a delay for INFO/DEBUG logs to get written, but WARNING/ERROR
-    # logs will still be flushed immediately.
+    # Default to buffering writes to log file for efficiency.
+    # WARNING/ERROR logs will still be flushed immediately, but there will be a
+    # delay (of up to `period` seconds, or until the buffer is full with
+    # `capacity` messages) before INFO/DEBUG logs get written.
     buffer:
         class: synapse.logging.handlers.PeriodicallyFlushingMemoryHandler
         target: file
-        # The capacity is the number of log lines that are buffered before
-        # being written to disk. Increasing this will lead to better
+        # The capacity is the maximum number of log lines that are buffered
+        # before being written to disk. Increasing this will lead to better
         # performance, at the expensive of it taking longer for log lines to
         # be written to disk.
+        # This parameter is required.
         capacity: 10
-        flushLevel: 30  # Flush for WARNING logs as well
+        # Logs with a level at or above the flush level will cause the buffer to
+        # be flushed immediately.
+        # Default value: 40 (ERROR)
+        # Other values: 50 (CRITICAL), 30 (WARNING), 20 (INFO), 10 (DEBUG)
+        flushLevel: 30  # Flush immediately for WARNING logs and higher
         # The period of time, in seconds, between forced flushes.
         # Messages will not be delayed for longer than this time.
         period: 5

--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -74,19 +74,23 @@ handlers:
     buffer:
         class: synapse.logging.handlers.PeriodicallyFlushingMemoryHandler
         target: file
+
         # The capacity is the maximum number of log lines that are buffered
         # before being written to disk. Increasing this will lead to better
         # performance, at the expensive of it taking longer for log lines to
         # be written to disk.
         # This parameter is required.
         capacity: 10
+
         # Logs with a level at or above the flush level will cause the buffer to
         # be flushed immediately.
         # Default value: 40 (ERROR)
         # Other values: 50 (CRITICAL), 30 (WARNING), 20 (INFO), 10 (DEBUG)
         flushLevel: 30  # Flush immediately for WARNING logs and higher
+
         # The period of time, in seconds, between forced flushes.
         # Messages will not be delayed for longer than this time.
+        # Default value: 5 seconds
         period: 5
 
     # A handler that writes logs to stderr. Unused by default, but can be used

--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -71,7 +71,7 @@ handlers:
     # will be a delay for INFO/DEBUG logs to get written, but WARNING/ERROR
     # logs will still be flushed immediately.
     buffer:
-        class: logging.handlers.MemoryHandler
+        class: synapse.logging.handlers.PeriodicallyFlushingMemoryHandler
         target: file
         # The capacity is the number of log lines that are buffered before
         # being written to disk. Increasing this will lead to better
@@ -79,6 +79,9 @@ handlers:
         # be written to disk.
         capacity: 10
         flushLevel: 30  # Flush for WARNING logs as well
+        # The period of time, in seconds, between forced flushes.
+        # Messages will not be delayed for longer than this time.
+        period: 5
 
     # A handler that writes logs to stderr. Unused by default, but can be used
     # instead of "buffer" and "file" in the logger handlers.


### PR DESCRIPTION
merge blocked:
- [x] check that #10517 is successful
- [x] check that it doesn't explode matrix.org