### PR TITLE
Don't fail CI when a job was skipped

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -367,12 +367,14 @@ jobs:
       - name: Set build result
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_STATUS: ${{ job.status }}
         # the `jq` incantation dumps out a series of "<job> <result>" lines.
         # we set it to an intermediate variable to avoid a pipe, which makes it
         # hard to set $rc.
         run: |
           rc=0
           results=$(jq -r 'to_entries[] | [.key,.value.result] | join(" ")' <<< $NEEDS_CONTEXT)
+          echo "Current job status: $JOB_STATUS"
           while read job result ; do
               if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
                   echo "::set-failed ::Job $job returned $result"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -374,7 +374,7 @@ jobs:
           rc=0
           results=$(jq -r 'to_entries[] | [.key,.value.result] | join(" ")' <<< $NEEDS_CONTEXT)
           while read job result ; do
-              if [ "$result" != "success" ]; then
+              if [ "$result" != "success" ] || [ "$result" != "skipped" ]; then
                   echo "::set-failed ::Job $job returned $result"
                   rc=1
               fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -374,7 +374,7 @@ jobs:
           rc=0
           results=$(jq -r 'to_entries[] | [.key,.value.result] | join(" ")' <<< $NEEDS_CONTEXT)
           while read job result ; do
-              if [ "$result" != "success" ] || [ "$result" != "skipped" ]; then
+              if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
                   echo "::set-failed ::Job $job returned $result"
                   rc=1
               fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -367,16 +367,19 @@ jobs:
       - name: Set build result
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
-          JOB_STATUS: ${{ job.status }}
         # the `jq` incantation dumps out a series of "<job> <result>" lines.
         # we set it to an intermediate variable to avoid a pipe, which makes it
         # hard to set $rc.
         run: |
           rc=0
           results=$(jq -r 'to_entries[] | [.key,.value.result] | join(" ")' <<< $NEEDS_CONTEXT)
-          echo "Current job status: $JOB_STATUS"
           while read job result ; do
-              if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              # The newsfile lint may be skipped on non PR builds
+              if [ $result == "skipped" ] && [ $job == "lint-newsfile" ]; then
+                continue
+              fi
+
+              if [ "$result" != "success" ]; then
                   echo "::set-failed ::Job $job returned $result"
                   rc=1
               fi

--- a/changelog.d/10529.misc
+++ b/changelog.d/10529.misc
@@ -1,0 +1,1 @@
+Fix CI to not break when run against branches rather than pull requests.


### PR DESCRIPTION
We don't always run all jobs, e.g. we only run the newsfile lint on PRs,
which means that currently CI always fails on the develop branch.
