### PR TITLE
Update the API response for spaces summary over federation

### DIFF
--- a/changelog.d/10530.misc
+++ b/changelog.d/10530.misc
@@ -1,0 +1,1 @@
+Prepare for the new spaces summary endpoint (updates to [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946)).

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -179,7 +179,7 @@ class SpaceSummaryHandler:
 
                     # Check if the user is a member of any of the allowed spaces
                     # from the response.
-                    allowed_rooms = room.get("allowed_spaces")
+                    allowed_rooms = room.get("allowed_room_ids") or room.get("allowed_spaces")
                     if (
                         not include_room
                         and allowed_rooms
@@ -236,9 +236,10 @@ class SpaceSummaryHandler:
                 )
                 processed_events.add(ev_key)
 
-        # Before returning to the client, remove the allowed_spaces key for any
-        # rooms.
+        # Before returning to the client, remove the allowed_room_ids and
+        # allowed_spaces key for any rooms.
         for room in rooms_result:
+            room.pop("allowed_room_ids", None)
             room.pop("allowed_spaces", None)
 
         return {"rooms": rooms_result, "events": events_result}
@@ -585,6 +586,8 @@ class SpaceSummaryHandler:
             "guest_can_join": stats["guest_access"] == "can_join",
             "creation_ts": create_event.origin_server_ts,
             "room_type": create_event.content.get(EventContentFields.ROOM_TYPE),
+            "allowed_room_ids": allowed_rooms,
+            # TODO Remove this key once the API is stable.
             "allowed_spaces": allowed_rooms,
         }
 

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -179,7 +179,9 @@ class SpaceSummaryHandler:
 
                     # Check if the user is a member of any of the allowed spaces
                     # from the response.
-                    allowed_rooms = room.get("allowed_room_ids") or room.get("allowed_spaces")
+                    allowed_rooms = room.get("allowed_room_ids") or room.get(
+                        "allowed_spaces"
+                    )
                     if (
                         not include_room
                         and allowed_rooms
@@ -198,6 +200,11 @@ class SpaceSummaryHandler:
 
                     # The user can see the room, include it!
                     if include_room:
+                        # Before returning to the client, remove the allowed_room_ids
+                        # and allowed_spaces keys.
+                        room.pop("allowed_room_ids", None)
+                        room.pop("allowed_spaces", None)
+
                         rooms_result.append(room)
                         events.extend(room_entry.children)
 
@@ -235,12 +242,6 @@ class SpaceSummaryHandler:
                     _RoomQueueEntry(ev["state_key"], ev["content"]["via"])
                 )
                 processed_events.add(ev_key)
-
-        # Before returning to the client, remove the allowed_room_ids and
-        # allowed_spaces key for any rooms.
-        for room in rooms_result:
-            room.pop("allowed_room_ids", None)
-            room.pop("allowed_spaces", None)
 
         return {"rooms": rooms_result, "events": events_result}
 
@@ -338,7 +339,7 @@ class SpaceSummaryHandler:
         if not await self._is_room_accessible(room_id, requester, origin):
             return None
 
-        room_entry = await self._build_room_entry(room_id)
+        room_entry = await self._build_room_entry(room_id, for_federation=bool(origin))
 
         # If the room is not a space, return just the room information.
         if room_entry.get("room_type") != RoomTypes.SPACE:
@@ -549,8 +550,18 @@ class SpaceSummaryHandler:
         )
         return False
 
-    async def _build_room_entry(self, room_id: str) -> JsonDict:
-        """Generate en entry suitable for the 'rooms' list in the summary response"""
+    async def _build_room_entry(self, room_id: str, for_federation: bool) -> JsonDict:
+        """
+        Generate en entry suitable for the 'rooms' list in the summary response.
+
+        Args:
+            room_id: The room ID to summarize.
+            for_federation: True if this is a summary requested over federation
+                (which includes additional fields).
+
+        Returns:
+            The JSON dictionary for the room.
+        """
         stats = await self._store.get_room_with_stats(room_id)
 
         # currently this should be impossible because we call
@@ -562,15 +573,6 @@ class SpaceSummaryHandler:
         create_event = await self._store.get_event(
             current_state_ids[(EventTypes.Create, "")]
         )
-
-        room_version = await self._store.get_room_version(room_id)
-        allowed_rooms = None
-        if await self._event_auth_handler.has_restricted_join_rules(
-            current_state_ids, room_version
-        ):
-            allowed_rooms = await self._event_auth_handler.get_rooms_that_allow_join(
-                current_state_ids
-            )
 
         entry = {
             "room_id": stats["room_id"],
@@ -586,10 +588,24 @@ class SpaceSummaryHandler:
             "guest_can_join": stats["guest_access"] == "can_join",
             "creation_ts": create_event.origin_server_ts,
             "room_type": create_event.content.get(EventContentFields.ROOM_TYPE),
-            "allowed_room_ids": allowed_rooms,
-            # TODO Remove this key once the API is stable.
-            "allowed_spaces": allowed_rooms,
         }
+
+        # Federation requests need to provide additional information so the
+        # requested server is able to filter the response appropriately.
+        if for_federation:
+            room_version = await self._store.get_room_version(room_id)
+            if await self._event_auth_handler.has_restricted_join_rules(
+                current_state_ids, room_version
+            ):
+                allowed_rooms = (
+                    await self._event_auth_handler.get_rooms_that_allow_join(
+                        current_state_ids
+                    )
+                )
+                if allowed_rooms:
+                    entry["allowed_room_ids"] = allowed_rooms
+                    # TODO Remove this key once the API is stable.
+                    entry["allowed_spaces"] = allowed_rooms
 
         # Filter out Nones – rather omit the field altogether
         room_entry = {k: v for k, v in entry.items() if v is not None}


### PR DESCRIPTION
This has two discrete, but related changes:

* Sends both the `allowed_room_ids` and `allowed_spaces` keys from [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946) (we send both for backwards compatibility, but prefer `allowed_room_ids` if it exists).
* Only includes this field if we're generating a response for federation, this allows skipping some unnecessary database access.

This relates to both #10495 and  #10523.

~~Builds on #10527.~~