### PR TITLE
Mark all MSC2716 events as historical

### DIFF
--- a/changelog.d/10537.misc
+++ b/changelog.d/10537.misc
@@ -1,0 +1,1 @@
+Mark all events stemming from the MSC2716 `/batch_send` endpoint as historical.

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -458,6 +458,9 @@ class RoomBatchSendEventRestServlet(TransactionRestServlet):
                 "state_key": state_event["state_key"],
             }
 
+            # Mark all events as historical
+            event_dict["content"][EventContentFields.MSC2716_HISTORICAL] = True
+
             # Make the state events float off on their own
             fake_prev_event_id = "$" + random_string(43)
 
@@ -562,7 +565,10 @@ class RoomBatchSendEventRestServlet(TransactionRestServlet):
             "type": EventTypes.MSC2716_CHUNK,
             "sender": requester.user.to_string(),
             "room_id": room_id,
-            "content": {EventContentFields.MSC2716_CHUNK_ID: chunk_id_to_connect_to},
+            "content": {
+                EventContentFields.MSC2716_CHUNK_ID: chunk_id_to_connect_to,
+                EventContentFields.MSC2716_HISTORICAL: True,
+            },
             # Since the chunk event is put at the end of the chunk,
             # where the newest-in-time event is, copy the origin_server_ts from
             # the last event we're inserting
@@ -589,10 +595,6 @@ class RoomBatchSendEventRestServlet(TransactionRestServlet):
         for ev in events_to_create:
             assert_params_in_dict(ev, ["type", "origin_server_ts", "content", "sender"])
 
-            # Mark all events as historical
-            # This has important semantics within the Synapse internals to backfill properly
-            ev["content"][EventContentFields.MSC2716_HISTORICAL] = True
-
             event_dict = {
                 "type": ev["type"],
                 "origin_server_ts": ev["origin_server_ts"],
@@ -601,6 +603,9 @@ class RoomBatchSendEventRestServlet(TransactionRestServlet):
                 "sender": ev["sender"],  # requester.user.to_string(),
                 "prev_events": prev_event_ids.copy(),
             }
+
+            # Mark all events as historical
+            event_dict["content"][EventContentFields.MSC2716_HISTORICAL] = True
 
             event, context = await self.event_creation_handler.create_event(
                 await self._create_requester_for_user_id_from_app_service(


### PR DESCRIPTION
Mark all MSC2716 events as historical

Part of MSC2716: https://github.com/matrix-org/matrix-doc/pull/2716

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)~~
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
