### PR TITLE
Clean up federation event auth code

### DIFF
--- a/changelog.d/10539.misc
+++ b/changelog.d/10539.misc
@@ -1,0 +1,1 @@
+Clean up some of the federation event authentication code for clarity.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2208,7 +2208,7 @@ class FederationHandler(BaseHandler):
         event: EventBase,
         context: EventContext,
         state: Optional[Iterable[EventBase]] = None,
-        auth_events: Optional[MutableStateMap[EventBase]] = None,
+        auth_events: Optional[StateMap[EventBase]] = None,
         backfilled: bool = False,
     ) -> None:
         """
@@ -2232,12 +2232,17 @@ class FederationHandler(BaseHandler):
                 server.
             backfilled: True if the event was backfilled.
         """
+        # take a copy of auth_events before _check_event_auth modifies it
+        mut_auth_events: Optional[MutableStateMap[EventBase]] = None
+        if auth_events:
+            mut_auth_events = dict(auth_events)
+
         context = await self._check_event_auth(
             origin,
             event,
             context,
             state=state,
-            auth_events=auth_events,
+            auth_events=mut_auth_events,
             backfilled=backfilled,
         )
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2220,7 +2220,6 @@ class FederationHandler(BaseHandler):
             context:
                 The event context.
 
-                NB that this function potentially modifies it.
             state:
                 The state events used to check the event for soft-fail. If this is
                 not provided the current state events will be used.
@@ -2579,8 +2578,6 @@ class FederationHandler(BaseHandler):
             event: The event itself.
             context:
                 The event context.
-
-                NB that this function potentially modifies it.
             state:
                 The state events used to check the event for soft-fail. If this is
                 not provided the current state events will be used.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -2611,16 +2611,6 @@ class FederationHandler(BaseHandler):
             auth_events_x = await self.store.get_events(auth_events_ids)
             auth_events = {(e.type, e.state_key): e for e in auth_events_x.values()}
 
-        # This is a hack to fix some old rooms where the initial join event
-        # didn't reference the create event in its auth events.
-        if event.type == EventTypes.Member and not event.auth_event_ids():
-            if len(event.prev_event_ids()) == 1 and event.depth < 5:
-                c = await self.store.get_event(
-                    event.prev_event_ids()[0], allow_none=True
-                )
-                if c and c.type == EventTypes.Create:
-                    auth_events[(c.type, c.state_key)] = c
-
         try:
             context = await self._update_auth_events_and_context_for_auth(
                 origin, event, context, auth_events

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -75,10 +75,8 @@ class MessageAcceptTests(unittest.HomeserverTestCase):
         )
 
         self.handler = self.homeserver.get_federation_handler()
-        self.handler._check_event_auth = (
-            lambda origin, event, context, state, auth_events, backfilled: succeed(
-                context
-            )
+        self.handler._check_event_auth = lambda origin, event, context, state, claimed_auth_event_map, backfilled: succeed(
+            context
         )
         self.client = self.homeserver.get_federation_client()
         self.client._check_sigs_and_hash_and_fetch = lambda dest, pdus, **k: succeed(


### PR DESCRIPTION
This is part of my work trying to sort out #9595. As a first step, this should be an (almost) non-functional change to try to make these code paths a little more understandable.

Reviewable commit by commit.