### PR TITLE
Fix exceptions in logs when failing to get remote room list

### DIFF
--- a/changelog.d/10541.bugfix
+++ b/changelog.d/10541.bugfix
@@ -1,0 +1,1 @@
+Fix exceptions in logs when failing to get remote room list.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -43,6 +43,7 @@ from synapse.api.errors import (
     Codes,
     FederationDeniedError,
     HttpResponseException,
+    RequestSendFailed,
     SynapseError,
     UnsupportedRoomVersionError,
 )
@@ -1113,14 +1114,17 @@ class FederationClient(FederationBase):
                 requests over federation
 
         """
-        return await self.transport_layer.get_public_rooms(
-            remote_server,
-            limit,
-            since_token,
-            search_filter,
-            include_all_networks=include_all_networks,
-            third_party_instance_id=third_party_instance_id,
-        )
+        try:
+            return await self.transport_layer.get_public_rooms(
+                remote_server,
+                limit,
+                since_token,
+                search_filter,
+                include_all_networks=include_all_networks,
+                third_party_instance_id=third_party_instance_id,
+            )
+        except (RequestSendFailed, HttpResponseException):
+            raise SynapseError(502, "Failed to fetch room list")
 
     async def get_missing_events(
         self,

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -43,7 +43,6 @@ from synapse.api.errors import (
     Codes,
     FederationDeniedError,
     HttpResponseException,
-    RequestSendFailed,
     SynapseError,
     UnsupportedRoomVersionError,
 )
@@ -1109,22 +1108,20 @@ class FederationClient(FederationBase):
             The response from the remote server.
 
         Raises:
-            HttpResponseException: There was an exception returned from the remote server
+            HttpResponseException / RequestSendFailed: There was an exception
+                returned from the remote server
             SynapseException: M_FORBIDDEN when the remote server has disallowed publicRoom
                 requests over federation
 
         """
-        try:
-            return await self.transport_layer.get_public_rooms(
-                remote_server,
-                limit,
-                since_token,
-                search_filter,
-                include_all_networks=include_all_networks,
-                third_party_instance_id=third_party_instance_id,
-            )
-        except (RequestSendFailed, HttpResponseException):
-            raise SynapseError(502, "Failed to fetch room list")
+        return await self.transport_layer.get_public_rooms(
+            remote_server,
+            limit,
+            since_token,
+            search_filter,
+            include_all_networks=include_all_networks,
+            third_party_instance_id=third_party_instance_id,
+        )
 
     async def get_missing_events(
         self,

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -356,6 +356,12 @@ class RoomListHandler(BaseHandler):
         include_all_networks: bool = False,
         third_party_instance_id: Optional[str] = None,
     ) -> JsonDict:
+        """Get the public room list from remote server
+
+        Raises:
+            SynapseError
+        """
+
         if not self.enable_room_list_search:
             return {"chunk": [], "total_room_count_estimate": 0}
 
@@ -395,13 +401,16 @@ class RoomListHandler(BaseHandler):
             limit = None
             since_token = None
 
-        res = await self._get_remote_list_cached(
-            server_name,
-            limit=limit,
-            since_token=since_token,
-            include_all_networks=include_all_networks,
-            third_party_instance_id=third_party_instance_id,
-        )
+        try:
+            res = await self._get_remote_list_cached(
+                server_name,
+                limit=limit,
+                since_token=since_token,
+                include_all_networks=include_all_networks,
+                third_party_instance_id=third_party_instance_id,
+            )
+        except (RequestSendFailed, HttpResponseException):
+            raise SynapseError(502, "Failed to fetch room list")
 
         if search_filter:
             res = {
@@ -423,6 +432,10 @@ class RoomListHandler(BaseHandler):
         include_all_networks: bool = False,
         third_party_instance_id: Optional[str] = None,
     ) -> JsonDict:
+        """Wrapper around FederationClient.get_public_rooms that caches the
+        result.
+        """
+
         repl_layer = self.hs.get_federation_client()
         if search_filter:
             # We can't cache when asking for search

--- a/synapse/handlers/room_list.py
+++ b/synapse/handlers/room_list.py
@@ -426,17 +426,14 @@ class RoomListHandler(BaseHandler):
         repl_layer = self.hs.get_federation_client()
         if search_filter:
             # We can't cache when asking for search
-            try:
-                return await repl_layer.get_public_rooms(
-                    server_name,
-                    limit=limit,
-                    since_token=since_token,
-                    search_filter=search_filter,
-                    include_all_networks=include_all_networks,
-                    third_party_instance_id=third_party_instance_id,
-                )
-            except (RequestSendFailed, HttpResponseException):
-                raise SynapseError(502, "Failed to fetch room list")
+            return await repl_layer.get_public_rooms(
+                server_name,
+                limit=limit,
+                since_token=since_token,
+                search_filter=search_filter,
+                include_all_networks=include_all_networks,
+                third_party_instance_id=third_party_instance_id,
+            )
 
         key = (
             server_name,

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -23,7 +23,6 @@ from synapse.api.constants import EventContentFields, EventTypes, Membership
 from synapse.api.errors import (
     AuthError,
     Codes,
-    HttpResponseException,
     InvalidClientCredentialsError,
     ShadowBanError,
     SynapseError,
@@ -778,12 +777,9 @@ class PublicRoomListRestServlet(TransactionRestServlet):
                     Codes.INVALID_PARAM,
                 )
 
-            try:
-                data = await handler.get_remote_public_room_list(
-                    server, limit=limit, since_token=since_token
-                )
-            except HttpResponseException as e:
-                raise e.to_synapse_error()
+            data = await handler.get_remote_public_room_list(
+                server, limit=limit, since_token=since_token
+            )
         else:
             data = await handler.get_local_public_room_list(
                 limit=limit, since_token=since_token
@@ -831,17 +827,15 @@ class PublicRoomListRestServlet(TransactionRestServlet):
                     Codes.INVALID_PARAM,
                 )
 
-            try:
-                data = await handler.get_remote_public_room_list(
-                    server,
-                    limit=limit,
-                    since_token=since_token,
-                    search_filter=search_filter,
-                    include_all_networks=include_all_networks,
-                    third_party_instance_id=third_party_instance_id,
-                )
-            except HttpResponseException as e:
-                raise e.to_synapse_error()
+            data = await handler.get_remote_public_room_list(
+                server,
+                limit=limit,
+                since_token=since_token,
+                search_filter=search_filter,
+                include_all_networks=include_all_networks,
+                third_party_instance_id=third_party_instance_id,
+            )
+
         else:
             data = await handler.get_local_public_room_list(
                 limit=limit,


### PR DESCRIPTION
Fixes exceptions:

```
TimeoutError: User timeout caused connection failure.
  File "synapse/http/matrixfederationclient.py", line 575, in _send_request
    response = await request_deferred
  File "twisted/internet/defer.py", line 1658, in _inlineCallbacks
    cast(Failure, result).throwExceptionIntoGenerator, gen
  File "twisted/python/failure.py", line 500, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "synapse/http/federation/matrix_federation_agent.py", line 190, in request
    self._agent.request(method, uri, request_headers, bodyProducer)
  File "twisted/internet/defer.py", line 1658, in _inlineCallbacks
    cast(Failure, result).throwExceptionIntoGenerator, gen
  File "twisted/python/failure.py", line 500, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "synapse/http/federation/matrix_federation_agent.py", line 295, in _do_connect
    raise first_exception
  File "synapse/http/federation/matrix_federation_agent.py", line 282, in _do_connect
    endpoint.connect(protocol_factory)
RequestSendFailed: Failed to send request: TimeoutError: User timeout caused connection failure.
  File "twisted/internet/defer.py", line 1658, in _inlineCallbacks
    cast(Failure, result).throwExceptionIntoGenerator, gen
  File "twisted/python/failure.py", line 500, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "synapse/federation/federation_client.py", line 1122, in get_public_rooms
    third_party_instance_id=third_party_instance_id,
  File "synapse/federation/transport/client.py", line 451, in get_public_rooms
    destination=remote_server, path=path, args=args, ignore_backoff=True
  File "synapse/http/matrixfederationclient.py", line 1013, in get_json
    timeout=timeout,
  File "synapse/http/matrixfederationclient.py", line 391, in _send_request_with_optional_trailing_slash
    response = await self._send_request(request, **send_request_args)
  File "synapse/http/matrixfederationclient.py", line 579, in _send_request
    raise RequestSendFailed(e, can_retry=True) from e
```

Sentry: https://sentry.matrix.org/sentry/synapse-matrixorg/issues/226330