### PR TITLE
Moved homeserver documentation above reverse proxy examples

### DIFF
--- a/changelog.d/10551.doc
+++ b/changelog.d/10551.doc
@@ -1,0 +1,1 @@
+Updated the reverse proxy documentation to highlight the homserver configuration that is needed to make Synapse aware that is is intentionally reverse proxied.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -41,9 +41,9 @@ client IP addresses and generate redirect URLs while behind a reverse proxy.
 
 In `homeserver.yaml` set `x_forwarded: true` in the port 8008 section and 
 consider setting `bind_addresses: ['127.0.0.1']` so that the server only
-listens to traffic on localhost (Do not change `bind_addresses` to `127.0.0.1` 
+listens to traffic on localhost. (Do not change `bind_addresses` to `127.0.0.1` 
 when using a containerized Synapse, as that will prevent it from responding
-to proxied traffic).
+to proxied traffic.)
 
 
 ## Reverse-proxy configuration examples

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -33,6 +33,19 @@ Let's assume that we expect clients to connect to our server at
 `https://example.com:8448`.  The following sections detail the configuration of
 the reverse proxy and the homeserver.
 
+
+## Homeserver Configuration
+
+The HTTP configuration will need to be updated for Synapse to correctly record 
+client IP addresses and generate redirect URLs while behind a reverse proxy. 
+
+In `homeserver.yaml` set `x_forwarded: true` in the port 8008 section and 
+consider setting `bind_addresses: ['127.0.0.1']` so that the server only
+listens to traffic on localhost (Do not change `bind_addresses` to `127.0.0.1` 
+when using a containerized Synapse, as that will prevent it from responding
+to proxied traffic).
+
+
 ## Reverse-proxy configuration examples
 
 **NOTE**: You only need one of these.
@@ -238,16 +251,6 @@ relay "matrix_federation" {
     forward to <matrixserver> port 8008 check tcp
 }
 ```
-
-## Homeserver Configuration
-
-You will also want to set `bind_addresses: ['127.0.0.1']` and
-`x_forwarded: true` for port 8008 in `homeserver.yaml` to ensure that
-client IP addresses are recorded correctly.
-
-Having done so, you can then use `https://matrix.example.com` (instead
-of `https://matrix.example.com:8448`) as the "Custom server" when
-connecting to Synapse from a client.
 
 
 ## Health check endpoint


### PR DESCRIPTION
Move the Synapse reverse proxy homeserver configuration documentation above the reverse proxy examples to highlight the importance of configuring the homeserver to be aware that it is being intentionally reverse proxied.

Documentation update recommended in #10492 

Signed-off-by: Drew Short <warrick@sothr.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
