### PR TITLE
Allow /createRoom to be run on workers

### DIFF
--- a/changelog.d/10564.feature
+++ b/changelog.d/10564.feature
@@ -1,0 +1,1 @@
+Allow creating a room to be handled by worker processes.

--- a/changelog.d/10564.feature
+++ b/changelog.d/10564.feature
@@ -1,1 +1,1 @@
-Allow creating a room to be handled by worker processes.
+Add support for routing `/createRoom` to workers.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -214,6 +214,7 @@ expressions:
     ^/_matrix/federation/v1/send/
 
     # Client API requests
+    ^/_matrix/client/(api/v1|r0|unstable)/createRoom$
     ^/_matrix/client/(api/v1|r0|unstable)/publicRooms$
     ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/joined_members$
     ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/context/.*$

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -1141,10 +1141,10 @@ def register_servlets(hs: "HomeServer", http_server, is_worker=False):
     JoinedRoomsRestServlet(hs).register(http_server)
     RoomAliasListServlet(hs).register(http_server)
     SearchRestServlet(hs).register(http_server)
+    RoomCreateRestServlet(hs).register(http_server)
 
     # Some servlets only get registered for the main process.
     if not is_worker:
-        RoomCreateRestServlet(hs).register(http_server)
         RoomForgetRestServlet(hs).register(http_server)
 
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/7867

As stated in the issue, `/createRoom` could only be run on the main process due to the `public_room_list_stream` only being writable by the main process. It turns out however that this stream was unused - meaning that we could simply rip it out. This unblocked moving `/createRoom` off the main process :tada: It potentially also unblocks moving the Delete Room Admin API - but that's the subject of another PR.

**This PR is based on https://github.com/matrix-org/synapse/pull/10565**, which removes `public_room_list_stream` (just reading/writing to the table - not the table itself, for now). This PR does the job of mounting the endpoint to workers and moving the database method `store_room` to the `RoomWorkerStore`.