### PR TITLE
Support federation in the new spaces summary API (MSC2946)

### DIFF
--- a/changelog.d/10569.feature
+++ b/changelog.d/10569.feature
@@ -1,0 +1,1 @@
+Add pagination to the spaces summary based on updates to [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946).

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -1332,14 +1332,28 @@ class FederationClient(FederationBase):
             if not isinstance(room, dict):
                 raise InvalidResponseError("'room' must be a dict")
 
-            # TODO Validate children_state of the room.
+            # Validate children_state of the room.
+            children_state = room.get("children_state", [])
+            if not isinstance(children_state, Sequence):
+                raise InvalidResponseError("'room.children_state' must be a list")
+            if any(not isinstance(e, dict) for e in children_state):
+                raise InvalidResponseError("Invalid event in 'children_state' list")
+            try:
+                [
+                    FederationSpaceSummaryEventResult.from_json_dict(e)
+                    for e in children_state
+                ]
+            except ValueError as e:
+                raise InvalidResponseError(str(e))
 
+            # Validate the children rooms.
             children = res.get("children", [])
             if not isinstance(children, Sequence):
                 raise InvalidResponseError("'children' must be a list")
             if any(not isinstance(r, dict) for r in children):
                 raise InvalidResponseError("Invalid room in 'children' list")
 
+            # Validate the inaccessible children.
             inaccessible_children = res.get("inaccessible_children", [])
             if not isinstance(inaccessible_children, Sequence):
                 raise InvalidResponseError("'inaccessible_children' must be a list")

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -1290,6 +1290,74 @@ class FederationClient(FederationBase):
             failover_on_unknown_endpoint=True,
         )
 
+    async def get_room_hierarchy(
+        self,
+        destinations: Iterable[str],
+        room_id: str,
+        suggested_only: bool,
+    ) -> Tuple[JsonDict, Sequence[JsonDict], Sequence[str]]:
+        """
+        Call other servers to get a hierarchy of the given room.
+
+        Performs simple data validates and parsing of the response.
+
+        Args:
+            destinations: The remote servers. We will try them in turn, omitting any
+                that have been blacklisted.
+            room_id: ID of the space to be queried
+            suggested_only:  If true, ask the remote server to only return children
+                with the "suggested" flag set
+
+        Returns:
+            A tuple of:
+                The room as a JSON dictionary.
+                A list of children rooms, as JSON dictionaries.
+                A list of inaccessible children room IDs.
+
+        Raises:
+            SynapseError if we were unable to get a valid summary from any of the
+               remote servers
+        """
+
+        async def send_request(
+            destination: str,
+        ) -> Tuple[JsonDict, Sequence[JsonDict], Sequence[str]]:
+            res = await self.transport_layer.get_room_hierarchy(
+                destination=destination,
+                room_id=room_id,
+                suggested_only=suggested_only,
+            )
+
+            room = res.get("room")
+            if not isinstance(room, dict):
+                raise InvalidResponseError("'room' must be a dict")
+
+            # TODO Validate children_state of the room.
+
+            children = res.get("children", [])
+            if not isinstance(children, Sequence):
+                raise InvalidResponseError("'children' must be a list")
+            if any(not isinstance(r, dict) for r in children):
+                raise InvalidResponseError("Invalid room in 'children' list")
+
+            inaccessible_children = res.get("inaccessible_children", [])
+            if not isinstance(inaccessible_children, Sequence):
+                raise InvalidResponseError("'inaccessible_children' must be a list")
+            if any(not isinstance(r, str) for r in inaccessible_children):
+                raise InvalidResponseError(
+                    "Invalid room ID in 'inaccessible_children' list"
+                )
+
+            return room, children, inaccessible_children
+
+        # TODO Fallback to the old federation API and translate the results.
+        return await self._try_destination_list(
+            "fetch room hierarchy",
+            destinations,
+            send_request,
+            failover_on_unknown_endpoint=True,
+        )
+
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class FederationSpaceSummaryEventResult:

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -1177,6 +1177,28 @@ class TransportLayerClient:
             destination=destination, path=path, data=params
         )
 
+    async def get_room_hierarchy(
+        self,
+        destination: str,
+        room_id: str,
+        suggested_only: bool,
+    ) -> JsonDict:
+        """
+        Args:
+            destination: The remote server
+            room_id: The room ID to ask about.
+            suggested_only: if True, only suggested rooms will be returned
+        """
+        path = _create_path(
+            FEDERATION_UNSTABLE_PREFIX, "/org.matrix.msc2946/hierarchy/%s", room_id
+        )
+
+        return await self.client.get_json(
+            destination=destination,
+            path=path,
+            args={"suggested_only": "true" if suggested_only else "false"},
+        )
+
 
 def _create_path(federation_prefix: str, path: str, *args: str) -> str:
     """

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -1936,6 +1936,33 @@ class FederationSpaceSummaryServlet(BaseFederationServlet):
         )
 
 
+class FederationRoomHierarchyServlet(BaseFederationServlet):
+    PREFIX = FEDERATION_UNSTABLE_PREFIX + "/org.matrix.msc2946"
+    PATH = "/hierarchy/(?P<room_id>[^/]*)"
+
+    def __init__(
+        self,
+        hs: HomeServer,
+        authenticator: Authenticator,
+        ratelimiter: FederationRateLimiter,
+        server_name: str,
+    ):
+        super().__init__(hs, authenticator, ratelimiter, server_name)
+        self.handler = hs.get_space_summary_handler()
+
+    async def on_GET(
+        self,
+        origin: str,
+        content: Literal[None],
+        query: Mapping[bytes, Sequence[bytes]],
+        room_id: str,
+    ) -> Tuple[int, JsonDict]:
+        suggested_only = parse_boolean_from_args(query, "suggested_only", default=False)
+        return 200, await self.handler.get_federation_hierarchy(
+            origin, room_id, suggested_only
+        )
+
+
 class RoomComplexityServlet(BaseFederationServlet):
     """
     Indicates to other servers how complex (and therefore likely
@@ -1999,6 +2026,7 @@ FEDERATION_SERVLET_CLASSES: Tuple[Type[BaseFederationServlet], ...] = (
     FederationVersionServlet,
     RoomComplexityServlet,
     FederationSpaceSummaryServlet,
+    FederationRoomHierarchyServlet,
     FederationV1SendKnockServlet,
     FederationMakeKnockServlet,
 )

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -407,6 +407,7 @@ class SpaceSummaryHandler:
                     room_entry = _RoomEntry(
                         queue_entry.room_id, queue_entry.remote_room
                     )
+                # Otherwise, attempt to fetch the room information over federation.
                 else:
                     (
                         room_entry,
@@ -1013,9 +1014,15 @@ class SpaceSummaryHandler:
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class _RoomQueueEntry:
+    # The room ID of this entry.
     room_id: str
+    # The server to query if the room is not known locally.
     via: Sequence[str]
+    # The minimum number of hops necessary to get to this room (compared to the
+    # originally requested room).
     depth: int = 0
+    # The room summary for this room returned via federation. This will only be
+    # used if the room is not known locally (and is not a space).
     remote_room: Optional[JsonDict] = None
 
 

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -526,7 +526,7 @@ class SpaceSummaryHandler:
         children_rooms_result: List[JsonDict] = []
         inaccessible_children: List[str] = []
 
-        # Iterate through each child and potentially add it, but not it's children,
+        # Iterate through each child and potentially add it, but not its children,
         # to the response.
         for child_room in root_room_entry.children:
             room_id = child_room.get("state_key")

--- a/synapse/handlers/space_summary.py
+++ b/synapse/handlers/space_summary.py
@@ -412,7 +412,8 @@ class SpaceSummaryHandler:
                             children_room_entries.get(ev["state_key"]),
                         )
                         for ev in reversed(room_entry.children)
-                        if ev["state_key"] not in inaccessible_children
+                        if ev["type"] == EventTypes.SpaceChild
+                        and ev["state_key"] not in inaccessible_children
                     )
 
         result: JsonDict = {"rooms": rooms_result}

--- a/tests/handlers/test_space_summary.py
+++ b/tests/handlers/test_space_summary.py
@@ -458,7 +458,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
         self.assertNotIn("next_token", result)
 
     def test_invalid_pagination_token(self):
-        """"""
+        """An invalid pagination token, or changing other parameters, shoudl be rejected."""
         room_ids = []
         for i in range(1, 10):
             room = self.helper.create_room_as(self.user, tok=self.token)
@@ -575,6 +575,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
             },
             [
                 {
+                    "type": EventTypes.SpaceChild,
                     "room_id": subspace,
                     "state_key": subroom,
                     "content": {"via": [fed_hostname]},
@@ -731,6 +732,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
             # Place each room in the sub-space.
             [
                 {
+                    "type": EventTypes.SpaceChild,
                     "room_id": subspace,
                     "state_key": room_id,
                     "content": {"via": [fed_hostname]},

--- a/tests/handlers/test_space_summary.py
+++ b/tests/handlers/test_space_summary.py
@@ -558,33 +558,39 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
         subspace = "#subspace:" + fed_hostname
         subroom = "#subroom:" + fed_hostname
 
+        # Generate some good data, and some bad data:
+        #
+        # * Event *back* to the root room.
+        # * Unrelated events / rooms
+        # * Multiple levels of events (in a not-useful order, e.g. grandchild
+        #   events before child events).
+
+        # Note that these entries are brief, but should contain enough info.
+        requested_room_entry = _RoomEntry(
+            subspace,
+            {
+                "room_id": subspace,
+                "world_readable": True,
+                "room_type": RoomTypes.SPACE,
+            },
+            [
+                {
+                    "room_id": subspace,
+                    "state_key": subroom,
+                    "content": {"via": [fed_hostname]},
+                }
+            ],
+        )
+        child_room = {
+            "room_id": subroom,
+            "world_readable": True,
+        }
+
         async def summarize_remote_room(
             _self, room, suggested_only, max_children, exclude_rooms
         ):
-            # Return some good data, and some bad data:
-            #
-            # * Event *back* to the root room.
-            # * Unrelated events / rooms
-            # * Multiple levels of events (in a not-useful order, e.g. grandchild
-            #   events before child events).
-
-            # Note that these entries are brief, but should contain enough info.
             return [
-                _RoomEntry(
-                    subspace,
-                    {
-                        "room_id": subspace,
-                        "world_readable": True,
-                        "room_type": RoomTypes.SPACE,
-                    },
-                    [
-                        {
-                            "room_id": subspace,
-                            "state_key": subroom,
-                            "content": {"via": [fed_hostname]},
-                        }
-                    ],
-                ),
+                requested_room_entry,
                 _RoomEntry(
                     subroom,
                     {
@@ -593,6 +599,9 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
                     },
                 ),
             ]
+
+        async def summarize_remote_room_hiearchy(_self, room, suggested_only):
+            return requested_room_entry, {subroom: child_room}, set()
 
         # Add a room to the space which is on another server.
         self._add_child(self.space, subspace, self.token)
@@ -612,6 +621,15 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
             (subroom, ()),
         ]
         self._assert_rooms(result, expected)
+
+        with mock.patch(
+            "synapse.handlers.space_summary.SpaceSummaryHandler._summarize_remote_room_hiearchy",
+            new=summarize_remote_room_hiearchy,
+        ):
+            result = self.get_success(
+                self.handler.get_room_hierarchy(self.user, self.space)
+            )
+        self._assert_hierarchy(result, expected)
 
     def test_fed_filtering(self):
         """
@@ -634,100 +652,105 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
         # Poke an invite over federation into the database.
         self._poke_fed_invite(invited_room, "@remote:" + fed_hostname)
 
+        # Note that these entries are brief, but should contain enough info.
+        children_rooms = (
+            (
+                public_room,
+                {
+                    "room_id": public_room,
+                    "world_readable": False,
+                    "join_rules": JoinRules.PUBLIC,
+                },
+            ),
+            (
+                knock_room,
+                {
+                    "room_id": knock_room,
+                    "world_readable": False,
+                    "join_rules": JoinRules.KNOCK,
+                },
+            ),
+            (
+                not_invited_room,
+                {
+                    "room_id": not_invited_room,
+                    "world_readable": False,
+                    "join_rules": JoinRules.INVITE,
+                },
+            ),
+            (
+                invited_room,
+                {
+                    "room_id": invited_room,
+                    "world_readable": False,
+                    "join_rules": JoinRules.INVITE,
+                },
+            ),
+            (
+                restricted_room,
+                {
+                    "room_id": restricted_room,
+                    "world_readable": False,
+                    "join_rules": JoinRules.RESTRICTED,
+                    "allowed_spaces": [],
+                },
+            ),
+            (
+                restricted_accessible_room,
+                {
+                    "room_id": restricted_accessible_room,
+                    "world_readable": False,
+                    "join_rules": JoinRules.RESTRICTED,
+                    "allowed_spaces": [self.room],
+                },
+            ),
+            (
+                world_readable_room,
+                {
+                    "room_id": world_readable_room,
+                    "world_readable": True,
+                    "join_rules": JoinRules.INVITE,
+                },
+            ),
+            (
+                joined_room,
+                {
+                    "room_id": joined_room,
+                    "world_readable": False,
+                    "join_rules": JoinRules.INVITE,
+                },
+            ),
+        )
+
+        subspace_room_entry = _RoomEntry(
+            subspace,
+            {
+                "room_id": subspace,
+                "world_readable": True,
+            },
+            # Place each room in the sub-space.
+            [
+                {
+                    "room_id": subspace,
+                    "state_key": room_id,
+                    "content": {"via": [fed_hostname]},
+                }
+                for room_id, _ in children_rooms
+            ],
+        )
+
         async def summarize_remote_room(
             _self, room, suggested_only, max_children, exclude_rooms
         ):
-            # Note that these entries are brief, but should contain enough info.
-            rooms = [
-                _RoomEntry(
-                    public_room,
-                    {
-                        "room_id": public_room,
-                        "world_readable": False,
-                        "join_rules": JoinRules.PUBLIC,
-                    },
-                ),
-                _RoomEntry(
-                    knock_room,
-                    {
-                        "room_id": knock_room,
-                        "world_readable": False,
-                        "join_rules": JoinRules.KNOCK,
-                    },
-                ),
-                _RoomEntry(
-                    not_invited_room,
-                    {
-                        "room_id": not_invited_room,
-                        "world_readable": False,
-                        "join_rules": JoinRules.INVITE,
-                    },
-                ),
-                _RoomEntry(
-                    invited_room,
-                    {
-                        "room_id": invited_room,
-                        "world_readable": False,
-                        "join_rules": JoinRules.INVITE,
-                    },
-                ),
-                _RoomEntry(
-                    restricted_room,
-                    {
-                        "room_id": restricted_room,
-                        "world_readable": False,
-                        "join_rules": JoinRules.RESTRICTED,
-                        "allowed_spaces": [],
-                    },
-                ),
-                _RoomEntry(
-                    restricted_accessible_room,
-                    {
-                        "room_id": restricted_accessible_room,
-                        "world_readable": False,
-                        "join_rules": JoinRules.RESTRICTED,
-                        "allowed_spaces": [self.room],
-                    },
-                ),
-                _RoomEntry(
-                    world_readable_room,
-                    {
-                        "room_id": world_readable_room,
-                        "world_readable": True,
-                        "join_rules": JoinRules.INVITE,
-                    },
-                ),
-                _RoomEntry(
-                    joined_room,
-                    {
-                        "room_id": joined_room,
-                        "world_readable": False,
-                        "join_rules": JoinRules.INVITE,
-                    },
-                ),
+            return [subspace_room_entry] + [
+                # A copy is made of the room data since the allowed_spaces key
+                # is removed.
+                _RoomEntry(child_room[0], dict(child_room[1]))
+                for child_room in children_rooms
             ]
 
-            # Also include the subspace.
-            rooms.insert(
-                0,
-                _RoomEntry(
-                    subspace,
-                    {
-                        "room_id": subspace,
-                        "world_readable": True,
-                    },
-                    # Place each room in the sub-space.
-                    [
-                        {
-                            "room_id": subspace,
-                            "state_key": room.room_id,
-                            "content": {"via": [fed_hostname]},
-                        }
-                        for room in rooms
-                    ],
-                ),
-            )
-            return rooms
+        async def summarize_remote_room_hiearchy(_self, room, suggested_only):
+            return subspace_room_entry, dict(children_rooms), set()
 
         # Add a room to the space which is on another server.
         self._add_child(self.space, subspace, self.token)
@@ -765,6 +788,15 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
         ]
         self._assert_rooms(result, expected)
 
+        with mock.patch(
+            "synapse.handlers.space_summary.SpaceSummaryHandler._summarize_remote_room_hiearchy",
+            new=summarize_remote_room_hiearchy,
+        ):
+            result = self.get_success(
+                self.handler.get_room_hierarchy(self.user, self.space)
+            )
+        self._assert_hierarchy(result, expected)
+
     def test_fed_invited(self):
         """
         A room which the user was invited to should be included in the response.
@@ -779,19 +811,22 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
         # Poke an invite over federation into the database.
         self._poke_fed_invite(fed_room, "@remote:" + fed_hostname)
 
+        fed_room_entry = _RoomEntry(
+            fed_room,
+            {
+                "room_id": fed_room,
+                "world_readable": False,
+                "join_rules": JoinRules.INVITE,
+            },
+        )
+
         async def summarize_remote_room(
             _self, room, suggested_only, max_children, exclude_rooms
         ):
-            return [
-                _RoomEntry(
-                    fed_room,
-                    {
-                        "room_id": fed_room,
-                        "world_readable": False,
-                        "join_rules": JoinRules.INVITE,
-                    },
-                ),
-            ]
+            return [fed_room_entry]
+
+        async def summarize_remote_room_hiearchy(_self, room, suggested_only):
+            return fed_room_entry, {}, set()
 
         # Add a room to the space which is on another server.
         self._add_child(self.space, fed_room, self.token)
@@ -810,3 +845,12 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
             (fed_room, ()),
         ]
         self._assert_rooms(result, expected)
+
+        with mock.patch(
+            "synapse.handlers.space_summary.SpaceSummaryHandler._summarize_remote_room_hiearchy",
+            new=summarize_remote_room_hiearchy,
+        ):
+            result = self.get_success(
+                self.handler.get_room_hierarchy(self.user, self.space)
+            )
+        self._assert_hierarchy(result, expected)


### PR DESCRIPTION
Adds federation APIs (and calls out to them) for the updated spaces summary API.

This should be reviewable commit-by-commit. Sorry for the size of it!

Step 3 in #10495.

~~Builds on #10549 and #10560.~~

See complement tests: matrix-org/complement#190.