### PR TITLE
Clarify error message when joining a restricted room.

### DIFF
--- a/changelog.d/10572.misc
+++ b/changelog.d/10572.misc
@@ -1,0 +1,1 @@
+Clarify error message when failing to join a restricted room.

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -213,7 +213,7 @@ class EventAuthHandler:
 
             raise AuthError(
                 403,
-                "You do not belong to any of the required rooms to join this room.",
+                "You do not belong to any of the required rooms/spaces to join this room.",
             )
 
     async def has_restricted_join_rules(


### PR DESCRIPTION
This clarifies the error message when you attempt to join a restricted room (from MSC3083) that you do not have permission to join. It now mentions both "rooms" and "spaces".

Note that this is shown to users:

![image](https://user-images.githubusercontent.com/517124/128906333-43f89586-b1c3-49b1-bcf9-e7580d1143cd.png)
