### PR TITLE
Query legacy spaces federation API if the hierarchy API is unavailable.

### DIFF
--- a/changelog.d/10583.feature
+++ b/changelog.d/10583.feature
@@ -1,0 +1,1 @@
+Add pagination to the spaces summary based on updates to [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946).


### PR DESCRIPTION
Adds a backwards compatibility path to the room hierarchy federation endpoint by using the `/spaces` endpoint and translating the results (and throwing some of it away).

The reasoning for wanting this is that the new `/hierarchy` federation endpoint will not be available on all servers initially, but we want the C-S endpoint to work as expected. This should allow clients to adopt the new endpoint quickly.

~~Builds on #10569.~~

Part of #10495.

I did some manual testing of this, but I'm not really sure how to make automated tests for this (as I had to manually run two different versions of Synapse, one which knew of the `/hierarchy` endpoint and one which did not).