### PR TITLE
Handle the staged events queue being empty.

### DIFF
--- a/changelog.d/10592.bugfix
+++ b/changelog.d/10592.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.37.1 where an error could occur in the asyncronous processing of PDUs when the queue was empty.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -977,7 +977,7 @@ class FederationServer(FederationBase):
                 latest_origin = None
                 latest_event = None
             else:
-                next_origin, next_event_id  = result
+                next_origin, next_event_id = result
                 if (
                     next_origin != latest_origin
                     or next_event_id != latest_event.event_id

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -972,13 +972,21 @@ class FederationServer(FederationBase):
         # the room, so instead of pulling the event out of the DB and parsing
         # the event we just pull out the next event ID and check if that matches.
         if latest_event is not None and latest_origin is not None:
-            (
-                next_origin,
-                next_event_id,
-            ) = await self.store.get_next_staged_event_id_for_room(room_id)
-            if next_origin != latest_origin or next_event_id != latest_event.event_id:
+            result = await self.store.get_next_staged_event_id_for_room(room_id)
+            if result is None:
                 latest_origin = None
                 latest_event = None
+            else:
+                (
+                    next_origin,
+                    next_event_id,
+                ) = result
+                if (
+                    next_origin != latest_origin
+                    or next_event_id != latest_event.event_id
+                ):
+                    latest_origin = None
+                    latest_event = None
 
         if latest_origin is None or latest_event is None:
             next = await self.store.get_next_staged_event_for_room(

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -977,10 +977,7 @@ class FederationServer(FederationBase):
                 latest_origin = None
                 latest_event = None
             else:
-                (
-                    next_origin,
-                    next_event_id,
-                ) = result
+                next_origin, next_event_id  = result
                 if (
                     next_origin != latest_origin
                     or next_event_id != latest_event.event_id


### PR DESCRIPTION
(I'm not 100% sure the title is correct.)

This attempts to fix https://sentry.matrix.org/sentry/synapse-matrixorg/issues/225383/ by properly handling the return value from `get_next_staged_event_id_for_room`, but I'm not 100% sure it is doing the right thing. :)