### PR TITLE
Manhole: wrap coroutines in `defer.ensureDeferred` automatically

### DIFF
--- a/changelog.d/10602.feature
+++ b/changelog.d/10602.feature
@@ -1,0 +1,1 @@
+The Synapse manhole no longer needs coroutines to be wrapped in `defer.ensureDeferred`.

--- a/docs/manhole.md
+++ b/docs/manhole.md
@@ -67,7 +67,7 @@ This gives a Python REPL in which `hs` gives access to the
 `synapse.server.HomeServer` object - which in turn gives access to many other
 parts of the process.
 
-Note that any call which returns a coroutine will need to be wrapped in `ensureDeferred`.
+Note that, prior to Synapse 1.41, any call which returns a coroutine will need to be wrapped in `ensureDeferred`.
 
 As a simple example, retrieving an event from the database:
 


### PR DESCRIPTION
tested on a test homeserver:

```python
>>> async def hi(): 
...     return 4 
...  
>>> hi() 
<Deferred at 0x7f8023392bb0 current result: 4> 

>>> hs.get_datastore().get_event('$1416420717069yeQaw:matrix.org') 
<Deferred #0> 
Deferred #0 failed: '404: Could not find event $1416420717069yeQaw:matrix.org' 

>>> hs.get_datastore().get_users() 
<Deferred #1> 
Deferred #1 called back: []
```