### PR TITLE
Stop setting the outlier flag for things that aren't

### DIFF
--- a/changelog.d/10614.misc
+++ b/changelog.d/10614.misc
@@ -1,0 +1,1 @@
+Clean up some of the federation event authentication code for clarity.


### PR DESCRIPTION
Marking things as outliers to inhibit pushes is a sledgehammer to crack a
nut. Move the test further down the stack so that we just inhibit the thing we
want.