### PR TITLE
Always list fallback key types in /sync

### DIFF
--- a/changelog.d/10623.bugfix
+++ b/changelog.d/10623.bugfix
@@ -1,0 +1,1 @@
+Revert behaviour introduced in v1.38.0 that strips `org.matrix.msc2732.device_unused_fallback_key_types` from `/sync` when its value is empty. This field should instead always be present according to [MSC2732](https://github.com/matrix-org/matrix-doc/blob/master/proposals/2732-olm-fallback-keys.md).

--- a/synapse/rest/client/v2_alpha/sync.py
+++ b/synapse/rest/client/v2_alpha/sync.py
@@ -259,10 +259,11 @@ class SyncRestServlet(RestServlet):
         # Corresponding synapse issue: https://github.com/matrix-org/synapse/issues/10456
         response["device_one_time_keys_count"] = sync_result.device_one_time_keys_count
 
-        if sync_result.device_unused_fallback_key_types:
-            response[
-                "org.matrix.msc2732.device_unused_fallback_key_types"
-            ] = sync_result.device_unused_fallback_key_types
+        # https://github.com/matrix-org/matrix-doc/blob/54255851f642f84a4f1aaf7bc063eebe3d76752b/proposals/2732-olm-fallback-keys.md
+        # states that this field should always be included, as long as the server supports the feature.
+        response[
+            "org.matrix.msc2732.device_unused_fallback_key_types"
+        ] = sync_result.device_unused_fallback_key_types
 
         if joined:
             response["rooms"][Membership.JOIN] = joined


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/10618

https://github.com/matrix-org/synapse/pull/9919 removed optional keys from `/sync`, though it was missed that `org.matrix.msc2732.device_unused_fallback_key_types` should always be included down `/sync` in accordance with [MSC2732](https://github.com/matrix-org/matrix-doc/blob/54255851f642f84a4f1aaf7bc063eebe3d76752b/proposals/2732-olm-fallback-keys.md).

This PR reintroduces the behaviour of always including the key.