### PR TITLE
Fix typo in release notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,7 +48,7 @@ Improved Documentation
 Deprecations and Removals
 -------------------------
 
-- No longer build `.deb` packages for Ubuntu 20.10 LTS Groovy Gorilla, which has now EOLed. ([\#10588](https://github.com/matrix-org/synapse/issues/10588))
+- No longer build `.deb` packages for Ubuntu 20.10 Groovy Gorilla, which has now EOLed. ([\#10588](https://github.com/matrix-org/synapse/issues/10588))
 - The `template_dir` configuration settings in the `sso`, `account_validity` and `email` sections of the configuration file are now deprecated in favour of the global `templates.custom_template_directory` setting. See the [upgrade notes](https://matrix-org.github.io/synapse/latest/upgrade.html) for more information. ([\#10596](https://github.com/matrix-org/synapse/issues/10596))
 
 


### PR DESCRIPTION
Ubuntu 20.10 was not an LTS release

Signed-off-by: John-Scott Atlakson <24574+jsma@users.noreply.github.com>