### PR TITLE
Run a nightly CI build against Twisted trunk.

### DIFF
--- a/.ci/patch_for_twisted_trunk.sh
+++ b/.ci/patch_for_twisted_trunk.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# replaces the dependency on Twisted in `python_dependencies` with trunk.
+
+set -e
+cd "$(dirname "$0")"/..
+
+sed -i -e 's#"Twisted.*"#"Twisted @ git+https://github.com/twisted/twisted"#' synapse/python_dependencies.py

--- a/.ci/twisted_trunk_build_failed_issue_template.md
+++ b/.ci/twisted_trunk_build_failed_issue_template.md
@@ -1,0 +1,4 @@
+----
+title: CI run against Twisted trunk is failing
+----
+See https://github.com/{{GITHUB_REPOSITORY}}/actions/runs/{{GITHUB_RUN_ID}}

--- a/.ci/twisted_trunk_build_failed_issue_template.md
+++ b/.ci/twisted_trunk_build_failed_issue_template.md
@@ -1,4 +1,4 @@
 ---
 title: CI run against Twisted trunk is failing
 ---
-See https://github.com/{{GITHUB_REPOSITORY}}/actions/runs/{{GITHUB_RUN_ID}}
+See https://github.com/{{env.GITHUB_REPOSITORY}}/actions/runs/{{env.GITHUB_RUN_ID}}

--- a/.ci/twisted_trunk_build_failed_issue_template.md
+++ b/.ci/twisted_trunk_build_failed_issue_template.md
@@ -1,4 +1,4 @@
-----
+---
 title: CI run against Twisted trunk is failing
-----
+---
 See https://github.com/{{GITHUB_REPOSITORY}}/actions/runs/{{GITHUB_RUN_ID}}

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -24,13 +24,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - run: sudo apt-get -qq install xmlsec1
       - uses: actions/setup-python@v2
         with:
           python-version: 3.6
-          
       - run: .ci/patch_for_twisted_trunk.sh
       - run: pip install tox
       - run: tox -e py
+        env:
+          TRIAL_FLAGS: "--jobs=2"
 
       - name: Dump logs
         # Note: Dumps to workflow logs instead of using actions/upload-artifact

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -6,6 +6,8 @@ on:
 
   workflow_dispatch:
 
+  push:
+
 jobs:
   mypy:
     runs-on: ubuntu-latest
@@ -14,9 +16,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: |
+          .ci/patch_for_twisted_trunk.sh
           pip install tox
-          tox --notest -e mypy
-          .tox/env/mypy/bin/pip install git+https://github.com/twisted/twisted
           tox -e mypy
 
   trial:
@@ -29,9 +30,8 @@ jobs:
           python-version: 3.6
           
       - run: |
+          .ci/patch_for_twisted_trunk.sh
           pip install tox
-          tox --notest -e py
-          .tox/env/mypy/bin/pip install git+https://github.com/twisted/twisted
           tox -e py
 
       - name: Dump logs
@@ -48,8 +48,27 @@ jobs:
   sytest:
     runs-on: ubuntu-latest
     container:
-        image: matrixdotorg/sytest-synapse:bionic
+      image: matrixdotorg/sytest-synapse:bullseye
+      volumes:
+        - ${{ github.workspace }}:/src
 
     steps:
       - uses: actions/checkout@v2
+      - name: Patch dependencies
+        run: .ci/patch_for_twisted_trunk.sh
+        working-directory: /src
+      - name: Run SyTest
+        run: /bootstrap.sh synapse
+        working-directory: /src
+      - name: Summarise results.tap
+        if: ${{ always() }}
+        run: /sytest/scripts/tap_to_gha.pl /logs/results.tap
+      - name: Upload SyTest logs
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: Sytest Logs - ${{ job.status }} - (${{ join(matrix.*, ', ') }})
+          path: |
+            /logs/results.tap
+            /logs/**/*.log*
         

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -15,10 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: |
-          .ci/patch_for_twisted_trunk.sh
-          pip install tox
-          tox -e mypy
+      - run: .ci/patch_for_twisted_trunk.sh
+      - run: pip install tox
+      - run: tox -e mypy
 
   trial:
     runs-on: ubuntu-latest
@@ -29,10 +28,9 @@ jobs:
         with:
           python-version: 3.6
           
-      - run: |
-          .ci/patch_for_twisted_trunk.sh
-          pip install tox
-          tox -e py
+      - run: .ci/patch_for_twisted_trunk.sh
+      - run: pip install tox
+      - run: tox -e py
 
       - name: Dump logs
         # Note: Dumps to workflow logs instead of using actions/upload-artifact
@@ -48,7 +46,7 @@ jobs:
   sytest:
     runs-on: ubuntu-latest
     container:
-      image: matrixdotorg/sytest-synapse:bullseye
+      image: matrixdotorg/sytest-synapse:buster
       volumes:
         - ${{ github.workspace }}:/src
 

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - run: false
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: .ci/patch_for_twisted_trunk.sh

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - run: false
       - uses: actions/checkout@v2
       - run: sudo apt-get -qq install xmlsec1
       - uses: actions/setup-python@v2
@@ -54,6 +55,7 @@ jobs:
         - ${{ github.workspace }}:/src
 
     steps:
+      - run: false
       - uses: actions/checkout@v2
       - name: Patch dependencies
         run: .ci/patch_for_twisted_trunk.sh

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -86,6 +86,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -1,0 +1,55 @@
+name: Twisted Trunk
+
+on:
+  schedule:
+    - cron: 0 8 * * *
+
+  workflow_dispatch:
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: |
+          pip install tox
+          tox --notest -e mypy
+          .tox/env/mypy/bin/pip install git+https://github.com/twisted/twisted
+          tox -e mypy
+
+  trial:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+          
+      - run: |
+          pip install tox
+          tox --notest -e py
+          .tox/env/mypy/bin/pip install git+https://github.com/twisted/twisted
+          tox -e py
+
+      - name: Dump logs
+        # Note: Dumps to workflow logs instead of using actions/upload-artifact
+        #       This keeps logs colocated with failing jobs
+        #       It also ignores find's exit code; this is a best effort affair
+        run: >-
+          find _trial_temp -name '*.log'
+          -exec echo "::group::{}" \;
+          -exec cat {} \;
+          -exec echo "::endgroup::" \;
+          || true
+
+  sytest:
+    runs-on: ubuntu-latest
+    container:
+        image: matrixdotorg/sytest-synapse:bionic
+
+    steps:
+      - uses: actions/checkout@v2
+        

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -87,4 +87,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          filename: .ci/twisted_trunk_build_failed_template.md
+          filename: .ci/twisted_trunk_build_failed_issue_template.md

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -71,4 +71,20 @@ jobs:
           path: |
             /logs/results.tap
             /logs/**/*.log*
-        
+
+  # open an issue if the build fails, so we know about it.
+  open-issue:
+    if: failure()
+    needs:
+      - mypy
+      - trial
+      - sytest
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .ci/twisted_trunk_build_failed_template.md

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -6,14 +6,11 @@ on:
 
   workflow_dispatch:
 
-  push:
-
 jobs:
   mypy:
     runs-on: ubuntu-latest
 
     steps:
-      - run: false
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: .ci/patch_for_twisted_trunk.sh
@@ -24,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - run: false
       - uses: actions/checkout@v2
       - run: sudo apt-get -qq install xmlsec1
       - uses: actions/setup-python@v2
@@ -55,7 +51,6 @@ jobs:
         - ${{ github.workspace }}:/src
 
     steps:
-      - run: false
       - uses: actions/checkout@v2
       - name: Patch dependencies
         run: .ci/patch_for_twisted_trunk.sh

--- a/changelog.d/10651.misc
+++ b/changelog.d/10651.misc
@@ -1,0 +1,1 @@
+Run a nightly CI build against Twisted trunk.


### PR DESCRIPTION
This creates a GHA workflow which runs at 8am every day, and runs `mypy`, `trial` and `sytest` against Twisted's current trunk. If any of the jobs fail, it opens an issue.

See https://github.com/matrix-org/synapse/actions/runs/1144688011 for an example of a successful run, and https://github.com/matrix-org/synapse/issues/10650 for what happens when the build fails.

Fixes: #10340.