### PR TITLE
Log exceptions in tests to stderr

### DIFF
--- a/changelog.d/10657.misc
+++ b/changelog.d/10657.misc
@@ -1,1 +1,1 @@
-Log exceptions in tests to stderr.
+Log errors in tests to stderr.

--- a/changelog.d/10657.misc
+++ b/changelog.d/10657.misc
@@ -1,0 +1,1 @@
+Log exceptions in tests to stderr.

--- a/tests/test_utils/logging_setup.py
+++ b/tests/test_utils/logging_setup.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import os
+import sys
 
 import twisted.logger
 
@@ -35,7 +36,8 @@ class ToTwistedHandler(logging.Handler):
 def setup_logging():
     """Configure the python logging appropriately for the tests.
 
-    (Logs will end up in _trial_temp.)
+    Logs will end up in _trial_temp. Exceptions are additionally
+    logged to stderr.
     """
     root_logger = logging.getLogger()
 
@@ -44,11 +46,16 @@ def setup_logging():
         "%(levelname)s - %(request)s - %(message)s"
     )
 
-    handler = ToTwistedHandler()
+    to_twisted_handler = ToTwistedHandler()
     formatter = logging.Formatter(log_format)
-    handler.setFormatter(formatter)
-    handler.addFilter(LoggingContextFilter())
-    root_logger.addHandler(handler)
+    to_twisted_handler.setFormatter(formatter)
+    to_twisted_handler.addFilter(LoggingContextFilter())
+    root_logger.addHandler(to_twisted_handler)
+
+    exception_handler = logging.StreamHandler(sys.stderr)
+    exception_handler.setLevel(logging.ERROR)
+    exception_handler.setFormatter(formatter)
+    root_logger.addHandler(exception_handler)
 
     log_level = os.environ.get("SYNAPSE_TEST_LOG_LEVEL", "ERROR")
     root_logger.setLevel(log_level)

--- a/tests/test_utils/logging_setup.py
+++ b/tests/test_utils/logging_setup.py
@@ -36,7 +36,7 @@ class ToTwistedHandler(logging.Handler):
 def setup_logging():
     """Configure the python logging appropriately for the tests.
 
-    Logs will end up in _trial_temp. Exceptions are additionally
+    Logs will end up in _trial_temp. Errors are additionally
     logged to stderr.
     """
     root_logger = logging.getLogger()
@@ -45,17 +45,19 @@ def setup_logging():
         "%(asctime)s - %(name)s - %(lineno)d - "
         "%(levelname)s - %(request)s - %(message)s"
     )
+    formatter = logging.Formatter(log_format)
+    filter = LoggingContextFilter()
 
     to_twisted_handler = ToTwistedHandler()
-    formatter = logging.Formatter(log_format)
     to_twisted_handler.setFormatter(formatter)
-    to_twisted_handler.addFilter(LoggingContextFilter())
+    to_twisted_handler.addFilter(filter)
     root_logger.addHandler(to_twisted_handler)
 
-    exception_handler = logging.StreamHandler(sys.stderr)
-    exception_handler.setLevel(logging.ERROR)
-    exception_handler.setFormatter(formatter)
-    root_logger.addHandler(exception_handler)
+    error_handler = logging.StreamHandler(sys.stderr)
+    error_handler.setLevel(logging.ERROR)
+    error_handler.setFormatter(formatter)
+    error_handler.addFilter(filter)
+    root_logger.addHandler(error_handler)
 
     log_level = os.environ.get("SYNAPSE_TEST_LOG_LEVEL", "ERROR")
     root_logger.setLevel(log_level)


### PR DESCRIPTION
This makes it easy to see errors in background processes when you're
writing unit tests. Otherwise, you have to know/remember to look at the
test logs in `_trial_temp`.