### PR TITLE
GHA: reintroduce an env var for `$GITHUB_HEAD_REF`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -192,6 +192,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/src
       env:
+        SYTEST_BRANCH: ${{ github.head_ref }}
         POSTGRES: ${{ matrix.postgres && 1}}
         MULTI_POSTGRES: ${{ (matrix.postgres == 'multi-postgres') && 1}}
         WORKERS: ${{ matrix.workers && 1 }}

--- a/changelog.d/10659.misc
+++ b/changelog.d/10659.misc
@@ -1,0 +1,1 @@
+Fix GitHub Actions config so we can run sytest on synapse from parallel branches.


### PR DESCRIPTION
This should checkout the dmr/cross-repo-branches sytest branch and run that against this

Requires the bootstrap.sh in the docker container used for sytest to have this change: https://github.com/matrix-org/sytest/pull/1123