### PR TITLE
Do not include stack traces for known exceptions when trying multiple federation destinations.

### DIFF
--- a/changelog.d/10662.misc
+++ b/changelog.d/10662.misc
@@ -1,0 +1,1 @@
+Do not print out stack traces for network errors when fetching data over federation.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -43,6 +43,7 @@ from synapse.api.errors import (
     Codes,
     FederationDeniedError,
     HttpResponseException,
+    RequestSendFailed,
     SynapseError,
     UnsupportedRoomVersionError,
 )
@@ -558,7 +559,11 @@ class FederationClient(FederationBase):
 
             try:
                 return await callback(destination)
-            except InvalidResponseError as e:
+            except (
+                RequestSendFailed,
+                InvalidResponseError,
+                NotRetryingDestination,
+            ) as e:
                 logger.warning("Failed to %s via %s: %s", description, destination, e)
             except UnsupportedRoomVersionError:
                 raise


### PR DESCRIPTION
This catches more "known" exceptions (generally network exceptions) and doesn't print out the entire stack trace when using `_try_destination_list`.

Fixes #10026