### PR TITLE
Only process replacement from `check_event_allowed` module callbacks after calling every callback

### DIFF
--- a/changelog.d/10682.misc
+++ b/changelog.d/10682.misc
@@ -1,0 +1,1 @@
+Only process replacement from `check_event_allowed` module callbacks after calling every callback.

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -328,7 +328,6 @@ class ThirdPartyRulesTestCase(unittest.HomeserverTestCase):
         """
         self.helper.create_room_as(self.user_id, tok=self.tok, expect_code=403)
 
-    @unittest.DEBUG
     def test_replacing_does_not_skip(self):
         """Tests that returning replacement content for an event in a check_event_allowed
         callback doesn't skip subsequent callbacks.

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -333,6 +333,7 @@ class ThirdPartyRulesTestCase(unittest.HomeserverTestCase):
         """Tests that returning replacement content for an event in a check_event_allowed
         callback doesn't skip subsequent callbacks.
         """
+
         async def replace(
             event: EventBase,
             state_events: StateMap[EventBase],
@@ -367,7 +368,9 @@ class ThirdPartyRulesTestCase(unittest.HomeserverTestCase):
 
         # Add the callbacks to the internal list.
         self.hs.get_third_party_event_rules()._check_event_allowed_callbacks = [
-            callback_replace, callback_more_replace, callback_allow_no_replace,
+            callback_replace,
+            callback_more_replace,
+            callback_allow_no_replace,
         ]
 
         # Send and get the event.


### PR DESCRIPTION
I haven't updated the documentation on this callback because I believe this would be the most logical way to handle this, but I'm happy to do it if the reviewer disagree.