### PR TITLE
In `_purge_history_txn`, ensure that txn.fetchall has elements before accessing rows

### DIFF
--- a/changelog.d/10690.bugfix
+++ b/changelog.d/10690.bugfix
@@ -1,1 +1,1 @@
-Ensure that a room has forward extremities before attempting to purging historical events.
+Fix a long-standing bug that caused an `AssertionError` when purging history in certain rooms. Contributed by @Kokokokoka.

--- a/changelog.d/10690.bugfix
+++ b/changelog.d/10690.bugfix
@@ -1,1 +1,1 @@
-Ensure that txn.fetchall has elements before accessing rows in  _purge_history_txn
+Ensure that a room has forward extremities before attempting to purging historical events.

--- a/changelog.d/10690.bugfix
+++ b/changelog.d/10690.bugfix
@@ -1,0 +1,1 @@
+Ensure that txn.fetchall has elements before accessing rows in  _purge_history_txn

--- a/synapse/storage/databases/main/purge_events.py
+++ b/synapse/storage/databases/main/purge_events.py
@@ -102,8 +102,8 @@ class PurgeEventsStore(StateGroupWorkerStore, CacheInvalidationWorkerStore):
             (room_id,),
         )
         rows = txn.fetchall()
-        # if we already have no forwards extremities (for example because they were 
-        # cleared out by the `delete_old_current_state_events` background database 
+        # if we already have no forwards extremities (for example because they were
+        # cleared out by the `delete_old_current_state_events` background database
         # update), then we may as well carry on.
         if rows:
             max_depth = max(row[1] for row in rows)

--- a/synapse/storage/databases/main/purge_events.py
+++ b/synapse/storage/databases/main/purge_events.py
@@ -102,6 +102,9 @@ class PurgeEventsStore(StateGroupWorkerStore, CacheInvalidationWorkerStore):
             (room_id,),
         )
         rows = txn.fetchall()
+        # if we already have no forwards extremities (for example because they were 
+        # cleared out by the `delete_old_current_state_events` background database 
+        # update), then we may as well carry on.
         if rows:
             max_depth = max(row[1] for row in rows)
 

--- a/synapse/storage/databases/main/purge_events.py
+++ b/synapse/storage/databases/main/purge_events.py
@@ -110,7 +110,7 @@ class PurgeEventsStore(StateGroupWorkerStore, CacheInvalidationWorkerStore):
                 # otherwise we wouldn't be able to send any events (due to not
                 # having any backwards extremities)
                 raise SynapseError(
-                    400, "topological_ordering is greater than forward extremeties"
+                    400, "topological_ordering is greater than forward extremities"
                 )
 
         logger.info("[purge] looking for events to delete")

--- a/synapse/storage/databases/main/purge_events.py
+++ b/synapse/storage/databases/main/purge_events.py
@@ -102,15 +102,16 @@ class PurgeEventsStore(StateGroupWorkerStore, CacheInvalidationWorkerStore):
             (room_id,),
         )
         rows = txn.fetchall()
-        max_depth = max(row[1] for row in rows)
+        if rows:
+            max_depth = max(row[1] for row in rows)
 
-        if max_depth < token.topological:
-            # We need to ensure we don't delete all the events from the database
-            # otherwise we wouldn't be able to send any events (due to not
-            # having any backwards extremities)
-            raise SynapseError(
-                400, "topological_ordering is greater than forward extremeties"
-            )
+            if max_depth < token.topological:
+                # We need to ensure we don't delete all the events from the database
+                # otherwise we wouldn't be able to send any events (due to not
+                # having any backwards extremities)
+                raise SynapseError(
+                    400, "topological_ordering is greater than forward extremeties"
+                )
 
         logger.info("[purge] looking for events to delete")
 


### PR DESCRIPTION
This change adds a check for row existence before accessing row element, this should fix issue #10669
Signed-off-by: Vasya Boytsov <vasiliy.boytsov@phystech.edu>
