### PR TITLE
Prevent local user profiles leaking when a "per-room profile" is changed

### DIFF
--- a/changelog.d/10695.bugfix
+++ b/changelog.d/10695.bugfix
@@ -1,1 +1,1 @@
-Stop leaking per-room nicknames and avatars for users on this homeserver. NB: synapse can still leak nicknames and avatars of users from *other* homeservers.
+Fixed one case of leaking per-room nicknames and avatar to the user directory, pending further work to tackle other cases.

--- a/changelog.d/10695.bugfix
+++ b/changelog.d/10695.bugfix
@@ -1,1 +1,1 @@
-TODO write a proper changelog dmr.
+Stop leaking per-room nicknames and avatars for users on this homeserver. NB: synapse can still leak nicknames and avatars of users from *other* homeservers.

--- a/changelog.d/10695.bugfix
+++ b/changelog.d/10695.bugfix
@@ -1,1 +1,1 @@
-Fixed one case of leaking per-room nicknames and avatar to the user directory, pending further work to tackle other cases.
+Fix leaking per-room nicknames and avatars to the user directory for local users when they update their per-room nickname or avatar.

--- a/changelog.d/10695.bugfix
+++ b/changelog.d/10695.bugfix
@@ -1,0 +1,1 @@
+TODO write a proper changelog dmr.

--- a/changelog.d/10762.bugfix
+++ b/changelog.d/10762.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where reactivated users would be missing from the user directory.

--- a/changelog.d/10762.bugfix
+++ b/changelog.d/10762.bugfix
@@ -1,1 +1,0 @@
-Fix a bug where reactivated users would be missing from the user directory.

--- a/docs/user_directory.md
+++ b/docs/user_directory.md
@@ -17,8 +17,7 @@ Data model
 There are five relevant tables:
 
 * `user_directory`. This contains the user_id, display name and avatar we'll
-  return when you search the directory. For some reason the `user_directory`
-  also tracks a room_id.
+  return when you search the directory.
   - Because there's only one directory entry per user, it's important that we only
     ever put publicly visible names here. Otherwise we might leak a private
     nickname or avatar used in a private room.
@@ -37,6 +36,6 @@ There are five relevant tables:
 * `users_in_public_rooms`. Contains associations between users and the public rooms they're in.
   Used to determine which users are in public rooms and should be publicly visible in the directory.
 
-* `users_who_share_private_rooms`. Rows are triples `(L, U, room id)` where `L`
-   is a local user and `R` is a local or remote user. `L` and `R` should be
+* `users_who_share_private_rooms`. Rows are triples `(L, M, room id)` where `L`
+   is a local user and `M` is a local or remote user. `L` and `M` should be
    different, but this isn't enforced by a constraint.

--- a/docs/user_directory.md
+++ b/docs/user_directory.md
@@ -10,3 +10,32 @@ DB corruption) get stale or out of sync.  If this happens, for now the
 solution to fix it is to execute the SQL [here](https://github.com/matrix-org/synapse/blob/master/synapse/storage/schema/main/delta/53/user_dir_populate.sql)
 and then restart synapse. This should then start a background task to
 flush the current tables and regenerate the directory.
+
+Data model
+----------
+
+There are five relevant tables:
+
+* `user_directory`. This contains the user_id, display name and avatar we'll
+  return when you search the directory. For some reason the `user_directory`
+  also tracks a room_id.
+  - Because there's only one directory entry per user, it's important that we only
+    ever put publicly visible names here. Otherwise we might leak a private
+    nickname or avatar used in a private room.
+  - Indexed on rooms. Indexed on users.
+
+* `user_directory_search`. To be joined to `user_directory`. It contains an extra
+  column that enables full text search based on user ids and display names.
+  Different schemas for sqlite and postgres with different code paths to match.
+  - Indexed on the full text search data. Indexed on users.
+
+* `user_directory_stream_pos`. When the initial background update to populate
+  the directory is complete, we record a stream position here. This indicates
+  that synapse should now listen for room changes and incrementally update
+  the directory where necessary.
+
+* `users_in_public_rooms`. Tracks both users and which rooms they're in.
+
+* `users_who_share_private_rooms`. Rows are triples `(L, U, room id)` where `L`
+   is a local user and `R` is a local or remote user. `L` and `R` should be
+   different, but this isn't enforced by a constraint.

--- a/docs/user_directory.md
+++ b/docs/user_directory.md
@@ -26,7 +26,7 @@ There are five relevant tables:
 
 * `user_directory_search`. To be joined to `user_directory`. It contains an extra
   column that enables full text search based on user ids and display names.
-  Different schemas for sqlite and postgres with different code paths to match.
+  Different schemas for SQLite and Postgres with different code paths to match.
   - Indexed on the full text search data. Indexed on users.
 
 * `user_directory_stream_pos`. When the initial background update to populate
@@ -34,7 +34,8 @@ There are five relevant tables:
   that synapse should now listen for room changes and incrementally update
   the directory where necessary.
 
-* `users_in_public_rooms`. Tracks both users and which rooms they're in.
+* `users_in_public_rooms`. Contains associations between users and the public rooms they're in.
+  Used to determine which users are in public rooms and should be publicly visible in the directory.
 
 * `users_who_share_private_rooms`. Rows are triples `(L, U, room id)` where `L`
    is a local user and `R` is a local or remote user. `L` and `R` should be

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -255,13 +255,16 @@ class DeactivateAccountHandler(BaseHandler):
         Args:
             user_id: ID of user to be re-activated
         """
-        # Add the user to the directory, if necessary.
         user = UserID.from_string(user_id)
-        profile = await self.store.get_profileinfo(user.localpart)
-        await self.user_directory_handler.handle_local_profile_change(user_id, profile)
 
         # Ensure the user is not marked as erased.
         await self.store.mark_user_not_erased(user_id)
 
         # Mark the user as active.
         await self.store.set_user_deactivated_status(user_id, False)
+
+        # Add the user to the directory, if necessary. Note that
+        # this must be done after the user is re-activated, because
+        # deactivated users are excluded from the user directory.
+        profile = await self.store.get_profileinfo(user.localpart)
+        await self.user_directory_handler.handle_local_profile_change(user_id, profile)

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -248,7 +248,7 @@ class DeactivateAccountHandler(BaseHandler):
         This marks the user as active and not erased in the database, but does
         not attempt to rejoin rooms, re-add threepids, etc.
 
-        If enabled, the user will be re-added to the user directory.
+        The user will be re-added to the user directory.
 
         The user will also need a password hash set to actually login.
 
@@ -257,9 +257,8 @@ class DeactivateAccountHandler(BaseHandler):
         """
         # Add the user to the directory, if necessary.
         user = UserID.from_string(user_id)
-        if self.hs.config.user_directory_search_all_users:
-            profile = await self.store.get_profileinfo(user.localpart)
-            await self.user_directory_handler.handle_local_profile_change(user_id, profile)
+        profile = await self.store.get_profileinfo(user.localpart)
+        await self.user_directory_handler.handle_local_profile_change(user_id, profile)
 
         # Ensure the user is not marked as erased.
         await self.store.mark_user_not_erased(user_id)

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -131,7 +131,7 @@ class DeactivateAccountHandler(BaseHandler):
         await self.store.add_user_pending_deactivation(user_id)
 
         # delete from user directory
-        await self.user_directory_handler.handle_user_deactivated(user_id)
+        await self.user_directory_handler.handle_local_user_deactivated(user_id)
 
         # Mark the user as erased, if they asked for that
         if erase_data:
@@ -259,9 +259,7 @@ class DeactivateAccountHandler(BaseHandler):
         user = UserID.from_string(user_id)
         if self.hs.config.user_directory_search_all_users:
             profile = await self.store.get_profileinfo(user.localpart)
-            await self.user_directory_handler.handle_local_profile_change(
-                user_id, profile
-            )
+            await self.user_directory_handler.handle_local_profile_change(user_id, profile)
 
         # Ensure the user is not marked as erased.
         await self.store.mark_user_not_erased(user_id)

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -255,16 +255,13 @@ class DeactivateAccountHandler(BaseHandler):
         Args:
             user_id: ID of user to be re-activated
         """
+        # Add the user to the directory, if necessary.
         user = UserID.from_string(user_id)
+        profile = await self.store.get_profileinfo(user.localpart)
+        await self.user_directory_handler.handle_local_profile_change(user_id, profile)
 
         # Ensure the user is not marked as erased.
         await self.store.mark_user_not_erased(user_id)
 
         # Mark the user as active.
         await self.store.set_user_deactivated_status(user_id, False)
-
-        # Add the user to the directory, if necessary. Note that
-        # this must be done after the user is re-activated, because
-        # deactivated users are excluded from the user directory.
-        profile = await self.store.get_profileinfo(user.localpart)
-        await self.user_directory_handler.handle_local_profile_change(user_id, profile)

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -214,11 +214,10 @@ class ProfileHandler(BaseHandler):
             target_user.localpart, displayname_to_set
         )
 
-        if self.hs.config.user_directory_search_all_users:
-            profile = await self.store.get_profileinfo(target_user.localpart)
-            await self.user_directory_handler.handle_local_profile_change(
-                target_user.to_string(), profile
-            )
+        profile = await self.store.get_profileinfo(target_user.localpart)
+        await self.user_directory_handler.handle_local_profile_change(
+            target_user.to_string(), profile
+        )
 
         await self._update_join_states(requester, target_user)
 
@@ -300,11 +299,10 @@ class ProfileHandler(BaseHandler):
             target_user.localpart, avatar_url_to_set
         )
 
-        if self.hs.config.user_directory_search_all_users:
-            profile = await self.store.get_profileinfo(target_user.localpart)
-            await self.user_directory_handler.handle_local_profile_change(
-                target_user.to_string(), profile
-            )
+        profile = await self.store.get_profileinfo(target_user.localpart)
+        await self.user_directory_handler.handle_local_profile_change(
+            target_user.to_string(), profile
+        )
 
         await self._update_join_states(requester, target_user)
 

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -289,11 +289,10 @@ class RegistrationHandler(BaseHandler):
                 shadow_banned=shadow_banned,
             )
 
-            if self.hs.config.user_directory_search_all_users:
-                profile = await self.store.get_profileinfo(localpart)
-                await self.user_directory_handler.handle_local_profile_change(
-                    user_id, profile
-                )
+            profile = await self.store.get_profileinfo(localpart)
+            await self.user_directory_handler.handle_local_profile_change(
+                user_id, profile
+            )
 
         else:
             # autogen a sequential user ID

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -376,11 +376,14 @@ class UserDirectoryHandler(StateDeltasHandler):
 
     async def _handle_remove_user(self, room_id: str, user_id: str) -> None:
         """Called in two cases:
-        - when the given user has left the room
-        - we can no longer see that the given user is in this room.
+        1. The given user has left the given room.
+        2. The last local user (someone else) just left the given room. So
+           so everyone else in the room is remote. We may no longer need to
+           include the given user (`user_id`) in the directory.
 
         Args:
-            room_id: The room ID which the given user was in
+            user_id: The user we may need to remove from the directory
+            room_id: The room which someone just left
         """
         logger.debug("Removing user %r", user_id)
 

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -341,11 +341,13 @@ class UserDirectoryHandler(StateDeltasHandler):
             room_id: The room ID that user joined or started being public
             user_id
         """
-        logger.debug("Adding new user to dir, %r", user_id)
-
-        await self.store.update_profile_in_user_dir(
-            user_id, profile.display_name, profile.avatar_url
-        )
+        # Local users' directory entries are created and updated in tandem with
+        # their global profile, not in response to room events.
+        if not self.is_mine_id(user_id):
+            logger.debug("Adding new user to dir, %r", user_id)
+            await self.store.update_profile_in_user_dir(
+                user_id, profile.display_name, profile.avatar_url
+            )
 
         is_public = await self.store.is_room_world_readable_or_publicly_joinable(
             room_id

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -228,11 +228,11 @@ class UserDirectoryHandler(StateDeltasHandler):
 
                     for user_id in user_ids:
                         await self._handle_remove_user(room_id, user_id)
-                    return
                 else:
                     logger.debug("Server is still in room: %r", room_id)
+                    await self._handle_remove_user(room_id, state_key)
 
-            if joined is MatchChange.no_change:
+            elif joined is MatchChange.no_change:
                 # Handle any profile changes for remote users
                 if not self.is_mine_id(state_key):
                     await self._handle_remote_possible_profile_change(
@@ -252,8 +252,6 @@ class UserDirectoryHandler(StateDeltasHandler):
                 )
 
                 await self._handle_new_user(room_id, state_key, profile)
-            else:  # The user left
-                await self._handle_remove_user(room_id, state_key)
         else:
             logger.debug("Ignoring irrelevant type: %r", typ)
 

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -236,7 +236,7 @@ class UserDirectoryHandler(StateDeltasHandler):
                 if joined is MatchChange.no_change:
                     # Handle any profile changes for remote users
                     if not self.is_mine_id(state_key):
-                        await self._handle_possible_remote_profile_change(
+                        await self._handle_remote_possible_profile_change(
                             state_key, room_id, prev_event_id, event_id
                         )
 
@@ -407,7 +407,7 @@ class UserDirectoryHandler(StateDeltasHandler):
         if len(rooms_user_is_in) == 0:
             await self.store.remove_from_user_dir(user_id)
 
-    async def _handle_possible_remote_profile_change(
+    async def _handle_remote_possible_profile_change(
         self,
         user_id: str,
         room_id: str,

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -229,7 +229,8 @@ class UserDirectoryHandler(StateDeltasHandler):
                     else:
                         logger.debug("Server is still in room: %r", room_id)
 
-                if self.store.is_support_user(state_key):
+                is_support_user = await self.store.is_support_user(state_key)
+                if is_support_user:
                     continue
 
                 if joined is MatchChange.no_change:

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -244,6 +244,7 @@ class UserDirectoryHandler(StateDeltasHandler):
                 if event is None:
                     return
 
+                # TODO this leaks per-room profiles to the directory.
                 profile = ProfileInfo(
                     avatar_url=event.content.get("avatar_url"),
                     display_name=event.content.get("displayname"),
@@ -421,6 +422,7 @@ class UserDirectoryHandler(StateDeltasHandler):
         if not isinstance(new_name, str):
             new_name = prev_name
 
+        # TODO this leaks per-room profiles to the directory.
         prev_avatar = prev_event.content.get("avatar_url")
         new_avatar = event.content.get("avatar_url")
         # If the new avatar is an unexpected form, do not update the directory.

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -236,7 +236,7 @@ class UserDirectoryHandler(StateDeltasHandler):
                 if joined is MatchChange.no_change:
                     # Handle any profile changes for remote users
                     if not self.is_mine_id(state_key):
-                        await self._handle_profile_change(
+                        await self._handle_possible_remote_profile_change(
                             state_key, room_id, prev_event_id, event_id
                         )
 
@@ -405,7 +405,7 @@ class UserDirectoryHandler(StateDeltasHandler):
         if len(rooms_user_is_in) == 0:
             await self.store.remove_from_user_dir(user_id)
 
-    async def _handle_profile_change(
+    async def _handle_possible_remote_profile_change(
         self,
         user_id: str,
         room_id: str,

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -232,7 +232,7 @@ class UserDirectoryHandler(StateDeltasHandler):
                 # Handle any profile changes for remote users
                 if not self.is_mine_id(state_key):
                     await self._handle_remote_possible_profile_change(
-                        state_key, room_id, prev_event_id, event_id
+                        state_key, prev_event_id, event_id
                     )
 
             elif joined is MatchChange.now_true:  # The user joined
@@ -411,7 +411,6 @@ class UserDirectoryHandler(StateDeltasHandler):
     async def _handle_remote_possible_profile_change(
         self,
         user_id: str,
-        room_id: str,
         prev_event_id: Optional[str],
         event_id: Optional[str],
     ) -> None:

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -201,6 +201,10 @@ class UserDirectoryHandler(StateDeltasHandler):
                 room_id, prev_event_id, event_id, typ
             )
         elif typ == EventTypes.Member:
+            is_support_user = await self.store.is_support_user(state_key)
+            if is_support_user:
+                return
+
             joined = await self._get_key_change(
                 prev_event_id,
                 event_id,
@@ -228,10 +232,6 @@ class UserDirectoryHandler(StateDeltasHandler):
                     return
                 else:
                     logger.debug("Server is still in room: %r", room_id)
-
-            is_support_user = await self.store.is_support_user(state_key)
-            if is_support_user:
-                return
 
             if joined is MatchChange.no_change:
                 # Handle any profile changes for remote users

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -232,10 +232,11 @@ class UserDirectoryHandler(StateDeltasHandler):
                 is_support = await self.store.is_support_user(state_key)
                 if not is_support:
                     if joined is MatchChange.no_change:
-                        # Handle any profile changes
-                        await self._handle_profile_change(
-                            state_key, room_id, prev_event_id, event_id
-                        )
+                        # Handle any profile changes for remote users
+                        if not self.is_mine_id(state_key):
+                            await self._handle_profile_change(
+                                state_key, room_id, prev_event_id, event_id
+                            )
                         continue
 
                     if joined is MatchChange.now_true:  # The user joined

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -214,17 +214,13 @@ class UserDirectoryHandler(StateDeltasHandler):
             if joined is MatchChange.now_false:
                 # Need to check if the server left the room entirely, if so
                 # we might need to remove all the users in that room
-                is_in_room = await self.store.is_host_joined(
-                    room_id, self.server_name
-                )
+                is_in_room = await self.store.is_host_joined(room_id, self.server_name)
                 if not is_in_room:
                     logger.debug("Server left room: %r", room_id)
                     # Fetch all the users that we marked as being in user
                     # directory due to being in the room and then check if
                     # need to remove those users or not
-                    user_ids = await self.store.get_users_in_dir_due_to_room(
-                        room_id
-                    )
+                    user_ids = await self.store.get_users_in_dir_due_to_room(room_id)
 
                     for user_id in user_ids:
                         await self._handle_remove_user(room_id, user_id)
@@ -335,7 +331,7 @@ class UserDirectoryHandler(StateDeltasHandler):
         # which when ran over an entire room, will result in the same values
         # being added multiple times. The batching upserts shouldn't make this
         # too bad, though.
-        for user_id  in other_users_in_room:
+        for user_id in other_users_in_room:
             await self._track_user_joined_room(room_id, user_id)
 
     async def _handle_remote_user_joining_room(

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -38,7 +38,7 @@ class UserDirectoryHandler(StateDeltasHandler):
 
     - users this server can see are joined to a world_readable or publicly
       joinable room, and
-    - users belonging to a private room that contains a local user.
+    - users belonging to a private room shared by that local user.
 
     The two cases are tracked separately in the `users_in_public_rooms` and
     `users_who_share_private_rooms` tables. Both kinds of users have their

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -299,8 +299,6 @@ class UserDirectoryHandler(StateDeltasHandler):
             )
         else:
             raise Exception("Invalid event type")
-        # If change is None, no change. True => become world_readable/public,
-        # False => was world_readable/public
         if publicity is MatchChange.no_change:
             logger.debug("No change")
             return

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -250,7 +250,10 @@ class UserDirectoryHandler(StateDeltasHandler):
                 )
 
                 if not self.is_mine_id(state_key):
-                    await self._handle_remote_user_joining_room(state_key, profile)
+                    logger.debug("Adding new user to dir, %r", state_key)
+                    await self.store.update_profile_in_user_dir(
+                        state_key, profile.display_name, profile.avatar_url
+                    )
         else:
             logger.debug("Ignoring irrelevant type: %r", typ)
 
@@ -333,23 +336,6 @@ class UserDirectoryHandler(StateDeltasHandler):
         # too bad, though.
         for user_id in other_users_in_room:
             await self._track_user_joined_room(room_id, user_id)
-
-    async def _handle_remote_user_joining_room(
-        self, user_id: str, profile: ProfileInfo
-    ) -> None:
-        """Called when we might need to add user to directory
-
-        Args:
-            room_id: The room ID that user joined or started being public
-            user_id
-        """
-        # Local users' directory entries are created and updated in tandem with
-        # their global profile, not in response to room events.
-        if not self.is_mine_id(user_id):
-            logger.debug("Adding new user to dir, %r", user_id)
-            await self.store.update_profile_in_user_dir(
-                user_id, profile.display_name, profile.avatar_url
-            )
 
     async def _track_user_joined_room(self, room_id: str, user_id: str) -> None:
         """Someone's just joined a room. Add to `users_in_public_rooms` and

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import synapse.metrics
 from synapse.api.constants import EventTypes, HistoryVisibility, JoinRules, Membership

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -340,7 +340,7 @@ class UserDirectoryHandler(StateDeltasHandler):
 
     async def _track_user_joined_room(self, room_id: str, user_id: str) -> None:
         """Someone's just joined a room. Add to `users_in_public_rooms` and
-        `users sharing private room` if necessary."""
+        `users_who_share_private_rooms` if necessary."""
         is_public = await self.store.is_room_world_readable_or_publicly_joinable(
             room_id
         )

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -196,6 +196,11 @@ class RoomMemberWorkerStore(EventsWorkerStore):
     ) -> Dict[str, ProfileInfo]:
         """Get a mapping from user ID to profile information for all users in a given room.
 
+        The profile information comes directly from this room's `m.room.member`
+        events, and so may be specific to this room rather than part of a user's
+        global profile. To avoid privacy leaks, the profile data should only be
+        revealed to users who are already in this room.
+
         Args:
             room_id: The ID of the room to retrieve the users of.
 

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -227,63 +227,65 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
 
         return processed_event_count
 
-    async def _populate_user_directory_process_single_room(self, room_id: str):
+    async def _populate_user_directory_process_single_room(self, room_id: str) -> None:
         is_in_room = await self.is_host_joined(room_id, self.server_name)
-        if is_in_room:
-            is_public = await self.is_room_world_readable_or_publicly_joinable(
-                room_id
+        if not is_in_room:
+            return
+        
+        is_public = await self.is_room_world_readable_or_publicly_joinable(
+            room_id
+        )
+        # TODO: this will leak per-room profiles to the user directory.
+        users_with_profile = await self.get_users_in_room_with_profiles(room_id)
+
+        # Update each remote user in the user directory.
+        # (Entries for local users are managed by the UserDirectoryHandler
+        # and do not require us to peek at room state/events.)
+        for user_id, profile in users_with_profile.items():
+            if self.hs.is_mine_id(user_id):
+                continue
+            await self.update_profile_in_user_dir(
+                user_id, profile.display_name, profile.avatar_url
             )
-            # TODO: this will leak per-room profiles to the user directory.
-            users_with_profile = await self.get_users_in_room_with_profiles(room_id)
 
-            # Update each remote user in the user directory.
-            # (Entries for local users are managed by the UserDirectoryHandler
-            # and do not require us to peek at room state/events.)
-            for user_id, profile in users_with_profile.items():
-                if self.hs.is_mine_id(user_id):
+        to_insert = set()
+
+        if is_public:
+            for user_id in users_with_profile:
+                if self.get_if_app_services_interested_in_user(user_id):
                     continue
-                await self.update_profile_in_user_dir(
-                    user_id, profile.display_name, profile.avatar_url
-                )
 
-            to_insert = set()
+                to_insert.add(user_id)
 
-            if is_public:
-                for user_id in users_with_profile:
-                    if self.get_if_app_services_interested_in_user(user_id):
+            if to_insert:
+                await self.add_users_in_public_rooms(room_id, to_insert)
+                to_insert.clear()
+        else:
+            for user_id in users_with_profile:
+                if not self.hs.is_mine_id(user_id):
+                    continue
+
+                if self.get_if_app_services_interested_in_user(user_id):
+                    continue
+
+                for other_user_id in users_with_profile:
+                    if user_id == other_user_id:
                         continue
 
-                    to_insert.add(user_id)
+                    user_set = (user_id, other_user_id)
+                    to_insert.add(user_set)
 
-                if to_insert:
-                    await self.add_users_in_public_rooms(room_id, to_insert)
-                    to_insert.clear()
-            else:
-                for user_id in users_with_profile:
-                    if not self.hs.is_mine_id(user_id):
-                        continue
+                    # If it gets too big, stop and write to the database
+                    # to prevent storing too much in RAM.
+                    if len(to_insert) >= self.SHARE_PRIVATE_WORKING_SET:
+                        await self.add_users_who_share_private_room(
+                            room_id, to_insert
+                        )
+                        to_insert.clear()
 
-                    if self.get_if_app_services_interested_in_user(user_id):
-                        continue
-
-                    for other_user_id in users_with_profile:
-                        if user_id == other_user_id:
-                            continue
-
-                        user_set = (user_id, other_user_id)
-                        to_insert.add(user_set)
-
-                        # If it gets too big, stop and write to the database
-                        # to prevent storing too much in RAM.
-                        if len(to_insert) >= self.SHARE_PRIVATE_WORKING_SET:
-                            await self.add_users_who_share_private_room(
-                                room_id, to_insert
-                            )
-                            to_insert.clear()
-
-                if to_insert:
-                    await self.add_users_who_share_private_room(room_id, to_insert)
-                    to_insert.clear()
+            if to_insert:
+                await self.add_users_who_share_private_room(room_id, to_insert)
+                to_insert.clear()
 
     async def _populate_user_directory_process_users(self, progress: ProgressDict, batch_size: int) -> int:
         def _get_next_batch(txn):

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -85,19 +85,17 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
             self.db_pool.simple_insert_many_txn(txn, TEMP_TABLE + "_rooms", rooms)
             del rooms
 
-            # If search all users is on, get all the users we want to add.
-            if self.hs.config.user_directory_search_all_users:
-                sql = (
-                    "CREATE TABLE IF NOT EXISTS "
-                    + TEMP_TABLE
-                    + "_users(user_id TEXT NOT NULL)"
-                )
-                txn.execute(sql)
+            sql = (
+                "CREATE TABLE IF NOT EXISTS "
+                + TEMP_TABLE
+                + "_users(user_id TEXT NOT NULL)"
+            )
+            txn.execute(sql)
 
-                txn.execute("SELECT name FROM users")
-                users = [{"user_id": x[0]} for x in txn.fetchall()]
+            txn.execute("SELECT name FROM users")
+            users = [{"user_id": x[0]} for x in txn.fetchall()]
 
-                self.db_pool.simple_insert_many_txn(txn, TEMP_TABLE + "_users", users)
+            self.db_pool.simple_insert_many_txn(txn, TEMP_TABLE + "_users", users)
 
         new_pos = await self.get_max_stream_id_in_current_state_deltas()
         await self.db_pool.runInteraction(
@@ -274,15 +272,6 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         return processed_event_count
 
     async def _populate_user_directory_process_users(self, progress, batch_size):
-        """
-        If search_all_users is enabled, add all of the users to the user directory.
-        """
-        if not self.hs.config.user_directory_search_all_users:
-            await self.db_pool.updates._end_background_update(
-                "populate_user_directory_process_users"
-            )
-            return 1
-
         def _get_next_batch(txn):
             sql = "SELECT user_id FROM %s LIMIT %s" % (
                 TEMP_TABLE + "_users",

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -63,7 +63,9 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
             "populate_user_directory_cleanup", self._populate_user_directory_cleanup
         )
 
-    async def _populate_user_directory_createtables(self, progress: Dict, batch_size: str) -> int:
+    async def _populate_user_directory_createtables(
+        self, progress: Dict, batch_size: str
+    ) -> int:
 
         # Get all the rooms that we want to process.
         def _make_staging_area(txn):
@@ -116,7 +118,9 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         )
         return 1
 
-    async def _populate_user_directory_cleanup(self, progress: Dict, batch_size: str) -> int:
+    async def _populate_user_directory_cleanup(
+        self, progress: Dict, batch_size: str
+    ) -> int:
         """
         Update the user directory stream position, then clean up the old tables.
         """
@@ -139,7 +143,9 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         )
         return 1
 
-    async def _populate_user_directory_process_rooms(self, progress: ProgressDict, batch_size: int) -> int:
+    async def _populate_user_directory_process_rooms(
+        self, progress: ProgressDict, batch_size: int
+    ) -> int:
         """
         Rescan the state of all rooms so we can track
 
@@ -242,10 +248,8 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         is_in_room = await self.is_host_joined(room_id, self.server_name)
         if not is_in_room:
             return
-        
-        is_public = await self.is_room_world_readable_or_publicly_joinable(
-            room_id
-        )
+
+        is_public = await self.is_room_world_readable_or_publicly_joinable(room_id)
         # TODO: this will leak per-room profiles to the user directory.
         users_with_profile = await self.get_users_in_room_with_profiles(room_id)
 
@@ -289,17 +293,18 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                     # If it gets too big, stop and write to the database
                     # to prevent storing too much in RAM.
                     if len(to_insert) >= self.SHARE_PRIVATE_WORKING_SET:
-                        await self.add_users_who_share_private_room(
-                            room_id, to_insert
-                        )
+                        await self.add_users_who_share_private_room(room_id, to_insert)
                         to_insert.clear()
 
             if to_insert:
                 await self.add_users_who_share_private_room(room_id, to_insert)
                 to_insert.clear()
 
-    async def _populate_user_directory_process_users(self, progress: ProgressDict, batch_size: int) -> int:
+    async def _populate_user_directory_process_users(
+        self, progress: ProgressDict, batch_size: int
+    ) -> int:
         """Upsert a user_directory entry for each local user."""
+
         def _get_next_batch(txn):
             sql = "SELECT user_id FROM %s LIMIT %s" % (
                 TEMP_TABLE + "_users",

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -14,10 +14,10 @@
 
 import logging
 import re
-from typing import Any, Dict, Iterable, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, Optional, Sequence, Set, Tuple
 
 from synapse.api.constants import EventTypes, HistoryVisibility, JoinRules
-from synapse.storage.database import DatabasePool
+from synapse.storage.database import DatabasePool, LoggingTransaction
 from synapse.storage.databases.main.state import StateFilter
 from synapse.storage.databases.main.state_deltas import StateDeltasStore
 from synapse.storage.engines import PostgresEngine, Sqlite3Engine
@@ -146,7 +146,9 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         if not progress:
             await self.delete_all_from_user_dir()
 
-        def _get_next_batch(txn):
+        def _get_next_batch(
+            txn: LoggingTransaction,
+        ) -> Optional[Sequence[Tuple[str, str]]]:
             # Only fetch 250 rooms, so we don't fetch too many at once, even
             # if those 250 rooms have less than batch_size state events.
             sql = """

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -137,6 +137,13 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
 
     async def _populate_user_directory_process_rooms(self, progress, batch_size):
         """
+        Scan through the historical record of room events so we can track
+
+        - who's in a public room;
+        - which local users share a private room with other users (local
+          and remote); and
+        - who should be in the user_directory.
+
         Args:
             progress (dict)
             batch_size (int): Maximum number of state events to process

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -211,6 +211,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                     room_id
                 )
 
+                # TODO: this will leak per-room profiles to the user directory.
                 users_with_profile = await self.get_users_in_room_with_profiles(room_id)
 
                 # Update each remote user in the user directory.

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -204,8 +204,12 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
 
                 users_with_profile = await self.get_users_in_room_with_profiles(room_id)
 
-                # Update each user in the user directory.
+                # Update each remote user in the user directory.
+                # (Entries for local users are managed by the UserDirectoryHandler
+                # and do not require us to peek at room state/events.)
                 for user_id, profile in users_with_profile.items():
+                    if self.hs.is_mine_id(user_id):
+                        continue
                     await self.update_profile_in_user_dir(
                         user_id, profile.display_name, profile.avatar_url
                     )

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -117,7 +117,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         Update the user directory stream position, then clean up the old tables.
         """
         position = await self.db_pool.simple_select_one_onecol(
-            TEMP_TABLE + "_position", None, "position"
+            TEMP_TABLE + "_position", {}, "position"
         )
         await self.update_user_directory_stream_pos(position)
 
@@ -443,7 +443,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                 for user_id, other_user_id in user_id_tuples
             ],
             value_names=(),
-            value_values=None,
+            value_values=(),
             desc="add_users_who_share_room",
         )
 
@@ -462,7 +462,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
             key_names=["user_id", "room_id"],
             key_values=[(user_id, room_id) for user_id in user_ids],
             value_names=(),
-            value_values=None,
+            value_values=(),
             desc="add_users_in_public_rooms",
         )
 

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -203,7 +203,6 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                 )
 
                 users_with_profile = await self.get_users_in_room_with_profiles(room_id)
-                user_ids = set(users_with_profile)
 
                 # Update each user in the user directory.
                 for user_id, profile in users_with_profile.items():
@@ -214,7 +213,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                 to_insert = set()
 
                 if is_public:
-                    for user_id in user_ids:
+                    for user_id in users_with_profile:
                         if self.get_if_app_services_interested_in_user(user_id):
                             continue
 
@@ -224,14 +223,14 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                         await self.add_users_in_public_rooms(room_id, to_insert)
                         to_insert.clear()
                 else:
-                    for user_id in user_ids:
+                    for user_id in users_with_profile:
                         if not self.hs.is_mine_id(user_id):
                             continue
 
                         if self.get_if_app_services_interested_in_user(user_id):
                             continue
 
-                        for other_user_id in user_ids:
+                        for other_user_id in users_with_profile:
                             if user_id == other_user_id:
                                 continue
 

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -50,7 +50,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         self.bob = UserID.from_string("@4567:test")
         self.alice = UserID.from_string("@alice:remote")
 
-        self.get_success(self.store.register_user(str(self.frank)))
+        self.get_success(self.register_user(self.frank.localpart, "frankpassword"))
 
         self.handler = hs.get_profile_handler()
 

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -16,6 +16,7 @@ from unittest.mock import Mock
 
 import synapse.types
 from synapse.api.errors import AuthError, SynapseError
+from synapse.rest import admin
 from synapse.types import UserID
 
 from tests import unittest
@@ -24,6 +25,8 @@ from tests.test_utils import make_awaitable
 
 class ProfileTestCase(unittest.HomeserverTestCase):
     """Tests profile management."""
+
+    servlets = [admin.register_servlets]
 
     def make_homeserver(self, reactor, clock):
         self.mock_federation = Mock()

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -50,7 +50,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         self.bob = UserID.from_string("@4567:test")
         self.alice = UserID.from_string("@alice:remote")
 
-        self.get_success(self.store.create_profile(self.frank.localpart))
+        self.get_success(self.store.register_user(str(self.frank)))
 
         self.handler = hs.get_profile_handler()
 

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -49,7 +49,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
     def prepare(self, reactor, clock, hs):
         self.store = hs.get_datastore()
 
-        self.frank = UserID.from_string("@1234ABCD:test")
+        self.frank = UserID.from_string("@1234abcd:test")
         self.bob = UserID.from_string("@4567:test")
         self.alice = UserID.from_string("@alice:remote")
 

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -679,6 +679,9 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
             state_key=alice,
         )
 
+        # Check Alice isn't recorded as being in a public room.
+        self.assertNotIn((alice, room), self.get_users_in_public_rooms())
+
         # One of them makes the room public.
         self.helper.send_state(
             room,
@@ -686,7 +689,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
             {"join_rule": "public"},
             alice_token,
         )
-        # Wait for the handler to process the event
+        # Check that Alice is now recorded as being in a public room
         self.assertIn((alice, room), self.get_users_in_public_rooms())
 
         # Alice's display name remains the same in the user directory.

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -641,6 +641,21 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         )
 
     def test_making_room_public_doesnt_alter_directory_entry(self):
+        """Per-room names shouldn't go to the directory when the room becomes public.
+
+        I made this a synapse test case rather than a complement one because
+        I think this is (strictly speaking) an implementation choice. Synapse
+        has chosen to only ever use the public profile when responding to a user
+        directory search. There's no privacy leak here, because making the room
+        public discloses the per-room name.
+
+        The spec doesn't mandate anything about _how_ a user
+        should appear in a /user_directory/search result. Hypothetical example:
+        suppose Bob searches for Alice. When representing Alice in a search
+        result, it's reasonable to use any of Alice's nicknames that Bob is
+        aware of. Heck, maybe we even want to use lots of them in a combined
+        displayname like `Alice (aka "ali", "ally", "41iC3")`.
+        """
         # TODO the same should apply when Alice is a remote user.
         alice = self.register_user("alice", "pass")
         alice_token = self.login(alice, "pass")

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -21,6 +21,7 @@ from synapse.api.constants import EventTypes, RoomEncryptionAlgorithms, UserType
 from synapse.api.room_versions import RoomVersion, RoomVersions
 from synapse.rest.client import login, room, user_directory
 from synapse.storage.roommember import ProfileInfo
+from synapse.types import create_requester
 
 from tests import unittest
 from tests.unittest import override_config
@@ -130,6 +131,50 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         self.store.remove_from_user_dir = Mock(return_value=defer.succeed(None))
         self.get_success(self.handler.handle_local_user_deactivated(r_user_id))
         self.store.remove_from_user_dir.called_once_with(r_user_id)
+
+    def test_reactivation_makes_regular_user_searchable(self):
+        user = self.register_user("regular", "pass")
+        password_hash = self.get_success(
+            self.store.db_pool.simple_select_one_onecol(
+                "users",
+                {"name": user},
+                "password_hash",
+            )
+        )
+        user_token = self.login(user, "pass")
+        admin_user = self.register_user("admin", "pass", admin=True)
+
+        # Ensure the regular user is publicly visible and searchable.
+        self.helper.create_room_as(user, is_public=True, tok=user_token)
+        s = self.get_success(self.handler.search_users(admin_user, user, 10))
+        self.assertEqual(len(s["results"]), 1)
+        self.assertEqual(s["results"][0]["user_id"], user)
+
+        # Deactivate the user and check they're not searchable.
+        deactivate_handler = self.hs._deactivate_account_handler
+        self.get_success(
+            deactivate_handler.deactivate_account(
+                user, erase_data=False, requester=create_requester(admin_user)
+            )
+        )
+        s = self.get_success(self.handler.search_users(admin_user, user, 10))
+        self.assertEqual(s["results"], [])
+
+        # Reactivate the user
+        self.get_success(deactivate_handler.activate_account(user))
+        # Hackily reset password by restoring the old pw hash.
+        self.get_success(
+            self.hs.get_set_password_handler().set_password(
+                user, password_hash, logout_devices=False
+            )
+        )
+        user_token = self.login(user, "pass")
+        self.helper.create_room_as(user, is_public=True, tok=user_token)
+
+        # Check they're searchable.
+        s = self.get_success(self.handler.search_users(admin_user, user, 10))
+        self.assertEqual(len(s["results"]), 1)
+        self.assertEqual(s["results"][0]["user_id"], user)
 
     def test_private_room(self):
         """

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -94,7 +94,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
 
         # deactivate user
         self.get_success(self.store.set_user_deactivated_status(r_user_id, True))
-        self.get_success(self.handler.handle_user_deactivated(r_user_id))
+        self.get_success(self.handler.handle_local_user_deactivated(r_user_id))
 
         # profile is not in directory
         profile = self.get_success(self.store.get_user_in_directory(r_user_id))
@@ -118,7 +118,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         )
 
         self.store.remove_from_user_dir = Mock(return_value=defer.succeed(None))
-        self.get_success(self.handler.handle_user_deactivated(s_user_id))
+        self.get_success(self.handler.handle_local_user_deactivated(s_user_id))
         self.store.remove_from_user_dir.not_called()
 
     def test_handle_user_deactivated_regular_user(self):
@@ -127,7 +127,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
             self.store.register_user(user_id=r_user_id, password_hash=None)
         )
         self.store.remove_from_user_dir = Mock(return_value=defer.succeed(None))
-        self.get_success(self.handler.handle_user_deactivated(r_user_id))
+        self.get_success(self.handler.handle_local_user_deactivated(r_user_id))
         self.store.remove_from_user_dir.called_once_with(r_user_id)
 
     def test_private_room(self):

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -23,7 +23,6 @@ from synapse.rest.client import login, room, user_directory
 from synapse.storage.roommember import ProfileInfo
 
 from tests import unittest
-from tests.server import make_request
 from tests.unittest import override_config
 
 
@@ -666,7 +665,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         )
 
         # One of them makes the room public.
-        res = self.helper.send_state(
+        self.helper.send_state(
             room,
             "m.room.join_rules",
             {"join_rule": "public"},

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Tuple, List
+from typing import List, Tuple
 from unittest.mock import Mock
 
 from twisted.internet import defer
@@ -678,7 +678,11 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         # Alice's nickname is now publicly visible, but this shouldn't change
         # her entry in the user directory.
         search_result = self.get_success(self.handler.search_users(bob, alice, 10))
-        self.assertEqual(search_result["results"], [{"display_name": "alice", "avatar_url": None, "user_id": alice}], 0)
+        self.assertEqual(
+            search_result["results"],
+            [{"display_name": "alice", "avatar_url": None, "user_id": alice}],
+            0,
+        )
 
 
 class TestUserDirSearchDisabled(unittest.HomeserverTestCase):

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -643,7 +643,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
     def test_making_room_public_doesnt_alter_directory_entry(self):
         """Per-room names shouldn't go to the directory when the room becomes public.
 
-        I made this a synapse test case rather than a complement one because
+        I made this a Synapse test case rather than a Complement one because
         I think this is (strictly speaking) an implementation choice. Synapse
         has chosen to only ever use the public profile when responding to a user
         directory search. There's no privacy leak here, because making the room
@@ -689,8 +689,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         # Wait for the handler to process the event
         self.assertIn((alice, room), self.get_users_in_public_rooms())
 
-        # Alice's nickname is now publicly visible, but this shouldn't change
-        # her entry in the user directory.
+        # Alice's display name remains the same in the user directory.
         search_result = self.get_success(self.handler.search_users(bob, alice, 10))
         self.assertEqual(
             search_result["results"],

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -705,7 +705,10 @@ class RoomJoinRatelimitTestCase(RoomBase):
     def prepare(self, reactor, clock, homeserver):
         super().prepare(reactor, clock, homeserver)
         # profile changes expect that the user is actually registered
-        self.register_user(UserID.from_string(self.user_id).localpart, "supersecretpassword")
+        user = UserID.from_string(self.user_id)
+        self.get_success(
+            self.register_user(user.localpart, "supersecretpassword")
+        )
 
     @unittest.override_config(
         {"rc_joins": {"local": {"per_second": 0.5, "burst_count": 3}}}

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -702,6 +702,11 @@ class RoomJoinRatelimitTestCase(RoomBase):
         room.register_servlets,
     ]
 
+    def prepare(self, reactor, clock, homeserver):
+        super().prepare(reactor, clock, homeserver)
+        # profile changes expect that the user is actually registered
+        self.register_user(UserID.from_string(self.user_id).localpart, "supersecretpassword")
+
     @unittest.override_config(
         {"rc_joins": {"local": {"per_second": 0.5, "burst_count": 3}}}
     )
@@ -730,12 +735,6 @@ class RoomJoinRatelimitTestCase(RoomBase):
         # Add one to make sure we're joined to more rooms than the config allows us to
         # join in a second.
         room_ids.append(self.helper.create_room_as(self.user_id))
-
-        # Create a profile for the user, since it hasn't been done on registration.
-        store = self.hs.get_datastore()
-        self.get_success(
-            store.create_profile(UserID.from_string(self.user_id).localpart)
-        )
 
         # Update the display name for the user.
         path = "/_matrix/client/r0/profile/%s/displayname" % self.user_id

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -706,9 +706,7 @@ class RoomJoinRatelimitTestCase(RoomBase):
         super().prepare(reactor, clock, homeserver)
         # profile changes expect that the user is actually registered
         user = UserID.from_string(self.user_id)
-        self.get_success(
-            self.register_user(user.localpart, "supersecretpassword")
-        )
+        self.get_success(self.register_user(user.localpart, "supersecretpassword"))
 
     @unittest.override_config(
         {"rc_joins": {"local": {"per_second": 0.5, "burst_count": 3}}}


### PR DESCRIPTION
The plan is described [here](https://gist.github.com/DMRobertson/b63d7caa1c7c1e39d88d98f27b233bc2). In a nutshell, I want to make it so that local users' entries in the user directory only ever refer to their "public" profile, and completely ignore any per-room nicknames.

This goes some way towards fixing #5677, but we still have the problem of how to handle remote users' profiles.