### PR TITLE
Populate `rooms.creator` field for easy lookup

### DIFF
--- a/changelog.d/10697.misc
+++ b/changelog.d/10697.misc
@@ -1,0 +1,1 @@
+Ensure `rooms.creator` field is always populated for easy lookup in [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) usage later.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -198,6 +198,7 @@ class EventContentFields:
     # cf https://github.com/matrix-org/matrix-doc/pull/1772
     ROOM_TYPE = "type"
 
+    # The creator of the room, as used in `m.room.create` events.
     ROOM_CREATOR = "creator"
 
     # Used on normal messages to indicate they were historically imported after the fact

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -198,6 +198,8 @@ class EventContentFields:
     # cf https://github.com/matrix-org/matrix-doc/pull/1772
     ROOM_TYPE = "type"
 
+    ROOM_CREATOR = "creator"
+
     # Used on normal messages to indicate they were historically imported after the fact
     MSC2716_HISTORICAL = "org.matrix.msc2716.historical"
     # For "insertion" events to indicate what the next chunk ID should be in

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1690,6 +1690,7 @@ class FederationHandler(BaseHandler):
             await self.store.upsert_room_on_join(
                 room_id=room_id,
                 room_version=room_version_obj,
+                auth_events=auth_chain,
             )
 
             max_stream_id = await self._persist_auth_tree(

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -19,7 +19,7 @@ from abc import abstractmethod
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
-from synapse.api.constants import EventTypes, JoinRules
+from synapse.api.constants import EventTypes, EventContentFields, JoinRules
 from synapse.api.errors import StoreError
 from synapse.api.room_versions import RoomVersion, RoomVersions
 from synapse.events import EventBase
@@ -1223,7 +1223,7 @@ class RoomBackgroundUpdateStore(SQLBaseStore):
             for room_id, event_json in txn:
                 event_dict = db_to_json(event_json)
 
-                creator = event_dict.get("content").get("creator")
+                creator = event_dict.get("content").get(EventContentFields.ROOM_CREATOR)
 
                 self.db_pool.simple_update_txn(
                     txn,
@@ -1439,7 +1439,7 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore, SearchStore):
             # invalid, and it would fail auth checks anyway.
             raise StoreError(400, "No create event in state")
 
-        room_creator = create_event.content.get("creator", None)
+        room_creator = create_event.content.get(EventContentFields.ROOM_CREATOR)
 
         if room_creator is None:
             # If the create event does not have a creator then the room is

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1370,9 +1370,10 @@ class RoomBackgroundUpdateStore(SQLBaseStore):
             """
 
             txn.execute(sql, (last_room_id, batch_size))
+            room_id_to_create_event_results = txn.fetchall()
 
             new_last_room_id = ""
-            for room_id, event_json in txn:
+            for room_id, event_json in room_id_to_create_event_results:
                 event_dict = db_to_json(event_json)
 
                 creator = event_dict.get("content").get(EventContentFields.ROOM_CREATOR)

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1441,7 +1441,7 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore, SearchStore):
 
         room_creator = create_event.content.get(EventContentFields.ROOM_CREATOR)
 
-        if room_creator is None:
+        if not isinstance(room_creator, str):
             # If the create event does not have a creator then the room is
             # invalid, and it would fail auth checks anyway.
             raise StoreError(400, "No creator defined on the create event")

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1209,9 +1209,10 @@ class RoomBackgroundUpdateStore(SQLBaseStore):
 
         def _background_populate_rooms_creator_column_txn(txn: LoggingTransaction):
             sql = """
-                SELECT room_id, json FROM current_state_events
-                INNER JOIN event_json USING (room_id, event_id)
-                WHERE room_id > ? AND type = 'm.room.create' AND state_key = ''
+                SELECT room_id, json FROM event_json
+                INNER JOIN rooms AS room USING (room_id)
+                INNER JOIN current_state_events AS state_event USING (room_id, event_id)
+                WHERE room_id > ? AND (room.creator IS NULL OR room.creator = '') AND state_event.type = 'm.room.create' AND state_event.state_key = ''
                 ORDER BY room_id
                 LIMIT ?
             """

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -19,7 +19,7 @@ from abc import abstractmethod
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
-from synapse.api.constants import EventTypes, EventContentFields, JoinRules
+from synapse.api.constants import EventContentFields, EventTypes, JoinRules
 from synapse.api.errors import StoreError
 from synapse.api.room_versions import RoomVersion, RoomVersions
 from synapse.events import EventBase

--- a/synapse/storage/schema/main/delta/63/02populate-rooms-creator.sql
+++ b/synapse/storage/schema/main/delta/63/02populate-rooms-creator.sql
@@ -13,5 +13,5 @@
  * limitations under the License.
  */
 
-INSERT into background_updates (update_name, progress_json)
+INSERT INTO background_updates (update_name, progress_json)
     VALUES ('populate_rooms_creator_column', '{}');

--- a/synapse/storage/schema/main/delta/63/02populate-rooms-creator.sql
+++ b/synapse/storage/schema/main/delta/63/02populate-rooms-creator.sql
@@ -13,5 +13,5 @@
  * limitations under the License.
  */
 
-INSERT INTO background_updates (update_name, progress_json)
-    VALUES ('populate_rooms_creator_column', '{}');
+INSERT INTO background_updates (ordering, update_name, progress_json)
+    VALUES (6302, 'populate_rooms_creator_column', '{}');

--- a/synapse/storage/schema/main/delta/63/02populate-rooms-creator.sql
+++ b/synapse/storage/schema/main/delta/63/02populate-rooms-creator.sql
@@ -1,0 +1,17 @@
+/* Copyright 2021 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+INSERT into background_updates (update_name, progress_json)
+    VALUES ('populate_rooms_creator_column', '{}');

--- a/tests/storage/databases/main/test_room.py
+++ b/tests/storage/databases/main/test_room.py
@@ -1,0 +1,98 @@
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from synapse.rest import admin
+from synapse.rest.client import login, room
+from synapse.storage.databases.main.room import _BackgroundUpdates
+
+from tests.unittest import HomeserverTestCase
+
+
+class RoomBackgroundUpdateStoreTestCase(HomeserverTestCase):
+
+    servlets = [
+        admin.register_servlets,
+        room.register_servlets,
+        login.register_servlets,
+    ]
+
+    def prepare(self, reactor, clock, hs):
+        self.store = hs.get_datastore()
+        self.user_id = self.register_user("foo", "pass")
+        self.token = self.login("foo", "pass")
+
+    def _generate_room(self) -> str:
+        room_id = self.helper.create_room_as(self.user_id, tok=self.token)
+
+        return room_id
+
+    def test_background_populate_rooms_creator_column(self):
+        """Test that the background update to populate the rooms creator column
+        works properly.
+        """
+
+        # Insert a room without the creator
+        room_id = self._generate_room()
+        self.get_success(
+            self.store.db_pool.simple_update(
+                table="rooms",
+                keyvalues={"room_id": room_id},
+                updatevalues={"creator": None},
+                desc="test",
+            )
+        )
+
+        # Make sure the test is starting out with a room without a creator
+        room_creator_before = self.get_success(
+            self.store.db_pool.simple_select_one_onecol(
+                table="rooms",
+                keyvalues={"room_id": room_id},
+                retcol="creator",
+                allow_none=True,
+            )
+        )
+        self.assertEqual(room_creator_before, None)
+
+        # Insert and run the background update.
+        self.get_success(
+            self.store.db_pool.simple_insert(
+                "background_updates",
+                {
+                    "update_name": _BackgroundUpdates.POPULATE_ROOMS_CREATOR_COLUMN,
+                    "progress_json": "{}",
+                },
+            )
+        )
+
+        # ... and tell the DataStore that it hasn't finished all updates yet
+        self.store.db_pool.updates._all_done = False
+
+        # Now let's actually drive the updates to completion
+        while not self.get_success(
+            self.store.db_pool.updates.has_completed_background_updates()
+        ):
+            self.get_success(
+                self.store.db_pool.updates.do_next_background_update(100), by=0.1
+            )
+
+        # Make sure the background update filled in the room creator
+        room_creator_after = self.get_success(
+            self.store.db_pool.simple_select_one_onecol(
+                table="rooms",
+                keyvalues={"room_id": room_id},
+                retcol="creator",
+                allow_none=True,
+            )
+        )
+        self.assertEqual(room_creator_after, self.user_id)


### PR DESCRIPTION
Populate `rooms.creator` field for easy lookup

Part of https://github.com/matrix-org/synapse/pull/10566 for [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716)

 - Fill in creator whenever we insert into the rooms table
 - Add background update to backfill any missing creator values
 
 
## Dev notes

```sh
$ psql synapse

# \d+ rooms
                                          Table "public.rooms"
        Column        |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description
----------------------+---------+-----------+----------+---------+----------+--------------+-------------
 room_id              | text    |           | not null |         | extended |              |
 is_public            | boolean |           |          |         | plain    |              |
 creator              | text    |           |          |         | extended |              |
 room_version         | text    |           |          |         | extended |              |
 has_auth_chain_index | boolean |           |          |         | plain    |              |
Indexes:
    "rooms_pkey" PRIMARY KEY, btree (room_id)
    "public_room_index" btree (is_public)
Referenced by:
    TABLE "destination_rooms" CONSTRAINT "destination_rooms_room_id_fkey" FOREIGN KEY (room_id) REFERENCES rooms(room_id)
Access method: heap

# \d+ current_state_events
                            Table "public.current_state_events"
   Column   | Type | Collation | Nullable | Default | Storage  | Stats target | Description
------------+------+-----------+----------+---------+----------+--------------+-------------
 event_id   | text |           | not null |         | extended |              |
 room_id    | text |           | not null |         | extended |              |
 type       | text |           | not null |         | extended |              |
 state_key  | text |           | not null |         | extended |              |
 membership | text |           |          |         | extended |              |
Indexes:
    "current_state_events_event_id_key" UNIQUE CONSTRAINT, btree (event_id)
    "current_state_events_member_index" btree (state_key) WHERE type = 'm.room.member'::text
    "current_state_events_room_id_type_state_key_key" UNIQUE CONSTRAINT, btree (room_id, type, state_key)
Access method: heap

# \d+ event_json
                                      Table "public.event_json"
      Column       |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description
-------------------+---------+-----------+----------+---------+----------+--------------+-------------
 event_id          | text    |           | not null |         | extended |              |
 room_id           | text    |           | not null |         | extended |              |
 internal_metadata | text    |           | not null |         | extended |              |
 json              | text    |           | not null |         | extended |              |
 format_version    | integer |           |          |         | plain    |              |
Indexes:
    "event_json_event_id_key" UNIQUE CONSTRAINT, btree (event_id)
Access method: heap

# \q
```


#### Background update

 - `register_background_update_handler`

See [`_background_add_rooms_room_version_column`](https://github.com/matrix-org/synapse/blob/e3abc0a5cc0669b76e5bdf2e1539645d790a7a3d/synapse/storage/databases/main/room.py#L1125-L1192) as a reference background update

---

Find where rows are inserted into `rooms`

 - `table="rooms",` (`simple_upsert_txn`)
 - `"rooms",` (`simple_insert`) 


---


```
SYNAPSE_TEST_LOG_LEVEL=INFO python -m twisted.trial tests.storage.databases.main.test_room

SYNAPSE_POSTGRES=1 SYNAPSE_TEST_LOG_LEVEL=INFO python -m twisted.trial tests.storage.databases.main.test_room

SYNAPSE_TEST_LOG_LEVEL=INFO python -m twisted.trial tests.handlers.test_room_summary.SpaceSummaryTestCase.test_fed_invited

SYNAPSE_TEST_LOG_LEVEL=INFO python -m twisted.trial tests.handlers.test_room_summary.SpaceSummaryTestCase.test_fed_filtering
```



### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)~~
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
