### PR TITLE
Fix perf of fetching the same events many times.

### DIFF
--- a/changelog.d/10703.bugfix
+++ b/changelog.d/10703.bugfix
@@ -1,1 +1,1 @@
-Fix performance of fetching the same large set of events repeatedly at the same time, which in extreme cases could wedge the process. Introduced in v1.41.0.
+Fix a regression introduced in v1.41.0 which affected the performance of concurrent fetches of large sets of events, in extreme cases causing the process to hang.

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -591,7 +591,7 @@ class EventsWorkerStore(SQLBaseStore):
 
             for result in results:
                 # We filter out events that we haven't asked for as we might get
-                # a *lot* of superfluous events back, and there is not point
+                # a *lot* of superfluous events back, and there is no point
                 # going through and inserting them all (which can take time).
                 event_entry_map.update(
                     (event_id, entry)


### PR DESCRIPTION
The code to deduplicate repeated fetches of the same set of events was
N<sup>2</sup> (over the number of events requested), which could lead to a process
being completely wedged.

The main fix is to deduplicate the returned deferreds so we only await
on a deferred once rather than many times. Seperately, when handling the
returned events from the defrered we only add the events we care about
to the event map to be returned (so that we don't pay the price of
inserting extraneous events into the dict).

Thanks to @squahtx for spotting the issue :heart: 

Hopefully fixes #10698

Introduced in #10119