### PR TITLE
Ignore rooms with unknown room versions in the spaces summary.

### DIFF
--- a/changelog.d/10727.misc
+++ b/changelog.d/10727.misc
@@ -1,0 +1,1 @@
+Do not include rooms with unknown room versions in the spaces summary results.

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -28,7 +28,14 @@ from synapse.api.constants import (
     Membership,
     RoomTypes,
 )
-from synapse.api.errors import AuthError, Codes, NotFoundError, StoreError, SynapseError
+from synapse.api.errors import (
+    AuthError,
+    Codes,
+    NotFoundError,
+    StoreError,
+    SynapseError,
+    UnsupportedRoomVersionError,
+)
 from synapse.events import EventBase
 from synapse.events.utils import format_event_for_client_v2
 from synapse.types import JsonDict
@@ -814,7 +821,10 @@ class RoomSummaryHandler:
             logger.info("room %s is unknown, omitting from summary", room_id)
             return False
 
-        room_version = await self._store.get_room_version(room_id)
+        try:
+            room_version = await self._store.get_room_version(room_id)
+        except UnsupportedRoomVersionError:
+            return False
 
         # Include the room if it has join rules of public or knock.
         join_rules_event_id = state_ids.get((EventTypes.JoinRules, ""))

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -824,6 +824,8 @@ class RoomSummaryHandler:
         try:
             room_version = await self._store.get_room_version(room_id)
         except UnsupportedRoomVersionError:
+            # If a room with an unsupported room version is encountered, ignore
+            # it to avoid breaking the entire summary response.
             return False
 
         # Include the room if it has join rules of public or knock.


### PR DESCRIPTION
Fixes #10724

This is the same strategy we used for `/sync` where we just ignore the room and do not return it.