### PR TITLE
Fix iteration in _remove_deleted_email_pushers background job.

### DIFF
--- a/changelog.d/10734.bugfix
+++ b/changelog.d/10734.bugfix
@@ -1,0 +1,1 @@
+Remove pushers when deleting a 3pid from an account. Pushers for old unlinked emails will also be deleted.

--- a/synapse/storage/databases/main/pusher.py
+++ b/synapse/storage/databases/main/pusher.py
@@ -430,10 +430,11 @@ class PusherWorkerStore(SQLBaseStore):
             """
 
             txn.execute(sql, (last_pusher, batch_size))
+            rows = txn.fetchall()
 
             last = None
             num_deleted = 0
-            for row in txn:
+            for row in rows:
                 last = row[0]
                 num_deleted += 1
                 self.db_pool.simple_delete_txn(

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -67,7 +67,7 @@ class EmailPusherTests(HomeserverTestCase):
         config["public_baseurl"] = "aaa"
         config["start_pushers"] = True
 
-        hs = self.setup_test_homeserver(config=config)
+        self.hs = self.setup_test_homeserver(config=config)
 
         # List[Tuple[Deferred, args, kwargs]]
         self.email_attempts = []
@@ -77,9 +77,9 @@ class EmailPusherTests(HomeserverTestCase):
             self.email_attempts.append((d, args, kwargs))
             return d
 
-        hs.get_send_email_handler()._sendmail = sendmail
+        self.hs.get_send_email_handler()._sendmail = sendmail
 
-        return hs
+        return self.hs
 
     def prepare(self, reactor, clock, hs):
         # Register the user who gets notified
@@ -338,6 +338,50 @@ class EmailPusherTests(HomeserverTestCase):
         )
 
         # check that the pusher for that email address has been deleted
+        pushers = self.get_success(
+            self.hs.get_datastore().get_pushers_by({"user_name": self.user_id})
+        )
+        pushers = list(pushers)
+        self.assertEqual(len(pushers), 0)
+
+    def test_remove_unlinked_pushers_background_job(self):
+        """Checks that all existing pushers associated with unlinked email addresses are removed
+        upon running the remove_deleted_email_pushers background update.
+        """
+        # disassociate the user's email address manually (without deleting the pusher).
+        # This resembles the old behaviour, which the background update below is intended
+        # to clean up.
+        self.get_success(
+            self.hs.get_datastore().user_delete_threepid(
+                self.user_id, "email", "a@example.com"
+            )
+        )
+
+        # Run the "remove_deleted_email_pushers" background job
+        self.get_success(
+            self.hs.get_datastore().db_pool.simple_insert(
+                table="background_updates",
+                values={
+                    "update_name": "remove_deleted_email_pushers",
+                    "progress_json": "{}",
+                    "depends_on": None,
+                },
+            )
+        )
+
+        # ... and tell the DataStore that it hasn't finished all updates yet
+        self.hs.get_datastore().db_pool.updates._all_done = False
+
+        # Now let's actually drive the updates to completion
+        while not self.get_success(
+            self.hs.get_datastore().db_pool.updates.has_completed_background_updates()
+        ):
+            self.get_success(
+                self.hs.get_datastore().db_pool.updates.do_next_background_update(100),
+                by=0.1,
+            )
+
+        # Check that all pushers with unlinked addresses were deleted
         pushers = self.get_success(
             self.hs.get_datastore().get_pushers_by({"user_name": self.user_id})
         )

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -67,7 +67,7 @@ class EmailPusherTests(HomeserverTestCase):
         config["public_baseurl"] = "aaa"
         config["start_pushers"] = True
 
-        self.hs = self.setup_test_homeserver(config=config)
+        hs = self.setup_test_homeserver(config=config)
 
         # List[Tuple[Deferred, args, kwargs]]
         self.email_attempts = []
@@ -77,9 +77,9 @@ class EmailPusherTests(HomeserverTestCase):
             self.email_attempts.append((d, args, kwargs))
             return d
 
-        self.hs.get_send_email_handler()._sendmail = sendmail
+        hs.get_send_email_handler()._sendmail = sendmail
 
-        return self.hs
+        return hs
 
     def prepare(self, reactor, clock, hs):
         # Register the user who gets notified


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/10729, see issue for context.

We were originally iterating over `txn`, which can work, but as `txn` was being used to run a
simple_delete operation inside the loop, it was actually being redefined mid-loop.

Thus, this caused the background job that was intended to remove old pushers that were
associated with an unlinked email address to fail if there were any to remove.We were originally iterating over 'txn', which can work, but as 'txn' was being used to run a
simple_delete operation inside the loop, it was actually being redefined mid-loop.

Thus, this caused the background job that was intended to remove old pushers that were
associated with an unlinked email address to fail if there were any to remove.