### PR TITLE
Raise an error if an unknown preset is passed from a client.

### DIFF
--- a/changelog.d/10738.misc
+++ b/changelog.d/10738.misc
@@ -1,0 +1,1 @@
+Additional error checking for the `preset` field when creating a room.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -909,7 +909,12 @@ class RoomCreationHandler(BaseHandler):
             )
             return last_stream_id
 
-        config = self._presets_dict[preset_config]
+        try:
+            config = self._presets_dict[preset_config]
+        except KeyError:
+            raise SynapseError(
+                400, f"'{preset_config}' is not a valid preset", errcode=Codes.BAD_JSON
+            )
 
         creation_content.update({"creator": creator_id})
         await send(etype=EventTypes.Create, content=creation_content)


### PR DESCRIPTION
This was an error I noticed when discussing how hard it would be to add another preset.

We could check this closer to the C-S API, but it seems that this code gets called from quite a few places, so thought it best to put here. I can add (or replace) this error checking though if people feel I should put it in the REST code.