### PR TITLE
Fix bug with reusing 'txn' when persisting event.

### DIFF
--- a/changelog.d/10743.bugfix
+++ b/changelog.d/10743.bugfix
@@ -1,1 +1,1 @@
-Fix joining room when the server has received multiple invites for different users in the room.
+Fix edge case when persisting events into a room where there are multiple events we previously hadn't calculated auth chains for (and hadn't marked as needing to be calculated).

--- a/changelog.d/10743.bugfix
+++ b/changelog.d/10743.bugfix
@@ -1,0 +1,1 @@
+Fix joining room when the server has received multiple invites for different users in the room.

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -575,7 +575,13 @@ class PersistEventsStore:
 
             missing_auth_chains.clear()
 
-            for auth_id, event_type, state_key, chain_id, sequence_number in txn:
+            for (
+                auth_id,
+                event_type,
+                state_key,
+                chain_id,
+                sequence_number,
+            ) in txn.fetchall():
                 event_to_types[auth_id] = (event_type, state_key)
 
                 if chain_id is None:


### PR DESCRIPTION
I don't think its possible for this to happen unless there are multiple out of band memberships in the room that were persisted in an older version of Synapse that didn't do auth chains.

Fixes #10739