### PR TITLE
Ease searching for M_TOO_LARGE-related error codes

### DIFF
--- a/changelog.d/10750.misc
+++ b/changelog.d/10750.misc
@@ -1,0 +1,1 @@
+Refactor event size checking code to simplify searching the codebase for the origins of certain error strings that are occasionally emitted.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -217,15 +217,15 @@ def check(
 
 def _check_size_limits(event: EventBase) -> None:
     if len(event.user_id) > 255:
-        EventSizeError("user_id too large")
+        EventSizeError("'user_id' too large")
     if len(event.room_id) > 255:
-        EventSizeError("room_id too large")
+        EventSizeError("'room_id' too large")
     if event.is_state() and len(event.state_key) > 255:
-        EventSizeError("state_key too large")
+        EventSizeError("'state_key' too large")
     if len(event.type) > 255:
-        EventSizeError("type too large")
+        EventSizeError("'type' too large")
     if len(event.event_id) > 255:
-        EventSizeError("event_id too large")
+        EventSizeError("'event_id' too large")
     if len(encode_canonical_json(event.get_pdu_json())) > MAX_PDU_SIZE:
         EventSizeError("event too large")
 

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -217,17 +217,17 @@ def check(
 
 def _check_size_limits(event: EventBase) -> None:
     if len(event.user_id) > 255:
-        EventSizeError("'user_id' too large")
+        raise EventSizeError("'user_id' too large")
     if len(event.room_id) > 255:
-        EventSizeError("'room_id' too large")
+        raise EventSizeError("'room_id' too large")
     if event.is_state() and len(event.state_key) > 255:
-        EventSizeError("'state_key' too large")
+        raise EventSizeError("'state_key' too large")
     if len(event.type) > 255:
-        EventSizeError("'type' too large")
+        raise EventSizeError("'type' too large")
     if len(event.event_id) > 255:
-        EventSizeError("'event_id' too large")
+        raise EventSizeError("'event_id' too large")
     if len(encode_canonical_json(event.get_pdu_json())) > MAX_PDU_SIZE:
-        EventSizeError("event too large")
+        raise EventSizeError("event too large")
 
 
 def _can_federate(event: EventBase, auth_events: StateMap[EventBase]) -> bool:

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -216,21 +216,18 @@ def check(
 
 
 def _check_size_limits(event: EventBase) -> None:
-    def too_big(field):
-        raise EventSizeError("%s too large" % (field,))
-
     if len(event.user_id) > 255:
-        too_big("user_id")
+        EventSizeError("user_id too large")
     if len(event.room_id) > 255:
-        too_big("room_id")
+        EventSizeError("room_id too large")
     if event.is_state() and len(event.state_key) > 255:
-        too_big("state_key")
+        EventSizeError("state_key too large")
     if len(event.type) > 255:
-        too_big("type")
+        EventSizeError("type too large")
     if len(event.event_id) > 255:
-        too_big("event_id")
+        EventSizeError("event_id too large")
     if len(encode_canonical_json(event.get_pdu_json())) > MAX_PDU_SIZE:
-        too_big("event")
+        EventSizeError("event too large")
 
 
 def _can_federate(event: EventBase, auth_events: StateMap[EventBase]) -> bool:


### PR DESCRIPTION
I recall having a difficult time searching through our GitHub org and Synapse's codebase directly in order to find the origin of an 'event_id too large' error message. I eventually found it here are asking around.

Then today someone else ran through the exact same failure mode, and I had to help them out.

This small commit should put an end to that needless cycle, and is a good lesson on making error messages easy to search for in a codebase.