### PR TITLE
Allow `room_alias_name` parameter to be handled by /createRoom calls on workers

### DIFF
--- a/changelog.d/10757.bugfix
+++ b/changelog.d/10757.bugfix
@@ -1,0 +1,1 @@
+Fix a bug which prevented calls to `/createRoom` that included the `room_alias_name` parameter from being handled by worker processes.

--- a/synapse/storage/databases/main/directory.py
+++ b/synapse/storage/databases/main/directory.py
@@ -75,8 +75,6 @@ class DirectoryWorkerStore(SQLBaseStore):
             desc="get_aliases_for_room",
         )
 
-
-class DirectoryStore(DirectoryWorkerStore):
     async def create_room_alias_association(
         self,
         room_alias: RoomAlias,
@@ -126,6 +124,8 @@ class DirectoryStore(DirectoryWorkerStore):
                 409, "Room alias %s already exists" % room_alias.to_string()
             )
 
+
+class DirectoryStore(DirectoryWorkerStore):
     async def delete_room_alias(self, room_alias: RoomAlias) -> str:
         room_id = await self.db_pool.runInteraction(
             "delete_room_alias", self._delete_room_alias_txn, room_alias


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/10716

[/createRoom](https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0createroom) recently gained support for being [run on worker processes](https://github.com/matrix-org/synapse/pull/10564). Unfortunately, it went unnoticed that passing the `room_alias_name` parameter to `/createRoom` fails on workers.

The reason for this not being caught beforehand was that the endpoint was never routed to workers in [sytest](https://github.com/matrix-org/sytest), thus the tests never raised a failure. Thus a PR for Sytest ~~will be coming along soon~~ is at https://github.com/matrix-org/sytest/pull/1128 which tests both this PR, and raises any other errors which may be lurking.