### PR TITLE
Return stripped state events for the room summary.

### DIFF
--- a/changelog.d/10760.bugfix
+++ b/changelog.d/10760.bugfix
@@ -1,0 +1,1 @@
+Only return the stripped state events for the `m.space.child` events in a room for the spaces summary from [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946).


### PR DESCRIPTION
The spaces summary / hierarchy endpoints should only return the stripped state events (+ `origin_server_ts`), not the entire event, for the children events of a room.

This is somewhat related to #10523 in that we'll be doing a decent chunk less work here.