### PR TITLE
Fix leaking per-room profiles for local users when rebuilding directory

### DIFF
--- a/changelog.d/10761.bugfix
+++ b/changelog.d/10761.bugfix
@@ -1,0 +1,1 @@
+Fix leaking per-room nicknames and avatars to the user directory for local users when the user directory is rebuilt.

--- a/docs/user_directory.md
+++ b/docs/user_directory.md
@@ -20,7 +20,7 @@ The last two (collectively called the "search tables") track who can
 see who.
 
 From all of these tables we exclude three types of local user:
-  - "support users"
+  - support users
   - appservice users
   - deactivated users
 

--- a/docs/user_directory.md
+++ b/docs/user_directory.md
@@ -14,7 +14,15 @@ flush the current tables and regenerate the directory.
 Data model
 ----------
 
-There are five relevant tables:
+There are five relevant tables that collectively form the "user directory".
+Three of them track a master list of all the users we could search for.
+The last two (collectively called the "search tables") track who can
+see who.
+
+From all of these tables we exclude three types of local user:
+  - "support users"
+  - appservice users
+  - deactivated users
 
 * `user_directory`. This contains the user_id, display name and avatar we'll
   return when you search the directory.

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -114,7 +114,7 @@ class UserDirectoryHandler(StateDeltasHandler):
         """
         # FIXME(#3714): We should probably do this in the same worker as all
         # the other changes.
-        excluded = await self.store.exclude_from_user_dir(user_id)
+        excluded = await self.store.is_excluded_from_user_dir(user_id)
         if not excluded:
             await self.store.update_profile_in_user_dir(
                 user_id, profile.display_name, profile.avatar_url
@@ -196,7 +196,7 @@ class UserDirectoryHandler(StateDeltasHandler):
                 room_id, prev_event_id, event_id, typ
             )
         elif typ == EventTypes.Member:
-            if await self.store.exclude_from_user_dir(state_key):
+            if await self.store.is_excluded_from_user_dir(state_key):
                 return
 
             joined = await self._get_key_change(
@@ -341,7 +341,7 @@ class UserDirectoryHandler(StateDeltasHandler):
             other_users_in_room = [
                 user
                 for user in users_in_room
-                if user != user_id and not await self.store.exclude_from_user_dir(user)
+                if user != user_id and not await self.store.is_excluded_from_user_dir(user)
             ]
 
             to_insert = set()

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -341,7 +341,8 @@ class UserDirectoryHandler(StateDeltasHandler):
             other_users_in_room = [
                 user
                 for user in users_in_room
-                if user != user_id and not await self.store.is_excluded_from_user_dir(user)
+                if user != user_id
+                and not await self.store.is_excluded_from_user_dir(user)
             ]
 
             to_insert = set()

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -341,8 +341,7 @@ class UserDirectoryHandler(StateDeltasHandler):
             other_users_in_room = [
                 user
                 for user in users_in_room
-                if user != user_id
-                   and not await self.store.exclude_from_user_dir(user)
+                if user != user_id and not await self.store.exclude_from_user_dir(user)
             ]
 
             to_insert = set()

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -550,10 +550,6 @@ class UserDirectoryStore(
     ApplicationServiceWorkerStore,
     RegistrationWorkerStore,
 ):
-    # How many records do we calculate before sending it to
-    # add_users_who_share_private_rooms?
-    SHARE_PRIVATE_WORKING_SET = 500
-
     def __init__(self, database: DatabasePool, db_conn, hs):
         super().__init__(database, db_conn, hs)
 

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -337,6 +337,8 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
 
         for user_id in users_to_work_on:
             if not await self.is_excluded_from_user_dir(user_id):
+                # Populate this local user's user directory entry with their
+                # profile information
                 profile = await self.get_profileinfo(get_localpart_from_id(user_id))
                 await self.update_profile_in_user_dir(
                     user_id, profile.display_name, profile.avatar_url

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -254,7 +254,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         users_with_profile = {
             user_id: profile
             for user_id, profile in users_with_profile.items()
-            if not await self.exclude_from_user_dir(user_id)
+            if not await self.is_excluded_from_user_dir(user_id)
         }
 
         # Upsert a user_directory record for each remote user we see.
@@ -336,7 +336,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         )
 
         for user_id in users_to_work_on:
-            if not await self.exclude_from_user_dir(user_id):
+            if not await self.is_excluded_from_user_dir(user_id):
                 profile = await self.get_profileinfo(get_localpart_from_id(user_id))
                 await self.update_profile_in_user_dir(
                     user_id, profile.display_name, profile.avatar_url
@@ -523,7 +523,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
             desc="update_user_directory_stream_pos",
         )
 
-    async def exclude_from_user_dir(self, user_id: str) -> bool:
+    async def is_excluded_from_user_dir(self, user_id: str) -> bool:
         """Certain classes of local user are omitted from the user directory.
         Is this user one of them?
         """

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -266,6 +266,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                 user_id, profile.display_name, profile.avatar_url
             )
 
+        # Now update the room sharing tables to include this room.
         is_public = await self.is_room_world_readable_or_publicly_joinable(room_id)
         if is_public:
             if users_with_profile:

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -16,16 +16,10 @@ from unittest.mock import Mock
 from twisted.internet import defer
 
 import synapse.rest.admin
-from synapse.api.constants import (
-    EventTypes,
-    Membership,
-    RoomEncryptionAlgorithms,
-    UserTypes,
-)
+from synapse.api.constants import EventTypes, RoomEncryptionAlgorithms, UserTypes
 from synapse.api.room_versions import RoomVersion, RoomVersions
 from synapse.rest.client import login, room, user_directory
 from synapse.storage.roommember import ProfileInfo
-from synapse.types import create_requester
 
 from tests import unittest
 from tests.storage.test_user_directory import GetUserDirectoryTables

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -143,36 +143,6 @@ class UserDirectoryTestCase(GetUserDirectoryTables, HomeserverTestCase):
         self.get_success(self.handler.handle_local_user_deactivated(r_user_id))
         self.store.remove_from_user_dir.called_once_with(r_user_id)
 
-    def test_reactivation_makes_regular_user_searchable(self):
-        user = self.register_user("regular", "pass")
-        user_token = self.login(user, "pass")
-        admin_user = self.register_user("admin", "pass", admin=True)
-
-        # Ensure the regular user is publicly visible and searchable.
-        public_room = self.helper.create_room_as(user, is_public=True, tok=user_token)
-        s = self.get_success(self.handler.search_users(admin_user, user, 10))
-        self.assertEqual(len(s["results"]), 1)
-        self.assertEqual(s["results"][0]["user_id"], user)
-
-        # Deactivate the user and check they're not searchable.
-        deactivate_handler = self.hs._deactivate_account_handler
-        self.get_success(
-            deactivate_handler.deactivate_account(
-                user, erase_data=False, requester=create_requester(admin_user)
-            )
-        )
-        s = self.get_success(self.handler.search_users(admin_user, user, 10))
-        self.assertEqual(s["results"], [])
-
-        # Reactivate the user and make them publicly visible again.
-        self.get_success(deactivate_handler.activate_account(user))
-        self.inject_room_member(public_room, user, Membership.JOIN)
-
-        # Check they're searchable.
-        s = self.get_success(self.handler.search_users(admin_user, user, 10))
-        self.assertEqual(len(s["results"]), 1)
-        self.assertEqual(s["results"][0]["user_id"], user)
-
     def test_private_room(self):
         """
         A user can be searched for only by people that are either in a public

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List, Set, Tuple
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import synapse
 from synapse.api.constants import UserTypes
 from synapse.appservice import ApplicationService
 from synapse.rest.client import login, room
 from synapse.storage import DataStore
-from synapse.storage.databases.main.appservice import _make_exclusive_regex
 
 from tests.test_utils.event_injection import inject_member_event
 from tests.unittest import HomeserverTestCase, override_config

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -287,6 +287,7 @@ class UserDirectoryInitialPopulationTestcase(
 
         users_in_directory = set(self.get_users_in_user_directory().keys())
         # No assertions about displaynames or avatars here.
+        # TODO extend this case to do so, or add a new test case to cover it
         self.assertEqual(users_in_directory, {u1, u2, remote1, remote2})
 
     def test_population_of_local_users_ignores_per_room_nicknames(self):

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -11,8 +11,277 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import List, Set, Tuple
 
+import synapse
+from synapse.api.constants import UserTypes
+from synapse.appservice import ApplicationService
+from synapse.rest.client import login, room
+from synapse.storage import DataStore
+
+from tests.test_utils.event_injection import inject_member_event
 from tests.unittest import HomeserverTestCase, override_config
+
+
+class GetUserDirectoryTables(HomeserverTestCase):
+    """These helpers aren't present on the store itself. We want to use them
+    here and in the handler's tests too.
+    """
+
+    store: DataStore
+
+    def get_users_in_public_rooms(self) -> List[Tuple[str, str]]:
+        r = self.get_success(
+            self.store.db_pool.simple_select_list(
+                "users_in_public_rooms", None, ("user_id", "room_id")
+            )
+        )
+        retval = []
+        for i in r:
+            retval.append((i["user_id"], i["room_id"]))
+        return retval
+
+    def get_users_who_share_private_rooms(self) -> List[Tuple[str, str, str]]:
+        return self.get_success(
+            self.store.db_pool.simple_select_list(
+                "users_who_share_private_rooms",
+                None,
+                ["user_id", "other_user_id", "room_id"],
+            )
+        )
+
+    def get_users_in_user_directory(self) -> Set[str]:
+        # Just the set of usernames for now
+        r = self.get_success(
+            self.store.db_pool.simple_select_list(
+                "user_directory", None, ("user_id", "display_name")
+            )
+        )
+        return {entry["user_id"] for entry in r}
+
+    def _compress_shared(self, shared):
+        """
+        Compress a list of users who share rooms dicts to a list of tuples.
+        """
+        r = set()
+        for i in shared:
+            r.add((i["user_id"], i["other_user_id"], i["room_id"]))
+        return r
+
+
+class UserDirectoryInitialPopulationTestcase(
+    GetUserDirectoryTables, HomeserverTestCase
+):
+    """Ensure that the initial background process creates the user directory data
+    as intended.
+
+    See also tests/handlers/test_user_directory.py for similar checks. They
+    test the incremental updates, rather than the big batch of updates.
+    """
+
+    servlets = [
+        login.register_servlets,
+        synapse.rest.admin.register_servlets_for_client_rest_resource,
+        room.register_servlets,
+    ]
+
+    def prepare(self, reactor, clock, hs):
+        self.store = hs.get_datastore()
+
+    def _purge_and_rebuild_user_dir(self):
+        """Nuke the user directory tables, start the background process to
+        repopulate them, and wait for the process to complete. This allows us
+        to inspect the outcome of the background process alone, without any of
+        the other incremental updates.
+        """
+        self.get_success(self.store.update_user_directory_stream_pos(None))
+        self.get_success(self.store.delete_all_from_user_dir())
+
+        shares_private = self.get_users_who_share_private_rooms()
+        public_users = self.get_users_in_public_rooms()
+
+        # Nothing updated yet
+        self.assertEqual(shares_private, [])
+        self.assertEqual(public_users, [])
+
+        # Ugh, have to reset this flag
+        self.store.db_pool.updates._all_done = False
+
+        self.get_success(
+            self.store.db_pool.simple_insert(
+                "background_updates",
+                {
+                    "update_name": "populate_user_directory_createtables",
+                    "progress_json": "{}",
+                },
+            )
+        )
+        self.get_success(
+            self.store.db_pool.simple_insert(
+                "background_updates",
+                {
+                    "update_name": "populate_user_directory_process_rooms",
+                    "progress_json": "{}",
+                    "depends_on": "populate_user_directory_createtables",
+                },
+            )
+        )
+        self.get_success(
+            self.store.db_pool.simple_insert(
+                "background_updates",
+                {
+                    "update_name": "populate_user_directory_process_users",
+                    "progress_json": "{}",
+                    "depends_on": "populate_user_directory_process_rooms",
+                },
+            )
+        )
+        self.get_success(
+            self.store.db_pool.simple_insert(
+                "background_updates",
+                {
+                    "update_name": "populate_user_directory_cleanup",
+                    "progress_json": "{}",
+                    "depends_on": "populate_user_directory_process_users",
+                },
+            )
+        )
+
+        while not self.get_success(
+            self.store.db_pool.updates.has_completed_background_updates()
+        ):
+            self.get_success(
+                self.store.db_pool.updates.do_next_background_update(100), by=0.1
+            )
+
+    def test_populates_local_users(self):
+        u1 = self.register_user("user1", "pass")
+        u1_token = self.login(u1, "pass")
+        u2 = self.register_user("user2", "pass")
+        u2_token = self.login(u2, "pass")
+        u3 = self.register_user("user3", "pass")
+        u3_token = self.login(u3, "pass")
+
+        room = self.helper.create_room_as(u1, is_public=True, tok=u1_token)
+        self.helper.invite(room, src=u1, targ=u2, tok=u1_token)
+        self.helper.join(room, user=u2, tok=u2_token)
+
+        private_room = self.helper.create_room_as(u1, is_public=False, tok=u1_token)
+        self.helper.invite(private_room, src=u1, targ=u3, tok=u1_token)
+        self.helper.join(private_room, user=u3, tok=u3_token)
+
+        self._purge_and_rebuild_user_dir()
+
+        shares_private = self.get_users_who_share_private_rooms()
+        public_users = self.get_users_in_public_rooms()
+
+        # User 1 and User 2 are in the same public room
+        self.assertEqual(set(public_users), {(u1, room), (u2, room)})
+
+        # User 1 and User 3 share private rooms
+        self.assertEqual(
+            self._compress_shared(shares_private),
+            {(u1, u3, private_room), (u3, u1, private_room)},
+        )
+
+        # All three should have entries in the directory
+        self.assertEqual(self.get_users_in_user_directory(), {u1, u2, u3})
+
+    def test_populates_users_in_zero_rooms(self):
+        billy_no_mates = self.register_user("user2", "pass")
+        self._purge_and_rebuild_user_dir()
+        self.assertEqual(self.get_users_in_user_directory(), {billy_no_mates})
+        self.assertEqual(self.get_users_in_public_rooms(), [])
+        self.assertEqual(self.get_users_who_share_private_rooms(), [])
+
+    def test_population_excludes_support_user(self):
+        support = "@support1:test"
+        self.get_success(
+            self.store.register_user(
+                user_id=support, password_hash=None, user_type=UserTypes.SUPPORT
+            )
+        )
+
+        self._purge_and_rebuild_user_dir()
+        # TODO add support user to a public and private room. Check that
+        # users_in_public_rooms and users_who_share_private_rooms is empty.
+        self.assertEqual(self.get_users_in_user_directory(), set())
+
+    def test_population_excludes_appservice_user(self):
+        as_token = "i_am_an_app_service"
+        appservice = ApplicationService(
+            as_token,
+            self.hs.config.server_name,
+            id="1234",
+            namespaces={"users": [{"regex": r"@as_user.*", "exclusive": True}]},
+            sender="@as:test",
+        )
+        as_user = "@as_user_potato:test"
+        self.hs.get_datastore().services_cache.append(appservice)
+        self.get_success(self.store.register_user(user_id=as_user, password_hash=None))
+
+        self._purge_and_rebuild_user_dir()
+
+        # TODO add AS user to a public and private room. Check that
+        # users_in_public_rooms and users_who_share_private_rooms is empty.
+        self.assertEqual(self.get_users_in_user_directory(), set())
+
+    def test_population_excludes_deactivated_user(self):
+        user = self.register_user("rip", "pass")
+        user_token = self.login(user, "pass")
+        self.helper.create_room_as(user, is_public=True, tok=user_token)
+        self.helper.create_room_as(user, is_public=False, tok=user_token)
+        self.get_success(self.store.set_user_deactivated_status(user, True))
+
+        self._purge_and_rebuild_user_dir()
+
+        self.assertEqual(self.get_users_in_public_rooms(), [])
+        self.assertEqual(self.get_users_who_share_private_rooms(), [])
+        self.assertEqual(self.get_users_in_user_directory(), set())
+
+    def test_populates_remote_and_local_users(self):
+        """All local users and remote users have entries in the user_directory table.
+
+        Test normal local user in a room is in the user directory.
+        Test remote user in a public room is in the user directory.
+        Test remote user in a private room is in the user directory.
+        """
+        u1 = self.register_user("user1", "pass")
+        u1_token = self.login(u1, "pass")
+        u2 = self.register_user("user2", "pass")
+
+        remote1 = "@c:other.server"
+        remote2 = "@d:other.server"
+
+        public_room = self.helper.create_room_as(u1, is_public=True, tok=u1_token)
+        self.get_success(
+            inject_member_event(
+                self.hs,
+                public_room,
+                remote1,
+                "join",
+            )
+        )
+
+        private_room = self.helper.create_room_as(u1, is_public=False, tok=u1_token)
+        self.get_success(
+            inject_member_event(self.hs, public_room, u1, "invite", remote2)
+        )
+        self.get_success(
+            inject_member_event(
+                self.hs,
+                private_room,
+                remote2,
+                "join",
+            )
+        )
+
+        self._purge_and_rebuild_user_dir()
+
+        users_in_directory = self.get_users_in_user_directory()
+        # No assertions about displaynames or avatars here.
+        self.assertEqual(users_in_directory, {u1, u2, remote1, remote2})
+
 
 ALICE = "@alice:a"
 BOB = "@bob:b"


### PR DESCRIPTION
Another step to tackle #5677.

I think this series of changes should ensure that _rebuilding_ the user directory doesn't leak per-room profiles for local users. To convince myself of this I added some extra test cases.

I also took the opportunity to try and apply some extra cleanups.