### PR TITLE
Fix reactivated users not being added to directory

### DIFF
--- a/changelog.d/10762.bugfix
+++ b/changelog.d/10762.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where reactivated users would be missing from the user directory.

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -263,6 +263,8 @@ class DeactivateAccountHandler(BaseHandler):
         # Mark the user as active.
         await self.store.set_user_deactivated_status(user_id, False)
 
-        # Add the user to the directory, if necessary.
+        # Add the user to the directory, if necessary. Note that
+        # this must be done after the user is re-activated, because
+        # deactivated users are excluded from the user directory.
         profile = await self.store.get_profileinfo(user.localpart)
         await self.user_directory_handler.handle_local_profile_change(user_id, profile)

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -257,11 +257,12 @@ class DeactivateAccountHandler(BaseHandler):
         """
         # Add the user to the directory, if necessary.
         user = UserID.from_string(user_id)
-        profile = await self.store.get_profileinfo(user.localpart)
-        await self.user_directory_handler.handle_local_profile_change(user_id, profile)
 
         # Ensure the user is not marked as erased.
         await self.store.mark_user_not_erased(user_id)
 
         # Mark the user as active.
         await self.store.set_user_deactivated_status(user_id, False)
+
+        profile = await self.store.get_profileinfo(user.localpart)
+        await self.user_directory_handler.handle_local_profile_change(user_id, profile)

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -255,7 +255,6 @@ class DeactivateAccountHandler(BaseHandler):
         Args:
             user_id: ID of user to be re-activated
         """
-        # Add the user to the directory, if necessary.
         user = UserID.from_string(user_id)
 
         # Ensure the user is not marked as erased.
@@ -264,5 +263,6 @@ class DeactivateAccountHandler(BaseHandler):
         # Mark the user as active.
         await self.store.set_user_deactivated_status(user_id, False)
 
+        # Add the user to the directory, if necessary.
         profile = await self.store.get_profileinfo(user.localpart)
         await self.user_directory_handler.handle_local_profile_change(user_id, profile)

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -164,10 +164,8 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         self.get_success(deactivate_handler.activate_account(user))
         # Hackily reset password by restoring the old pw hash.
         self.get_success(
-            self.store.db_pool.simple_update_one(
-                "users",
-                {"name": user},
-                {"password_hash": password_hash},
+            self.hs.get_set_password_handler().set_password(
+                user, password_hash, logout_devices=False
             )
         )
         user_token = self.login(user, "pass")

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -21,6 +21,7 @@ from synapse.api.constants import EventTypes, RoomEncryptionAlgorithms, UserType
 from synapse.api.room_versions import RoomVersion, RoomVersions
 from synapse.rest.client import login, room, user_directory
 from synapse.storage.roommember import ProfileInfo
+from synapse.types import create_requester
 
 from tests import unittest
 from tests.unittest import override_config
@@ -133,11 +134,13 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
 
     def test_reactivation_makes_regular_user_searchable(self):
         user = self.register_user("regular", "pass")
-        password_hash = self.get_success(self.store.db_pool.simple_select_one_onecol(
-            "users",
-            {"name": user},
-            "password_hash",
-        ))
+        password_hash = self.get_success(
+            self.store.db_pool.simple_select_one_onecol(
+                "users",
+                {"name": user},
+                "password_hash",
+            )
+        )
         user_token = self.login(user, "pass")
         admin_user = self.register_user("admin", "pass", admin=True)
 
@@ -160,11 +163,13 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         # Reactivate the user
         self.get_success(deactivate_handler.activate_account(user))
         # Hackily reset password by restoring the old pw hash.
-        self.get_success(self.store.db_pool.simple_update_one(
-            "users",
-            {"name": user},
-            {"password_hash": password_hash},
-        ))
+        self.get_success(
+            self.store.db_pool.simple_update_one(
+                "users",
+                {"name": user},
+                {"password_hash": password_hash},
+            )
+        )
         user_token = self.login(user, "pass")
         self.helper.create_room_as(user, is_public=True, tok=user_token)
 


### PR DESCRIPTION
Pulled this out of larger WIP changes because it's small and relatively isolated from the other changes.

The problem here is that `handle_local_profile_change` checks the DB to ensure the user isn't deactivated before upserting a directory entry.. So we need to reactivate them before calling this function, otherwise it'll do nothing.