### PR TITLE
Persist auth events before the events that rely on them

### DIFF
--- a/changelog.d/10771.misc
+++ b/changelog.d/10771.misc
@@ -1,0 +1,1 @@
+Clean up some of the federation event authentication code for clarity.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1129,7 +1129,19 @@ class FederationEventHandler:
 
         await concurrently_execute(get_event, event_ids, 5)
         logger.info("Fetched %i events of %i requested", len(event_map), len(event_ids))
+        await self._auth_and_persist_fetched_events(destination, room_id, event_map)
 
+    async def _auth_and_persist_fetched_events(
+        self, origin: str, room_id: str, event_map: Dict[str, EventBase]
+    ) -> None:
+        """Persist the events fetched by _get_events_and_persist
+
+        Params:
+            origin: where the events came from
+            room_id: the room that the events are meant to be in (though this has
+               not yet been checked)
+            event_id: map from event_id -> event for the fetched events
+        """
         # Make a map of auth events for each event. We do this after fetching
         # all the events as some of the events' auth events will be in the list
         # of requested events.
@@ -1159,7 +1171,7 @@ class FederationEventHandler:
 
         if event_infos:
             await self._auth_and_persist_events(
-                destination,
+                origin,
                 room_id,
                 event_infos,
             )

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1085,7 +1085,7 @@ class FederationEventHandler:
         )
 
     async def _get_events_and_persist(
-        self, destination: str, room_id: str, event_ids: Iterable[str]
+        self, destination: str, room_id: str, event_ids: Collection[str]
     ) -> None:
         """Fetch the given events from a server, and persist them as outliers.
 
@@ -1128,6 +1128,7 @@ class FederationEventHandler:
                     )
 
         await concurrently_execute(get_event, event_ids, 5)
+        logger.info("Fetched %i events of %i requested", len(event_map), len(event_ids))
 
         # Make a map of auth events for each event. We do this after fetching
         # all the events as some of the events' auth events will be in the list

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1167,7 +1167,16 @@ class FederationEventHandler:
     async def _auth_and_persist_fetched_events(
         self, origin: str, room_id: str, fetched_events: Collection[EventBase]
     ) -> None:
-        """Persist the events fetched by _get_events_and_persist
+        """Persist the events fetched by _get_events_and_persist.
+
+        The events should not depend on one another, e.g. this should be used to persist
+        a bunch of outliers, but not a chunk of individual events that depend
+        on each other for state calculations.
+
+        We also assume that all of the auth events for all of the events have already
+        been persisted.
+
+        Notifies about the events where appropriate.
 
         Params:
             origin: where the events came from
@@ -1196,27 +1205,6 @@ class FederationEventHandler:
                     logger.info("Missing auth event %s", auth_event_id)
 
             event_infos.append(_NewEventInfo(event, auth))
-
-        if event_infos:
-            await self._auth_and_persist_events(
-                origin,
-                room_id,
-                event_infos,
-            )
-
-    async def _auth_and_persist_events(
-        self,
-        origin: str,
-        room_id: str,
-        event_infos: Collection[_NewEventInfo],
-    ) -> None:
-        """Creates the appropriate contexts and persists events. The events
-        should not depend on one another, e.g. this should be used to persist
-        a bunch of outliers, but not a chunk of individual events that depend
-        on each other for state calculations.
-
-        Notifies about the events where appropriate.
-        """
 
         if not event_infos:
             return

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -818,7 +818,7 @@ class FederationEventHandler:
         missing_events = missing_desired_events | missing_auth_events
         logger.debug("Fetching %i events from remote", len(missing_events))
         await self._get_events_and_persist(
-            destination=destination, room_id=room_id, events=missing_events
+            destination=destination, room_id=room_id, event_ids=missing_events
         )
 
         # we need to make sure we re-load from the database to get the rejected
@@ -1085,12 +1085,12 @@ class FederationEventHandler:
         )
 
     async def _get_events_and_persist(
-        self, destination: str, room_id: str, events: Iterable[str]
+        self, destination: str, room_id: str, event_ids: Iterable[str]
     ) -> None:
         """Fetch the given events from a server, and persist them as outliers.
 
         This function *does not* recursively get missing auth events of the
-        newly fetched events. Callers must include in the `events` argument
+        newly fetched events. Callers must include in the `event_ids` argument
         any missing events from the auth chain.
 
         Logs a warning if we can't find the given event.
@@ -1127,7 +1127,7 @@ class FederationEventHandler:
                         e,
                     )
 
-        await concurrently_execute(get_event, events, 5)
+        await concurrently_execute(get_event, event_ids, 5)
 
         # Make a map of auth events for each event. We do this after fetching
         # all the events as some of the events' auth events will be in the list


### PR DESCRIPTION
If we're persisting an event `E` which has `auth_event`s `A1`, `A2`, then we ought to make sure that we correctly auth and persist `A1` and `A2`, before we blindly accept `E`.

This PR does *part* of that - it persists the auth events first - but it does not fully solve the problem, because we still don't check that the auth events weren't rejected.

It's a bit of a refactorathon, but it should be reviewable commit-by-commit.
