### PR TITLE
Prefer room v9 for restricted rooms.

### DIFF
--- a/changelog.d/10772.feature
+++ b/changelog.d/10772.feature
@@ -1,0 +1,1 @@
+Prefer [room version 9](https://github.com/matrix-org/matrix-doc/pull/3375) for restricted rooms per the [room version caapabilities](https://github.com/matrix-org/matrix-doc/pull/3244) API.

--- a/synapse/api/room_versions.py
+++ b/synapse/api/room_versions.py
@@ -324,7 +324,7 @@ MSC3244_CAPABILITIES = {
         ),
         RoomVersionCapability(
             "restricted",
-            RoomVersions.V8,
+            RoomVersions.V9,
             lambda room_version: room_version.msc3083_join_rules,
         ),
     )


### PR DESCRIPTION
Per the discussion in #10747, this flips clients from preferring room version 8 to room version 9 when creating restricted rooms.

We believe that waiting a single release will give enough uptick across federation that most users will be on a Synapse that supports room version 9 (and wish to push it out a bit quickly since room version 8 is buggy).