### PR TITLE
Add a script to update the debian changelog for non-Debian systems

### DIFF
--- a/changelog.d/10778.misc
+++ b/changelog.d/10778.misc
@@ -1,0 +1,1 @@
+Add a script to update the Debian changelog in a Docker container for systems that aren't Debian-based.

--- a/scripts-dev/docker_update_debian_changelog.sh
+++ b/scripts-dev/docker_update_debian_changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2021 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,7 +47,9 @@ fi
 
 # We set -x here rather than in the shebang so that if we need to exit early because no
 # version was provided, the message doesn't get drowned in useless output.
-set -x
+# We also set -e here rather than in the shebang, because we don't want the script to exit
+# without any error message if one of the checks before (which and grep) returned 1.
+set -xe
 
 # Make the root of the Synapse checkout the current working directory.
 cd /synapse

--- a/scripts-dev/docker_update_debian_changelog.sh
+++ b/scripts-dev/docker_update_debian_changelog.sh
@@ -18,7 +18,7 @@
 # not easily accessible.
 #
 # Running it (when if the current working directory is the root of the Synapse checkout):
-#   docker run -v $PWD:/synapse ubuntu:latest /synapse/scripts-dev/update_debian_changelog.sh VERSION
+#   docker run -v $PWD:/synapse ubuntu:latest /synapse/scripts-dev/docker_update_debian_changelog.sh VERSION
 #
 # The image can be replaced by any other Debian-based image (as long as the `devscripts`
 # package exists in the default repository).
@@ -28,6 +28,20 @@
 if [ "$#" -ne 1 ]; then
   echo "Usage: update_debian_changelog.sh VERSION"
   echo "VERSION is the version of Synapse being released in the form 1.42.0 (without the leading \"v\")"
+  exit 1
+fi
+
+# Check that apt-get is available on the system.
+which apt-get > /dev/null 2>&1
+if [ "$?" -ne 0 ]; then
+  echo "\"apt-get\" isn't available on this system. This script needs to be run in a Docker container using a Debian-based image."
+  exit 1
+fi
+
+# Check if devscripts is available in the default repos for this distro.
+apt-cache search devscripts | grep -E "^devscripts \-" > /dev/null
+if [ "$?" -ne 0 ]; then
+  echo "The package \"devscripts\" needs to exist in the default repositories for this distribution."
   exit 1
 fi
 

--- a/scripts-dev/docker_update_debian_changelog.sh
+++ b/scripts-dev/docker_update_debian_changelog.sh
@@ -54,8 +54,8 @@ set -x
 # Make the root of the Synapse checkout the current working directory.
 cd /synapse
 
-# Install devscripts (which provides dch). We need to make the Debian frontent noninteractive
-# because installing devscripts otherwise asks for the machine's location.
+# Install devscripts (which provides dch). We need to make the Debian frontend
+# noninteractive because installing devscripts otherwise asks for the machine's location.
 DEBIAN_FRONTEND=noninteractive apt-get install -y devscripts
 
 # Update the Debian changelog.

--- a/scripts-dev/docker_update_debian_changelog.sh
+++ b/scripts-dev/docker_update_debian_changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # Copyright 2021 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,9 +49,7 @@ fi
 
 # We set -x here rather than in the shebang so that if we need to exit early because no
 # version was provided, the message doesn't get drowned in useless output.
-# We also set -e here rather than in the shebang, because we don't want the script to exit
-# without any error message if one of the checks before (which and grep) returned 1.
-set -xe
+set -x
 
 # Make the root of the Synapse checkout the current working directory.
 cd /synapse

--- a/scripts-dev/update_debian_changelog.sh
+++ b/scripts-dev/update_debian_changelog.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is meant to be used inside a Docker container to run the `dch` incantations
+# needed to release Synapse. This is useful on systems like macOS where such scripts are
+# not easily accessible.
+#
+# Running it (when if the current working directory is the root of the Synapse checkout):
+#   docker run -v $PWD:/synapse ubuntu:latest /synapse/scripts-dev/update_debian_changelog.sh VERSION
+#
+# The image can be replaced by any other Debian-based image (as long as the `devscripts`
+# package exists in the default repository).
+# `VERSION` is the version of Synapse being released without the leading "v" (e.g. 1.42.0).
+
+# Check if a version was provided.
+if [ "$#" -ne 1 ]; then
+  echo "Usage: update_debian_changelog.sh VERSION"
+  echo "VERSION is the version of Synapse being released in the form 1.42.0 (without the leading \"v\")"
+  exit 1
+fi
+
+# We set -x here rather than in the shebang so that if we need to exit early because no
+# version was provided, the message doesn't get drowned in useless output.
+set -x
+
+# Make the root of the Synapse checkout the current working directory.
+cd /synapse
+
+# Update the packages list and install devscripts (which provides dch). We need to make
+# the Debian frontent noninteractive because installing devscripts otherwise asks for the
+# machine's location.
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y devscripts
+
+# Update the Debian changelog.
+ver=${1}
+dch -M -v $(sed -Ee 's/(rc|a|b|c)/~\1/' <<<$ver) "New synapse release $ver."
+dch -M -r -D stable ""


### PR DESCRIPTION
When releasing 1.42.0 with @Azrenbeth and talking with @clokep yesterday I realised doing the `dch` incantations related to releasing Synapse wasn't trivial, so I thought I'd write a script to run in a Debian container to make things a bit easier.