### PR TITLE
Change logging of puppeted requests to better differentiate users

### DIFF
--- a/changelog.d/10779.misc
+++ b/changelog.d/10779.misc
@@ -1,0 +1,1 @@
+Change the format of authenticated users in logs when a user is being puppeted by and admin user.

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -384,7 +384,7 @@ class SynapseRequest(Request):
         # authenticated (e.g. and admin is puppetting a user) then we log both.
         requester, authenticated_entity = self.get_authenticated_entity()
         if authenticated_entity:
-            requester = f"{authenticated_entity}.{requester}"
+            requester = f"{authenticated_entity}|{requester}"
 
         self.site.access_logger.log(
             log_level,


### PR DESCRIPTION
This used to be a comma and got accidentally changed to a period in https://github.com/matrix-org/synapse/pull/9654, but a pipe character is more easier to parse visually

```
{@ems_administrator:one-staging.ems.host,@eotestingcheckboxtest:one-staging.ems.host}
```

vs
```
{@ems_administrator:one-staging.ems.host|@eotestingcheckboxtest:one-staging.ems.host}
```
