### PR TITLE
Skip handling of push actions for outlier events

### DIFF
--- a/changelog.d/10780.misc
+++ b/changelog.d/10780.misc
@@ -1,0 +1,1 @@
+Minor speed ups when joining large rooms over federation.

--- a/tests/storage/test_event_push_actions.py
+++ b/tests/storage/test_event_push_actions.py
@@ -69,6 +69,7 @@ class EventPushActionsStoreTestCase(HomeserverTestCase):
             event.room_id = room_id
             event.event_id = "$test:example.com"
             event.internal_metadata.stream_ordering = stream
+            event.internal_metadata.is_outlier.return_value = False
             event.depth = stream
 
             self.get_success(


### PR DESCRIPTION
Outlier events don't ever have push actions associated with them, so we
can skip some expensive queries during event persistence.