### PR TITLE
Fix frontend_proxy jinja script in docker workers

### DIFF
--- a/changelog.d/10783.bugfix
+++ b/changelog.d/10783.bugfix
@@ -1,0 +1,1 @@
+Fix a bug which generated invalid homeserver config when the `frontend_proxy` worker type was passed to the Synapse Worker-based Complement image.

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -162,7 +162,7 @@ WORKERS_CONFIG = {
         "shared_extra_conf": {},
         "worker_extra_conf": (
             "worker_main_http_uri: http://127.0.0.1:%d"
-            % (MAIN_PROCESS_HTTP_LISTENER_PORT,),
+            % (MAIN_PROCESS_HTTP_LISTENER_PORT,)
         ),
     },
 }


### PR DESCRIPTION
With the trailing comma, the output is:
```
('worker_main_http_uri: http://127.0.0.1:8080',)
```
whereas we really want:
```
worker_main_http_uri: http://127.0.0.1:8080
```
This manifests itself as the upload key endpoint failing with:
```
  File "/usr/local/lib/python3.8/site-packages/synapse/app/generic_worker.py", line 208, in on_POST
    self.main_uri + request.uri.decode("ascii"), body, headers=headers
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```