### PR TITLE
Use  the BaseReporter super-class for _WrappedRustReporter.

### DIFF
--- a/changelog.d/10799.misc
+++ b/changelog.d/10799.misc
@@ -1,0 +1,1 @@
+Add a max version for the `jaeger-client` dependency for an incompatibility with the rust reporter.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -236,8 +236,16 @@ except ImportError:
 try:
     from rust_python_jaeger_reporter import Reporter
 
+    # jaeger-client 4.7.0 requires that reporters inherit from BaseReporter, which
+    # didn't exist before that version.
+    try:
+        from jaeger_client.reporter import BaseReporter
+    except ImportError:
+        class BaseReporter:  # type: ignore[no-redef]
+            pass
+
     @attr.s(slots=True, frozen=True)
-    class _WrappedRustReporter:
+    class _WrappedRustReporter(BaseReporter):
         """Wrap the reporter to ensure `report_span` never throws."""
 
         _reporter = attr.ib(type=Reporter, default=attr.Factory(Reporter))
@@ -382,6 +390,7 @@ def init_tracer(hs: "HomeServer"):
     # If we have the rust jaeger reporter available let's use that.
     if RustReporter:
         logger.info("Using rust_python_jaeger_reporter library")
+        assert config.sampler is not None
         tracer = config.create_tracer(RustReporter(), config.sampler)
         opentracing.set_global_tracer(tracer)
     else:

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -241,6 +241,7 @@ try:
     try:
         from jaeger_client.reporter import BaseReporter
     except ImportError:
+
         class BaseReporter:  # type: ignore[no-redef]
             pass
 

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -107,7 +107,7 @@ CONDITIONAL_REQUIREMENTS = {
     "systemd": ["systemd-python>=231"],
     "url_preview": ["lxml>=3.5.0"],
     "sentry": ["sentry-sdk>=0.7.2"],
-    "opentracing": ["jaeger-client>=4.0.0,<4.7.0", "opentracing>=2.2.0"],
+    "opentracing": ["jaeger-client>=4.0.0", "opentracing>=2.2.0"],
     "jwt": ["pyjwt>=1.6.4"],
     # hiredis is not a *strict* dependency, but it makes things much faster.
     # (if it is not installed, we fall back to slow code.)

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -107,7 +107,7 @@ CONDITIONAL_REQUIREMENTS = {
     "systemd": ["systemd-python>=231"],
     "url_preview": ["lxml>=3.5.0"],
     "sentry": ["sentry-sdk>=0.7.2"],
-    "opentracing": ["jaeger-client>=4.0.0", "opentracing>=2.2.0"],
+    "opentracing": ["jaeger-client>=4.0.0,<4.7.0", "opentracing>=2.2.0"],
     "jwt": ["pyjwt>=1.6.4"],
     # hiredis is not a *strict* dependency, but it makes things much faster.
     # (if it is not installed, we fall back to slow code.)


### PR DESCRIPTION
Add a max version for the `jaeger-client` dependency for an incompatibility with the rust reporter.

Without this you get an error:

```
synapse/logging/opentracing.py:385: error: Argument 1 to "create_tracer" of "Config" has incompatible type "_WrappedRustReporter"; expected "BaseReporter"  [arg-type]
synapse/logging/opentracing.py:385: error: Argument 2 to "create_tracer" of "Config" has incompatible type "Optional[Sampler]"; expected "Sampler"  [arg-type]
```