### PR TITLE
Improve oEmbed previews

### DIFF
--- a/changelog.d/10819.feature
+++ b/changelog.d/10819.feature
@@ -1,0 +1,1 @@
+Improve oEmbed previews by processing the author name, photo, and video information.

--- a/synapse/rest/media/v1/oembed.py
+++ b/synapse/rest/media/v1/oembed.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class OEmbedResult:
     # The Open Graph result (converted from the oEmbed result).
     open_graph_result: JsonDict
-    # Number of seconds to cache the content, according to the oEmbed response.
+    # Number of milliseconds to cache the content, according to the oEmbed response.
     #
     # This will be None if no cache-age is provided in the oEmbed response (or
     # if the oEmbed response cannot be turned into an Open Graph response).
@@ -121,7 +121,7 @@ class OEmbedProvider:
             # Ensure the cache age is None or an int.
             cache_age = oembed.get("cache_age")
             if cache_age:
-                cache_age = int(cache_age)
+                cache_age = int(cache_age) * 1000
 
             # The results.
             open_graph_response = {

--- a/synapse/rest/media/v1/oembed.py
+++ b/synapse/rest/media/v1/oembed.py
@@ -124,7 +124,9 @@ class OEmbedProvider:
                 cache_age = int(cache_age)
 
             # The results.
-            open_graph_response = {}
+            open_graph_response = {
+                "og:url": url,
+            }
 
             # Use either title or author's name as the title.
             title = oembed.get("title") or oembed.get("author_name")

--- a/synapse/rest/media/v1/oembed.py
+++ b/synapse/rest/media/v1/oembed.py
@@ -122,7 +122,17 @@ class OEmbedProvider:
                 cache_age = int(cache_age)
 
             # The results.
-            open_graph_response = {"og:title": oembed.get("title")}
+            open_graph_response = {}
+
+            # Use either title or author's name as the title.
+            title = oembed.get("title") or oembed.get("author_name")
+            if title:
+                open_graph_response["og:title"] = title
+
+            # Use the provider name and as the site.
+            provider_name = oembed.get("provider_name")
+            if provider_name:
+                open_graph_response["og:site_name"] = provider_name
 
             # If a thumbnail exists, use it. Note that dimensions will be calculated later.
             if "thumbnail_url" in oembed:

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -305,7 +305,7 @@ class PreviewUrlResource(DirectServeJsonResource):
             with open(media_info.filename, "rb") as file:
                 body = file.read()
 
-            oembed_response = self._oembed.parse_oembed_response(media_info.uri, body)
+            oembed_response = self._oembed.parse_oembed_response(url, body)
             og = oembed_response.open_graph_result
 
             # Use the cache age from the oEmbed result, instead of the HTTP response.

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -620,6 +620,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.assertIn(b"/matrixdotorg", server.data)
 
         self.assertEqual(channel.code, 200)
+        self.assertIn("og:url", channel.json_body)
         self.assertTrue(channel.json_body["og:image"].startswith("mxc://"))
         self.assertEqual(channel.json_body["og:image:height"], 1)
         self.assertEqual(channel.json_body["og:image:width"], 1)
@@ -661,9 +662,11 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         self.pump()
         self.assertEqual(channel.code, 200)
+        # The JSON body should have a URL, but we don't really care what it is.
+        body = channel.json_body
+        body.pop("og:url")
         self.assertEqual(
-            channel.json_body,
-            {"og:title": "Alice", "og:description": "Content Preview"},
+            body, {"og:title": "Alice", "og:description": "Content Preview"}
         )
 
     def test_oembed_format(self):
@@ -706,7 +709,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.assertIn(b"format=json", server.data)
 
         self.assertEqual(channel.code, 200)
-        self.assertEqual(
-            channel.json_body,
-            {"og:description": "Content Preview"},
-        )
+        # The JSON body should have a URL, but we don't really care what it is.
+        body = channel.json_body
+        body.pop("og:url")
+        self.assertEqual(body, {"og:description": "Content Preview"})

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -620,7 +620,6 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.assertIn(b"/matrixdotorg", server.data)
 
         self.assertEqual(channel.code, 200)
-        self.assertIsNone(channel.json_body["og:title"])
         self.assertTrue(channel.json_body["og:image"].startswith("mxc://"))
         self.assertEqual(channel.json_body["og:image:height"], 1)
         self.assertEqual(channel.json_body["og:image:width"], 1)
@@ -633,6 +632,8 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         result = {
             "version": "1.0",
             "type": "rich",
+            # Note that this provides the author, not the title.
+            "author_name": "Alice",
             "html": "<div>Content Preview</div>",
         }
         end_content = json.dumps(result).encode("utf-8")
@@ -662,7 +663,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, 200)
         self.assertEqual(
             channel.json_body,
-            {"og:title": None, "og:description": "Content Preview"},
+            {"og:title": "Alice", "og:description": "Content Preview"},
         )
 
     def test_oembed_format(self):
@@ -707,5 +708,5 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, 200)
         self.assertEqual(
             channel.json_body,
-            {"og:title": None, "og:description": "Content Preview"},
+            {"og:description": "Content Preview"},
         )

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -620,11 +620,12 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.assertIn(b"/matrixdotorg", server.data)
 
         self.assertEqual(channel.code, 200)
-        self.assertIn("og:url", channel.json_body)
-        self.assertTrue(channel.json_body["og:image"].startswith("mxc://"))
-        self.assertEqual(channel.json_body["og:image:height"], 1)
-        self.assertEqual(channel.json_body["og:image:width"], 1)
-        self.assertEqual(channel.json_body["og:image:type"], "image/png")
+        body = channel.json_body
+        self.assertEqual(body["og:url"], "http://twitter.com/matrixdotorg/status/12345")
+        self.assertTrue(body["og:image"].startswith("mxc://"))
+        self.assertEqual(body["og:image:height"], 1)
+        self.assertEqual(body["og:image:width"], 1)
+        self.assertEqual(body["og:image:type"], "image/png")
 
     def test_oembed_rich(self):
         """Test an oEmbed endpoint which returns HTML content via the 'rich' type."""
@@ -662,11 +663,14 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         self.pump()
         self.assertEqual(channel.code, 200)
-        # The JSON body should have a URL, but we don't really care what it is.
         body = channel.json_body
-        body.pop("og:url")
         self.assertEqual(
-            body, {"og:title": "Alice", "og:description": "Content Preview"}
+            body,
+            {
+                "og:url": "http://twitter.com/matrixdotorg/status/12345",
+                "og:title": "Alice",
+                "og:description": "Content Preview",
+            },
         )
 
     def test_oembed_format(self):
@@ -709,7 +713,11 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.assertIn(b"format=json", server.data)
 
         self.assertEqual(channel.code, 200)
-        # The JSON body should have a URL, but we don't really care what it is.
         body = channel.json_body
-        body.pop("og:url")
-        self.assertEqual(body, {"og:description": "Content Preview"})
+        self.assertEqual(
+            body,
+            {
+                "og:url": "http://www.hulu.com/watch/12345",
+                "og:description": "Content Preview",
+            },
+        )


### PR DESCRIPTION
* Better titles (fall back to the author name if there's not title).
* Parse photo/video payloads.
* Include the original URL in the Open Graph response.
* Uses the proper expiration time (the cache age was not being converted from seconds to milliseconds).

~~Builds on #10814~~

Related to #2752, #9733

## Open questions:

* Does it make sense to include YouTube in our list of default oEmbed providers included with Synapse?
		* With this change, YouTube previews work when using oEmbed, but they aren't as good as parsing the HTML directly (you end up with no description). This is better than having no preview, as reported in #9733, but I've been unable to reproduce that.
		* Based on response in #9733, I don't think it makes sense to.

## Twitter previews

### Before this PR

<img width="753" alt="Screen Shot 2021-09-21 at 1 00 30 PM" src="https://user-images.githubusercontent.com/517124/134215285-a3389db2-7da7-41fe-a836-48e9b067e6dc.png">

### After this PR

<img width="748" alt="Screen Shot 2021-09-21 at 12 59 10 PM" src="https://user-images.githubusercontent.com/517124/134215305-35918a5b-f2b1-47ae-b1db-d485cd1dc9c6.png">

Note the added title (`Matrix - Twitter`).

## YouTube previews

### Without oEmbed

<img width="769" alt="Screen Shot 2021-09-21 at 12 56 47 PM" src="https://user-images.githubusercontent.com/517124/134215361-9f8778f3-83e5-43cc-8086-d05eb2aee2b5.png">

### After this PR

<img width="746" alt="Screen Shot 2021-09-21 at 12 55 41 PM" src="https://user-images.githubusercontent.com/517124/134215390-776b8216-ad21-4c56-9511-a23c71c67942.png">


