### PR TITLE
Return request ID in HTTP response headers

### DIFF
--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -377,6 +377,7 @@ class GenericWorkerServer(HomeServer):
                 self.version_string,
                 max_request_body_size=max_request_body_size(self.config),
                 reactor=self.get_reactor(),
+                instance_name=f"generic_worker_{site_tag}",
             ),
             reactor=self.get_reactor(),
         )

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -142,6 +142,7 @@ class SynapseHomeServer(HomeServer):
             self.version_string,
             max_request_body_size=max_request_body_size(self.config),
             reactor=self.get_reactor(),
+            instance_name="homeserver",
         )
 
         if tls:

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -361,6 +361,7 @@ class BaseMultiWorkerStreamTestCase(unittest.HomeserverTestCase):
             server_version_string="1",
             max_request_body_size=4096,
             reactor=self.reactor,
+            instance_name="test",
         )
 
         if worker_hs.config.redis.redis_enabled:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -204,6 +204,7 @@ class OptionsResourceTests(unittest.TestCase):
             "1.0",
             max_request_body_size=1234,
             reactor=self.reactor,
+            instance_name="test",
         )
 
         # render the request and return the channel

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -250,6 +250,7 @@ class HomeserverTestCase(TestCase):
             server_version_string="1",
             max_request_body_size=1234,
             reactor=self.reactor,
+            instance_name="test",
         )
 
         from tests.rest.client.utils import RestHelper


### PR DESCRIPTION
We already have something like this when opentracing is enabled, see #10199. But that's only across federation.

When investigating test failures it's really useful to cross-reference HTTP responses with synapse logs. I propose exposing the request id to facilitate that. I've tried to change the request ids to be unique across all workers now, by including an instance name.

See also matrix-org/sytest#1144.