### PR TITLE
Fix invalidating OTK count cache after claim

### DIFF
--- a/changelog.d/10875.bugfix
+++ b/changelog.d/10875.bugfix
@@ -1,0 +1,1 @@
+Fix invalidating one-time key count cache after claiming keys. Contributed by Tulir at Beeper.

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -824,6 +824,10 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore):
             if otk_row is None:
                 return None
 
+            self._invalidate_cache_and_stream(
+                txn, self.count_e2e_one_time_keys, (user_id, device_id)
+            )
+
             key_id, key_json = otk_row
             return f"{algorithm}:{key_id}", key_json
 


### PR DESCRIPTION
The invalidation was missing in `_claim_e2e_one_time_key_returning`, which is used on SQLite 3.24+ and Postgres. This could break e2ee if nothing else happened to invalidate the caches before the keys ran out. It was probably a regression in #10504, which was released in v1.41.0rc1.

Signed-off-by: Tulir Asokan <tulir@beeper.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog).
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
