### PR TITLE
Ensure `(room_id, next_batch_id)` is unique to avoid cross-talk/conflicts between batches (MSC2716)

### DIFF
--- a/changelog.d/10877.feature
+++ b/changelog.d/10877.feature
@@ -1,0 +1,1 @@
+Ensure `(room_id, next_batch_id)` is unique across [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) insertion events in rooms to avoid cross-talk/conflicts between batches

--- a/changelog.d/10877.feature
+++ b/changelog.d/10877.feature
@@ -1,1 +1,1 @@
-Ensure `(room_id, next_batch_id)` is unique across [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) insertion events in rooms to avoid cross-talk/conflicts between batches
+Ensure `(room_id, next_batch_id)` is unique across [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) insertion events in rooms to avoid cross-talk/conflicts between batches.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1466,15 +1466,13 @@ class EventCreationHandler:
             room_version = await self.store.get_room_version_id(event.room_id)
             room_version_obj = KNOWN_ROOM_VERSIONS[room_version]
 
-            create_event = await self.store.get_create_event_for_room(
-                event.room_id
-            )
+            create_event = await self.store.get_create_event_for_room(event.room_id)
             room_creator = create_event.content.get(EventContentFields.ROOM_CREATOR)
 
             # Only check an insertion event if the room version
             # supports it or the event is from the room creator.
             if room_version_obj.msc2716_historical or (
-                self._config.experimental.msc2716_enabled
+                self.config.experimental.msc2716_enabled
                 and event.sender == room_creator
             ):
                 next_batch_id = event.content.get(

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 import logging
 import random
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple
 
 from canonicaljson import encode_canonical_json
@@ -1389,6 +1390,9 @@ class EventCreationHandler:
                     self.room_prejoin_state_types,
                 )
 
+        room_version = await self.store.get_room_version_id(event.room_id)
+        room_version_obj = KNOWN_ROOM_VERSIONS[room_version]
+
         if event.type == EventTypes.Redaction:
             original_event = await self.store.get_event(
                 event.redacts,
@@ -1397,9 +1401,6 @@ class EventCreationHandler:
                 allow_rejected=False,
                 allow_none=True,
             )
-
-            room_version = await self.store.get_room_version_id(event.room_id)
-            room_version_obj = KNOWN_ROOM_VERSIONS[room_version]
 
             # we can make some additional checks now if we have the original event.
             if original_event:
@@ -1460,6 +1461,21 @@ class EventCreationHandler:
             prev_state_ids = await context.get_prev_state_ids()
             if prev_state_ids:
                 raise AuthError(403, "Changing the room create event is forbidden")
+
+        if room_version_obj.msc2716_historical and event.type == EventTypes.MSC2716_INSERTION:
+            next_batch_id = event.content.get(EventContentFields.MSC2716_NEXT_BATCH_ID)
+            conflicting_insertion_event_id = await self.store.get_insertion_event_by_batch_id(event.room_id, next_batch_id)
+            if conflicting_insertion_event_id is not None:
+                # The current insertion event that we're processing is invalid
+                # because an insertion event already exists in the room with the
+                # same next_batch_id. We can't allow multiple because the batch
+                # pointing will get weird, e.g. we can't determine which insertion
+                # event the batch event is pointing to.
+                raise SynapseError(
+                    HTTPStatus.BAD_REQUEST,
+                    "Another insertion event already exists with the same next_batch_id",
+                    errcode=Codes.INVALID_PARAM,
+                )
 
         # Mark any `m.historical` messages as backfilled so they don't appear
         # in `/sync` and have the proper decrementing `stream_ordering` as we import

--- a/synapse/rest/client/room_batch.py
+++ b/synapse/rest/client/room_batch.py
@@ -306,11 +306,11 @@ class RoomBatchSendEventRestServlet(RestServlet):
             # Verify the batch_id_from_query corresponds to an actual insertion event
             # and have the batch connected.
             corresponding_insertion_event_id = (
-                await self.store.get_insertion_event_by_batch_id(batch_id_from_query)
+                await self.store.get_insertion_event_by_batch_id(room_id, batch_id_from_query)
             )
             if corresponding_insertion_event_id is None:
                 raise SynapseError(
-                    400,
+                    HTTPStatus.BAD_REQUEST,
                     "No insertion event corresponds to the given ?batch_id",
                     errcode=Codes.INVALID_PARAM,
                 )

--- a/synapse/rest/client/room_batch.py
+++ b/synapse/rest/client/room_batch.py
@@ -306,7 +306,9 @@ class RoomBatchSendEventRestServlet(RestServlet):
             # Verify the batch_id_from_query corresponds to an actual insertion event
             # and have the batch connected.
             corresponding_insertion_event_id = (
-                await self.store.get_insertion_event_by_batch_id(room_id, batch_id_from_query)
+                await self.store.get_insertion_event_by_batch_id(
+                    room_id, batch_id_from_query
+                )
             )
             if corresponding_insertion_event_id is None:
                 raise SynapseError(

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1795,24 +1795,6 @@ class PersistEventsStore:
             # Invalid insertion event without next batch ID
             return
 
-        conflicting_insertion_event_id = self.db_pool.simple_select_one_onecol_txn(
-            txn,
-            table="insertion_events",
-            keyvalues={
-                "room_id": event.room_id,
-                "next_batch_id": next_batch_id,
-            },
-            retcol="event_id",
-            allow_none=True,
-        )
-        if conflicting_insertion_event_id is not None:
-            # The new  insertion event is invalid because there already exists
-            # and insertion event in the room with the same next_batch_id. We
-            # can't allow multiple because the batch pointing will get weird,
-            # e.g. we can't determine which insertion event the batch event is
-            # pointing to.
-            return
-
         logger.debug(
             "_handle_insertion_event (next_batch_id=%s) %s", next_batch_id, event
         )

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1795,6 +1795,25 @@ class PersistEventsStore:
             # Invalid insertion event without next batch ID
             return
 
+        conflicting_insertion_event_id = self.db_pool.simple_select_one_onecol_txn(
+            txn,
+            table="insertion_events",
+            keyvalues={
+                "room_id": event.room_id,
+                "next_batch_id": next_batch_id,
+            },
+            retcol="event_id",
+            desc="get_device_list_last_stream_id_for_remote",
+            allow_none=True,
+        )
+        if conflicting_insertion_event_id is not None:
+            # The new  insertion event is invalid because there already exists
+            # and insertion event in the room with the same next_batch_id. We
+            # can't allow multiple because the batch pointing will get weird,
+            # e.g. we can't determine which insertion event the batch event is
+            # pointing to.
+            return
+
         logger.debug(
             "_handle_insertion_event (next_batch_id=%s) %s", next_batch_id, event
         )

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1803,7 +1803,6 @@ class PersistEventsStore:
                 "next_batch_id": next_batch_id,
             },
             retcol="event_id",
-            desc="get_device_list_last_stream_id_for_remote",
             allow_none=True,
         )
         if conflicting_insertion_event_id is not None:

--- a/synapse/storage/databases/main/room_batch.py
+++ b/synapse/storage/databases/main/room_batch.py
@@ -18,7 +18,9 @@ from synapse.storage._base import SQLBaseStore
 
 
 class RoomBatchStore(SQLBaseStore):
-    async def get_insertion_event_by_batch_id(self, room_id: str, batch_id: str) -> Optional[str]:
+    async def get_insertion_event_by_batch_id(
+        self, room_id: str, batch_id: str
+    ) -> Optional[str]:
         """Retrieve a insertion event ID.
 
         Args:
@@ -30,10 +32,7 @@ class RoomBatchStore(SQLBaseStore):
         """
         return await self.db_pool.simple_select_one_onecol(
             table="insertion_events",
-            keyvalues={
-                "room_id": room_id,
-                "next_batch_id": batch_id
-            },
+            keyvalues={"room_id": room_id, "next_batch_id": batch_id},
             retcol="event_id",
             allow_none=True,
         )

--- a/synapse/storage/databases/main/room_batch.py
+++ b/synapse/storage/databases/main/room_batch.py
@@ -18,7 +18,7 @@ from synapse.storage._base import SQLBaseStore
 
 
 class RoomBatchStore(SQLBaseStore):
-    async def get_insertion_event_by_batch_id(self, batch_id: str) -> Optional[str]:
+    async def get_insertion_event_by_batch_id(self, room_id: str, batch_id: str) -> Optional[str]:
         """Retrieve a insertion event ID.
 
         Args:
@@ -30,7 +30,10 @@ class RoomBatchStore(SQLBaseStore):
         """
         return await self.db_pool.simple_select_one_onecol(
             table="insertion_events",
-            keyvalues={"next_batch_id": batch_id},
+            keyvalues={
+                "room_id": room_id,
+                "next_batch_id": batch_id
+            },
             retcol="event_id",
             allow_none=True,
         )


### PR DESCRIPTION
Ensure `(room_id, next_batch_id)` is unique across insertion events to avoid cross-talk/conflicts between batches. Currently does not stop duplicate insertion events over federation, see https://github.com/matrix-org/synapse/pull/10877#discussion_r715315789


Part of [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716)

Part of https://github.com/matrix-org/synapse/issues/10737

Complement changes in https://github.com/matrix-org/complement/pull/207

Briefly discussed at https://github.com/matrix-org/synapse/pull/10245#discussion_r669641879


### Dev notes

`soft_failed` vs `rejected`?

 - `rejected`: when an event doesn't pass event auth rules based on the auth events given and state at the event
    - https://matrix.org/docs/spec/server_server/r0.1.4#rejection
 - `soft_fail`: when an event doesn't pass the event auth rules based on current state of the room
    - " If the event does not pass the auth checks based on the current state of the room (but does pass the auth checks based on the state at that event) it should be "soft failed".", https://matrix.org/docs/spec/server_server/r0.1.4#soft-failure
    - `_check_for_soft_fail`


---

 - `_persist_events_txn`
 - `_update_metadata_tables_txn`


---


 - `auth_types_for_event`

---


`synapse/storage/databases/main/events.py` -> `_handle_insertion_event`

```python
conflicting_insertion_event_id = self.db_pool.simple_select_one_onecol_txn(
    txn,
    table="insertion_events",
    keyvalues={
        "room_id": event.room_id,
        "next_batch_id": next_batch_id,
    },
    retcol="event_id",
    allow_none=True,
)
if conflicting_insertion_event_id is not None:
    # The current insertion event that we're processing is invalid
    # because an insertion event already exists in the room with the
    # same next_batch_id. We can't allow multiple because the batch
    # pointing will get weird, e.g. we can't determine which insertion
    # event the batch event is pointing to.
    return
```


### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)~~
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
