### PR TITLE
Include outlier status in `str(event)` for V2/V3 events

### DIFF
--- a/changelog.d/10879.misc
+++ b/changelog.d/10879.misc
@@ -1,0 +1,1 @@
+Include outlier status when we log V2 or V3 events.

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -344,6 +344,18 @@ class EventBase(metaclass=abc.ABCMeta):
         # this will be a no-op if the event dict is already frozen.
         self._dict = freeze(self._dict)
 
+    def __str__(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        return "<%s event_id=%r, type=%r, state_key=%r, outlier=%s>" % (
+            self.__class__.__name__,
+            self.event_id,
+            self.get("type", None),
+            self.get("state_key", None),
+            self.internal_metadata.is_outlier(),
+        )
+
 
 class FrozenEvent(EventBase):
     format_version = EventFormatVersions.V1  # All events of this type are V1
@@ -391,17 +403,6 @@ class FrozenEvent(EventBase):
     @property
     def event_id(self) -> str:
         return self._event_id
-
-    def __str__(self):
-        return self.__repr__()
-
-    def __repr__(self):
-        return "<FrozenEvent event_id=%r, type=%r, state_key=%r, outlier=%s>" % (
-            self.get("event_id", None),
-            self.get("type", None),
-            self.get("state_key", None),
-            self.internal_metadata.is_outlier(),
-        )
 
 
 class FrozenEventV2(EventBase):
@@ -477,17 +478,6 @@ class FrozenEventV2(EventBase):
             list[str]: The list of event IDs of this event's auth_events
         """
         return self.auth_events
-
-    def __str__(self):
-        return self.__repr__()
-
-    def __repr__(self):
-        return "<%s event_id=%r, type=%r, state_key=%r>" % (
-            self.__class__.__name__,
-            self.event_id,
-            self.get("type", None),
-            self.get("state_key", None),
-        )
 
 
 class FrozenEventV3(FrozenEventV2):


### PR DESCRIPTION
I meant to do this before, in #10591, but because I'm stupid I forgot to do it for V2 and V3 events.

I've factored the common code out to `EventBase` to save us having two copies of it.

This means that for `FrozenEvent` we replace `self.get("event_id", None)` with `self.event_id`, which I think is safe. `get()` is an alias for `self._dict.get()`, whereas `event_id()` is an `@property` method which looks up `self._event_id`, which is populated during construction from the same dict. We don't seem to rely on the fallback, because if the `event_id` key is absent from the dict then construction of the `EventBase` object will fail.

Long story short, the only way this could change behaviour is if `event_dict["event_id"]` is changed *after* the `EventBase` object is constructed without updating the `_event_id` field, or vice versa - either of which would be very problematic anyway and the behavior of `str(event)` is the least of our worries.