### PR TITLE
Factor out common code for persisting fetched auth events

### DIFF
--- a/changelog.d/10896.misc
+++ b/changelog.d/10896.misc
@@ -1,0 +1,1 @@
+ Clean up some of the federation event authentication code for clarity.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -501,8 +501,6 @@ class FederationClient(FederationBase):
             destination, auth_chain, outlier=True, room_version=room_version
         )
 
-        signed_auth.sort(key=lambda e: e.depth)
-
         return signed_auth
 
     def _is_unknown_endpoint(

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1650,7 +1650,6 @@ class FederationEventHandler:
                     for e in remote_auth_chain
                     if e.event_id in auth_ids or e.type == EventTypes.Create
                 }
-                auth_event.internal_metadata.outlier = True
 
                 logger.debug(
                     "_check_event_auth %s missing_auth: %s",

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1144,12 +1144,10 @@ class FederationEventHandler:
     ) -> None:
         """Persist the events fetched by _get_events_and_persist or _get_remote_auth_chain_for_event
 
-        The events should not depend on one another, e.g. this should be used to persist
-        a bunch of outliers, but not a chunk of individual events that depend
-        on each other for state calculations.
+        The events to be persisted must be outliers.
 
-        We first sort the events so that they do not depend on each other, then
-        persist them.
+        We first sort the events to make sure that we process each event's auth_events
+        before the event itself, and then auth and persist them.
 
         Notifies about the events where appropriate.
 
@@ -1161,9 +1159,6 @@ class FederationEventHandler:
         """
         event_map = {event.event_id: event for event in events}
 
-        # we now need to auth the events in an order which ensures that each event's
-        # auth_events are authed before the event itself.
-        #
         # XXX: it might be possible to kick this process off in parallel with fetching
         # the events.
         while event_map:

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -308,7 +308,12 @@ class FederationTestCase(unittest.HomeserverTestCase):
         async def get_event_auth(
             destination: str, room_id: str, event_id: str
         ) -> List[EventBase]:
-            return auth_events
+            return [
+                event_from_pdu_json(
+                    ae.get_pdu_json(), room_version=room_version, outlier=True
+                )
+                for ae in auth_events
+            ]
 
         self.handler.federation_client.get_event_auth = get_event_auth
 


### PR DESCRIPTION
We currently have two codepaths that are used for persisting fetched auth events:
 * `_get_events_and_persist`, which is used to fetch the state events and auth events for a new backwards extremity.
 * `_get_remote_auth_chain_for_event`, which is called when we are missing the auth events for any other regular event.

There is common code between the two paths which can be factored out.

Should be reviewable commit by commit. It's independent of #10901, but the similarity between the two codepaths might be clearer once that has landed.