### PR TITLE
Simplify `_auth_and_persist_fetched_events`

### DIFF
--- a/changelog.d/10901.misc
+++ b/changelog.d/10901.misc
@@ -1,0 +1,1 @@
+Clean up some of the federation event authentication code for clarity.


### PR DESCRIPTION
Combine the two loops over the list of events, and hence get rid of `_NewEventInfo`. Also pass the event back from `prep` alongside the context, so that it's easier to process the result.