### PR TITLE
Update utility code to handle C implementations of frozendict

### DIFF
--- a/changelog.d/10902.misc
+++ b/changelog.d/10902.misc
@@ -1,0 +1,1 @@
+Update utility code to handle C implementations of frozendict.

--- a/synapse/util/__init__.py
+++ b/synapse/util/__init__.py
@@ -50,7 +50,10 @@ def _handle_frozendict(obj: Any) -> Dict[Any, Any]:
     if type(obj) is frozendict:
         # fishing the protected dict out of the object is a bit nasty,
         # but we don't really want the overhead of copying the dict.
-        return obj._dict
+        try:
+            return obj._dict
+        except AttributeError:
+            return dict(obj)
     raise TypeError(
         "Object of type %s is not JSON serializable" % obj.__class__.__name__
     )

--- a/synapse/util/__init__.py
+++ b/synapse/util/__init__.py
@@ -53,6 +53,9 @@ def _handle_frozendict(obj: Any) -> Dict[Any, Any]:
         try:
             return obj._dict
         except AttributeError:
+            # When the C implementation of frozendict is used,
+            # there isn't a `_dict` attribute with a dict
+            # so we resort to making a copy of the frozendict
             return dict(obj)
     raise TypeError(
         "Object of type %s is not JSON serializable" % obj.__class__.__name__


### PR DESCRIPTION
Background: some versions of frozendict contain a C implementation of frozendict that was incompatible with our code. This PR adds logic to catch and handle those cases. See also https://github.com/matrix-org/python-canonicaljson/issues/36 for more context. 