### PR TITLE
Stop prematurely rejecting outlier events with missing auth_events

### DIFF
--- a/changelog.d/10907.bugfix
+++ b/changelog.d/10907.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug which could cause events pulled over federation to be incorrectly rejected.


### PR DESCRIPTION
# Context

There are a couple of situations under which we will end up persisting a bunch of events as `outliers`:
 * when we form a new backwards extremity (typically after backfilling a bunch of events), we need to record the state of the room at that backwards extremity, which in turn requires us to have all the state events that form that state (and, recursively, their auth events). In this case, we request each event we don't already have, and then auth/persist them all.
 * when we receive a regular event which refers to auth events which we are missing. In this case, we request the "auth chain" for the event from the remote server, and then auth/persist any events in that auth chain we didn't already have.

In either case, we need to decide what to do when we *still* don't have some of the auth events somewhere in the chain (in the first case, because we couldn't find a correctly-signed copy anywhere; in the second, because the remote server's auth chain is incomplete).

Currently, we will make a (possibly second) request for the auth chain. If that produces the missing events, that's fine - but if we didn't get the auth events the first time, it seems unlikely to work the second time.

We then try and auth the relevant event, *despite* the missing auth events. This will more than likely fail, so the event is rejected.

# Change

This all leads to the question: what *should* we do with an event whose auth events we have failed to fetch. As discussed above, it's more than likely we will end up rejecting it, but I would say that is incorrect - the fact that we cannot *find* a given auth event doesn't mean it doesn't exist somewhere out there, so a permanent rejection is incorrect.

This PR changes things so that we just drop the relevant event (and, by induction, any other events further down the chain).