### PR TITLE
e2e: return newly fetched cross-signing keys

### DIFF
--- a/changelog.d/10912.bugfix
+++ b/changelog.d/10912.bugfix
@@ -1,0 +1,1 @@
+return E2E cross signing keys fetched over federation when to a client.


### PR DESCRIPTION
without this patch, only the cached cross-signing keys are returned when
a client requests them, although a federation request is done
in case there's no cache entry.
this patch returns newly fetched entries directly.

This is a stripped-down version of #10668, which needs some discussion and/or root cause analysis.