### PR TITLE
Fix empty `url_cache_thumbnails/yyyy-mm-dd/` directories being left behind

### DIFF
--- a/changelog.d/10924.bugfix
+++ b/changelog.d/10924.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where empty `yyyy-mm-dd/` directories would be left behind in the media store's `url_cache_thumbnails/` directory.

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -72,6 +72,7 @@ OG_TAG_VALUE_MAXLEN = 1000
 
 ONE_HOUR = 60 * 60 * 1000
 ONE_DAY = 24 * ONE_HOUR
+IMAGE_CACHE_EXPIRY_MS = 2 * ONE_DAY
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
@@ -529,7 +530,7 @@ class PreviewUrlResource(DirectServeJsonResource):
         # These may be cached for a bit on the client (i.e., they
         # may have a room open with a preview url thing open).
         # So we wait a couple of days before deleting, just in case.
-        expire_before = now - 2 * ONE_DAY
+        expire_before = now - IMAGE_CACHE_EXPIRY_MS
         media_ids = await self.store.get_url_cache_media_before(expire_before)
 
         removed_media = []

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -512,12 +512,14 @@ class PreviewUrlResource(DirectServeJsonResource):
 
             removed_media.append(media_id)
 
-            try:
-                dirs = self.filepaths.url_cache_filepath_dirs_to_delete(media_id)
-                for dir in dirs:
+            dirs = self.filepaths.url_cache_filepath_dirs_to_delete(media_id)
+            for dir in dirs:
+                try:
                     os.rmdir(dir)
-            except Exception:
-                pass
+                except FileNotFoundError:
+                    pass  # Already deleted, continue with deleting the rest
+                except Exception:
+                    break  # Failed, skip deleting the rest of the parent dirs
 
         await self.store.delete_url_cache(removed_media)
 
@@ -544,12 +546,14 @@ class PreviewUrlResource(DirectServeJsonResource):
                 logger.warning("Failed to remove media: %r: %s", media_id, e)
                 continue
 
-            try:
-                dirs = self.filepaths.url_cache_filepath_dirs_to_delete(media_id)
-                for dir in dirs:
+            dirs = self.filepaths.url_cache_filepath_dirs_to_delete(media_id)
+            for dir in dirs:
+                try:
                     os.rmdir(dir)
-            except Exception:
-                pass
+                except FileNotFoundError:
+                    pass  # Already deleted, continue with deleting the rest
+                except Exception:
+                    break  # Failed, skip deleting the rest of the parent dirs
 
             thumbnail_dir = self.filepaths.url_cache_thumbnail_directory(media_id)
             try:
@@ -562,12 +566,16 @@ class PreviewUrlResource(DirectServeJsonResource):
 
             removed_media.append(media_id)
 
-            try:
-                dirs = self.filepaths.url_cache_thumbnail_dirs_to_delete(media_id)
-                for dir in dirs:
+            dirs = self.filepaths.url_cache_thumbnail_dirs_to_delete(media_id)
+            # Note that one of the directories to be deleted has already been
+            # removed by the `rmtree` above.
+            for dir in dirs:
+                try:
                     os.rmdir(dir)
-            except Exception:
-                pass
+                except FileNotFoundError:
+                    pass  # Already deleted, continue with deleting the rest
+                except Exception:
+                    break  # Failed, skip deleting the rest of the parent dirs
 
         await self.store.delete_url_cache_media(removed_media)
 

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import datetime
-import errno
 import fnmatch
 import itertools
 import logging
@@ -504,11 +503,11 @@ class PreviewUrlResource(DirectServeJsonResource):
             fname = self.filepaths.url_cache_filepath(media_id)
             try:
                 os.remove(fname)
+            except FileNotFoundError:
+                pass  # If the path doesn't exist, meh
             except OSError as e:
-                # If the path doesn't exist, meh
-                if e.errno != errno.ENOENT:
-                    logger.warning("Failed to remove media: %r: %s", media_id, e)
-                    continue
+                logger.warning("Failed to remove media: %r: %s", media_id, e)
+                continue
 
             removed_media.append(media_id)
 
@@ -538,11 +537,11 @@ class PreviewUrlResource(DirectServeJsonResource):
             fname = self.filepaths.url_cache_filepath(media_id)
             try:
                 os.remove(fname)
+            except FileNotFoundError:
+                pass  # If the path doesn't exist, meh
             except OSError as e:
-                # If the path doesn't exist, meh
-                if e.errno != errno.ENOENT:
-                    logger.warning("Failed to remove media: %r: %s", media_id, e)
-                    continue
+                logger.warning("Failed to remove media: %r: %s", media_id, e)
+                continue
 
             try:
                 dirs = self.filepaths.url_cache_filepath_dirs_to_delete(media_id)
@@ -554,11 +553,11 @@ class PreviewUrlResource(DirectServeJsonResource):
             thumbnail_dir = self.filepaths.url_cache_thumbnail_directory(media_id)
             try:
                 shutil.rmtree(thumbnail_dir)
+            except FileNotFoundError:
+                pass  # If the path doesn't exist, meh
             except OSError as e:
-                # If the path doesn't exist, meh
-                if e.errno != errno.ENOENT:
-                    logger.warning("Failed to remove media: %r: %s", media_id, e)
-                    continue
+                logger.warning("Failed to remove media: %r: %s", media_id, e)
+                continue
 
             removed_media.append(media_id)
 


### PR DESCRIPTION
Fixes observation 4 in #10863.

When we get around to cleaning up the parents of the thumbnail directory, the thumbnail directory itself has already been deleted.  Instead of continuing with the deletion of the rest of the parent paths, we currently abort, which leaves empty directories lying around:
https://github.com/matrix-org/synapse/blob/f7768f62cbf7579a1a91e694f83d47d275373369/synapse/rest/media/v1/preview_url_resource.py#L565-L570