### PR TITLE
Only do restricted join rules signature checks for room versions 8/9.

### DIFF
--- a/changelog.d/10927.bugfix
+++ b/changelog.d/10927.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse v1.40.0 where the signature checks for room version 8/9 could be applied to earlier room versions in some situations.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -113,8 +113,8 @@ def check(
                 raise AuthError(403, "Event not signed by sending server")
 
         is_invite_via_allow_rule = (
-            room_version_obj.msc3083_join_rules and
-            event.type == EventTypes.Member
+            room_version_obj.msc3083_join_rules
+            and event.type == EventTypes.Member
             and event.membership == Membership.JOIN
             and "join_authorised_via_users_server" in event.content
         )

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -113,6 +113,7 @@ def check(
                 raise AuthError(403, "Event not signed by sending server")
 
         is_invite_via_allow_rule = (
+            room_version_obj.msc3083_join_rules and
             event.type == EventTypes.Member
             and event.membership == Membership.JOIN
             and "join_authorised_via_users_server" in event.content


### PR DESCRIPTION
Fixes #10923

The clause was being applied for rooms which don't support this feature. My hope is this will have minimal impact since the additional field shouldn't exist for non- v8/v9 rooms.