### PR TITLE
Fix exception responding to request that has been closed

### DIFF
--- a/changelog.d/10932.feature
+++ b/changelog.d/10932.feature
@@ -1,0 +1,1 @@
+Speed up responding with large JSON objects to requests.


### PR DESCRIPTION
Introduced in #10905

It's a bit icky, but a) matches what we do when we call `.finish()`, and b) there isn't a more specific exception class really as the problem is that it raises an `AttributeError`. The alternative is to check if `request.channel` is still set, but that seems a bit brittle

c.f. https://sentry.matrix.org/sentry/synapse-matrixorg/issues/231719/events/b3e541e6016d43f3a584f986d07bc132/