### PR TITLE
Use `RoomVersion` objects

### DIFF
--- a/changelog.d/10934.misc
+++ b/changelog.d/10934.misc
@@ -1,0 +1,1 @@
+Refactor various parts of the codebase to use `RoomVersion` objects instead of room version identifier strings.

--- a/synapse/events/builder.py
+++ b/synapse/events/builder.py
@@ -18,10 +18,8 @@ import attr
 from nacl.signing import SigningKey
 
 from synapse.api.constants import MAX_DEPTH
-from synapse.api.errors import UnsupportedRoomVersionError
 from synapse.api.room_versions import (
     KNOWN_EVENT_FORMAT_VERSIONS,
-    KNOWN_ROOM_VERSIONS,
     EventFormatVersions,
     RoomVersion,
 )
@@ -196,24 +194,6 @@ class EventBuilderFactory:
         self.store = hs.get_datastore()
         self.state = hs.get_state_handler()
         self._event_auth_handler = hs.get_event_auth_handler()
-
-    def new(self, room_version: str, key_values: dict) -> EventBuilder:
-        """Generate an event builder appropriate for the given room version
-
-        Deprecated: use for_room_version with a RoomVersion object instead
-
-        Args:
-            room_version: Version of the room that we're creating an event builder for
-            key_values: Fields used as the basis of the new event
-
-        Returns:
-            EventBuilder
-        """
-        v = KNOWN_ROOM_VERSIONS.get(room_version)
-        if not v:
-            # this can happen if support is withdrawn for a room version
-            raise UnsupportedRoomVersionError()
-        return self.for_room_version(v, key_values)
 
     def for_room_version(
         self, room_version: RoomVersion, key_values: dict

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1256,7 +1256,7 @@ class FederationHandler(BaseHandler):
             )
 
             event, context = await self.add_display_name_to_third_party_invite(
-                room_version_obj.identifier, event_dict, event, context
+                room_version_obj, event_dict, event, context
             )
 
             EventValidator().validate_new(event, self.config)
@@ -1313,7 +1313,7 @@ class FederationHandler(BaseHandler):
             builder=builder
         )
         event, context = await self.add_display_name_to_third_party_invite(
-            room_version_obj.identifier, event_dict, event, context
+            room_version_obj, event_dict, event, context
         )
 
         try:
@@ -1335,7 +1335,7 @@ class FederationHandler(BaseHandler):
 
     async def add_display_name_to_third_party_invite(
         self,
-        room_version: str,
+        room_version_obj: RoomVersion,
         event_dict: JsonDict,
         event: EventBase,
         context: EventContext,
@@ -1367,7 +1367,9 @@ class FederationHandler(BaseHandler):
             # auth checks. If we need the invite and don't have it then the
             # auth check code will explode appropriately.
 
-        builder = self.event_builder_factory.new(room_version, event_dict)
+        builder = self.event_builder_factory.for_room_version(
+            room_version_obj, event_dict
+        )
         EventValidator().validate_builder(builder)
         event, context = await self.event_creation_handler.create_new_client_event(
             builder=builder

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -718,8 +718,8 @@ class FederationHandler(BaseHandler):
                         state_ids,
                     )
 
-        builder = self.event_builder_factory.new(
-            room_version.identifier,
+        builder = self.event_builder_factory.for_room_version(
+            room_version,
             {
                 "type": EventTypes.Member,
                 "content": event_content,

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -237,9 +237,9 @@ class RoomCreationHandler(BaseHandler):
                 },
             },
         )
-        old_room_version = await self.store.get_room_version_id(old_room_id)
+        old_room_version = await self.store.get_room_version(old_room_id)
         await self._event_auth_handler.check_from_context(
-            old_room_version, tombstone_event, tombstone_context
+            old_room_version.identifier, tombstone_event, tombstone_context
         )
 
         await self.clone_existing_room(


### PR DESCRIPTION
Various refactors to use `RoomVersion` objects instead of room version identifieers.

Should be reviewable commit-by-commit