### PR TITLE
Fix MSC2716 `/batch_send` endpoint not being able to create outlier events

### DIFF
--- a/changelog.d/10938.bugfix
+++ b/changelog.d/10938.bugfix
@@ -1,1 +1,1 @@
-Fix [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) `/batch_send` endpoint not being able to create outlier events.
+Fix bug introduced in Synapse 1.44 which caused the experimental [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) `/batch_send` endpoint to return a 500 error.

--- a/changelog.d/10938.bugfix
+++ b/changelog.d/10938.bugfix
@@ -1,0 +1,1 @@
+Fix [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) `/batch_send` endpoint not being able to create outlier events.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -958,7 +958,7 @@ class EventCreationHandler:
         # Pass on the outlier property from the builder to the event
         # after it is created
         if builder.internal_metadata.outlier:
-            event.internal_metadata.outlier = builder.internal_metadata.outlier
+            event.internal_metadata.outlier = True
             context = EventContext.for_outlier()
 
         if requester:

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -953,18 +953,13 @@ class EventCreationHandler:
             depth=depth,
         )
 
-        old_state = None
+        context = await self.state.compute_event_context(event)
 
         # Pass on the outlier property from the builder to the event
         # after it is created
         if builder.internal_metadata.outlier:
             event.internal_metadata.outlier = builder.internal_metadata.outlier
-
-            # Calculate the state for outliers that pass in their own `auth_event_ids`
-            if auth_event_ids:
-                old_state = await self.store.get_events_as_list(auth_event_ids)
-
-        context = await self.state.compute_event_context(event, old_state=old_state)
+            context = EventContext.for_outlier()
 
         if requester:
             context.app_service = requester.app_service

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -953,13 +953,13 @@ class EventCreationHandler:
             depth=depth,
         )
 
-        context = await self.state.compute_event_context(event)
-
         # Pass on the outlier property from the builder to the event
         # after it is created
         if builder.internal_metadata.outlier:
             event.internal_metadata.outlier = True
             context = EventContext.for_outlier()
+        else:
+            context = await self.state.compute_event_context(event)
 
         if requester:
             context.app_service = requester.app_service


### PR DESCRIPTION
Fix MSC2716 `/batch_send` endpoint not being able to create outlier events.

The `EventContext.for_outlier` refactor happened in https://github.com/matrix-org/synapse/pull/10883 and this spot was left out.

Part of https://github.com/matrix-org/matrix-doc/pull/2716


### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)~~
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
