### PR TITLE
Annotate `log_function` decorator

### DIFF
--- a/changelog.d/10943.misc
+++ b/changelog.d/10943.misc
@@ -1,0 +1,1 @@
+Add type annotations for the `log_function` decorator.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -250,6 +250,8 @@ class FederationClient(FederationBase):
 
         logger.debug("backfill transaction_data=%r", transaction_data)
 
+        assert transaction_data is not None
+
         room_version = await self.store.get_room_version(room_id)
 
         pdus = [

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -634,7 +634,7 @@ class FederationServer(FederationBase):
 
     async def on_make_knock_request(
         self, origin: str, room_id: str, user_id: str, supported_versions: List[str]
-    ) -> Dict[str, Union[EventBase, str]]:
+    ) -> Dict[str, Union[JsonDict, str]]:
         """We've received a /make_knock/ request, so we create a partial knock
         event for the room and hand that back, along with the room version, to the knocking
         homeserver. We do *not* persist or process this event until the other server has

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -295,14 +295,16 @@ class FederationServer(FederationBase):
         Returns:
             HTTP response code and body
         """
-        response = await self.transaction_actions.have_responded(origin, transaction)
+        existing_response = await self.transaction_actions.have_responded(
+            origin, transaction
+        )
 
-        if response:
+        if existing_response:
             logger.debug(
                 "[%s] We've already responded to this request",
                 transaction.transaction_id,
             )
-            return response
+            return existing_response
 
         logger.debug("[%s] Transaction is new", transaction.transaction_id)
 

--- a/synapse/federation/sender/transaction_manager.py
+++ b/synapse/federation/sender/transaction_manager.py
@@ -149,7 +149,6 @@ class TransactionManager:
                 )
             except HttpResponseException as e:
                 code = e.code
-                response = e.response
 
                 set_tag(tags.ERROR, True)
 

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -15,7 +15,18 @@
 
 import logging
 import urllib
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import attr
 import ijson
@@ -786,7 +797,7 @@ class TransportLayerClient:
     @log_function
     def join_group(
         self, destination: str, group_id: str, user_id: str, content: JsonDict
-    ) -> JsonDict:
+    ) -> Awaitable[JsonDict]:
         """Attempts to join a group"""
         path = _create_v1_path("/groups/%s/users/%s/join", group_id, user_id)
 

--- a/synapse/handlers/account_data.py
+++ b/synapse/handlers/account_data.py
@@ -174,6 +174,7 @@ class AccountDataEventSource(EventSource[int, JsonDict]):
     async def get_new_events(
         self,
         user: UserID,
+        *,
         from_key: int,
         limit: Optional[int],
         room_ids: Collection[str],

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -246,7 +246,7 @@ class DirectoryHandler(BaseHandler):
                 servers = result.servers
         else:
             try:
-                fed_result = await self.federation.make_query(
+                fed_result: Optional[JsonDict] = await self.federation.make_query(
                     destination=room_alias.domain,
                     query_type="directory",
                     args={"room_alias": room_alias.to_string()},

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -384,7 +384,7 @@ class FederationEventHandler:
 
     @log_function
     async def backfill(
-        self, dest: str, room_id: str, limit: int, extremities: List[str]
+        self, dest: str, room_id: str, limit: int, extremities: Iterable[str]
     ) -> None:
         """Trigger a backfill request to `dest` for the given `room_id`
 

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -52,6 +52,7 @@ import synapse.metrics
 from synapse.api.constants import EventTypes, Membership, PresenceState
 from synapse.api.errors import SynapseError
 from synapse.api.presence import UserPresenceState
+from synapse.appservice import ApplicationService
 from synapse.events.presence_router import PresenceRouter
 from synapse.logging.context import run_in_background
 from synapse.logging.utils import log_function
@@ -1519,12 +1520,14 @@ class PresenceEventSource(EventSource[int, UserPresenceState]):
     async def get_new_events(
         self,
         user: UserID,
+        *,
         from_key: Optional[int],
         limit: Optional[int] = None,
-        room_ids: Optional[List[str]] = None,
+        room_ids: Optional[Collection[str]] = None,
         is_guest: bool = False,
         explicit_room_id: Optional[str] = None,
         include_offline: bool = True,
+        service: Optional[ApplicationService] = None,
     ) -> Tuple[List[UserPresenceState], int]:
         # The process for getting presence events are:
         #  1. Get the rooms the user is in.

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -455,7 +455,11 @@ class ProfileHandler(BaseHandler):
                 continue
 
             new_name = profile.get("displayname")
+            if new_name is not None and not isinstance(new_name, str):
+                new_name = None
             new_avatar = profile.get("avatar_url")
+            if new_avatar is not None and not isinstance(new_avatar, str):
+                new_avatar = None
 
             # We always hit update to update the last_check timestamp
             await self.store.update_remote_profile_cache(user_id, new_name, new_avatar)

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -219,6 +219,7 @@ class ReceiptEventSource(EventSource[int, JsonDict]):
     async def get_new_events(
         self,
         user: UserID,
+        *,
         from_key: int,
         limit: Optional[int],
         room_ids: Iterable[str],

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1198,6 +1198,7 @@ class RoomEventSource(EventSource[RoomStreamToken, EventBase]):
     async def get_new_events(
         self,
         user: UserID,
+        *,
         from_key: RoomStreamToken,
         limit: Optional[int],
         room_ids: Collection[str],

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -488,6 +488,7 @@ class TypingNotificationEventSource(EventSource[int, JsonDict]):
     async def get_new_events(
         self,
         user: UserID,
+        *,
         from_key: int,
         limit: Optional[int],
         room_ids: Iterable[str],

--- a/synapse/logging/utils.py
+++ b/synapse/logging/utils.py
@@ -16,6 +16,7 @@
 import logging
 from functools import wraps
 from inspect import getcallargs
+from typing import Callable, TypeVar, cast
 
 _TIME_FUNC_ID = 0
 
@@ -41,7 +42,10 @@ def _log_debug_as_f(f, msg, msg_args):
         logger.handle(record)
 
 
-def log_function(f):
+F = TypeVar("F", bound=Callable)
+
+
+def log_function(f: F) -> F:
     """Function decorator that logs every call to that function."""
     func_name = f.__name__
 
@@ -69,4 +73,4 @@ def log_function(f):
         return f(*args, **kwargs)
 
     wrapped.__name__ = func_name
-    return wrapped
+    return cast(F, wrapped)

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -26,6 +26,7 @@ from typing import (
     FrozenSet,
     Iterable,
     List,
+    Mapping,
     Optional,
     Sequence,
     Set,
@@ -519,7 +520,7 @@ class StateResolutionHandler:
         self,
         room_id: str,
         room_version: str,
-        state_groups_ids: Dict[int, StateMap[str]],
+        state_groups_ids: Mapping[int, StateMap[str]],
         event_map: Optional[Dict[str, EventBase]],
         state_res_store: "StateResolutionStore",
     ) -> _StateCacheEntry:
@@ -703,7 +704,7 @@ class StateResolutionHandler:
 
 
 def _make_state_cache_entry(
-    new_state: StateMap[str], state_groups_ids: Dict[int, StateMap[str]]
+    new_state: StateMap[str], state_groups_ids: Mapping[int, StateMap[str]]
 ) -> _StateCacheEntry:
     """Given a resolved state, and a set of input state groups, pick one to base
     a new state group on (if any), and return an appropriately-constructed

--- a/synapse/storage/databases/main/profile.py
+++ b/synapse/storage/databases/main/profile.py
@@ -91,7 +91,7 @@ class ProfileWorkerStore(SQLBaseStore):
         )
 
     async def update_remote_profile_cache(
-        self, user_id: str, displayname: str, avatar_url: str
+        self, user_id: str, displayname: Optional[str], avatar_url: Optional[str]
     ) -> int:
         return await self.db_pool.simple_update(
             table="remote_profile_cache",

--- a/synapse/streams/__init__.py
+++ b/synapse/streams/__init__.py
@@ -26,6 +26,7 @@ class EventSource(Generic[K, R]):
     async def get_new_events(
         self,
         user: UserID,
+        *,
         from_key: K,
         limit: Optional[int],
         room_ids: Collection[str],


### PR DESCRIPTION
This one was concealing quite a few type errors because it didn't pass through the function signature.