### PR TITLE
Clean-up registration tests

### DIFF
--- a/changelog.d/10945.misc
+++ b/changelog.d/10945.misc
@@ -1,0 +1,1 @@
+Fix a broken test to ensure that consent configuration works during registration.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -340,6 +340,8 @@ class RegistrationHandler(BaseHandler):
             auth_provider=(auth_provider_id or ""),
         ).inc()
 
+        # If the user does not need to consent at registration, auto-join any
+        # configured rooms.
         if not self.hs.config.consent.user_consent_at_registration:
             if not self.hs.config.auto_join_rooms_for_guests and make_guest:
                 logger.info(

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -387,7 +387,7 @@ class RegistrationHandler(BaseHandler):
             "preset": self.hs.config.registration.autocreate_auto_join_room_preset,
         }
 
-        # If the configuration providers a user ID to create rooms with, use
+        # If the configuration provides a user ID to create rooms with, use
         # that instead of the first user registered.
         requires_join = False
         if self.hs.config.registration.auto_join_user_id:


### PR DESCRIPTION
This has a couple non-functional changes and then attempts to have the `test_auto_create_auto_join_where_no_consent` test what the comments say.

* Mocks out some federation logic.
* Uses `override_config` in places.
* Update the config in `test_auto_create_auto_join_where_no_consent`  to have auto-join rooms, which then breaks the test. (The test wasn't setting `auto_join_rooms` properly so it wasn't attempting to join rooms ever.)

Open questions:

* There's a race in the consent logic that if another user registers before the first user registers & completes consent than the auto-join rooms will never be created. I wonder if it would be more robust to attempt to join the room if it exists, otherwise create it for every user?

See #4886 which tried to fix this previously.