### PR TITLE
Draft: Add proper state and state_groups to historical events so they return state from `/context` (avatar/displayname) (MSC2716)

### DIFF
--- a/synapse/rest/client/room_batch.py
+++ b/synapse/rest/client/room_batch.py
@@ -176,6 +176,8 @@ class RoomBatchSendEventRestServlet(RestServlet):
     async def on_POST(
         self, request: SynapseRequest, room_id: str
     ) -> Tuple[int, JsonDict]:
+        logger.info("room batch send =====================================================")
+        logger.info("=====================================================================")
         requester = await self.auth.get_user_by_req(request, allow_guest=False)
 
         if not requester.app_service:


### PR DESCRIPTION
Add proper state and state_groups to historical events so they return state from `/context` and we see the appropriate avatar/displayname in Element.

See https://gitlab.com/gitterHQ/webapp/-/merge_requests/2229#note_683532091

Also seems to fix https://github.com/matrix-org/synapse/issues/10764

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [ ] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
