### PR TITLE
Ensure that we reject events which use rejected events for auth

### DIFF
--- a/changelog.d/10956.bugfix
+++ b/changelog.d/10956.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug which meant that events received over federation were sometimes incorrectly accepted into the room state.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -155,6 +155,12 @@ def check_auth_rules_for_event(
                 "which is in room %s"
                 % (event.event_id, room_id, auth_event.event_id, auth_event.room_id),
             )
+        if auth_event.rejected_reason:
+            raise AuthError(
+                403,
+                "During auth for event %s: found rejected event %s in the state"
+                % (event.event_id, auth_event.event_id),
+            )
 
     # Implementation of https://matrix.org/docs/spec/rooms/v1#authorization-rules
     #


### PR DESCRIPTION
When we consider whether to accept events, we should not accept those which depend on rejected events for their auth events.

This (together with earlier changes such as https://github.com/matrix-org/synapse/pull/10771 and https://github.com/matrix-org/synapse/pull/10896) forms a partial fix to https://github.com/matrix-org/synapse/issues/9595. There still remain code paths where we do not check the `auth_events` at all.

Complement doesn't work with versions of synapse before 1.8.0 (it relies on send_join v2), but this bug seems to have existed since at least then.