### PR TITLE
Consistently exclude from user_directory, round 2

### DIFF
--- a/changelog.d/10960.bugfix
+++ b/changelog.d/10960.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where rebuilding the user directory wouldn't exclude support and disabled users.

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -132,12 +132,7 @@ class UserDirectoryHandler(StateDeltasHandler):
         # FIXME(#3714): We should probably do this in the same worker as all
         # the other changes.
 
-        # Support users are for diagnostics and should not appear in the user directory.
-        is_support = await self.store.is_support_user(user_id)
-        # When change profile information of deactivated user it should not appear in the user directory.
-        is_deactivated = await self.store.get_user_deactivated_status(user_id)
-
-        if not (is_support or is_deactivated):
+        if await self.store.should_include_local_user_in_dir(user_id):
             await self.store.update_profile_in_user_dir(
                 user_id, profile.display_name, profile.avatar_url
             )
@@ -229,8 +224,10 @@ class UserDirectoryHandler(StateDeltasHandler):
                     else:
                         logger.debug("Server is still in room: %r", room_id)
 
-                is_support = await self.store.is_support_user(state_key)
-                if not is_support:
+                include_in_dir = not self.is_mine_id(
+                    state_key
+                ) or await self.store.should_include_local_user_in_dir(state_key)
+                if include_in_dir:
                     if change is MatchChange.no_change:
                         # Handle any profile changes
                         await self._handle_profile_change(
@@ -356,13 +353,7 @@ class UserDirectoryHandler(StateDeltasHandler):
 
             # First, if they're our user then we need to update for every user
             if self.is_mine_id(user_id):
-
-                is_appservice = self.store.get_if_app_services_interested_in_user(
-                    user_id
-                )
-
-                # We don't care about appservice users.
-                if not is_appservice:
+                if await self.store.should_include_local_user_in_dir(user_id):
                     for other_user_id in other_users_in_room:
                         if user_id == other_user_id:
                             continue
@@ -374,10 +365,10 @@ class UserDirectoryHandler(StateDeltasHandler):
                 if user_id == other_user_id:
                     continue
 
-                is_appservice = self.store.get_if_app_services_interested_in_user(
+                include_other_user = self.is_mine_id(
                     other_user_id
-                )
-                if self.is_mine_id(other_user_id) and not is_appservice:
+                ) and await self.store.should_include_local_user_in_dir(other_user_id)
+                if include_other_user:
                     to_insert.add((other_user_id, user_id))
 
             if to_insert:

--- a/tests/rest/client/test_login.py
+++ b/tests/rest/client/test_login.py
@@ -1064,13 +1064,6 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
         register.register_servlets,
     ]
 
-    def register_as_user(self, username):
-        self.make_request(
-            b"POST",
-            "/_matrix/client/r0/register?access_token=%s" % (self.service.token,),
-            {"username": username},
-        )
-
     def make_homeserver(self, reactor, clock):
         self.hs = self.setup_test_homeserver()
 
@@ -1107,7 +1100,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
 
     def test_login_appservice_user(self):
         """Test that an appservice user can use /login"""
-        self.register_as_user(AS_USER)
+        self.register_appservice_user(AS_USER, self.service.token)
 
         params = {
             "type": login.LoginRestServlet.APPSERVICE_TYPE,
@@ -1121,7 +1114,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
 
     def test_login_appservice_user_bot(self):
         """Test that the appservice bot can use /login"""
-        self.register_as_user(AS_USER)
+        self.register_appservice_user(AS_USER, self.service.token)
 
         params = {
             "type": login.LoginRestServlet.APPSERVICE_TYPE,
@@ -1135,7 +1128,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
 
     def test_login_appservice_wrong_user(self):
         """Test that non-as users cannot login with the as token"""
-        self.register_as_user(AS_USER)
+        self.register_appservice_user(AS_USER, self.service.token)
 
         params = {
             "type": login.LoginRestServlet.APPSERVICE_TYPE,
@@ -1149,7 +1142,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
 
     def test_login_appservice_wrong_as(self):
         """Test that as users cannot login with wrong as token"""
-        self.register_as_user(AS_USER)
+        self.register_appservice_user(AS_USER, self.service.token)
 
         params = {
             "type": login.LoginRestServlet.APPSERVICE_TYPE,
@@ -1165,7 +1158,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
         """Test that users must provide a token when using the appservice
         login method
         """
-        self.register_as_user(AS_USER)
+        self.register_appservice_user(AS_USER, self.service.token)
 
         params = {
             "type": login.LoginRestServlet.APPSERVICE_TYPE,

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -238,7 +238,7 @@ class UserDirectoryInitialPopulationTestcase(HomeserverTestCase):
         users = self.get_success(self.user_dir_helper.get_users_in_user_directory())
         self.assertEqual(users, {u1, u2, u3})
 
-    # The next three tests (test_population_excludes_*) all setup
+    # The next three tests (test_population_excludes_*) all set up
     #   - A normal user included in the user dir
     #   - A public and private room created by that user
     #   - A user excluded from the room dir, belonging to both rooms

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -233,6 +233,10 @@ class UserDirectoryInitialPopulationTestcase(HomeserverTestCase):
             {(u1, u3, private_room), (u3, u1, private_room)},
         )
 
+        # All three should have entries in the directory
+        users = self.get_success(self.user_dir_helper.get_users_in_user_directory())
+        self.assertEqual(users, {u1, u2, u3})
+
     def test_population_excludes_support_user(self) -> None:
         support = "@support1:test"
         self.get_success(

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -22,7 +22,6 @@ import secrets
 import time
 from typing import Callable, Dict, Iterable, Optional, Tuple, Type, TypeVar, Union
 from unittest.mock import Mock, patch
-from urllib.parse import quote
 
 from canonicaljson import json
 
@@ -616,11 +615,12 @@ class HomeserverTestCase(TestCase):
         """
         channel = self.make_request(
             "POST",
-            f"/_matrix/client/r0/register?access_token={urlencoded_token}",
+            "/_matrix/client/r0/register",
             {
                 "username": username,
                 "type": "m.login.application_service",
             },
+            access_token=appservice_token,
         )
         return channel.json_body["user_id"]
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -622,6 +622,7 @@ class HomeserverTestCase(TestCase):
             },
             access_token=appservice_token,
         )
+        self.assertEqual(channel.code, 200, channel.json_body)
         return channel.json_body["user_id"]
 
     def login(

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -602,10 +602,18 @@ class HomeserverTestCase(TestCase):
         username: str,
         appservice_token: str,
     ) -> str:
-        """Register an appservice user. Requires the client-facing registration API be registered.
+        """Register an appservice user as an application service.
+        Requires the client-facing registration API be registered.
 
-        Returns the MXID of the new user."""
-        urlencoded_token = quote(appservice_token)
+        Args:
+            username: the user to be registered by an application service.
+                Should be a full username, i.e. ""@localpart:hostname" as opposed to just "localpart"
+            appservice_token: the acccess token for that application service.
+
+        Raises: if the request to '/register' does not return 200 OK.
+
+        Returns: the MXID of the new user.
+        """
         channel = self.make_request(
             "POST",
             f"/_matrix/client/r0/register?access_token={urlencoded_token}",

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -22,6 +22,7 @@ import secrets
 import time
 from typing import Callable, Dict, Iterable, Optional, Tuple, Type, TypeVar, Union
 from unittest.mock import Mock, patch
+from urllib.parse import quote
 
 from canonicaljson import json
 
@@ -595,6 +596,25 @@ class HomeserverTestCase(TestCase):
 
         user_id = channel.json_body["user_id"]
         return user_id
+
+    def register_appservice_user(
+        self,
+        username: str,
+        appservice_token: str,
+    ) -> str:
+        """Register an appservice user. Requires the client-facing registration API be registered.
+
+        Returns the MXID of the new user."""
+        urlencoded_token = quote(appservice_token)
+        channel = self.make_request(
+            "POST",
+            f"/_matrix/client/r0/register?access_token={urlencoded_token}",
+            {
+                "username": username,
+                "type": "m.login.application_service",
+            },
+        )
+        return channel.json_body["user_id"]
 
     def login(
         self,


### PR DESCRIPTION
Spun off from #10914, alongside #10891. Please review commit-by-commit.

Most of the effort here went into writing test cases. There's some duplication between testing the incremental updates and testing the complete rebuild.

In the rebuild functions I filter `users_with_profile` to exclude users early (rather than at the point of potentially putting them in the DB). That's because there was a code path that missed this check even before my changes. 

I think we could probably do a similar thing in the incremental update functions, but I didn't do that here to keep the changeset minimal.