### PR TITLE
Fix logic flaw preventing tracking of MSC2716 events in existing room versions

### DIFF
--- a/changelog.d/10962.bugfix
+++ b/changelog.d/10962.bugfix
@@ -1,0 +1,1 @@
+Fix [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) `/batch_send` endpoint rejecting subsequent batches with unknown batch ID error in existing room versions from the room creator.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1010,9 +1010,8 @@ class FederationEventHandler:
         room_version = await self._store.get_room_version(marker_event.room_id)
         create_event = await self._store.get_create_event_for_room(marker_event.room_id)
         room_creator = create_event.content.get(EventContentFields.ROOM_CREATOR)
-        if (
-            not room_version.msc2716_historical
-            or not self._config.experimental.msc2716_enabled
+        if not room_version.msc2716_historical and (
+            not self._config.experimental.msc2716_enabled
             or marker_event.sender != room_creator
         ):
             return

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1763,9 +1763,8 @@ class PersistEventsStore:
             retcol="creator",
             allow_none=True,
         )
-        if (
-            not room_version.msc2716_historical
-            or not self.hs.config.experimental.msc2716_enabled
+        if not room_version.msc2716_historical and (
+            not self.hs.config.experimental.msc2716_enabled
             or event.sender != room_creator
         ):
             return
@@ -1825,9 +1824,8 @@ class PersistEventsStore:
             retcol="creator",
             allow_none=True,
         )
-        if (
-            not room_version.msc2716_historical
-            or not self.hs.config.experimental.msc2716_enabled
+        if not room_version.msc2716_historical and (
+            not self.hs.config.experimental.msc2716_enabled
             or event.sender != room_creator
         ):
             return


### PR DESCRIPTION
Fix logic flaw preventing tracking of MSC2716 events in existing room versions

We correctly allowed using the MSC2716 batch endpoint for
the room creator in existing room versions but accidentally didn't track
the events because of a logic flaw.

This prevented you from connecting subsequent batches together because it would
throw the unknown batch ID error.

Complement tests: https://github.com/matrix-org/complement/pull/209

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)~~
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
