### PR TITLE
Fix inconsistent behavior of `get_last_client_by_ip`

### DIFF
--- a/changelog.d/10970.misc
+++ b/changelog.d/10970.misc
@@ -1,0 +1,1 @@
+Fix inconsistent behavior of `get_last_client_by_ip` when reporting data that has not been stored in the database yet.


### PR DESCRIPTION
Make `get_last_client_by_ip` return the same dictionary structure
regardless of whether the data has been persisted to the database.

This change will allow slightly cleaner type hints to be applied later
on.
