### PR TITLE
Fix potential leak of per-room profiles when the user dir is rebuilt.

### DIFF
--- a/changelog.d/10981.bugfix
+++ b/changelog.d/10981.bugfix
@@ -1,0 +1,1 @@
+Fix a bug that could leak local users' per-room nicknames and avatars when the user directory is rebuilt.

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -248,18 +248,15 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                     )
 
                 # Now update the room sharing tables to include this room.
-                to_insert = set()
                 is_public = await self.is_room_world_readable_or_publicly_joinable(
                     room_id
                 )
-                if is_public:
-                    for user_id in users_with_profile:
-                        to_insert.add(user_id)
-
-                    if to_insert:
-                        await self.add_users_in_public_rooms(room_id, to_insert)
-                        to_insert.clear()
+                if is_public and users_with_profile:
+                    await self.add_users_in_public_rooms(
+                        room_id, users_with_profile.keys()
+                    )
                 else:
+                    to_insert = set()
                     for user_id in users_with_profile:
                         # We want the set of pairs (L, M) where L and M are
                         # in `users_with_profile` and L is local.

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -228,10 +228,6 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
             is_in_room = await self.is_host_joined(room_id, self.server_name)
 
             if is_in_room:
-                is_public = await self.is_room_world_readable_or_publicly_joinable(
-                    room_id
-                )
-
                 # TODO this leaks per-room profiles!
                 users_with_profile = await self.get_users_in_room_with_profiles(room_id)
                 # Throw away users excluded from the directory.
@@ -251,8 +247,11 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                         user_id, profile.display_name, profile.avatar_url
                     )
 
+                # Now update the room sharing tables to include this room.
                 to_insert = set()
-
+                is_public = await self.is_room_world_readable_or_publicly_joinable(
+                    room_id
+                )
                 if is_public:
                     for user_id in users_with_profile:
                         to_insert.add(user_id)

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -251,7 +251,8 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                 is_public = await self.is_room_world_readable_or_publicly_joinable(
                     room_id
                 )
-                if is_public and users_with_profile:
+                if is_public:
+                  if users_with_profile:
                     await self.add_users_in_public_rooms(
                         room_id, users_with_profile.keys()
                     )

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -252,10 +252,10 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                     room_id
                 )
                 if is_public:
-                  if users_with_profile:
-                    await self.add_users_in_public_rooms(
-                        room_id, users_with_profile.keys()
-                    )
+                    if users_with_profile:
+                        await self.add_users_in_public_rooms(
+                            room_id, users_with_profile.keys()
+                        )
                 else:
                     to_insert = set()
                     for user_id in users_with_profile:

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -54,6 +54,11 @@ class GetUserDirectoryTables:
         return r
 
     async def get_users_in_public_rooms(self) -> List[Tuple[str, str]]:
+        """Fetch the entire `users_in_public_rooms` table.
+
+        Returns a list of tuples (user_id, room_id) where room_id is public and
+        contains the user with the given id.
+        """
         r = await self.store.db_pool.simple_select_list(
             "users_in_public_rooms", None, ("user_id", "room_id")
         )
@@ -64,6 +69,13 @@ class GetUserDirectoryTables:
         return retval
 
     async def get_users_who_share_private_rooms(self) -> List[Dict[str, str]]:
+        """Fetch the entire `users_who_share_private_rooms` table.
+
+        Returns a dict containing "user_id", "other_user_id" and "room_id" keys.
+        The dicts can be flattened to Tuples with the `_compress_shared` method.
+        (This seems a little awkward---maybe we could clean this up.)
+        """
+
         return await self.store.db_pool.simple_select_list(
             "users_who_share_private_rooms",
             None,
@@ -71,6 +83,10 @@ class GetUserDirectoryTables:
         )
 
     async def get_users_in_user_directory(self) -> Set[str]:
+        """Fetch the set of users in the `user_directory` table.
+
+        This is useful when checking we've correctly excluded users from the directory.
+        """
         result = await self.store.db_pool.simple_select_list(
             "user_directory",
             None,
@@ -79,6 +95,12 @@ class GetUserDirectoryTables:
         return {row["user_id"] for row in result}
 
     async def get_profiles_in_user_directory(self) -> Dict[str, ProfileInfo]:
+        """Fetch users and their profiles from the `user_directory` table.
+
+        This is useful when we want to inspect display names and avatars.
+        It's almost the entire contents of the `user_directory` table: the only
+        thing missing is an unused room_id column.
+        """
         rows = await self.store.db_pool.simple_select_list(
             "user_directory",
             None,

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -216,20 +216,6 @@ class UserDirectoryInitialPopulationTestcase(HomeserverTestCase):
         self.helper.invite(private_room, src=u1, targ=u3, tok=u1_token)
         self.helper.join(private_room, user=u3, tok=u3_token)
 
-        self.get_success(self.store.update_user_directory_stream_pos(None))
-        self.get_success(self.store.delete_all_from_user_dir())
-
-        shares_private = self.get_success(
-            self.user_dir_helper.get_users_who_share_private_rooms()
-        )
-        public_users = self.get_success(
-            self.user_dir_helper.get_users_in_public_rooms()
-        )
-
-        # Nothing updated yet
-        self.assertEqual(shares_private, [])
-        self.assertEqual(public_users, [])
-
         # Do the initial population of the user directory via the background update
         self._purge_and_rebuild_user_dir()
 


### PR DESCRIPTION
The meat is in the first commit. The next two are small cleanups that I'd like to make, but don't have a functional impact and aren't necessary.