### PR TITLE
Log stack traces when a missing opentracing span is detected

### DIFF
--- a/changelog.d/10983.misc
+++ b/changelog.d/10983.misc
@@ -1,0 +1,1 @@
+Log stack traces when a missing opentracing span is detected.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -339,6 +339,7 @@ def ensure_active_span(message, ret=None):
                     "There was no active span when trying to %s."
                     " Did you forget to start one or did a context slip?",
                     message,
+                    stack_info=True,
                 )
 
                 return ret


### PR DESCRIPTION
 Make it easier to track down where opentracing spans are going missing
by including stack traces in the logs.
