### PR TITLE
Fix logging context warnings when losing replication connection

### DIFF
--- a/changelog.d/10984.misc
+++ b/changelog.d/10984.misc
@@ -1,0 +1,1 @@
+Fix spurious "Expected logging context replication_command_handler-############### was lost" warnings when losing the replication connection.

--- a/synapse/replication/tcp/protocol.py
+++ b/synapse/replication/tcp/protocol.py
@@ -434,8 +434,9 @@ class BaseReplicationStreamProtocol(LineOnlyReceiver):
         if self.transport:
             self.transport.unregisterProducer()
 
-        # mark the logging context as finished
-        self._logging_context.__exit__(None, None, None)
+        # mark the logging context as finished by triggering `__exit__()`
+        with self._logging_context:
+            pass
 
     def __str__(self):
         addr = None

--- a/synapse/replication/tcp/redis.py
+++ b/synapse/replication/tcp/redis.py
@@ -182,8 +182,9 @@ class RedisSubscriber(txredisapi.SubscriberProtocol):
         super().connectionLost(reason)
         self.synapse_handler.lost_connection(self)
 
-        # mark the logging context as finished
-        self._logging_context.__exit__(None, None, None)
+        # mark the logging context as finished by triggering `__exit__()`
+        with self._logging_context:
+            pass
 
     def send_command(self, cmd: Command):
         """Send a command if connection has been established.


### PR DESCRIPTION
Instead of triggering `__exit__` manually on the replication handler's
logging context, use it as a context manager so that there is an
`__enter__` call to balance the `__exit__`.
