### PR TITLE
`_check_event_auth`: move event validation earlier

### DIFF
--- a/changelog.d/10988.misc
+++ b/changelog.d/10988.misc
@@ -1,0 +1,1 @@
+Clean up some of the federation event authentication code for clarity.


### PR DESCRIPTION
There's little point in doing a fancy state reconciliation dance if the event
itself is invalid.

Likewise, there's no point checking it again in `_check_for_soft_fail`.