### PR TITLE
Run CI with Python 3.10 and Postgres 14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,11 +76,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         database: ["sqlite"]
         include:
           # Newest Python without optional deps
-          - python-version: "3.9"
+          - python-version: "3.10"
             toxenv: "py-noextras,combine"
 
           # Oldest Python with PostgreSQL
@@ -88,10 +88,10 @@ jobs:
             database: "postgres"
             postgres-version: "9.6"
 
-          # Newest Python with PostgreSQL
-          - python-version: "3.9"
+          # Newest Python with newest PostgreSQL
+          - python-version: "3.10"
             database: "postgres"
-            postgres-version: "13"
+            postgres-version: "14"
 
     steps:
       - uses: actions/checkout@v2
@@ -256,8 +256,8 @@ jobs:
           - python-version: "3.6"
             postgres-version: "9.6"
 
-          - python-version: "3.9"
-            postgres-version: "13"
+          - python-version: "3.10"
+            postgres-version: "14"
 
     services:
       postgres:

--- a/changelog.d/10992.misc
+++ b/changelog.d/10992.misc
@@ -1,0 +1,1 @@
+Update GHA config to run tests against Python 3.10 and PostgreSQL 14.


### PR DESCRIPTION
Python 3.10 was [released yesterday](https://www.python.org/downloads/release/python-3100/), and the `setup-python` action supports it [as of three hours ago](https://github.com/actions/python-versions/releases/tag/3.10.0-117470).

Postgres 14 was [released at the end of September](https://www.postgresql.org/docs/14/release-14.html) and the dockerhub container [is at least two hours old](https://hub.docker.com/layers/postgres/library/postgres/14.0/images/sha256-da98eb3d0ac42daede96c9cdf77ac57ef8e3c50614f48fcafe55e691b7d9a590?context=explore).

Bump the CI jobs that run on the latest versions of python and postgres to use these. (Should we use postgres:latest rather than pinning a specific number?)

Also include an explicit matrix job for trial under Python 3.10.