### PR TITLE
Fix long-standing bug where `ReadWriteLock` could drop logging contexts

### DIFF
--- a/changelog.d/10993.misc
+++ b/changelog.d/10993.misc
@@ -1,0 +1,1 @@
+Fix a long-standing bug where `ReadWriteLock`s could drop logging contexts on exit.

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -438,7 +438,8 @@ class ReadWriteLock:
             try:
                 yield
             finally:
-                new_defer.callback(None)
+                with PreserveLoggingContext():
+                    new_defer.callback(None)
                 self.key_to_current_readers.get(key, set()).discard(new_defer)
 
         return _ctx_manager()
@@ -466,7 +467,8 @@ class ReadWriteLock:
             try:
                 yield
             finally:
-                new_defer.callback(None)
+                with PreserveLoggingContext():
+                    new_defer.callback(None)
                 if self.key_to_current_writer[key] == new_defer:
                     self.key_to_current_writer.pop(key)
 


### PR DESCRIPTION
Use `PreserveLoggingContext()` to ensure that logging contexts are not
lost when exiting a read/write lock.

When exiting a read/write lock, callbacks on a `Deferred` are triggered
as a signal to any waiting coroutines. Any waiting coroutine that
becomes runnable is likely to follow the Synapse logging context rules
and will restore its own logging context, then either run to completion
or await another `Deferred`, resetting the logging context in the
process.
