### PR TITLE
Catch AttributeErrors when calling registerProducer

### DIFF
--- a/changelog.d/10995.bugfix
+++ b/changelog.d/10995.bugfix
@@ -1,0 +1,1 @@
+Correct a bugfix introduced in Synapse v1.44.0 that wouldn't catch every error of the connection breaks before a response could be written to it.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -563,7 +563,7 @@ class _ByteProducer:
 
         try:
             self._request.registerProducer(self, True)
-        except RuntimeError as e:
+        except (AttributeError, RuntimeError) as e:
             logger.info("Connection disconnected before response was written: %r", e)
 
             # We drop our references to data we'll not use.


### PR DESCRIPTION
Looks like this was missed in https://github.com/matrix-org/synapse/pull/10932 despite said PR mentioning it.