### PR TITLE
Improve the logging in _auth_and_persist_outliers

### DIFF
--- a/changelog.d/11010.misc
+++ b/changelog.d/11010.misc
@@ -1,0 +1,1 @@
+Clean up some of the federation event authentication code for clarity.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1158,7 +1158,10 @@ class FederationEventHandler:
                 return
 
             logger.info(
-                "Persisting %i of %i remaining events", len(roots), len(event_map)
+                "Persisting %i of %i remaining outliers: %s",
+                len(roots),
+                len(event_map),
+                shortstr(e.event_id for e in roots),
             )
 
             await self._auth_and_persist_fetched_events_inner(origin, room_id, roots)


### PR DESCRIPTION
Include the event ids being peristed