### PR TITLE
Document fail-open behaviour of `check_event_allowed` module API callback

### DIFF
--- a/changelog.d/11030.doc
+++ b/changelog.d/11030.doc
@@ -1,0 +1,1 @@
+Document the *fail open* behaviour of the Module API's `check_event_allowed` callback for third-party rules.

--- a/docs/modules/third_party_rules_callbacks.md
+++ b/docs/modules/third_party_rules_callbacks.md
@@ -41,6 +41,10 @@ event with new data by returning the new event's data as a dictionary. In order 
 that, it is recommended the module calls `event.get_dict()` to get the current event as a
 dictionary, and modify the returned dictionary accordingly.
 
+If `check_event_allowed` raises an exception, the check will fail open: the event
+is taken to be permitted by the module. If there are more `check_event_allowed` callbacks,
+the event proceeds to the next one. Otherwise, the event is accepted.
+
 Note that replacing the event only works for events sent by local users, not for events
 received over federation.
 


### PR DESCRIPTION
Signed-off-by: Olivier Wilkinson (reivilibre) <oliverw@matrix.org>

With my module developer hat on, this behaviour didn't seem expected.

It's probably not my say whether we should change this (I guess it's been thought through already) but it should at least be documented, I think.