### PR TITLE
Adds config to disable verify_signature of jwt

### DIFF
--- a/synapse/config/jwt.py
+++ b/synapse/config/jwt.py
@@ -35,6 +35,7 @@ class JWTConfig(Config):
             # that the claims exist on the JWT.
             self.jwt_issuer = jwt_config.get("issuer")
             self.jwt_audiences = jwt_config.get("audiences")
+            self.jwt_verify_signature = jwt_config.get("verify_signature", True)
 
             try:
                 import jwt
@@ -48,6 +49,7 @@ class JWTConfig(Config):
             self.jwt_algorithm = None
             self.jwt_issuer = None
             self.jwt_audiences = None
+            self.jwt_verify_signature = True
 
     def generate_config_section(self, **kwargs):
         return """\
@@ -105,4 +107,9 @@ class JWTConfig(Config):
             #
             #audiences:
             #    - "provided-by-your-issuer"
+
+            # Uncomment the following to disable verify_signature of JSON web
+            # tokens. Defaults to True.
+            #
+            #verify_signature: false
         """

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -74,6 +74,7 @@ class LoginRestServlet(RestServlet):
         self.jwt_algorithm = hs.config.jwt.jwt_algorithm
         self.jwt_issuer = hs.config.jwt.jwt_issuer
         self.jwt_audiences = hs.config.jwt.jwt_audiences
+        self.jwt_verify_signature = hs.config.jwt.jwt_verify_signature
 
         # SSO configuration.
         self.saml2_enabled = hs.config.saml2.saml2_enabled
@@ -399,6 +400,7 @@ class LoginRestServlet(RestServlet):
                 algorithms=[self.jwt_algorithm],
                 issuer=self.jwt_issuer,
                 audience=self.jwt_audiences,
+                options={"verify_signature": self.jwt_verify_signature}
             )
         except jwt.PyJWTError as e:
             # A JWT error occurred, return some info back to the client.


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog).
- `RS256` algorithm signed jwt token is failing to verify due to this `PyJWT` [issue](https://github.com/jpadilla/pyjwt/issues/359).
- As a workaround, adding an option to disable signature verification, solves the problem
- Adds a jwt_config option to disable signature verification.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
