### PR TITLE
Pass through `SynapseError`s that are raised from experimental `check_event_allowed` callback of the module API

### DIFF
--- a/changelog.d/11042.bugfix
+++ b/changelog.d/11042.bugfix
@@ -1,1 +1,1 @@
-Work around a regression, introduced in Synapse 1.39.0, that caused `SynapseError`s raised by the experimental Module API callback `check_event_allowed` to be ignored.
+Work around a regression, introduced in Synapse 1.39.0, that caused `SynapseError`s raised by the experimental third-party rules module callback `check_event_allowed` to be ignored.

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -218,12 +218,12 @@ class ThirdPartyEventRules:
             try:
                 res, replacement_data = await callback(event, state_events)
             except SynapseError as e:
-                # HACK. Being able to throw SynapseErrors is relied upon by
+                # FIXME: Being able to throw SynapseErrors is relied upon by
                 # some modules. PR #10386 accidentally broke this ability.
                 # That said, we aren't keen on exposing this implementation detail
                 # to modules and we should one day have a proper way to do what
                 # is wanted.
-                # This module API callback needs a rework so that hacks such as
+                # This module callback needs a rework so that hacks such as
                 # this one are not necessary.
                 raise e
             except Exception as e:


### PR DESCRIPTION
Signed-off-by: Olivier Wilkinson (reivilibre) <oliverw@matrix.org>

Regression introduced by #10386.