### PR TITLE
Fix error during logging of oEmbed errors, introduced in v1.44.0

### DIFF
--- a/changelog.d/11062.bugfix
+++ b/changelog.d/11062.bugfix
@@ -1,0 +1,1 @@
+Fix error during logging of oEmbed errors, introduced in v1.44.0.

--- a/synapse/rest/media/v1/oembed.py
+++ b/synapse/rest/media/v1/oembed.py
@@ -191,7 +191,7 @@ class OEmbedProvider:
 
         except Exception as e:
             # Trap any exception and let the code follow as usual.
-            logger.warning(f"Error parsing oEmbed metadata from {url}: {e:r}")
+            logger.warning("Error parsing oEmbed metadata from %s: %r", url, e)
             open_graph_response = {}
             cache_age = None
 


### PR DESCRIPTION
Targetting the release branch since it's showing up as of the latest RC.