### PR TITLE
Consider IP whitelist for identity server resolution

### DIFF
--- a/changelog.d/11120.bugfix
+++ b/changelog.d/11120.bugfix
@@ -1,0 +1,1 @@
+Identity server connection is no longer ignoring `ip_range_whitelist`.

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -54,7 +54,9 @@ class IdentityHandler:
         self.http_client = SimpleHttpClient(hs)
         # An HTTP client for contacting identity servers specified by clients.
         self.blacklisting_http_client = SimpleHttpClient(
-            hs, ip_blacklist=hs.config.server.federation_ip_range_blacklist
+            hs,
+            ip_blacklist=hs.config.server.federation_ip_range_blacklist,
+            ip_whitelist=hs.config.server.federation_ip_range_whitelist,
         )
         self.federation_http_client = hs.get_federation_http_client()
         self.hs = hs


### PR DESCRIPTION
The identity server connection enforces `ip_range_blacklist` but ignores `ip_range_whitelist`. This fixes that.

### Pull Request Checklist


* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
