### PR TITLE
Drop synapse_storage_transaction_time_bucket

### DIFF
--- a/changelog.d/11124.removal
+++ b/changelog.d/11124.removal
@@ -1,0 +1,1 @@
+Remove the `synapse_storage_transaction_time_bucket` metric due to the high cardinality of the metric putting undue strain on Prometheus deployments. This metric is not used in Synapse's included Grafana dashboards.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -64,7 +64,6 @@ perf_logger = logging.getLogger("synapse.storage.TIME")
 sql_scheduling_timer = Histogram("synapse_storage_schedule_time", "sec")
 
 sql_query_timer = Histogram("synapse_storage_query_time", "sec", ["verb"])
-sql_txn_timer = Histogram("synapse_storage_transaction_time", "sec", ["desc"])
 
 
 # Unique indexes which have been added in background updates. Maps from table name
@@ -639,7 +638,6 @@ class DatabasePool:
 
             self._current_txn_total_time += duration
             self._txn_perf_counters.update(desc, duration)
-            sql_txn_timer.labels(desc).observe(duration)
 
     async def runInteraction(
         self,


### PR DESCRIPTION
This particular metric has a much too high cardinality due to the fact
that the desc label can have (at present) 248 values. This results in
over 3k series per Synapse. If you have a Prometheus instance that
monitors multiple Synpase instances it results in a huge amount of
additional series to ingest.

The metric in question is also not used in the Synapse dashboard and
the core team has indicated they're happy to drop this metric entirely.

Fixes #11081

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
