### PR TITLE
Add domain specific matching for haproxy config

### DIFF
--- a/changelog.d/11128.doc
+++ b/changelog.d/11128.doc
@@ -1,1 +1,1 @@
-Improve example HAProxy config in the docs to properly handle host headers with port information. This is required for federation to work correctly.
+Improve example HAProxy config in the docs to properly handle host headers with port information. This is required for federation over port 443 to work correctly.

--- a/changelog.d/11128.doc
+++ b/changelog.d/11128.doc
@@ -1,0 +1,1 @@
+Improve example HAProxy config in the docs to properly handle host headers with port information. This is required for federation to work correctly.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -188,7 +188,7 @@ frontend https
   http-request set-header X-Forwarded-For %[src]
 
   # Matrix client traffic
-  acl matrix-host hdr_dom(host) -i matrix.example.com
+  acl matrix-host hdr(host) -i matrix.example.com matrix.example.com:443
   acl matrix-path path_beg /_matrix
   acl matrix-path path_beg /_synapse/client
 

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -188,7 +188,7 @@ frontend https
   http-request set-header X-Forwarded-For %[src]
 
   # Matrix client traffic
-  acl matrix-host hdr(host) -i matrix.example.com
+  acl matrix-host hdr_dom(host) -i matrix.example.com
   acl matrix-path path_beg /_matrix
   acl matrix-path path_beg /_synapse/client
 


### PR DESCRIPTION
I ran into trouble getting federation working properly with the haproxy config specified here.  After some debugging, I discovered that many federation HTTP requests, including the ones sent by the [federation tester](https://federationtester.matrix.org/), include the port number in the HTTP Host header field.  For example, instead of `Host: matrix.example.com`, these federation requests look like `Host: matrix.example.com:443`.  At least on haproxy 2.3, the extra port information causes the `acl matrix-host hdr(host) -i matrix.example.com` match to fail, since this is looking for an exact string match by default according to the [haproxy docs](http://cbonte.github.io/haproxy-dconv/2.3/configuration.html#7.1).  This failure, in turn, causes haproxy to return error codes and causes federation to fail.  Using `hdr_dom(host)`, which ignores the port information, fixes the issue in my setup.