### PR TITLE
Fix providing a `RoomStreamToken` instance to `_notify_app_services_ephemeral`

### DIFF
--- a/changelog.d/11137.bugfix
+++ b/changelog.d/11137.bugfix
@@ -1,0 +1,1 @@
+Partially address occasional bursts of old read receipt and presence data being sent to application services that have opted in to receiving them.

--- a/changelog.d/11137.bugfix
+++ b/changelog.d/11137.bugfix
@@ -1,1 +1,0 @@
-Partially address occasional bursts of old read receipt and presence data being sent to application services that have opted in to receiving them.

--- a/changelog.d/11137.misc
+++ b/changelog.d/11137.misc
@@ -1,0 +1,1 @@
+Remove and document unnecessary `RoomStreamToken` checks in application service ephemeral event code.

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -212,12 +212,18 @@ class ApplicationServicesHandler:
         if stream_key not in ("typing_key", "receipt_key", "presence_key"):
             return
 
-        # Convert new_token from a RoomStreamToken to an int if necessary.
-        # We just use the minimum stream ordering and ignore the vector clock
-        # component. This is safe to do as long as we *always* ignore the vector
-        # clock components.
-        if isinstance(new_token, RoomStreamToken):
-            new_token = new_token.stream
+        # Assert that new_token is an integer (and not a RoomStreamToken).
+        # All of the supported streams that this function handles uses an
+        # integer to track progress (rather than a RoomStreamToken - a
+        # vector clock implementation - as they don't support multiple
+        # stream writers).
+        #
+        # As a result, we simply assert that new_token is an integer.
+        # If we do end up needing to pass a RoomStreamToken down here
+        # in the future, using RoomStreamToken.stream (the minimum stream
+        # position) to convert to an ascending integer value should work.
+        # Additional context: https://github.com/matrix-org/synapse/pull/11137
+        assert isinstance(new_token, int)
 
         services = [
             service

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -213,10 +213,10 @@ class ApplicationServicesHandler:
             return
 
         # Assert that new_token is an integer (and not a RoomStreamToken).
-        # All of the supported streams that this function handles uses an
+        # All of the supported streams that this function handles use an
         # integer to track progress (rather than a RoomStreamToken - a
-        # vector clock implementation - as they don't support multiple
-        # stream writers).
+        # vector clock implementation) as they don't support multiple
+        # stream writers.
         #
         # As a result, we simply assert that new_token is an integer.
         # If we do end up needing to pass a RoomStreamToken down here

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -182,7 +182,7 @@ class ApplicationServicesHandler:
     def notify_interested_services_ephemeral(
         self,
         stream_key: str,
-        new_token: int,
+        new_token: Union[int, RoomStreamToken],
         users: Optional[Collection[Union[str, UserID]]] = None,
     ) -> None:
         """
@@ -203,7 +203,7 @@ class ApplicationServicesHandler:
                 Appservices will only receive ephemeral events that fall within their
                 registered user and room namespaces.
 
-            new_token: The latest stream token.
+            new_token: The stream token of the event.
             users: The users that should be informed of the new event, if any.
         """
         if not self.notify_appservices:
@@ -211,6 +211,13 @@ class ApplicationServicesHandler:
 
         if stream_key not in ("typing_key", "receipt_key", "presence_key"):
             return
+
+        # Convert new_token from a RoomStreamToken to an int if necessary.
+        # We just use the minimum stream ordering and ignore the vector clock
+        # component. This is safe to do as long as we *always* ignore the vector
+        # clock components.
+        if isinstance(new_token, RoomStreamToken):
+            new_token = new_token.stream
 
         services = [
             service

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -182,7 +182,7 @@ class ApplicationServicesHandler:
     def notify_interested_services_ephemeral(
         self,
         stream_key: str,
-        new_token: Optional[int],
+        new_token: int,
         users: Optional[Collection[Union[str, UserID]]] = None,
     ) -> None:
         """This is called by the notifier in the background
@@ -224,14 +224,13 @@ class ApplicationServicesHandler:
         self,
         services: List[ApplicationService],
         stream_key: str,
-        new_token: Optional[int],
+        new_token: int,
         users: Collection[Union[str, UserID]],
     ) -> None:
         logger.debug("Checking interested services for %s" % (stream_key))
         with Measure(self.clock, "notify_interested_services_ephemeral"):
             for service in services:
-                # Only handle typing if we have the latest token
-                if stream_key == "typing_key" and new_token is not None:
+                if stream_key == "typing_key":
                     events = await self._handle_typing(service, new_token)
                     if events:
                         self.scheduler.submit_ephemeral_events_for_as(service, events)

--- a/synapse/notifier.py
+++ b/synapse/notifier.py
@@ -381,11 +381,12 @@ class Notifier:
         users: Optional[Collection[Union[str, UserID]]] = None,
     ):
         try:
-            stream_token = None
-            if isinstance(new_token, int):
-                stream_token = new_token
+            # Convert new_token from a RoomStreamToken to an int if necessary
+            if isinstance(new_token, RoomStreamToken):
+                new_token = new_token.stream
+
             self.appservice_handler.notify_interested_services_ephemeral(
-                stream_key, stream_token, users or []
+                stream_key, new_token, users or []
             )
         except Exception:
             logger.exception("Error notifying application services of event")

--- a/synapse/notifier.py
+++ b/synapse/notifier.py
@@ -444,7 +444,7 @@ class Notifier:
 
             self.notify_replication()
 
-            # Notify appservices
+            # Notify appservices.
             try:
                 self.appservice_handler.notify_interested_services_ephemeral(
                     stream_key,

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -414,7 +414,7 @@ class DeviceWorkerStore(SQLBaseStore):
             user_ids: the users who were signed
 
         Returns:
-            THe new stream ID.
+            The new stream ID.
         """
 
         async with self._device_list_id_gen.get_next() as stream_id:
@@ -1302,7 +1302,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
 
     async def add_device_change_to_streams(
         self, user_id: str, device_ids: Collection[str], hosts: List[str]
-    ):
+    ) -> int:
         """Persist that a user's devices have been updated, and which hosts
         (if any) should be poked.
         """

--- a/synapse/storage/databases/main/presence.py
+++ b/synapse/storage/databases/main/presence.py
@@ -92,7 +92,7 @@ class PresenceStore(PresenceBackgroundUpdateStore):
             prefilled_cache=presence_cache_prefill,
         )
 
-    async def update_presence(self, presence_states):
+    async def update_presence(self, presence_states) -> Tuple[int, int]:
         assert self._can_persist_presence
 
         stream_ordering_manager = self._presence_id_gen.get_next_mult(


### PR DESCRIPTION
We typically figure out which EDUs to send to application services based the last stream token that appservice successfully received. This is true for read receipts and user presence, however for typing we always just send the last typing event. This process is started whenever a new read receipt, presence update or typing event is processed by the server. In that case, `notify_interested_services_ephemeral` will be called with the new event and its stream token (so we can check whether we need to send any other events to the appservice may have missed).

With all that in mind, I believe I've found a bug in the implementation. If a `RoomStreamToken` object was provided as the `new_token` argument to `_notify_app_services_ephemeral`, `new_token` would be set to `None`, before then being passed to `notify_interested_services_ephemeral` and then `_notify_interested_services_ephemeral`. The commit that introduced this change (559974fb4bc1872abced395de22ffbd2292b2f8b) was intended to prevent mypy from failing. `(_)notify_app_services_ephemeral` was also configured to allow `new_token` to be an `Optional[int]` as a result.

However, if `None` is provided, `_notify_app_services_ephemeral` will end up passing `None` to `set_type_stream_id_for_appservice`, which will clear each appservice's stream token for the given `stream_key`. ~~Doing so means that we send all presence or read receipt data from a None stream token up until the latest token(!). This seems like a bug to do every time we have a `RoomStreamToken` rather than an `int`.~~ Actually, all stream keys that are passed to `_notify_interested_services_ephemeral` (`typing_key`, `receipt_key`, `presence_key`) are passing `int` values for `new_token`, so the buggy code would have never fired anyways.

Regardless, I propose converting the `RoomStreamToken` to an `int` using `RoomStreamToken.stream` (~~I _think_ this is the right way to convert it. [`RoomStreamToken`](https://github.com/matrix-org/synapse/blob/aa2c027792d04c36b17866710e95a41d31f5d99c/synapse/types.py#L415-L464) can end up being a vector clock when you have multiple event persister workers; in this case `stream` will be the minimum stream token amongst all workers... which I think is fine... maybe?~~ This appears to be correct, we do it [elsewhere as well](https://github.com/matrix-org/synapse/blob/9abbd08e33fc7710d952e870e26368d17915bbba/synapse/handlers/appservice.py#L67-L70).)

~~This may relate to the large bursts of EDU traffic Synapse is sending to AS's ala https://github.com/matrix-org/synapse/issues/10836.~~ See above. The code should not have actually resulted in broken behaviour.