### PR TITLE
Test that `ClientIpStore` combines database and in-memory data correctly

### DIFF
--- a/changelog.d/11179.misc
+++ b/changelog.d/11179.misc
@@ -1,0 +1,1 @@
+Add tests to check that `ClientIpStore.get_last_client_ip_by_device` and `get_user_ip_and_agents` combine database and in-memory data correctly.


### PR DESCRIPTION
Following on from a suggestion in https://github.com/matrix-org/synapse/pull/11112