### PR TITLE
Force deb compression with `xz`.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+matrix-synapse-py3 (1.46.0~rc1ubuntu1) UNRELEASED; urgency=medium
+
+  * Compress debs with xz, to fix incompatibility of impish debs with reprepro.
+
+ -- Richard van der Hoff <richard@matrix.org>  Wed, 27 Oct 2021 15:32:51 +0100
+
 matrix-synapse-py3 (1.46.0~rc1) stable; urgency=medium
 
   * New synapse release 1.46.0~rc1.

--- a/debian/rules
+++ b/debian/rules
@@ -51,5 +51,11 @@ override_dh_shlibdeps:
 override_dh_virtualenv:
 	./debian/build_virtualenv
 
+override_dh_builddeb:
+        # force the compression to xzip, to stop dpkg-deb on impish defaulting to zstd
+        # (which requires reprepro 5.3.0-1.3, which is currently only in 'experimental' in Debian:
+        # https://metadata.ftp-master.debian.org/changelogs/main/r/reprepro/reprepro_5.3.0-1.3_changelog)
+	dh_builddeb -- -Zxz
+
 %:
 	dh $@ --with python-virtualenv


### PR DESCRIPTION
Fixes a problem where `impish` packages could not be processed by `reprepro`.