### PR TITLE
Handle missing Content-Type header when accessing remote media

### DIFF
--- a/changelog.d/11200.bugfix
+++ b/changelog.d/11200.bugfix
@@ -1,1 +1,1 @@
-Fixes a long-standing bug wherein a missing Content-Type header when downloading remote media causes Synapse to throw an error.
+Fix a long-standing bug wherein a missing `Content-Type` header when downloading remote media would cause Synapse to throw an error.

--- a/changelog.d/11200.bugfix
+++ b/changelog.d/11200.bugfix
@@ -1,0 +1,1 @@
+Fixes a long-standing bug wherein a missing Content-Type header when downloading remote media causes Synapse to throw an error.

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -214,7 +214,7 @@ class MediaRepository:
 
         self.mark_recently_accessed(None, media_id)
 
-        media_type = media_info["media_type"]
+        media_type = media_info.get("media_type", "application/octet-stream")
         media_length = media_info["media_length"]
         upload_name = name if name else media_info["upload_name"]
         url_cache = media_info["url_cache"]

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -214,7 +214,9 @@ class MediaRepository:
 
         self.mark_recently_accessed(None, media_id)
 
-        media_type = media_info.get("media_type", "application/octet-stream")
+        media_type = media_info.get("media_type")
+        if not media_type:
+            media_type = "application/octect-stream"
         media_length = media_info["media_length"]
         upload_name = name if name else media_info["upload_name"]
         url_cache = media_info["url_cache"]
@@ -333,6 +335,9 @@ class MediaRepository:
                 logger.info("Media is quarantined")
                 raise NotFoundError()
 
+            if not media_info["media_type"]:
+                media_info["media_type"] = "application/octect-stream"
+
             responder = await self.media_storage.fetch_media(file_info)
             if responder:
                 return responder, media_info
@@ -354,6 +359,8 @@ class MediaRepository:
                 raise e
 
         file_id = media_info["filesystem_id"]
+        if not media_info["media_type"]:
+            media_info["media_type"] = "application/octect-stream"
         file_info = FileInfo(server_name, file_id)
 
         # We generate thumbnails even if another process downloaded the media

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -445,7 +445,10 @@ class MediaRepository:
 
             await finish()
 
-            media_type = headers[b"Content-Type"][0].decode("ascii")
+            if b"Content-Type" in headers:
+                media_type = headers[b"Content-Type"][0].decode("ascii")
+            else:
+                media_type = "application/octet-stream"
             upload_name = get_filename_from_headers(headers)
             time_now_ms = self.clock.time_msec()
 

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -214,9 +214,9 @@ class MediaRepository:
 
         self.mark_recently_accessed(None, media_id)
 
-        media_type = media_info.get("media_type")
+        media_type = media_info["media_type"]
         if not media_type:
-            media_type = "application/octect-stream"
+            media_type = "application/octet-stream"
         media_length = media_info["media_length"]
         upload_name = name if name else media_info["upload_name"]
         url_cache = media_info["url_cache"]
@@ -336,7 +336,7 @@ class MediaRepository:
                 raise NotFoundError()
 
             if not media_info["media_type"]:
-                media_info["media_type"] = "application/octect-stream"
+                media_info["media_type"] = "application/octet-stream"
 
             responder = await self.media_storage.fetch_media(file_info)
             if responder:
@@ -360,7 +360,7 @@ class MediaRepository:
 
         file_id = media_info["filesystem_id"]
         if not media_info["media_type"]:
-            media_info["media_type"] = "application/octect-stream"
+            media_info["media_type"] = "application/octet-stream"
         file_info = FileInfo(server_name, file_id)
 
         # We generate thumbnails even if another process downloaded the media

--- a/synapse/rest/media/v1/upload_resource.py
+++ b/synapse/rest/media/v1/upload_resource.py
@@ -80,7 +80,7 @@ class UploadResource(DirectServeJsonResource):
             assert content_type_headers  # for mypy
             media_type = content_type_headers[0].decode("ascii")
         else:
-            raise SynapseError(msg="Upload request missing 'Content-Type'", code=400)
+            media_type = "application/octet-stream"
 
         # if headers.hasHeader(b"Content-Disposition"):
         #     disposition = headers.getRawHeaders(b"Content-Disposition")[0]

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -285,44 +285,43 @@ class MediaRepoTests(unittest.HomeserverTestCase):
 
         return channel
 
-    def _req_missing_headers(self, content_disposition):
-
-        channel = make_request(
-            self.reactor,
-            FakeSite(self.download_resource, self.reactor),
-            "GET",
-            self.media_id,
-            shorthand=False,
-            await_result=False,
-        )
-        self.pump()
-
-        # We've made one fetch, to example.com, using the media URL, and asking
-        # the other server not to do a remote fetch
-        self.assertEqual(len(self.fetches), 1)
-        self.assertEqual(self.fetches[0][1], "example.com")
-        self.assertEqual(
-            self.fetches[0][2], "/_matrix/media/r0/download/" + self.media_id
-        )
-        self.assertEqual(self.fetches[0][3], {"allow_remote": "false"})
-
-        headers = {
-            b"Content-Length": [b"%d" % (len(self.test_image.data))],
-        }
-        if content_disposition:
-            headers[b"Content-Disposition"] = [content_disposition]
-
-        self.fetches[0][0].callback(
-            (self.test_image.data, (len(self.test_image.data), headers))
-        )
-
-        self.pump()
-        self.assertEqual(channel.code, 200)
-
-        return channel
-
     def test_handle_missing_content_type(self):
-        channel = self._req_missing_headers(
+        def _req_missing_headers(content_disposition):
+            channel = make_request(
+                self.reactor,
+                FakeSite(self.download_resource, self.reactor),
+                "GET",
+                self.media_id,
+                shorthand=False,
+                await_result=False,
+            )
+            self.pump()
+
+            # We've made one fetch, to example.com, using the media URL, and asking
+            # the other server not to do a remote fetch
+            self.assertEqual(len(self.fetches), 1)
+            self.assertEqual(self.fetches[0][1], "example.com")
+            self.assertEqual(
+                self.fetches[0][2], "/_matrix/media/r0/download/" + self.media_id
+            )
+            self.assertEqual(self.fetches[0][3], {"allow_remote": "false"})
+
+            headers = {
+                b"Content-Length": [b"%d" % (len(self.test_image.data))],
+            }
+            if content_disposition:
+                headers[b"Content-Disposition"] = [content_disposition]
+
+            self.fetches[0][0].callback(
+                (self.test_image.data, (len(self.test_image.data), headers))
+            )
+
+            self.pump()
+            self.assertEqual(channel.code, 200)
+
+            return channel
+
+        channel = _req_missing_headers(
             b"inline; filename=out" + self.test_image.extension
         )
         headers = channel.headers

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -269,15 +269,12 @@ class MediaRepoTests(unittest.HomeserverTestCase):
         )
         self.assertEqual(self.fetches[0][3], {"allow_remote": "false"})
 
+        headers = {
+            b"Content-Length": [b"%d" % (len(self.test_image.data))],
+        }
+
         if include_content_type:
-            headers = {
-                b"Content-Length": [b"%d" % (len(self.test_image.data))],
-                b"Content-Type": [self.test_image.content_type],
-            }
-        else:
-            headers = {
-                b"Content-Length": [b"%d" % (len(self.test_image.data))],
-            }
+            headers[b"Content-Type"] = [self.test_image.content_type]
 
         if content_disposition:
             headers[b"Content-Disposition"] = [content_disposition]
@@ -292,7 +289,10 @@ class MediaRepoTests(unittest.HomeserverTestCase):
         return channel
 
     def test_handle_missing_content_type(self):
-        channel = self._req(b"inline; filename=out" + self.test_image.extension, False)
+        channel = self._req(
+            b"inline; filename=out" + self.test_image.extension,
+            include_content_type=False,
+        )
         headers = channel.headers
         self.assertEqual(channel.code, 200)
         self.assertEqual(


### PR DESCRIPTION
Fixes issue #11044. Currently Synapse throws an error when fetching media without a `Content-Type` header. This PR adds logic to check for missing `Content-Type` headers when downloading remote media and default the `Content-Type` to `application/octet-stream` (per https://httpwg.org/specs/rfc7231.html#header.content-type) where that is the case. It also does the same for when media is being uploaded, and when media is pulled out of the local database.  