### PR TITLE
Add a linearizer on (appservice, stream) when handling ephemeral events.

### DIFF
--- a/changelog.d/11207.bugfix
+++ b/changelog.d/11207.bugfix
@@ -1,0 +1,1 @@
+Linearize appservice ephemeral event handling, fixing serialization errors. Contributed by @Fizzadar at Beeper.

--- a/changelog.d/11207.bugfix
+++ b/changelog.d/11207.bugfix
@@ -1,1 +1,1 @@
-Linearize appservice ephemeral event handling, fixing serialization errors. Contributed by @Fizzadar at Beeper.
+Fix a long-standing bug which could result in serialization errors and potentially duplicate transaction data when sending ephemeral events to application services. Contributed by @Fizzadar at Beeper.

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -268,10 +268,10 @@ class ApplicationServicesHandler:
                                 service, events
                             )
 
-                        # Persist the latest handled stream token for this appservice
-                        await self.store.set_type_stream_id_for_appservice(
-                            service, "read_receipt", new_token
-                        )
+                            # Persist the latest handled stream token for this appservice
+                            await self.store.set_type_stream_id_for_appservice(
+                                service, "read_receipt", new_token
+                            )
 
                     elif stream_key == "presence_key":
                         events = await self._handle_presence(service, users, new_token)
@@ -280,10 +280,10 @@ class ApplicationServicesHandler:
                                 service, events
                             )
 
-                        # Persist the latest handled stream token for this appservice
-                        await self.store.set_type_stream_id_for_appservice(
-                            service, "presence", new_token
-                        )
+                            # Persist the latest handled stream token for this appservice
+                            await self.store.set_type_stream_id_for_appservice(
+                                service, "presence", new_token
+                            )
 
     async def _handle_typing(
         self, service: ApplicationService, new_token: int
@@ -342,7 +342,8 @@ class ApplicationServicesHandler:
             service, "read_receipt"
         )
         if new_token is not None and new_token <= from_key:
-            raise Exception("Rejecting token lower than stored: %s" % (new_token,))
+            logger.debug("Rejecting token lower than stored: %s" % (new_token,))
+            return []
 
         receipts_source = self.event_sources.sources.receipt
         receipts, _ = await receipts_source.get_new_events_as(
@@ -378,7 +379,8 @@ class ApplicationServicesHandler:
             service, "presence"
         )
         if new_token is not None and new_token <= from_key:
-            raise Exception("Rejecting token lower than stored: %s" % (new_token,))
+            logger.debug("Rejecting token lower than stored: %s" % (new_token,))
+            return []
 
         for user in users:
             if isinstance(user, str):

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -342,7 +342,7 @@ class ApplicationServicesHandler:
             service, "read_receipt"
         )
         if new_token is not None and new_token <= from_key:
-            logger.debug("Rejecting token lower than stored: %s" % (new_token,))
+            logger.debug("Rejecting token lower than or equal to stored: %s" % (new_token,))
             return []
 
         receipts_source = self.event_sources.sources.receipt
@@ -379,7 +379,7 @@ class ApplicationServicesHandler:
             service, "presence"
         )
         if new_token is not None and new_token <= from_key:
-            logger.debug("Rejecting token lower than stored: %s" % (new_token,))
+            logger.debug("Rejecting token lower than or equal to stored: %s" % (new_token,))
             return []
 
         for user in users:

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -59,7 +59,7 @@ class ApplicationServicesHandler:
         self.current_max = 0
         self.is_processing = False
 
-        self._ephemeral_events_linearizer = Linearizer(name="ephemeral_events")
+        self._ephemeral_events_linearizer = Linearizer(name="appservice_ephemeral_events")
 
     def notify_interested_services(self, max_token: RoomStreamToken) -> None:
         """Notifies (pushes) all application services interested in this event.

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -268,10 +268,10 @@ class ApplicationServicesHandler:
                                 service, events
                             )
 
-                            # Persist the latest handled stream token for this appservice
-                            await self.store.set_type_stream_id_for_appservice(
-                                service, "read_receipt", new_token
-                            )
+                        # Persist the latest handled stream token for this appservice
+                        await self.store.set_type_stream_id_for_appservice(
+                            service, "read_receipt", new_token
+                        )
 
                     elif stream_key == "presence_key":
                         events = await self._handle_presence(service, users, new_token)
@@ -280,10 +280,10 @@ class ApplicationServicesHandler:
                                 service, events
                             )
 
-                            # Persist the latest handled stream token for this appservice
-                            await self.store.set_type_stream_id_for_appservice(
-                                service, "presence", new_token
-                            )
+                        # Persist the latest handled stream token for this appservice
+                        await self.store.set_type_stream_id_for_appservice(
+                            service, "presence", new_token
+                        )
 
     async def _handle_typing(
         self, service: ApplicationService, new_token: int

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -342,7 +342,9 @@ class ApplicationServicesHandler:
             service, "read_receipt"
         )
         if new_token is not None and new_token <= from_key:
-            logger.debug("Rejecting token lower than or equal to stored: %s" % (new_token,))
+            logger.debug(
+                "Rejecting token lower than or equal to stored: %s" % (new_token,)
+            )
             return []
 
         receipts_source = self.event_sources.sources.receipt
@@ -379,7 +381,9 @@ class ApplicationServicesHandler:
             service, "presence"
         )
         if new_token is not None and new_token <= from_key:
-            logger.debug("Rejecting token lower than or equal to stored: %s" % (new_token,))
+            logger.debug(
+                "Rejecting token lower than or equal to stored: %s" % (new_token,)
+            )
             return []
 
         for user in users:

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -258,17 +258,23 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         services = [interested_service]
 
         self.mock_store.get_app_services.return_value = services
-        self.mock_store.get_type_stream_id_for_appservice.return_value = make_awaitable(579)
+        self.mock_store.get_type_stream_id_for_appservice.return_value = make_awaitable(
+            579
+        )
 
         event = Mock(event_id="event_1")
-        self.event_source.sources.receipt.get_new_events_as.return_value = make_awaitable(([event], None))
+        self.event_source.sources.receipt.get_new_events_as.return_value = (
+            make_awaitable(([event], None))
+        )
 
         self.handler.notify_interested_services_ephemeral("receipt_key", 580)
         self.mock_scheduler.submit_ephemeral_events_for_as.assert_called_once_with(
             interested_service, [event]
         )
         self.mock_store.set_type_stream_id_for_appservice.assert_called_once_with(
-            interested_service, "read_receipt", 580,
+            interested_service,
+            "read_receipt",
+            580,
         )
 
     def test_notify_interested_services_ephemeral_out_of_order(self):
@@ -276,10 +282,14 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         services = [interested_service]
 
         self.mock_store.get_app_services.return_value = services
-        self.mock_store.get_type_stream_id_for_appservice.return_value = make_awaitable(580)
+        self.mock_store.get_type_stream_id_for_appservice.return_value = make_awaitable(
+            580
+        )
 
         event = Mock(event_id="event_1")
-        self.event_source.sources.receipt.get_new_events_as.return_value = make_awaitable(([event], None))
+        self.event_source.sources.receipt.get_new_events_as.return_value = (
+            make_awaitable(([event], None))
+        )
 
         self.handler.notify_interested_services_ephemeral("receipt_key", 579)
         self.mock_scheduler.submit_ephemeral_events_for_as.assert_not_called()

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -40,6 +40,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         hs.get_application_service_scheduler.return_value = self.mock_scheduler
         hs.get_clock.return_value = MockClock()
         self.handler = ApplicationServicesHandler(hs)
+        self.event_source = hs.get_event_sources()
 
     def test_notify_interested_services(self):
         interested_service = self._mkservice(is_interested=True)
@@ -251,6 +252,38 @@ class AppServiceHandlerTestCase(unittest.TestCase):
                 },
             },
         )
+
+    def test_notify_interested_services_ephemeral(self):
+        interested_service = self._mkservice(is_interested=True)
+        services = [interested_service]
+
+        self.mock_store.get_app_services.return_value = services
+        self.mock_store.get_type_stream_id_for_appservice.return_value = make_awaitable(579)
+
+        event = Mock(event_id="event_1")
+        self.event_source.sources.receipt.get_new_events_as.return_value = make_awaitable(([event], None))
+
+        self.handler.notify_interested_services_ephemeral("receipt_key", 580)
+        self.mock_scheduler.submit_ephemeral_events_for_as.assert_called_once_with(
+            interested_service, [event]
+        )
+        self.mock_store.set_type_stream_id_for_appservice.assert_called_once_with(
+            interested_service, "read_receipt", 580,
+        )
+
+    def test_notify_interested_services_ephemeral_out_of_order(self):
+        interested_service = self._mkservice(is_interested=True)
+        services = [interested_service]
+
+        self.mock_store.get_app_services.return_value = services
+        self.mock_store.get_type_stream_id_for_appservice.return_value = make_awaitable(580)
+
+        event = Mock(event_id="event_1")
+        self.event_source.sources.receipt.get_new_events_as.return_value = make_awaitable(([event], None))
+
+        self.handler.notify_interested_services_ephemeral("receipt_key", 579)
+        self.mock_scheduler.submit_ephemeral_events_for_as.assert_not_called()
+        self.mock_store.set_type_stream_id_for_appservice.assert_not_called()
 
     def _mkservice(self, is_interested, protocols=None):
         service = Mock()

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -254,6 +254,11 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         )
 
     def test_notify_interested_services_ephemeral(self):
+        """
+        Test sending ephemeral events to the appservice handler are scheduled
+        to be pushed out to interested appservices, and that the stream ID is
+        updated accordingly.
+        """
         interested_service = self._mkservice(is_interested=True)
         services = [interested_service]
 
@@ -278,6 +283,10 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         )
 
     def test_notify_interested_services_ephemeral_out_of_order(self):
+        """
+        Test sending out of order ephemeral events to the appservice handler
+        are ignored.
+        """
         interested_service = self._mkservice(is_interested=True)
         services = [interested_service]
 

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -302,7 +302,6 @@ class AppServiceHandlerTestCase(unittest.TestCase):
 
         self.handler.notify_interested_services_ephemeral("receipt_key", 579)
         self.mock_scheduler.submit_ephemeral_events_for_as.assert_not_called()
-        self.mock_store.set_type_stream_id_for_appservice.assert_not_called()
 
     def _mkservice(self, is_interested, protocols=None):
         service = Mock()


### PR DESCRIPTION
To close: https://github.com/matrix-org/synapse/issues/11195

Skipped the linearization for typing events as they're a special case and unaffected by this issue.

Signed-off-by: Nick Barrett <nick@beeper.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
* [x] Code style is correct (run the [linters](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#code-style))
