### PR TITLE
Add `use_float=true` to ijson calls in Synapse

### DIFF
--- a/changelog.d/11217.bugfix
+++ b/changelog.d/11217.bugfix
@@ -1,1 +1,1 @@
-Fixes a bug introduced in #9958 which made it impossible to join rooms that return a send_join response containing floats.
+Fix a bug introduced in 1.35.0 which made it impossible to join rooms that return a `send_join` response containing floats.

--- a/changelog.d/11217.bugfix
+++ b/changelog.d/11217.bugfix
@@ -1,0 +1,1 @@
+Fixes a bug introduced in #9958 which made it impossible to join rooms that return a send_join response containing floats.

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -1309,15 +1309,15 @@ class SendJoinParser(ByteParser[SendJoinResponse]):
 
         self._coro_state = ijson.items_coro(
             _event_list_parser(room_version, self._response.state),
-            prefix + "state.item",
+            prefix + "state.item", use_float=True
         )
         self._coro_auth = ijson.items_coro(
             _event_list_parser(room_version, self._response.auth_events),
-            prefix + "auth_chain.item",
+            prefix + "auth_chain.item", use_float=True
         )
         self._coro_event = ijson.kvitems_coro(
             _event_parser(self._response.event_dict),
-            prefix + "org.matrix.msc3083.v2.event",
+            prefix + "org.matrix.msc3083.v2.event", use_float=True
         )
 
     def write(self, data: bytes) -> int:

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -1309,15 +1309,18 @@ class SendJoinParser(ByteParser[SendJoinResponse]):
 
         self._coro_state = ijson.items_coro(
             _event_list_parser(room_version, self._response.state),
-            prefix + "state.item", use_float=True
+            prefix + "state.item",
+            use_float=True,
         )
         self._coro_auth = ijson.items_coro(
             _event_list_parser(room_version, self._response.auth_events),
-            prefix + "auth_chain.item", use_float=True
+            prefix + "auth_chain.item",
+            use_float=True,
         )
         self._coro_event = ijson.kvitems_coro(
             _event_parser(self._response.event_dict),
-            prefix + "org.matrix.msc3083.v2.event", use_float=True
+            prefix + "org.matrix.msc3083.v2.event",
+            use_float=True,
         )
 
     def write(self, data: bytes) -> int:


### PR DESCRIPTION
Fixes  #11135, which appears to have been introduced in #9958. Prior to this change, when `ijson` parsed floats it returned a `Decimal`, which is incompatible with `canonicaljson` and caused an error wherein users were unable to join some rooms that returned a `send_join` response containing floats. I tested this solution by spinning up a homeserver,  reproducing the failed `send_join` to `#ghidra:matrix.org` (a room known to be prone to this error), making the below edits in the code used for the homeserver, restarting, and verifying that I could successfully join `ghidra:matrix.org`. 