### PR TITLE
ObservableDeferred: run observers in order

### DIFF
--- a/changelog.d/11229.misc
+++ b/changelog.d/11229.misc
@@ -1,0 +1,1 @@
+`ObservableDeferred`: run registered observers in order.

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -76,7 +76,7 @@ class ObservableDeferred(Generic[_T]):
     def __init__(self, deferred: "defer.Deferred[_T]", consumeErrors: bool = False):
         object.__setattr__(self, "_deferred", deferred)
         object.__setattr__(self, "_result", None)
-        object.__setattr__(self, "_observers", list())
+        object.__setattr__(self, "_observers", [])
 
         def callback(r):
             object.__setattr__(self, "_result", (True, r))
@@ -84,7 +84,7 @@ class ObservableDeferred(Generic[_T]):
             # once we have set _result, no more entries will be added to _observers,
             # so it's safe to replace it with the empty tuple.
             observers = self._observers
-            object.__setattr__(self, "_observers", tuple())
+            object.__setattr__(self, "_observers", ())
 
             for observer in observers:
                 try:
@@ -104,7 +104,7 @@ class ObservableDeferred(Generic[_T]):
             # once we have set _result, no more entries will be added to _observers,
             # so it's safe to replace it with the empty tuple.
             observers = self._observers
-            object.__setattr__(self, "_observers", tuple())
+            object.__setattr__(self, "_observers", ())
 
             for observer in observers:
                 # This is a little bit of magic to correctly propagate stack

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -17,6 +17,7 @@ import collections
 import inspect
 import itertools
 import logging
+from collections import Collection
 from contextlib import contextmanager
 from typing import (
     Any,
@@ -26,7 +27,6 @@ from typing import (
     Generic,
     Hashable,
     Iterable,
-    List,
     Optional,
     Set,
     TypeVar,
@@ -76,12 +76,17 @@ class ObservableDeferred(Generic[_T]):
     def __init__(self, deferred: "defer.Deferred[_T]", consumeErrors: bool = False):
         object.__setattr__(self, "_deferred", deferred)
         object.__setattr__(self, "_result", None)
-        object.__setattr__(self, "_observers", set())
+        object.__setattr__(self, "_observers", list())
 
         def callback(r):
             object.__setattr__(self, "_result", (True, r))
-            while self._observers:
-                observer = self._observers.pop()
+
+            # once we have set _result, no more entries will be added to _observers,
+            # so it's safe to replace it with the empty tuple.
+            observers = self._observers
+            object.__setattr__(self, "_observers", tuple())
+
+            for observer in observers:
                 try:
                     observer.callback(r)
                 except Exception as e:
@@ -95,12 +100,16 @@ class ObservableDeferred(Generic[_T]):
 
         def errback(f):
             object.__setattr__(self, "_result", (False, f))
-            while self._observers:
+
+            # once we have set _result, no more entries will be added to _observers,
+            # so it's safe to replace it with the empty tuple.
+            observers = self._observers
+            object.__setattr__(self, "_observers", tuple())
+
+            for observer in observers:
                 # This is a little bit of magic to correctly propagate stack
                 # traces when we `await` on one of the observer deferreds.
                 f.value.__failure__ = f
-
-                observer = self._observers.pop()
                 try:
                     observer.errback(f)
                 except Exception as e:
@@ -127,20 +136,13 @@ class ObservableDeferred(Generic[_T]):
         """
         if not self._result:
             d: "defer.Deferred[_T]" = defer.Deferred()
-
-            def remove(r):
-                self._observers.discard(d)
-                return r
-
-            d.addBoth(remove)
-
-            self._observers.add(d)
+            self._observers.append(d)
             return d
         else:
             success, res = self._result
             return defer.succeed(res) if success else defer.fail(res)
 
-    def observers(self) -> "List[defer.Deferred[_T]]":
+    def observers(self) -> "Collection[defer.Deferred[_T]]":
         return self._observers
 
     def has_called(self) -> bool:

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -17,12 +17,12 @@ import collections
 import inspect
 import itertools
 import logging
-from collections import Collection
 from contextlib import contextmanager
 from typing import (
     Any,
     Awaitable,
     Callable,
+    Collection,
     Dict,
     Generic,
     Hashable,

--- a/tests/util/caches/test_deferred_cache.py
+++ b/tests/util/caches/test_deferred_cache.py
@@ -47,9 +47,7 @@ class DeferredCacheTestCase(TestCase):
             self.assertTrue(set_d.called)
             return r
 
-        # TODO: Actually ObservableDeferred *doesn't* run its tests in order on py3.8.
-        #   maybe we should fix that?
-        # get_d.addCallback(check1)
+        get_d.addCallback(check1)
 
         # now fire off all the deferreds
         origin_d.callback(99)


### PR DESCRIPTION
It came as a bit of a surprise to me that `ObservableDeferred` *doesn't* run its registered observers in order. This has ramifications like meaning that, if we have two things waiting for a database lookup, we don't run them in a first come, first served order.

I'm not really sure that the existing behaviour breaks anything, but I think a bit more determinism is probably a good thing, as is doing what people expect.