### PR TITLE
Add twine and towncrier as dev dependencies

### DIFF
--- a/changelog.d/11233.misc
+++ b/changelog.d/11233.misc
@@ -1,0 +1,1 @@
+Add `twine` and `towncrier` as dev dependencies, as they're used by the release script.

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,9 @@ CONDITIONAL_REQUIREMENTS["dev"] = (
         "GitPython==3.1.14",
         "commonmark==0.9.1",
         "pygithub==1.55",
+        # The following are executed as commands by the release script.
+        "twine",
+        "towncrier",
     ]
 )
 


### PR DESCRIPTION
We don't pin them as we execute them as commands, rather than use them
as libs.