### PR TITLE
Remove a debug statement from tests.

### DIFF
--- a/changelog.d/11239.misc
+++ b/changelog.d/11239.misc
@@ -1,0 +1,1 @@
+Remove debugging statement in tests.

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -116,7 +116,6 @@ class ModuleApiTestCase(HomeserverTestCase):
 
         # Insert a second ip, agent at a later date. We should be able to retrieve it.
         last_seen_2 = last_seen_1 + 10000
-        print("%s => %s" % (last_seen_1, last_seen_2))
         self.get_success(
             self.store.insert_client_ip(
                 user_id, "access_token", "ip_2", "user_agent_2", "device_2", last_seen_2


### PR DESCRIPTION
There was a leftover `print()` statement in one of the tests which I noticed. 😄 