### PR TITLE
Track ongoing event fetches correctly in the presence of failure

### DIFF
--- a/changelog.d/11240.bugfix
+++ b/changelog.d/11240.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where all requests that read events from the database could get stuck as a result of losing the database connection.


### PR DESCRIPTION
When an event fetcher aborts due to an exception, `_event_fetch_ongoing`
must be decremented, otherwise the event fetcher would never be
replaced. If enough event fetchers were to fail, no more events would be
fetched and requests would get stuck waiting for events.

Fixes part of #11167