### PR TITLE
Split out federated PDU retrieval into a non-cached version

### DIFF
--- a/changelog.d/11242.misc
+++ b/changelog.d/11242.misc
@@ -1,0 +1,1 @@
+Split out federated PDU retrieval function into a non-cached version.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -286,8 +286,8 @@ class FederationClient(FederationBase):
         timeout: Optional[int] = None,
     ) -> Optional[EventBase]:
         """Requests the PDU with given origin and ID from the remote home
-        server.
-        Does not have any caching or rate limiting!
+        server. Does not have any caching or rate limiting!
+
         Args:
             destination: Which homeserver to query
             event_id: event to fetch
@@ -297,8 +297,10 @@ class FederationClient(FederationBase):
                 of the current block of PDUs. Defaults to `False`
             timeout: How long to try (in ms) each destination for before
                 moving to the next destination. None indicates no timeout.
+
         Returns:
             The requested PDU, or None if we were unable to find it.
+
         Raises:
             SynapseError, NotRetryingDestination, FederationDeniedError
         """

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -304,14 +304,11 @@ class FederationClient(FederationBase):
         Raises:
             SynapseError, NotRetryingDestination, FederationDeniedError
         """
-
-        signed_pdu = None
-
         transaction_data = await self.transport_layer.get_event(
             destination, event_id, timeout=timeout
         )
 
-        logger.info(
+        logger.debug(
             "retrieved event id %s from %s: %r",
             event_id,
             destination,
@@ -328,8 +325,9 @@ class FederationClient(FederationBase):
 
             # Check signatures are correct.
             signed_pdu = await self._check_sigs_and_hash(room_version, pdu)
+            return signed_pdu
 
-        return signed_pdu
+        return None
 
     async def get_pdu(
         self,

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -277,6 +277,58 @@ class FederationClient(FederationBase):
 
         return pdus
 
+    async def get_pdu_from_destination_raw(
+        self,
+        destination: str,
+        event_id: str,
+        room_version: RoomVersion,
+        outlier: bool = False,
+        timeout: Optional[int] = None,
+    ) -> Optional[EventBase]:
+        """Requests the PDU with given origin and ID from the remote home
+        server.
+        Does not have any caching or rate limiting!
+        Args:
+            destination: Which homeserver to query
+            event_id: event to fetch
+            room_version: version of the room
+            outlier: Indicates whether the PDU is an `outlier`, i.e. if
+                it's from an arbitrary point in the context as opposed to part
+                of the current block of PDUs. Defaults to `False`
+            timeout: How long to try (in ms) each destination for before
+                moving to the next destination. None indicates no timeout.
+        Returns:
+            The requested PDU, or None if we were unable to find it.
+        Raises:
+            SynapseError, NotRetryingDestination, FederationDeniedError
+        """
+
+        signed_pdu = None
+
+        transaction_data = await self.transport_layer.get_event(
+            destination, event_id, timeout=timeout
+        )
+
+        logger.info(
+            "retrieved event id %s from %s: %r",
+            event_id,
+            destination,
+            transaction_data,
+        )
+
+        pdu_list: List[EventBase] = [
+            event_from_pdu_json(p, room_version, outlier=outlier)
+            for p in transaction_data["pdus"]
+        ]
+
+        if pdu_list and pdu_list[0]:
+            pdu = pdu_list[0]
+
+            # Check signatures are correct.
+            signed_pdu = await self._check_sigs_and_hash(room_version, pdu)
+
+        return signed_pdu
+
     async def get_pdu(
         self,
         destinations: Iterable[str],
@@ -321,29 +373,13 @@ class FederationClient(FederationBase):
                 continue
 
             try:
-                transaction_data = await self.transport_layer.get_event(
-                    destination, event_id, timeout=timeout
+                signed_pdu = await self.get_pdu_from_destination_raw(
+                    destination=destination,
+                    event_id=event_id,
+                    room_version=room_version,
+                    outlier=outlier,
+                    timeout=timeout,
                 )
-
-                logger.debug(
-                    "retrieved event id %s from %s: %r",
-                    event_id,
-                    destination,
-                    transaction_data,
-                )
-
-                pdu_list: List[EventBase] = [
-                    event_from_pdu_json(p, room_version, outlier=outlier)
-                    for p in transaction_data["pdus"]
-                ]
-
-                if pdu_list and pdu_list[0]:
-                    pdu = pdu_list[0]
-
-                    # Check signatures are correct.
-                    signed_pdu = await self._check_sigs_and_hash(room_version, pdu)
-
-                    break
 
                 pdu_attempts[destination] = now
 


### PR DESCRIPTION
Split out federated PDU retrieval into a non-cached version

Context: https://github.com/matrix-org/synapse/pull/11114/files#r741643968

This code is unused but thought it seemed like a small refactor with a little bit of value to split some of the logic out. And the caching/rate-limiting is handled in the `get_pdu` consumer.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
