### PR TITLE
Prevent historical state from being pushed to an application service via `/transactions` (MSC2716)

### DIFF
--- a/changelog.d/11265.bugfix
+++ b/changelog.d/11265.bugfix
@@ -1,0 +1,1 @@
+Prevent [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) historical state events from being pushed to an application service via `/transactions`.

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -231,17 +231,22 @@ class ApplicationServiceApi(SimpleHttpClient):
                 json_body=body,
                 args={"access_token": service.hs_token},
             )
-            logger.debug(
-                "push_bulk to %s succeeded! events=%s",
-                uri,
-                [event.get("event_id") for event in events],
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "push_bulk to %s succeeded! events=%s",
+                    uri,
+                    [event.get("event_id") for event in events],
+                )
             sent_transactions_counter.labels(service.id).inc()
             sent_events_counter.labels(service.id).inc(len(events))
             return True
         except CodeMessageException as e:
             logger.warning(
-                "push_bulk to %s received code=%s msg=%s", uri, e.code, e.msg
+                "push_bulk to %s received code=%s msg=%s",
+                uri,
+                e.code,
+                e.msg,
+                exc_info=logger.isEnabledFor(logging.DEBUG),
             )
         except Exception as ex:
             logger.warning(
@@ -250,6 +255,7 @@ class ApplicationServiceApi(SimpleHttpClient):
                 type(ex).__name__,
                 ex,
                 ex.args,
+                exc_info=logger.isEnabledFor(logging.DEBUG),
             )
         failed_transactions_counter.labels(service.id).inc()
         return False

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -231,13 +231,26 @@ class ApplicationServiceApi(SimpleHttpClient):
                 json_body=body,
                 args={"access_token": service.hs_token},
             )
+            logger.debug(
+                "push_bulk to %s succeeded! events=%s",
+                uri,
+                [event.get("event_id") for event in events],
+            )
             sent_transactions_counter.labels(service.id).inc()
             sent_events_counter.labels(service.id).inc(len(events))
             return True
         except CodeMessageException as e:
-            logger.warning("push_bulk to %s received %s", uri, e.code)
+            logger.warning(
+                "push_bulk to %s received code=%s msg=%s", uri, e.code, e.msg
+            )
         except Exception as ex:
-            logger.warning("push_bulk to %s threw exception %s", uri, ex)
+            logger.warning(
+                "push_bulk to %s threw exception(%s) %s args=%s",
+                uri,
+                type(ex).__name__,
+                ex,
+                ex.args,
+            )
         failed_transactions_counter.labels(service.id).inc()
         return False
 

--- a/synapse/handlers/room_batch.py
+++ b/synapse/handlers/room_batch.py
@@ -221,6 +221,7 @@ class RoomBatchHandler:
                     action=membership,
                     content=event_dict["content"],
                     outlier=True,
+                    historical=True,
                     prev_event_ids=[prev_event_id_for_state_chain],
                     # Make sure to use a copy of this list because we modify it
                     # later in the loop here. Otherwise it will be the same
@@ -240,6 +241,7 @@ class RoomBatchHandler:
                     ),
                     event_dict,
                     outlier=True,
+                    historical=True,
                     prev_event_ids=[prev_event_id_for_state_chain],
                     # Make sure to use a copy of this list because we modify it
                     # later in the loop here. Otherwise it will be the same

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -268,6 +268,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         content: Optional[dict] = None,
         require_consent: bool = True,
         outlier: bool = False,
+        historical: bool = False,
     ) -> Tuple[str, int]:
         """
         Internal membership update function to get an existing event or create
@@ -337,6 +338,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             auth_event_ids=auth_event_ids,
             require_consent=require_consent,
             outlier=outlier,
+            historical=historical,
         )
 
         prev_state_ids = await context.get_prev_state_ids()
@@ -433,6 +435,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         new_room: bool = False,
         require_consent: bool = True,
         outlier: bool = False,
+        historical: bool = False,
         prev_event_ids: Optional[List[str]] = None,
         auth_event_ids: Optional[List[str]] = None,
     ) -> Tuple[str, int]:
@@ -487,6 +490,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 new_room=new_room,
                 require_consent=require_consent,
                 outlier=outlier,
+                historical=historical,
                 prev_event_ids=prev_event_ids,
                 auth_event_ids=auth_event_ids,
             )
@@ -507,6 +511,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         new_room: bool = False,
         require_consent: bool = True,
         outlier: bool = False,
+        historical: bool = False,
         prev_event_ids: Optional[List[str]] = None,
         auth_event_ids: Optional[List[str]] = None,
     ) -> Tuple[str, int]:
@@ -657,6 +662,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 content=content,
                 require_consent=require_consent,
                 outlier=outlier,
+                historical=historical,
             )
 
         latest_event_ids = await self.store.get_prev_events_for_room(room_id)

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -294,6 +294,9 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             outlier: Indicates whether the event is an `outlier`, i.e. if
                 it's from an arbitrary point and floating in the DAG as
                 opposed to being inline with the current DAG.
+            historical: Indicates whether the message is being inserted
+                back in time around some existing events. This is used to skip
+                a few checks and mark the event as backfilled.
 
         Returns:
             Tuple of event ID and stream ordering position
@@ -457,6 +460,9 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             outlier: Indicates whether the event is an `outlier`, i.e. if
                 it's from an arbitrary point and floating in the DAG as
                 opposed to being inline with the current DAG.
+            historical: Indicates whether the message is being inserted
+                back in time around some existing events. This is used to skip
+                a few checks and mark the event as backfilled.
             prev_event_ids: The event IDs to use as the prev events
             auth_event_ids:
                 The event ids to use as the auth_events for the new event.
@@ -535,6 +541,9 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             outlier: Indicates whether the event is an `outlier`, i.e. if
                 it's from an arbitrary point and floating in the DAG as
                 opposed to being inline with the current DAG.
+            historical: Indicates whether the message is being inserted
+                back in time around some existing events. This is used to skip
+                a few checks and mark the event as backfilled.
             prev_event_ids: The event IDs to use as the prev events
             auth_event_ids:
                 The event ids to use as the auth_events for the new event.


### PR DESCRIPTION
Prevent historical state from being pushed to an application service via `/transactions`. We now mark historical state from the MSC2716 `/batch_send` endpoint as `historical` which makes it `backfilled` and have a negative `stream_ordering` so it doesn't get queried by `/transactions`.

Fix https://github.com/matrix-org/synapse/issues/11241

Complement tests: https://github.com/matrix-org/complement/pull/221

Part of MSC2716: https://github.com/matrix-org/matrix-doc/pull/2716

### Dev notes


```
update_membership
update_membership_locked
_local_membership_update
create_event

create_and_send_nonmember_event
create_event
```



`/sync` looks for `stream_ordering` but excludes all `outliers`.

https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/storage/databases/main/stream.py#L519-L527

Whereas `/transactions` only cares about `stream_ordering`. Perhaps we should exclude `outliers` in `/transactions`?

https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/storage/databases/main/appservice.py#L358-L368



 
## `/sync` stack trace

 - [`SyncRestServlet.on_GET`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/rest/client/sync.py#L113)
 - [`wait_for_sync_for_user`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/handlers/sync.py#L299)
 - [`_wait_for_sync_for_user`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/handlers/sync.py#L329)
 - [`current_sync_for_user`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/handlers/sync.py#L399)
 - [`generate_sync_result`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/handlers/sync.py#L1039)
 - [`_generate_sync_entry_for_rooms`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/handlers/sync.py#L1455)
 - [`_get_rooms_changed`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/handlers/sync.py#L1614)
 - [`get_room_events_stream_for_rooms`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/storage/databases/main/stream.py#L409)
 - [`get_room_events_stream_for_room`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/storage/databases/main/stream.py#L478-L527)


## `/transactions` stack trace

 - [`notify_interested_services`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/handlers/appservice.py#L66-L87)
 - [`_notify_interested_services`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/handlers/appservice.py#L90-L135)
    - [`get_new_events_for_appservice`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/storage/databases/main/appservice.py#L353-L368)
    - [`submit_event_for_as`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/handlers/appservice.py#L133-L135)

[`submit_event_for_as`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/appservice/scheduler.py#L94-L95) ->

 - [`enqueue_event`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/appservice/scheduler.py#L129-L131)
 - [`_send_request`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/appservice/scheduler.py#L137-L157)
 - `appservice.scheduler.send`
 - [`create_appservice_txn`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/appservice/scheduler.py#L196-L201)
 - [`AppServiceTransaction.send`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/appservice/__init__.py#L338)
 - [`push_bulk`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/appservice/api.py#L202)
 - [`/transactions`](https://github.com/matrix-org/synapse/blob/b09d90cac9179f84024d4cb3ab4574480c1fd1df/synapse/appservice/api.py#L220)
 
 



### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
