### PR TITLE
Wrong DTLS port in TURN server "Troubleshooting" section.

### DIFF
--- a/docs/turn-howto.md
+++ b/docs/turn-howto.md
@@ -204,7 +204,7 @@ Here are a few things to try:
    anyone who has successfully set this up.
 
  * Check that you have opened your firewall to allow TCP and UDP traffic to the
-   TURN ports (normally 3478 and 5479).
+   TURN ports (normally 3478 and 5349).
 
  * Check that you have opened your firewall to allow UDP traffic to the UDP
    relay ports (49152-65535 by default).


### PR DESCRIPTION
Port 5349, not 5479.