### PR TITLE
Ignore missing imports for parameterized.

### DIFF
--- a/changelog.d/11285.misc
+++ b/changelog.d/11285.misc
@@ -1,0 +1,1 @@
+Require all files in synapse/ and tests/ to pass mypy unless specifically excluded.

--- a/mypy.ini
+++ b/mypy.ini
@@ -363,6 +363,9 @@ ignore_missing_imports = True
 [mypy-opentracing]
 ignore_missing_imports = True
 
+[mypy-parameterized.*]
+ignore_missing_imports = True
+
 [mypy-phonenumbers.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
This seems to be from a conflict between #11282 and #11228.

Example failing run: https://github.com/matrix-org/synapse/runs/4154822727?check_suite_focus=true