### PR TITLE
Move sql file for `remove_deleted_devices_from_device_inbox` into v65

### DIFF
--- a/changelog.d/11303.feature
+++ b/changelog.d/11303.feature
@@ -1,0 +1,1 @@
+Fix a long-standing bug where messages in the `device_inbox` table for deleted devices would persist indefinitely. Contributed by @dklimpel and @JohannesKleine.

--- a/changelog.d/11303.feature
+++ b/changelog.d/11303.feature
@@ -1,1 +1,0 @@
-Fix an issue which prevented the 'remove deleted devices from device_inbox column' background process from running when updating from a recent Synapse version. 

--- a/changelog.d/11303.feature
+++ b/changelog.d/11303.feature
@@ -1,1 +1,1 @@
-Fix a long-standing bug where messages in the `device_inbox` table for deleted devices would persist indefinitely. Contributed by @dklimpel and @JohannesKleine.
+Fix an issue which prevented the 'remove deleted devices from device_inbox column' background process from running when updating from a recent Synapse version. 

--- a/changelog.d/11303.misc
+++ b/changelog.d/11303.misc
@@ -1,0 +1,1 @@
+Fix an issue which prevented the 'remove deleted devices from device_inbox column' background process from running when updating from a recent Synapse version.

--- a/synapse/storage/schema/main/delta/65/05remove_deleted_devices_from_device_inbox.sql
+++ b/synapse/storage/schema/main/delta/65/05remove_deleted_devices_from_device_inbox.sql
@@ -19,4 +19,4 @@
 -- This runs as background task, but may take a bit to finish.
 
 INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
-  (6402, 'remove_deleted_devices_from_device_inbox', '{}');
+  (6505, 'remove_deleted_devices_from_device_inbox', '{}');


### PR DESCRIPTION
Between creation and merging PR #10969 was an schema update in #10975 (v1.46.0). That is the reason why the bg task remove_deleted_devices_from_device_inbox is not running in v1.47.0.rc2. https://github.com/matrix-org/synapse/pull/10969/files#diff-d664ca027d1e3730574905917ca3ab47ab476edca1434fe0ae08b8bce06d1fdb has to move from schema 64 to 65.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Dirk Klimpel dirk@klimpel.org

