### PR TITLE
Correct type hint for room_batch.py

### DIFF
--- a/changelog.d/11310.misc
+++ b/changelog.d/11310.misc
@@ -1,1 +1,1 @@
-Correct a type annotation in `room_batches.py`.
+Add type hints to storage classes.

--- a/changelog.d/11310.misc
+++ b/changelog.d/11310.misc
@@ -1,0 +1,1 @@
+Correct a type annotation in `room_batches.py`.

--- a/mypy.ini
+++ b/mypy.ini
@@ -46,7 +46,6 @@ exclude = (?x)
    |synapse/storage/databases/main/push_rule.py
    |synapse/storage/databases/main/receipts.py
    |synapse/storage/databases/main/room.py
-   |synapse/storage/databases/main/room_batch.py
    |synapse/storage/databases/main/roommember.py
    |synapse/storage/databases/main/search.py
    |synapse/storage/databases/main/signatures.py
@@ -181,6 +180,9 @@ disallow_untyped_defs = True
 disallow_untyped_defs = True
 
 [mypy-synapse.storage.databases.main.client_ips]
+disallow_untyped_defs = True
+
+[mypy-synapse.storage.databases.main.room_batch]
 disallow_untyped_defs = True
 
 [mypy-synapse.storage.util.*]

--- a/synapse/storage/databases/main/room_batch.py
+++ b/synapse/storage/databases/main/room_batch.py
@@ -39,13 +39,11 @@ class RoomBatchStore(SQLBaseStore):
 
     async def store_state_group_id_for_event_id(
         self, event_id: str, state_group_id: int
-    ) -> Optional[str]:
-        {
-            await self.db_pool.simple_upsert(
-                table="event_to_state_groups",
-                keyvalues={"event_id": event_id},
-                values={"state_group": state_group_id, "event_id": event_id},
-                # Unique constraint on event_id so we don't have to lock
-                lock=False,
-            )
-        }
+    ) -> None:
+        await self.db_pool.simple_upsert(
+            table="event_to_state_groups",
+            keyvalues={"event_id": event_id},
+            values={"state_group": state_group_id, "event_id": event_id},
+            # Unique constraint on event_id so we don't have to lock
+            lock=False,
+        )


### PR DESCRIPTION
#10975 introduce a function of the form

```
async def foo(*args, **kwargs) -> Optional[str]:
    {
        await expression
    }
```

This is legit syntax (it's building a set literal) but unusual (see `python -c "from __future__ import braces"`). The function as written will always return None. We don't inspect the return value of this function at its only call site, so it's safe to remove the braces and declare a return type of `None`.