### PR TITLE
Annotations for state_deltas.py

### DIFF
--- a/changelog.d/11316.misc
+++ b/changelog.d/11316.misc
@@ -1,0 +1,1 @@
+Add type hints to storage classes.

--- a/mypy.ini
+++ b/mypy.ini
@@ -51,7 +51,6 @@ exclude = (?x)
    |synapse/storage/databases/main/search.py
    |synapse/storage/databases/main/signatures.py
    |synapse/storage/databases/main/state.py
-   |synapse/storage/databases/main/state_deltas.py
    |synapse/storage/databases/main/stats.py
    |synapse/storage/databases/main/transactions.py
    |synapse/storage/databases/main/user_directory.py
@@ -181,6 +180,9 @@ disallow_untyped_defs = True
 disallow_untyped_defs = True
 
 [mypy-synapse.storage.databases.main.client_ips]
+disallow_untyped_defs = True
+
+[mypy-synapse.storage.databases.main.state_deltas]
 disallow_untyped_defs = True
 
 [mypy-synapse.storage.util.*]


### PR DESCRIPTION
I was sad that I couldn't do better for
`_curr_state_delta_stream_cache`. At least it's explicitly called out in
a comment with #TODO.