### PR TITLE
Generalize the disallowed_untyped_defs in mypy.ini

### DIFF
--- a/changelog.d/11322.misc
+++ b/changelog.d/11322.misc
@@ -1,0 +1,1 @@
+Add type hints to storage classes.

--- a/mypy.ini
+++ b/mypy.ini
@@ -270,10 +270,7 @@ disallow_untyped_defs = True
 [mypy-synapse.util.versionstring]
 disallow_untyped_defs = True
 
-[mypy-tests.handlers.test_user_directory]
-disallow_untyped_defs = True
-
-[mypy-tests.storage.test_user_directory]
+[mypy-tests]
 disallow_untyped_defs = True
 
 ;; Dependencies without annotations

--- a/mypy.ini
+++ b/mypy.ini
@@ -177,16 +177,7 @@ disallow_untyped_defs = True
 [mypy-synapse.state.*]
 disallow_untyped_defs = True
 
-[mypy-synapse.storage.databases.main.client_ips]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.room_batch]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.user_erasure_store]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.util.*]
+[mypy-synapse.storage]
 disallow_untyped_defs = True
 
 [mypy-synapse.streams.*]


### PR DESCRIPTION
Instead of including specific files we include full modules.

The main benefit to this is that as we removed ignored files from mypy we require all the type hints in those files.