### PR TITLE
Add dedicated admin API for blocking a room

### DIFF
--- a/changelog.d/11324.feature
+++ b/changelog.d/11324.feature
@@ -1,0 +1,1 @@
+Add dedicated admin API for blocking a room.

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -3,6 +3,7 @@
 - [Room Details API](#room-details-api)
 - [Room Members API](#room-members-api)
 - [Room State API](#room-state-api)
+- [Block Room API](#block-room-api)
 - [Delete Room API](#delete-room-api)
   * [Version 1 (old version)](#version-1-old-version)
   * [Version 2 (new version)](#version-2-new-version)
@@ -385,6 +386,82 @@ A response body like the following is returned:
   ]
 }
 ```
+
+# Block Room API
+The Block Room admin API allows server admins to block rooms and get the status.
+This API can be used to pre-emptively block a room, even if it's unknown to this
+homeserver. Users will be prevented from joining a blocked room.
+
+## Block or unblock a room
+
+The API is:
+
+```
+PUT /_synapse/admin/v1/rooms/<room_id>/block
+```
+
+with a body of:
+
+```json
+{
+    "block": true
+}
+```
+
+A response body like the following is returned:
+
+```json
+{
+    "block": true
+}
+```
+
+**Parameters**
+
+The following parameters should be set in the URL:
+
+- `room_id` - The ID of the room.
+
+The following JSON body parameters are available:
+
+- `block` - If `true` the room will be blocked and if `false` the room will be unblocked.
+
+**Response**
+
+The following fields are possible in the JSON response body:
+
+- `block` - A boolean if the room is blocked or not.
+
+## Get block status
+
+The API is:
+
+```
+GET /_synapse/admin/v1/rooms/<room_id>/block
+```
+
+A response body like the following is returned:
+
+```json
+{
+    "block": true,
+    "user_id": "<user_id>"
+}
+```
+
+**Parameters**
+
+The following parameters should be set in the URL:
+
+- `room_id` - The ID of the room.
+
+**Response**
+
+The following fields are possible in the JSON response body:
+
+- `block` - A boolean if the room is blocked or not.
+- `user_id` - Optional. If the room is blocked (`block` is `true`) shows the user who has
+  add the room to blocking list. Otherwise it is not displayed.
 
 # Delete Room API
 

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -388,7 +388,7 @@ A response body like the following is returned:
 ```
 
 # Block Room API
-The Block Room admin API allows server admins to block rooms and get the status.
+The Block Room admin API allows server admins to block and unblock rooms, and query to see if a given room is blocked.
 This API can be used to pre-emptively block a room, even if it's unknown to this
 homeserver. Users will be prevented from joining a blocked room.
 
@@ -430,7 +430,7 @@ The following JSON body parameters are available:
 
 The following fields are possible in the JSON response body:
 
-- `block` - A boolean if the room is blocked or not.
+- `block` - A boolean. `true` if the room is blocked, otherwise `false`
 
 ## Get block status
 
@@ -459,7 +459,7 @@ The following parameters should be set in the URL:
 
 The following fields are possible in the JSON response body:
 
-- `block` - A boolean if the room is blocked or not.
+- `block` - A boolean. `true` if the room is blocked, otherwise `false`
 - `user_id` - Optional. If the room is blocked (`block` is `true`) shows the user who has
   add the room to blocking list. Otherwise it is not displayed.
 

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -388,7 +388,8 @@ A response body like the following is returned:
 ```
 
 # Block Room API
-The Block Room admin API allows server admins to block and unblock rooms, and query to see if a given room is blocked.
+The Block Room admin API allows server admins to block and unblock rooms,
+and query to see if a given room is blocked.
 This API can be used to pre-emptively block a room, even if it's unknown to this
 homeserver. Users will be prevented from joining a blocked room.
 
@@ -460,8 +461,8 @@ The following parameters should be set in the URL:
 The following fields are possible in the JSON response body:
 
 - `block` - A boolean. `true` if the room is blocked, otherwise `false`
-- `user_id` - Optional. If the room is blocked (`block` is `true`) shows the user who has
-  add the room to blocking list. Otherwise it is not displayed.
+- `user_id` - A optional string. If the room is blocked (`block` is `true`) shows
+  the user who has add the room to blocking list. Otherwise it is not displayed.
 
 # Delete Room API
 

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -461,7 +461,7 @@ The following parameters should be set in the URL:
 The following fields are possible in the JSON response body:
 
 - `block` - A boolean. `true` if the room is blocked, otherwise `false`
-- `user_id` - A optional string. If the room is blocked (`block` is `true`) shows
+- `user_id` - An optional string. If the room is blocked (`block` is `true`) shows
   the user who has add the room to blocking list. Otherwise it is not displayed.
 
 # Delete Room API

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -46,6 +46,7 @@ from synapse.rest.admin.registration_tokens import (
     RegistrationTokenRestServlet,
 )
 from synapse.rest.admin.rooms import (
+    BlockRoomRestServlet,
     DeleteRoomStatusByDeleteIdRestServlet,
     DeleteRoomStatusByRoomIdRestServlet,
     ForwardExtremitiesRestServlet,
@@ -223,6 +224,7 @@ def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
     Register all the admin servlets.
     """
     register_servlets_for_client_rest_resource(hs, http_server)
+    BlockRoomRestServlet(hs).register(http_server)
     ListRoomRestServlet(hs).register(http_server)
     RoomStateRestServlet(hs).register(http_server)
     RoomRestServlet(hs).register(http_server)

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -808,7 +808,9 @@ class BlockRoomRestServlet(RestServlet):
             )
 
         blocked_by = await self._store.room_is_blocked_by(room_id)
-        if blocked_by:
+        # Test `not None` if `user_id` is an empty string
+        # if someone add manually an entry in database
+        if blocked_by is not None:
             response = {"block": True, "user_id": blocked_by}
         else:
             response = {"block": False}

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -782,3 +782,64 @@ class RoomEventContextServlet(RestServlet):
         )
 
         return 200, results
+
+
+class BlockRoomRestServlet(RestServlet):
+    """
+    Manage blocking of rooms.
+    On PUT: Add or remove a room from blocking list.
+    On GET: Get blocking status of room and user who has blocked this room.
+    """
+
+    PATTERNS = admin_patterns("/rooms/(?P<room_id>[^/]+)/block$")
+
+    def __init__(self, hs: "HomeServer"):
+        self._auth = hs.get_auth()
+        self._store = hs.get_datastore()
+
+    async def on_GET(
+        self, request: SynapseRequest, room_id: str
+    ) -> Tuple[int, JsonDict]:
+        await assert_requester_is_admin(self._auth, request)
+
+        if not RoomID.is_valid(room_id):
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST, "%s is not a legal room ID" % (room_id,)
+            )
+
+        blocked_by = await self._store.room_is_blocked_by(room_id)
+        if blocked_by:
+            response = {"block": True, "user_id": blocked_by}
+        else:
+            response = {"block": False}
+
+        return 200, response
+
+    async def on_PUT(
+        self, request: SynapseRequest, room_id: str
+    ) -> Tuple[int, JsonDict]:
+        requester = await self._auth.get_user_by_req(request)
+        await assert_user_is_admin(self._auth, requester.user)
+
+        content = parse_json_object_from_request(request)
+
+        if not RoomID.is_valid(room_id):
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST, "%s is not a legal room ID" % (room_id,)
+            )
+
+        assert_params_in_dict(content, ["block"])
+        block = content.get("block")
+        if not isinstance(block, bool):
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                "Param 'block' must be a boolean.",
+                Codes.BAD_JSON,
+            )
+
+        if block:
+            await self._store.block_room(room_id, requester.user.to_string())
+        else:
+            await self._store.unblock_room(room_id)
+
+        return 200, {"block": block}

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -813,7 +813,7 @@ class BlockRoomRestServlet(RestServlet):
         else:
             response = {"block": False}
 
-        return 200, response
+        return HTTPStatus.OK, response
 
     async def on_PUT(
         self, request: SynapseRequest, room_id: str
@@ -842,4 +842,4 @@ class BlockRoomRestServlet(RestServlet):
         else:
             await self._store.unblock_room(room_id)
 
-        return 200, {"block": block}
+        return HTTPStatus.OK, {"block": block}

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -398,7 +398,11 @@ class RoomWorkerStore(SQLBaseStore):
         )
 
     async def room_is_blocked_by(self, room_id: str) -> Optional[str]:
-        """Function to retrieve user who has blocked the room"""
+        """
+        Function to retrieve user who has blocked the room.
+        user_id is non-nullable
+        It returns None if the room is not blocked.
+        """
         return await self.db_pool.simple_select_one_onecol(
             table="blocked_rooms",
             keyvalues={"room_id": room_id},

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -397,6 +397,16 @@ class RoomWorkerStore(SQLBaseStore):
             desc="is_room_blocked",
         )
 
+    async def room_is_blocked_by(self, room_id: str) -> Optional[str]:
+        """Function to retrieve user who has blocked the room"""
+        return await self.db_pool.simple_select_one_onecol(
+            table="blocked_rooms",
+            keyvalues={"room_id": room_id},
+            retcol="user_id",
+            allow_none=True,
+            desc="room_is_blocked_by",
+        )
+
     async def get_rooms_paginate(
         self,
         start: int,
@@ -1768,6 +1778,24 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore, SearchStore):
             values={},
             insertion_values={"user_id": user_id},
             desc="block_room",
+        )
+        await self.db_pool.runInteraction(
+            "block_room_invalidation",
+            self._invalidate_cache_and_stream,
+            self.is_room_blocked,
+            (room_id,),
+        )
+
+    async def unblock_room(self, room_id: str) -> None:
+        """Remove the room from blocking list.
+
+        Args:
+            room_id: Room to unblock
+        """
+        await self.db_pool.simple_delete(
+            table="blocked_rooms",
+            keyvalues={"room_id": room_id},
+            desc="unblock_room",
         )
         await self.db_pool.runInteraction(
             "block_room_invalidation",


### PR DESCRIPTION
Fix some parts of #11283
Add new admin API:
- `GET /_synapse/admin/v1/rooms/<room_id>/block`
- `PUT /_synapse/admin/v1/rooms/<room_id>/block`

I am not sure what is the best http method. `POST` vs. `PUT`

### Pull Request Checklist
<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Dirk Klimpel dirk@klimpel.org