### PR TITLE
Rollback #11322 due to wrong syntax in mypy.ini

### DIFF
--- a/changelog.d/11332.misc
+++ b/changelog.d/11332.misc
@@ -1,0 +1,1 @@
+Add type hints to storage classes.

--- a/mypy.ini
+++ b/mypy.ini
@@ -175,7 +175,16 @@ disallow_untyped_defs = True
 [mypy-synapse.state.*]
 disallow_untyped_defs = True
 
-[mypy-synapse.storage]
+[mypy-synapse.storage.databases.main.client_ips]
+disallow_untyped_defs = True
+
+[mypy-synapse.storage.databases.main.room_batch]
+disallow_untyped_defs = True
+
+[mypy-synapse.storage.databases.main.user_erasure_store]
+disallow_untyped_defs = True
+
+[mypy-synapse.storage.util.*]
 disallow_untyped_defs = True
 
 [mypy-synapse.streams.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -268,7 +268,10 @@ disallow_untyped_defs = True
 [mypy-synapse.util.versionstring]
 disallow_untyped_defs = True
 
-[mypy-tests]
+[mypy-tests.handlers.test_user_directory]
+disallow_untyped_defs = True
+
+[mypy-tests.storage.test_user_directory]
 disallow_untyped_defs = True
 
 ;; Dependencies without annotations


### PR DESCRIPTION
It should have been `[mypy-tests.*]` but that obviously won't work.