### PR TITLE
Remove legacy code related to deprecated `trust_identity_server_for_password_resets` config flag

### DIFF
--- a/changelog.d/11333.misc
+++ b/changelog.d/11333.misc
@@ -1,0 +1,1 @@
+Remove legacy code related to depreciated "trust_identity_server_for_password_resets" config flag.

--- a/changelog.d/11333.misc
+++ b/changelog.d/11333.misc
@@ -1,1 +1,1 @@
-Remove legacy code related to depreciated "trust_identity_server_for_password_resets" config flag.
+Remove deprecated `trust_identity_server_for_password_resets` configuration flag.

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -138,7 +138,7 @@ class EmailConfig(Config):
             else ThreepidBehaviour.LOCAL
         )
 
-        if "trust_identity_server_for_password_resets" in config:
+        if config.get("trust_identity_server_for_password_resets"):
             raise ConfigError(
                 'The config option "trust_identity_server_for_password_resets" '
                 'has been replaced by "account_threepid_delegate". '

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -137,33 +137,14 @@ class EmailConfig(Config):
             if self.root.registration.account_threepid_delegate_email
             else ThreepidBehaviour.LOCAL
         )
-        # Prior to Synapse v1.4.0, there was another option that defined whether Synapse would
-        # use an identity server to password reset tokens on its behalf. We now warn the user
-        # if they have this set and tell them to use the updated option, while using a default
-        # identity server in the process.
-        self.using_identity_server_from_trusted_list = False
-        if (
-            not self.root.registration.account_threepid_delegate_email
-            and config.get("trust_identity_server_for_password_resets", False) is True
-        ):
-            # Use the first entry in self.trusted_third_party_id_servers instead
-            if self.trusted_third_party_id_servers:
-                # XXX: It's a little confusing that account_threepid_delegate_email is modified
-                # both in RegistrationConfig and here. We should factor this bit out
 
-                first_trusted_identity_server = self.trusted_third_party_id_servers[0]
-
-                # trusted_third_party_id_servers does not contain a scheme whereas
-                # account_threepid_delegate_email is expected to. Presume https
-                self.root.registration.account_threepid_delegate_email = (
-                    "https://" + first_trusted_identity_server
-                )
-                self.using_identity_server_from_trusted_list = True
-            else:
-                raise ConfigError(
-                    "Attempted to use an identity server from"
-                    '"trusted_third_party_id_servers" but it is empty.'
-                )
+        if "trust_identity_server_for_password_resets" in config:
+            raise ConfigError(
+                'The config option "trust_identity_server_for_password_resets" '
+                'has been replaced by "account_threepid_delegate". '
+                "Please consult the sample config at docs/sample_config.yaml for "
+                "details and update your config file."
+            )
 
         self.local_threepid_handling_disabled_due_to_email_config = False
         if (

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -39,9 +39,7 @@ class RegistrationConfig(Config):
         self.registration_shared_secret = config.get("registration_shared_secret")
 
         self.bcrypt_rounds = config.get("bcrypt_rounds", 12)
-        self.trusted_third_party_id_servers = config.get(
-            "trusted_third_party_id_servers", ["matrix.org", "vector.im"]
-        )
+
         account_threepid_delegates = config.get("account_threepid_delegates") or {}
         self.account_threepid_delegate_email = account_threepid_delegates.get("email")
         self.account_threepid_delegate_msisdn = account_threepid_delegates.get("msisdn")

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -464,15 +464,6 @@ class IdentityHandler:
         if next_link:
             params["next_link"] = next_link
 
-        if self.hs.config.email.using_identity_server_from_trusted_list:
-            # Warn that a deprecated config option is in use
-            logger.warning(
-                'The config option "trust_identity_server_for_password_resets" '
-                'has been replaced by "account_threepid_delegate". '
-                "Please consult the sample config at docs/sample_config.yaml for "
-                "details and update your config file."
-            )
-
         try:
             data = await self.http_client.post_json_get_json(
                 id_server + "/_matrix/identity/api/v1/validate/email/requestToken",
@@ -516,15 +507,6 @@ class IdentityHandler:
         }
         if next_link:
             params["next_link"] = next_link
-
-        if self.hs.config.email.using_identity_server_from_trusted_list:
-            # Warn that a deprecated config option is in use
-            logger.warning(
-                'The config option "trust_identity_server_for_password_resets" '
-                'has been replaced by "account_threepid_delegate". '
-                "Please consult the sample config at docs/sample_config.yaml for "
-                "details and update your config file."
-            )
 
         try:
             data = await self.http_client.post_json_get_json(

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -94,3 +94,16 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
         # The default Metrics Flags are off by default.
         config = HomeServerConfig.load_config("", ["-c", self.config_file])
         self.assertFalse(config.metrics.metrics_flags.known_servers)
+
+    def test_depreciated_identity_server_flag_throws_error(self):
+        self.generate_config()
+        # Needed to ensure that actual key/value pair added below don't end up on a line with a comment
+        self.add_lines_to_config([" "])
+        # Check that presence of "trust_identity_server_for_password" throws config error whether
+        # true or false
+        self.add_lines_to_config(["trust_identity_server_for_password_resets: true"])
+        with self.assertRaises(ConfigError):
+            HomeServerConfig.load_config("", ["-c", self.config_file])
+        self.add_lines_to_config(["trust_identity_server_for_password_resets: false"])
+        with self.assertRaises(ConfigError):
+            HomeServerConfig.load_config("", ["-c", self.config_file])

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -99,11 +99,7 @@ class ConfigLoadingFileTestCase(ConfigFileTestCase):
         self.generate_config()
         # Needed to ensure that actual key/value pair added below don't end up on a line with a comment
         self.add_lines_to_config([" "])
-        # Check that presence of "trust_identity_server_for_password" throws config error whether
-        # true or false
+        # Check that presence of "trust_identity_server_for_password" throws config error
         self.add_lines_to_config(["trust_identity_server_for_password_resets: true"])
-        with self.assertRaises(ConfigError):
-            HomeServerConfig.load_config("", ["-c", self.config_file])
-        self.add_lines_to_config(["trust_identity_server_for_password_resets: false"])
         with self.assertRaises(ConfigError):
             HomeServerConfig.load_config("", ["-c", self.config_file])


### PR DESCRIPTION
Fixes #10545. As the title says, removes code associated with handling the deprecated config option, and Synapse refuses to start if this flag is set in the config. 