### PR TITLE
Run _upgrade_existing_database on workers if at current schema_version

### DIFF
--- a/changelog.d/11346.bugfix
+++ b/changelog.d/11346.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.47.0rc1 which caused worker processes to not halt startup in the presence of outstanding database migrations.

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -351,7 +351,7 @@ def _upgrade_existing_database(
     is_worker = config and config.worker.worker_app is not None
 
     # If the schema version needs to be updated, and we are on a worker, we immediately
-    # know to bail out as workers cannot update the database schema. Only one worker
+    # know to bail out as workers cannot update the database schema. Only one process
     # must update the database at the time, therefore we delegate this task to the master.
     if is_worker and current_schema_state.current_version < SCHEMA_VERSION:
         # If the DB is on an older version than we expect then we refuse

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -131,38 +131,16 @@ def prepare_database(
                     "config==None in prepare_database, but database is not empty"
                 )
 
-            # If the schema version needs to be updated, and we are on a worker, we immediately
-            # know to bail out as workers cannot update the database schema. Only one worker
-            # must update the database at the time, therefore we delegate this task to the master.
-            if (
-                config.worker.worker_app is not None
-                and version_info.current_version < SCHEMA_VERSION
-            ):
-                # If the DB is on an older version than we expect then we refuse
-                # to start the worker (as the main process needs to run first to
-                # update the schema).
-                raise UpgradeDatabaseException(
-                    OUTDATED_SCHEMA_ON_WORKER_ERROR
-                    % (SCHEMA_VERSION, version_info.current_version)
-                )
-
-            # Otherwise if we are on the current schema version, we need to check if there
-            # are any unapplied delta files to process. This should be run on all processes,
-            # master or worker. The master will apply the deltas, workers will check if any
-            # outstanding deltas exist and bail out if they do.
-            if version_info.current_version == SCHEMA_VERSION:
-                _upgrade_existing_database(
-                    cur,
-                    version_info,
-                    database_engine,
-                    config,
-                    databases=databases,
-                )
-
-            # If SCHEMA_VERSION is greater than version_info.current_version (for instance,
-            # if we're rolling back the database) then don't apply any migrations.
-            # Things should work as long as one hasn't rolled back past the
-            # SCHEMA_COMPAT_VERSION.
+            # This should be run on all processes, master or worker. The master will
+            # apply the deltas, while workers will check if any outstanding deltas
+            # exist and raise an PrepareDatabaseException if they do.
+            _upgrade_existing_database(
+                cur,
+                version_info,
+                database_engine,
+                config,
+                databases=databases,
+            )
 
         else:
             logger.info("%r: Initialising new database", databases)
@@ -371,6 +349,18 @@ def _upgrade_existing_database(
         assert config
 
     is_worker = config and config.worker.worker_app is not None
+
+    # If the schema version needs to be updated, and we are on a worker, we immediately
+    # know to bail out as workers cannot update the database schema. Only one worker
+    # must update the database at the time, therefore we delegate this task to the master.
+    if is_worker and current_schema_state.current_version < SCHEMA_VERSION:
+        # If the DB is on an older version than we expect then we refuse
+        # to start the worker (as the main process needs to run first to
+        # update the schema).
+        raise UpgradeDatabaseException(
+            OUTDATED_SCHEMA_ON_WORKER_ERROR
+            % (SCHEMA_VERSION, current_schema_state.current_version)
+        )
 
     if (
         current_schema_state.compat_version is not None

--- a/tests/storage/test_rollback_worker.py
+++ b/tests/storage/test_rollback_worker.py
@@ -11,12 +11,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import List
+from unittest import mock
+
 from synapse.app.generic_worker import GenericWorkerServer
 from synapse.storage.database import LoggingDatabaseConnection
 from synapse.storage.prepare_database import PrepareDatabaseException, prepare_database
 from synapse.storage.schema import SCHEMA_VERSION
 
 from tests.unittest import HomeserverTestCase
+
+
+def fake_listdir(filepath: str) -> List[str]:
+    """
+    A fake implementation of os.listdir which we can use to mock out the filesystem.
+
+    Args:
+        filepath: The directory to list files for.
+
+    Returns:
+        A list of files and folders in the directory.
+    """
+    if filepath.endswith("full_schemas"):
+        return [SCHEMA_VERSION]
+
+    return ["99_add_unicorn_to_database.sql"]
 
 
 class WorkerSchemaTests(HomeserverTestCase):
@@ -51,7 +70,7 @@ class WorkerSchemaTests(HomeserverTestCase):
 
         prepare_database(db_conn, db_pool.engine, self.hs.config)
 
-    def test_not_upgraded(self):
+    def test_not_upgraded_old_schema_version(self):
         """Test that workers don't start if the DB has an older schema version"""
         db_pool = self.hs.get_datastore().db_pool
         db_conn = LoggingDatabaseConnection(
@@ -67,3 +86,34 @@ class WorkerSchemaTests(HomeserverTestCase):
 
         with self.assertRaises(PrepareDatabaseException):
             prepare_database(db_conn, db_pool.engine, self.hs.config)
+
+    def test_not_upgraded_current_schema_version_with_outstanding_deltas(self):
+        """
+        Test that workers don't start if the DB is on the current schema version,
+        but there are still outstanding delta migrations to run.
+        """
+        db_pool = self.hs.get_datastore().db_pool
+        db_conn = LoggingDatabaseConnection(
+            db_pool._db_pool.connect(),
+            db_pool.engine,
+            "tests",
+        )
+
+        # Set the schema version of the database to the current version
+        cur = db_conn.cursor()
+        cur.execute("UPDATE schema_version SET version = ?", (SCHEMA_VERSION,))
+
+        db_conn.commit()
+
+        # Path `os.listdir` here to make synapse think that there is a migration
+        # file ready to be run.
+        # Note that we can't patch this function for the whole method, else Synapse
+        # will try to find the file when building the database initially.
+        with mock.patch("os.listdir", mock.Mock(side_effect=fake_listdir)):
+            with self.assertRaises(PrepareDatabaseException):
+                # Synapse should think that there is an outstanding migration file due to
+                # patching 'os.listdir' in the function decorator.
+                #
+                # We expect Synapse to raise an exception to indicate the master process
+                # needs to apply this migration file.
+                prepare_database(db_conn, db_pool.engine, self.hs.config)


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/11344.

Workers need to run `_upgrade_existing_database` to figure out if any outstanding delta files exist (it's the thing that actually traverses the filesystem for new delta files to apply). But, workers only need to run this if we're currently on the latest schema version.

If the database reports that we're not on the latest schema version, then we can simply bail out without needing to run `_upgrade_existing_database`.

#11255 made the correct fix for when we roll back the database schema version, in that `_upgrade_existing_database` should not be run if `version_info.schema_version` > SCHEMA_VERSION. But we still need to run this method on workers if `version_info.schema_version` == SCHEMA_VERSION to get them to halt startup, and let the sysadmin know that they need to run the master first.

Merging to the `release-v1.47` branch as this is intended to be included in v1.47.0rc3.