### PR TITLE
Make tests.utils pass `mypy`

### DIFF
--- a/changelog.d/11349.misc
+++ b/changelog.d/11349.misc
@@ -1,0 +1,1 @@
+Fix type hints to allow `tests.utils` to pass `mypy`.

--- a/mypy.ini
+++ b/mypy.ini
@@ -142,7 +142,6 @@ exclude = (?x)
    |tests/util/test_lrucache.py
    |tests/util/test_rwlock.py
    |tests/util/test_wheel_timer.py
-   |tests/utils.py
    )$
 
 [mypy-synapse.api.*]

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ CONDITIONAL_REQUIREMENTS["mypy"] = [
     "types-bleach>=4.1.0",
     "types-jsonschema>=3.2.0",
     "types-Pillow>=8.3.4",
+    "types-psycopg2>=2.9.1",
     "types-pyOpenSSL>=20.0.7",
     "types-PyYAML>=5.4.10",
     "types-requests>=2.26.0",

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -224,7 +224,10 @@ class HomeServer(metaclass=abc.ABCMeta):
     # This is overridden in derived application classes
     # (such as synapse.app.homeserver.SynapseHomeServer) and gives the class to be
     # instantiated during setup() for future return by get_datastore()
-    DATASTORE_CLASS = abc.abstractproperty()
+    @property
+    @abc.abstractmethod
+    def DATASTORE_CLASS(self):
+        pass
 
     tls_server_context_factory: Optional[IOpenSSLContextFactory]
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -300,7 +300,9 @@ class LoggingTransaction:
         from psycopg2.extras import execute_values  # type: ignore
 
         return self._do_execute(
-            lambda *x: execute_values(self.txn, *x, fetch=fetch), sql, *args
+            lambda sql, argslist: execute_values(self.txn, sql, argslist, fetch=fetch),
+            sql,
+            *args,
         )
 
     def execute(self, sql: str, *args: Any) -> None:

--- a/synapse/storage/databases/__init__.py
+++ b/synapse/storage/databases/__init__.py
@@ -52,7 +52,7 @@ class Databases(Generic[DataStoreT]):
         # Note we pass in the main store class here as workers use a different main
         # store.
 
-        self.databases = []
+        self.databases: List[DatabasePool] = []
         main: Optional[DataStoreT] = None
         state: Optional[StateGroupDataStore] = None
         persist_events: Optional[PersistEventsStore] = None

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -67,7 +67,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
 
         self.mock_resolver = Mock()
 
-        config_dict = default_config("test", parse=False)
+        config_dict = default_config("test")
         config_dict["federation_custom_ca_list"] = [get_test_ca_cert_file()]
 
         self._config = config = HomeServerConfig()
@@ -957,7 +957,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self.mock_resolver.resolve_service.side_effect = generate_resolve_service([])
         self.reactor.lookups["testserv"] = "1.2.3.4"
 
-        config = default_config("test", parse=True)
+        config_dict = default_config("test")
+        config = HomeServerConfig()
+        config.parse_config_dict(config_dict)
 
         # Build a new agent and WellKnownResolver with a different tls factory
         tls_factory = FederationPolicyForHTTPS(config)

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 
 from twisted.internet import defer
 
+from synapse.config.homeserver import HomeServerConfig
 from synapse.storage._base import SQLBaseStore
 from synapse.storage.database import DatabasePool
 from synapse.storage.engines import create_engine
@@ -47,7 +48,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
 
         self.db_pool.runWithConnection = runWithConnection
 
-        config = default_config(name="test", parse=True)
+        config_dict = default_config(name="test")
+        config = HomeServerConfig()
+        config.parse_config_dict(config_dict)
+
         hs = TestHomeServer("test", config=config)
 
         sqlite_config = {"name": "sqlite3"}

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -22,6 +22,7 @@ from synapse.config.homeserver import HomeServerConfig
 from synapse.storage._base import SQLBaseStore
 from synapse.storage.database import DatabasePool
 from synapse.storage.engines import create_engine
+from synapse.storage.types import Connection
 
 from tests import unittest
 from tests.utils import TestHomeServer, default_config
@@ -63,7 +64,7 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         db = DatabasePool(Mock(), Mock(config=sqlite_config), fake_engine)
         db._db_pool = self.db_pool
 
-        self.datastore = SQLBaseStore(db, None, hs)
+        self.datastore = SQLBaseStore(db, Mock(spec=Connection), hs)
 
     @defer.inlineCallbacks
     def test_insert_1col(self):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -19,6 +19,7 @@ from twisted.internet import defer
 from synapse.api.auth import Auth
 from synapse.api.constants import EventTypes, Membership
 from synapse.api.room_versions import RoomVersions
+from synapse.config.homeserver import HomeServerConfig
 from synapse.events import make_event_from_dict
 from synapse.events.snapshot import EventContext
 from synapse.state import StateHandler, StateResolutionHandler
@@ -172,7 +173,11 @@ class StateTestCase(unittest.TestCase):
                 "hostname",
             ]
         )
-        hs.config = default_config("tesths", True)
+
+        config_dict = default_config("tesths")
+        hs.config = HomeServerConfig()
+        hs.config.parse_config_dict(config_dict)
+
         hs.get_datastore.return_value = self.store
         hs.get_state_handler.return_value = None
         hs.get_clock.return_value = MockClock()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -282,7 +282,6 @@ def setup_test_homeserver(
 
     # Mock TLS
     hs.tls_server_context_factory = Mock()
-    hs.tls_client_options_factory = Mock()
 
     hs.setup()
     if homeserver_to_use == TestHomeServer:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -104,9 +104,15 @@ def setupdb():
         atexit.register(_cleanup)
 
 
-def default_config(name, parse=False):
+def default_config(name: str) -> Dict[str, Any]:
     """
     Create a reasonable test config.
+
+    Args:
+        name: The value of the 'server_name' option in the returned config.
+
+    Returns:
+        A sensible, default homeserver config.
     """
     config_dict = {
         "server_name": name,
@@ -175,11 +181,6 @@ def default_config(name, parse=False):
         "listeners": [{"port": 0, "type": "http"}],
     }
 
-    if parse:
-        config = HomeServerConfig()
-        config.parse_config_dict(config_dict, "", "")
-        return config
-
     return config_dict
 
 
@@ -212,9 +213,10 @@ def setup_test_homeserver(
         from twisted.internet import reactor
 
     if config is None:
-        config = default_config(name, parse=True)
+        config_dict = default_config(name)
 
-    config.ldap_enabled = False
+        config = HomeServerConfig()
+        config.parse_config_dict(config_dict)
 
     if "clock" not in kwargs:
         kwargs["clock"] = MockClock()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -341,12 +341,12 @@ def setup_test_homeserver(
     async def hash(p):
         return hashlib.md5(p.encode("utf8")).hexdigest()
 
-    hs.get_auth_handler().hash = hash
+    hs.get_auth_handler().hash = hash  # type: ignore
 
     async def validate_hash(p, h):
         return hashlib.md5(p.encode("utf8")).hexdigest() == h
 
-    hs.get_auth_handler().validate_hash = validate_hash
+    hs.get_auth_handler().validate_hash = validate_hash  # type: ignore
 
     return hs
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -189,10 +189,10 @@ class TestHomeServer(HomeServer):
 
 
 def setup_test_homeserver(
-    cleanup_func,
-    name="test",
-    config=None,
-    reactor=None,
+    cleanup_func: Callable[[Callable], Any],
+    name: str = "test",
+    config: Optional[HomeServerConfig] = None,
+    reactor: Optional[ModuleType] = None,
     homeserver_to_use: Type[HomeServer] = TestHomeServer,
     **kwargs,
 ):
@@ -224,7 +224,7 @@ def setup_test_homeserver(
     if USE_POSTGRES_FOR_TESTS:
         test_db = "synapse_test_%s" % uuid.uuid4().hex
 
-        database_config = {
+        database_config_dict = {
             "name": "psycopg2",
             "args": {
                 "database": test_db,
@@ -236,18 +236,18 @@ def setup_test_homeserver(
             },
         }
     else:
-        database_config = {
+        database_config_dict = {
             "name": "sqlite3",
             "args": {"database": ":memory:", "cp_min": 1, "cp_max": 1},
         }
 
     if "db_txn_limit" in kwargs:
-        database_config["txn_limit"] = kwargs["db_txn_limit"]
+        database_config_dict["txn_limit"] = kwargs["db_txn_limit"]
 
-    database = DatabaseConnectionConfig("master", database_config)
-    config.database.databases = [database]
+    database_config = DatabaseConnectionConfig("master", database_config_dict)
+    config.database.databases = [database_config]
 
-    db_engine = create_engine(database.config)
+    db_engine = create_engine(database_config.config)
 
     # Create the database before we actually try and connect to it, based off
     # the template database we generate in setupdb()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -210,7 +210,9 @@ def setup_test_homeserver(
     HomeserverTestCase.
     """
     if reactor is None:
-        from twisted.internet import reactor
+        from twisted.internet import reactor as _reactor
+
+        reactor = _reactor
 
     if config is None:
         config_dict = default_config(name)


### PR DESCRIPTION
A separate PR will allow this file to pass `mypy --disallow-untyped-defs`.

This was a bit of adding type hints, but for the most part functional changes were needed to make this work. All unit tests still pass.

Reviewable commit-by-commit. Some comments and questions are in the commit descriptions, and are recommended reading.