### PR TITLE
Track ongoing event fetches correctly (again)

### DIFF
--- a/changelog.d/11376.bugfix
+++ b/changelog.d/11376.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where all requests that read events from the database could get stuck as a result of losing the database connection, for real this time. Also fix a race condition introduced in the previous insufficient fix in 1.47.0.

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -804,9 +804,10 @@ class EventsWorkerStore(SQLBaseStore):
                     # We exited cleanly but noticed more work.
                     self._maybe_start_fetch_thread()
 
-                if exc is not None and event_fetches_to_fail:
+                if event_fetches_to_fail:
                     # We were the last remaining fetcher and failed.
                     # Fail any outstanding fetches since no one else will handle them.
+                    assert exc is not None
                     with PreserveLoggingContext():
                         for _, deferred in event_fetches_to_fail:
                             deferred.errback(exc)

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -736,8 +736,8 @@ class EventsWorkerStore(SQLBaseStore):
             for e in state_to_include.values()
         ]
 
-    def _start_fetch_thread(self) -> None:
-        """Starts an event fetcher."""
+    def _maybe_start_fetch_thread(self) -> None:
+        """Starts an event fetch thread if we are not yet at the maximum number."""
         with self._event_fetch_lock:
             if (
                 self._event_fetch_list
@@ -774,7 +774,7 @@ class EventsWorkerStore(SQLBaseStore):
                             self._event_fetch_list = []
 
                 if should_restart:
-                    self._start_fetch_thread()
+                    self._maybe_start_fetch_thread()
 
                 if exc is not None:
                     for _, deferred in failed_event_list:
@@ -1030,7 +1030,7 @@ class EventsWorkerStore(SQLBaseStore):
             self._event_fetch_list.append((events, events_d))
             self._event_fetch_lock.notify()
 
-        self._start_fetch_thread()
+        self._maybe_start_fetch_thread()
 
         logger.debug("Loading %d events: %s", len(events), events)
         with PreserveLoggingContext():

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -757,6 +757,8 @@ class EventsWorkerStore(SQLBaseStore):
                 if not deferred.called:
                     with PreserveLoggingContext():
                         deferred.errback(e)
+
+            raise
         else:
             should_restart = False
             with self._event_fetch_lock:

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -740,7 +740,7 @@ class EventsWorkerStore(SQLBaseStore):
         """Services requests for events from the `_event_fetch_list` queue."""
         try:
             await self.db_pool.runWithConnection(self._do_fetch_txn)
-        except BaseException as e:
+        except Exception as e:
             failed_event_list = []
             with self._event_fetch_lock:
                 if self._event_fetch_ongoing == 1 and self._event_fetch_list:

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -777,8 +777,9 @@ class EventsWorkerStore(SQLBaseStore):
                             # Unfortunately it is not possible to tell whether a new
                             # event fetch thread was started, so we restart
                             # unconditionally. If we are unlucky, we will end up with
-                            # extra idle threads holding database connections for up to
-                            # `EVENT_QUEUE_ITERATIONS * EVENT_QUEUE_TIMEOUT_S` seconds.
+                            # an idle fetch thread, but it will time out after 
+                            # `EVENT_QUEUE_ITERATIONS * EVENT_QUEUE_TIMEOUT_S` seconds
+                            # in any case.
                             should_restart = True
                         elif isinstance(exc, Exception):
                             if self._event_fetch_ongoing == 0:

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -774,12 +774,16 @@ class EventsWorkerStore(SQLBaseStore):
                             # If a new event fetch thread was not started, we should
                             # restart ourselves since the remaining event fetch threads
                             # may take a while to get around to the new work.
+                            #
                             # Unfortunately it is not possible to tell whether a new
                             # event fetch thread was started, so we restart
                             # unconditionally. If we are unlucky, we will end up with
-                            # an idle fetch thread, but it will time out after 
+                            # an idle fetch thread, but it will time out after
                             # `EVENT_QUEUE_ITERATIONS * EVENT_QUEUE_TIMEOUT_S` seconds
                             # in any case.
+                            #
+                            # Note that multiple fetch threads may run down this path at
+                            # the same time.
                             should_restart = True
                         elif isinstance(exc, Exception):
                             if self._event_fetch_ongoing == 0:

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -12,11 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from contextlib import contextmanager
+from typing import Generator
 
+from twisted.enterprise.adbapi import ConnectionPool
+from twisted.internet.defer import ensureDeferred
+from twisted.test.proto_helpers import MemoryReactor
+
+from synapse.api.room_versions import EventFormatVersions, RoomVersions
 from synapse.logging.context import LoggingContext
 from synapse.rest import admin
 from synapse.rest.client import login, room
-from synapse.storage.databases.main.events_worker import EventsWorkerStore
+from synapse.server import HomeServer
+from synapse.storage.databases.main.events_worker import (
+    EVENT_QUEUE_THREADS,
+    EventsWorkerStore,
+)
+from synapse.storage.types import Connection
+from synapse.util import Clock
 from synapse.util.async_helpers import yieldable_gather_results
 
 from tests import unittest
@@ -144,3 +157,108 @@ class EventCacheTestCase(unittest.HomeserverTestCase):
 
             # We should have fetched the event from the DB
             self.assertEqual(ctx.get_resource_usage().evt_db_fetch_count, 1)
+
+
+class DatabaseOutageTestCase(unittest.HomeserverTestCase):
+    """Test event fetching during a database outage."""
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer):
+        self.store: EventsWorkerStore = hs.get_datastore()
+
+        self.room_id = f"!room:{hs.hostname}"
+        self.event_ids = [f"event{i}" for i in range(20)]
+
+        self._populate_events()
+
+    def _populate_events(self) -> None:
+        """Ensure that there are test events in the database."""
+        self.get_success(
+            self.store.db_pool.simple_upsert(
+                "rooms",
+                {"room_id": self.room_id},
+                {"room_version": RoomVersions.V4.identifier},
+            )
+        )
+
+        self.event_ids = [f"event{i}" for i in range(20)]
+        for idx, event_id in enumerate(self.event_ids):
+            self.get_success(
+                self.store.db_pool.simple_upsert(
+                    "events",
+                    {"event_id": event_id},
+                    {
+                        "event_id": event_id,
+                        "room_id": self.room_id,
+                        "topological_ordering": idx,
+                        "stream_ordering": idx,
+                        "type": "test",
+                        "processed": True,
+                        "outlier": False,
+                    },
+                )
+            )
+            self.get_success(
+                self.store.db_pool.simple_upsert(
+                    "event_json",
+                    {"event_id": event_id},
+                    {
+                        "room_id": self.room_id,
+                        "json": json.dumps({"type": "test", "room_id": self.room_id}),
+                        "internal_metadata": "{}",
+                        "format_version": EventFormatVersions.V3,
+                    },
+                )
+            )
+
+    @contextmanager
+    def _outage(self) -> Generator[None, None, None]:
+        """Simulate a database outage."""
+        connection_pool = self.store.db_pool._db_pool
+        connection_pool.close()
+        connection_pool.start()
+        original_connection_factory = connection_pool.connectionFactory
+
+        def connection_factory(_pool: ConnectionPool) -> Connection:
+            raise Exception("Could not connect to the database.")
+
+        connection_pool.connectionFactory = connection_factory  # type: ignore[assignment]
+        try:
+            yield
+        finally:
+            connection_pool.connectionFactory = original_connection_factory
+
+            # If the in-memory SQLite database is being used, all the events are gone.
+            # Restore the test data.
+            self._populate_events()
+
+    def test_failure(self) -> None:
+        """Test that event fetches do not get stuck during a database outage."""
+        with self._outage():
+            failure = self.get_failure(
+                self.store.get_event(self.event_ids[0]), Exception
+            )
+            self.assertEqual(str(failure.value), "Could not connect to the database.")
+
+    def test_recovery(self) -> None:
+        """Test that event fetchers recover after a database outage."""
+        with self._outage():
+            # Kick off a bunch of event fetches but do not pump the reactor
+            event_deferreds = []
+            for event_id in self.event_ids:
+                event_deferreds.append(ensureDeferred(self.store.get_event(event_id)))
+
+            # We should have maxed out on event fetcher threads
+            self.assertEqual(self.store._event_fetch_ongoing, EVENT_QUEUE_THREADS)
+
+            # All the event fetchers will fail
+            self.pump()
+            self.assertEqual(self.store._event_fetch_ongoing, 0)
+
+            for event_deferred in event_deferreds:
+                failure = self.get_failure(event_deferred, Exception)
+                self.assertEqual(
+                    str(failure.value), "Could not connect to the database."
+                )
+
+        # This next event fetch should succeed
+        self.get_success(self.store.get_event(self.event_ids[0]))

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -212,10 +212,20 @@ class DatabaseOutageTestCase(unittest.HomeserverTestCase):
 
     @contextmanager
     def _outage(self) -> Generator[None, None, None]:
-        """Simulate a database outage."""
+        """Simulate a database outage.
+
+        Returns:
+            A context manager. While the context is active, any attempts to connect to
+            the database will fail.
+        """
         connection_pool = self.store.db_pool._db_pool
+
+        # Close all connections and shut down the database `ThreadPool`.
         connection_pool.close()
+
+        # Restart the database `ThreadPool`.
         connection_pool.start()
+
         original_connection_factory = connection_pool.connectionFactory
 
         def connection_factory(_pool: ConnectionPool) -> Connection:

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -173,8 +173,8 @@ class DatabaseOutageTestCase(unittest.HomeserverTestCase):
     def _populate_events(self) -> None:
         """Ensure that there are test events in the database.
 
-        When testing with the in-memory SQLite database is being used, all the events
-        are lost during the simulated outage.
+        When testing with the in-memory SQLite database, all the events are lost during
+        the simulated outage.
 
         To ensure consistency between `room_id`s and `event_id`s before and after the
         outage, rows are built and inserted manually.

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -171,7 +171,16 @@ class DatabaseOutageTestCase(unittest.HomeserverTestCase):
         self._populate_events()
 
     def _populate_events(self) -> None:
-        """Ensure that there are test events in the database."""
+        """Ensure that there are test events in the database.
+
+        When testing with the in-memory SQLite database is being used, all the events
+        are lost during the simulated outage.
+
+        To ensure consistency between `room_id`s and `event_id`s before and after the
+        outage, rows are built and inserted manually.
+
+        Upserts are used to handle the non-SQLite case where events are not lost.
+        """
         self.get_success(
             self.store.db_pool.simple_upsert(
                 "rooms",


### PR DESCRIPTION
The previous fix for the ongoing event fetches counter
(8eec25a1d9d656905db18a2c62a5552e63db2667) was both insufficient and
incorrect.

When the database is unreachable, `_do_fetch` never gets run and so
`_event_fetch_ongoing` is never decremented.

The previous fix also moved the `_event_fetch_ongoing` decrement outside
of the `_event_fetch_lock` which allowed race conditions to corrupt the
counter.

Fixes #11167
