### PR TITLE
Publish a `develop` docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ name: Build docker images
 on:
   push:
     tags: ["v*"]
-    branches: [ master, main ]
+    branches: [ master, main, develop ]
   workflow_dispatch:
 
 permissions:
@@ -38,6 +38,9 @@ jobs:
         id: set-tag
         run: |
           case "${GITHUB_REF}" in
+              refs/heads/develop)
+                  tag=develop
+                  ;;
               refs/heads/master|refs/heads/main)
                   tag=latest
                   ;;

--- a/changelog.d/11380.misc
+++ b/changelog.d/11380.misc
@@ -1,0 +1,1 @@
+Publish a `develop` image to dockerhub.


### PR DESCRIPTION
I'd find it helpful to have a docker image corresponding to current develop, without having to build my own.