### PR TITLE
Refactor `backfilled` into specific behavior function arguments pt.1

### DIFF
--- a/changelog.d/11396.misc
+++ b/changelog.d/11396.misc
@@ -1,0 +1,1 @@
+Refactor `backfilled` into specific behavior function arguments (`persist_events_and_notify` and downstream calls).

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1814,7 +1814,7 @@ class FederationEventHandler:
                 # We should not send notifications about backfilled events.
                 inhibit_push_notifications=backfilled,
                 # We don't need to calculate the state for backfilled events and
-                # we there is no need to update the forward extrems because we
+                # there is no need to update the forward extrems because we
                 # already know this event happened in the past if it was
                 # backfilled.
                 should_calculate_state_and_forward_extrems=not backfilled,
@@ -1823,7 +1823,7 @@ class FederationEventHandler:
                 use_negative_stream_ordering=backfilled,
                 # Backfilled events do not affect the current local state
                 inhibit_local_membership_updates=backfilled,
-                # Backfilled events have negative stream ordering and happened
+                # Backfilled events have negative stream_ordering and happened
                 # in the past so we know that we don't need to update the
                 # stream_ordering tip for the room.
                 update_room_forward_stream_ordering=not backfilled,
@@ -1854,21 +1854,30 @@ class FederationEventHandler:
                 context that should be persisted. All events must belong to
                 the same room.
             inhibit_push_notifications: Whether to stop the notifiers/pushers
-                from knowing about the event. Usually this is done for any backfilled
-                event.
+                from knowing about the event. This should be set as True
+                for backfilled events because there is no need to send push
+                notifications for events in the past.
             should_calculate_state_and_forward_extrems: Determines whether we
                 need to calculate the state and new forward extremities for the
-                room. This should be set to false for backfilled events.
+                room. This should be set to false for backfilled events because
+                we don't need to calculate the state for backfilled events and
+                there is no need to update the forward extrems because we
+                already know this event happened in the past if it was
+                backfilled.
             use_negative_stream_ordering: Whether to start stream_ordering on
-                the negative side and decrement. Usually this is done for any
-                backfilled event.
+                the negative side and decrement. This should be set as True
+                for backfilled events because backfilled events get a negative
+                stream ordering so they don't come down incremental `/sync`.
             inhibit_local_membership_updates: Stop the local_current_membership
-                from being updated by these events. Usually this is done for
-                backfilled events.
+                from being updated by these events. This should be set to True
+                for backfilled events because backfilled events in the past do
+                not affect the current local state.
             update_room_forward_stream_ordering: Whether to update the
                 stream_ordering position to mark the latest event as the front
-                of the room. This should only be set as false for backfilled
-                events.
+                of the room. This should be set as False for backfilled
+                events because backfilled events have negative stream_ordering
+                and happened in the past so we know that we don't need to
+                update the stream_ordering tip for the room.
 
         Returns:
             The stream ID after which all events have been persisted.

--- a/synapse/replication/http/federation.py
+++ b/synapse/replication/http/federation.py
@@ -85,21 +85,30 @@ class ReplicationFederationSendEventsRestServlet(ReplicationEndpoint):
             room_id (str)
             event_and_contexts (list[tuple[FrozenEvent, EventContext]])
             inhibit_push_notifications: Whether to stop the notifiers/pushers
-                from knowing about the event. Usually this is done for any backfilled
-                event.
+                from knowing about the event. This should be set as True
+                for backfilled events because there is no need to send push
+                notifications for events in the past.
             should_calculate_state_and_forward_extrems: Determines whether we
                 need to calculate the state and new forward extremities for the
-                room. This should be set to false for backfilled events.
+                room. This should be set to false for backfilled events because
+                we don't need to calculate the state for backfilled events and
+                there is no need to update the forward extrems because we
+                already know this event happened in the past if it was
+                backfilled.
             use_negative_stream_ordering: Whether to start stream_ordering on
-                the negative side and decrement. Usually this is done for any
-                backfilled event.
+                the negative side and decrement. This should be set as True
+                for backfilled events because backfilled events get a negative
+                stream ordering so they don't come down incremental `/sync`.
             inhibit_local_membership_updates: Stop the local_current_membership
-                from being updated by these events. Usually this is done for
-                backfilled events.
+                from being updated by these events. This should be set to True
+                for backfilled events because backfilled events in the past do
+                not affect the current local state.
             update_room_forward_stream_ordering: Whether to update the
                 stream_ordering position to mark the latest event as the front
-                of the room. This should only be set as false for backfilled
-                events.
+                of the room. This should be set as False for backfilled
+                events because backfilled events have negative stream_ordering
+                and happened in the past so we know that we don't need to
+                update the stream_ordering tip for the room.
         """
         event_payloads = []
         for event, context in event_and_contexts:

--- a/synapse/replication/http/federation.py
+++ b/synapse/replication/http/federation.py
@@ -73,12 +73,11 @@ class ReplicationFederationSendEventsRestServlet(ReplicationEndpoint):
         store,
         room_id,
         event_and_contexts,
-        *,
-        inhibit_push_notifications: bool = False,
-        should_calculate_state_and_forward_extrems: bool = True,
-        use_negative_stream_ordering: bool = False,
-        inhibit_local_membership_updates: bool = False,
-        update_room_forward_stream_ordering: bool = True,
+        inhibit_push_notifications,
+        should_calculate_state_and_forward_extrems,
+        use_negative_stream_ordering,
+        inhibit_local_membership_updates,
+        update_room_forward_stream_ordering,
     ):
         """
         Args:

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -180,17 +180,25 @@ class _EventPeristenceQueue(Generic[_PersistResult]):
             events_and_contexts (list[(EventBase, EventContext)]):
             should_calculate_state_and_forward_extrems: Determines whether we
                 need to calculate the state and new forward extremities for the
-                room. This should be set to false for backfilled events.
+                room. This should be set to false for backfilled events because
+                we don't need to calculate the state for backfilled events and
+                there is no need to update the forward extrems because we
+                already know this event happened in the past if it was
+                backfilled.
             use_negative_stream_ordering: Whether to start stream_ordering on
-                the negative side and decrement. Usually this is done for any
-                backfilled event.
+                the negative side and decrement. This should be set as True
+                for backfilled events because backfilled events get a negative
+                stream ordering so they don't come down incremental `/sync`.
             inhibit_local_membership_updates: Stop the local_current_membership
-                from being updated by these events. Usually this is done for
-                backfilled events.
+                from being updated by these events. This should be set to True
+                for backfilled events because backfilled events in the past do
+                not affect the current local state.
             update_room_forward_stream_ordering: Whether to update the
                 stream_ordering position to mark the latest event as the front
-                of the room. This should only be set as false for backfilled
-                events.
+                of the room. This should be set as False for backfilled
+                events because backfilled events have negative stream_ordering
+                and happened in the past so we know that we don't need to
+                update the stream_ordering tip for the room.
 
         Returns:
             the result returned by the `_per_item_callback` passed to
@@ -348,17 +356,25 @@ class EventsPersistenceStorage:
             events_and_contexts: list of tuples of (event, context)
             should_calculate_state_and_forward_extrems: Determines whether we
                 need to calculate the state and new forward extremities for the
-                room. This should be set to false for backfilled events.
+                room. This should be set to false for backfilled events because
+                we don't need to calculate the state for backfilled events and
+                there is no need to update the forward extrems because we
+                already know this event happened in the past if it was
+                backfilled.
             use_negative_stream_ordering: Whether to start stream_ordering on
-                the negative side and decrement. Usually this is done for any
-                backfilled event.
+                the negative side and decrement. This should be set as True
+                for backfilled events because backfilled events get a negative
+                stream ordering so they don't come down incremental `/sync`.
             inhibit_local_membership_updates: Stop the local_current_membership
-                from being updated by these events. Usually this is done for
-                backfilled events.
+                from being updated by these events. This should be set to True
+                for backfilled events because backfilled events in the past do
+                not affect the current local state.
             update_room_forward_stream_ordering: Whether to update the
                 stream_ordering position to mark the latest event as the front
-                of the room. This should only be set as false for backfilled
-                events.
+                of the room. This should be set as False for backfilled
+                events because backfilled events have negative stream_ordering
+                and happened in the past so we know that we don't need to
+                update the stream_ordering tip for the room.
 
         Returns:
             List of events persisted, the current position room stream position.
@@ -426,17 +442,25 @@ class EventsPersistenceStorage:
             context:
             should_calculate_state_and_forward_extrems: Determines whether we
                 need to calculate the state and new forward extremities for the
-                room. This should be set to false for backfilled events.
+                room. This should be set to false for backfilled events because
+                we don't need to calculate the state for backfilled events and
+                there is no need to update the forward extrems because we
+                already know this event happened in the past if it was
+                backfilled.
             use_negative_stream_ordering: Whether to start stream_ordering on
-                the negative side and decrement. Usually this is done for any
-                backfilled event.
+                the negative side and decrement. This should be set as True
+                for backfilled events because backfilled events get a negative
+                stream ordering so they don't come down incremental `/sync`.
             inhibit_local_membership_updates: Stop the local_current_membership
-                from being updated by these events. Usually this is done for
-                backfilled events.
+                from being updated by these events. This should be set to True
+                for backfilled events because backfilled events in the past do
+                not affect the current local state.
             update_room_forward_stream_ordering: Whether to update the
                 stream_ordering position to mark the latest event as the front
-                of the room. This should only be set as false for backfilled
-                events.
+                of the room. This should be set as False for backfilled
+                events because backfilled events have negative stream_ordering
+                and happened in the past so we know that we don't need to
+                update the stream_ordering tip for the room.
 
         Returns:
             The event, stream ordering of `event`, and the stream ordering of the
@@ -484,17 +508,25 @@ class EventsPersistenceStorage:
             events_and_contexts:
             should_calculate_state_and_forward_extrems: Determines whether we
                 need to calculate the state and new forward extremities for the
-                room. This should be set to false for backfilled events.
+                room. This should be set to false for backfilled events because
+                we don't need to calculate the state for backfilled events and
+                there is no need to update the forward extrems because we
+                already know this event happened in the past if it was
+                backfilled.
             use_negative_stream_ordering: Whether to start stream_ordering on
-                the negative side and decrement. Usually this is done for any
-                backfilled event.
+                the negative side and decrement. This should be set as True
+                for backfilled events because backfilled events get a negative
+                stream ordering so they don't come down incremental `/sync`.
             inhibit_local_membership_updates: Stop the local_current_membership
-                from being updated by these events. Usually this is done for
-                backfilled events.
+                from being updated by these events. This should be set to True
+                for backfilled events because backfilled events in the past do
+                not affect the current local state.
             update_room_forward_stream_ordering: Whether to update the
                 stream_ordering position to mark the latest event as the front
-                of the room. This should only be set as false for backfilled
-                events.
+                of the room. This should be set as False for backfilled
+                events because backfilled events have negative stream_ordering
+                and happened in the past so we know that we don't need to
+                update the stream_ordering tip for the room.
 
         Returns:
             A dictionary of event ID to event ID we didn't persist as we already

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -379,12 +379,18 @@ class EventsPersistenceStorage:
     async def _persist_event_batch(
         self,
         events_and_contexts: List[Tuple[EventBase, EventContext]],
-        backfilled: bool = False,
+        should_calculate_state_and_forward_extrems: bool = True,
     ) -> Dict[str, str]:
         """Callback for the _event_persist_queue
 
         Calculates the change to current state and forward extremities, and
         persists the given events and with those updates.
+
+        Args:
+            events_and_contexts:
+            should_calculate_state_and_forward_extrems: Determines whether we
+                need to calculate the state and new forward extremities for the
+                room. This should be set to false for backfilled events.
 
         Returns:
             A dictionary of event ID to event ID we didn't persist as we already
@@ -448,7 +454,7 @@ class EventsPersistenceStorage:
             # device lists as stale.
             potentially_left_users: Set[str] = set()
 
-            if not backfilled:
+            if should_calculate_state_and_forward_extrems:
                 with Measure(self._clock, "_calculate_state_and_extrem"):
                     # Work out the new "current state" for each room.
                     # We do this by working out what the new extremities are and then

--- a/tests/replication/slave/storage/test_events.py
+++ b/tests/replication/slave/storage/test_events.py
@@ -323,7 +323,12 @@ class SlavedEventStoreTestCase(BaseSlavedStoreTestCase):
         if backfill:
             self.get_success(
                 self.storage.persistence.persist_events(
-                    [(event, context)], backfilled=True
+                    [(event, context)],
+                    # Backfilled event
+                    should_calculate_state_and_forward_extrems=False,
+                    use_negative_stream_ordering=True,
+                    inhibit_local_membership_updates=True,
+                    update_room_forward_stream_ordering=False,
                 )
             )
         else:


### PR DESCRIPTION
Refactor `backfilled` into specific behavior function arguments pt.1. This PR does not replace all `backfilled` instances. Just `persist_events_and_notify` and all downstream calls

Using keyword-only arguments (`*`) to reduce the mistakes from `backfilled` being left as a positional argument somewhere and being interpreted wrong by our new arguments.

Part of https://github.com/matrix-org/synapse/issues/11300

### Dev notes

 - `persist_events_and_notify` (added `inhibit_push_notifications`)
    - `persist_events` and `persist_event`
       - `_event_persist_queue`

`_event_persist_queue` -> 

 - `_persist_event_batch` (added `should_calculate_state_and_forward_extrems`)
    - `_persist_events_and_state_updates` (added `use_negative_stream_ordering`)
       - `_persist_events_txn`
          - `_update_room_depths_txn` (added `update_room_forward_stream_ordering`)
          - `_update_metadata_tables_txn`
             - `_store_room_members_txn` (added `inhibit_local_membership_updates`)



### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
