### PR TITLE
fix push notifications for invites from remote servers

### DIFF
--- a/changelog.d/11410.bugfix
+++ b/changelog.d/11410.bugfix
@@ -1,0 +1,1 @@
+Fix not sending out push notifications for invites from remote servers.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -818,6 +818,8 @@ class FederationHandler:
             event.room_id, [(event, context)]
         )
 
+        await self._federation_event_handler.notify_remote_invite(event, context)
+
         return event
 
     async def do_remotely_reject_invite(

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -154,9 +154,9 @@ class FederationEventHandler:
             "actions": actions_by_user[event.state_key],
             "event_id": event.event_id,
         }
-        pusherConfigs = await self._store.get_pushers_by_user_id(event.state_key)
-        for pusherConfig in pusherConfigs:
-            p = HttpPusher(self._hs, pusherConfig)
+        pusher_configs = await self._store.get_pushers_by_user_id(event.state_key)
+        for pusher_config in pusher_configs:
+            p = HttpPusher(self._hs, pusher_config)
             await p.process_push_action(action_for_pusher)
 
     async def on_receive_pdu(self, origin: str, pdu: EventBase) -> None:

--- a/synapse/push/action_generator.py
+++ b/synapse/push/action_generator.py
@@ -41,4 +41,4 @@ class ActionGenerator:
         self, event: EventBase, context: EventContext
     ) -> None:
         with Measure(self.clock, "action_for_event_by_user"):
-            await self.bulk_evaluator.action_for_event_by_user(event, context)
+            await self.bulk_evaluator.store_action_for_event_by_user(event, context)

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -26,7 +26,7 @@ from synapse.events import EventBase
 from synapse.logging import opentracing
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.push import Pusher, PusherConfig, PusherConfigException
-from synapse.storage.databases.main.event_push_actions import HttpPushAction
+from synapse.storage.databases.main.event_push_actions import BasePushAction
 
 from . import push_rule_evaluator, push_tools
 
@@ -204,7 +204,7 @@ class HttpPusher(Pusher):
                     "app_display_name": self.app_display_name,
                 },
             ):
-                processed = await self._process_one(push_action)
+                processed = await self.process_push_action(push_action)
 
             if processed:
                 http_push_processed_counter.inc()
@@ -274,7 +274,7 @@ class HttpPusher(Pusher):
                     )
                     break
 
-    async def _process_one(self, push_action: HttpPushAction) -> bool:
+    async def process_push_action(self, push_action: BasePushAction) -> bool:
         if "notify" not in push_action["actions"]:
             return True
 


### PR DESCRIPTION
So while this solution works and actually solves the referenced bug, I'm not sure if this is doing things correctly. In fact I'm almost certain it's not doing things correctly, but I don't have enough insight into why the push code is structured as is to say why exactly circumventing that structure is bad. This bypasses any database persistence for this specific case of pushes and just directly sends those out.

I'm happy to restructure this with advice from someone with more background knowledge here.

Based on #11409
Closes #8626

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
