### PR TITLE
Don't start Synapse master process if `worker_app` is set

### DIFF
--- a/changelog.d/11416.misc
+++ b/changelog.d/11416.misc
@@ -1,0 +1,1 @@
+Add a check to ensure that users cannot start the Synapse master process when `worker_app` is set.

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -357,7 +357,7 @@ def setup(config_options: List[str]) -> SynapseHomeServer:
         # generating config files and shouldn't try to continue.
         sys.exit(0)
 
-    if config.worker:
+    if config.worker.worker_app:
         raise ConfigError(
             "You have specified worker app/s in the config but are attempting to start a non-worker "
             "instance. Please use `python -m synapse.app.generic_worker` instead."

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -359,7 +359,7 @@ def setup(config_options: List[str]) -> SynapseHomeServer:
 
     if config.worker.worker_app:
         raise ConfigError(
-            "You have specified worker app/s in the config but are attempting to start a non-worker "
+            "You have specified `worker_app` in the config but are attempting to start a non-worker "
             "instance. Please use `python -m synapse.app.generic_worker` instead."
         )
         sys.exit(1)

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -360,7 +360,7 @@ def setup(config_options: List[str]) -> SynapseHomeServer:
     if config.worker.worker_app:
         raise ConfigError(
             "You have specified `worker_app` in the config but are attempting to start a non-worker "
-            "instance. Please use `python -m synapse.app.generic_worker` instead."
+            "instance. Please use `python -m synapse.app.generic_worker` instead (or remove the option if this is the main process)."
         )
         sys.exit(1)
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -357,6 +357,13 @@ def setup(config_options: List[str]) -> SynapseHomeServer:
         # generating config files and shouldn't try to continue.
         sys.exit(0)
 
+    if config.worker:
+        raise ConfigError(
+            "You have specified worker app/s in the config but are attempting to start a non-worker "
+            "instance. Please use `python -m synapse.app.generic_worker` instead."
+        )
+        sys.exit(1)
+
     events.USE_FROZEN_DICTS = config.server.use_frozen_dicts
     synapse.util.caches.TRACK_MEMORY_USAGE = config.caches.track_memory_usage
 

--- a/tests/app/test_homeserver_start.py
+++ b/tests/app/test_homeserver_start.py
@@ -22,6 +22,8 @@ class HomeserverAppStartTestCase(ConfigFileTestCase):
     def test_wrong_start_caught(self):
         # Generate a config with a worker_app
         self.generate_config()
+        # Add a blank line as otherwise the next addition ends up on a line with a comment
+        self.add_lines_to_config(["  "])
         self.add_lines_to_config(["worker_app: test_worker_app"])
 
         # Ensure that starting master process with worker config raises an exception

--- a/tests/app/test_homeserver_start.py
+++ b/tests/app/test_homeserver_start.py
@@ -1,0 +1,29 @@
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import synapse.app.homeserver
+from synapse.config._base import ConfigError
+
+from tests.config.utils import ConfigFileTestCase
+
+
+class HomeserverAppStartTestCase(ConfigFileTestCase):
+    def test_wrong_start_caught(self):
+        # Generate a config with a worker_app
+        self.generate_config()
+        self.add_lines_to_config(["worker_app: test_worker_app"])
+
+        # Ensure that starting master process with worker config raises an exception
+        with self.assertRaises(ConfigError):
+            synapse.app.homeserver.setup(["-c", self.config_file])


### PR DESCRIPTION
Fixes #11366. Basically checks to ensure that if you are starting Synapse via `synapse.app.homeserver` that you don't have `worker_app` set in the config and refuses to start if so. 