### PR TITLE
Improve performance of `remove_hidden_devices_from_device_inbox`

### DIFF
--- a/changelog.d/11420.bugfix
+++ b/changelog.d/11420.bugfix
@@ -1,0 +1,1 @@
+Fix performance issues with the `remove_hidden_devices_from_device_inbox` database background update.

--- a/changelog.d/11420.bugfix
+++ b/changelog.d/11420.bugfix
@@ -1,1 +1,1 @@
-Fix performance issues with the `remove_hidden_devices_from_device_inbox` database background update.
+Improve performance of various background updates related to device inboxes.

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -748,7 +748,7 @@ class DeviceInboxBackgroundUpdateStore(SQLBaseStore):
             last_user_id = progress.get("user_id", "")
 
             sql = """
-                SELECT user_id, device_id, stream_id
+                SELECT device_id, user_id, stream_id
                 FROM devices
                 INNER JOIN device_inbox USING (device_id, user_id)
                 WHERE

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -745,7 +745,7 @@ class DeviceInboxBackgroundUpdateStore(SQLBaseStore):
             due to a single device having lots of device messages.
             """
 
-            last_user_id = progress.get("user_id", "")
+            last_user_id = progress.get("mxid", "")
 
             sql = """
                 SELECT device_id, user_id, stream_id
@@ -779,7 +779,7 @@ class DeviceInboxBackgroundUpdateStore(SQLBaseStore):
                     self.REMOVE_HIDDEN_DEVICES,
                     {
                         "device_id": rows[-1][0],
-                        "user_id": rows[-1][1],
+                        "mxid": rows[-1][1],
                         "stream_id": rows[-1][2],
                     },
                 )


### PR DESCRIPTION
See https://github.com/matrix-org/synapse/issues/11401 for context.

By walking the `devices` table instead of the `device_inbox` one.

Here's the query details on abolivier.bzh's database:

```
synapse=# explain analyze SELECT user_id, device_id, stream_id
FROM devices
INNER JOIN device_inbox USING (user_id, device_id)
WHERE
    hidden = TRUE
    AND user_id >= '@foo:bar'
ORDER BY user_id
LIMIT 100;
                                                                                 QUERY PLAN                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=24.36..13861.73 rows=100 width=65) (actual time=106.046..106.047 rows=0 loops=1)
   ->  Merge Join  (cost=24.36..100898.78 rows=729 width=65) (actual time=106.044..106.046 rows=0 loops=1)
         Merge Cond: ((devices.user_id = device_inbox.user_id) AND (devices.device_id = device_inbox.device_id))
         ->  Index Scan using device_uniqueness on devices  (cost=0.28..180.59 rows=560 width=57) (actual time=0.075..0.911 rows=467 loops=1)
               Index Cond: (user_id >= '@foo:bar'::text)
               Filter: hidden
               Rows Removed by Filter: 147
         ->  Index Only Scan using device_inbox_user_stream_id on device_inbox  (cost=0.54..100217.89 rows=109879 width=42) (actual time=0.141..92.477 rows=101229 loops=1)
               Heap Fetches: 6968
 Planning time: 3.127 ms
 Execution time: 106.130 ms
(11 rows)
```

So not ideal but looks like an improvement over its previous incarnation.