### PR TITLE
Update docker image to permit running as non-root and other tweaks for complement build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ __pycache__/
 
 # docs
 book/
+
+# complement
+/complement-master
+/master.tar.gz

--- a/changelog.d/11431.docker
+++ b/changelog.d/11431.docker
@@ -1,0 +1,1 @@
+Permit docker container to be run as non-root.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,6 +82,14 @@ COPY --from=builder /install /usr/local
 COPY ./docker/start.py /start.py
 COPY ./docker/conf /conf
 
+RUN mkdir /data
+
+# Set permissions for GID=0 to be able to interact with /conf and /data
+# Allows container to be deployed in OpenShift without UID 0
+# https://docs.openshift.com/container-platform/4.7/openshift_images/create-images.html#images-create-guide-openshift_create-images
+RUN chgrp -R 0 /conf /data && \
+    chmod -R g+rw /conf /data
+
 VOLUME ["/data"]
 
 EXPOSE 8008/tcp 8009/tcp 8448/tcp

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -14,9 +14,6 @@ COPY ./docker/conf-workers/* /conf/
 # Expose nginx listener port
 EXPOSE 8080/tcp
 
-# Volume for user-editable config files, logs etc.
-VOLUME ["/data"]
-
 # A script to read environment variables and create the necessary
 # files to run the desired worker configuration. Will start supervisord.
 COPY ./docker/configure_workers_and_start.py /configure_workers_and_start.py

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -11,6 +11,12 @@ RUN rm /etc/nginx/sites-enabled/default
 # Copy Synapse worker, nginx and supervisord configuration template files
 COPY ./docker/conf-workers/* /conf/
 
+# Set permissions for GID=0 to be able to interact with configuration files and data
+# Allows container to be deployed in OpenShift without UID 0
+# https://docs.openshift.com/container-platform/4.7/openshift_images/create-images.html#images-create-guide-openshift_create-images
+RUN chgrp -R 0 /etc/nginx /etc/redis /etc/supervisor /var/log /run /var/lib/redis /var/lib/nginx && \
+    chmod -R g+rw /etc/nginx /etc/redis /etc/supervisor /var/log /run /var/lib/redis /var/lib/nginx
+
 # Expose nginx listener port
 EXPOSE 8080/tcp
 

--- a/docker/conf-workers/nginx.conf.j2
+++ b/docker/conf-workers/nginx.conf.j2
@@ -18,7 +18,7 @@ server {
 {{ worker_locations }}
 
     # Send all other traffic to the main process
-    location ~* ^(\\/_matrix|\\/_synapse) {
+    location ~* ^(\\/_matrix|\\/_synapse|\\/health) {
         proxy_pass http://localhost:8080;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/docker/conf-workers/supervisord.conf.j2
+++ b/docker/conf-workers/supervisord.conf.j2
@@ -3,7 +3,6 @@
 # that have been selected.
 [supervisord]
 nodaemon=true
-user=root
 
 [program:nginx]
 command=/usr/sbin/nginx -g "daemon off;"
@@ -12,7 +11,6 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-username=www-data
 autorestart=true
 
 [program:redis]
@@ -22,7 +20,6 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-username=redis
 autorestart=true
 
 [program:synapse_main]

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -47,7 +47,7 @@ if [[ -n "$WORKERS" ]]; then
   COMPLEMENT_DOCKERFILE=SynapseWorkers.Dockerfile
   # And provide some more configuration to complement.
   export COMPLEMENT_CA=true
-  export COMPLEMENT_VERSION_CHECK_ITERATIONS=500
+  export COMPLEMENT_SPAWN_HS_TIMEOUT_SECS=25
 else
   export COMPLEMENT_BASE_IMAGE=complement-synapse
   COMPLEMENT_DOCKERFILE=Synapse.Dockerfile


### PR DESCRIPTION
I'm attempting to get the complement-perf image running on an openshift cluster, one part of which is that the containers should not run as root by default. This is kinda rolling all the way back to the source images in synapse.

The main change removes the requirement to run as root but when testing locally and under complement the containers continue to run fine.

To attempt to run the container as non-root, try adding `-u 1000:0` to a docker run line; pick a random 1000 and it should continue to function.

I think the first commits (except for 67e20f2 ) to be mainly uncontroversial, but that last commit to maybe raise some eyebrows.

I've tested the containers by running the complement.sh script and that works fine; if there's other places I should test i'm not breaking things then pointers welcome, this is probably a subtle change permissions change that might break downstream users.

This also tidies up gitignore and updates an environment variable to remove a warning when running the `scripts-dev/complement.sh`.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
