### PR TITLE
Stabilise support for MSC2918 refresh tokens as they have now been merged into the Matrix specification.

### DIFF
--- a/changelog.d/11435.feature
+++ b/changelog.d/11435.feature
@@ -1,0 +1,1 @@
+Stabilise support for [MSC2918](https://github.com/matrix-org/matrix-doc/blob/main/proposals/2918-refreshtokens.md#msc2918-refresh-tokens) refresh tokens as they have now been merged into the Matrix specification.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1215,6 +1215,9 @@ oembed:
 # Note that this only applies to clients which advertise support for
 # refresh tokens.
 #
+# Note also that this is calculated at login time and refresh time:
+# changes are not applied to existing sessions until they are refreshed.
+#
 # By default, this is 5 minutes.
 #
 #refreshable_access_token_lifetime: 5m
@@ -1223,6 +1226,9 @@ oembed:
 # exchanged for another one first).
 # This option can be used to automatically log-out inactive sessions.
 # Please see the manual for more information.
+#
+# Note also that this is calculated at login time and refresh time:
+# changes are not applied to existing sessions until they are refreshed.
 #
 # By default, this is infinite.
 #
@@ -1233,6 +1239,9 @@ oembed:
 # Please note that not all clients support refresh tokens, so setting
 # this to a short value may be inconvenient for some users who will
 # then be logged out frequently.
+#
+# Note also that this is calculated at login time: changes are not applied
+# retrospectively to existing sessions for users that have already logged in.
 #
 # By default, this is infinite.
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1209,6 +1209,35 @@ oembed:
 #
 #session_lifetime: 24h
 
+# Time that an access token remains valid for, if the session is
+# using refresh tokens.
+# For more information about refresh tokens, please see the manual.
+# Note that this only applies to clients which advertise support for
+# refresh tokens.
+#
+# By default, this is 5 minutes.
+#
+#refreshable_access_token_lifetime: 5m
+
+# Time that a refresh token remains valid for (provided that it is not
+# exchanged for another one first).
+# This option can be used to automatically log-out inactive sessions.
+# Please see the manual for more information.
+#
+# By default, this is infinite.
+#
+#refresh_token_lifetime: 24h
+
+# Time that an access token remains valid for, if the session is NOT
+# using refresh tokens.
+# Please note that not all clients support refresh tokens, so setting
+# this to a short value may be inconvenient for some users who will
+# then be logged out frequently.
+#
+# By default, this is infinite.
+#
+#nonrefreshable_access_token_lifetime: 24h
+
 # The user must provide all of the below types of 3PID when registering.
 #
 #registrations_require_3pid:

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -172,6 +172,9 @@ class RegistrationConfig(Config):
         # Note that this only applies to clients which advertise support for
         # refresh tokens.
         #
+        # Note also that this is calculated at login time and refresh time:
+        # changes are not applied to existing sessions until they are refreshed.
+        #
         # By default, this is 5 minutes.
         #
         #refreshable_access_token_lifetime: 5m
@@ -180,6 +183,9 @@ class RegistrationConfig(Config):
         # exchanged for another one first).
         # This option can be used to automatically log-out inactive sessions.
         # Please see the manual for more information.
+        #
+        # Note also that this is calculated at login time and refresh time:
+        # changes are not applied to existing sessions until they are refreshed.
         #
         # By default, this is infinite.
         #
@@ -190,6 +196,9 @@ class RegistrationConfig(Config):
         # Please note that not all clients support refresh tokens, so setting
         # this to a short value may be inconvenient for some users who will
         # then be logged out frequently.
+        #
+        # Note also that this is calculated at login time: changes are not applied
+        # retrospectively to existing sessions for users that have already logged in.
         #
         # By default, this is infinite.
         #

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -166,6 +166,35 @@ class RegistrationConfig(Config):
         #
         #session_lifetime: 24h
 
+        # Time that an access token remains valid for, if the session is
+        # using refresh tokens.
+        # For more information about refresh tokens, please see the manual.
+        # Note that this only applies to clients which advertise support for
+        # refresh tokens.
+        #
+        # By default, this is 5 minutes.
+        #
+        #refreshable_access_token_lifetime: 5m
+
+        # Time that a refresh token remains valid for (provided that it is not
+        # exchanged for another one first).
+        # This option can be used to automatically log-out inactive sessions.
+        # Please see the manual for more information.
+        #
+        # By default, this is infinite.
+        #
+        #refresh_token_lifetime: 24h
+
+        # Time that an access token remains valid for, if the session is NOT
+        # using refresh tokens.
+        # Please note that not all clients support refresh tokens, so setting
+        # this to a short value may be inconvenient for some users who will
+        # then be logged out frequently.
+        #
+        # By default, this is infinite.
+        #
+        #nonrefreshable_access_token_lifetime: 24h
+
         # The user must provide all of the below types of 3PID when registering.
         #
         #registrations_require_3pid:

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -90,7 +90,7 @@ class LoginRestServlet(RestServlet):
         self.saml2_enabled = hs.config.saml2.saml2_enabled
         self.cas_enabled = hs.config.cas.cas_enabled
         self.oidc_enabled = hs.config.oidc.oidc_enabled
-        self._msc2918_enabled = (
+        self._refresh_tokens_enabled = (
             hs.config.registration.refreshable_access_token_lifetime is not None
         )
 
@@ -163,7 +163,7 @@ class LoginRestServlet(RestServlet):
     async def on_POST(self, request: SynapseRequest) -> Tuple[int, LoginResponse]:
         login_submission = parse_json_object_from_request(request)
 
-        if self._msc2918_enabled:
+        if self._refresh_tokens_enabled:
             # Check if this login should also issue a refresh token, as per MSC2918
             should_issue_refresh_token = login_submission.get(
                 LoginRestServlet.REFRESH_TOKEN_PARAM, False

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -459,7 +459,7 @@ def _get_auth_flow_dict_for_idp(idp: SsoIdentityProvider) -> JsonDict:
 
 
 class RefreshTokenServlet(RestServlet):
-    PATTERNS = [re.compile("^" + CLIENT_API_PREFIX + "/v1/refresh$")]
+    PATTERNS = (re.compile("^/_matrix/client/v1/refresh$"),)
 
     def __init__(self, hs: "HomeServer"):
         self._auth_handler = hs.get_auth_handler()

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -72,7 +72,7 @@ class LoginRestServlet(RestServlet):
     JWT_TYPE_DEPRECATED = "m.login.jwt"
     APPSERVICE_TYPE = "m.login.application_service"
     APPSERVICE_TYPE_UNSTABLE = "uk.half-shot.msc2778.login.application_service"
-    REFRESH_TOKEN_PARAM = "org.matrix.msc2918.refresh_token"
+    REFRESH_TOKEN_PARAM = "refresh_token"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -166,12 +166,10 @@ class LoginRestServlet(RestServlet):
         if self._msc2918_enabled:
             # Check if this login should also issue a refresh token, as per MSC2918
             should_issue_refresh_token = login_submission.get(
-                "org.matrix.msc2918.refresh_token", False
+                LoginRestServlet.REFRESH_TOKEN_PARAM, False
             )
             if not isinstance(should_issue_refresh_token, bool):
-                raise SynapseError(
-                    400, "`org.matrix.msc2918.refresh_token` should be true or false."
-                )
+                raise SynapseError(400, "`refresh_token` should be true or false.")
         else:
             should_issue_refresh_token = False
 

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -458,9 +458,7 @@ def _get_auth_flow_dict_for_idp(idp: SsoIdentityProvider) -> JsonDict:
 
 
 class RefreshTokenServlet(RestServlet):
-    PATTERNS = client_patterns(
-        "/org.matrix.msc2918.refresh_token/refresh$", releases=(), unstable=True
-    )
+    PATTERNS = [re.compile("^" + CLIENT_API_PREFIX + "/v1/refresh$")]
 
     def __init__(self, hs: "HomeServer"):
         self._auth_handler = hs.get_auth_handler()

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -419,7 +419,7 @@ class RegisterRestServlet(RestServlet):
         self.password_policy_handler = hs.get_password_policy_handler()
         self.clock = hs.get_clock()
         self._registration_enabled = self.hs.config.registration.enable_registration
-        self._msc2918_enabled = (
+        self._refresh_tokens_enabled = (
             hs.config.registration.refreshable_access_token_lifetime is not None
         )
 
@@ -445,7 +445,7 @@ class RegisterRestServlet(RestServlet):
                 f"Do not understand membership kind: {kind}",
             )
 
-        if self._msc2918_enabled:
+        if self._refresh_tokens_enabled:
             # Check if this registration should also issue a refresh token, as
             # per MSC2918
             should_issue_refresh_token = body.get("refresh_token", False)

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -445,14 +445,15 @@ class RegisterRestServlet(RestServlet):
                 f"Do not understand membership kind: {kind}",
             )
 
-        if self._refresh_tokens_enabled:
-            # Check if this registration should also issue a refresh token, as
-            # per MSC2918
-            should_issue_refresh_token = body.get("refresh_token", False)
-            if not isinstance(should_issue_refresh_token, bool):
-                raise SynapseError(400, "`refresh_token` should be true or false.")
-        else:
-            should_issue_refresh_token = False
+        # Check if the clients wishes for this registration to issue a refresh
+        # token.
+        client_requested_refresh_tokens = body.get("refresh_token", False)
+        if not isinstance(client_requested_refresh_tokens, bool):
+            raise SynapseError(400, "`refresh_token` should be true or false.")
+
+        should_issue_refresh_token = (
+            self._refresh_tokens_enabled and client_requested_refresh_tokens
+        )
 
         # Pull out the provided username and do basic sanity checks early since
         # the auth layer will store these in sessions.

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -448,13 +448,9 @@ class RegisterRestServlet(RestServlet):
         if self._msc2918_enabled:
             # Check if this registration should also issue a refresh token, as
             # per MSC2918
-            should_issue_refresh_token = body.get(
-                "org.matrix.msc2918.refresh_token", False
-            )
+            should_issue_refresh_token = body.get("refresh_token", False)
             if not isinstance(should_issue_refresh_token, bool):
-                raise SynapseError(
-                    400, "`org.matrix.msc2918.refresh_token` should be true or false."
-                )
+                raise SynapseError(400, "`refresh_token` should be true or false.")
         else:
             should_issue_refresh_token = False
 

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -544,7 +544,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
         login_with_refresh = self.make_request(
             "POST",
             "/_matrix/client/r0/login",
-            {"org.matrix.msc2918.refresh_token": True, **body},
+            {"refresh_token": True, **body},
         )
         self.assertEqual(login_with_refresh.code, 200, login_with_refresh.result)
         self.assertIn("refresh_token", login_with_refresh.json_body)
@@ -575,7 +575,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
                 "username": "test3",
                 "password": self.user_pass,
                 "auth": {"type": LoginType.DUMMY},
-                "org.matrix.msc2918.refresh_token": True,
+                "refresh_token": True,
             },
         )
         self.assertEqual(register_with_refresh.code, 200, register_with_refresh.result)
@@ -590,7 +590,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
             "type": "m.login.password",
             "user": "test",
             "password": self.user_pass,
-            "org.matrix.msc2918.refresh_token": True,
+            "refresh_token": True,
         }
         login_response = self.make_request(
             "POST",
@@ -628,7 +628,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
             "type": "m.login.password",
             "user": "test",
             "password": self.user_pass,
-            "org.matrix.msc2918.refresh_token": True,
+            "refresh_token": True,
         }
         login_response = self.make_request(
             "POST",
@@ -792,7 +792,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
             "type": "m.login.password",
             "user": "test",
             "password": self.user_pass,
-            "org.matrix.msc2918.refresh_token": True,
+            "refresh_token": True,
         }
         login_response = self.make_request(
             "POST",

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -520,7 +520,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
         """
         return self.make_request(
             "POST",
-            "/_matrix/client/unstable/org.matrix.msc2918.refresh_token/refresh",
+            "/_matrix/client/v1/refresh",
             {"refresh_token": refresh_token},
         )
 
@@ -601,7 +601,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
 
         refresh_response = self.make_request(
             "POST",
-            "/_matrix/client/unstable/org.matrix.msc2918.refresh_token/refresh",
+            "/_matrix/client/v1/refresh",
             {"refresh_token": login_response.json_body["refresh_token"]},
         )
         self.assertEqual(refresh_response.code, 200, refresh_response.result)
@@ -642,7 +642,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
 
         refresh_response = self.make_request(
             "POST",
-            "/_matrix/client/unstable/org.matrix.msc2918.refresh_token/refresh",
+            "/_matrix/client/v1/refresh",
             {"refresh_token": login_response.json_body["refresh_token"]},
         )
         self.assertEqual(refresh_response.code, 200, refresh_response.result)
@@ -804,7 +804,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
         # This first refresh should work properly
         first_refresh_response = self.make_request(
             "POST",
-            "/_matrix/client/unstable/org.matrix.msc2918.refresh_token/refresh",
+            "/_matrix/client/v1/refresh",
             {"refresh_token": login_response.json_body["refresh_token"]},
         )
         self.assertEqual(
@@ -814,7 +814,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
         # This one as well, since the token in the first one was never used
         second_refresh_response = self.make_request(
             "POST",
-            "/_matrix/client/unstable/org.matrix.msc2918.refresh_token/refresh",
+            "/_matrix/client/v1/refresh",
             {"refresh_token": login_response.json_body["refresh_token"]},
         )
         self.assertEqual(
@@ -824,7 +824,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
         # This one should not, since the token from the first refresh is not valid anymore
         third_refresh_response = self.make_request(
             "POST",
-            "/_matrix/client/unstable/org.matrix.msc2918.refresh_token/refresh",
+            "/_matrix/client/v1/refresh",
             {"refresh_token": first_refresh_response.json_body["refresh_token"]},
         )
         self.assertEqual(
@@ -852,7 +852,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
         # Now that the access token from the last valid refresh was used once, refreshing with the N-1 token should fail
         fourth_refresh_response = self.make_request(
             "POST",
-            "/_matrix/client/unstable/org.matrix.msc2918.refresh_token/refresh",
+            "/_matrix/client/v1/refresh",
             {"refresh_token": login_response.json_body["refresh_token"]},
         )
         self.assertEqual(
@@ -862,7 +862,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
         # But refreshing from the last valid refresh token still works
         fifth_refresh_response = self.make_request(
             "POST",
-            "/_matrix/client/unstable/org.matrix.msc2918.refresh_token/refresh",
+            "/_matrix/client/v1/refresh",
             {"refresh_token": second_refresh_response.json_body["refresh_token"]},
         )
         self.assertEqual(

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -685,7 +685,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
             "type": "m.login.password",
             "user": "test",
             "password": self.user_pass,
-            "org.matrix.msc2918.refresh_token": True,
+            "refresh_token": True,
         }
         login_response = self.make_request(
             "POST",
@@ -735,7 +735,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
             "type": "m.login.password",
             "user": "test",
             "password": self.user_pass,
-            "org.matrix.msc2918.refresh_token": True,
+            "refresh_token": True,
         }
         login_response = self.make_request(
             "POST",


### PR DESCRIPTION
Also documents the config options, which is one of the crucial parts of stabilising a feature :).

