### PR TITLE
Add a test case for the SendJoinParser

### DIFF
--- a/changelog.d/11441.misc
+++ b/changelog.d/11441.misc
@@ -1,1 +1,1 @@
-Add a test case to sanity check that we parse `/send_join` responses correctly.
+Fix a bug introduced in 1.47.0 where `send_join` could fail due to an outdated `ijson` version.

--- a/changelog.d/11441.misc
+++ b/changelog.d/11441.misc
@@ -1,0 +1,1 @@
+Add a test case to sanity check that we parse `/send_join` responses correctly.

--- a/mypy.ini
+++ b/mypy.ini
@@ -220,6 +220,10 @@ disallow_untyped_defs = True
 [mypy-tests.rest.client.test_directory]
 disallow_untyped_defs = True
 
+[mypy-tests.federation.transport.test_client]
+disallow_untyped_defs = True
+
+
 ;; Dependencies without annotations
 ;; Before ignoring a module, check to see if type stubs are available.
 ;; The `typeshed` project maintains stubs here:

--- a/tests/federation/transport/test_client.py
+++ b/tests/federation/transport/test_client.py
@@ -2,11 +2,12 @@ import json
 
 from synapse.api.room_versions import RoomVersions
 from synapse.federation.transport.client import SendJoinParser
+
 from tests.unittest import TestCase
 
 
 class SendJoinParserTestCase(TestCase):
-    def test_two_writes(self):
+    def test_two_writes(self) -> None:
         """Test that the parser can sensibly deserialise an input given in two slices."""
         parser = SendJoinParser(RoomVersions.V1, True)
         parent_event = {
@@ -40,10 +41,10 @@ class SendJoinParserTestCase(TestCase):
         parser.write(serialised_response[100:])
 
         # Retrieve the parsed SendJoinResponse
-        response = parser.finish()
+        parsed_response = parser.finish()
 
         # Sanity check the parsing gave us sensible data.
-        self.assertEqual(len(response.auth_events), 1, response)
-        self.assertEqual(len(response.state), 1, response)
-        self.assertEqual(response.event_dict, {}, response)
-        self.assertIsNone(response.event, response)
+        self.assertEqual(len(parsed_response.auth_events), 1, parsed_response)
+        self.assertEqual(len(parsed_response.state), 1, parsed_response)
+        self.assertEqual(parsed_response.event_dict, {}, parsed_response)
+        self.assertIsNone(parsed_response.event, parsed_response)

--- a/tests/federation/transport/test_client.py
+++ b/tests/federation/transport/test_client.py
@@ -1,0 +1,49 @@
+import json
+
+from synapse.api.room_versions import RoomVersions
+from synapse.federation.transport.client import SendJoinParser
+from tests.unittest import TestCase
+
+
+class SendJoinParserTestCase(TestCase):
+    def test_two_writes(self):
+        """Test that the parser can sensibly deserialise an input given in two slices."""
+        parser = SendJoinParser(RoomVersions.V1, True)
+        parent_event = {
+            "content": {
+                "see_room_version_spec": "The event format changes depending on the room version."
+            },
+            "event_id": "$authparent",
+            "room_id": "!somewhere:example.org",
+            "type": "m.room.minimal_pdu",
+        }
+        state = {
+            "content": {
+                "see_room_version_spec": "The event format changes depending on the room version."
+            },
+            "event_id": "$DoNotThinkAboutTheEvent",
+            "room_id": "!somewhere:example.org",
+            "type": "m.room.minimal_pdu",
+        }
+        response = [
+            200,
+            {
+                "auth_chain": [parent_event],
+                "origin": "matrix.org",
+                "state": [state],
+            },
+        ]
+        serialised_response = json.dumps(response).encode()
+
+        # Send data to the parser
+        parser.write(serialised_response[:100])
+        parser.write(serialised_response[100:])
+
+        # Retrieve the parsed SendJoinResponse
+        response = parser.finish()
+
+        # Sanity check the parsing gave us sensible data.
+        self.assertEqual(len(response.auth_events), 1, response)
+        self.assertEqual(len(response.state), 1, response)
+        self.assertEqual(response.event_dict, {}, response)
+        self.assertIsNone(response.event, response)


### PR DESCRIPTION
This would have caught the bug #11438 introduced in #11217 and fixed in #11439. I confirmed this by `pip install ijson==3.0`, running the test and seeing a failure.