### PR TITLE
Support configuring the lifetime of non-refreshable access tokens separately to refreshable access tokens.

### DIFF
--- a/changelog.d/11445.feature
+++ b/changelog.d/11445.feature
@@ -1,0 +1,1 @@
+Support configuring the lifetime of non-refreshable access tokens separately to refreshable access tokens.

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -144,6 +144,17 @@ class RegistrationConfig(Config):
             )
         self.nonrefreshable_access_token_lifetime = nonrefreshable_access_token_lifetime
 
+        if (
+            self.session_lifetime is not None
+            and self.nonrefreshable_access_token_lifetime is not None
+        ):
+            if self.session_lifetime < self.nonrefreshable_access_token_lifetime:
+                raise ConfigError(
+                    "Both `session_lifetime` and `nonrefreshable_access_token_lifetime` "
+                    "configuration options have been set, but `nonrefreshable_access_token_lifetime` "
+                    " exceeds `session_lifetime`!"
+                )
+
         refresh_token_lifetime = config.get("refresh_token_lifetime")
         if refresh_token_lifetime is not None:
             refresh_token_lifetime = self.parse_duration(refresh_token_lifetime)

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -128,6 +128,17 @@ class RegistrationConfig(Config):
             int
         ] = refreshable_access_token_lifetime
 
+        if (
+            self.session_lifetime is not None
+            and "refreshable_access_token_lifetime" in config
+        ):
+            if self.session_lifetime < self.refreshable_access_token_lifetime:
+                raise ConfigError(
+                    "Both `session_lifetime` and `refreshable_access_token_lifetime` "
+                    "configuration options have been set, but `refreshable_access_token_lifetime` "
+                    " exceeds `session_lifetime`!"
+                )
+
         # The `nonrefreshable_access_token_lifetime` applies for tokens that can NOT be
         # refreshed using a refresh token.
         # If it is None, then these tokens last for the entire length of the session,
@@ -159,6 +170,17 @@ class RegistrationConfig(Config):
         if refresh_token_lifetime is not None:
             refresh_token_lifetime = self.parse_duration(refresh_token_lifetime)
         self.refresh_token_lifetime: Optional[int] = refresh_token_lifetime
+
+        if (
+            self.session_lifetime is not None
+            and self.refresh_token_lifetime is not None
+        ):
+            if self.session_lifetime < self.refresh_token_lifetime:
+                raise ConfigError(
+                    "Both `session_lifetime` and `refresh_token_lifetime` "
+                    "configuration options have been set, but `refresh_token_lifetime` "
+                    " exceeds `session_lifetime`!"
+                )
 
         # The fallback template used for authenticating using a registration token
         self.registration_token_template = self.read_template("registration_token.html")

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -125,6 +125,22 @@ class RegistrationConfig(Config):
             )
         self.refreshable_access_token_lifetime = refreshable_access_token_lifetime
 
+        # The `nonrefreshable_access_token_lifetime` applies for tokens that can NOT be
+        # refreshed using a refresh token.
+        # If it is None, then these tokens last for the entire length of the session,
+        # which is infinite by default.
+        # The intention behind this configuration option is to help with requiring
+        # all clients to use refresh tokens, if the homeserver administrator requires.
+        nonrefreshable_access_token_lifetime = config.get(
+            "nonrefreshable_access_token_lifetime",
+            None,
+        )
+        if nonrefreshable_access_token_lifetime is not None:
+            nonrefreshable_access_token_lifetime = self.parse_duration(
+                nonrefreshable_access_token_lifetime
+            )
+        self.nonrefreshable_access_token_lifetime = nonrefreshable_access_token_lifetime
+
         refresh_token_lifetime = config.get("refresh_token_lifetime")
         if refresh_token_lifetime is not None:
             refresh_token_lifetime = self.parse_duration(refresh_token_lifetime)

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -1,4 +1,5 @@
 # Copyright 2014 - 2016 OpenMarket Ltd
+# Copyright 2021 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -794,13 +794,14 @@ class RegistrationHandler:
         class and RegisterDeviceReplicationServlet.
         """
         assert not self.hs.config.worker.worker_app
+        now_ms = self.clock.time_msec()
         access_token_expiry = None
         if self.session_lifetime is not None:
             if is_guest:
                 raise Exception(
                     "session_lifetime is not currently implemented for guest access"
                 )
-            access_token_expiry = self.clock.time_msec() + self.session_lifetime
+            access_token_expiry = now_ms + self.session_lifetime
 
         refresh_token = None
         refresh_token_id = None
@@ -813,7 +814,6 @@ class RegistrationHandler:
             access_token = self.macaroon_gen.generate_guest_access_token(user_id)
         else:
             if should_issue_refresh_token:
-                now_ms = self.clock.time_msec()
 
                 # Set the expiry time of the refreshable access token
                 access_token_expiry = now_ms + self.refreshable_access_token_lifetime

--- a/tests/config/test_registration_config.py
+++ b/tests/config/test_registration_config.py
@@ -1,0 +1,78 @@
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from synapse.config import ConfigError
+from synapse.config.homeserver import HomeServerConfig
+
+from tests.unittest import TestCase
+from tests.utils import default_config
+
+
+class RegistrationConfigTestCase(TestCase):
+    def test_session_lifetime_must_not_be_exceeded_by_smaller_lifetimes(self):
+        """
+        session_lifetime should logically be larger than, or at least as large as,
+        all the different token lifetimes.
+        Test that the user is faced with configuration errors if they make it
+        smaller, as that configuration doesn't make sense.
+        """
+        config_dict = default_config("test")
+
+        # First test all the error conditions
+        with self.assertRaises(ConfigError):
+            HomeServerConfig().parse_config_dict(
+                {
+                    "session_lifetime": "30m",
+                    "nonrefreshable_access_token_lifetime": "31m",
+                    **config_dict,
+                }
+            )
+
+        with self.assertRaises(ConfigError):
+            HomeServerConfig().parse_config_dict(
+                {
+                    "session_lifetime": "30m",
+                    "refreshable_access_token_lifetime": "31m",
+                    **config_dict,
+                }
+            )
+
+        with self.assertRaises(ConfigError):
+            HomeServerConfig().parse_config_dict(
+                {
+                    "session_lifetime": "30m",
+                    "refresh_token_lifetime": "31m",
+                    **config_dict,
+                }
+            )
+
+        # Then test all the fine conditions
+        HomeServerConfig().parse_config_dict(
+            {
+                "session_lifetime": "31m",
+                "nonrefreshable_access_token_lifetime": "31m",
+                **config_dict,
+            }
+        )
+
+        HomeServerConfig().parse_config_dict(
+            {
+                "session_lifetime": "31m",
+                "refreshable_access_token_lifetime": "31m",
+                **config_dict,
+            }
+        )
+
+        HomeServerConfig().parse_config_dict(
+            {"session_lifetime": "31m", "refresh_token_lifetime": "31m", **config_dict}
+        )

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -632,12 +632,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
             refresh_response.json_body["refresh_token"],
         )
 
-    @override_config(
-        {
-            "refreshable_access_token_lifetime": "1m",
-            "nonrefreshable_access_token_lifetime": "10m",
-        }
-    )
+    @override_config({"refreshable_access_token_lifetime": "1m"})
     def test_refreshable_access_token_expiration(self):
         """
         The access token should have some time as specified in the config.

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -524,6 +524,19 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
             {"refresh_token": refresh_token},
         )
 
+    def is_access_token_valid(self, access_token) -> bool:
+        """
+        Checks whether an access token is valid, returning whether it is or not.
+        """
+        code = self.make_request(
+            "GET", "/_matrix/client/v3/account/whoami", access_token=access_token
+        ).code
+
+        # Either 200 or 401 is what we get back; anything else is a bug.
+        assert code in {HTTPStatus.OK, HTTPStatus.UNAUTHORIZED}
+
+        return code == HTTPStatus.OK
+
     def test_login_issue_refresh_token(self):
         """
         A login response should include a refresh_token only if asked.
@@ -619,7 +632,12 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
             refresh_response.json_body["refresh_token"],
         )
 
-    @override_config({"refreshable_access_token_lifetime": "1m"})
+    @override_config(
+        {
+            "refreshable_access_token_lifetime": "1m",
+            "nonrefreshable_access_token_lifetime": "10m",
+        }
+    )
     def test_refreshable_access_token_expiration(self):
         """
         The access token should have some time as specified in the config.
@@ -670,6 +688,101 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
             ).code,
             HTTPStatus.UNAUTHORIZED,
         )
+
+    @override_config(
+        {
+            "refreshable_access_token_lifetime": "1m",
+            "nonrefreshable_access_token_lifetime": "10m",
+        }
+    )
+    def test_differnt_expiry_for_refreshable_and_nonrefreshable_access_tokens(self):
+        """
+        Tests that the expiry times for refreshable and non-refreshable access
+        tokens can be different.
+        """
+        body = {
+            "type": "m.login.password",
+            "user": "test",
+            "password": self.user_pass,
+        }
+        login_response1 = self.make_request(
+            "POST",
+            "/_matrix/client/r0/login",
+            {"org.matrix.msc2918.refresh_token": True, **body},
+        )
+        self.assertEqual(login_response1.code, 200, login_response1.result)
+        self.assertApproximates(
+            login_response1.json_body["expires_in_ms"], 60 * 1000, 100
+        )
+        refreshable_access_token = login_response1.json_body["access_token"]
+
+        login_response2 = self.make_request(
+            "POST",
+            "/_matrix/client/r0/login",
+            body,
+        )
+        self.assertEqual(login_response2.code, 200, login_response2.result)
+        nonrefreshable_access_token = login_response2.json_body["access_token"]
+
+        # Advance 59 seconds in the future (just shy of 1 minute, the time of expiry)
+        self.reactor.advance(59.0)
+
+        # Both tokens should still be valid.
+        self.assertTrue(self.is_access_token_valid(refreshable_access_token))
+        self.assertTrue(self.is_access_token_valid(nonrefreshable_access_token))
+
+        # Advance to 61 s (just past 1 minute, the time of expiry)
+        self.reactor.advance(2.0)
+
+        # Only the non-refreshable token is still valid.
+        self.assertFalse(self.is_access_token_valid(refreshable_access_token))
+        self.assertTrue(self.is_access_token_valid(nonrefreshable_access_token))
+
+        # Advance to 599 s (just shy of 10 minutes, the time of expiry)
+        self.reactor.advance(599.0 - 61.0)
+
+        # It's still the case that only the non-refreshable token is still valid.
+        self.assertFalse(self.is_access_token_valid(refreshable_access_token))
+        self.assertTrue(self.is_access_token_valid(nonrefreshable_access_token))
+
+        # Advance to 601 s (just past 10 minutes, the time of expiry)
+        self.reactor.advance(2.0)
+
+        # Now neither token is valid.
+        self.assertFalse(self.is_access_token_valid(refreshable_access_token))
+        self.assertFalse(self.is_access_token_valid(nonrefreshable_access_token))
+
+    @override_config(
+        {"session_lifetime": "10m", "nonrefreshable_access_token_lifetime": "20m"}
+    )
+    def test_nonrefreshable_access_tokens_do_not_outlive_session(self):
+        """
+        Tests that non-refreshable access tokens do not outlive the session.
+        """
+        login_response1 = self.make_request(
+            "POST",
+            "/_matrix/client/r0/login",
+            {
+                "type": "m.login.password",
+                "user": "test",
+                "password": self.user_pass,
+            },
+        )
+        self.assertEqual(login_response1.code, 200, login_response1.result)
+        access_token = login_response1.json_body["access_token"]
+
+        # Advance to 599 s (just shy of 10 minutes, the time of session expiry)
+        self.reactor.advance(599.0)
+
+        # The access token should still be valid.
+        self.assertTrue(self.is_access_token_valid(access_token))
+
+        # Advance to 601 s (just past 10 minutes, the time of expiry)
+        self.reactor.advance(2.0)
+
+        # Now the token is no longer valid, because the session lifetime was
+        # 10 minutes.
+        self.assertFalse(self.is_access_token_valid(access_token))
 
     @override_config(
         {"refreshable_access_token_lifetime": "1m", "refresh_token_lifetime": "2m"}

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -748,38 +748,6 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
         self.assertFalse(self.is_access_token_valid(nonrefreshable_access_token))
 
     @override_config(
-        {"session_lifetime": "10m", "nonrefreshable_access_token_lifetime": "20m"}
-    )
-    def test_nonrefreshable_access_tokens_do_not_outlive_session(self):
-        """
-        Tests that non-refreshable access tokens do not outlive the session.
-        """
-        login_response1 = self.make_request(
-            "POST",
-            "/_matrix/client/r0/login",
-            {
-                "type": "m.login.password",
-                "user": "test",
-                "password": self.user_pass,
-            },
-        )
-        self.assertEqual(login_response1.code, 200, login_response1.result)
-        access_token = login_response1.json_body["access_token"]
-
-        # Advance to 599 s (just shy of 10 minutes, the time of session expiry)
-        self.reactor.advance(599.0)
-
-        # The access token should still be valid.
-        self.assertTrue(self.is_access_token_valid(access_token))
-
-        # Advance to 601 s (just past 10 minutes, the time of expiry)
-        self.reactor.advance(2.0)
-
-        # Now the token is no longer valid, because the session lifetime was
-        # 10 minutes.
-        self.assertFalse(self.is_access_token_valid(access_token))
-
-    @override_config(
         {"refreshable_access_token_lifetime": "1m", "refresh_token_lifetime": "2m"}
     )
     def test_refresh_token_expiry(self):

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -690,7 +690,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
             "nonrefreshable_access_token_lifetime": "10m",
         }
     )
-    def test_differnt_expiry_for_refreshable_and_nonrefreshable_access_tokens(self):
+    def test_different_expiry_for_refreshable_and_nonrefreshable_access_tokens(self):
         """
         Tests that the expiry times for refreshable and non-refreshable access
         tokens can be different.


### PR DESCRIPTION
Precursor to #11435 (which stabilises refresh tokens and documents these configuration flags).

`nonrefreshable_access_token_lifetime` is introduced as a configuration option so that homeserver admins can prevent bypassing auto-logout through the use
of clients that don't advertise support for refresh tokens.

