### PR TITLE
Expose worker & homeserver as entrypoints in `setup.py`

### DIFF
--- a/changelog.d/11449.feature
+++ b/changelog.d/11449.feature
@@ -1,0 +1,1 @@
+'Expose synapse_homeserver and synapse_worker commands as entry points to run Synapse's main process and worker processes, respectively. Contributed by @Ma27.'

--- a/changelog.d/11449.feature
+++ b/changelog.d/11449.feature
@@ -1,1 +1,1 @@
-'Expose synapse_homeserver and synapse_worker commands as entry points to run Synapse's main process and worker processes, respectively. Contributed by @Ma27.'
+Expose synapse_homeserver and synapse_worker commands as entry points to run Synapse's main process and worker processes, respectively. Contributed by @Ma27.

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,8 @@ setup(
     python_requires="~=3.6",
     entry_points={
         'console_scripts': [
-            'homeserver = synapse.app.homeserver:main'
+            'homeserver = synapse.app.homeserver:main',
+            'worker = synapse.app.generic_worker:main'
         ]
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
     entry_points={
         "console_scripts": [
             "synapse_homeserver = synapse.app.homeserver:main",
-            "synapse_worker = synapse.app.generic_worker:main"
+            "synapse_worker = synapse.app.generic_worker:main",
         ]
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -153,9 +153,9 @@ setup(
     long_description_content_type="text/x-rst",
     python_requires="~=3.6",
     entry_points={
-        'console_scripts': [
-            'homeserver = synapse.app.homeserver:main',
-            'worker = synapse.app.generic_worker:main'
+        "console_scripts": [
+            "synapse_homeserver = synapse.app.homeserver:main",
+            "synapse_worker = synapse.app.generic_worker:main"
         ]
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -152,6 +152,11 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     python_requires="~=3.6",
+    entry_points={
+        'console_scripts': [
+            'homeserver = synapse.app.homeserver:main'
+        ]
+    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Topic :: Communications :: Chat",

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -505,7 +505,7 @@ def start(config_options: List[str]) -> None:
     _base.start_worker_reactor("synapse-generic-worker", config)
 
 
-def main():
+def main() -> None:
     with LoggingContext("main"):
         start(sys.argv[1:])
 

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -505,6 +505,10 @@ def start(config_options: List[str]) -> None:
     _base.start_worker_reactor("synapse-generic-worker", config)
 
 
-if __name__ == "__main__":
+def main():
     with LoggingContext("main"):
         start(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This exposes `worker` & `synapse` as executables using the [`entry_points`](https://setuptools.pypa.io/en/latest/userguide/entry_point.html)-feature of `setup.py`.

This change is used by the `matrix-synapse`-package in `nixpkgs` to automatically install `worker` & `homeserver` into `$out/bin` to make them available in the output-path of the package. This change only affects `generic_worker.py` since all other workers seem to call `generic_worker.py` and everything else happens based on the worker's configuration.

Not sure if that's useful to you, but I thought I'd file these patches anyways :) 

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
