### PR TITLE
Register the login redirect endpoint for v3

### DIFF
--- a/changelog.d/11451.bugfix
+++ b/changelog.d/11451.bugfix
@@ -1,0 +1,1 @@
+Add support for the `/_matrix/client/v3/login/sso/redirect/{idpId}` API from Matrix v1.1. This endpoint was overlooked when support for v3 endpoints was added in v1.48.0rc1.

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -513,7 +513,7 @@ class SsoRedirectServlet(RestServlet):
         re.compile(
             "^"
             + CLIENT_API_PREFIX
-            + "/r0/login/sso/redirect/(?P<idp_id>[A-Za-z0-9_.~-]+)$"
+            + "/(r0|v3)/login/sso/redirect/(?P<idp_id>[A-Za-z0-9_.~-]+)$"
         )
     ]
 

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -1138,12 +1138,12 @@ class RoomSpaceSummaryRestServlet(RestServlet):
 
 
 class RoomHierarchyRestServlet(RestServlet):
-    PATTERNS = [
+    PATTERNS = (
         re.compile(
             "^/_matrix/client/(v1|unstable/org.matrix.msc2946)"
             "/rooms/(?P<room_id>[^/]*)/hierarchy$"
         ),
-    ]
+    )
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()


### PR DESCRIPTION
This is a follow-up to #11318 which registers the login redirect endpoint for v3 since it doesn't use `client_patterns`.

There are a variety of other places that `/r0` is mentioned in our code, some of those are places where Synapse generates a URL back to itself (e.g. login fallback, SSO redirect URLs, etc.) We don't *have* to update those today, but we should eventually.

Part of #11079 