### PR TITLE
Fix `LruCache` corruption bug with a `size_callback` that can return 0

### DIFF
--- a/changelog.d/11454.bugfix
+++ b/changelog.d/11454.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing `LruCache` corruption bug that would cause requests to fail.

--- a/changelog.d/11454.bugfix
+++ b/changelog.d/11454.bugfix
@@ -1,1 +1,1 @@
-Fix a long-standing `LruCache` corruption bug that would cause requests to fail.
+Fix an `LruCache` corruption bug, introduced in 1.38.0, that would cause certain requests to fail until the next Synapse restart.

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -271,7 +271,10 @@ class _Node(Generic[KT, VT]):
         removed from all lists.
         """
         cache = self._cache()
-        if cache is None or cache.pop(self.key, None) is None:
+        if (
+            cache is None
+            or cache.pop(self.key, _Sentinel.sentinel) is _Sentinel.sentinel
+        ):
             # `cache.pop` should call `drop_from_lists()`, unless this Node had
             # already been removed from the cache.
             self.drop_from_lists()

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -270,7 +270,7 @@ class _Node(Generic[KT, VT]):
         removed from all lists.
         """
         cache = self._cache()
-        if cache is None or not cache.pop(self.key, None):
+        if cache is None or cache.pop(self.key, None) is None:
             # `cache.pop` should call `drop_from_lists()`, unless this Node had
             # already been removed from the cache.
             self.drop_from_lists()

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -270,7 +270,7 @@ class _Node(Generic[KT, VT]):
         removed from all lists.
         """
         cache = self._cache()
-        if not cache or not cache.pop(self.key, None):
+        if cache is None or not cache.pop(self.key, None):
             # `cache.pop` should call `drop_from_lists()`, unless this Node had
             # already been removed from the cache.
             self.drop_from_lists()

--- a/tests/util/test_lrucache.py
+++ b/tests/util/test_lrucache.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from typing import List
 from unittest.mock import Mock
 
 from synapse.util.caches.lrucache import LruCache, setup_expire_lru_cache_entries
@@ -260,6 +261,17 @@ class LruCacheSizedTestCase(unittest.HomeserverTestCase):
         self.assertEquals(cache["key3"], [3])
         self.assertEquals(cache["key4"], [4])
         self.assertEquals(cache["key5"], [5, 6])
+
+    def test_zero_size_drop_from_cache(self) -> None:
+        """Test that `drop_from_cache` works correctly with 0-sized entries"""
+        cache: LruCache[str, List[int]] = LruCache(5, size_callback=lambda x: 0)
+        cache["key1"] = []
+
+        self.assertEqual(len(cache), 0)
+        cache.cache["key1"].drop_from_cache()
+        self.assertIsNone(
+            cache.pop("key1"), "Cache entry should have been evicted but wasn't"
+        )
 
 
 class TimeEvictionTestCase(unittest.HomeserverTestCase):

--- a/tests/util/test_lrucache.py
+++ b/tests/util/test_lrucache.py
@@ -263,7 +263,7 @@ class LruCacheSizedTestCase(unittest.HomeserverTestCase):
         self.assertEquals(cache["key5"], [5, 6])
 
     def test_zero_size_drop_from_cache(self) -> None:
-        """Test that `drop_from_cache` works correctly with 0-sized entries"""
+        """Test that `drop_from_cache` works correctly with 0-sized entries."""
         cache: LruCache[str, List[int]] = LruCache(5, size_callback=lambda x: 0)
         cache["key1"] = []
 


### PR DESCRIPTION
When all entries in an `LruCache` have a size of 0 according to the
provided `size_callback`, and `drop_from_cache` is called on a cache
node, the node would be unlinked from the LRU linked list but remain in
the cache dictionary. An assertion would be later be tripped due to the
inconsistency.

Avoid unintentionally calling `__len__` and use a strict `is None`
check instead when unwrapping the weak reference.

Fixes #11436