### PR TITLE
Clean-up get_version_string

### DIFF
--- a/changelog.d/11468.misc
+++ b/changelog.d/11468.misc
@@ -1,0 +1,1 @@
+Refactor `get_version_string` to fix-up types and duplicated code.

--- a/synapse/util/versionstring.py
+++ b/synapse/util/versionstring.py
@@ -65,9 +65,9 @@ def get_version_string(module: ModuleType) -> str:
             git_commit = _run_git_command("", "rev-parse", "--short", "HEAD")
 
             dirty_string = "-this_is_a_dirty_checkout"
-            is_dirty = _run_git_command("", "describe", "--dirty=" + dirty_string).endswith(
-                dirty_string
-            )
+            is_dirty = _run_git_command(
+                "", "describe", "--dirty=" + dirty_string
+            ).endswith(dirty_string)
             git_dirty = "dirty" if is_dirty else ""
 
             if git_branch or git_tag or git_commit or git_dirty:

--- a/synapse/util/versionstring.py
+++ b/synapse/util/versionstring.py
@@ -1,4 +1,5 @@
 # Copyright 2016 OpenMarket Ltd
+# Copyright 2021 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,10 +30,11 @@ def get_version_string(module: ModuleType) -> str:
     If called on a module not in a git checkout will return `__version__`.
 
     Args:
-        module (module)
+        module: The module to check the version of. Must declare a __version__
+            attribute.
 
     Returns:
-        str
+        The module version (as a string).
     """
 
     cached_version = version_cache.get(module)
@@ -46,7 +48,7 @@ def get_version_string(module: ModuleType) -> str:
     try:
         with open(os.devnull, "w") as null:
             cwd = os.path.dirname(os.path.abspath(module.__file__))
-    
+
             def _run_git_command(prefix: str, *params: str) -> str:
                 try:
                     result = (

--- a/synapse/util/versionstring.py
+++ b/synapse/util/versionstring.py
@@ -44,36 +44,36 @@ def get_version_string(module: ModuleType) -> str:
     version_string = module.__version__  # type: ignore[attr-defined]
 
     try:
-        null = open(os.devnull, "w")
-        cwd = os.path.dirname(os.path.abspath(module.__file__))
+        with open(os.devnull, "w") as null:
+            cwd = os.path.dirname(os.path.abspath(module.__file__))
+    
+            def _run_git_command(prefix: str, *params: str) -> str:
+                try:
+                    result = (
+                        subprocess.check_output(["git", *params], stderr=null, cwd=cwd)
+                        .strip()
+                        .decode("ascii")
+                    )
+                    return prefix + result
+                except (subprocess.CalledProcessError, FileNotFoundError):
+                    return ""
 
-        def _run_git_command(prefix: str, *params: str) -> str:
-            try:
-                result = (
-                    subprocess.check_output(["git", *params], stderr=null, cwd=cwd)
-                    .strip()
-                    .decode("ascii")
-                )
-                return prefix + result
-            except (subprocess.CalledProcessError, FileNotFoundError):
-                return ""
+            git_branch = _run_git_command("b=", "rev-parse", "--abbrev-ref", "HEAD")
+            git_tag = _run_git_command("t=", "describe", "--exact-match")
+            git_commit = _run_git_command("", "rev-parse", "--short", "HEAD")
 
-        git_branch = _run_git_command("b=", "rev-parse", "--abbrev-ref", "HEAD")
-        git_tag = _run_git_command("t=", "describe", "--exact-match")
-        git_commit = _run_git_command("", "rev-parse", "--short", "HEAD")
-
-        dirty_string = "-this_is_a_dirty_checkout"
-        is_dirty = _run_git_command("", "describe", "--dirty=" + dirty_string).endswith(
-            dirty_string
-        )
-        git_dirty = "dirty" if is_dirty else ""
-
-        if git_branch or git_tag or git_commit or git_dirty:
-            git_version = ",".join(
-                s for s in (git_branch, git_tag, git_commit, git_dirty) if s
+            dirty_string = "-this_is_a_dirty_checkout"
+            is_dirty = _run_git_command("", "describe", "--dirty=" + dirty_string).endswith(
+                dirty_string
             )
+            git_dirty = "dirty" if is_dirty else ""
 
-            version_string = f"{version_string} ({git_version})"
+            if git_branch or git_tag or git_commit or git_dirty:
+                git_version = ",".join(
+                    s for s in (git_branch, git_tag, git_commit, git_dirty) if s
+                )
+
+                version_string = f"{version_string} ({git_version})"
     except Exception as e:
         logger.info("Failed to check for git repository: %s", e)
 

--- a/synapse/util/versionstring.py
+++ b/synapse/util/versionstring.py
@@ -46,36 +46,37 @@ def get_version_string(module: ModuleType) -> str:
     version_string = module.__version__  # type: ignore[attr-defined]
 
     try:
-        with open(os.devnull, "w") as null:
-            cwd = os.path.dirname(os.path.abspath(module.__file__))
+        cwd = os.path.dirname(os.path.abspath(module.__file__))
 
-            def _run_git_command(prefix: str, *params: str) -> str:
-                try:
-                    result = (
-                        subprocess.check_output(["git", *params], stderr=null, cwd=cwd)
-                        .strip()
-                        .decode("ascii")
+        def _run_git_command(prefix: str, *params: str) -> str:
+            try:
+                result = (
+                    subprocess.check_output(
+                        ["git", *params], stderr=subprocess.DEVNULL, cwd=cwd
                     )
-                    return prefix + result
-                except (subprocess.CalledProcessError, FileNotFoundError):
-                    return ""
-
-            git_branch = _run_git_command("b=", "rev-parse", "--abbrev-ref", "HEAD")
-            git_tag = _run_git_command("t=", "describe", "--exact-match")
-            git_commit = _run_git_command("", "rev-parse", "--short", "HEAD")
-
-            dirty_string = "-this_is_a_dirty_checkout"
-            is_dirty = _run_git_command(
-                "", "describe", "--dirty=" + dirty_string
-            ).endswith(dirty_string)
-            git_dirty = "dirty" if is_dirty else ""
-
-            if git_branch or git_tag or git_commit or git_dirty:
-                git_version = ",".join(
-                    s for s in (git_branch, git_tag, git_commit, git_dirty) if s
+                    .strip()
+                    .decode("ascii")
                 )
+                return prefix + result
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                return ""
 
-                version_string = f"{version_string} ({git_version})"
+        git_branch = _run_git_command("b=", "rev-parse", "--abbrev-ref", "HEAD")
+        git_tag = _run_git_command("t=", "describe", "--exact-match")
+        git_commit = _run_git_command("", "rev-parse", "--short", "HEAD")
+
+        dirty_string = "-this_is_a_dirty_checkout"
+        is_dirty = _run_git_command("", "describe", "--dirty=" + dirty_string).endswith(
+            dirty_string
+        )
+        git_dirty = "dirty" if is_dirty else ""
+
+        if git_branch or git_tag or git_commit or git_dirty:
+            git_version = ",".join(
+                s for s in (git_branch, git_tag, git_commit, git_dirty) if s
+            )
+
+            version_string = f"{version_string} ({git_version})"
     except Exception as e:
         logger.info("Failed to check for git repository: %s", e)
 

--- a/synapse/util/versionstring.py
+++ b/synapse/util/versionstring.py
@@ -73,12 +73,7 @@ def get_version_string(module: ModuleType) -> str:
                 s for s in (git_branch, git_tag, git_commit, git_dirty) if s
             )
 
-            version_string = "%s (%s)" % (
-                # If the __version__ attribute doesn't exist, we'll have failed
-                # loudly above.
-                module.__version__,  # type: ignore[attr-defined]
-                git_version,
-            )
+            version_string = f"{version_string} ({git_version})"
     except Exception as e:
         logger.info("Failed to check for git repository: %s", e)
 


### PR DESCRIPTION
This cleans-up `get_version_string` a bit by factoring out common-code, fixing up some types and explicitly closing `/dev/null` (instead of assuming garbage collection will do it).

Note that this code is also shared by sydent so we might want to move it out at some point.