### PR TITLE
Update backward extremity docs to make it clear that it does not indicate whether we have fetched an events' `prev_events`

### DIFF
--- a/changelog.d/11469.doc
+++ b/changelog.d/11469.doc
@@ -1,0 +1,1 @@
+Update section about backward extremities in the room DAG concepts doc to correct the misconception about backward extremities indicating whether we have fetched an events' `prev_events`.

--- a/docs/development/room-dag-concepts.md
+++ b/docs/development/room-dag-concepts.md
@@ -47,14 +47,6 @@ When we persist a non-outlier event, we clear it as a backward extremity and set
 all of its `prev_events` as the new backward extremities if they aren't already
 persisted in the `events` table.
 
-If an event is marked as a backward extremity by being a `prev_event` of some
-other event, then persisted as an `outlier`, it can be a backward extremity while
-still being in the `events` table. 
-
-If an event is first persited as an `outlier`, then comes across the backward
-extremity update by being a `prev_event` of some other event, it won't become a
-backward extremity.
-
 
 ## Outliers
 

--- a/docs/development/room-dag-concepts.md
+++ b/docs/development/room-dag-concepts.md
@@ -47,6 +47,14 @@ When we persist a non-outlier event, we clear it as a backward extremity and set
 all of its `prev_events` as the new backward extremities if they aren't already
 persisted in the `events` table.
 
+If an event is marked as a backward extremity by being a `prev_event` of some
+other event, then persisted as an `outlier`, it can be a backward extremity while
+still being in the `events` table. 
+
+If an event is first persited as an `outlier`, then comes across the backward
+extremity update by being a `prev_event` of some other event, it won't become a
+backward extremity.
+
 
 ## Outliers
 

--- a/docs/development/room-dag-concepts.md
+++ b/docs/development/room-dag-concepts.md
@@ -41,7 +41,8 @@ The forward extremities of a room are used as the `prev_events` when the next ev
 ## Backward extremity
 
 The current marker of where we have backfilled up to and will generally be the
-oldest-in-time events we know of in the DAG.
+oldest-in-time events we know of in the DAG. This gives a starting point when
+backfilling history.
 
 When we persist a non-outlier event, we clear it as a backward extremity and set
 all of its `prev_events` as the new backward extremities if they aren't already

--- a/docs/development/room-dag-concepts.md
+++ b/docs/development/room-dag-concepts.md
@@ -38,16 +38,14 @@ Most-recent-in-time events in the DAG which are not referenced by any other even
 The forward extremities of a room are used as the `prev_events` when the next event is sent.
 
 
-## Backwards extremity
+## Backward extremity
 
 The current marker of where we have backfilled up to and will generally be the
 oldest-in-time events we know of in the DAG.
 
-This is an event where we haven't fetched all of the `prev_events` for.
-
-Once we have fetched all of its `prev_events`, it's unmarked as a backwards
-extremity (although we may have formed new backwards extremities from the prev
-events during the backfilling process).
+When we persist a non-outlier event, we clear it as a backward extremity and set
+all of its `prev_events` as the new backward extremities if they aren't already
+persisted in the `events` table.
 
 
 ## Outliers
@@ -56,8 +54,7 @@ We mark an event as an `outlier` when we haven't figured out the state for the
 room at that point in the DAG yet.
 
 We won't *necessarily* have the `prev_events` of an `outlier` in the database,
-but it's entirely possible that we *might*. The status of whether we have all of
-the `prev_events` is marked as a [backwards extremity](#backwards-extremity).
+but it's entirely possible that we *might*.
 
 For example, when we fetch the event auth chain or state for a given event, we
 mark all of those claimed auth events as outliers because we haven't done the

--- a/docs/development/room-dag-concepts.md
+++ b/docs/development/room-dag-concepts.md
@@ -41,7 +41,7 @@ The forward extremities of a room are used as the `prev_events` when the next ev
 ## Backward extremity
 
 The current marker of where we have backfilled up to and will generally be the
-oldest-in-time events we know of in the DAG. This gives a starting point when
+`prev_events` of the oldest-in-time events we have in the DAG. This gives a starting point when
 backfilling history.
 
 When we persist a non-outlier event, we clear it as a backward extremity and set


### PR DESCRIPTION
Update backward extremity docs to make it clear that it does not indicate whether we have fetched an events' `prev_events`.

This update was spawned by this discussion: https://github.com/matrix-org/synapse/pull/9445#discussion_r758958181

Follow-up to https://github.com/matrix-org/synapse/pull/10464 where the `room-dag-concepts.md` developer docs were first added.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
