### PR TITLE
Link background update controller docs to summary

### DIFF
--- a/changelog.d/11475.feature
+++ b/changelog.d/11475.feature
@@ -1,0 +1,1 @@
+Add plugin support for controlling database background updates.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -44,6 +44,7 @@
         - [Presence router callbacks](modules/presence_router_callbacks.md)
         - [Account validity callbacks](modules/account_validity_callbacks.md)
         - [Password auth provider callbacks](modules/password_auth_provider_callbacks.md)
+        - [Background update controller callbacks](modules/background_update_controller_callbacks.md)
         - [Porting a legacy module to the new interface](modules/porting_legacy_module.md)
     - [Workers](workers.md)
       - [Using `synctl` with Workers](synctl_workers.md)


### PR DESCRIPTION
Looks like I forgot to do that in #11306
