### PR TITLE
Import mock from unittest.

### DIFF
--- a/changelog.d/11477.feature
+++ b/changelog.d/11477.feature
@@ -1,0 +1,1 @@
+Add plugin support for controlling database background updates.

--- a/tests/storage/test_background_update.py
+++ b/tests/storage/test_background_update.py
@@ -1,4 +1,18 @@
-from mock import Mock
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
 
 from twisted.internet.defer import Deferred, ensureDeferred
 

--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,8 @@ setenv =
 passenv = *
 
 commands =
+    pip show mock
+
     # the "env" invocation enables coverage checking for sub-processes. This is
     # particularly important when running trial with `-j`, since that will make
     # it run tests in a subprocess, whose coverage would otherwise not be


### PR DESCRIPTION
These tests fail for me locally with `builtins.ModuleNotFoundError: No module named 'mock'`

I'm not sure why they're working in CI since we shouldn't be install `mock` anymore.

This also adds a license header. Broken from #11306.