### PR TITLE
Additional type hints for config module, part 2.

### DIFF
--- a/changelog.d/11480.misc
+++ b/changelog.d/11480.misc
@@ -1,0 +1,1 @@
+Add missing type hints to `synapse.config` module.

--- a/synapse/config/metrics.py
+++ b/synapse/config/metrics.py
@@ -22,10 +22,12 @@ from ._base import Config, ConfigError
 
 @attr.s
 class MetricsFlags:
-    known_servers = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+    known_servers: bool = attr.ib(
+        default=False, validator=attr.validators.instance_of(bool)
+    )
 
     @classmethod
-    def all_off(cls):
+    def all_off(cls) -> "MetricsFlags":
         """
         Instantiate the flags with all options set to off.
         """

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -1257,9 +1257,7 @@ class ServerConfig(Config):
             help="Turn on the twisted telnet manhole service on the given port.",
         )
 
-    def read_gc_intervals(
-        self, durations: Optional[List[Any]]
-    ) -> Optional[Tuple[float, float, float]]:
+    def read_gc_intervals(self, durations: Any) -> Optional[Tuple[float, float, float]]:
         """Reads the three durations for the GC min interval option, returning seconds."""
         if durations is None:
             return None

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -1257,7 +1257,9 @@ class ServerConfig(Config):
             help="Turn on the twisted telnet manhole service on the given port.",
         )
 
-    def read_gc_intervals(self, durations) -> Optional[Tuple[float, float, float]]:
+    def read_gc_intervals(
+        self, durations: Optional[List[Any]]
+    ) -> Optional[Tuple[float, float, float]]:
         """Reads the three durations for the GC min interval option, returning seconds."""
         if durations is None:
             return None

--- a/synapse/config/tls.py
+++ b/synapse/config/tls.py
@@ -132,7 +132,7 @@ class TlsConfig(Config):
         self.tls_certificate: Optional[crypto.X509] = None
         self.tls_private_key: Optional[crypto.PKey] = None
 
-    def read_certificate_from_disk(self):
+    def read_certificate_from_disk(self) -> None:
         """
         Read the certificates and private key from disk.
         """


### PR DESCRIPTION
Builds on #11465 to add a few more missing type hints in helpers, etc.

After this the only untyped things in `synapse.config` should be each classes `read_config` and `generate_config_section` methods. I have some WIPs for those to make the parameter explicit and such, so they're a bit more work.