### PR TITLE
Avoid waiting for zombie processes in `synctl stop`

### DIFF
--- a/changelog.d/11490.feature
+++ b/changelog.d/11490.feature
@@ -1,0 +1,1 @@
+`synctl stop` will now wait for Synapse to exit before returning.

--- a/synctl
+++ b/synctl
@@ -52,7 +52,6 @@ def pid_running(pid):
     try:
         with open(f"/proc/{pid}/status") as status_file:
             if "zombie" in status_file.read():
-                subprocess.run(["ps", "auxf"])
                 return False
     except Exception:
         # This isn't Linux or `/proc/` is unavailable.

--- a/synctl
+++ b/synctl
@@ -41,11 +41,24 @@ NORMAL = "\x1b[m"
 def pid_running(pid):
     try:
         os.kill(pid, 0)
-        return True
     except OSError as err:
         if err.errno == errno.EPERM:
-            return True
-        return False
+            pass  # process exists
+        else:
+            return False
+
+    # When running in a container, orphan processes may not get reaped and their
+    # PIDs may remain valid. Try to work around the issue.
+    try:
+        with open(f"/proc/{pid}/status") as status_file:
+            if "zombie" in status_file.read():
+                return False
+    except Exception:
+        # This isn't Linux or `/proc/` is unavailable.
+        # Assume that the process is still running.
+        pass
+
+    return True
 
 
 def write(message, colour=NORMAL, stream=sys.stdout):

--- a/synctl
+++ b/synctl
@@ -52,6 +52,7 @@ def pid_running(pid):
     try:
         with open(f"/proc/{pid}/status") as status_file:
             if "zombie" in status_file.read():
+                subprocess.run(["ps", "auxf"])
                 return False
     except Exception:
         # This isn't Linux or `/proc/` is unavailable.


### PR DESCRIPTION
Fixes #11471

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
