### PR TITLE
Refactors in `_generate_sync_entry_for_rooms`

### DIFF
--- a/changelog.d/11494.misc
+++ b/changelog.d/11494.misc
@@ -1,1 +1,1 @@
-Add comments to various parts of the `/sync` handler.
+Refactor various parts of the `/sync` handler.

--- a/changelog.d/11515.misc
+++ b/changelog.d/11515.misc
@@ -1,0 +1,1 @@
+Refactor various parts of the `/sync` handler.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1612,6 +1612,12 @@ class SyncHandler:
         )
 
     async def _get_ignored_users(self, user_id: str) -> FrozenSet[str]:
+        """Retrieve the users ignored by the given user from their global account_data.
+
+        Returns an empty set if
+        - there is no global account_data entry for ignored_users
+        - there is such an entry, but it's not a JSON object.
+        """
         ignored_account_data = (
             await self.store.get_global_account_data_by_type_for_user(
                 AccountDataTypes.IGNORED_USER_LIST, user_id=user_id

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1512,8 +1512,8 @@ class SyncHandler:
             account_data_by_room: Dictionary of per room account data
 
         Returns:
-            Returns a 4-tuple describing rooms we've joined or left, and users who've
-            joined or left rooms we're in. This gets used later in
+            Returns a 4-tuple describing rooms the user has joined or left, and users who've
+            joined or left rooms any rooms the user is in. This gets used later in
             `_generate_sync_entry_for_device_list`.
 
             Its entries are:

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -2341,7 +2341,7 @@ class SyncResultBuilder:
 
 
 def _calculate_user_changes(
-    sync_result_builder: "SyncResultBuilder",
+    sync_result_builder: SyncResultBuilder,
 ) -> Tuple[Set[str], Set[str]]:
     """Work out which other users have joined or left rooms we are joined to.
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1512,10 +1512,12 @@ class SyncHandler:
             - newly_left_rooms
             - newly_left_users
         """
+        since_token = sync_result_builder.since_token
+
         # Start by fetching all ephemeral events in rooms we've joined (if required).
         user_id = sync_result_builder.sync_config.user.to_string()
         block_all_room_ephemeral = (
-            sync_result_builder.since_token is None
+            since_token is None
             and sync_result_builder.sync_config.filter_collection.blocks_all_room_ephemeral()
         )
 
@@ -1531,7 +1533,6 @@ class SyncHandler:
 
         # We check up front if anything has changed, if it hasn't then there is
         # no point in going further.
-        since_token = sync_result_builder.since_token
         if not sync_result_builder.full_state:
             if since_token and not ephemeral_by_room and not account_data_by_room:
                 have_changed = await self._have_rooms_changed(sync_result_builder)

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1596,7 +1596,7 @@ class SyncHandler:
         (
             newly_joined_or_invited_or_knocked_users,
             newly_left_users,
-        ) = _calculate_user_changes(sync_result_builder)
+        ) = sync_result_builder.calculate_user_changes()
 
         return (
             set(newly_joined_rooms),
@@ -2339,39 +2339,38 @@ class SyncResultBuilder:
     groups: Optional[GroupsSyncResult] = None
     to_device: List[JsonDict] = attr.Factory(list)
 
+    def calculate_user_changes(self) -> Tuple[Set[str], Set[str]]:
+        """Work out which other users have joined or left rooms we are joined to.
 
-def _calculate_user_changes(
-    sync_result_builder: SyncResultBuilder,
-) -> Tuple[Set[str], Set[str]]:
-    """Work out which other users have joined or left rooms we are joined to.
+        This data only is only useful for an incremental sync.
 
-    Only applies to an incremental sync.
+        The SyncResultBuilder is not modified by this function.
+        """
+        newly_joined_or_invited_or_knocked_users = set()
+        newly_left_users = set()
+        if self.since_token:
+            for joined_sync in self.joined:
+                it = itertools.chain(
+                    joined_sync.timeline.events, joined_sync.state.values()
+                )
+                for event in it:
+                    if event.type == EventTypes.Member:
+                        if (
+                            event.membership == Membership.JOIN
+                            or event.membership == Membership.INVITE
+                            or event.membership == Membership.KNOCK
+                        ):
+                            newly_joined_or_invited_or_knocked_users.add(
+                                event.state_key
+                            )
+                        else:
+                            prev_content = event.unsigned.get("prev_content", {})
+                            prev_membership = prev_content.get("membership", None)
+                            if prev_membership == Membership.JOIN:
+                                newly_left_users.add(event.state_key)
 
-    The sync_result_builder is not modified by this function.
-    """
-    newly_joined_or_invited_or_knocked_users = set()
-    newly_left_users = set()
-    if sync_result_builder.since_token:
-        for joined_sync in sync_result_builder.joined:
-            it = itertools.chain(
-                joined_sync.timeline.events, joined_sync.state.values()
-            )
-            for event in it:
-                if event.type == EventTypes.Member:
-                    if (
-                        event.membership == Membership.JOIN
-                        or event.membership == Membership.INVITE
-                        or event.membership == Membership.KNOCK
-                    ):
-                        newly_joined_or_invited_or_knocked_users.add(event.state_key)
-                    else:
-                        prev_content = event.unsigned.get("prev_content", {})
-                        prev_membership = prev_content.get("membership", None)
-                        if prev_membership == Membership.JOIN:
-                            newly_left_users.add(event.state_key)
-
-    newly_left_users -= newly_joined_or_invited_or_knocked_users
-    return newly_joined_or_invited_or_knocked_users, newly_left_users
+        newly_left_users -= newly_joined_or_invited_or_knocked_users
+        return newly_joined_or_invited_or_knocked_users, newly_left_users
 
 
 @attr.s(slots=True, auto_attribs=True)

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -2336,6 +2336,12 @@ class SyncResultBuilder:
 def _calculate_user_changes(
     sync_result_builder: "SyncResultBuilder",
 ) -> Tuple[Set[str], Set[str]]:
+    """Work out which other users have joined or left rooms we are joined to.
+
+    Only applies to an incremental sync.
+
+    The sync_result_builder is not modified by this function.
+    """
     newly_joined_or_invited_or_knocked_users = set()
     newly_left_users = set()
     if sync_result_builder.since_token:

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -184,6 +184,20 @@ class GroupsSyncResult:
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
+class MembershipChangesSummary:
+    """
+    A summary of rooms we've joined or left, plus users who we've seen join or leave.
+
+    Used to create the DeviceLists struct below.
+    """
+
+    newly_joined_rooms: Collection[str]
+    newly_joined_or_invited_or_knocked_users: Collection[str]
+    newly_left_rooms: Collection[str]
+    newly_left_users: Collection[str]
+
+
+@attr.s(slots=True, frozen=True, auto_attribs=True)
 class DeviceLists:
     """
     Attributes:
@@ -1112,11 +1126,9 @@ class SyncHandler:
 
         logger.debug("Fetching room data")
 
-        res = await self._generate_sync_entry_for_rooms(
+        membership_changes_summary = await self._generate_sync_entry_for_rooms(
             sync_result_builder, account_data_by_room
         )
-        newly_joined_rooms, newly_joined_or_invited_or_knocked_users, _, _ = res
-        _, _, newly_left_rooms, newly_left_users = res
 
         block_all_presence_data = (
             since_token is None and sync_config.filter_collection.blocks_all_presence()
@@ -1125,8 +1137,8 @@ class SyncHandler:
             logger.debug("Fetching presence data")
             await self._generate_sync_entry_for_presence(
                 sync_result_builder,
-                newly_joined_rooms,
-                newly_joined_or_invited_or_knocked_users,
+                membership_changes_summary.newly_joined_rooms,
+                membership_changes_summary.newly_joined_or_invited_or_knocked_users,
             )
 
         logger.debug("Fetching to-device data")
@@ -1134,10 +1146,7 @@ class SyncHandler:
 
         device_lists = await self._generate_sync_entry_for_device_list(
             sync_result_builder,
-            newly_joined_rooms=newly_joined_rooms,
-            newly_joined_or_invited_or_knocked_users=newly_joined_or_invited_or_knocked_users,
-            newly_left_rooms=newly_left_rooms,
-            newly_left_users=newly_left_users,
+            membership_changes_summary,
         )
 
         logger.debug("Fetching OTK data")
@@ -1164,7 +1173,7 @@ class SyncHandler:
         # debug for https://github.com/matrix-org/synapse/issues/4422
         for joined_room in sync_result_builder.joined:
             room_id = joined_room.room_id
-            if room_id in newly_joined_rooms:
+            if room_id in membership_changes_summary.newly_joined_rooms:
                 issue4422_logger.debug(
                     "Sync result for newly joined room %s: %r", room_id, joined_room
                 )
@@ -1242,10 +1251,7 @@ class SyncHandler:
     async def _generate_sync_entry_for_device_list(
         self,
         sync_result_builder: "SyncResultBuilder",
-        newly_joined_rooms: Set[str],
-        newly_joined_or_invited_or_knocked_users: Set[str],
-        newly_left_rooms: Set[str],
-        newly_left_users: Set[str],
+        mem_changes: MembershipChangesSummary,
     ) -> DeviceLists:
         """Generate the DeviceLists section of sync
 
@@ -1266,9 +1272,9 @@ class SyncHandler:
         # We're going to mutate these fields, so lets copy them rather than
         # assume they won't get used later.
         newly_joined_or_invited_or_knocked_users = set(
-            newly_joined_or_invited_or_knocked_users
+            mem_changes.newly_joined_or_invited_or_knocked_users
         )
-        newly_left_users = set(newly_left_users)
+        newly_left_users = set(mem_changes.newly_left_users)
 
         if since_token and since_token.device_list_key:
             # We want to figure out what user IDs the client should refetch
@@ -1304,7 +1310,7 @@ class SyncHandler:
             )
 
             # Step 1b, check for newly joined rooms
-            for room_id in newly_joined_rooms:
+            for room_id in mem_changes.newly_joined_rooms:
                 joined_users = await self.store.get_users_in_room(room_id)
                 newly_joined_or_invited_or_knocked_users.update(joined_users)
 
@@ -1320,7 +1326,7 @@ class SyncHandler:
             users_that_have_changed.update(user_signatures_changed)
 
             # Now find users that we no longer track
-            for room_id in newly_left_rooms:
+            for room_id in mem_changes.newly_left_rooms:
                 left_users = await self.store.get_users_in_room(room_id)
                 newly_left_users.update(left_users)
 
@@ -1434,8 +1440,8 @@ class SyncHandler:
     async def _generate_sync_entry_for_presence(
         self,
         sync_result_builder: "SyncResultBuilder",
-        newly_joined_rooms: Set[str],
-        newly_joined_or_invited_users: Set[str],
+        newly_joined_rooms: Collection[str],
+        newly_joined_or_invited_users: Collection[str],
     ) -> None:
         """Generates the presence portion of the sync response. Populates the
         `sync_result_builder` with the result.
@@ -1493,7 +1499,7 @@ class SyncHandler:
         self,
         sync_result_builder: "SyncResultBuilder",
         account_data_by_room: Dict[str, Dict[str, JsonDict]],
-    ) -> Tuple[Set[str], Set[str], Set[str], Set[str]]:
+    ) -> MembershipChangesSummary:
         """Generates the rooms portion of the sync response. Populates the
         `sync_result_builder` with the result.
 
@@ -1547,7 +1553,7 @@ class SyncHandler:
                     )
                     if not tags_by_room:
                         logger.debug("no-oping sync")
-                        return set(), set(), set(), set()
+                        return MembershipChangesSummary(set(), set(), set(), set())
 
         # 3. Work out which rooms need reporting in the sync response.
         ignored_users = await self._get_ignored_users(user_id)
@@ -1598,7 +1604,7 @@ class SyncHandler:
             newly_left_users,
         ) = _calculate_user_changes(sync_result_builder)
 
-        return (
+        return MembershipChangesSummary(
             set(newly_joined_rooms),
             newly_joined_or_invited_or_knocked_users,
             set(newly_left_rooms),

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1618,6 +1618,7 @@ class SyncHandler:
         - there is no global account_data entry for ignored_users
         - there is such an entry, but it's not a JSON object.
         """
+        # TODO: Can we `SELECT ignored_user_id FROM ignored_users WHERE ignorer_user_id=?;` instead?
         ignored_account_data = (
             await self.store.get_global_account_data_by_type_for_user(
                 AccountDataTypes.IGNORED_USER_LIST, user_id=user_id


### PR DESCRIPTION
Small things that helped me when I was reading all of this stuff.

- 0af0643c7 is probably the most useful.
- f9dff2d60 and 963de4e5c pull out isolated chunks of code into their own functions.
- 0e2c6f6fc: I'm not sure if this makes things clearer or just introduces more noise. Input welcome.