### PR TITLE
Fix the test breakage introduced by #11435 as a result of concurrent PRs

### DIFF
--- a/changelog.d/11522.feature
+++ b/changelog.d/11522.feature
@@ -1,0 +1,1 @@
+Stabilise support for [MSC2918](https://github.com/matrix-org/matrix-doc/blob/main/proposals/2918-refreshtokens.md#msc2918-refresh-tokens) refresh tokens as they have now been merged into the Matrix specification.

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -703,7 +703,7 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
         login_response1 = self.make_request(
             "POST",
             "/_matrix/client/r0/login",
-            {"org.matrix.msc2918.refresh_token": True, **body},
+            {"refresh_token": True, **body},
         )
         self.assertEqual(login_response1.code, 200, login_response1.result)
         self.assertApproximates(


### PR DESCRIPTION
Typical story, one of the PRs changed something that needed tests changing,

another PR had a test added because 'this needs more tests!'

and oops.

Sorry :)
