### PR TITLE
A third batch of refactors to the sync handler

### DIFF
--- a/changelog.d/11532.misc
+++ b/changelog.d/11532.misc
@@ -1,0 +1,1 @@
+Further refactors of the `/sync` handler.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -222,6 +222,7 @@ class _RoomChanges:
     join        leave     join
     invite      join      leave
     """
+
     newly_left_rooms: List[str]
     """Rooms we are not joined to at the `now_token` and left between `since` and `now`.
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1885,20 +1885,15 @@ class SyncHandler:
                     newly_left_rooms.append(room_id)
 
             # 3. Should we add this room to `invited`?
-            # Only bother if we're still currently invited
             last_non_join = non_joins[-1]
-            should_invite = last_non_join.membership == Membership.INVITE
-            if should_invite:
+            if last_non_join.membership == Membership.INVITE:
                 if last_non_join.sender not in ignored_users:
                     invite_room_sync = InvitedSyncResult(room_id, invite=last_non_join)
                     if invite_room_sync:
                         invited.append(invite_room_sync)
 
             # 4. Should we add this room to `knocked`?
-            # Only bother if our latest membership in the room is knock (and we haven't
-            # been accepted/rejected in the meantime).
-            should_knock = last_non_join.membership == Membership.KNOCK
-            if should_knock:
+            elif last_non_join.membership == Membership.KNOCK:
                 knock_room_sync = KnockedSyncResult(room_id, knock=last_non_join)
                 if knock_room_sync:
                     knocked.append(knock_room_sync)

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1855,11 +1855,10 @@ class SyncHandler:
                 # User is in the room so we don't need to do the invite/leave checks
                 continue
 
+            old_mem_ev = await self._fetch_membership_event_at(
+                room_id, user_id, since_token
+            )
             if room_id in sync_result_builder.joined_room_ids or has_join:
-                old_mem_ev = await self._fetch_membership_event_at(
-                    room_id, user_id, since_token
-                )
-
                 # debug for #4422
                 if has_join and old_mem_ev is not None:
                     issue4422_logger.debug(
@@ -1883,9 +1882,6 @@ class SyncHandler:
                 if has_join:
                     newly_left_rooms.append(room_id)
                 else:
-                    old_mem_ev = await self._fetch_membership_event_at(
-                        room_id, user_id, since_token
-                    )
                     if (
                         old_mem_ev is not None
                         and old_mem_ev.membership == Membership.JOIN

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1878,15 +1878,11 @@ class SyncHandler:
             # 2. Should we add this to `newly_left_rooms`?
             # Check if we have left the room. This can either be because we were
             # joined before *or* that we since joined and then left.
-            if events[-1].membership != Membership.JOIN:
-                if has_join:
+            if has_join:
+                newly_left_rooms.append(room_id)
+            else:
+                if old_mem_ev is not None and old_mem_ev.membership == Membership.JOIN:
                     newly_left_rooms.append(room_id)
-                else:
-                    if (
-                        old_mem_ev is not None
-                        and old_mem_ev.membership == Membership.JOIN
-                    ):
-                        newly_left_rooms.append(room_id)
 
             # 3. Should we add this room to `invited`?
             # Only bother if we're still currently invited


### PR DESCRIPTION
This time I'm concentrating on a big chunk of the logic behind incremental syncs.

These commits are more about refactoring rather than adding comments. Only really reviewable commit-by-commit, and even then there might be too much stuff here. I'm happy to chop this up into smaller PRs if helpful.

There are three scary commits here in particular: bca64f9, 0d0783c and a5deabb. They all remove code with the aim of making `_classify_rooms_by_membership_changes` easier to follow. Please see their commit messages for why I think the changes are justified.