### PR TITLE
Stop populating `state_events.prev_state`

### DIFF
--- a/changelog.d/11558.misc
+++ b/changelog.d/11558.misc
@@ -1,0 +1,1 @@
+Stop populating unused database column `state_events.prev_state`.

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1410,10 +1410,6 @@ class PersistEventsStore:
                 "state_key": event.state_key,
             }
 
-            # TODO: How does this work with backfilling?
-            if hasattr(event, "replaces_state"):
-                vals["prev_state"] = event.replaces_state
-
             state_values.append(vals)
 
         self.db_pool.simple_insert_many_txn(

--- a/synapse/storage/schema/__init__.py
+++ b/synapse/storage/schema/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SCHEMA_VERSION = 66  # remember to update the list below when updating
+SCHEMA_VERSION = 67  # remember to update the list below when updating
 """Represents the expectations made by the codebase about the database schema
 
 This should be incremented whenever the codebase changes its requirements on the
@@ -50,6 +50,9 @@ Changes in SCHEMA_VERSION = 65:
 Changes in SCHEMA_VERSION = 66:
     - Queries on state_key columns are now disambiguated (ie, the codebase can handle
       the `events` table having a `state_key` column).
+
+Changes in SCHEMA_VERSION = 67:
+    - state_events.prev_state is no longer written to.
 """
 
 


### PR DESCRIPTION
this field is never read, so we may as well stop populating it.