### PR TITLE
checks for generators in database functions

### DIFF
--- a/changelog.d/11564.misc
+++ b/changelog.d/11564.misc
@@ -1,0 +1,1 @@
+Add some safety checks that storage functions are used correctly.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -548,14 +548,21 @@ class DatabasePool:
         # will fail if we have to repeat the transaction.
         # For now, we just log an error, and hope that it works on the first attempt.
         # TODO: raise an exception.
-        for arg in args:
+        for i, arg in enumerate(args):
             if inspect.isgenerator(arg):
-                logger.error("Programming error: generator passed to new_transaction")
+                logger.error(
+                    "Programming error: generator passed to new_transaction as "
+                    "argument %i to function %s",
+                    i,
+                    func,
+                )
         for name, val in kwargs.items():
             if inspect.isgenerator(val):
                 logger.error(
-                    "Programming error: generator passed to new_transaction as argument %s",
+                    "Programming error: generator passed to new_transaction as "
+                    "argument %s to function %s",
                     name,
+                    func,
                 )
         # also check variables referenced in func's closure
         if inspect.isfunction(func):
@@ -564,7 +571,8 @@ class DatabasePool:
                 for i, cell in enumerate(f.__closure__):
                     if inspect.isgenerator(cell.cell_contents):
                         logger.error(
-                            "Programming error: function %s references generator %s via its closure",
+                            "Programming error: function %s references generator %s "
+                            "via its closure",
                             f,
                             f.__code__.co_freevars[i],
                         )

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -528,6 +528,12 @@ class DatabasePool:
         the function will correctly handle being aborted and retried half way
         through its execution.
 
+        Similarly, the arguments to `func` (`args`, `kwargs`) should not be generators,
+        since they could be evaluated multiple times (which would produce an empty
+        result on the second or subsequent evaluation). Likewise, the closure of `func`
+        must not reference any generators.  This method attempts to detect such usage
+        and will log an error.
+
         Args:
             conn
             desc

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -552,14 +552,16 @@ class DatabasePool:
                     name,
                 )
         # also check variables referenced in func's closure
-        if inspect.isfunction(func) and func.__closure__:
-            for i, cell in enumerate(func.__closure__):
-                if inspect.isgenerator(cell.cell_contents):
-                    logger.error(
-                        "Programming error: function %s references generator %s via its closure",
-                        func,
-                        func.__code__.co_freevars[i],
-                    )
+        if inspect.isfunction(func):
+            f = cast(types.FunctionType, func)
+            if f.__closure__:
+                for i, cell in enumerate(f.__closure__):
+                    if inspect.isgenerator(cell.cell_contents):
+                        logger.error(
+                            "Programming error: function %s references generator %s via its closure",
+                            f,
+                            f.__code__.co_freevars[i],
+                        )
 
         start = monotonic_time()
         txn_id = self._TXN_ID

--- a/synapse/storage/databases/main/presence.py
+++ b/synapse/storage/databases/main/presence.py
@@ -269,6 +269,7 @@ class PresenceStore(PresenceBackgroundUpdateStore):
         """
         # Add user entries to the table, updating the presence_stream_id column if the user already
         # exists in the table.
+        presence_stream_id = self._presence_id_gen.get_current_token()
         await self.db_pool.simple_upsert_many(
             table="users_to_send_full_presence_to",
             key_names=("user_id",),
@@ -279,9 +280,7 @@ class PresenceStore(PresenceBackgroundUpdateStore):
             # devices at different times, each device will receive full presence once - when
             # the presence stream ID in their sync token is less than the one in the table
             # for their user ID.
-            value_values=(
-                (self._presence_id_gen.get_current_token(),) for _ in user_ids
-            ),
+            value_values=[(presence_stream_id,) for _ in user_ids],
             desc="add_users_to_send_full_presence_to",
         )
 


### PR DESCRIPTION
A couple of safety-checks to hopefully stop people doing what I just did, and create a storage function which only works the first time it is called (and not when it is re-run due to a database concurrency error or similar). It's not water-tight, of course, but it should catch the most obvious failure modes.

Ideally, I'd have this throw a ValueError or somesuch, but I'm a bit worried it'll break existing code that I haven't yet found, so for now at least, let's just log an error.

Also fixes up a particular case that I discovered during testing. In theory this is bug which could have caused us to send fewer presence updates than we should have done. In practice, it's such an edge-case I can't really imagine anyone will ever have hit it.