### PR TITLE
Convert EventStreamResult to attrs.

### DIFF
--- a/changelog.d/11574.misc
+++ b/changelog.d/11574.misc
@@ -1,0 +1,1 @@
+Convert `EventStreamResult` from a `namedtuple` to `attrs` to improve type hints.

--- a/synapse/handlers/events.py
+++ b/synapse/handlers/events.py
@@ -79,13 +79,14 @@ class EventStreamHandler:
                 # thundering herds on restart.
                 timeout = random.randint(int(timeout * 0.9), int(timeout * 1.1))
 
-            events, tokens = await self.notifier.get_events_for(
+            stream_result = await self.notifier.get_events_for(
                 auth_user,
                 pagin_config,
                 timeout,
                 is_guest=is_guest,
                 explicit_room_id=room_id,
             )
+            events = stream_result.events
 
             time_now = self.clock.time_msec()
 
@@ -128,8 +129,8 @@ class EventStreamHandler:
 
             chunk = {
                 "chunk": chunks,
-                "start": await tokens[0].to_string(self.store),
-                "end": await tokens[1].to_string(self.store),
+                "start": await stream_result.start_token.to_string(self.store),
+                "end": await stream_result.end_token.to_string(self.store),
             }
 
             return chunk


### PR DESCRIPTION
I was attempting to convince myself that `serialize_events` never took a `JsonDict` and only ever received `EventBase` instances...well turns out it does take them via the event streams.

I fixed up some of the types around this to use `attrs` instead of a `namedtuple` to avoid `Any` being passed around.

Vaguely related to #11399 since that spurred the original work.