### PR TITLE
Remove the 'password_hash' from the Users Admin API endpoint response dictionary

### DIFF
--- a/changelog.d/11576.feature
+++ b/changelog.d/11576.feature
@@ -1,0 +1,1 @@
+Add a v3 of the Users Admin API which removes `"password_hash"` from response dictionaries. Deprecates the v2 version of the API.

--- a/changelog.d/11576.feature
+++ b/changelog.d/11576.feature
@@ -1,1 +1,1 @@
-Add a v3 of the Users Admin API which removes `"password_hash"` from response dictionaries. Deprecates the v2 version of the API.
+Remove the `"password_hash"` field from the response dictionaries of the [Users Admin API](https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html).

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -17,6 +17,7 @@ It returns a JSON body like the following:
 
 ```json
 {
+    "name": "@user:example.com",
     "displayname": "User",
     "threepids": [
         {
@@ -33,6 +34,7 @@ It returns a JSON body like the following:
         }
     ],
     "avatar_url": "<avatar_url>",
+    "is_guest": 0,
     "admin": 0,
     "deactivated": 0,
     "shadow_banned": 0,

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -36,7 +36,6 @@ It returns a JSON body like the following:
     "admin": 0,
     "deactivated": 0,
     "shadow_banned": 0,
-    "password_hash": "$2b$12$p9B4GkqYdRTPGD",
     "creation_ts": 1560432506,
     "appservice_id": null,
     "consent_server_notice_sent": null,

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -15,10 +15,10 @@ server admin: [Admin API](../usage/administration/admin_api)
 
 It returns a JSON body like the following:
 
-```json
+```jsonc
 {
     "name": "@user:example.com",
-    "displayname": "User",
+    "displayname": "User", // can be null if not set
     "threepids": [
         {
             "medium": "email",
@@ -33,7 +33,7 @@ It returns a JSON body like the following:
             "validated_at": 1586458409743
         }
     ],
-    "avatar_url": "<avatar_url>",
+    "avatar_url": "<avatar_url>",  // can be null if not set
     "is_guest": 0,
     "admin": 0,
     "deactivated": 0,

--- a/synapse/handlers/admin.py
+++ b/synapse/handlers/admin.py
@@ -55,21 +55,43 @@ class AdminHandler:
 
     async def get_user(self, user: UserID) -> Optional[JsonDict]:
         """Function to get user details"""
-        ret = await self.store.get_user_by_id(user.to_string())
-        if ret:
-            profile = await self.store.get_profileinfo(user.localpart)
-            threepids = await self.store.user_get_threepids(user.to_string())
-            external_ids = [
-                ({"auth_provider": auth_provider, "external_id": external_id})
-                for auth_provider, external_id in await self.store.get_external_ids_by_user(
-                    user.to_string()
-                )
-            ]
-            ret["displayname"] = profile.display_name
-            ret["avatar_url"] = profile.avatar_url
-            ret["threepids"] = threepids
-            ret["external_ids"] = external_ids
-        return ret
+        user_info_dict = await self.store.get_user_by_id(user.to_string())
+        if user_info_dict is None:
+            return None
+
+        # Restrict returned information to a known set of fields. This prevents additional
+        # fields added to get_user_by_id from modifying Synapse's external API surface.
+        user_info_to_return = [
+            "admin",
+            "deactivated",
+            "shadow_banned",
+            "creation_ts",
+            "appservice_id",
+            "consent_server_notice_sent",
+            "consent_version",
+            "user_type",
+        ]
+
+        # Restrict returned keys to a known set.
+        user_info_dict = {
+            key: value for key, value in user_info_dict if key in user_info_to_return
+        }
+
+        # Add additional user metadata
+        profile = await self.store.get_profileinfo(user.localpart)
+        threepids = await self.store.user_get_threepids(user.to_string())
+        external_ids = [
+            ({"auth_provider": auth_provider, "external_id": external_id})
+            for auth_provider, external_id in await self.store.get_external_ids_by_user(
+                user.to_string()
+            )
+        ]
+        user_info_dict["displayname"] = profile.display_name
+        user_info_dict["avatar_url"] = profile.avatar_url
+        user_info_dict["threepids"] = threepids
+        user_info_dict["external_ids"] = external_ids
+
+        return user_info_dict
 
     async def export_user_data(self, user_id: str, writer: "ExfiltrationWriter") -> Any:
         """Write all data we have on the user to the given writer.

--- a/synapse/handlers/admin.py
+++ b/synapse/handlers/admin.py
@@ -61,7 +61,7 @@ class AdminHandler:
 
         # Restrict returned information to a known set of fields. This prevents additional
         # fields added to get_user_by_id from modifying Synapse's external API surface.
-        user_info_to_return = [
+        user_info_to_return = {
             "name",
             "admin",
             "deactivated",
@@ -72,7 +72,7 @@ class AdminHandler:
             "consent_version",
             "user_type",
             "is_guest",
-        ]
+        }
 
         # Restrict returned keys to a known set.
         user_info_dict = {

--- a/synapse/handlers/admin.py
+++ b/synapse/handlers/admin.py
@@ -62,6 +62,7 @@ class AdminHandler:
         # Restrict returned information to a known set of fields. This prevents additional
         # fields added to get_user_by_id from modifying Synapse's external API surface.
         user_info_to_return = [
+            "name",
             "admin",
             "deactivated",
             "shadow_banned",
@@ -70,11 +71,14 @@ class AdminHandler:
             "consent_server_notice_sent",
             "consent_version",
             "user_type",
+            "is_guest",
         ]
 
         # Restrict returned keys to a known set.
         user_info_dict = {
-            key: value for key, value in user_info_dict if key in user_info_to_return
+            key: value
+            for key, value in user_info_dict.items()
+            if key in user_info_to_return
         }
 
         # Add additional user metadata

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -80,6 +80,7 @@ from synapse.rest.admin.users import (
     UserMembershipRestServlet,
     UserRegisterServlet,
     UserRestServletV2,
+    UserRestServletV3,
     UsersRestServletV2,
     UserTokenRestServlet,
     WhoisRestServlet,
@@ -247,6 +248,7 @@ def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
     UserAdminServlet(hs).register(http_server)
     UserMembershipRestServlet(hs).register(http_server)
     UserTokenRestServlet(hs).register(http_server)
+    UserRestServletV3(hs).register(http_server)
     UserRestServletV2(hs).register(http_server)
     UsersRestServletV2(hs).register(http_server)
     DeviceRestServlet(hs).register(http_server)

--- a/synapse/rest/admin/__init__.py
+++ b/synapse/rest/admin/__init__.py
@@ -80,7 +80,6 @@ from synapse.rest.admin.users import (
     UserMembershipRestServlet,
     UserRegisterServlet,
     UserRestServletV2,
-    UserRestServletV3,
     UsersRestServletV2,
     UserTokenRestServlet,
     WhoisRestServlet,
@@ -248,7 +247,6 @@ def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
     UserAdminServlet(hs).register(http_server)
     UserMembershipRestServlet(hs).register(http_server)
     UserTokenRestServlet(hs).register(http_server)
-    UserRestServletV3(hs).register(http_server)
     UserRestServletV2(hs).register(http_server)
     UsersRestServletV2(hs).register(http_server)
     DeviceRestServlet(hs).register(http_server)

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -135,6 +135,8 @@ class UserRestServletV2(RestServlet):
     returns:
         200 OK with user details if success otherwise an error.
 
+    THIS ENDPOINT IS DEPRECATED IN FAVOUR OF ITS V3 VARIANT.
+
     Put request to allow an administrator to add or modify a user.
     This needs user to have administrator access in Synapse.
     We use PUT instead of POST since we already know the id of the user
@@ -403,6 +405,38 @@ class UserRestServletV2(RestServlet):
             assert user is not None
 
             return 201, user
+
+
+class UserRestServletV3(UserRestServletV2):
+    PATTERNS = admin_patterns("/users/(?P<user_id>[^/]*)$", "v3")
+
+    """Get request to list or update user details.
+
+    This currently only differs from UserRestServletV2 in that it does not return
+    the 'password_hash' field for users.
+    """
+
+    async def on_GET(
+        self, request: SynapseRequest, user_id: str
+    ) -> Tuple[int, JsonDict]:
+        status_code, response_body = await super().on_GET(request, user_id)
+
+        # Remove "password_hash" from the response in v3 of this API
+        if "password_hash" in response_body:
+            del response_body["password_hash"]
+
+        return status_code, response_body
+
+    async def on_PUT(
+        self, request: SynapseRequest, user_id: str
+    ) -> Tuple[int, JsonDict]:
+        status_code, response_body = await super().on_PUT(request, user_id)
+
+        # Remove "password_hash" from the response in v3 of this API
+        if "password_hash" in response_body:
+            del response_body["password_hash"]
+
+        return status_code, response_body
 
 
 class UserRegisterServlet(RestServlet):

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -401,7 +401,7 @@ class UserRestServletV2(RestServlet):
             user_info_dict = await self.admin_handler.get_user(target_user)
             assert user_info_dict is not None
 
-            return 201, user_info_dict
+            return HTTPStatus.CREATED, user_info_dict
 
 
 class UserRegisterServlet(RestServlet):

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -135,8 +135,6 @@ class UserRestServletV2(RestServlet):
     returns:
         200 OK with user details if success otherwise an error.
 
-    THIS ENDPOINT IS DEPRECATED IN FAVOUR OF ITS V3 VARIANT.
-
     Put request to allow an administrator to add or modify a user.
     This needs user to have administrator access in Synapse.
     We use PUT instead of POST since we already know the id of the user
@@ -404,34 +402,6 @@ class UserRestServletV2(RestServlet):
             assert user_info_dict is not None
 
             return 201, user_info_dict
-
-
-class UserRestServletV3(UserRestServletV2):
-    PATTERNS = admin_patterns("/users/(?P<user_id>[^/]*)$", "v3")
-
-    """Get request to list or update user details.
-
-    This currently only differs from UserRestServletV2 in that it does not return
-    the 'password_hash' field for users.
-    """
-
-    async def on_GET(
-        self, request: SynapseRequest, user_id: str
-    ) -> Tuple[int, JsonDict]:
-        status_code, response_body = await super().on_GET(request, user_id)
-
-        return status_code, response_body
-
-    async def on_PUT(
-        self, request: SynapseRequest, user_id: str
-    ) -> Tuple[int, JsonDict]:
-        status_code, response_body = await super().on_PUT(request, user_id)
-
-        # Remove "password_hash" from the response in v3 of this API
-        if "password_hash" in response_body:
-            del response_body["password_hash"]
-
-        return status_code, response_body
 
 
 class UserRegisterServlet(RestServlet):

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -175,12 +175,11 @@ class UserRestServletV2(RestServlet):
         if not self.hs.is_mine(target_user):
             raise SynapseError(HTTPStatus.BAD_REQUEST, "Can only look up local users")
 
-        ret = await self.admin_handler.get_user(target_user)
-
-        if not ret:
+        user_info_dict = await self.admin_handler.get_user(target_user)
+        if not user_info_dict:
             raise NotFoundError("User not found")
 
-        return HTTPStatus.OK, ret
+        return HTTPStatus.OK, user_info_dict
 
     async def on_PUT(
         self, request: SynapseRequest, user_id: str
@@ -401,10 +400,10 @@ class UserRestServletV2(RestServlet):
                     target_user, requester, body["avatar_url"], True
                 )
 
-            user = await self.admin_handler.get_user(target_user)
-            assert user is not None
+            user_info_dict = await self.admin_handler.get_user(target_user)
+            assert user_info_dict is not None
 
-            return 201, user
+            return 201, user_info_dict
 
 
 class UserRestServletV3(UserRestServletV2):
@@ -420,10 +419,6 @@ class UserRestServletV3(UserRestServletV2):
         self, request: SynapseRequest, user_id: str
     ) -> Tuple[int, JsonDict]:
         status_code, response_body = await super().on_GET(request, user_id)
-
-        # Remove "password_hash" from the response in v3 of this API
-        if "password_hash" in response_body:
-            del response_body["password_hash"]
 
         return status_code, response_body
 

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -1154,13 +1154,6 @@ class DeactivateAccountTestCase(unittest.HomeserverTestCase):
             self.assertFalse(self.get_success(d))
 
 
-# Test both v2 and v3 versions of this API
-# TODO: Remove v2 once it is deprecated. Note that this may need to be
-# changed if v3 of the endpoint diverges from v2 significantly
-@parameterized_class(
-    ("endpoint_version",),
-    [("v2",), ("v3",)],
-)
 class UserRestTestCase(unittest.HomeserverTestCase):
 
     servlets = [
@@ -1189,8 +1182,7 @@ class UserRestTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        # self.endpoint_version is set by the @parameterized_class decorator above
-        self.url_prefix = f"/_synapse/admin/{self.endpoint_version}/users/%s"
+        self.url_prefix = "/_synapse/admin/v2/users/%s"
         self.url_other_user = self.url_prefix % self.other_user
 
     def test_requester_is_no_admin(self):
@@ -2098,10 +2090,6 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual("mxc://servername/mediaid", channel.json_body["avatar_url"])
         self.assertEqual("User", channel.json_body["displayname"])
 
-        # This key is removed from v3 of the API
-        if self.endpoint_version == "v2":
-            self.assertIsNone(channel.json_body["password_hash"])
-
         # the user is deactivated, the threepid will be deleted
 
         # Get user
@@ -2117,10 +2105,6 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual(0, len(channel.json_body["threepids"]))
         self.assertEqual("mxc://servername/mediaid", channel.json_body["avatar_url"])
         self.assertEqual("User", channel.json_body["displayname"])
-
-        # Field 'password_hash' has been removed in v3 of this endpoint
-        if self.endpoint_version == "v2":
-            self.assertIsNone(channel.json_body["password_hash"])
 
     @override_config({"user_directory": {"enabled": True, "search_all_users": True}})
     def test_change_name_deactivate_user_user_directory(self):
@@ -2195,10 +2179,6 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertFalse(channel.json_body["deactivated"])
         self._is_erased("@user:test", False)
 
-        # This key is removed from v3 of the API
-        if self.endpoint_version == "v2":
-            self.assertIsNotNone(channel.json_body["password_hash"])
-
     @override_config({"password_config": {"localdb_enabled": False}})
     def test_reactivate_user_localdb_disabled(self):
         """
@@ -2230,10 +2210,6 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertFalse(channel.json_body["deactivated"])
         self._is_erased("@user:test", False)
 
-        # This key is removed from v3 of the API
-        if self.endpoint_version == "v2":
-            self.assertIsNone(channel.json_body["password_hash"])
-
     @override_config({"password_config": {"enabled": False}})
     def test_reactivate_user_password_disabled(self):
         """
@@ -2264,10 +2240,6 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual("@user:test", channel.json_body["name"])
         self.assertFalse(channel.json_body["deactivated"])
         self._is_erased("@user:test", False)
-
-        # This key is removed from v3 of the API
-        if self.endpoint_version == "v2":
-            self.assertIsNone(channel.json_body["password_hash"])
 
     def test_set_user_as_admin(self):
         """
@@ -2428,10 +2400,6 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertIsNone(self.get_success(d))
         self._is_erased(user_id, True)
 
-        # This key is removed from v3 of the API
-        if self.endpoint_version == "v2":
-            self.assertIsNone(channel.json_body["password_hash"])
-
     def _check_fields(self, content: JsonDict):
         """Checks that the expected user attributes are present in content
 
@@ -2449,12 +2417,6 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertIn("consent_server_notice_sent", content)
         self.assertIn("consent_version", content)
         self.assertIn("external_ids", content)
-
-        # This key is removed from v3 of the API
-        if self.endpoint_version == "v2":
-            self.assertIn("password_hash", content)
-        else:
-            self.assertNotIn("password_hash", content)
 
 
 class UserMembershipRestTestCase(unittest.HomeserverTestCase):

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -2090,6 +2090,9 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual("mxc://servername/mediaid", channel.json_body["avatar_url"])
         self.assertEqual("User", channel.json_body["displayname"])
 
+        # This key was removed intentionally. Ensure it is not accidentally re-included.
+        self.assertNotIn("password_hash", channel.json_body)
+
         # the user is deactivated, the threepid will be deleted
 
         # Get user
@@ -2105,6 +2108,9 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual(0, len(channel.json_body["threepids"]))
         self.assertEqual("mxc://servername/mediaid", channel.json_body["avatar_url"])
         self.assertEqual("User", channel.json_body["displayname"])
+
+        # This key was removed intentionally. Ensure it is not accidentally re-included.
+        self.assertNotIn("password_hash", channel.json_body)
 
     @override_config({"user_directory": {"enabled": True, "search_all_users": True}})
     def test_change_name_deactivate_user_user_directory(self):
@@ -2179,6 +2185,9 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertFalse(channel.json_body["deactivated"])
         self._is_erased("@user:test", False)
 
+        # This key was removed intentionally. Ensure it is not accidentally re-included.
+        self.assertNotIn("password_hash", channel.json_body)
+
     @override_config({"password_config": {"localdb_enabled": False}})
     def test_reactivate_user_localdb_disabled(self):
         """
@@ -2210,6 +2219,9 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertFalse(channel.json_body["deactivated"])
         self._is_erased("@user:test", False)
 
+        # This key was removed intentionally. Ensure it is not accidentally re-included.
+        self.assertNotIn("password_hash", channel.json_body)
+
     @override_config({"password_config": {"enabled": False}})
     def test_reactivate_user_password_disabled(self):
         """
@@ -2240,6 +2252,9 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertEqual("@user:test", channel.json_body["name"])
         self.assertFalse(channel.json_body["deactivated"])
         self._is_erased("@user:test", False)
+
+        # This key was removed intentionally. Ensure it is not accidentally re-included.
+        self.assertNotIn("password_hash", channel.json_body)
 
     def test_set_user_as_admin(self):
         """
@@ -2400,6 +2415,9 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertIsNone(self.get_success(d))
         self._is_erased(user_id, True)
 
+        # This key was removed intentionally. Ensure it is not accidentally re-included.
+        self.assertNotIn("password_hash", channel.json_body)
+
     def _check_fields(self, content: JsonDict):
         """Checks that the expected user attributes are present in content
 
@@ -2417,6 +2435,9 @@ class UserRestTestCase(unittest.HomeserverTestCase):
         self.assertIn("consent_server_notice_sent", content)
         self.assertIn("consent_version", content)
         self.assertIn("external_ids", content)
+
+        # This key was removed intentionally. Ensure it is not accidentally re-included.
+        self.assertNotIn("password_hash", content)
 
 
 class UserMembershipRestTestCase(unittest.HomeserverTestCase):


### PR DESCRIPTION
A `password_hash` field is returned by both `GET` and `PUT` methods of `/_synapse/admin/v2/users/<user_id>`. There is little use for this to be returned, and returning it is an unnecessary security risk.

Note that I don't believe this field was included on purpose. It is simple a consequence of using `get_user_by_id` directly for this Admin API endpoint (which we probably shouldn't do, as it means that changing an internal storage method changes an external API shape!).

~~As this is a backwards-incompatible change, the endpoint version has been bumped.~~ This ended up being considered a bug, slight security risk, and not intentionally included in the first place. Additionally, we're not aware of any usecases for it. Thus we have simply dropped it from the existing v2 API.

Reviewable commit-by-commit.