### PR TITLE
Disable aggregation bundling on `/sync` responses

### DIFF
--- a/changelog.d/11583.bugfix
+++ b/changelog.d/11583.bugfix
@@ -1,0 +1,1 @@
+Fix a performance regression in `/sync` handling, introduced in 1.49.0.

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -522,7 +522,13 @@ class SyncRestServlet(RestServlet):
                 time_now=time_now,
                 # Don't bother to bundle aggregations if the timeline is unlimited,
                 # as clients will have all the necessary information.
-                bundle_aggregations=room.timeline.limited,
+                # bundle_aggregations=room.timeline.limited,
+                #
+                # richvdh 2021-12-15: disable this temporarily as it has too high an
+                # overhead for initialsyncs. We need to figure out a way that the
+                # bundling can be done *before* the events are stored in the
+                # SyncResponseCache so that this part can be synchronous.
+                bundle_aggregations=False,
                 token_id=token_id,
                 event_format=event_formatter,
                 only_event_fields=only_fields,


### PR DESCRIPTION
A partial revert of #11478. This turns out to have had a significant CPU impact on initial-sync handling. For now, let's disable it, until we find a more efficient way of achieving this.

(PR targeting `release-v1.49` while we decide if we want to make a 1.49.1 for this)