### PR TITLE
Fix get federation status of destination if no error occured

### DIFF
--- a/changelog.d/11593.bugfix
+++ b/changelog.d/11593.bugfix
@@ -1,1 +1,1 @@
-Fix an error to get federation status of a destination server even if no error has occurred.
+Fix an error in to get federation status of a destination server even if no error has occurred. This admin API was new introduced in Synapse 1.49.0.

--- a/changelog.d/11593.bugfix
+++ b/changelog.d/11593.bugfix
@@ -1,0 +1,1 @@
+Fix an error to get federation status of a destination server even if no error has occurred.

--- a/synapse/rest/admin/federation.py
+++ b/synapse/rest/admin/federation.py
@@ -111,7 +111,7 @@ class DestinationsRestServlet(RestServlet):
     ) -> Tuple[int, JsonDict]:
         await assert_requester_is_admin(self._auth, request)
 
-        if not await self._store.is_destination(destination):
+        if not await self._store.is_destination_known(destination):
             raise NotFoundError("Unknown destination")
 
         destination_retry_timings = await self._store.get_destination_retry_timings(

--- a/synapse/rest/admin/federation.py
+++ b/synapse/rest/admin/federation.py
@@ -118,30 +118,30 @@ class DestinationsRestServlet(RestServlet):
             destination
         )
 
-        retry_timing_response: JsonDict = {}
-        if destination_retry_timings:
-            retry_timing_response = {
-                "failure_ts": destination_retry_timings.failure_ts,
-                "retry_last_ts": destination_retry_timings.retry_last_ts,
-                "retry_interval": destination_retry_timings.retry_interval,
-            }
-        else:
-            retry_timing_response = {
-                "failure_ts": None,
-                "retry_last_ts": 0,
-                "retry_interval": 0,
-            }
-
         last_successful_stream_ordering = (
             await self._store.get_destination_last_successful_stream_ordering(
                 destination
             )
         )
 
-        response = {
+        response: JsonDict = {
             "destination": destination,
             "last_successful_stream_ordering": last_successful_stream_ordering,
-            **retry_timing_response,
         }
+
+        if destination_retry_timings:
+            response = {
+                **response,
+                "failure_ts": destination_retry_timings.failure_ts,
+                "retry_last_ts": destination_retry_timings.retry_last_ts,
+                "retry_interval": destination_retry_timings.retry_interval,
+            }
+        else:
+            response = {
+                **response,
+                "failure_ts": None,
+                "retry_last_ts": 0,
+                "retry_interval": 0,
+            }
 
         return HTTPStatus.OK, response

--- a/synapse/rest/admin/federation.py
+++ b/synapse/rest/admin/federation.py
@@ -118,15 +118,15 @@ class DestinationsRestServlet(RestServlet):
             destination
         )
 
-        retry_timing_respone: JsonDict = {}
+        retry_timing_response: JsonDict = {}
         if destination_retry_timings:
-            retry_timing_respone = {
+            retry_timing_response = {
                 "failure_ts": destination_retry_timings.failure_ts,
                 "retry_last_ts": destination_retry_timings.retry_last_ts,
                 "retry_interval": destination_retry_timings.retry_interval,
             }
         else:
-            retry_timing_respone = {
+            retry_timing_response = {
                 "failure_ts": None,
                 "retry_last_ts": 0,
                 "retry_interval": 0,
@@ -141,7 +141,7 @@ class DestinationsRestServlet(RestServlet):
         response = {
             "destination": destination,
             "last_successful_stream_ordering": last_successful_stream_ordering,
-            **retry_timing_respone,
+            **retry_timing_response,
         }
 
         return HTTPStatus.OK, response

--- a/synapse/storage/databases/main/transactions.py
+++ b/synapse/storage/databases/main/transactions.py
@@ -559,3 +559,13 @@ class TransactionWorkerStore(CacheInvalidationWorkerStore):
         return await self.db_pool.runInteraction(
             "get_destinations_paginate_txn", get_destinations_paginate_txn
         )
+
+    async def is_destination(self, destination: str) -> Optional[bool]:
+        """Function to check if a destination is a destination of this server."""
+        return await self.db_pool.simple_select_one_onecol(
+            table="destinations",
+            keyvalues={"destination": destination},
+            retcol="1",
+            allow_none=True,
+            desc="is_destination",
+        )

--- a/synapse/storage/databases/main/transactions.py
+++ b/synapse/storage/databases/main/transactions.py
@@ -561,12 +561,13 @@ class TransactionWorkerStore(CacheInvalidationWorkerStore):
             "get_destinations_paginate_txn", get_destinations_paginate_txn
         )
 
-    async def is_destination(self, destination: str) -> Optional[bool]:
-        """Function to check if a destination is a destination of this server."""
-        return await self.db_pool.simple_select_one_onecol(
+    async def is_destination_known(self, destination: str) -> bool:
+        """Check if a destination is known to the server."""
+        result = await self.db_pool.simple_select_one_onecol(
             table="destinations",
             keyvalues={"destination": destination},
             retcol="1",
             allow_none=True,
-            desc="is_destination",
+            desc="is_destination_known",
         )
+        return bool(result)

--- a/tests/rest/admin/test_federation.py
+++ b/tests/rest/admin/test_federation.py
@@ -311,15 +311,12 @@ class FederationTestCase(unittest.HomeserverTestCase):
             retry_interval,
             last_successful_stream_ordering,
         ) in dest:
-            self.get_success(
-                self.store.set_destination_retry_timings(
-                    destination, failure_ts, retry_last_ts, retry_interval
-                )
-            )
-            self.get_success(
-                self.store.set_destination_last_successful_stream_ordering(
-                    destination, last_successful_stream_ordering
-                )
+            self._create_destination(
+                destination,
+                failure_ts,
+                retry_last_ts,
+                retry_interval,
+                last_successful_stream_ordering,
             )
 
         # order by default (destination)
@@ -410,11 +407,9 @@ class FederationTestCase(unittest.HomeserverTestCase):
         _search_test(None, "foo")
         _search_test(None, "bar")
 
-    def test_get_single_destination(self):
-        """
-        Get one specific destinations.
-        """
-        self._create_destinations(5)
+    def test_get_single_destination_with_retry_timings(self) -> None:
+        """Get one specific destination which has retry timings."""
+        self._create_destinations(1)
 
         channel = self.make_request(
             "GET",
@@ -429,7 +424,53 @@ class FederationTestCase(unittest.HomeserverTestCase):
         # convert channel.json_body into a List
         self._check_fields([channel.json_body])
 
-    def _create_destinations(self, number_destinations: int):
+    def test_get_single_destination_no_retry_timings(self) -> None:
+        """Get one specific destination which has no retry timings."""
+        self._create_destination("sub0.example.com")
+
+        channel = self.make_request(
+            "GET",
+            self.url + "/sub0.example.com",
+            access_token=self.admin_user_tok,
+        )
+
+        self.assertEqual(HTTPStatus.OK, channel.code, msg=channel.json_body)
+        self.assertEqual("sub0.example.com", channel.json_body["destination"])
+        self.assertEqual(0, channel.json_body["retry_last_ts"])
+        self.assertEqual(0, channel.json_body["retry_interval"])
+        self.assertIsNone(channel.json_body["failure_ts"])
+        self.assertIsNone(channel.json_body["last_successful_stream_ordering"])
+
+    def _create_destination(
+        self,
+        destination: str,
+        failure_ts: Optional[int] = None,
+        retry_last_ts: int = 0,
+        retry_interval: int = 0,
+        last_successful_stream_ordering: Optional[int] = None,
+    ) -> None:
+        """Create one specific destination
+
+        Args:
+            destination: the destination we have successfully sent to
+            failure_ts: when the server started failing (ms since epoch)
+            retry_last_ts: time of last retry attempt in unix epoch ms
+            retry_interval: how long until next retry in ms
+            last_successful_stream_ordering: the stream_ordering of the most
+                recent successfully-sent PDU
+        """
+        self.get_success(
+            self.store.set_destination_retry_timings(
+                destination, failure_ts, retry_last_ts, retry_interval
+            )
+        )
+        self.get_success(
+            self.store.set_destination_last_successful_stream_ordering(
+                destination, last_successful_stream_ordering
+            )
+        )
+
+    def _create_destinations(self, number_destinations: int) -> None:
         """Create a number of destinations
 
         Args:
@@ -437,10 +478,7 @@ class FederationTestCase(unittest.HomeserverTestCase):
         """
         for i in range(0, number_destinations):
             dest = f"sub{i}.example.com"
-            self.get_success(self.store.set_destination_retry_timings(dest, 50, 50, 50))
-            self.get_success(
-                self.store.set_destination_last_successful_stream_ordering(dest, 100)
-            )
+            self._create_destination(dest, 50, 50, 50, 100)
 
     def _check_fields(self, content: List[JsonDict]):
         """Checks that the expected destination attributes are present in content

--- a/tests/rest/admin/test_federation.py
+++ b/tests/rest/admin/test_federation.py
@@ -464,11 +464,12 @@ class FederationTestCase(unittest.HomeserverTestCase):
                 destination, failure_ts, retry_last_ts, retry_interval
             )
         )
-        self.get_success(
-            self.store.set_destination_last_successful_stream_ordering(
-                destination, last_successful_stream_ordering
+        if last_successful_stream_ordering is not None:
+            self.get_success(
+                self.store.set_destination_last_successful_stream_ordering(
+                    destination, last_successful_stream_ordering
+                )
             )
-        )
 
     def _create_destinations(self, number_destinations: int) -> None:
         """Create a number of destinations


### PR DESCRIPTION
At the moment you get a `NotFoundError` if you request `GET /_synapse/admin/v1/federation/destinations/<destination>` and the destination has no problems.

The reason is that `get_destination_retry_timings` returns `None` if there is no problem with the destination.

This PR fix it:
- add DB function to query that a destination exists
- update rest API
- add a test

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Dirk Klimpel dirk@klimpel.org
