### PR TITLE
Return JSON errors instead of HTML errors for unknown resources. 

### DIFF
--- a/changelog.d/11602.bugfix
+++ b/changelog.d/11602.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug that some unknown endpoints would return HTML 404 errors instead of JSON 400 errors.

--- a/changelog.d/11602.bugfix
+++ b/changelog.d/11602.bugfix
@@ -1,1 +1,1 @@
-Fix a long-standing bug that some unknown endpoints would return HTTP 404 errors instead of JSON `M_UNRECOGNIZED` errors.
+Fix a long-standing bug that some unknown endpoints would return HTML error pages instead of JSON `M_UNRECOGNIZED` errors.

--- a/changelog.d/11602.bugfix
+++ b/changelog.d/11602.bugfix
@@ -1,1 +1,1 @@
-Fix a long-standing bug that some unknown endpoints would return HTML 404 errors instead of JSON 400 errors.
+Fix a long-standing bug that some unknown endpoints would return HTTP 404 errors instead of JSON `M_UNRECOGNIZED` errors.

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -27,6 +27,7 @@ import synapse
 import synapse.config.logger
 from synapse import events
 from synapse.api.urls import (
+    CLIENT_API_PREFIX,
     FEDERATION_PREFIX,
     LEGACY_MEDIA_PREFIX,
     MEDIA_R0_PREFIX,
@@ -192,13 +193,7 @@ class SynapseHomeServer(HomeServer):
 
             resources.update(
                 {
-                    "/_matrix/client/api/v1": client_resource,
-                    "/_matrix/client/r0": client_resource,
-                    "/_matrix/client/v1": client_resource,
-                    "/_matrix/client/v3": client_resource,
-                    "/_matrix/client/unstable": client_resource,
-                    "/_matrix/client/v2_alpha": client_resource,
-                    "/_matrix/client/versions": client_resource,
+                    CLIENT_API_PREFIX: client_resource,
                     "/.well-known": well_known_resource(self),
                     "/_synapse/admin": AdminRestResource(self),
                     **build_synapse_client_resource_tree(self),

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -559,6 +559,17 @@ class OptionsResource(resource.Resource):
         return super().getChildWithDefault(path, request)
 
 
+class MissingResource(resource.Resource):
+    """Similar to resource.NoResource, but returns a JSON error with proper CORS headers."""
+
+    def render(self, request: SynapseRequest) -> int:
+        return_json_error(failure.Failure(UnrecognizedRequestError()), request)
+        return NOT_DONE_YET
+
+    def getChild(self, name: str, request: Request) -> resource.Resource:
+        return self
+
+
 class RootOptionsRedirectResource(OptionsResource, RootRedirect):
     pass
 

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -559,17 +559,6 @@ class OptionsResource(resource.Resource):
         return super().getChildWithDefault(path, request)
 
 
-class MissingResource(resource.Resource):
-    """Similar to resource.NoResource, but returns a JSON error with proper CORS headers."""
-
-    def render(self, request: SynapseRequest) -> int:
-        return_json_error(failure.Failure(UnrecognizedRequestError()), request)
-        return NOT_DONE_YET
-
-    def getChild(self, name: str, request: Request) -> resource.Resource:
-        return self
-
-
 class RootOptionsRedirectResource(OptionsResource, RootRedirect):
     pass
 

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -530,7 +530,7 @@ class RootRedirect(resource.Resource):
     """Redirects the root '/' path to another path."""
 
     def __init__(self, path: str):
-        resource.Resource.__init__(self)
+        super().__init__()
         self.url = path
 
     def render_GET(self, request: Request) -> bytes:
@@ -539,7 +539,7 @@ class RootRedirect(resource.Resource):
     def getChild(self, name: str, request: Request) -> resource.Resource:
         if len(name) == 0:
             return self  # select ourselves as the child to render
-        return resource.Resource.getChild(self, name, request)
+        return super().getChild(name, request)
 
 
 class OptionsResource(resource.Resource):
@@ -556,7 +556,7 @@ class OptionsResource(resource.Resource):
     def getChildWithDefault(self, path: str, request: Request) -> resource.Resource:
         if request.method == b"OPTIONS":
             return self  # select ourselves as the child to render
-        return resource.Resource.getChildWithDefault(self, path, request)
+        return super().getChildWithDefault(path, request)
 
 
 class RootOptionsRedirectResource(OptionsResource, RootRedirect):

--- a/synapse/util/httpresourcetree.py
+++ b/synapse/util/httpresourcetree.py
@@ -15,9 +15,7 @@
 import logging
 from typing import Dict
 
-from twisted.web.resource import Resource
-
-from synapse.http.server import MissingResource
+from twisted.web.resource import NoResource, Resource
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +49,7 @@ def create_resource_tree(
         for path_seg in full_path.split(b"/")[1:-1]:
             if path_seg not in last_resource.listNames():
                 # resource doesn't exist, so make a "dummy resource"
-                child_resource: Resource = MissingResource()
+                child_resource: Resource = NoResource()
                 last_resource.putChild(path_seg, child_resource)
                 res_id = _resource_id(last_resource, path_seg)
                 resource_mappings[res_id] = child_resource

--- a/synapse/util/httpresourcetree.py
+++ b/synapse/util/httpresourcetree.py
@@ -15,7 +15,9 @@
 import logging
 from typing import Dict
 
-from twisted.web.resource import NoResource, Resource
+from twisted.web.resource import Resource
+
+from synapse.http.server import MissingResource
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +51,7 @@ def create_resource_tree(
         for path_seg in full_path.split(b"/")[1:-1]:
             if path_seg not in last_resource.listNames():
                 # resource doesn't exist, so make a "dummy resource"
-                child_resource: Resource = NoResource()
+                child_resource: Resource = MissingResource()
                 last_resource.putChild(path_seg, child_resource)
                 res_id = _resource_id(last_resource, path_seg)
                 resource_mappings[res_id] = child_resource


### PR DESCRIPTION
Fixes #11600 by returning JSON errors with CORS for unknown URLs from prefixes.

You can test this before/after this change via:

```bash
$ curl http://localhost:8080/_matrix/client/v2/foo
$ curl -vv -X OPTIONS http://localhost:8080/_matrix/client/v2/foo
$ curl http://localhost:8080/_matrix/client/v2/
$ curl http://localhost:8080/_matrix/client/
```

These now all return something like:

```json
{"errcode":"M_UNRECOGNIZED","error":"Unrecognized request"}
```

instead of:

```html
<html>
  <head><title>404 - No Such Resource</title></head>
  <body>
    <h1>No Such Resource</h1>
    <p>Sorry. No luck finding that resource.</p>
  </body>
</html>
```