### PR TITLE
Add opentracing types

### DIFF
--- a/changelog.d/11603.misc
+++ b/changelog.d/11603.misc
@@ -1,0 +1,1 @@
+Add opentracing type stubs and fix associated mypy errors.

--- a/mypy.ini
+++ b/mypy.ini
@@ -286,9 +286,6 @@ ignore_missing_imports = True
 [mypy-netaddr]
 ignore_missing_imports = True
 
-[mypy-opentracing]
-ignore_missing_imports = True
-
 [mypy-parameterized.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ CONDITIONAL_REQUIREMENTS["mypy"] = [
     "mypy-zope==0.3.2",
     "types-bleach>=4.1.0",
     "types-jsonschema>=3.2.0",
+    "types-opentracing>=2.4.2",
     "types-Pillow>=8.3.4",
     "types-pyOpenSSL>=20.0.7",
     "types-PyYAML>=5.4.10",

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -168,10 +168,9 @@ import inspect
 import logging
 import re
 from functools import wraps
-from typing import TYPE_CHECKING, Collection, Dict, List, Optional, Pattern, Type, Union
+from typing import TYPE_CHECKING, Collection, Dict, List, Optional, Pattern, Type
 
 import attr
-from mypy.typeshed.stdlib.modulefinder import Module
 
 from twisted.internet import defer
 from twisted.web.http_headers import Headers
@@ -216,6 +215,7 @@ class _DummyTagNames:
     SPAN_KIND_PRODUCER = INVALID_TAG
     SPAN_KIND_RPC_CLIENT = INVALID_TAG
     SPAN_KIND_RPC_SERVER = INVALID_TAG
+
 
 try:
     import opentracing
@@ -553,7 +553,7 @@ def start_active_span_from_edu(
     references = references or []
 
     if opentracing is None:
-        return noop_context_manager() # type: ignore[unreachable]
+        return noop_context_manager()  # type: ignore[unreachable]
 
     carrier = json_decoder.decode(edu_content.get("context", "{}")).get(
         "opentracing", {}

--- a/synapse/logging/scopecontextmanager.py
+++ b/synapse/logging/scopecontextmanager.py
@@ -71,7 +71,7 @@ class LogContextScopeManager(ScopeManager):
         if not ctx:
             # We don't want this scope to affect.
             logger.error("Tried to activate scope outside of loggingcontext")
-            return Scope(None, span)
+            return Scope(None, span)  # type: ignore[arg-type]
         elif ctx.scope is not None:
             # We want the logging scope to look exactly the same so we give it
             # a blank suffix


### PR DESCRIPTION
This one was a little tricky due to the conditional import. After some consultation it was decided it was prudent to ignore the case where `opentracing` is set to `None`, rather than doing a larger refactor that is difficult to test. Happy to do it a different way but I figure this way would allow the types to be used and still checks that we are using `opentracing` correctly in this file, and doesn't involve a non-negligible refactor. 