### PR TITLE
Cap the number of in-flight requests for state from a single group

### DIFF
--- a/changelog.d/11608.misc
+++ b/changelog.d/11608.misc
@@ -1,0 +1,1 @@
+Deduplicate in-flight requests in `_get_state_for_groups`.

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -294,13 +294,15 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
                 # to cover our StateFilter and give us the state we need.
                 break
 
-        if state_filter_left_over != StateFilter.none():
-            if len(inflight_requests) >= MAX_INFLIGHT_REQUESTS_PER_GROUP:
-                # There are too many requests for this group.
-                # To prevent even more from building up, we request the whole
-                # state filter to guarantee that we can be reused by any subsequent
-                # requests for this state group.
-                return (), StateFilter.all()
+        if (
+            state_filter_left_over != StateFilter.none()
+            and len(inflight_requests) >= MAX_INFLIGHT_REQUESTS_PER_GROUP
+        ):
+            # There are too many requests for this group.
+            # To prevent even more from building up, we request the whole
+            # state filter to guarantee that we can be reused by any subsequent
+            # requests for this state group.
+            return (), StateFilter.all()
 
         return reusable_requests, state_filter_left_over
 

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 MAX_STATE_DELTA_HOPS = 100
+MAX_INFLIGHT_REQUESTS_PER_GROUP = 5
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
@@ -258,6 +259,11 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
         Attempts to gather in-flight requests and re-use them to retrieve state
         for the given state group, filtered with the given state filter.
 
+        If there are more than MAX_INFLIGHT_REQUESTS_PER_GROUP in-flight requests,
+        and there *still* isn't enough information to complete the request by solely
+        reusing others, a full state filter will be requested to ensure that subsequent
+        requests can reuse this request.
+
         Used as part of _get_state_for_group_using_inflight_cache.
 
         Returns:
@@ -287,6 +293,14 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
                 # we have managed to collect enough of the in-flight requests
                 # to cover our StateFilter and give us the state we need.
                 break
+
+        if state_filter_left_over != StateFilter.none():
+            if len(inflight_requests) >= MAX_INFLIGHT_REQUESTS_PER_GROUP:
+                # There are too many requests for this group.
+                # To prevent even more from building up, we request the whole
+                # state filter to guarantee that we can be reused by any subsequent
+                # requests for this state group.
+                return (), StateFilter.all()
 
         return reusable_requests, state_filter_left_over
 

--- a/tests/storage/databases/test_state_store.py
+++ b/tests/storage/databases/test_state_store.py
@@ -138,7 +138,8 @@ class StateGroupInflightCachingTestCase(HomeserverTestCase):
         Tests that the number of in-flight requests is capped to 5.
 
         - requests several pieces of state separately
-          (5 to hit the limit, 1 to 'shunt out', another that
+          (5 to hit the limit, 1 to 'shunt out', another that comes after the
+          group has been 'shunted out')
         - checks to see that the torrent of requests is shunted out by
           rewriting one of the filters as the 'all' state filter
         - requests after that one do not cause any additional queries

--- a/tests/storage/databases/test_state_store.py
+++ b/tests/storage/databases/test_state_store.py
@@ -143,7 +143,8 @@ class StateGroupInflightCachingTestCase(HomeserverTestCase):
           rewriting one of the filters as the 'all' state filter
         - requests after that one do not cause any additional queries
         """
-        CAP_COUNT = 5
+        # 5 at the time of writing.
+        CAP_COUNT = MAX_INFLIGHT_REQUESTS_PER_GROUP
 
         reqs = []
 

--- a/tests/storage/databases/test_state_store.py
+++ b/tests/storage/databases/test_state_store.py
@@ -148,7 +148,7 @@ class StateGroupInflightCachingTestCase(HomeserverTestCase):
 
         reqs = []
 
-        # Request 7 different keys (1..=7) of the `some.state` type.
+        # Request 7 different keys (1 to 7) of the `some.state` type.
         for req_id in range(CAP_COUNT + 2):
             reqs.append(
                 ensureDeferred(


### PR DESCRIPTION
Small incremental change above #10870 that prevents too many concurrent requests being in-flight for a single state group, by just requesting the whole state filter from the database.

