### PR TITLE
Order in-flight state group queries in biggest-first order

### DIFF
--- a/changelog.d/11610.misc
+++ b/changelog.d/11610.misc
@@ -1,0 +1,1 @@
+Deduplicate in-flight requests in `_get_state_for_groups`.

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -85,7 +85,7 @@ def state_filter_rough_priority_comparator(
     have any particular meaning. The representation may also change
 
     The current implementation returns a tuple of the form:
-        * -1 for include_others, -0 otherwise
+        * -1 for include_others, 0 otherwise
         * -(number of entries in state_filter.types)
     """
     return -int(state_filter.include_others), -len(state_filter.types)

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -72,6 +72,26 @@ class _GetStateGroupDelta:
         return len(self.delta_ids) if self.delta_ids else 0
 
 
+# Return type of state_filter_rough_size_comparator. Must be comparable.
+StateFilterRoughSizeComparator = Tuple[int, int]
+
+
+def state_filter_rough_size_comparator(
+    state_filter: StateFilter,
+) -> StateFilterRoughSizeComparator:
+    """
+    Returns a comparable value that roughly indicates the relative size of this
+    state filter compared to others.
+    It should be treated as a rough guide only and should not be interpreted to
+    have any particular meaning. The representation may also change
+
+    The current implementation returns a tuple of the form:
+        * 1 for include_others, 0 otherwise
+        * number of entries in state_filter.types
+    """
+    return int(state_filter.include_others), len(state_filter.types)
+
+
 class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
     """A data store for fetching/storing state groups."""
 

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -73,13 +73,9 @@ class _GetStateGroupDelta:
         return len(self.delta_ids) if self.delta_ids else 0
 
 
-# Return type of state_filter_rough_size_comparator. Must be comparable.
-StateFilterRoughSizeComparator = Tuple[int, int]
-
-
 def state_filter_rough_size_comparator(
     state_filter: StateFilter,
-) -> StateFilterRoughSizeComparator:
+) -> Tuple[int, int]:
     """
     Returns a comparable value that roughly indicates the relative size of this
     state filter compared to others.

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -300,7 +300,12 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
 
         # The list of ongoing requests which will help narrow the current request.
         reusable_requests = []
-        for (request_state_filter, request_deferred) in inflight_requests.items():
+
+        # Iterate over existing requests in roughly biggest-first order.
+        # reversed(inflight_requests) has an efficient iterator implementation,
+        # but reversed(inflight_requests.items()) does not, sadly.
+        for request_state_filter in reversed(inflight_requests):
+            request_deferred = inflight_requests[request_state_filter]
             new_state_filter_left_over = state_filter_left_over.approx_difference(
                 request_state_filter
             )

--- a/tests/storage/databases/test_state_store.py
+++ b/tests/storage/databases/test_state_store.py
@@ -23,7 +23,7 @@ from twisted.test.proto_helpers import MemoryReactor
 from synapse.api.constants import EventTypes
 from synapse.storage.databases.state.store import (
     MAX_INFLIGHT_REQUESTS_PER_GROUP,
-    state_filter_rough_size_comparator,
+    state_filter_rough_priority_comparator,
 )
 from synapse.storage.state import StateFilter
 from synapse.types import StateMap
@@ -409,9 +409,11 @@ class StateGroupInflightCachingTestCase(HomeserverTestCase):
             biggest_state_filter_idx = 1
 
         # This assertion is for our own sanity more than anything else.
-        self.assertGreater(
-            state_filter_rough_size_comparator(state_filters[biggest_state_filter_idx]),
-            state_filter_rough_size_comparator(
+        self.assertLess(
+            state_filter_rough_priority_comparator(
+                state_filters[biggest_state_filter_idx]
+            ),
+            state_filter_rough_priority_comparator(
                 state_filters[smallest_state_filter_idx]
             ),
             "Test invalid: bigger state filter is not actually bigger.",


### PR DESCRIPTION
The rough idea is that we should favour re-using a small number of broad state filters that are already in-flight, rather than needing to wait for them ALL.

Builds on #10870 and #11608.
