### PR TITLE
Fix mypy error with opentracing.tags.

### DIFF
--- a/changelog.d/11622.misc
+++ b/changelog.d/11622.misc
@@ -1,0 +1,1 @@
+Add opentracing type stubs and fix associated mypy errors.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -220,6 +220,7 @@ class _DummyTagNames:
 
 try:
     import opentracing
+    import opentracing.tags
 
     tags = opentracing.tags
 except ImportError:


### PR DESCRIPTION
On `develop` I was getting an error with mypy:

```
synapse/logging/opentracing.py:224: error: Module has no attribute "tags"  [attr-defined]
synapse/logging/opentracing.py:587: error: Module has no attribute "tags"  [attr-defined]
```

I think this is due to the `tags` module under `opentracing` not being imported anywhere, but used. This generally works, but is poor form.