### PR TITLE
Do not attempt to bundled aggregations for /members and /state.

### DIFF
--- a/changelog.d/11623.bugfix
+++ b/changelog.d/11623.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where responses included bundled aggregations when they should not, per [MSC2675](https://github.com/matrix-org/matrix-doc/pull/2675).

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -246,9 +246,7 @@ class MessageHandler:
                 room_state = room_state_events[membership_event_id]
 
         now = self.clock.time_msec()
-        events = await self._event_serializer.serialize_events(
-            room_state.values(), now, bundle_aggregations=True
-        )
+        events = await self._event_serializer.serialize_events(room_state.values(), now)
         return events
 
     async def get_joined_members(self, requester: Requester, room_id: str) -> dict:


### PR DESCRIPTION
I made a minor mistake in #11592 where it requested to bundle aggregations when fetching the room state for `/members` and `/state` -- the bundled aggregations wouldn't actually get added ([since we don't include them for state events](https://github.com/matrix-org/synapse/blob/dd4778875213d9cb8be7ee71d32751fbd6cdaba2/synapse/events/utils.py#L430)), but it means that we're "opting-in" to something that makes no sense for the APIs.