### PR TITLE
Better error messages from `get_create_event_for_room`

### DIFF
--- a/changelog.d/11638.misc
+++ b/changelog.d/11638.misc
@@ -1,0 +1,1 @@
+Improve the error messages from  `get_create_event_for_room`.

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -191,11 +191,15 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
             NotFoundError if the room is unknown
         """
         state_ids = await self.get_current_state_ids(room_id)
+
+        if not state_ids:
+            raise NotFoundError(f"Current state for room {room_id} is empty")
+
         create_id = state_ids.get((EventTypes.Create, ""))
 
         # If we can't find the create event, assume we've hit a dead end
         if not create_id:
-            raise NotFoundError("Unknown room %s" % (room_id,))
+            raise NotFoundError(f"No create event in current state for room {room_id}")
 
         # Retrieve the room's create event and return
         create_event = await self.get_event(create_id)


### PR DESCRIPTION
"Unknown room" can mean a multitude of things here. To help with debugging, add
some more words to the exception text.