### PR TITLE
Include the topic event in the prejoin state, per MSC3173.

### DIFF
--- a/changelog.d/11666.feature
+++ b/changelog.d/11666.feature
@@ -1,0 +1,1 @@
+Include the room topic in the stripped state included with invites and knocking.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1488,6 +1488,7 @@ room_prejoin_state:
    # - m.room.encryption
    # - m.room.name
    # - m.room.create
+   # - m.room.topic
    #
    # Uncomment the following to disable these defaults (so that only the event
    # types listed in 'additional_event_types' are shared). Defaults to 'false'.

--- a/synapse/config/api.py
+++ b/synapse/config/api.py
@@ -107,6 +107,8 @@ _DEFAULT_PREJOIN_STATE_TYPES = [
     EventTypes.Name,
     # Per MSC1772.
     EventTypes.Create,
+    # Per MSC3173.
+    EventTypes.Topic,
 ]
 
 

--- a/tests/federation/transport/test_knocking.py
+++ b/tests/federation/transport/test_knocking.py
@@ -108,6 +108,15 @@ class KnockingStrippedStateEventHelperMixin(TestCase):
                         "state_key": "",
                     },
                 ),
+                (
+                    EventTypes.Topic,
+                    {
+                        "content": {
+                            "topic": "A really cool room",
+                        },
+                        "state_key": "",
+                    },
+                ),
             ]
         )
 


### PR DESCRIPTION
[MSC3173](https://github.com/matrix-org/matrix-doc/pull/3173) suggests that the topic of a room should be included in the prejoin state. Synapse does not currently do this, but it is easy enough to include it.