### PR TITLE
Fix space hierarchy endpoint to match MSC

### DIFF
--- a/changelog.d/11667.bugfix
+++ b/changelog.d/11667.bugfix
@@ -1,1 +1,1 @@
-Fix `/_matrix/client/v1/room/{roomId}/hierarchy` endpoint returning incorrect fields.
+Fix `/_matrix/client/v1/room/{roomId}/hierarchy` endpoint returning incorrect fields which have been present since Synapse 1.49.0.

--- a/changelog.d/11667.bugfix
+++ b/changelog.d/11667.bugfix
@@ -1,0 +1,1 @@
+Fix `/_matrix/client/v1/room/{roomId}/hierarchy` endpoint returning incorrect fields.

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -209,7 +209,7 @@ class RoomSummaryHandler:
                         # Before returning to the client, remove the allowed_room_ids
                         # and allowed_spaces keys.
                         room.pop("allowed_room_ids", None)
-                        room.pop("allowed_spaces", None)
+                        room.pop("allowed_spaces", None)  # historical
 
                         rooms_result.append(room)
                         events.extend(room_entry.children_state_events)
@@ -981,19 +981,24 @@ class RoomSummaryHandler:
             current_state_ids[(EventTypes.Create, "")]
         )
 
+        aliases = await self._store.get_aliases_for_room(room_id)
+
         entry = {
             "room_id": stats["room_id"],
             "name": stats["name"],
             "topic": stats["topic"],
             "canonical_alias": stats["canonical_alias"],
+            "aliases": aliases,
             "num_joined_members": stats["joined_members"],
             "avatar_url": stats["avatar"],
+            # plural join_rules is a documentation error but kept for historical
+            # purposes. Should match /publicRooms.
             "join_rules": stats["join_rules"],
+            "join_rule": stats["join_rules"],
             "world_readable": (
                 stats["history_visibility"] == HistoryVisibility.WORLD_READABLE
             ),
             "guest_can_join": stats["guest_access"] == "can_join",
-            "creation_ts": create_event.origin_server_ts,
             "room_type": create_event.content.get(EventContentFields.ROOM_TYPE),
         }
 
@@ -1011,8 +1016,6 @@ class RoomSummaryHandler:
                 )
                 if allowed_rooms:
                     entry["allowed_room_ids"] = allowed_rooms
-                    # TODO Remove this key once the API is stable.
-                    entry["allowed_spaces"] = allowed_rooms
 
         # Filter out Nones – rather omit the field altogether
         room_entry = {k: v for k, v in entry.items() if v is not None}

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -1016,6 +1016,8 @@ class RoomSummaryHandler:
                 )
                 if allowed_rooms:
                     entry["allowed_room_ids"] = allowed_rooms
+                    # TODO Remove this key once the API is stable.
+                    entry["allowed_spaces"] = allowed_rooms
 
         # Filter out Nones – rather omit the field altogether
         room_entry = {k: v for k, v in entry.items() if v is not None}

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -981,14 +981,11 @@ class RoomSummaryHandler:
             current_state_ids[(EventTypes.Create, "")]
         )
 
-        aliases = await self._store.get_aliases_for_room(room_id)
-
         entry = {
             "room_id": stats["room_id"],
             "name": stats["name"],
             "topic": stats["topic"],
             "canonical_alias": stats["canonical_alias"],
-            "aliases": aliases,
             "num_joined_members": stats["joined_members"],
             "avatar_url": stats["avatar"],
             # plural join_rules is a documentation error but kept for historical


### PR DESCRIPTION
* `creation_ts` isn't a thing, and doesn't appear to be used by anything.
* ~~`aliases` is *technically* required by the MSC, but not provided and wasn't in the MSC example. It's required by `PublicRoomsChunk`.~~ See https://github.com/matrix-org/matrix-doc/pull/3624
* `join_rule` was spelled incorrectly in the MSC and should have been copied from `PublicRoomsChunk`.
* ~~`allowed_spaces` feels like it can be removed from the federation response now.~~

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
