### PR TITLE
Fix preview of some gif URLs

### DIFF
--- a/changelog.d/11669.bugfix
+++ b/changelog.d/11669.bugfix
@@ -1,0 +1,1 @@
+Fix preview of some gif URLs (like tenor.com). Contributed by Philippe Daouadi.

--- a/docs/development/url_previews.md
+++ b/docs/development/url_previews.md
@@ -34,19 +34,23 @@ When Synapse is asked to preview a URL it does the following:
       2. Generates an Open Graph response based on image properties.
    5. If the media is HTML:
       1. Decodes the HTML via the stored file.
-      2. Generates an Open Graph response from the HTML.
-      3. If an image exists in the Open Graph response:
+      2. If a JSON oEmbed URL was found in the HTML:
+         1. Convert the oEmbed response to an Open Graph response.
+         2. If a thumbnail or image is in the oEmbed response:
+            1. Downloads the URL and stores it into a file via the media storage
+               provider and saves the local media metadata.
+            2. Generates thumbnails.
+            3. Updates the Open Graph response based on image properties.
+         3. If the oEmbed type is video but no video is provided, abort oEmbed
+            parsing and fall back to Open Graph
+      3. Generates an Open Graph response from the HTML.
+      4. If an image exists in the Open Graph response:
          1. Downloads the URL and stores it into a file via the media storage
             provider and saves the local media metadata.
          2. Generates thumbnails.
          3. Updates the Open Graph response based on image properties.
    6. If the media is JSON and an oEmbed URL was found:
-      1. Convert the oEmbed response to an Open Graph response.
-      2. If a thumbnail or image is in the oEmbed response:
-         1. Downloads the URL and stores it into a file via the media storage
-            provider and saves the local media metadata.
-         2. Generates thumbnails.
-         3. Updates the Open Graph response based on image properties.
+      1. Parse it as described in 3.5.2
    7. Stores the result in the database cache.
 4. Returns the result.
 

--- a/docs/development/url_previews.md
+++ b/docs/development/url_previews.md
@@ -34,23 +34,24 @@ When Synapse is asked to preview a URL it does the following:
       2. Generates an Open Graph response based on image properties.
    5. If the media is HTML:
       1. Decodes the HTML via the stored file.
-      2. If a JSON oEmbed URL was found in the HTML:
-         1. Convert the oEmbed response to an Open Graph response.
-         2. If a thumbnail or image is in the oEmbed response:
-            1. Downloads the URL and stores it into a file via the media storage
-               provider and saves the local media metadata.
-            2. Generates thumbnails.
-            3. Updates the Open Graph response based on image properties.
-         3. If the oEmbed type is video but no video is provided, abort oEmbed
-            parsing and fall back to Open Graph
-      3. Generates an Open Graph response from the HTML.
+      2. Generates an Open Graph response from the HTML.
+      3. If a JSON oEmbed URL was found in the HTML via autodiscovery:
+         1. Downloads the URL and stores it into a file via the media storage provider
+            and saves the local media metadata.
+         2. Convert the oEmbed response to an Open Graph response.
+         3. Override any Open Graph data from the HTML with data from oEmbed.
       4. If an image exists in the Open Graph response:
          1. Downloads the URL and stores it into a file via the media storage
             provider and saves the local media metadata.
          2. Generates thumbnails.
          3. Updates the Open Graph response based on image properties.
    6. If the media is JSON and an oEmbed URL was found:
-      1. Parse it as described in 3.5.2
+      1. Convert the oEmbed response to an Open Graph response.
+      2. If a thumbnail or image is in the oEmbed response:
+         1. Downloads the URL and stores it into a file via the media storage
+            provider and saves the local media metadata.
+         2. Generates thumbnails.
+         3. Updates the Open Graph response based on image properties.
    7. Stores the result in the database cache.
 4. Returns the result.
 

--- a/synapse/rest/media/v1/oembed.py
+++ b/synapse/rest/media/v1/oembed.py
@@ -154,10 +154,13 @@ class OEmbedProvider:
                 "og:url": url,
             }
 
-            # Use either title or author's name as the title.
-            title = oembed.get("title") or oembed.get("author_name")
+            title = oembed.get("title")
             if title:
                 open_graph_response["og:title"] = title
+
+            author_name = oembed.get("author_name")
+            if author_name:
+                open_graph_response["og:author_name"] = author_name
 
             # Use the provider name and as the site.
             provider_name = oembed.get("provider_name")

--- a/synapse/rest/media/v1/oembed.py
+++ b/synapse/rest/media/v1/oembed.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class OEmbedResult:
     # The Open Graph result (converted from the oEmbed result).
     open_graph_result: JsonDict
-    # The author_name of the OEmbed result
+    # The author_name of the oEmbed result
     author_name: Optional[str]
     # Number of milliseconds to cache the content, according to the oEmbed response.
     #
@@ -196,6 +196,7 @@ class OEmbedProvider:
             # Trap any exception and let the code follow as usual.
             logger.warning("Error parsing oEmbed metadata from %s: %r", url, e)
             open_graph_response = {}
+            author_name = None
             cache_age = None
 
         return OEmbedResult(open_graph_response, author_name, cache_age)

--- a/synapse/rest/media/v1/oembed.py
+++ b/synapse/rest/media/v1/oembed.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 class OEmbedResult:
     # The Open Graph result (converted from the oEmbed result).
     open_graph_result: JsonDict
+    # The author_name of the OEmbed result
+    author_name: Optional[str]
     # Number of milliseconds to cache the content, according to the oEmbed response.
     #
     # This will be None if no cache-age is provided in the oEmbed response (or
@@ -159,8 +161,6 @@ class OEmbedProvider:
                 open_graph_response["og:title"] = title
 
             author_name = oembed.get("author_name")
-            if author_name:
-                open_graph_response["og:author_name"] = author_name
 
             # Use the provider name and as the site.
             provider_name = oembed.get("provider_name")
@@ -198,7 +198,7 @@ class OEmbedProvider:
             open_graph_response = {}
             cache_age = None
 
-        return OEmbedResult(open_graph_response, cache_age)
+        return OEmbedResult(open_graph_response, author_name, cache_age)
 
 
 def _fetch_urls(tree: "etree.Element", tag_name: str) -> List[str]:

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -674,6 +674,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
                 "og:url": "http://twitter.com/matrixdotorg/status/12345",
                 "og:title": "Alice",
                 "og:description": "Content Preview",
+                "og:author_name": "Alice",
             },
         )
 

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -674,7 +674,6 @@ class URLPreviewTests(unittest.HomeserverTestCase):
                 "og:url": "http://twitter.com/matrixdotorg/status/12345",
                 "og:title": "Alice",
                 "og:description": "Content Preview",
-                "og:author_name": "Alice",
             },
         )
 


### PR DESCRIPTION
Related to #11563

This PR fixes the preview of tenor.com URLs.

Before: 
![image](https://user-images.githubusercontent.com/1370530/147852443-a560833f-d225-4359-91df-080a66135938.png)

After:
![image](https://user-images.githubusercontent.com/1370530/147852455-5e9aba27-d5ca-45f7-8b14-69f9ebab6eaa.png)

This was broken because oEmbed JSON from tenor.com looks like:

```json
{
  "type": "video",
  "version": "1.0",
  "provider_name": "Tenor",
  "provider_url": "https://tenor.com/",
  "cache_age": 86400,
  "html": "<iframe src=\"https://tenor.com/embed/4945328\" width=\"600\" height=\"400\" frameborder=\"0\"></iframe>",
  "width": 600,
  "height": 400
}
```

And we don't know how to handle the iframe. This PR fixes it by aborting the oEmbed preview and falling back to the Open Graph one (which I think was what was done before).

Note that this does not completely fix #11563 because imgur previews are still broken. The oEmbed looks like

```json
{
  "version": "1.0",
  "type": "rich",
  "provider_name": "Imgur",
  "provider_url": "https://imgur.com",
  "width": 540,
  "height": 500,
  "html": "<blockquote class=\"imgur-embed-pub\" lang=\"en\" data-id=\"a/Ojsfo1t\"><a href=\"https://imgur.com/a/Ojsfo1t\">self-quarantine New Years Celebration</a></blockquote><script async src=\"//s.imgur.com/min/embed.js\" charset=\"utf-8\"></script>"
}
```

There are multiple issues here:
1. The type is "rich", so we can't know if there is supposed to be an image or video in that preview.
2. The `html` does not contain the preview per-se, we need to interpret the HTML and JavaScript (that script sources another script!) to render it.
3. The Open Graph response does not contain the preview, only the imgur logo itself.

So this PR will not fix imgur previews.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
