### PR TITLE
Make room creations denied by `user_may_create_room` cause an `M_FORBIDDEN` error to be returned, not `M_UNKNOWN`

### DIFF
--- a/changelog.d/11672.feature
+++ b/changelog.d/11672.feature
@@ -1,4 +1,1 @@
-Whenever the `spamcheck` forbids a user to create a room, a `SynapseError` with `errcode` `M_UNKNOWN` is returned to the client. However, it would be more specific to return the `errcode` `M_UNKNOWN`.
-
-Therefore, this PR will raise `M_FORBIDDEN` instead of `M_UNKNOWN` whenever `synapse/events/spamcheck.py:user_may_create_room` returns `False`.
-Note: The `M_FORBIDDEN` code is set in the methods which currently call `user_may_create_room`, not in the method `user_may_create_room` itself.
+Return an `M_FORBIDDEN` error code instead of `M_UNKNOWN` when a spam checker module prevents a user from creating a room.

--- a/changelog.d/11672.feature
+++ b/changelog.d/11672.feature
@@ -1,0 +1,4 @@
+Whenever the `spamcheck` forbids a user to create a room, a `SynapseError` with `errcode` `M_UNKNOWN` is returned to the client. However, it would be more specific to return the `errcode` `M_UNKNOWN`.
+
+Therefore, this PR will raise `M_FORBIDDEN` instead of `M_UNKNOWN` whenever `synapse/events/spamcheck.py:user_may_create_room` returns `False`.
+Note: The `M_FORBIDDEN` code is set in the methods which currently call `user_may_create_room`, not in the method `user_may_create_room` itself.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -393,7 +393,9 @@ class RoomCreationHandler:
         user_id = requester.user.to_string()
 
         if not await self.spam_checker.user_may_create_room(user_id):
-            raise SynapseError(403, "You are not permitted to create rooms")
+            raise SynapseError(
+                403, "You are not permitted to create rooms", Codes.FORBIDDEN
+            )
 
         creation_content: JsonDict = {
             "room_version": new_room_version.identifier,
@@ -685,7 +687,9 @@ class RoomCreationHandler:
                 invite_3pid_list,
             )
         ):
-            raise SynapseError(403, "You are not permitted to create rooms")
+            raise SynapseError(
+                403, "You are not permitted to create rooms", Codes.FORBIDDEN
+            )
 
         if ratelimit:
             await self.request_ratelimiter.ratelimit(requester)


### PR DESCRIPTION
Solve issue #11245

Whenever the `spamcheck` forbids a user to create a room, a `SynapseError` with `errcode` `M_UNKNOWN` is returned to the client. However, it would be more specific to return the `errcode` `M_UNKNOWN`.  
Therefore, this PR will raise `M_FORBIDDEN` instead of `M_UNKNOWN` whenever `synapse/events/spamcheck.py:user_may_create_room` returns `False`.
Note: The `M_FORBIDDEN` code is set in the methods which currently call `user_may_create_room`, not in the method `user_may_create_room` itself.

Signed-off-by: Lukas Denk <lukasdenk@web.de>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
