### PR TITLE
Respond with 400 rather than 403 when inviting someone to a room who is already in the room

### DIFF
--- a/changelog.d/11674.feature
+++ b/changelog.d/11674.feature
@@ -1,0 +1,1 @@
+Inviting someone to a room who is already in the room caused a `403 Forbidden`. Now, it causes a `400 Bad Request` since this is more expected.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -391,7 +391,7 @@ def _is_membership_change_allowed(
         if target_banned:
             raise AuthError(403, "%s is banned from the room" % (target_user_id,))
         elif target_in_room:  # the target is already in the room.
-            raise AuthError(403, "%s is already in the room." % target_user_id)
+            raise AuthError(400, "%s is already in the room." % target_user_id)
         else:
             if user_level < invite_level:
                 raise AuthError(403, "You don't have permission to invite users")


### PR DESCRIPTION
Fixes #10740.

Inviting someone to a room who is already in the room caused a `403 Forbidden`. Now, it causes a `400 Bad Request` since this is more expected.

**Signed-off-by**: Lukas Denk <lukasdenk@web.de>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
