### PR TITLE
Add a flag to the `synapse_review_recent_signups` script to ignore and filter appservice users.

### DIFF
--- a/changelog.d/11675.feature
+++ b/changelog.d/11675.feature
@@ -1,1 +1,1 @@
-Adds a flag to the `synapse_review_recent_signups` script to ignore and filter appservice users.
+Add a flag to the `synapse_review_recent_signups` script to ignore and filter appservice users.

--- a/changelog.d/11675.feature
+++ b/changelog.d/11675.feature
@@ -1,0 +1,1 @@
+Adds a flag to the `synapse_review_recent_signups` script to ignore and filter appservice users.

--- a/synapse/_scripts/review_recent_signups.py
+++ b/synapse/_scripts/review_recent_signups.py
@@ -59,7 +59,7 @@ def get_recent_users(
     """
 
     if exclude_app_service:
-        sql += "\n AND appservice_id IS NOT NULL"
+        sql += " AND appservice_id IS NULL"
 
     txn.execute(sql, (since_ms / 1000,))
 
@@ -118,7 +118,7 @@ def main() -> None:
         "-e",
         "--exclude-emails",
         action="store_true",
-        help="Exclude users that have validated email addresses",
+        help="Exclude users that have validated email addresses.",
     )
     parser.add_argument(
         "-u",
@@ -127,7 +127,10 @@ def main() -> None:
         help="Only print user IDs that match.",
     )
     parser.add_argument(
-        "-a", "--exclude-app-service", help="Exclude appservice users.", default=False
+        "-a",
+        "--exclude-app-service",
+        help="Exclude appservice users.",
+        action="store_true",
     )
 
     config = ReviewConfig()

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -979,16 +979,18 @@ class RegistrationHandler:
         if (
             self.hs.config.email.email_enable_notifs
             and self.hs.config.email.email_notif_for_new_users
-            and token
         ):
             # Pull the ID of the access token back out of the db
             # It would really make more sense for this to be passed
             # up when the access token is saved, but that's quite an
             # invasive change I'd rather do separately.
-            user_tuple = await self.store.get_user_by_access_token(token)
-            # The token better still exist.
-            assert user_tuple
-            token_id = user_tuple.token_id
+            if token:
+                user_tuple = await self.store.get_user_by_access_token(token)
+                # The token better still exist.
+                assert user_tuple
+                token_id = user_tuple.token_id
+            else:
+                token_id = None
 
             await self.pusher_pool.add_pusher(
                 user_id=user_id,


### PR DESCRIPTION
Solve issue #10699

Adds a flag to the `synapse_review_recent_signups` script to ignore and filter appservice users.

**Signed-off-by:** Lukas Denk <lukasdenk@web.de>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
