### PR TITLE
Fix SimpleHttpClient not sending Accept header in `get_json`

### DIFF
--- a/changelog.d/11677.bugfix
+++ b/changelog.d/11677.bugfix
@@ -1,0 +1,1 @@
+Fix wrong variable reference in `SimpleHttpClient.get_json` that results in abscense of "Accept" header in the request.

--- a/changelog.d/11677.bugfix
+++ b/changelog.d/11677.bugfix
@@ -1,1 +1,1 @@
-Fix wrong variable reference in `SimpleHttpClient.get_json` that results in abscense of "Accept" header in the request.
+Fix wrong variable reference in `SimpleHttpClient.get_json` that results in the absence of the `Accept` header in the request.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -588,7 +588,7 @@ class SimpleHttpClient:
         if headers:
             actual_headers.update(headers)  # type: ignore
 
-        body = await self.get_raw(uri, args, headers=headers)
+        body = await self.get_raw(uri, args, headers=actual_headers)
         return json_decoder.decode(body.decode("utf-8"))
 
     async def put_json(


### PR DESCRIPTION
I suppose that in `SimpleHttpClient.get_json` function, `actual_headers` dict should be used in `SimpleHttpClient.get_raw` call instead of passed `headers` dict.