### PR TITLE
Warn against using Let's Encrypt certs for encrypted TURN

### DIFF
--- a/changelog.d/11686.doc
+++ b/changelog.d/11686.doc
@@ -1,1 +1,1 @@
-Warn against using a Let's Encrypt certificate for TLS/DTLS TURN server client connections, and suggest using ZeroSSL certificate instead. This bypasses client-side connectivity errors focaused by WebRTC libraries that reject Let's Encrypt certificates. Contibuted by @AndrewFerr.
+Warn against using a Let's Encrypt certificate for TLS/DTLS TURN server client connections, and suggest using ZeroSSL certificate instead. This bypasses client-side connectivity errors caused by WebRTC libraries that reject Let's Encrypt certificates. Contibuted by @AndrewFerr.

--- a/changelog.d/11686.doc
+++ b/changelog.d/11686.doc
@@ -1,0 +1,1 @@
+Warn against using a Let's Encrypt certificate for TLS/DTLS TURN server client connections, and suggest using ZeroSSL certificate instead. This bypasses client-side connectivity errors focaused by WebRTC libraries that reject Let's Encrypt certificates. Contibuted by @AndrewFerr.

--- a/docs/turn-howto.md
+++ b/docs/turn-howto.md
@@ -151,8 +151,8 @@ This will install and start a systemd service called `coturn`.
 
     NB: If your TLS certificate was provided by Let's Encrypt, TLS/DTLS will
     not work with any Matrix client that uses Chromium's WebRTC library. This
-    currently includes Element Android/iOS; see their [respective](https://github.com/vector-im/element-android/issues/1533)
-    [issues](https://github.com/vector-im/element-ios/issues/2712) for more details.
+    currently includes Element Android & iOS. For more details, read the underlying
+    [WebRTC issue](https://bugs.chromium.org/p/webrtc/issues/detail?id=11710).
     Consider using a ZeroSSL certificate for your TURN server as a working alternative.
 
 1.  Ensure your firewall allows traffic into the TURN server on the ports

--- a/docs/turn-howto.md
+++ b/docs/turn-howto.md
@@ -137,6 +137,10 @@ This will install and start a systemd service called `coturn`.
 
     # TLS private key file
     pkey=/path/to/privkey.pem
+
+    # Ensure the configuration lines that disable TLS/DTLS are commented-out or removed
+    #no-tls
+    #no-dtls
     ```
 
     In this case, replace the `turn:` schemes in the `turn_uris` settings below
@@ -144,6 +148,12 @@ This will install and start a systemd service called `coturn`.
 
     We recommend that you only try to set up TLS/DTLS once you have set up a
     basic installation and got it working.
+
+    NB: If your TLS certificate was provided by Let's Encrypt, TLS/DTLS will
+    not work with any Matrix client that uses Chromium's WebRTC library. This
+    currently includes Element Android/iOS; see their [respective](https://github.com/vector-im/element-android/issues/1533)
+    [issues](https://github.com/vector-im/element-ios/issues/2712) for more details.
+    Consider using a ZeroSSL certificate for your TURN server as a working alternative.
 
 1.  Ensure your firewall allows traffic into the TURN server on the ports
     you've configured it to listen on (By default: 3478 and 5349 for TURN
@@ -249,6 +259,10 @@ Here are a few things to try:
 
  * Check that you have opened your firewall to allow UDP traffic to the UDP
    relay ports (49152-65535 by default).
+
+ * Try disabling `coturn`'s TLS/DTLS listeners and enable only its (unencrypted)
+   TCP/UDP listeners. (This will only leave signaling traffic unencrypted;
+   voice & video WebRTC traffic is always encrypted.)
 
  * Some WebRTC implementations (notably, that of Google Chrome) appear to get
    confused by TURN servers which are reachable over IPv6 (this appears to be

--- a/docs/turn-howto.md
+++ b/docs/turn-howto.md
@@ -151,7 +151,9 @@ This will install and start a systemd service called `coturn`.
 
     NB: If your TLS certificate was provided by Let's Encrypt, TLS/DTLS will
     not work with any Matrix client that uses Chromium's WebRTC library. This
-    currently includes Element Android & iOS. For more details, read the underlying
+    currently includes Element Android & iOS; for more details, see their
+    [respective](https://github.com/vector-im/element-android/issues/1533)
+    [issues](https://github.com/vector-im/element-ios/issues/2712) as well as the underlying
     [WebRTC issue](https://bugs.chromium.org/p/webrtc/issues/detail?id=11710).
     Consider using a ZeroSSL certificate for your TURN server as a working alternative.
 


### PR DESCRIPTION
This helps to avoid client-side issues:
* https://github.com/vector-im/element-android/issues/1533
* https://github.com/vector-im/element-ios/issues/2712

Signed-off-by: Andrew Ferrazzutti <fair@miscworks.net>

I can confirm that using a ZeroSSL certificate instead of a Let's Encrypt one allows `turns:` connections to work. To test this, I configured my `coturn` to enable only TLS/DTLS listeners. By doing nothing other than switching certs, calls work with the ZeroSSL cert and fail with the Let's Encrypt cert. I tested this with both Element Android and Jitsi Meet.

This PR can be treated as a more complete version of https://github.com/matrix-org/synapse/pull/10358.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
