### PR TITLE
Include `io.element.thread` capability for MSC3440.

### DIFF
--- a/changelog.d/11690.misc
+++ b/changelog.d/11690.misc
@@ -1,0 +1,1 @@
+Update the `/capabilities` response to include whether support for [MSC3440](https://github.com/matrix-org/matrix-doc/pull/3440) is available.

--- a/synapse/rest/client/capabilities.py
+++ b/synapse/rest/client/capabilities.py
@@ -73,6 +73,9 @@ class CapabilitiesRestServlet(RestServlet):
                 "enabled": self.config.registration.enable_3pid_changes
             }
 
+        if self.config.experimental.msc3440_enabled:
+            response["capabilities"]["io.element.thread"] = {"enabled": True}
+
         return 200, response
 
 


### PR DESCRIPTION
Fixes #11689, per MSC3440.