### PR TITLE
Work around Mjolnir compatibility issue by adding an import for `glob_to_regex` in `synapse.util`, where it moved from.

### DIFF
--- a/changelog.d/11696.misc
+++ b/changelog.d/11696.misc
@@ -1,0 +1,1 @@
+Work around Mjolnir compatibility issue by adding an import for `glob_to_regex` in `synapse.util`, where it moved from.

--- a/synapse/util/__init__.py
+++ b/synapse/util/__init__.py
@@ -31,6 +31,13 @@ from synapse.logging import context
 if typing.TYPE_CHECKING:
     pass
 
+# FIXME Mjolnir imports glob_to_regex from this file, but it was moved to
+#       matrix_common.
+#       As a temporary workaround, we import glob_to_regex here for
+#       compatibility with current versions of Mjolnir.
+# See https://github.com/matrix-org/mjolnir/pull/174
+from matrix_common.regex import glob_to_regex  # noqa
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This will be unnecessary once https://github.com/matrix-org/mjolnir/pull/174 lands.

