### PR TITLE
Test case for an edgy race

### DIFF
--- a/changelog.d/11701.misc
+++ b/changelog.d/11701.misc
@@ -1,0 +1,1 @@
+Add a test for [an edge case](https://github.com/matrix-org/synapse/pull/11532#discussion_r769104461) in the `/sync` logic.

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -27,7 +27,6 @@ from synapse.types import UserID, create_requester
 import tests.unittest
 import tests.utils
 from tests.test_utils import make_awaitable
-from tests.test_utils.event_injection import inject_event
 
 
 class SyncTestCase(tests.unittest.HomeserverTestCase):

--- a/tests/rest/client/utils.py
+++ b/tests/rest/client/utils.py
@@ -196,14 +196,14 @@ class RestHelper:
             expect_code=expect_code,
         )
 
-    def ban(self, room=None, src=None, targ=None, expect_code=200, tok=None):
+    def ban(self, room: str, src: str, targ: str, **kwargs: object):
+        """A convenience helper: `change_membership` with `membership` preset to "ban"."""
         self.change_membership(
             room=room,
             src=src,
             targ=targ,
-            tok=tok,
             membership=Membership.BAN,
-            expect_code=expect_code,
+            **kwargs,
         )
 
     def change_membership(

--- a/tests/rest/client/utils.py
+++ b/tests/rest/client/utils.py
@@ -196,6 +196,16 @@ class RestHelper:
             expect_code=expect_code,
         )
 
+    def ban(self, room=None, src=None, targ=None, expect_code=200, tok=None):
+        self.change_membership(
+            room=room,
+            src=src,
+            targ=targ,
+            tok=tok,
+            membership=Membership.BAN,
+            expect_code=expect_code,
+        )
+
     def change_membership(
         self,
         room: str,


### PR DESCRIPTION
I have tried to capture the race described by @richvdh in [this comment](https://github.com/matrix-org/synapse/pull/11532#discussion_r769104461).

It passes when I ran the test against develop locally, and it fails when I run it against #11532.
