### PR TITLE
Optionally use an on-disk sqlite db in tests

### DIFF
--- a/changelog.d/11702.misc
+++ b/changelog.d/11702.misc
@@ -1,0 +1,1 @@
+Add the option to write sqlite test dbs to disk when running tests.

--- a/tests/server.py
+++ b/tests/server.py
@@ -14,6 +14,7 @@
 import hashlib
 import json
 import logging
+import os
 import time
 import uuid
 import warnings
@@ -71,6 +72,7 @@ from tests.utils import (
     POSTGRES_HOST,
     POSTGRES_PASSWORD,
     POSTGRES_USER,
+    SQLITE_TEST_DB_LOCATION,
     USE_POSTGRES_FOR_TESTS,
     MockClock,
     default_config,
@@ -739,9 +741,16 @@ def setup_test_homeserver(
             },
         }
     else:
+        if SQLITE_TEST_DB_LOCATION != ":memory:":
+            # nuke the DB on disk
+            try:
+                os.remove(SQLITE_TEST_DB_LOCATION)
+            except FileNotFoundError:
+                pass
+
         database_config = {
             "name": "sqlite3",
-            "args": {"database": ":memory:", "cp_min": 1, "cp_max": 1},
+            "args": {"database": SQLITE_TEST_DB_LOCATION, "cp_min": 1, "cp_max": 1},
         }
 
     if "db_txn_limit" in kwargs:

--- a/tests/server.py
+++ b/tests/server.py
@@ -745,9 +745,7 @@ def setup_test_homeserver(
         if SQLITE_PERSIST_DB:
             # The current working directory is in _trial_temp, so this gets created within that directory.
             test_db_location = os.path.abspath("test.db")
-            logger.debug(
-                "Will persist db to %s", test_db_location
-            )
+            logger.debug("Will persist db to %s", test_db_location)
             # Ensure each test gets a clean database.
             try:
                 os.remove(test_db_location)

--- a/tests/server.py
+++ b/tests/server.py
@@ -747,7 +747,7 @@ def setup_test_homeserver(
             logger.debug(
                 "Will persist db to %s", test_db_location
             )
-            # nuke the DB on disk if it already exists
+            # Ensure each test gets a clean database.
             try:
                 os.remove(test_db_location)
             except FileNotFoundError:

--- a/tests/server.py
+++ b/tests/server.py
@@ -743,6 +743,7 @@ def setup_test_homeserver(
         }
     else:
         if SQLITE_PERSIST_DB:
+            # The current working directory is in _trial_temp, so this gets created within that directory.
             test_db_location = os.path.abspath("test.db")
             logger.debug(
                 "Will persist db to %s", test_db_location

--- a/tests/server.py
+++ b/tests/server.py
@@ -745,7 +745,7 @@ def setup_test_homeserver(
         if SQLITE_PERSIST_DB:
             test_db_location = os.path.abspath("test.db")
             logger.debug(
-                "Will persist db to %s",
+                "Will persist db to %s", test_db_location
             )
             # nuke the DB on disk if it already exists
             try:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,8 +43,8 @@ POSTGRES_PASSWORD = os.environ.get("SYNAPSE_POSTGRES_PASSWORD", None)
 POSTGRES_BASE_DB = "_synapse_unit_tests_base_%s" % (os.getpid(),)
 
 # When debugging a specific test, it's occasionally useful to write the
-# DB to /tmp and query it with the sqlite CLI.
-SQLITE_TEST_DB_LOCATION = os.environ.get("SYNAPSE_TEST_SQLITE_DB_LOCATION", ":memory:")
+# DB to disk and query it with the sqlite CLI.
+SQLITE_PERSIST_DB = os.environ.get("SYNAPSE_TEST_PERSIST_SQLITE_DB") is not None
 
 # the dbname we will connect to in order to create the base database.
 POSTGRES_DBNAME_FOR_INITIAL_CREATE = "postgres"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,6 +42,10 @@ POSTGRES_HOST = os.environ.get("SYNAPSE_POSTGRES_HOST", None)
 POSTGRES_PASSWORD = os.environ.get("SYNAPSE_POSTGRES_PASSWORD", None)
 POSTGRES_BASE_DB = "_synapse_unit_tests_base_%s" % (os.getpid(),)
 
+# When debugging a specific test, it's occasionally useful to write the
+# DB to /tmp and query it with the sqlite CLI.
+SQLITE_TEST_DB_LOCATION = os.environ.get("SYNAPSE_TEST_SQLITE_DB_LOCATION", ":memory:")
+
 # the dbname we will connect to in order to create the base database.
 POSTGRES_DBNAME_FOR_INITIAL_CREATE = "postgres"
 


### PR DESCRIPTION
When debugging a test it is sometimes useful to inspect the state of the
DB. This is not easy when the db is in-memory: one cannot attach the
sqlite CLI to another process's DB. (I suppose you could ferret out the
sqlite connection object from within the debugger and sending text
directly but... that is painful and doesn't have tab completion.)

With this change, if SYNAPSE_TEST_SQLITE_DB_LOCATION is set, we try to
write the DB to disk at that location (deleting any existing db file as
necessary).

Quick and dirty.