### PR TITLE
Fix docstring on `add_account_data_for_user`.

### DIFF
--- a/changelog.d/11716.misc
+++ b/changelog.d/11716.misc
@@ -1,0 +1,1 @@
+Fix docstring on `add_account_data_for_user`.

--- a/synapse/handlers/account_data.py
+++ b/synapse/handlers/account_data.py
@@ -77,7 +77,7 @@ class AccountDataHandler:
     async def add_account_data_for_user(
         self, user_id: str, account_data_type: str, content: JsonDict
     ) -> int:
-        """Add some account_data to a room for a user.
+        """Add some global account_data for a user.
 
         Args:
             user_id: The user to add a tag for.

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -450,7 +450,7 @@ class AccountDataWorkerStore(CacheInvalidationWorkerStore):
     async def add_account_data_for_user(
         self, user_id: str, account_data_type: str, content: JsonDict
     ) -> int:
-        """Add some account_data to a room for a user.
+        """Add some global account_data for a user.
 
         Args:
             user_id: The user to add a tag for.


### PR DESCRIPTION
It looks like a copy and paste mistake: the previous function has the same docstring and *is* intended for room account data.
