### PR TITLE
Fix a bug introduced in Synapse v1.0.0 whereby device list updates would not be sent to remote homeservers if there were too many to send at once.

### DIFF
--- a/changelog.d/11729.bugfix
+++ b/changelog.d/11729.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse v1.0.0 whereby device list updates would not be sent to remote homeservers if there were too many to send at once.

--- a/changelog.d/11729.bugfix
+++ b/changelog.d/11729.bugfix
@@ -1,1 +1,1 @@
-Fix a bug introduced in Synapse v1.0.0 whereby device list updates would not be sent to remote homeservers if there were too many to send at once.
+Fix a bug introduced in Synapse v1.0.0 whereby some device list updates would not be sent to remote homeservers if there were too many to send at once.


### PR DESCRIPTION
Fixes #11727: you can't resume reading the stream if there are more than `limit` entries because you get told to continue from the end of the stream, not the end of where you read up to.

Of note: #7010: stream_ids used to not be unique, but the ones produced in modern times are (since v1.13.0). Thanks Erik for saving me a lot of pain!

It appears to have been introduced in https://github.com/matrix-org/synapse/commit/2d1d7b7e6f2bec3b96b0d23993369ce46aad4f32, which has been there since the good ol' days of v1.0.0 :).

Required change for the fix to #11719, which is a release blocker.