### PR TITLE
Fix a bug introduced in Synapse v1.50.0rc1 whereby outbound federation could fail because too many EDUs were produced for device updates.

### DIFF
--- a/changelog.d/11730.bugfix
+++ b/changelog.d/11730.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse v1.50.0rc1 whereby outbound federation could fail because too many EDUs were produced for device updates.

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -191,7 +191,7 @@ class DeviceWorkerStore(SQLBaseStore):
     @trace
     async def get_device_updates_by_remote(
         self, destination: str, from_stream_id: int, limit: int
-    ) -> Tuple[int, List[Tuple[str, dict]]]:
+    ) -> Tuple[int, List[Tuple[str, JsonDict]]]:
         """Get a stream of device updates to send to the given remote server.
 
         Args:

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -378,6 +378,9 @@ class DeviceWorkerStore(SQLBaseStore):
         """
         devices = (
             await self.get_e2e_device_keys_and_signatures(
+                # Because these are (user_id, device_id) tuples with all
+                # device_ids not being None, the returned list's length will not
+                # exceed that of query_map.
                 query_map.keys(),
                 include_all_devices=True,
                 include_deleted_devices=True,

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -280,6 +280,15 @@ class DeviceWorkerStore(SQLBaseStore):
         query_map = {}
         cross_signing_keys_by_user = {}
         for user_id, device_id, update_stream_id, update_context in updates:
+            is_master_key_update = (
+                user_id in master_key_by_user
+                and device_id == master_key_by_user[user_id]["device_id"]
+            )
+            is_self_signing_key_update = (
+                user_id in self_signing_key_by_user
+                and device_id == self_signing_key_by_user[user_id]["device_id"]
+            )
+
             if (
                 user_id in master_key_by_user
                 and device_id == master_key_by_user[user_id]["device_id"]

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -222,6 +222,8 @@ class DeviceWorkerStore(SQLBaseStore):
             limit,
         )
 
+        # len(updates) <= limit.
+
         # Return an empty list if there are no updates
         if not updates:
             return now_stream_id, []
@@ -302,11 +304,17 @@ class DeviceWorkerStore(SQLBaseStore):
 
             last_processed_stream_id = update_stream_id
 
+        # len(query_map) + len(cross_signing_keys_by_user) <= len(updates) here,
+        # so len(query_map) + len(cross_signing_keys_by_user) <= limit.
+
         results = await self._get_device_update_edus_by_remote(
             destination, from_stream_id, query_map
         )
 
-        # add the updated cross-signing keys to the results list
+        # len(results) <= len(query_map) here,
+        # so len(results) + len(cross_signing_keys_by_user) <= limit.
+
+        # Add the updated cross-signing keys to the results list
         for user_id, result in cross_signing_keys_by_user.items():
             result["user_id"] = user_id
             results.append(("m.signing_key_update", result))

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -366,12 +366,15 @@ class DeviceWorkerStore(SQLBaseStore):
         Args:
             destination: The host the device updates are intended for
             from_stream_id: The minimum stream_id to filter updates by, exclusive
-            query_map (Dict[(str, str): (int, str|None)]): Dictionary mapping
-                user_id/device_id to update stream_id and the relevant json-encoded
-                opentracing context
+            query_map: Dictionary mapping (user_id, device_id) to
+                (update stream_id, the relevant json-encoded opentracing context)
 
         Returns:
-            List of objects representing an device update EDU
+            List of objects representing a device update EDU.
+
+        Postconditions:
+            The returned list has a length not exceeding that of the query_map:
+                len(result) <= len(query_map)
         """
         devices = (
             await self.get_e2e_device_keys_and_signatures(

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -332,6 +332,11 @@ class DeviceWorkerStore(SQLBaseStore):
                 previous_update_stream_id, _ = query_map.get(key, (0, None))
 
                 if update_stream_id > previous_update_stream_id:
+                    # FIXME If this overwrites an older update, this discards the
+                    #  previous OpenTracing context.
+                    #  It might make it harder to track down issues using OpenTracing.
+                    #  If there's a good reason why it doesn't matter, a comment here
+                    #  about that would not hurt.
                     query_map[key] = (update_stream_id, update_context)
 
             # As this update has been added to the response, advance the stream

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -200,9 +200,10 @@ class DeviceWorkerStore(SQLBaseStore):
             limit: Maximum number of device updates to return
 
         Returns:
-            A mapping from the  current stream id (ie, the stream id of the last
-            update included in the response), and the list of updates, where
-            each update is a pair of EDU type and EDU contents.
+            - The current stream id (i.e. the stream id of the last update included
+              in the response); and
+            - The list of updates, where each update is a pair of EDU type and
+              EDU contents.
         """
         now_stream_id = self.get_device_stream_token()
 

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -351,6 +351,7 @@ class DeviceWorkerStore(SQLBaseStore):
             results.append(("m.signing_key_update", result))
             # also send the unstable version
             # FIXME: remove this when enough servers have upgraded
+            #        and remove the length budgeting above.
             results.append(("org.matrix.signing_key_update", result))
 
         return last_processed_stream_id, results

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -222,7 +222,8 @@ class DeviceWorkerStore(SQLBaseStore):
             limit,
         )
 
-        # len(updates) <= limit.
+        # We need to ensure `updates` doesn't grow too big. 
+        # Currently: `len(updates) <= limit`.
 
         # Return an empty list if there are no updates
         if not updates:
@@ -283,7 +284,7 @@ class DeviceWorkerStore(SQLBaseStore):
             # Calculate the remaining length budget.
             # Note that, for now, each entry in `cross_signing_keys_by_user`
             # gives rise to two device updates in the result, so those cost twice
-            # as much (and are the whole reason we need to separatly calculate
+            # as much (and are the whole reason we need to separately calculate
             # the budget; we know len(updates) <= limit otherwise!)
             # N.B. len() on dicts is cheap since they store their size.
             remaining_length_budget = limit - (

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -289,16 +289,10 @@ class DeviceWorkerStore(SQLBaseStore):
                 and device_id == self_signing_key_by_user[user_id]["device_id"]
             )
 
-            if (
-                user_id in master_key_by_user
-                and device_id == master_key_by_user[user_id]["device_id"]
-            ):
+            if is_master_key_update:
                 result = cross_signing_keys_by_user.setdefault(user_id, {})
                 result["master_key"] = master_key_by_user[user_id]["key_info"]
-            elif (
-                user_id in self_signing_key_by_user
-                and device_id == self_signing_key_by_user[user_id]["device_id"]
-            ):
+            elif is_self_signing_key_update:
                 result = cross_signing_keys_by_user.setdefault(user_id, {})
                 result["self_signing_key"] = self_signing_key_by_user[user_id][
                     "key_info"

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -331,7 +331,7 @@ class DeviceWorkerStore(SQLBaseStore):
         from_stream_id: int,
         now_stream_id: int,
         limit: int,
-    ):
+    ) -> List[Tuple[str, str, int, Optional[str]]]:
         """Return device update information for a given remote destination
 
         Args:
@@ -342,7 +342,11 @@ class DeviceWorkerStore(SQLBaseStore):
             limit: Maximum number of device updates to return
 
         Returns:
-            List: List of device updates
+            List: List of device update tuples:
+                - user_id
+                - device_id
+                - stream_id
+                - opentracing_context
         """
         # get the list of device updates that need to be sent
         sql = """

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -222,7 +222,7 @@ class DeviceWorkerStore(SQLBaseStore):
             limit,
         )
 
-        # We need to ensure `updates` doesn't grow too big. 
+        # We need to ensure `updates` doesn't grow too big.
         # Currently: `len(updates) <= limit`.
 
         # Return an empty list if there are no updates
@@ -334,8 +334,13 @@ class DeviceWorkerStore(SQLBaseStore):
                 if update_stream_id > previous_update_stream_id:
                     query_map[key] = (update_stream_id, update_context)
 
+            # As this update has been added to the response, advance the stream
+            # position.
             last_processed_stream_id = update_stream_id
 
+        # In the worst case scenario, each update is for a distinct user and is
+        # added either to the query_map or to cross_signing_keys_by_user,
+        # but not both:
         # len(query_map) + len(cross_signing_keys_by_user) <= len(updates) here,
         # so len(query_map) + len(cross_signing_keys_by_user) <= limit.
 

--- a/tests/storage/test_devices.py
+++ b/tests/storage/test_devices.py
@@ -155,6 +155,12 @@ class DeviceStoreTestCase(HomeserverTestCase):
         # Check the newly-added device_ids are contained within these updates
         self._check_devices_in_updates(device_ids, device_updates)
 
+        # Check there are no more device updates left.
+        _, device_updates = self.get_success(
+            self.store.get_device_updates_by_remote("somehost", next_stream_id, limit=3)
+        )
+        self.assertEqual(device_updates, [])
+
     def test_get_device_updates_by_remote_cross_signing_key_updates(
         self,
     ) -> None:
@@ -252,6 +258,12 @@ class DeviceStoreTestCase(HomeserverTestCase):
         self.assertEqual(
             device_updates[1][0], "org.matrix.signing_key_update", device_updates[1]
         )
+
+        # Check there are no more device updates left.
+        _, device_updates = self.get_success(
+            self.store.get_device_updates_by_remote("somehost", next_stream_id, limit=3)
+        )
+        self.assertEqual(device_updates, [])
 
     def _check_devices_in_updates(self, expected_device_ids, device_updates):
         """Check that an specific device ids exist in a list of device update EDUs"""

--- a/tests/storage/test_devices.py
+++ b/tests/storage/test_devices.py
@@ -223,11 +223,16 @@ class DeviceStoreTestCase(HomeserverTestCase):
             self.store.get_device_updates_by_remote("somehost", -1, limit=3)
         )
 
-        # Even though the limit has not been hit, the next update will be duplicated
-        # but there's no space for it here.
+        # Here we expect the device updates for `device_id1` and `device_id2`.
+        # That means we only receive 2 updates this time around.
+        # If we had a higher limit, we would expect to see the pair of
+        # (unstable-prefixed & unprefixed) signing key updates for the device
+        # represented by `fakeMaster` and `fakeSelfSigning`.
+        # Our implementation only sends these two variants together, so we get
+        # a short batch.
         self.assertEqual(len(device_updates), 2, device_updates)
 
-        # Check the first two devices came out.
+        # Check the first two devices (device_id1, device_id2) came out.
         self._check_devices_in_updates(device_ids[:2], device_updates)
 
         # Get more device updates meant for this remote
@@ -237,8 +242,8 @@ class DeviceStoreTestCase(HomeserverTestCase):
 
         # The next 2 updates should be a cross-signing key update
         # (the master key update and the self-signing key update are combined into
-        # one, but the cross-signing key update is emitted twice, once with an unprefixed
-        # type and one with an unstable-prefixed type)
+        # one 'signing key update', but the cross-signing key update is emitted
+        # twice, once with an unprefixed type and once again with an unstable-prefixed type)
         # (This is a temporary arrangement for backwards compatibility!)
         self.assertEqual(len(device_updates), 2, device_updates)
         self.assertEqual(

--- a/tests/storage/test_devices.py
+++ b/tests/storage/test_devices.py
@@ -159,8 +159,8 @@ class DeviceStoreTestCase(HomeserverTestCase):
         self,
     ) -> None:
         """
-        Tests that `get_device_updates_by_remote` limits the length of the return properly
-        when cross-signing key updates are present.
+        Tests that `get_device_updates_by_remote` limits the length of the return value
+        properly when cross-signing key updates are present.
         Current behaviour is that the cross-signing key updates will always come in pairs,
         even if that means leaving an earlier batch one EDU short of the limit.
         """


### PR DESCRIPTION
Follows on from: #11729.

Fixes #11719.

Basically, sending both a prefixed and unprefixed copy of cross-signing key updates meant that `get_device_updates_by_remote` was blowing the budget and producing more EDUs than the limit it was given.
Working around this is a little bit ugly but the principle is simple: if there won't be room for a device update, stop early!

The ugliness arises because depending on the row that comes back from the database (and whether it's a duplicate of another or not), there could be 0, 1 or 2 EDUs produced.

This can all be stripped out once we remove the duplication of cross-signing key updates.