### PR TITLE
Make pagination of rooms in admin api stable

### DIFF
--- a/changelog.d/11737.bugfix
+++ b/changelog.d/11737.bugfix
@@ -1,0 +1,1 @@
+Make the list rooms admin api sort stable. Contributed by Daniël Sonck.

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -552,7 +552,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
             INNER JOIN room_stats_current curr USING (room_id)
             INNER JOIN rooms USING (room_id)
             %s
-            ORDER BY %s %s
+            ORDER BY %s %s, state.room_id ASC
             LIMIT ?
             OFFSET ?
         """ % (

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -551,24 +551,24 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
             FROM room_stats_state state
             INNER JOIN room_stats_current curr USING (room_id)
             INNER JOIN rooms USING (room_id)
-            %s
-            ORDER BY %s %s, state.room_id ASC
+            {where}
+            ORDER BY {order_by} {direction}, state.room_id {direction}
             LIMIT ?
             OFFSET ?
-        """ % (
-            where_statement,
-            order_by_column,
-            "ASC" if order_by_asc else "DESC",
+        """.format(
+            where=where_statement,
+            order_by=order_by_column,
+            direction="ASC" if order_by_asc else "DESC",
         )
 
         # Use a nested SELECT statement as SQL can't count(*) with an OFFSET
         count_sql = """
             SELECT count(*) FROM (
               SELECT room_id FROM room_stats_state state
-              %s
+              {where}
             ) AS get_room_ids
-        """ % (
-            where_statement,
+        """.format(
+            where=where_statement,
         )
 
         def _get_rooms_paginate_txn(

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1363,8 +1363,10 @@ class RoomTestCase(unittest.HomeserverTestCase):
         room_id_3 = self.helper.create_room_as(self.admin_user, tok=self.admin_user_tok)
 
         # Also create a list sorted by IDs for properties that are equal (and thus sorted by room_id)
-        all_ids = [room_id_1, room_id_2, room_id_3]
-        all_ids.sort()
+        sorted_by_room_id_asc = [room_id_1, room_id_2, room_id_3]
+        sorted_by_room_id_asc.sort()
+        sorted_by_room_id_desc = sorted_by_room_id_asc.copy()
+        sorted_by_room_id_desc.reverse()
 
         # Set room names in alphabetical order. room 1 -> A, 2 -> B, 3 -> C
         self.helper.send_state(
@@ -1419,31 +1421,30 @@ class RoomTestCase(unittest.HomeserverTestCase):
             "joined_local_members", [room_id_1, room_id_2, room_id_3], reverse=True
         )
 
-        _order_test("version", all_ids)
-        _order_test("version", all_ids, reverse=True)
+        _order_test("version", sorted_by_room_id_asc, reverse=True)
+        _order_test("version", sorted_by_room_id_desc)
 
-        _order_test("creator", all_ids)
-        _order_test("creator", all_ids, reverse=True)
+        _order_test("creator", sorted_by_room_id_asc)
+        _order_test("creator", sorted_by_room_id_desc, reverse=True)
 
-        _order_test("encryption", all_ids)
-        _order_test("encryption", all_ids, reverse=True)
+        _order_test("encryption", sorted_by_room_id_asc)
+        _order_test("encryption", sorted_by_room_id_desc, reverse=True)
 
-        _order_test("federatable", all_ids)
-        _order_test("federatable", all_ids, reverse=True)
+        _order_test("federatable", sorted_by_room_id_asc)
+        _order_test("federatable", sorted_by_room_id_desc, reverse=True)
 
-        _order_test("public", all_ids)
-        # Different sort order of SQlite and PostreSQL
-        # _order_test("public", [room_id_3, room_id_2, room_id_1], reverse=True)
+        _order_test("public", sorted_by_room_id_asc)
+        _order_test("public", sorted_by_room_id_desc, reverse=True)
 
-        _order_test("join_rules", all_ids)
-        _order_test("join_rules", all_ids, reverse=True)
+        _order_test("join_rules", sorted_by_room_id_asc)
+        _order_test("join_rules", sorted_by_room_id_desc, reverse=True)
 
-        _order_test("guest_access", all_ids)
-        _order_test("guest_access", all_ids, reverse=True)
+        _order_test("guest_access", sorted_by_room_id_asc)
+        _order_test("guest_access", sorted_by_room_id_desc, reverse=True)
 
-        _order_test("history_visibility", all_ids)
+        _order_test("history_visibility", sorted_by_room_id_asc)
         _order_test(
-            "history_visibility", all_ids, reverse=True
+            "history_visibility", sorted_by_room_id_desc, reverse=True
         )
 
         _order_test("state_events", [room_id_3, room_id_2, room_id_1])

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1443,9 +1443,7 @@ class RoomTestCase(unittest.HomeserverTestCase):
         _order_test("guest_access", sorted_by_room_id_desc, reverse=True)
 
         _order_test("history_visibility", sorted_by_room_id_asc)
-        _order_test(
-            "history_visibility", sorted_by_room_id_desc, reverse=True
-        )
+        _order_test("history_visibility", sorted_by_room_id_desc, reverse=True)
 
         _order_test("state_events", [room_id_3, room_id_2, room_id_1])
         _order_test("state_events", [room_id_1, room_id_2, room_id_3], reverse=True)

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1413,14 +1413,17 @@ class RoomTestCase(unittest.HomeserverTestCase):
         _order_test("canonical_alias", [room_id_1, room_id_2, room_id_3])
         _order_test("canonical_alias", [room_id_3, room_id_2, room_id_1], reverse=True)
 
+        # Note: joined_member counts are sorted in descending order when dir=f
         _order_test("joined_members", [room_id_3, room_id_2, room_id_1])
         _order_test("joined_members", [room_id_1, room_id_2, room_id_3], reverse=True)
 
+        # Note: joined_local_member counts are sorted in descending order when dir=f
         _order_test("joined_local_members", [room_id_3, room_id_2, room_id_1])
         _order_test(
             "joined_local_members", [room_id_1, room_id_2, room_id_3], reverse=True
         )
 
+        # Note: versions are sorted in descending order when dir=f
         _order_test("version", sorted_by_room_id_asc, reverse=True)
         _order_test("version", sorted_by_room_id_desc)
 
@@ -1445,6 +1448,7 @@ class RoomTestCase(unittest.HomeserverTestCase):
         _order_test("history_visibility", sorted_by_room_id_asc)
         _order_test("history_visibility", sorted_by_room_id_desc, reverse=True)
 
+        # Note: state_event counts are sorted in descending order when dir=f
         _order_test("state_events", [room_id_3, room_id_2, room_id_1])
         _order_test("state_events", [room_id_1, room_id_2, room_id_3], reverse=True)
 

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1089,6 +1089,8 @@ class RoomTestCase(unittest.HomeserverTestCase):
             )
             room_ids.append(room_id)
 
+        room_ids.sort()
+
         # Request the list of rooms
         url = "/_synapse/admin/v1/rooms"
         channel = self.make_request(
@@ -1360,6 +1362,10 @@ class RoomTestCase(unittest.HomeserverTestCase):
         room_id_2 = self.helper.create_room_as(self.admin_user, tok=self.admin_user_tok)
         room_id_3 = self.helper.create_room_as(self.admin_user, tok=self.admin_user_tok)
 
+        # Also create a list sorted by IDs for properties that are equal (and thus sorted by room_id)
+        all_ids = [room_id_1, room_id_2, room_id_3]
+        all_ids.sort()
+
         # Set room names in alphabetical order. room 1 -> A, 2 -> B, 3 -> C
         self.helper.send_state(
             room_id_1,
@@ -1413,31 +1419,31 @@ class RoomTestCase(unittest.HomeserverTestCase):
             "joined_local_members", [room_id_1, room_id_2, room_id_3], reverse=True
         )
 
-        _order_test("version", [room_id_1, room_id_2, room_id_3])
-        _order_test("version", [room_id_1, room_id_2, room_id_3], reverse=True)
+        _order_test("version", all_ids)
+        _order_test("version", all_ids, reverse=True)
 
-        _order_test("creator", [room_id_1, room_id_2, room_id_3])
-        _order_test("creator", [room_id_1, room_id_2, room_id_3], reverse=True)
+        _order_test("creator", all_ids)
+        _order_test("creator", all_ids, reverse=True)
 
-        _order_test("encryption", [room_id_1, room_id_2, room_id_3])
-        _order_test("encryption", [room_id_1, room_id_2, room_id_3], reverse=True)
+        _order_test("encryption", all_ids)
+        _order_test("encryption", all_ids, reverse=True)
 
-        _order_test("federatable", [room_id_1, room_id_2, room_id_3])
-        _order_test("federatable", [room_id_1, room_id_2, room_id_3], reverse=True)
+        _order_test("federatable", all_ids)
+        _order_test("federatable", all_ids, reverse=True)
 
-        _order_test("public", [room_id_1, room_id_2, room_id_3])
+        _order_test("public", all_ids)
         # Different sort order of SQlite and PostreSQL
         # _order_test("public", [room_id_3, room_id_2, room_id_1], reverse=True)
 
-        _order_test("join_rules", [room_id_1, room_id_2, room_id_3])
-        _order_test("join_rules", [room_id_1, room_id_2, room_id_3], reverse=True)
+        _order_test("join_rules", all_ids)
+        _order_test("join_rules", all_ids, reverse=True)
 
-        _order_test("guest_access", [room_id_1, room_id_2, room_id_3])
-        _order_test("guest_access", [room_id_1, room_id_2, room_id_3], reverse=True)
+        _order_test("guest_access", all_ids)
+        _order_test("guest_access", all_ids, reverse=True)
 
-        _order_test("history_visibility", [room_id_1, room_id_2, room_id_3])
+        _order_test("history_visibility", all_ids)
         _order_test(
-            "history_visibility", [room_id_1, room_id_2, room_id_3], reverse=True
+            "history_visibility", all_ids, reverse=True
         )
 
         _order_test("state_events", [room_id_3, room_id_2, room_id_1])


### PR DESCRIPTION
Always add `state.room_id` after the configurable ORDER BY. Otherwise,
for any sort, certain pages can contain results from
other pages. (Especially when sorting by creator, since there may
be many rooms by the same creator)

Fixes: #11736 

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
