### PR TITLE
Fetch thread summaries for multiple events in a single query

### DIFF
--- a/changelog.d/11752.misc
+++ b/changelog.d/11752.misc
@@ -1,0 +1,1 @@
+Improve performance when fetching bundled aggregations for multiple events.

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1812,7 +1812,7 @@ class PersistEventsStore:
             # potentially error-prone) so it is always invalidated.
             txn.call_after(
                 self.store.get_thread_participated.invalidate,
-                (parent_id, event.room_id, event.sender),
+                (parent_id, event.sender),
             )
 
     def _handle_insertion_event(self, txn: LoggingTransaction, event: EventBase):

--- a/synapse/storage/databases/main/relations.py
+++ b/synapse/storage/databases/main/relations.py
@@ -518,7 +518,7 @@ class RelationsWorkerStore(SQLBaseStore):
 
             txn.execute(sql % (clause,), args)
             latest_event_ids = {}
-            for parent_event_id, child_event_id in txn.fetchall():
+            for parent_event_id, child_event_id in txn:
                 # Only consider the latest threaded reply (by topological ordering).
                 if parent_event_id not in latest_event_ids:
                     latest_event_ids[parent_event_id] = child_event_id


### PR DESCRIPTION
This uses the same approach as #11660, but for the thread relation type instead of the edit relation type.

I did similar performance testing on this as in #11660 and #11612 and it seems to be ~15-20% improvement compared to develop when MSC3440 enabled. (The changes in this PR bring performance roughly on par as develop with MSC3440 *disabled*.)

Part of #11825.

Should be reviewable commit-by-commit.