### PR TITLE
Debug for device lists updates

### DIFF
--- a/changelog.d/11760.misc
+++ b/changelog.d/11760.misc
@@ -1,0 +1,1 @@
+Add optional debugging to investigate [issue 8631](https://github.com/matrix-org/synapse/issues/8631).

--- a/synapse/federation/sender/transaction_manager.py
+++ b/synapse/federation/sender/transaction_manager.py
@@ -132,7 +132,7 @@ class TransactionManager:
                 ]
                 if device_list_updates:
                     issue_8631_logger.debug(
-                        "transaction [%s] includes device list updates: %s",
+                        "about to send txn [%s] including device list updates: %s",
                         transaction.transaction_id,
                         device_list_updates,
                     )

--- a/synapse/federation/sender/transaction_manager.py
+++ b/synapse/federation/sender/transaction_manager.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     import synapse.server
 
 logger = logging.getLogger(__name__)
+issue_8631_logger = logging.getLogger("synapse.8631_debug")
 
 last_pdu_ts_metric = Gauge(
     "synapse_federation_last_sent_pdu_time",
@@ -124,6 +125,17 @@ class TransactionManager:
                 len(pdus),
                 len(edus),
             )
+            if issue_8631_logger.isEnabledFor(logging.DEBUG):
+                DEVICE_UPDATE_EDUS = {"m.device_list_update", "m.signing_key_update"}
+                device_list_updates = [
+                    edu.content for edu in edus if edu.edu_type in DEVICE_UPDATE_EDUS
+                ]
+                if device_list_updates:
+                    issue_8631_logger.debug(
+                        "transaction [%s] includes device list updates: %s",
+                        transaction.transaction_id,
+                        device_list_updates,
+                    )
 
             # Actually send the transaction
 

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -105,7 +105,7 @@ class FederationSendServlet(BaseFederationServerServlet):
                 ]
                 if device_list_updates:
                     issue_8631_logger.debug(
-                        "transaction [%s] includes device list updates: %s",
+                        "received transaction [%s] including device list updates: %s",
                         transaction_id,
                         device_list_updates,
                     )

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -36,6 +36,7 @@ from synapse.util.ratelimitutils import FederationRateLimiter
 from synapse.util.versionstring import get_version_string
 
 logger = logging.getLogger(__name__)
+issue_8631_logger = logging.getLogger("synapse.8631_debug")
 
 
 class BaseFederationServerServlet(BaseFederationServlet):
@@ -94,6 +95,20 @@ class FederationSendServlet(BaseFederationServerServlet):
                 len(transaction_data.get("pdus", [])),
                 len(transaction_data.get("edus", [])),
             )
+
+            if issue_8631_logger.isEnabledFor(logging.DEBUG):
+                DEVICE_UPDATE_EDUS = {"m.device_list_update", "m.signing_key_update"}
+                device_list_updates = [
+                    edu.content
+                    for edu in transaction_data.get("edus", [])
+                    if edu.edu_type in DEVICE_UPDATE_EDUS
+                ]
+                if device_list_updates:
+                    issue_8631_logger.debug(
+                        "transaction [%s] includes device list updates: %s",
+                        transaction_id,
+                        device_list_updates,
+                    )
 
         except Exception as e:
             logger.exception(e)

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -223,7 +223,8 @@ class DeviceWorkerStore(SQLBaseStore):
             limit,
         )
 
-        # Note for later that `len(updates) <= limit`.
+        # We need to ensure `updates` doesn't grow too big.
+        # Currently: `len(updates) <= limit`.
 
         # Return an empty list if there are no updates
         if not updates:


### PR DESCRIPTION
Debug for #8631. I want to establish if we actually _are_ sending out the
correct EDUs over federation.

I'm having a hard time tracking down what's going wrong in that issue.
In the reported example, I could see server A sending federation traffic
to server B and all was well. Yet B reports out-of-sync device updates
from A.

I couldn't see what was _in_ the events being sent from A to B. So I
have added some entirely untested crude logging to track

- when we have updates to send to a remote HS
- the edus we actually accumulate to send
- when a federation transaction includes a device list update edu
- when such an EDU is received

This is a bit of a sledgehammer. Is this a good idea? I'm anxious that this might create too much logspam.