### PR TITLE
Revert #11602 to prevent webclient overriding client resource

### DIFF
--- a/changelog.d/11764.bugfix
+++ b/changelog.d/11764.bugfix
@@ -1,0 +1,1 @@
+Fixes a bug introduced in Synapse 1.50.0rc1 that could cause Matrix clients to be unable to connect to Synapse instances with the 'webclient' resource enabled.

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -27,7 +27,6 @@ import synapse
 import synapse.config.logger
 from synapse import events
 from synapse.api.urls import (
-    CLIENT_API_PREFIX,
     FEDERATION_PREFIX,
     LEGACY_MEDIA_PREFIX,
     MEDIA_R0_PREFIX,
@@ -193,7 +192,13 @@ class SynapseHomeServer(HomeServer):
 
             resources.update(
                 {
-                    CLIENT_API_PREFIX: client_resource,
+                    "/_matrix/client/api/v1": client_resource,
+                    "/_matrix/client/r0": client_resource,
+                    "/_matrix/client/v1": client_resource,
+                    "/_matrix/client/v3": client_resource,
+                    "/_matrix/client/unstable": client_resource,
+                    "/_matrix/client/v2_alpha": client_resource,
+                    "/_matrix/client/versions": client_resource,
                     "/.well-known": well_known_resource(self),
                     "/_synapse/admin": AdminRestResource(self),
                     **build_synapse_client_resource_tree(self),


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/11763

#11602 compiled known client resource prefixes under one, simplified '/_matrix/client' prefix. Unfortunately, '/_matrix/client' is already a prefix used by the 'webclient' resource. As we use a Python dictionary to hold a mapping from prefix to resource, configuring a 'webclient' resource after a 'client' resource would end up with all client requests being redirected to the 'webclient' resource (which doesn't know how to handle things like `/login` or `/sync`).

This PR essentially reverts #11602 in order to provide a working version of Synapse v1.50.x. A proper fix will come later. Additionally, this bug has highlighted how fragile the resource code is currently.