### PR TITLE
Add a regression test for using both webclient and client resources simultaneously

### DIFF
--- a/changelog.d/11765.misc
+++ b/changelog.d/11765.misc
@@ -1,0 +1,1 @@
+Add a unit test that checks both `client` and `webclient` resources will function when simultaneously enabled.

--- a/tests/http/test_webclient.py
+++ b/tests/http/test_webclient.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from http import HTTPStatus
 from typing import Dict
 
 from twisted.web.resource import Resource
@@ -90,7 +91,8 @@ class WebClientTests(HomeserverTestCase):
             method="GET",
             path="/_matrix/client",
         )
-        self.assertEqual(channel.code, 302)
+        # Check that we are being redirected to the webclient location URI.
+        self.assertEqual(channel.code, HTTPStatus.FOUND)
         self.assertEqual(
             channel.headers.getRawHeaders("Location"), ["https://example.org"]
         )
@@ -102,5 +104,5 @@ class WebClientTests(HomeserverTestCase):
             method="GET",
             path="/_matrix/client/v3/login",
         )
-        self.assertEqual(channel.code, 200)
+        self.assertEqual(channel.code, HTTPStatus.OK)
         self.assertIn("flows", channel.json_body)

--- a/tests/http/test_webclient.py
+++ b/tests/http/test_webclient.py
@@ -1,0 +1,106 @@
+# Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Dict
+
+from twisted.web.resource import Resource
+
+from synapse.app.homeserver import SynapseHomeServer
+from synapse.config.server import HttpListenerConfig, HttpResourceConfig, ListenerConfig
+from synapse.http.site import SynapseSite
+
+from tests.server import make_request
+from tests.unittest import HomeserverTestCase, create_resource_tree, override_config
+
+
+class WebClientTests(HomeserverTestCase):
+    @override_config(
+        {
+            "web_client_location": "https://example.org",
+        }
+    )
+    def test_webclient_resolves_with_client_resource(self):
+        """
+        Tests that both client and webclient resources can be accessed simultaneously.
+
+        This is a regression test created in response to https://github.com/matrix-org/synapse/issues/11763.
+        """
+        for resource_name_order_list in [
+            ["webclient", "client"],
+            ["client", "webclient"],
+        ]:
+            # Create a dictionary from path regex -> resource
+            resource_dict: Dict[str, Resource] = {}
+
+            for resource_name in resource_name_order_list:
+                resource_dict.update(
+                    SynapseHomeServer._configure_named_resource(self.hs, resource_name)
+                )
+
+            # Create a root resource which ties the above resources together into one
+            root_resource = Resource()
+            create_resource_tree(resource_dict, root_resource)
+
+            # Create a site configured with this resource to make HTTP requests against
+            listener_config = ListenerConfig(
+                port=8008,
+                bind_addresses=["127.0.0.1"],
+                type="http",
+                http_options=HttpListenerConfig(
+                    resources=[HttpResourceConfig(names=resource_name_order_list)]
+                ),
+            )
+            test_site = SynapseSite(
+                logger_name="synapse.access.http.fake",
+                site_tag=self.hs.config.server.server_name,
+                config=listener_config,
+                resource=root_resource,
+                server_version_string="1",
+                max_request_body_size=1234,
+                reactor=self.reactor,
+            )
+
+            # Attempt to make requests to endpoints on both the webclient and client resources
+            # on test_site.
+            self._request_client_and_webclient_resources(test_site)
+
+    def _request_client_and_webclient_resources(self, test_site: SynapseSite) -> None:
+        """Make a request to an endpoint on both the webclient and client-server resources
+        of the given SynapseSite.
+
+        Args:
+            test_site: The SynapseSite object to make requests against.
+        """
+
+        # Ensure that the *webclient* resource is behaving as expected (we get redirected to
+        # the configured web_client_location)
+        channel = make_request(
+            self.reactor,
+            site=test_site,
+            method="GET",
+            path="/_matrix/client",
+        )
+        self.assertEqual(channel.code, 302)
+        self.assertEqual(
+            channel.headers.getRawHeaders("Location"), ["https://example.org"]
+        )
+
+        # Ensure that a request to the *client* resource works.
+        channel = make_request(
+            self.reactor,
+            site=test_site,
+            method="GET",
+            path="/_matrix/client/v3/login",
+        )
+        self.assertEqual(channel.code, 200)
+        self.assertIn("flows", channel.json_body)


### PR DESCRIPTION
Add a regression test for the bug detailed in https://github.com/matrix-org/synapse/issues/11763.

This test configures a `SynapseSite` with both a `webclient` and `client` resource, then makes a `GET` request against both `/_matrix/client` and `/_matrix/client/v3/login`, check that the appropriate status codes and response header/bodies were returned. Both possible orderings of configuring `webclient` and `client` are attempted (`[webclient, client]` vs `[client, webclient]`).

Manipulating resources in unit tests ended up a lot more complicated than originally desired. I was hoping to just be able to `override_config` with the `listeners` section and be done with it. Unfortunately, resources for homeservers created when inheriting `HomeserverTestCase` are hardcoded: https://github.com/matrix-org/synapse/blob/d6fb96e056f79de220d8d59429d89a61498e9af3/tests/unittest.py#L257-L267

Note that I don't think inheriting from `HomeserverTestCase` is actually necessary for this test - but it may be useful if we ever add more test cases to this class (if we do before we drop `webclient` entirely: #9078).