### PR TITLE
Add missing `auto_attribs=True` to the `_WrappedRustReporter` class

### DIFF
--- a/changelog.d/11768.misc
+++ b/changelog.d/11768.misc
@@ -1,0 +1,1 @@
+Use `auto_attribs` and native type hints for attrs classes.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -247,7 +247,7 @@ try:
         class BaseReporter:  # type: ignore[no-redef]
             pass
 
-    @attr.s(slots=True, frozen=True)
+    @attr.s(slots=True, frozen=True, auto_attribs=True)
     class _WrappedRustReporter(BaseReporter):
         """Wrap the reporter to ensure `report_span` never throws."""
 


### PR DESCRIPTION
Otherwise `_reporter` would end up as a `attr.Factory`, not a `Reporter`.

Uses the same changelog as #11692.