### PR TITLE
Partially revert #11675; prevent attempting to create pushers on workers

### DIFF
--- a/changelog.d/11770.feature
+++ b/changelog.d/11770.feature
@@ -1,0 +1,1 @@
+Add a flag to the `synapse_review_recent_signups` script to ignore and filter appservice users.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -979,18 +979,16 @@ class RegistrationHandler:
         if (
             self.hs.config.email.email_enable_notifs
             and self.hs.config.email.email_notif_for_new_users
+            and token
         ):
             # Pull the ID of the access token back out of the db
             # It would really make more sense for this to be passed
             # up when the access token is saved, but that's quite an
             # invasive change I'd rather do separately.
-            if token:
-                user_tuple = await self.store.get_user_by_access_token(token)
-                # The token better still exist.
-                assert user_tuple
-                token_id = user_tuple.token_id
-            else:
-                token_id = None
+            user_tuple = await self.store.get_user_by_access_token(token)
+            # The token better still exist.
+            assert user_tuple
+            token_id = user_tuple.token_id
 
             await self.pusher_pool.add_pusher(
                 user_id=user_id,


### PR DESCRIPTION
Closes https://github.com/matrix-org/synapse/issues/11769. Necessary context is in the issue.

