### PR TITLE
Fix a bug that corrupted the cache of federated space hierarchies

### DIFF
--- a/changelog.d/11775.bugfix
+++ b/changelog.d/11775.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where space hierarchy over federation would only work correctly some of the time.

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -780,6 +780,7 @@ class RoomSummaryHandler:
         try:
             (
                 room_response,
+                children_state_events,
                 children,
                 inaccessible_children,
             ) = await self._federation_client.get_room_hierarchy(
@@ -803,10 +804,8 @@ class RoomSummaryHandler:
             if "room_id" in c and isinstance(c["room_id"], str)
         }
 
-        room_response = dict(room_response)
-        children_state = room_response.pop("children_state", ())
         return (
-            _RoomEntry(room_id, room_response, children_state),
+            _RoomEntry(room_id, room_response, children_state_events),
             children_by_room_id,
             set(inaccessible_children),
         )

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -803,8 +803,10 @@ class RoomSummaryHandler:
             if "room_id" in c and isinstance(c["room_id"], str)
         }
 
+        room_response = dict(room_response)
+        children_state = room_response.pop("children_state", ())
         return (
-            _RoomEntry(room_id, room_response, room_response.pop("children_state", ())),
+            _RoomEntry(room_id, room_response, children_state),
             children_by_room_id,
             set(inaccessible_children),
         )


### PR DESCRIPTION
`FederationClient.get_room_hierarchy()` caches its return values, so
avoid modifying the returned room summary and clone it instead.

Fixes #11773.