### PR TITLE
installation.md: drop python 3.6 support

### DIFF
--- a/changelog.d/11781.doc
+++ b/changelog.d/11781.doc
@@ -1,0 +1,1 @@
+Update installation instructions to note that Python 3.6 is no longer supported.

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -194,7 +194,7 @@ When following this route please make sure that the [Platform-specific prerequis
 System requirements:
 
 - POSIX-compliant system (tested on Linux & OS X)
-- Python 3.6 or later, up to Python 3.9.
+- Python 3.7 or later, up to Python 3.9.
 - At least 1GB of free RAM if you want to join large public rooms like #matrix:matrix.org
 
 To install the Synapse homeserver run:


### PR DESCRIPTION
#11595 dropped support for python 3.6, but forgot to update this doc.