### PR TITLE
Fix redirecting to the webclient for non-HTTP(S) web_client_location.

### DIFF
--- a/changelog.d/11783.misc
+++ b/changelog.d/11783.misc
@@ -1,0 +1,1 @@
+Deprecate support for `webclient` listeners and non-HTTP(S) `web_client_location` configuration.

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -142,7 +142,7 @@ class SynapseHomeServer(HomeServer):
                 self.config.server.web_client_location
             )
         elif WEB_CLIENT_PREFIX in resources:
-            root_resource: Resource = RootOptionsRedirectResource(WEB_CLIENT_PREFIX)
+            root_resource = RootOptionsRedirectResource(WEB_CLIENT_PREFIX)
         elif STATIC_PREFIX in resources:
             root_resource = RootOptionsRedirectResource(STATIC_PREFIX)
         else:

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -131,11 +131,18 @@ class SynapseHomeServer(HomeServer):
         resources.update(self._module_web_resources)
         self._module_web_resources_consumed = True
 
-        # try to find something useful to redirect '/' to
+        # Try to find something useful to serve at '/':
+        #
+        # 1. Redirect to the web client if it is an HTTP(S) URL.
+        # 2. Redirect to the web client served via Synapse.
+        # 3. Redirect to the static "Synapse is running" page.
+        # 4. Do not redirect and use a blank resource.
         if self.config.server.web_client_location_is_redirect:
             root_resource: Resource = RootOptionsRedirectResource(
                 self.config.server.web_client_location
             )
+        elif WEB_CLIENT_PREFIX in resources:
+            root_resource: Resource = RootOptionsRedirectResource(WEB_CLIENT_PREFIX)
         elif STATIC_PREFIX in resources:
             root_resource = RootOptionsRedirectResource(STATIC_PREFIX)
         else:


### PR DESCRIPTION
Follow-on to #11774 which fixes redirection `/` -> `/_matrix/client` in the situation where a non-HTTP(S) `web_client_location` option is given.

Related to #9078.