### PR TITLE
Apply a timeout to reading the body when fetching a file.

### DIFF
--- a/changelog.d/11784.bugfix
+++ b/changelog.d/11784.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug that media streams could cause long-lived connections when generating URL previews.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -734,7 +734,7 @@ class SimpleHttpClient:
             d = read_body_with_max_size(response, output_stream, max_size)
 
             # Ensure that the body is not read forever.
-            d = timeout_deferred(d, 60, self.hs.get_reactor())
+            d = timeout_deferred(d, 30, self.hs.get_reactor())
 
             length = await make_deferred_yieldable(d)
         except BodyExceededMaxSize:

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -731,13 +731,22 @@ class SimpleHttpClient:
         # straight back in again
 
         try:
-            length = await make_deferred_yieldable(
-                read_body_with_max_size(response, output_stream, max_size)
-            )
+            d = read_body_with_max_size(response, output_stream, max_size)
+
+            # Ensure that the body is not read forever.
+            d = timeout_deferred(d, 60, self.hs.get_reactor())
+
+            length = await make_deferred_yieldable(d)
         except BodyExceededMaxSize:
             raise SynapseError(
                 HTTPStatus.BAD_GATEWAY,
                 "Requested file is too large > %r bytes" % (max_size,),
+                Codes.TOO_LARGE,
+            )
+        except defer.TimeoutError:
+            raise SynapseError(
+                HTTPStatus.BAD_GATEWAY,
+                "Requested file took too long to download",
                 Codes.TOO_LARGE,
             )
         except Exception as e:


### PR DESCRIPTION
Fixes #8302.

Applies a timeout to reading the body for `SimpleHttpClient.get_file()`. This brings the code more inline with `MatrixFederationHttpClient.get_file`, although that uses `addTimeout` instead of `timeout_deferred`.

I tested this by attempting to preview a stream (I used a local radio station), waiting several minutes and noticing the file was still growing. With this patch the download stops after 60 seconds and the client receives an error message:

```json
{"errcode":"M_TOO_LARGE","error":"Requested file took too long to download"}
```

We are rather inconsistent with using timeouts when reading bodies, we seem to do it in some places, but not many other places. It is unclear if this is on purpose or not though. This particular method is only used by URL previews.