### PR TITLE
Correctly await on_logged_out callbacks

### DIFF
--- a/changelog.d/11786.bugfix
+++ b/changelog.d/11786.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.46.0 that prevented `on_logged_out` module callbacks from being correctly awaited by Synapse.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -2281,7 +2281,7 @@ class PasswordAuthProvider:
         # call all of the on_logged_out callbacks
         for callback in self.on_logged_out_callbacks:
             try:
-                callback(user_id, device_id, access_token)
+                await callback(user_id, device_id, access_token)
             except Exception as e:
                 logger.warning("Failed to run module API callback %s: %s", callback, e)
                 continue

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -727,10 +727,15 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         tok = self.login("rin", "password")
 
         on_logged_out = Mock(return_value=make_awaitable(None))
-        self.hs.get_password_auth_provider().on_logged_out_callbacks.append(on_logged_out)
+        self.hs.get_password_auth_provider().on_logged_out_callbacks.append(
+            on_logged_out
+        )
 
         channel = self.make_request(
-            "POST", "/_matrix/client/v3/logout", {}, access_token=tok,
+            "POST",
+            "/_matrix/client/v3/logout",
+            {},
+            access_token=tok,
         )
         self.assertEqual(channel.code, 200)
         on_logged_out.assert_called_once()

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -27,7 +27,6 @@ from synapse.types import JsonDict
 
 from tests import unittest
 from tests.server import FakeChannel
-from tests.test_utils import make_awaitable
 from tests.unittest import override_config
 
 # (possibly experimental) login flows we expect to appear in the list after the normal

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -22,11 +22,12 @@ from twisted.internet import defer
 import synapse
 from synapse.handlers.auth import load_legacy_password_auth_providers
 from synapse.module_api import ModuleApi
-from synapse.rest.client import devices, login
+from synapse.rest.client import devices, login, logout
 from synapse.types import JsonDict
 
 from tests import unittest
 from tests.server import FakeChannel
+from tests.test_utils import make_awaitable
 from tests.unittest import override_config
 
 # (possibly experimental) login flows we expect to appear in the list after the normal
@@ -155,6 +156,7 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         synapse.rest.admin.register_servlets,
         login.register_servlets,
         devices.register_servlets,
+        logout.register_servlets,
     ]
 
     def setUp(self):
@@ -718,6 +720,20 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         # ("unknown login type")
         channel = self._send_password_login("localuser", "localpass")
         self.assertEqual(channel.code, 400, channel.result)
+
+    def test_on_logged_out(self):
+        """Tests that the on_logged_out callback is called when the user logs out."""
+        self.register_user("rin", "password")
+        tok = self.login("rin", "password")
+
+        on_logged_out = Mock(return_value=make_awaitable(None))
+        self.hs.get_password_auth_provider().on_logged_out_callbacks.append(on_logged_out)
+
+        channel = self.make_request(
+            "POST", "/_matrix/client/v3/logout", {}, access_token=tok,
+        )
+        self.assertEqual(channel.code, 200)
+        on_logged_out.assert_called_once()
 
     def _get_login_flows(self) -> JsonDict:
         channel = self.make_request("GET", "/_matrix/client/r0/login")

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -726,7 +726,12 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         self.register_user("rin", "password")
         tok = self.login("rin", "password")
 
-        on_logged_out = Mock(return_value=make_awaitable(None))
+        self.called = False
+
+        async def on_logged_out(user_id, device_id, access_token):
+            self.called = True
+
+        on_logged_out = Mock(side_effect=on_logged_out)
         self.hs.get_password_auth_provider().on_logged_out_callbacks.append(
             on_logged_out
         )
@@ -739,6 +744,7 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, 200)
         on_logged_out.assert_called_once()
+        self.assertTrue(self.called)
 
     def _get_login_flows(self) -> JsonDict:
         channel = self.make_request("GET", "/_matrix/client/r0/login")


### PR DESCRIPTION
Looks like this was an oversight from https://github.com/matrix-org/synapse/pull/10548