### PR TITLE
Make `get_account_data_for_room_and_type` a tree cache

### DIFF
--- a/changelog.d/11789.feature
+++ b/changelog.d/11789.feature
@@ -1,0 +1,1 @@
+Remove account data (including client config, push rules and ignored users) upon user deactivation.

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -210,7 +210,7 @@ class AccountDataWorkerStore(CacheInvalidationWorkerStore):
             "get_account_data_for_room", get_account_data_for_room_txn
         )
 
-    @cached(num_args=3, max_entries=5000)
+    @cached(num_args=3, max_entries=5000, tree=True)
     async def get_account_data_for_room_and_type(
         self, user_id: str, room_id: str, account_data_type: str
     ) -> Optional[JsonDict]:


### PR DESCRIPTION
This is useful as part of #11621 to allow invalidating all the rows by user ID.

