### PR TITLE
Drop unused table `public_room_list_stream`.

### DIFF
--- a/changelog.d/11795.misc
+++ b/changelog.d/11795.misc
@@ -1,0 +1,1 @@
+Drop unused table `public_room_list_stream`.

--- a/synapse/storage/databases/main/purge_events.py
+++ b/synapse/storage/databases/main/purge_events.py
@@ -390,7 +390,6 @@ class PurgeEventsStore(StateGroupWorkerStore, CacheInvalidationWorkerStore):
             "event_search",
             "events",
             "group_rooms",
-            "public_room_list_stream",
             "receipts_graph",
             "receipts_linearized",
             "room_aliases",

--- a/synapse/storage/schema/__init__.py
+++ b/synapse/storage/schema/__init__.py
@@ -57,7 +57,9 @@ Changes in SCHEMA_VERSION = 67:
 
 
 SCHEMA_COMPAT_VERSION = (
-    61  # 61: Remove unused tables `user_stats_historical` and `room_stats_historical`
+    # we have removed the public_room_list_stream table, so are now incompatible with
+    # synapses wth SCHEMA_VERSION < 63.
+    63
 )
 """Limit on how far the synapse codebase can be rolled back without breaking db compat
 

--- a/synapse/storage/schema/main/delta/67/01drop_public_room_list_stream.sql
+++ b/synapse/storage/schema/main/delta/67/01drop_public_room_list_stream.sql
@@ -1,0 +1,18 @@
+/* Copyright 2022 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- this table is unused as of Synapse 1.41
+DROP TABLE public_room_list_stream;
+

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -2468,7 +2468,6 @@ PURGE_TABLES = [
     "event_search",
     "events",
     "group_rooms",
-    "public_room_list_stream",
     "receipts_graph",
     "receipts_linearized",
     "room_aliases",


### PR DESCRIPTION
This is a follow-up to #10565.