### PR TITLE
Include `prev_content` field in AS events

### DIFF
--- a/changelog.d/11798.bugfix
+++ b/changelog.d/11798.bugfix
@@ -1,0 +1,1 @@
+Include `prev_content` field in state events sent to Application Services. Contributed by @totallynotvaishnav.

--- a/changelog.d/11798.bugfix
+++ b/changelog.d/11798.bugfix
@@ -1,1 +1,1 @@
-Include `prev_content` field in state events sent to Application Services. Contributed by @totallynotvaishnav.
+Include a `prev_content` field in state events sent to Application Services. Contributed by @totallynotvaishnav.

--- a/synapse/storage/databases/main/appservice.py
+++ b/synapse/storage/databases/main/appservice.py
@@ -384,7 +384,7 @@ class ApplicationServiceTransactionWorkerStore(
             "get_new_events_for_appservice", get_new_events_for_appservice_txn
         )
 
-        events = await self.get_events_as_list(event_ids)
+        events = await self.get_events_as_list(event_ids, get_prev_content=True)
 
         return upper_bound, events
 


### PR DESCRIPTION
Signed-off-by: Vaishnav Nair <nairvaishnav007@icloud.com>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Fixes #11732