### PR TITLE
Db txn set isolation level

### DIFF
--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -702,6 +702,7 @@ class DatabasePool:
         func: Callable[..., R],
         *args: Any,
         db_autocommit: bool = False,
+        isolation_level: Optional[int] = None,
         **kwargs: Any,
     ) -> R:
         """Starts a transaction on the database and runs a given function
@@ -724,6 +725,7 @@ class DatabasePool:
                 called multiple times if the transaction is retried, so must
                 correctly handle that case.
 
+            isolation_level: Set the server isolation level for this transaction.
             args: positional args to pass to `func`
             kwargs: named args to pass to `func`
 
@@ -763,6 +765,7 @@ class DatabasePool:
         func: Callable[..., R],
         *args: Any,
         db_autocommit: bool = False,
+        isolation_level: Optional[int] = None,
         **kwargs: Any,
     ) -> R:
         """Wraps the .runWithConnection() method on the underlying db_pool.
@@ -775,6 +778,7 @@ class DatabasePool:
             db_autocommit: Whether to run the function in "autocommit" mode,
                 i.e. outside of a transaction. This is useful for transaction
                 that are only a single query. Currently only affects postgres.
+            isolation_level: Set the server isolation level for this transaction.
             kwargs: named args to pass to `func`
 
         Returns:
@@ -834,6 +838,10 @@ class DatabasePool:
                     try:
                         if db_autocommit:
                             self.engine.attempt_to_set_autocommit(conn, True)
+                        if isolation_level:
+                            self.engine.attempt_to_set_isolation_level(
+                                conn, isolation_level
+                            )
 
                         db_conn = LoggingDatabaseConnection(
                             conn, self.engine, "runWithConnection"
@@ -842,6 +850,8 @@ class DatabasePool:
                     finally:
                         if db_autocommit:
                             self.engine.attempt_to_set_autocommit(conn, False)
+                        if isolation_level:
+                            self.engine.attempt_to_set_isolation_level(conn, None)
 
         return await make_deferred_yieldable(
             self._db_pool.runWithConnection(inner_func, *args, **kwargs)

--- a/synapse/storage/engines/_base.py
+++ b/synapse/storage/engines/_base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Optional
 
 from synapse.storage.types import Connection
 
@@ -107,5 +107,13 @@ class BaseDatabaseEngine(Generic[ConnectionType], metaclass=abc.ABCMeta):
 
         Note: This has no effect on SQLite3, so callers still need to
         commit/rollback the connections.
+        """
+        ...
+
+    @abc.abstractmethod
+    def attempt_to_set_isolation_level(self, conn: Connection, isolation_level: Optional[int]):
+        """Attempt to set the connections isolation level.
+
+        Note: This has no effect on SQLite3, as transactions are SERIALIZABLE by default.
         """
         ...

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from typing import Optional
 
 from synapse.storage.engines._base import BaseDatabaseEngine, IncorrectDatabaseSetup
 from synapse.storage.types import Connection
@@ -175,3 +176,8 @@ class PostgresEngine(BaseDatabaseEngine):
 
     def attempt_to_set_autocommit(self, conn: Connection, autocommit: bool):
         return conn.set_session(autocommit=autocommit)  # type: ignore
+
+    def attempt_to_set_isolation_level(self, conn: Connection, isolation_level: Optional[int]):
+        if isolation_level is None:
+            isolation_level = self.module.extensions.ISOLATION_LEVEL_REPEATABLE_READ
+        return conn.set_isolation_level(isolation_level)  # type: ignore

--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -15,6 +15,7 @@ import platform
 import struct
 import threading
 import typing
+from typing import Optional
 
 from synapse.storage.engines import BaseDatabaseEngine
 from synapse.storage.types import Connection
@@ -120,6 +121,10 @@ class Sqlite3Engine(BaseDatabaseEngine["sqlite3.Connection"]):
     def attempt_to_set_autocommit(self, conn: Connection, autocommit: bool):
         # Twisted doesn't let us set attributes on the connections, so we can't
         # set the connection to autocommit mode.
+        pass
+
+    def attempt_to_set_isolation_level(self, conn: Connection, isolation_level: Optional[int]):
+        # All transactions are SERIALIZABLE by default in sqllite
         pass
 
 


### PR DESCRIPTION
Part of: https://github.com/matrix-org/synapse/issues/11567

Some things to figure out:

+ How should codepaths calling `runInteraction` specify the TXN level? They exist as constants within `psycopg2` which may not be installed. One option is a mapping of `str` -> level in the postgres engine module.
+ Is `None` the right value to reset the TXN level back to the (synapse specific) default

Signed-off-by: Nick Barrett nick@beeper.com

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
