### PR TITLE
WIP: Enable email notification on SSO when set in the config

### DIFF
--- a/changelog.d/11805.bugfix
+++ b/changelog.d/11805.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where email notifications were not enabled when the user logged in via an SSO even though in the config `email.notif_for_new_users` and `email.enable_notifs` were set to `true`.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -979,16 +979,18 @@ class RegistrationHandler:
         if (
             self.hs.config.email.email_enable_notifs
             and self.hs.config.email.email_notif_for_new_users
-            and token
         ):
             # Pull the ID of the access token back out of the db
             # It would really make more sense for this to be passed
             # up when the access token is saved, but that's quite an
             # invasive change I'd rather do separately.
-            user_tuple = await self.store.get_user_by_access_token(token)
-            # The token better still exist.
-            assert user_tuple
-            token_id = user_tuple.token_id
+            if token:
+                user_tuple = await self.store.get_user_by_access_token(token)
+                # The token better still exist.
+                assert user_tuple
+                token_id = user_tuple.token_id
+            else:
+                token_id = None
 
             await self.pusher_pool.add_pusher(
                 user_id=user_id,


### PR DESCRIPTION
Fixes #10882. 

Fix a bug where email notifications were not enabled when the user logged in via an SSO even though in the config `email.notif_for_new_users` and `email.enable_notifs` were set to `true`.

Tested with keycloak.

**Signed-off by:** Lukas Denk, lukasdenk@web.de 

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
