### PR TITLE
Fix logic for dropping old events in fed queue

### DIFF
--- a/changelog.d/11806.bugfix
+++ b/changelog.d/11806.bugfix
@@ -1,1 +1,1 @@
-Fix a bug introduced in v1.40.0 that caused Synapse to fail to process incoming federation traffic after handling a large amount of events in a v1 room.
+Fix a bug introduced in Synapse 1.40.0 that caused Synapse to fail to process incoming federation traffic after handling a large amount of events in a v1 room.

--- a/changelog.d/11806.bugfix
+++ b/changelog.d/11806.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.40.0 that caused Synapse to fail to process incoming federation traffic after handling a large amount of events in a v1 room.

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1432,7 +1432,10 @@ class EventFederationWorkerStore(EventsWorkerStore, SignatureWorkerStore, SQLBas
 
             if room_version.event_format == EventFormatVersions.V1:
                 for prev_event_tuple in prev_events:
-                    if not isinstance(prev_event_tuple, list) or len(prev_events) != 2:
+                    if (
+                        not isinstance(prev_event_tuple, list)
+                        or len(prev_event_tuple) != 2
+                    ):
                         logger.info("Invalid prev_events for %s", event_id)
                         break
 

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Tuple, Union
+
 import attr
 from parameterized import parameterized
 
-from synapse.api.room_versions import RoomVersions
+from synapse.api.room_versions import RoomVersion, RoomVersions
 from synapse.events import _EventInternalMetadata
 from synapse.util import json_encoder
 
@@ -506,10 +508,23 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         )
         self.assertSetEqual(difference, set())
 
-    def test_prune_inbound_federation_queue(self):
-        "Test that pruning of inbound federation queues work"
+    @parameterized.expand(
+        [
+            (RoomVersions.V1,),
+            (RoomVersions.V9,),
+        ]
+    )
+    def test_prune_inbound_federation_queue(self, room_version: RoomVersion):
+        """Test that pruning of inbound federation queues work"""
 
         room_id = "some_room_id"
+
+        def prev_event_format(prev_event_id: str) -> Union[Tuple[str, dict], str]:
+            """Account for differences in prev_events format across room versions"""
+            if room_version == RoomVersions.V1:
+                return prev_event_id, {}
+
+            return prev_event_id
 
         # Insert a bunch of events that all reference the previous one.
         self.get_success(
@@ -529,7 +544,9 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
                         room_id,
                         0,
                         f"$fake_event_id_{i + 1}",
-                        json_encoder.encode({"prev_events": [f"$fake_event_id_{i}"]}),
+                        json_encoder.encode(
+                            {"prev_events": [prev_event_format(f"$fake_event_id_{i}")]}
+                        ),
                         "{}",
                     )
                     for i in range(500)
@@ -541,12 +558,12 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         # Calling prune once should return True, i.e. a prune happen. The second
         # time it shouldn't.
         pruned = self.get_success(
-            self.store.prune_staged_events_in_room(room_id, RoomVersions.V6)
+            self.store.prune_staged_events_in_room(room_id, room_version)
         )
         self.assertTrue(pruned)
 
         pruned = self.get_success(
-            self.store.prune_staged_events_in_room(room_id, RoomVersions.V6)
+            self.store.prune_staged_events_in_room(room_id, room_version)
         )
         self.assertFalse(pruned)
 

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -17,7 +17,11 @@ from typing import Tuple, Union
 import attr
 from parameterized import parameterized
 
-from synapse.api.room_versions import EventFormatVersions, RoomVersion, RoomVersions
+from synapse.api.room_versions import (
+    KNOWN_ROOM_VERSIONS,
+    EventFormatVersions,
+    RoomVersion,
+)
 from synapse.events import _EventInternalMetadata
 from synapse.util import json_encoder
 
@@ -509,10 +513,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
         self.assertSetEqual(difference, set())
 
     @parameterized.expand(
-        [
-            (RoomVersions.V1,),
-            (RoomVersions.V9,),
-        ]
+        [(room_version,) for room_version in KNOWN_ROOM_VERSIONS.values()]
     )
     def test_prune_inbound_federation_queue(self, room_version: RoomVersion):
         """Test that pruning of inbound federation queues work"""

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -17,7 +17,7 @@ from typing import Tuple, Union
 import attr
 from parameterized import parameterized
 
-from synapse.api.room_versions import RoomVersion, RoomVersions
+from synapse.api.room_versions import EventFormatVersions, RoomVersion, RoomVersions
 from synapse.events import _EventInternalMetadata
 from synapse.util import json_encoder
 
@@ -521,7 +521,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
 
         def prev_event_format(prev_event_id: str) -> Union[Tuple[str, dict], str]:
             """Account for differences in prev_events format across room versions"""
-            if room_version == RoomVersions.V1:
+            if room_version.event_format == EventFormatVersions.V1:
                 return prev_event_id, {}
 
             return prev_event_id


### PR DESCRIPTION
This PR is a cherry-pick of a patch by @richvdh and fixes #11802.

There was a typo for `prev_events_tuple` in #10390 which lead to the infinite looping.

Fixes infinite loops of:

> logger.info("Invalid prev_events for %s", event_id)