### PR TITLE
Make get_room_version use cached get_room_version_id.

### DIFF
--- a/changelog.d/11808.misc
+++ b/changelog.d/11808.misc
@@ -1,0 +1,1 @@
+Make method `get_room_version` use cached `get_room_version_id`.

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -62,7 +62,7 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
                 Typically this happens if support for the room's version has been
                 removed from Synapse.
         """
-        room_version_id = self.get_room_version_id(room_id)
+        room_version_id = await self.get_room_version_id(room_id)
         return self.__retrieve_and_check_room_version(room_id, room_version_id)
 
     def get_room_version_txn(

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -63,7 +63,7 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
                 removed from Synapse.
         """
         room_version_id = await self.get_room_version_id(room_id)
-        return self.__retrieve_and_check_room_version(room_id, room_version_id)
+        return self._retrieve_and_check_room_version(room_id, room_version_id)
 
     def get_room_version_txn(
         self, txn: LoggingTransaction, room_id: str
@@ -79,9 +79,9 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
                 removed from Synapse.
         """
         room_version_id = self.get_room_version_id_txn(txn, room_id)
-        return self.__retrieve_and_check_room_version(room_id, room_version_id)
+        return self._retrieve_and_check_room_version(room_id, room_version_id)
 
-    def __retrieve_and_check_room_version(
+    def _retrieve_and_check_room_version(
         self, room_id: str, room_version_id: str
     ) -> RoomVersion:
         v = KNOWN_ROOM_VERSIONS.get(room_version_id)

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -715,7 +715,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
 
     def test_unknown_room_version(self):
         """
-        If an room with an unknown room version is encountered it should not cause
+        If a room with an unknown room version is encountered it should not cause
         the entire summary to skip.
         """
         # Poke the database and update the room version to an unknown one.
@@ -727,6 +727,8 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
                 desc="updated-room-version",
             )
         )
+        # Invalidate method so that it returns the currently updated version
+        # instead of the cached version.
         self.hs.get_datastores().main.get_room_version_id.invalidate((self.room,))
 
         result = self.get_success(self.handler.get_space_summary(self.user, self.space))

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -727,6 +727,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
                 desc="updated-room-version",
             )
         )
+        self.hs.get_datastores().main.get_room_version_id.invalidate((self.room,))
 
         result = self.get_success(self.handler.get_space_summary(self.user, self.space))
         # The result should have only the space, along with a link from space -> room.


### PR DESCRIPTION
Fixes #11706.

Make method `get_room_version` use cached `get_room_version_id`.

**Signed-off by:** Lukas Denk, lukasdenk@web.de

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
