### PR TITLE
Log modules at startup

### DIFF
--- a/changelog.d/11813.misc
+++ b/changelog.d/11813.misc
@@ -1,0 +1,1 @@
+Log module names at startup.

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -435,7 +435,8 @@ async def start(hs: "HomeServer") -> None:
     # before we start the listeners.
     module_api = hs.get_module_api()
     for module, config in hs.config.modules.loaded_modules:
-        module(config=config, api=module_api)
+        m = module(config=config, api=module_api)
+        logger.info("Loaded module %s", m)
 
     load_legacy_spam_checkers(hs)
     load_legacy_third_party_event_rules(hs)


### PR DESCRIPTION
It's probably useful to log a list of all modules Synapse loads at startup now that we're moving towards one standardised and ordered interface, at least to allow server admins to see that their modules are starting correctly, and in which order they're being loaded.

An example of what this looks like in the startup logs:

```
[...]
2022-01-24 18:29:27,145 - synapse.federation.federation_server - 1281 - INFO - main - Registering federation query handler for 'directory'
2022-01-24 18:29:27,145 - twisted - 279 - INFO - main - Redirected stdout/stderr to logs
2022-01-24 18:29:27,145 - synapse.app.homeserver - 156 - INFO - sentinel - Running
2022-01-24 18:29:27,147 - synapse.app.homeserver - 29 - INFO - sentinel - Set file limit to: 524288
2022-01-24 18:29:27,147 - synapse.handlers.deactivate_account - 208 - INFO - user_parter_loop-0 - Starting user parter
2022-01-24 18:29:27,148 - synapse.app._base - 439 - INFO - sentinel - Loaded module <fosdem22_demo.FosdemDemo object at 0x7fb23220c100>
2022-01-24 18:29:27,155 - synapse.federation.federation_server - 1261 - INFO - sentinel - Registering federation EDU handler for 'm.receipt'
2022-01-24 18:29:27,155 - synapse.federation.federation_server - 1261 - INFO - sentinel - Registering federation EDU handler for 'm.signing_key_update'
2022-01-24 18:29:27,156 - synapse.federation.federation_server - 1261 - INFO - sentinel - Registering federation EDU handler for 'org.matrix.signing_key_update'
2022-01-24 18:29:27,156 - synapse.federation.federation_server - 1281 - INFO - sentinel - Registering federation query handler for 'client_keys'
[...]
```