### PR TITLE
Check that `gc` method is available before using in `synapse/app/_base` 

### DIFF
--- a/changelog.d/11816.misc
+++ b/changelog.d/11816.misc
@@ -1,0 +1,1 @@
+Drop support for Python 3.6, which is EOL.

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -468,7 +468,7 @@ async def start(hs: "HomeServer") -> None:
     # rest of time. Doing so means less work each GC (hopefully).
     #
     # gc.freeze may not be available in all Python implementations, thus we check here
-    if hasattr(gc, 'freeze'):
+    if hasattr(gc, "freeze"):
         gc.collect()
         gc.freeze()
 

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -467,12 +467,14 @@ async def start(hs: "HomeServer") -> None:
     # everything currently allocated are things that will be used for the
     # rest of time. Doing so means less work each GC (hopefully).
     #
-    gc.collect()
-    gc.freeze()
+    # gc.freeze may not be available in all Python implementations, thus we check here
+    if hasattr(gc, 'freeze'):
+        gc.collect()
+        gc.freeze()
 
-    # Speed up shutdowns by freezing all allocated objects. This moves everything
-    # into the permanent generation and excludes them from the final GC.
-    atexit.register(gc.freeze)
+        # Speed up shutdowns by freezing all allocated objects. This moves everything
+        # into the permanent generation and excludes them from the final GC.
+        atexit.register(gc.freeze)
 
 
 def setup_sentry(hs: "HomeServer") -> None:

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -467,7 +467,7 @@ async def start(hs: "HomeServer") -> None:
     # everything currently allocated are things that will be used for the
     # rest of time. Doing so means less work each GC (hopefully).
     #
-    # gc.freeze may not be available in all Python implementations, thus we check here
+    # PyPy does not (yet?) implement gc.freeze()
     if hasattr(gc, "freeze"):
         gc.collect()
         gc.freeze()


### PR DESCRIPTION
A similar check was removed in #11683. The check determined whether the program was being run on Python 3.7 before using a garbage collection method and thus was deemed redundant in this comment: https://github.com/matrix-org/synapse/pull/11683#pullrequestreview-859931689, so I removed it. However, it was pointed out here: https://github.com/matrix-org/synapse/pull/11683#discussion_r790695704 that not all implementations of Python have that API so I have restored a version of the removed check in this new PR.