### PR TITLE
Ignore the jsonschema type.

### DIFF
--- a/changelog.d/11817.misc
+++ b/changelog.d/11817.misc
@@ -1,0 +1,1 @@
+Compatibility with updated type hints for jsonschema 4.4.0.

--- a/synapse/events/validator.py
+++ b/synapse/events/validator.py
@@ -246,7 +246,9 @@ POWER_LEVELS_SCHEMA = {
 
 # This could return something newer than Draft 7, but that's the current "latest"
 # validator.
-def _create_power_level_validator() -> jsonschema.Draft7Validator:
+#
+# See https://github.com/python/typeshed/issues/7028 for the ignored return type.
+def _create_power_level_validator() -> jsonschema.Draft7Validator:  # type: ignore[valid-type]
     validator = jsonschema.validators.validator_for(POWER_LEVELS_SCHEMA)
 
     # by default jsonschema does not consider a frozendict to be an object so


### PR DESCRIPTION
types-jsonschema 4.4.0 broke our mypy, see python/typeshed#7028.

Previously the type was just an alias for `Any`, so we're not missing much by ignoring it.