### PR TITLE
Fix another jsonschema typecheck error

### DIFF
--- a/changelog.d/11817.misc
+++ b/changelog.d/11817.misc
@@ -1,1 +1,1 @@
-Compatibility with updated type hints for jsonschema 4.4.0.
+Correct a type annotation in the event validation logic.

--- a/changelog.d/11830.misc
+++ b/changelog.d/11830.misc
@@ -1,0 +1,1 @@
+Correct a type annotation in the event validation logic.

--- a/synapse/events/validator.py
+++ b/synapse/events/validator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import collections.abc
-from typing import Iterable, Union
+from typing import Iterable, Type, Union
 
 import jsonschema
 
@@ -246,9 +246,7 @@ POWER_LEVELS_SCHEMA = {
 
 # This could return something newer than Draft 7, but that's the current "latest"
 # validator.
-#
-# See https://github.com/python/typeshed/issues/7028 for the ignored return type.
-def _create_power_level_validator() -> jsonschema.Draft7Validator:  # type: ignore[valid-type]
+def _create_power_level_validator() -> Type[jsonschema.Draft7Validator]:
     validator = jsonschema.validators.validator_for(POWER_LEVELS_SCHEMA)
 
     # by default jsonschema does not consider a frozendict to be an object so


### PR DESCRIPTION
Similar to #11817.

In `_create_power_level_validator` we
- retrieve `validator`. This is a class implementing the
  `jsonschema.protocols.Validator` interface. In other words,
  `validator: Type[jsonschema.protocols.Validator]`.
- we then create an second validtor class by modifying the original
  `validator`. We return that class, which is also of type
  `Type[jsonschema.protocols.Validator]`.

So the original annotation was incorrect: it claimed we were returning
an instance of jsonSchema.Draft7Validator, not the class (or a subclass)
itself. (Stricly speaking this is incorrect, because `POWER_LEVELS_SCHEMA`
isn't pinned to a particular version of JSON Schema. But there are other
complications with the type stubs if you try to fix this; I felt like
the change herein was a decent compromise that better expresses intent).

(I suspect/hope the typeshed project would welcome an effort to improve
the jsonschema stubs. Let's see if I get some spare time.)
