### PR TITLE
Prevent duplicate push notifications for room reads

### DIFF
--- a/changelog.d/11835.feature
+++ b/changelog.d/11835.feature
@@ -1,0 +1,1 @@
+Make a `POST` to `/rooms/<room_id>/receipt/m.read/<event_id>` only trigger a push notification if the count of unread messages is different to the one in the last successfully sent push.

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -109,7 +109,7 @@ class HttpPusher(Pusher):
         self.data_minus_url = {}
         self.data_minus_url.update(self.data)
         del self.data_minus_url["url"]
-        self.badge_count_last_call = -1
+        self.badge_count_last_call: Optional[int] = None
 
     def on_started(self, should_check_for_notifs: bool) -> None:
         """Called when this pusher has been started.

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -109,6 +109,7 @@ class HttpPusher(Pusher):
         self.data_minus_url = {}
         self.data_minus_url.update(self.data)
         del self.data_minus_url["url"]
+        self.badge_count_last_call = -1
 
     def on_started(self, should_check_for_notifs: bool) -> None:
         """Called when this pusher has been started.
@@ -136,7 +137,9 @@ class HttpPusher(Pusher):
             self.user_id,
             group_by_room=self._group_unread_count_by_room,
         )
-        await self._send_badge(badge)
+        if self.badge_count_last_call is None or self.badge_count_last_call != badge:
+            self.badge_count_last_call = badge
+            await self._send_badge(badge)
 
     def on_timer(self) -> None:
         self._start_processing()
@@ -402,6 +405,8 @@ class HttpPusher(Pusher):
         rejected = []
         if "rejected" in resp:
             rejected = resp["rejected"]
+        else:
+            self.badge_count_last_call = badge
         return rejected
 
     async def _send_badge(self, badge: int) -> None:

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -572,7 +572,7 @@ class HTTPPusherTests(HomeserverTestCase):
         #
         # This push should still only contain an unread count of 1 (for 1 unread room)
         self.assertEqual(
-            self.push_attempts[5][2]["notification"]["counts"]["unread"], 1
+            self.push_attempts[4][2]["notification"]["counts"]["unread"], 1
         )
 
     @override_config({"push": {"group_unread_count_by_room": False}})
@@ -588,7 +588,7 @@ class HTTPPusherTests(HomeserverTestCase):
         # We're counting every unread message, so there should now be 4 since the
         # last read receipt
         self.assertEqual(
-            self.push_attempts[5][2]["notification"]["counts"]["unread"], 4
+            self.push_attempts[4][2]["notification"]["counts"]["unread"], 4
         )
 
     def _test_push_unread_count(self):
@@ -673,30 +673,20 @@ class HTTPPusherTests(HomeserverTestCase):
         )
         self.assertEqual(channel.code, 200, channel.json_body)
 
-        # Advance time and make the push succeed
-        self.push_attempts[1][0].callback({})
-        self.pump()
-
-        # Unread count is still zero as we've read the only message in the room
-        self.assertEqual(len(self.push_attempts), 2)
-        self.assertEqual(
-            self.push_attempts[1][2]["notification"]["counts"]["unread"], 0
-        )
-
         # Send another message
         self.helper.send(
             room_id, body="How's the weather today?", tok=other_access_token
         )
 
         # Advance time and make the push succeed
-        self.push_attempts[2][0].callback({})
+        self.push_attempts[1][0].callback({})
         self.pump()
 
         # This push should contain an unread count of 1 as there's now been one
         # message since our last read receipt
-        self.assertEqual(len(self.push_attempts), 3)
+        self.assertEqual(len(self.push_attempts), 2)
         self.assertEqual(
-            self.push_attempts[2][2]["notification"]["counts"]["unread"], 1
+            self.push_attempts[1][2]["notification"]["counts"]["unread"], 1
         )
 
         # Since we're grouping by room, sending more messages shouldn't increase the
@@ -705,18 +695,18 @@ class HTTPPusherTests(HomeserverTestCase):
 
         # Advance time and make the push succeed
         self.pump()
-        self.push_attempts[3][0].callback({})
+        self.push_attempts[2][0].callback({})
 
         self.helper.send(room_id, body="Hello??", tok=other_access_token)
 
         # Advance time and make the push succeed
         self.pump()
-        self.push_attempts[4][0].callback({})
+        self.push_attempts[3][0].callback({})
 
         self.helper.send(room_id, body="HELLO???", tok=other_access_token)
 
         # Advance time and make the push succeed
         self.pump()
-        self.push_attempts[5][0].callback({})
+        self.push_attempts[4][0].callback({})
 
-        self.assertEqual(len(self.push_attempts), 6)
+        self.assertEqual(len(self.push_attempts), 5)

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -691,8 +691,8 @@ class HTTPPusherTests(HomeserverTestCase):
         self.push_attempts[expected_push_attempts - 1][0].callback({})
 
     def _check_push_attempt(
-        self, expected_push_attempts, expected_unread_count_last_push
-    ):
+        self, expected_push_attempts: int, expected_unread_count_last_push: int
+    ) -> None:
         """
         Makes sure that the last expected push attempt succeeds and checks whether
         it contains the expected unread count.

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -700,17 +700,16 @@ class HTTPPusherTests(HomeserverTestCase):
         self._advance_time_and_make_push_succeed(expected_push_attempts)
         # Check our push made it
         self.assertEqual(len(self.push_attempts), expected_push_attempts)
+        _, push_url, push_body = self.push_attempts[expected_push_attempts - 1]
         self.assertEqual(
-            self.push_attempts[expected_push_attempts - 1][1],
+            push_url,
             "http://example.com/_matrix/push/v1/notify",
         )
         # Check that the unread count for the room is 0
         #
         # The unread count is zero as the user has no read receipt in the room yet
         self.assertEqual(
-            self.push_attempts[expected_push_attempts - 1][2]["notification"]["counts"][
-                "unread"
-            ],
+            push_body["notification"]["counts"]["unread"],
             expected_unread_count_last_push,
         )
 


### PR DESCRIPTION
Fixes #11704.

Make a `POST` to `/rooms/<room_id>/receipt/m.read/<event_id>` only trigger a push notification when the count of unread messages is different to the one in the last successfully sent push.

**Signed-off by:** Lukas Denk, lukasdenk@web.de

@reivilibre:
-  As I believe, every message sent to a room triggers a push notification to be sent. So is there actually a scenario in which a `POST` to `/rooms/<room_id>/receipt/m.read/<event_id>` will still trigger a push now?
- I have not written an extra test since `test_push_unread_count_message_count` will now fail in case a `POST` to `/rooms/<room_id>/receipt/m.read/<event_id>` erroneaously causes a push notification to be sent.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
