### PR TITLE
Create singletons for `StateFilter.{all,none}()`

### DIFF
--- a/changelog.d/11836.misc
+++ b/changelog.d/11836.misc
@@ -1,0 +1,1 @@
+Minor performance improvement in room state lookup.

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -74,21 +74,21 @@ class StateFilter:
 
     @staticmethod
     def all() -> "StateFilter":
-        """Creates a filter that fetches everything.
+        """Returns a filter that fetches everything.
 
         Returns:
-            The new state filter.
+            The state filter.
         """
-        return StateFilter(types=frozendict(), include_others=True)
+        return _ALL_STATE_FILTER
 
     @staticmethod
     def none() -> "StateFilter":
-        """Creates a filter that fetches nothing.
+        """Returns a filter that fetches nothing.
 
         Returns:
             The new state filter.
         """
-        return StateFilter(types=frozendict(), include_others=False)
+        return _NONE_STATE_FILTER
 
     @staticmethod
     def from_types(types: Iterable[Tuple[str, Optional[str]]]) -> "StateFilter":
@@ -525,6 +525,10 @@ class StateFilter:
         return StateFilter._recompose_from_four_parts(
             new_all, new_excludes, new_wildcards, new_concrete_keys
         )
+
+
+_ALL_STATE_FILTER = StateFilter(types=frozendict(), include_others=True)
+_NONE_STATE_FILTER = StateFilter(types=frozendict(), include_others=False)
 
 
 class StateGroupStorage:


### PR DESCRIPTION
No point recreating these for each call, since they are frozen