### PR TITLE
Allow modules to run only on specific worker

### DIFF
--- a/changelog.d/11845.feature
+++ b/changelog.d/11845.feature
@@ -1,0 +1,1 @@
+Allow modules to run only on specific worker.

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -14,14 +14,19 @@ To use a module on Synapse, add it to the `modules` section of the configuration
 ```yaml
 modules:
   - module: my_super_module.MySuperClass
+    worker_name: None
     config:
       do_thing: true
   - module: my_other_super_module.SomeClass
+    worker_name: my_module_worker
     config: {}
 ```
 
 Each module is defined by a path to a Python class as well as a configuration. This
 information for a given module should be available in the module's own documentation.
+
+`worker_name` defines on wich worker the module is loaded. If `worker_name` is not set
+or is `None` the module is loaded on the main process.
 
 ## Using multiple modules
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -42,9 +42,11 @@
 #
 modules:
   #- module: my_super_module.MySuperClass
+  #  worker_name: None
   #  config:
   #    do_thing: true
   #- module: my_other_super_module.SomeClass
+  #  worker_name: my_module_worker
   #  config: {}
 
 

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -436,8 +436,8 @@ async def start(hs: "HomeServer") -> None:
     module_api = hs.get_module_api()
     for module, config, worker_name in hs.config.modules.loaded_modules:
         if (
-            hs.config.worker_name is None and worker_name == "master"
-        ) or worker_name == hs.config.worker_name:
+            hs.config.worker.worker_name is None and worker_name == "master"
+        ) or worker_name == hs.config.worker.worker_name:
             m = module(config=config, api=module_api)
             logger.info("Loaded module %s", m)
 

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -434,9 +434,12 @@ async def start(hs: "HomeServer") -> None:
     # Instantiate the modules so they can register their web resources to the module API
     # before we start the listeners.
     module_api = hs.get_module_api()
-    for module, config in hs.config.modules.loaded_modules:
-        m = module(config=config, api=module_api)
-        logger.info("Loaded module %s", m)
+    for module, config, worker_name in hs.config.modules.loaded_modules:
+        if (
+            hs.config.worker_name is None and worker_name == "master"
+        ) or worker_name == hs.config.worker_name:
+            m = module(config=config, api=module_api)
+            logger.info("Loaded module %s", m)
 
     load_legacy_spam_checkers(hs)
     load_legacy_third_party_event_rules(hs)

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -143,7 +143,7 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
         )
         # Load the modules into the homeserver
         module_api = hs.get_module_api()
-        for module, config in hs.config.modules.loaded_modules:
+        for module, config, _ in hs.config.modules.loaded_modules:
             module(config=config, api=module_api)
 
         load_legacy_presence_router(hs)

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -169,7 +169,7 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         hs = self.setup_test_homeserver()
         # Load the modules into the homeserver
         module_api = hs.get_module_api()
-        for module, config in hs.config.modules.loaded_modules:
+        for module, config, _ in hs.config.modules.loaded_modules:
             module(config=config, api=module_api)
         load_legacy_password_auth_providers(hs)
 

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -147,7 +147,7 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
         load_legacy_spam_checkers(hs)
 
         module_api = hs.get_module_api()
-        for module, config in hs.config.modules.loaded_modules:
+        for module, config, _ in hs.config.modules.loaded_modules:
             module(config=config, api=module_api)
 
         return hs


### PR DESCRIPTION
Fixes: #10701

This is not the requested solution of #10701
I am not sure if a module should decide independently where it runs.

This makes it possible to configure the workers at a central location (homerserver.yaml).
I am not sure if a config value is needed to run a module on all servers with the same configuration.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))


Signed-off-by: Dirk Klimpel dirk@klimpel.org