### PR TITLE
Pass `isolation_level` to `runWithConnection`

### DIFF
--- a/changelog.d/11847.misc
+++ b/changelog.d/11847.misc
@@ -1,0 +1,1 @@
+Preparation for reducing Postgres serialization errors: allow setting transaction isolation level. Contributed by Nick @ Beeper.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -748,6 +748,7 @@ class DatabasePool:
                     func,
                     *args,
                     db_autocommit=db_autocommit,
+                    isolation_level=isolation_level,
                     **kwargs,
                 )
 


### PR DESCRIPTION
This was missed in https://github.com/matrix-org/synapse/pull/11799