### PR TITLE
Disable coverage calculation for olddeps build.

### DIFF
--- a/.ci/scripts/test_old_deps.sh
+++ b/.ci/scripts/test_old_deps.sh
@@ -15,4 +15,4 @@ export LANG="C.UTF-8"
 # Prevent virtualenv from auto-updating pip to an incompatible version
 export VIRTUALENV_NO_DOWNLOAD=1
 
-exec tox -e py3-old,combine
+exec tox -e py3-old

--- a/changelog.d/11888.misc
+++ b/changelog.d/11888.misc
@@ -1,0 +1,1 @@
+Disable coverage calculation for olddeps build.


### PR DESCRIPTION
We disabled coverage calculation for most of CI in #11017, but the olddeps
build uses a separate script and got forgotten.