### PR TITLE
Require a description of changes on hotfix branch

### DIFF
--- a/.github/workflows/hotfixes-changelog.yml
+++ b/.github/workflows/hotfixes-changelog.yml
@@ -1,0 +1,23 @@
+name: Hotfixes
+on:
+  pull_request:
+    branches:
+      - 'matrix-org-hotfixes'
+jobs:
+  check-changelog:
+    name: Check change is described
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: git fetch origin ${{ github.base_ref }}
+
+      - name: Check CHANGES_HOTFIX.md has changed
+        run: |
+          # --exit-code: returns 1 if there were differences, 0 otherwise
+          if git diff --exit-code origin/${{ github.base_ref }} HEAD -- CHANGES_HOTFIXES.md; then
+            echo PRs to the hotfixes branch must update CHANGES_HOTFIXES.md
+            exit 1
+          else
+            echo All good
+          fi

--- a/CHANGES_HOTFIXES.md
+++ b/CHANGES_HOTFIXES.md
@@ -1,0 +1,10 @@
+Differences between the hotfixes release branch
+===============================================
+
+- 2017/05/23: [e5537cf98333b428dbc481ed443daed2f0cfa074](https://github.com/matrix-org/synapse/commit/e5537cf98333b428dbc481ed443daed2f0cfa074) and introduced a `member_limiter` on the
+  `RoomMemberHandler`, later tweaked by subsequent commits. This wraps the call to `update_membership_locked` and there looks to be timing-related changes.
+- 2017/10/12: [fae708c0e8c35930f1172322b7c0e9f0b1b3f9a4](https://github.com/matrix-org/synapse/commit/fae708c0e8c35930f1172322b7c0e9f0b1b3f9a4) from [matrix-appservice-irc#506](https://github.com/matrix-org/matrix-appservice-irc/issues/506) suppresses the requirement that application services can only lookup joined members if they control a user which is already in this room.
+- 2018/02/14: [66dcbf47a36b5ca0e88d4658578d6fb5e6dbd910](https://github.com/matrix-org/synapse/commit/66dcbf47a36b5ca0e88d4658578d6fb5e6dbd910) disables auto search for prefixes in event search.
+- 2018/02/14: [8f8ea91eefcc43c5ac24e85b14a86af4da53e6e0](https://github.com/matrix-org/synapse/commit/8f8ea91eefcc43c5ac24e85b14a86af4da53e6e0) bumps client_ip LAST_SEEN_GRANULARITY from 2 to 10 minutes.
+- 2018/06/04: [9e38981ae47d03467a954c3c540c51b567f6e50b](https://github.com/matrix-org/synapse/commit/9e38981ae47d03467a954c3c540c51b567f6e50b) and subsequent commits send http pushes directly to a local address, rather than via cloudflare.
+- 2022/01/07: [5cc41f1b05416954f4c9e7aea1df308f4a451abe](https://github.com/matrix-org/synapse/commit/5cc41f1b05416954f4c9e7aea1df308f4a451abe) introduces debug logging


### PR DESCRIPTION
I noted in #11891 (c.f. https://github.com/matrix-org/synapse/issues/4826) that we don't really have a good idea of how the hotfixes branch differs to the releases branch. I propose that we require PRs against the hotfixes branch to include a changelog, and that we enforce this via a github action.

If we commit directly to the branch then this check is avoided. But that's not unique to this specific workflow.

Note that the Hotfixes workflow failed in 18f87a4 but suceeded in de277d8. The checks still fail overall in both cases because linting fails on `matrix-org-hotfixes`.