### PR TITLE
Notify users, rather than rooms, of device list updates

### DIFF
--- a/changelog.d/11905.misc
+++ b/changelog.d/11905.misc
@@ -1,0 +1,1 @@
+Some changes to eventually support the implementation of sending device list updates to application services.

--- a/changelog.d/11905.misc
+++ b/changelog.d/11905.misc
@@ -1,1 +1,1 @@
-Some changes to eventually support the implementation of sending device list updates to application services.
+Preparation to support sending device list updates to application services.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -495,13 +495,11 @@ class DeviceHandler(DeviceWorkerHandler):
                 "Notifying about update %r/%r, ID: %r", user_id, device_id, position
             )
 
-        room_ids = await self.store.get_rooms_for_user(user_id)
-
         # specify the user ID too since the user should always get their own device list
         # updates, even if they aren't in any rooms.
-        self.notifier.on_new_event(
-            "device_list_key", position, users=[user_id], rooms=room_ids
-        )
+        users_to_notify = users_who_share_room.union(user_id)
+
+        self.notifier.on_new_event("device_list_key", position, users=users_to_notify)
 
         if hosts:
             logger.info(

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -497,7 +497,7 @@ class DeviceHandler(DeviceWorkerHandler):
 
         # specify the user ID too since the user should always get their own device list
         # updates, even if they aren't in any rooms.
-        users_to_notify = users_who_share_room.union(user_id)
+        users_to_notify = users_who_share_room.union({user_id})
 
         self.notifier.on_new_event("device_list_key", position, users=users_to_notify)
 


### PR DESCRIPTION
When a device list update occurs, [`Notifier.on_new_event`](https://github.com/matrix-org/synapse/blob/610578e27177136b6a4b187783c490d35c688272/synapse/notifier.py#L406) is called with the key `device_list`. This method determines the set of users to notify of this update from both a collection of `users` and a collection of `rooms`. 

Users are consolidated before notifying (waking up sync streams etc.) occurs. `Notifier.rooms_to_users_state` is used to translate from a given room ID to a set of users in the room. Those users are then merged into the list of those to notify.

This all works pretty well, until we [hooked into this method](https://github.com/matrix-org/synapse/pull/8437) to send EDUs to AS's:

https://github.com/matrix-org/synapse/blob/610578e27177136b6a4b187783c490d35c688272/synapse/notifier.py#L461-L472

This method only receives the original collection of users, not the one derived from rooms. Eventually, it should accept a list of room IDs as well (https://github.com/matrix-org/synapse/issues/11152), but not in the case of device list updates.

Technically speaking, device list updates aren't tied to a room. We just use rooms to determine who to send our device list updates to.

Therefore, this PR aims to fix both problems:

* For device list changes, `on_new_event` should receive a collection of users, derived from the rooms the requester is in. Relevant users should then be notified.
* `AppserviceHandler.notify_interested_services_ephemeral` will automatically receive a complete list of users who should be notified, allowing us to send device list updates to AS's.