### PR TITLE
Add a unit test for users receiving their own device list updates

### DIFF
--- a/changelog.d/11909.misc
+++ b/changelog.d/11909.misc
@@ -1,0 +1,1 @@
+Add a test that checks users receive their own device list updates down `/sync`.


### PR DESCRIPTION
The need was discovered after a [silly bug](https://github.com/matrix-org/synapse/pull/11905/files#r798840354) in https://github.com/matrix-org/synapse/pull/11905 wasn't being caught automatically. This test will fail when that bug is present.

We always try to send device list changes of users down to their own devices, so that multiple devices of the same user stay in sync. This wasn't being verified by our unit tests.