### PR TITLE
Clean up an indirect reference to the homeserver datastore

### DIFF
--- a/changelog.d/11914.misc
+++ b/changelog.d/11914.misc
@@ -1,0 +1,1 @@
+Various refactors to the typing notifications code.

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -446,7 +446,7 @@ class TypingWriterHandler(FollowerTypingHandler):
 
 class TypingNotificationEventSource(EventSource[int, JsonDict]):
     def __init__(self, hs: "HomeServer"):
-        self.hs = hs
+        self._main_store = hs.get_datastore()
         self.clock = hs.get_clock()
         # We can't call get_typing_handler here because there's a cycle:
         #
@@ -487,7 +487,7 @@ class TypingNotificationEventSource(EventSource[int, JsonDict]):
                     continue
 
                 if not await service.matches_user_in_member_list(
-                    room_id, handler.store
+                    room_id, self._main_store
                 ):
                     continue
 


### PR DESCRIPTION
A small clean up to some rather dubious access to the datastore. The variable name `_main_store` comes from https://github.com/matrix-org/synapse/issues/11733.