### PR TITLE
Pass the proper type when uploading files.

### DIFF
--- a/changelog.d/11927.misc
+++ b/changelog.d/11927.misc
@@ -1,0 +1,1 @@
+Use the proper type for the Content-Length header in the `UploadResource`.

--- a/synapse/rest/media/v1/upload_resource.py
+++ b/synapse/rest/media/v1/upload_resource.py
@@ -70,7 +70,8 @@ class UploadResource(DirectServeJsonResource):
                 upload_name: Optional[str] = upload_name_bytes.decode("utf8")
             except UnicodeDecodeError:
                 raise SynapseError(
-                    msg="Invalid UTF-8 filename parameter: %r" % (upload_name), code=400
+                    msg="Invalid UTF-8 filename parameter: %r" % (upload_name_bytes,),
+                    code=400,
                 )
 
         # If the name is falsey (e.g. an empty byte string) ensure it is None.

--- a/synapse/rest/media/v1/upload_resource.py
+++ b/synapse/rest/media/v1/upload_resource.py
@@ -49,10 +49,14 @@ class UploadResource(DirectServeJsonResource):
 
     async def _async_render_POST(self, request: SynapseRequest) -> None:
         requester = await self.auth.get_user_by_req(request)
-        content_length = request.getHeader("Content-Length")
-        if content_length is None:
+        raw_content_length = request.getHeader("Content-Length")
+        if raw_content_length is None:
             raise SynapseError(msg="Request must specify a Content-Length", code=400)
-        if int(content_length) > self.max_upload_size:
+        try:
+            content_length = int(raw_content_length)
+        except ValueError:
+            raise SynapseError(msg="Content-Length value is invalid", code=400)
+        if content_length > self.max_upload_size:
             raise SynapseError(
                 msg="Upload request body is too large",
                 code=413,


### PR DESCRIPTION
I believe twisted/twisted#1669 being merged caused this error to be spotted by mypy.

Hopefully the fix should be pretty straightforward, but now we operate over the integer version of the `Content-Length` header, instead of the string one. In reality I don't think this caused an issue since the database would cast it eventually anyway (?).

This also fixes a separate issue if decoding the uploaded name failed. (We would reference an invalid variable name.)

Fixes #11923