### PR TITLE
Support the `dir` parameter for `/relations`.

### DIFF
--- a/changelog.d/11941.feature
+++ b/changelog.d/11941.feature
@@ -1,0 +1,1 @@
+Support the `dir` parameter on the `/relations` endpoint, per [MSC3715](https://github.com/matrix-org/matrix-doc/pull/3715).

--- a/synapse/rest/client/relations.py
+++ b/synapse/rest/client/relations.py
@@ -111,7 +111,9 @@ class RelationPaginationServlet(RestServlet):
             raise SynapseError(404, "Unknown parent event.")
 
         limit = parse_integer(request, "limit", default=5)
-        direction = parse_string(request, "dir", default="b", allowed_values=["f", "b"])
+        direction = parse_string(
+            request, "org.matrix.msc3715.dir", default="b", allowed_values=["f", "b"]
+        )
         from_token_str = parse_string(request, "from")
         to_token_str = parse_string(request, "to")
 

--- a/synapse/rest/client/relations.py
+++ b/synapse/rest/client/relations.py
@@ -80,6 +80,7 @@ class RelationPaginationServlet(RestServlet):
             raise SynapseError(404, "Unknown parent event.")
 
         limit = parse_integer(request, "limit", default=5)
+        direction = parse_string(request, "dir", default="b", allowed_values=["f", "b"])
         from_token_str = parse_string(request, "from")
         to_token_str = parse_string(request, "to")
 
@@ -102,6 +103,7 @@ class RelationPaginationServlet(RestServlet):
                 relation_type=relation_type,
                 event_type=event_type,
                 limit=limit,
+                direction=direction,
                 from_token=from_token,
                 to_token=to_token,
             )

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -208,7 +208,8 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         # Request the relations again, but with a different direction.
         channel = self.make_request(
             "GET",
-            f"/_matrix/client/unstable/rooms/{self.room}/relations/{self.parent_id}?limit=1&dir=f",
+            f"/_matrix/client/unstable/rooms/{self.room}/relations"
+            f"/{self.parent_id}?limit=1&org.matrix.msc3715.dir=f",
             access_token=self.user_token,
         )
         self.assertEquals(200, channel.code, channel.json_body)


### PR DESCRIPTION
Implements MSC3715 to add a `dir` parameter to `/relations`.

This API is currently unstable and the default behavior is the same, so I think it is safe to just add, but willing to hear alternatives!