### PR TITLE
Fix stream location for StreamHandler

### DIFF
--- a/changelog.d/11946.doc
+++ b/changelog.d/11946.doc
@@ -1,1 +1,1 @@
-Fixes incorrect yaml key in structured logging example.
+Correct the structured logging configuration example. Contributed by Brad Jones.

--- a/changelog.d/11946.doc
+++ b/changelog.d/11946.doc
@@ -1,0 +1,1 @@
+Fixes incorrect yaml key in structured logging example.

--- a/docs/structured_logging.md
+++ b/docs/structured_logging.md
@@ -141,7 +141,7 @@ formatters:
 handlers:
     console:
         class: logging.StreamHandler
-        location: ext://sys.stdout
+        stream: ext://sys.stdout
     file:
         class: logging.FileHandler
         formatter: json


### PR DESCRIPTION
This should read `stream` instead of `location`.

### Pull Request Checklist

* [x] Pull request is based on the develop branch

This is a docs-only change.