### PR TITLE
Fetch images when previewing Twitter

### DIFF
--- a/changelog.d/11985.feature
+++ b/changelog.d/11985.feature
@@ -1,1 +1,1 @@
-Fetch images when previewing Twitter URLs. Contributed by @AndrewRyanChama
+Fetch images when previewing Twitter URLs. Contributed by @AndrewRyanChama.

--- a/changelog.d/11985.feature
+++ b/changelog.d/11985.feature
@@ -1,0 +1,1 @@
+Fetch images when previewing Twitter URLs. Contributed by @AndrewRyanChama

--- a/changelog.d/11985.misc
+++ b/changelog.d/11985.misc
@@ -1,0 +1,1 @@
+Use bot user agent for openGraph queries.

--- a/changelog.d/11985.misc
+++ b/changelog.d/11985.misc
@@ -1,1 +1,0 @@
-Use a bot User-Agent for URL preview queries.

--- a/changelog.d/11985.misc
+++ b/changelog.d/11985.misc
@@ -1,1 +1,1 @@
-Use bot user agent for openGraph queries.
+Use a bot User-Agent for URL preview queries.

--- a/synapse/res/providers.json
+++ b/synapse/res/providers.json
@@ -5,8 +5,6 @@
         "endpoints": [
             {
                 "schemes": [
-                    "https://twitter.com/*/status/*",
-                    "https://*.twitter.com/*/status/*",
                     "https://twitter.com/*/moments/*",
                     "https://*.twitter.com/*/moments/*"
                 ],

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -404,6 +404,9 @@ class PreviewUrlResource(DirectServeJsonResource):
                 max_size=self.max_spider_size,
                 headers={
                     b"Accept-Language": self.url_preview_accept_language,
+                    # Use a custom user agent for the preview because some sites will only return
+                    # openGraph metadata to crawler user agents. We specifically omit the version
+                    # string to avoid leaking the this information.
                     b"User-Agent": [
                         "Synapse (bot; +https://github.com/matrix-org/synapse)"
                     ],

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -405,8 +405,8 @@ class PreviewUrlResource(DirectServeJsonResource):
                 headers={
                     b"Accept-Language": self.url_preview_accept_language,
                     # Use a custom user agent for the preview because some sites will only return
-                    # openGraph metadata to crawler user agents. We specifically omit the version
-                    # string to avoid leaking the this information.
+                    # Open Graph metadata to crawler user agents. Omit the Synapse version
+                    # string to avoid leaking information.
                     b"User-Agent": [
                         "Synapse (bot; +https://github.com/matrix-org/synapse)"
                     ],

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -402,7 +402,12 @@ class PreviewUrlResource(DirectServeJsonResource):
                 url,
                 output_stream=output_stream,
                 max_size=self.max_spider_size,
-                headers={"Accept-Language": self.url_preview_accept_language},
+                headers={
+                    b"Accept-Language": self.url_preview_accept_language,
+                    b"User-Agent": [
+                        "Synapse (bot; +https://github.com/matrix-org/synapse)"
+                    ],
+                },
                 is_allowed_content_type=_is_previewable,
             )
         except SynapseError:


### PR DESCRIPTION
We found that some websites return opengraph information based
on the user agent.

In order to address this, using (bot) in the user agent string
may help the website behave correctly. When testing Twitter, we
found that the correct metadata is returned with the (bot) user
agent while it isn't for the default user agent.

This change additionally updates providers.json, as with the
user agent fix twitter will now return the expected openGraph
metadata.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Before:
<img width="488" alt="Screen Shot 2022-02-13 at 7 12 10 AM" src="https://user-images.githubusercontent.com/89478935/153759744-b5193edf-b0e7-443e-869b-e23838c06f04.png">
After:
<img width="540" alt="Screen Shot 2022-02-13 at 7 11 26 AM" src="https://user-images.githubusercontent.com/89478935/153759746-f685b0bf-ea1f-406d-a44d-dec0d8a2fed1.png">
