### PR TITLE
Note when unstable MSC3283 prefixes will be removed

### DIFF
--- a/changelog.d/11989.feature
+++ b/changelog.d/11989.feature
@@ -1,0 +1,1 @@
+Support the stable API endpoint for [MSC3283](https://github.com/matrix-org/matrix-doc/pull/3283): new settings in `/capabilities` endpoint.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -129,7 +129,7 @@ The old `capabilities`
 - `org.matrix.msc3283.set_avatar_url` and
 - `org.matrix.msc3283.3pid_changes`
 
-are deprecated and scheduled to be removed in Synapse v1.(next+1).0.
+are deprecated and scheduled to be removed in Synapse v1.54.0.
 
 The new `capabilities`
 - `m.set_displayname`,


### PR DESCRIPTION
This entry in the upgrade notes was added in https://github.com/matrix-org/synapse/pull/11933/files#diff-3ec187be4d5027db52c481841dbbf321b2f4b39dea03033c971aeba9a4a20e51R113, however included a placeholder for an unknown Synapse version. That version is likely going to be 1.54.0, and we need to pick a number before putting out 1.53.0rc1 -- due tomorrow.

Filing as a release blocker so that it gets picked up in time. Uses the same changelog as #11933.