### PR TITLE
`_auth_and_persist_outliers`: drop events we have already seen

### DIFF
--- a/changelog.d/11994.misc
+++ b/changelog.d/11994.misc
@@ -1,0 +1,1 @@
+Move common deduplication code down into `_auth_and_persist_outliers`.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1735,9 +1735,9 @@ class FederationEventHandler:
         logger.info("/event_auth returned %i events", len(remote_events))
 
         # `event` may be returned, but we should not yet process it.
-        remote_events = (e for e in remote_events if e.event_id != event_id)
+        remote_auth_events = (e for e in remote_events if e.event_id != event_id)
 
-        await self._auth_and_persist_outliers(room_id, remote_events)
+        await self._auth_and_persist_outliers(room_id, remote_auth_events)
 
     async def _update_context_for_auth_events(
         self, event: EventBase, context: EventContext, auth_events: StateMap[EventBase]


### PR DESCRIPTION
`_auth_and_persist_outliers` is called in three places:
 * `process_remote_join`
 * `_get_remote_auth_chain_for_event`
 * `_get_events_and_persist`.

The first two of those contain code to filter out any events we have already seen, with a call to `have_seen_events`. (The third, `_get_events_and_persist`, doesn't bother, because in theory it is only called for events we don't already have).

I'm shortly going to add a fourth caller, which will also need to filter out events we have already seen. Rather than add yet a third copy of the deduplication code, let's just push it down into `auth_and_persist_outliers`.