### PR TITLE
Limit concurrent AS joins

### DIFF
--- a/changelog.d/11996.misc
+++ b/changelog.d/11996.misc
@@ -1,0 +1,1 @@
+Limit concurrent applications service joins.

--- a/changelog.d/11996.misc
+++ b/changelog.d/11996.misc
@@ -1,1 +1,1 @@
-Limit concurrent applications service joins.
+Limit concurrent joins from applications services.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -82,6 +82,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         self.event_auth_handler = hs.get_event_auth_handler()
 
         self.member_linearizer: Linearizer = Linearizer(name="member")
+        self.member_as_limiter = Linearizer(max_count=10, name="member_as_limiter")
 
         self.clock = hs.get_clock()
         self.spam_checker = hs.get_spam_checker()
@@ -500,25 +501,30 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
 
         key = (room_id,)
 
-        with (await self.member_linearizer.queue(key)):
-            result = await self.update_membership_locked(
-                requester,
-                target,
-                room_id,
-                action,
-                txn_id=txn_id,
-                remote_room_hosts=remote_room_hosts,
-                third_party_signed=third_party_signed,
-                ratelimit=ratelimit,
-                content=content,
-                new_room=new_room,
-                require_consent=require_consent,
-                outlier=outlier,
-                historical=historical,
-                allow_no_prev_events=allow_no_prev_events,
-                prev_event_ids=prev_event_ids,
-                auth_event_ids=auth_event_ids,
-            )
+        as_id = object()
+        if requester.app_service:
+            as_id = requester.app_service.id
+
+        with (await self.member_as_limiter.queue(as_id)):
+            with (await self.member_linearizer.queue(key)):
+                result = await self.update_membership_locked(
+                    requester,
+                    target,
+                    room_id,
+                    action,
+                    txn_id=txn_id,
+                    remote_room_hosts=remote_room_hosts,
+                    third_party_signed=third_party_signed,
+                    ratelimit=ratelimit,
+                    content=content,
+                    new_room=new_room,
+                    require_consent=require_consent,
+                    outlier=outlier,
+                    historical=historical,
+                    allow_no_prev_events=allow_no_prev_events,
+                    prev_event_ids=prev_event_ids,
+                    auth_event_ids=auth_event_ids,
+                )
 
         return result
 

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -505,6 +505,8 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         if requester.app_service:
             as_id = requester.app_service.id
 
+        # We first linearise by the application service (to try to limit concurrent joins
+        # by application services), and then by room ID.
         with (await self.member_as_limiter.queue(as_id)):
             with (await self.member_linearizer.queue(key)):
                 result = await self.update_membership_locked(


### PR DESCRIPTION
Initially introduced in `matrix-org-hotfixes` by https://github.com/matrix-org/synapse/commit/e5537cf98333b428dbc481ed443daed2f0cfa074 (and tweaked by later commits).

Fixes https://github.com/matrix-org/synapse/issues/11995

See also https://github.com/matrix-org/synapse/issues/4826

I haven't ported https://github.com/matrix-org/synapse/commit/ca21957b8a4942e829050834297afb290338c120 as part of this PR because it looks like something that should be done separately and would need a switch from hardcoded settings to configuration knobs.