### PR TITLE
Enable complexity checking in complexity checking docs example

### DIFF
--- a/docs/other/running_synapse_on_single_board_computers.md
+++ b/docs/other/running_synapse_on_single_board_computers.md
@@ -38,8 +38,7 @@ use_presence: false
 # joins a new remote room. If it is above the complexity limit, the server will
 # disallow joining, or will instantly leave.
 limit_remote_rooms:
-  # Uncomment to enable room complexity checking.
-  #enabled: true
+  enabled: true
   complexity: 3.0
 
 # Database configuration


### PR DESCRIPTION
@youphyun noticed in https://github.com/matrix-org/synapse/issues/8428#issuecomment-1040223558 that the recommended config for complexity checking on single board computers (SBCs) did not actually enable complexity checking.

This PR uncomments the `enabled: true` line in order to actually enable it.

Complexity checking is disabled by default: https://github.com/matrix-org/synapse/blob/119edf51eb3e4f5ed5139dc370f5d7aed46edc1c/synapse/config/server.py#L231-L232