### PR TITLE
`send_join` response: get create event from `state`, not `auth_chain`

### DIFF
--- a/changelog.d/12005.misc
+++ b/changelog.d/12005.misc
@@ -1,0 +1,1 @@
+Preparation for faster-room-join work: when parsing the `send_join` response, get the `m.room.create` event from `state`, not `auth_chain`.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -420,7 +420,7 @@ class FederationEventHandler:
             SynapseError if the response is in some way invalid.
         """
         create_event = None
-        for e in auth_events:
+        for e in state:
             if (e.type, e.state_key) == (EventTypes.Create, ""):
                 create_event = e
                 break


### PR DESCRIPTION
https://github.com/matrix-org/matrix-doc/blob/rav/proposal/partial_state_on_join/proposals/3706-partial-state-in-send-join.md#changes-to-the-response proposes changing the `/send_join` response:

> Any events returned within `state` can be omitted from `auth_chain`.

Currently, we rely on `m.room.create` being returned in `auth_chain`, but since the `m.room.create` event must necessarily be part of the state, the above change will break this.

In short, let's look for `m.room.create` in `state` rather than `auth_chain`.