### PR TITLE
Allow modules to set a display name on registration

### DIFF
--- a/changelog.d/12009.feature
+++ b/changelog.d/12009.feature
@@ -1,0 +1,1 @@
+Enable modules to set a custom display name when registering a user.

--- a/docs/modules/password_auth_provider_callbacks.md
+++ b/docs/modules/password_auth_provider_callbacks.md
@@ -166,6 +166,34 @@ any of the subsequent implementations of this callback. If every callback return
 the username provided by the user is used, if any (otherwise one is automatically
 generated).
 
+### `get_display_name_for_registration`
+
+_First introduced in Synapse v1.54.0_
+
+```python
+async def get_display_name_for_registration(
+    uia_results: Dict[str, Any],
+    params: Dict[str, Any],
+) -> Optional[str]
+```
+
+Called when registering a new user. The module can return a display name to set for the
+user being registered by returning it as a string, or `None` if it doesn't wish to force a
+display name for this user.
+
+This callback is called once [User-Interactive Authentication](https://spec.matrix.org/latest/client-server-api/#user-interactive-authentication-api)
+has been completed by the user. It is not called when registering a user via SSO. It is
+passed two dictionaries, which include the information that the user has provided during
+the registration process. These dictionaries are identical to the ones passed to
+[`get_username_for_registration`](#get_username_for_registration), so refer to the
+documentation of this callback for more information about them.
+
+If multiple modules implement this callback, they will be considered in order. If a
+callback returns `None`, Synapse falls through to the next one. The value of the first
+callback that does not return `None` will be used. If this happens, Synapse will not call
+any of the subsequent implementations of this callback. If every callback return `None`,
+the username will be used (e.g. `alice` if the user being registered is `@alice:example.com`).
+
 ## `is_3pid_allowed`
 
 _First introduced in Synapse v1.53.0_
@@ -195,7 +223,6 @@ The example module below implements authentication checkers for two different lo
 - `m.login.password` (defined in [the spec](https://matrix.org/docs/spec/client_server/latest#password-based))
     - Expects a `password` field to be sent to `/login`
     - Is checked by the method: `self.check_pass` 
-
 
 ```python
 from typing import Awaitable, Callable, Optional, Tuple

--- a/docs/modules/password_auth_provider_callbacks.md
+++ b/docs/modules/password_auth_provider_callbacks.md
@@ -166,12 +166,12 @@ any of the subsequent implementations of this callback. If every callback return
 the username provided by the user is used, if any (otherwise one is automatically
 generated).
 
-### `get_display_name_for_registration`
+### `get_displayname_for_registration`
 
 _First introduced in Synapse v1.54.0_
 
 ```python
-async def get_display_name_for_registration(
+async def get_displayname_for_registration(
     uia_results: Dict[str, Any],
     params: Dict[str, Any],
 ) -> Optional[str]

--- a/docs/modules/password_auth_provider_callbacks.md
+++ b/docs/modules/password_auth_provider_callbacks.md
@@ -85,7 +85,7 @@ If the authentication is unsuccessful, the module must return `None`.
 If multiple modules implement this callback, they will be considered in order. If a
 callback returns `None`, Synapse falls through to the next one. The value of the first
 callback that does not return `None` will be used. If this happens, Synapse will not call
-any of the subsequent implementations of this callback. If every callback return `None`,
+any of the subsequent implementations of this callback. If every callback returns `None`,
 the authentication is denied.
 
 ### `on_logged_out`
@@ -162,7 +162,7 @@ return `None`.
 If multiple modules implement this callback, they will be considered in order. If a
 callback returns `None`, Synapse falls through to the next one. The value of the first
 callback that does not return `None` will be used. If this happens, Synapse will not call
-any of the subsequent implementations of this callback. If every callback return `None`,
+any of the subsequent implementations of this callback. If every callback returns `None`,
 the username provided by the user is used, if any (otherwise one is automatically
 generated).
 
@@ -191,7 +191,7 @@ documentation of this callback for more information about them.
 If multiple modules implement this callback, they will be considered in order. If a
 callback returns `None`, Synapse falls through to the next one. The value of the first
 callback that does not return `None` will be used. If this happens, Synapse will not call
-any of the subsequent implementations of this callback. If every callback return `None`,
+any of the subsequent implementations of this callback. If every callback returns `None`,
 the username will be used (e.g. `alice` if the user being registered is `@alice:example.com`).
 
 ## `is_3pid_allowed`
@@ -222,7 +222,7 @@ The example module below implements authentication checkers for two different lo
     - Is checked by the method: `self.check_my_login`
 - `m.login.password` (defined in [the spec](https://matrix.org/docs/spec/client_server/latest#password-based))
     - Expects a `password` field to be sent to `/login`
-    - Is checked by the method: `self.check_pass` 
+    - Is checked by the method: `self.check_pass`
 
 ```python
 from typing import Awaitable, Callable, Optional, Tuple

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -2064,6 +2064,10 @@ GET_USERNAME_FOR_REGISTRATION_CALLBACK = Callable[
     [JsonDict, JsonDict],
     Awaitable[Optional[str]],
 ]
+GET_DISPLAY_NAME_FOR_REGISTRATION_CALLBACK = Callable[
+    [JsonDict, JsonDict],
+    Awaitable[Optional[str]],
+]
 IS_3PID_ALLOWED_CALLBACK = Callable[[str, str, bool], Awaitable[bool]]
 
 
@@ -2079,6 +2083,9 @@ class PasswordAuthProvider:
         self.on_logged_out_callbacks: List[ON_LOGGED_OUT_CALLBACK] = []
         self.get_username_for_registration_callbacks: List[
             GET_USERNAME_FOR_REGISTRATION_CALLBACK
+        ] = []
+        self.get_display_name_for_registration_callbacks: List[
+            GET_DISPLAY_NAME_FOR_REGISTRATION_CALLBACK
         ] = []
         self.is_3pid_allowed_callbacks: List[IS_3PID_ALLOWED_CALLBACK] = []
 
@@ -2098,6 +2105,9 @@ class PasswordAuthProvider:
         ] = None,
         get_username_for_registration: Optional[
             GET_USERNAME_FOR_REGISTRATION_CALLBACK
+        ] = None,
+        get_display_name_for_registration: Optional[
+            GET_DISPLAY_NAME_FOR_REGISTRATION_CALLBACK
         ] = None,
     ) -> None:
         # Register check_3pid_auth callback
@@ -2146,6 +2156,11 @@ class PasswordAuthProvider:
         if get_username_for_registration is not None:
             self.get_username_for_registration_callbacks.append(
                 get_username_for_registration,
+            )
+
+        if get_display_name_for_registration is not None:
+            self.get_display_name_for_registration_callbacks.append(
+                get_display_name_for_registration,
             )
 
         if is_3pid_allowed is not None:
@@ -2344,6 +2359,49 @@ class PasswordAuthProvider:
             except Exception as e:
                 logger.error(
                     "Module raised an exception in get_username_for_registration: %s",
+                    e,
+                )
+                raise SynapseError(code=500, msg="Internal Server Error")
+
+        return None
+
+    async def get_display_name_for_registration(
+        self,
+        uia_results: JsonDict,
+        params: JsonDict,
+    ) -> Optional[str]:
+        """Defines the profile information to use when registering the user, using the
+        credentials and parameters provided during the UIA flow.
+
+        Stops at the first callback that returns a tuple containing at least one string.
+
+        Args:
+            uia_results: The credentials provided during the UIA flow.
+            params: The parameters provided by the registration request.
+
+        Returns:
+            A tuple which first element is the display name, and the second is an MXC URL
+            to the user's avatar.
+        """
+        for callback in self.get_display_name_for_registration_callbacks:
+            try:
+                res = await callback(uia_results, params)
+
+                if isinstance(res, str):
+                    return res
+                elif res is not None:
+                    # mypy complains that this line is unreachable because it assumes the
+                    # data returned by the module fits the expected type. We just want
+                    # to make sure this is the case.
+                    logger.warning(  # type: ignore[unreachable]
+                        "Ignoring non-string value returned by"
+                        " get_display_name_for_registration callback %s: %s",
+                        callback,
+                        res,
+                    )
+            except Exception as e:
+                logger.error(
+                    "Module raised an exception in get_profile_for_registration: %s",
                     e,
                 )
                 raise SynapseError(code=500, msg="Internal Server Error")

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -2040,9 +2040,11 @@ def load_single_legacy_password_auth_provider(
         # need to use a tuple here for ("password",) not a list since lists aren't hashable
         auth_checkers[(LoginType.PASSWORD, ("password",))] = check_password
 
-    api.register_password_auth_provider_callbacks(check_3pid_auth=check_3pid_auth_hook,
-                                                  on_logged_out=on_logged_out_hook,
-                                                  auth_checkers=auth_checkers)
+    api.register_password_auth_provider_callbacks(
+        check_3pid_auth=check_3pid_auth_hook,
+        on_logged_out=on_logged_out_hook,
+        auth_checkers=auth_checkers,
+    )
 
 
 CHECK_3PID_AUTH_CALLBACK = Callable[

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -2040,11 +2040,9 @@ def load_single_legacy_password_auth_provider(
         # need to use a tuple here for ("password",) not a list since lists aren't hashable
         auth_checkers[(LoginType.PASSWORD, ("password",))] = check_password
 
-    api.register_password_auth_provider_callbacks(
-        check_3pid_auth=check_3pid_auth_hook,
-        on_logged_out=on_logged_out_hook,
-        auth_checkers=auth_checkers,
-    )
+    api.register_password_auth_provider_callbacks(check_3pid_auth=check_3pid_auth_hook,
+                                                  on_logged_out=on_logged_out_hook,
+                                                  auth_checkers=auth_checkers)
 
 
 CHECK_3PID_AUTH_CALLBACK = Callable[
@@ -2064,7 +2062,7 @@ GET_USERNAME_FOR_REGISTRATION_CALLBACK = Callable[
     [JsonDict, JsonDict],
     Awaitable[Optional[str]],
 ]
-GET_DISPLAY_NAME_FOR_REGISTRATION_CALLBACK = Callable[
+GET_DISPLAYNAME_FOR_REGISTRATION_CALLBACK = Callable[
     [JsonDict, JsonDict],
     Awaitable[Optional[str]],
 ]
@@ -2084,8 +2082,8 @@ class PasswordAuthProvider:
         self.get_username_for_registration_callbacks: List[
             GET_USERNAME_FOR_REGISTRATION_CALLBACK
         ] = []
-        self.get_display_name_for_registration_callbacks: List[
-            GET_DISPLAY_NAME_FOR_REGISTRATION_CALLBACK
+        self.get_displayname_for_registration_callbacks: List[
+            GET_DISPLAYNAME_FOR_REGISTRATION_CALLBACK
         ] = []
         self.is_3pid_allowed_callbacks: List[IS_3PID_ALLOWED_CALLBACK] = []
 
@@ -2106,8 +2104,8 @@ class PasswordAuthProvider:
         get_username_for_registration: Optional[
             GET_USERNAME_FOR_REGISTRATION_CALLBACK
         ] = None,
-        get_display_name_for_registration: Optional[
-            GET_DISPLAY_NAME_FOR_REGISTRATION_CALLBACK
+        get_displayname_for_registration: Optional[
+            GET_DISPLAYNAME_FOR_REGISTRATION_CALLBACK
         ] = None,
     ) -> None:
         # Register check_3pid_auth callback
@@ -2158,9 +2156,9 @@ class PasswordAuthProvider:
                 get_username_for_registration,
             )
 
-        if get_display_name_for_registration is not None:
-            self.get_display_name_for_registration_callbacks.append(
-                get_display_name_for_registration,
+        if get_displayname_for_registration is not None:
+            self.get_displayname_for_registration_callbacks.append(
+                get_displayname_for_registration,
             )
 
         if is_3pid_allowed is not None:
@@ -2365,12 +2363,12 @@ class PasswordAuthProvider:
 
         return None
 
-    async def get_display_name_for_registration(
+    async def get_displayname_for_registration(
         self,
         uia_results: JsonDict,
         params: JsonDict,
     ) -> Optional[str]:
-        """Defines the profile information to use when registering the user, using the
+        """Defines the display name to use when registering the user, using the
         credentials and parameters provided during the UIA flow.
 
         Stops at the first callback that returns a tuple containing at least one string.
@@ -2383,7 +2381,7 @@ class PasswordAuthProvider:
             A tuple which first element is the display name, and the second is an MXC URL
             to the user's avatar.
         """
-        for callback in self.get_display_name_for_registration_callbacks:
+        for callback in self.get_displayname_for_registration_callbacks:
             try:
                 res = await callback(uia_results, params)
 
@@ -2395,13 +2393,13 @@ class PasswordAuthProvider:
                     # to make sure this is the case.
                     logger.warning(  # type: ignore[unreachable]
                         "Ignoring non-string value returned by"
-                        " get_display_name_for_registration callback %s: %s",
+                        " get_displayname_for_registration callback %s: %s",
                         callback,
                         res,
                     )
             except Exception as e:
                 logger.error(
-                    "Module raised an exception in get_profile_for_registration: %s",
+                    "Module raised an exception in get_displayname_for_registration: %s",
                     e,
                 )
                 raise SynapseError(code=500, msg="Internal Server Error")

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -70,7 +70,7 @@ from synapse.handlers.account_validity import (
 from synapse.handlers.auth import (
     CHECK_3PID_AUTH_CALLBACK,
     CHECK_AUTH_CALLBACK,
-    GET_DISPLAY_NAME_FOR_REGISTRATION_CALLBACK,
+    GET_DISPLAYNAME_FOR_REGISTRATION_CALLBACK,
     GET_USERNAME_FOR_REGISTRATION_CALLBACK,
     IS_3PID_ALLOWED_CALLBACK,
     ON_LOGGED_OUT_CALLBACK,
@@ -318,8 +318,8 @@ class ModuleApi:
         get_username_for_registration: Optional[
             GET_USERNAME_FOR_REGISTRATION_CALLBACK
         ] = None,
-        get_display_name_for_registration: Optional[
-            GET_DISPLAY_NAME_FOR_REGISTRATION_CALLBACK
+        get_displayname_for_registration: Optional[
+            GET_DISPLAYNAME_FOR_REGISTRATION_CALLBACK
         ] = None,
     ) -> None:
         """Registers callbacks for password auth provider capabilities.
@@ -332,7 +332,7 @@ class ModuleApi:
             is_3pid_allowed=is_3pid_allowed,
             auth_checkers=auth_checkers,
             get_username_for_registration=get_username_for_registration,
-            get_display_name_for_registration=get_display_name_for_registration,
+            get_displayname_for_registration=get_displayname_for_registration,
         )
 
     def register_background_update_controller_callbacks(

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -70,6 +70,7 @@ from synapse.handlers.account_validity import (
 from synapse.handlers.auth import (
     CHECK_3PID_AUTH_CALLBACK,
     CHECK_AUTH_CALLBACK,
+    GET_DISPLAY_NAME_FOR_REGISTRATION_CALLBACK,
     GET_USERNAME_FOR_REGISTRATION_CALLBACK,
     IS_3PID_ALLOWED_CALLBACK,
     ON_LOGGED_OUT_CALLBACK,
@@ -317,6 +318,9 @@ class ModuleApi:
         get_username_for_registration: Optional[
             GET_USERNAME_FOR_REGISTRATION_CALLBACK
         ] = None,
+        get_display_name_for_registration: Optional[
+            GET_DISPLAY_NAME_FOR_REGISTRATION_CALLBACK
+        ] = None,
     ) -> None:
         """Registers callbacks for password auth provider capabilities.
 
@@ -328,6 +332,7 @@ class ModuleApi:
             is_3pid_allowed=is_3pid_allowed,
             auth_checkers=auth_checkers,
             get_username_for_registration=get_username_for_registration,
+            get_display_name_for_registration=get_display_name_for_registration,
         )
 
     def register_background_update_controller_callbacks(

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -694,10 +694,9 @@ class RegisterRestServlet(RestServlet):
                 session_id
             )
 
-            desired_display_name = await (
-                self.password_auth_provider.get_display_name_for_registration(
-                    auth_result,
-                    params,
+            display_name = await (
+                self.password_auth_provider.get_displayname_for_registration(
+                    auth_result, params
                 )
             )
 
@@ -706,7 +705,7 @@ class RegisterRestServlet(RestServlet):
                 password_hash=password_hash,
                 guest_access_token=guest_access_token,
                 threepid=threepid,
-                default_display_name=desired_display_name,
+                default_display_name=display_name,
                 address=client_addr,
                 user_agent_ips=entries,
             )

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -694,11 +694,19 @@ class RegisterRestServlet(RestServlet):
                 session_id
             )
 
+            desired_display_name = await (
+                self.password_auth_provider.get_display_name_for_registration(
+                    auth_result,
+                    params,
+                )
+            )
+
             registered_user_id = await self.registration_handler.register_user(
                 localpart=desired_username,
                 password_hash=password_hash,
                 guest_access_token=guest_access_token,
                 threepid=threepid,
+                default_display_name=desired_display_name,
                 address=client_addr,
                 user_agent_ips=entries,
             )

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -807,7 +807,7 @@ class PasswordAuthProviderTests(unittest.HomeserverTestCase):
         self._test_3pid_allowed("kitay", True)
 
     def test_displayname(self):
-        """Tests that the get_display_name_for_registration callback can define the
+        """Tests that the get_displayname_for_registration callback can define the
         display name of a user when registering.
         """
         self._setup_get_name_for_registration(

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -84,7 +84,8 @@ class CustomAuthProvider:
 
     def __init__(self, config, api: ModuleApi):
         api.register_password_auth_provider_callbacks(
-            auth_checkers={("test.login_type", ("test_field",)): self.check_auth})
+            auth_checkers={("test.login_type", ("test_field",)): self.check_auth}
+        )
 
     def check_auth(self, *args):
         return mock_password_provider.check_auth(*args)
@@ -117,10 +118,12 @@ class PasswordCustomAuthProvider:
         pass
 
     def __init__(self, config, api: ModuleApi):
-        api.register_password_auth_provider_callbacks(auth_checkers={
-            ("test.login_type", ("test_field",)): self.check_auth,
-            ("m.login.password", ("password",)): self.check_auth,
-        })
+        api.register_password_auth_provider_callbacks(
+            auth_checkers={
+                ("test.login_type", ("test_field",)): self.check_auth,
+                ("m.login.password", ("password",)): self.check_auth,
+            }
+        )
         pass
 
     def check_auth(self, *args):


### PR DESCRIPTION
Part of the Tchap mainlining. Very similar to [`get_username_for_registration`](https://matrix-org.github.io/synapse/latest/modules/password_auth_provider_callbacks.html#get_username_for_registration), except for setting the display name. The reason this is needed is because Tchap's Synapse fork derives the display name from the email address on registration - see [this code](https://github.com/matrix-org/synapse-dinsic/blob/f20caae101a482f19c81fbf36d4952388274d2d8/synapse/rest/client/register.py#L700-L710).