### PR TITLE
Faster joins: Support for calling `/federation/v1/state`

### DIFF
--- a/changelog.d/12013.misc
+++ b/changelog.d/12013.misc
@@ -1,0 +1,1 @@
+Preparation for faster-room-join work: Support for calling `/federation/v1/state` on a remote server.

--- a/synapse/federation/federation_base.py
+++ b/synapse/federation/federation_base.py
@@ -47,6 +47,11 @@ class FederationBase:
     ) -> EventBase:
         """Checks that event is correctly signed by the sending server.
 
+        Also checks the content hash, and redacts the event if there is a mismatch.
+
+        Also runs the event through the spam checker; if it fails, redacts the event
+        and flags it as soft-failed.
+
         Args:
             room_version: The room version of the PDU
             pdu: the event to be checked
@@ -55,7 +60,10 @@ class FederationBase:
               * the original event if the checks pass
               * a redacted version of the event (if the signature
                 matched but the hash did not)
-              * throws a SynapseError if the signature check failed."""
+
+        Raises:
+              SynapseError if the signature check failed.
+        """
         try:
             await _check_sigs_on_pdu(self.keyring, room_version, pdu)
         except SynapseError as e:

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -464,11 +464,11 @@ class FederationClient(FederationBase):
         )
 
         valid_auth_events = await self._check_sigs_and_hash_and_fetch(
-            destination, auth_events, room_version
+            destination, auth_event_map.values(), room_version
         )
 
         valid_state_events = await self._check_sigs_and_hash_and_fetch(
-            destination, state_events, room_version
+            destination, state_event_map.values(), room_version
         )
 
         return valid_state_events, valid_auth_events

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -17,7 +17,6 @@
 import copy
 import itertools
 import logging
-from functools import partial
 from typing import (
     TYPE_CHECKING,
     Awaitable,

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -424,6 +424,14 @@ class FederationClient(FederationBase):
         """Calls the /state endpoint to fetch the state at a particular point
         in the room.
 
+        Any invalid events (those with incorrect or unverifiable signatures or hashes)
+        are filtered out from the response, and any duplicate events are removed.
+
+        (Size limits and other event-format checks are *not* performed.)
+
+        Note that the result is not ordered, so callers must be careful to process
+        the events in an order that handles dependencies.
+
         Returns:
             a tuple of (state events, auth events)
         """
@@ -437,7 +445,7 @@ class FederationClient(FederationBase):
         auth_events = result.auth_events
 
         # we may as well filter out any duplicates from the response, to save
-        # processing them multiple times. (In particular, events may be present in 
+        # processing them multiple times. (In particular, events may be present in
         # `auth_events` as well as `state`, which is redundant).
         #
         # We don't rely on the sort order of the events, so we can just stick them

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -455,31 +455,12 @@ class FederationClient(FederationBase):
             len(auth_event_map),
         )
 
-        valid_state_events: List[EventBase] = []
-        valid_auth_events: List[EventBase] = []
-
-        async def _append_valid_events_to_list(
-            pdu: EventBase,
-            target_list: List[EventBase],
-        ) -> None:
-            valid_pdu = await self._check_sigs_and_hash_and_fetch_one(
-                pdu=pdu,
-                origin=destination,
-                room_version=room_version,
-            )
-
-            if valid_pdu:
-                target_list.append(valid_pdu)
-
-        await concurrently_execute(
-            partial(_append_valid_events_to_list, target_list=valid_state_events),
-            state_events,
-            10000,
+        valid_auth_events = await self._check_sigs_and_hash_and_fetch(
+            destination, auth_events, room_version
         )
-        await concurrently_execute(
-            partial(_append_valid_events_to_list, target_list=valid_auth_events),
-            state_events,
-            10000,
+
+        valid_state_events = await self._check_sigs_and_hash_and_fetch(
+            destination, state_events, room_version
         )
 
         return valid_state_events, valid_auth_events

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -436,8 +436,9 @@ class FederationClient(FederationBase):
         state_events = result.state
         auth_events = result.auth_events
 
-        # we may as filter out any duplicates from the response, which avoids some
-        # potential failure modes later.
+        # we may as well filter out any duplicates from the response, to save
+        # processing them multiple times. (In particular, events may be present in 
+        # `auth_events` as well as `state`, which is redundant).
         #
         # We don't rely on the sort order of either of them, which makes it easier
         state_event_map = {event.event_id: event for event in state_events}

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -440,7 +440,8 @@ class FederationClient(FederationBase):
         # processing them multiple times. (In particular, events may be present in 
         # `auth_events` as well as `state`, which is redundant).
         #
-        # We don't rely on the sort order of either of them, which makes it easier
+        # We don't rely on the sort order of the events, so we can just stick them
+        # in a dict.
         state_event_map = {event.event_id: event for event in state_events}
         auth_event_map = {
             event.event_id: event

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -64,13 +64,12 @@ class TransportLayerClient:
     async def get_room_state_ids(
         self, destination: str, room_id: str, event_id: str
     ) -> JsonDict:
-        """Requests all state for a given room from the given server at the
-        given event. Returns the state's event_id's
+        """Requests the IDs of all state for a given room at the given event.
 
         Args:
             destination: The host name of the remote homeserver we want
                 to get the state from.
-            context: The name of the context we want the state of
+            room_id: the room we want the state of
             event_id: The event we want the context at.
 
         Returns:
@@ -84,6 +83,29 @@ class TransportLayerClient:
             path=path,
             args={"event_id": event_id},
             try_trailing_slash_on_400=True,
+        )
+
+    async def get_room_state(
+        self, room_version: RoomVersion, destination: str, room_id: str, event_id: str
+    ) -> "StateRequestResponse":
+        """Requests the full state for a given room at the given event.
+
+        Args:
+            room_version: the version of the room (required to build the event objects)
+            destination: The host name of the remote homeserver we want
+                to get the state from.
+            room_id: the room we want the state of
+            event_id: The event we want the context at.
+
+        Returns:
+            Results in a dict received from the remote homeserver.
+        """
+        path = _create_v1_path("/state/%s", room_id)
+        return await self.client.get_json(
+            destination,
+            path=path,
+            args={"event_id": event_id},
+            parser=_StateParser(room_version),
         )
 
     async def get_event(
@@ -1272,6 +1294,14 @@ class SendJoinResponse:
     event: Optional[EventBase] = None
 
 
+@attr.s(slots=True, auto_attribs=True)
+class StateRequestResponse:
+    """The parsed response of a `/state` request."""
+
+    auth_events: List[EventBase]
+    state: List[EventBase]
+
+
 @ijson.coroutine
 def _event_parser(event_dict: JsonDict) -> Generator[None, Tuple[str, Any], None]:
     """Helper function for use with `ijson.kvitems_coro` to parse key-value pairs
@@ -1354,4 +1384,38 @@ class SendJoinParser(ByteParser[SendJoinResponse]):
             self._response.event = make_event_from_dict(
                 self._response.event_dict, self._room_version
             )
+        return self._response
+
+
+class _StateParser(ByteParser[StateRequestResponse]):
+    """A parser for the response to `/state` requests.
+
+    Args:
+        room_version: The version of the room.
+    """
+
+    CONTENT_TYPE = "application/json"
+
+    def __init__(self, room_version: RoomVersion):
+        self._response = StateRequestResponse([], [])
+        self._room_version = room_version
+        self._coros = [
+            ijson.items_coro(
+                _event_list_parser(room_version, self._response.state),
+                "pdus.item",
+                use_float=True,
+            ),
+            ijson.items_coro(
+                _event_list_parser(room_version, self._response.auth_events),
+                "auth_chain.item",
+                use_float=True,
+            ),
+        ]
+
+    def write(self, data: bytes) -> int:
+        for c in self._coros:
+            c.send(data)
+        return len(data)
+
+    def finish(self) -> StateRequestResponse:
         return self._response

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -978,13 +978,13 @@ class MatrixFederationHttpClient:
         self,
         destination: str,
         path: str,
-        args: Optional[QueryArgs] = None,
-        retry_on_dns_fail: bool = True,
-        timeout: Optional[int] = None,
-        ignore_backoff: bool = False,
-        try_trailing_slash_on_400: bool = False,
-        parser: Optional[ByteParser[T]] = None,
-        max_response_size: Optional[int] = None,
+        args: Optional[QueryArgs] = ...,
+        retry_on_dns_fail: bool = ...,
+        timeout: Optional[int] = ...,
+        ignore_backoff: bool = ...,
+        try_trailing_slash_on_400: bool = ...,
+        parser: ByteParser[T] = ...,
+        max_response_size: Optional[int] = ...,
     ) -> T:
         ...
 

--- a/tests/federation/test_federation_client.py
+++ b/tests/federation/test_federation_client.py
@@ -42,7 +42,9 @@ class FederationClientTest(FederatingHomeserverTestCase):
         creator = f"@creator:{self.OTHER_SERVER_NAME}"
         test_room_id = "!room_id"
 
-        # mock up some events to use in the response
+        # mock up some events to use in the response.
+        # In real life, these would have things in `prev_events` and `auth_events`, but that's
+        # a bit annoying to mock up, and the code under test doesn't care, so we don't bother.
         create_event_dict = self.add_hashes_and_signatures(
             {
                 "room_id": test_room_id,

--- a/tests/federation/test_federation_client.py
+++ b/tests/federation/test_federation_client.py
@@ -1,0 +1,147 @@
+# Copyright 2022 Matrix.org Federation C.I.C
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from unittest import mock
+
+import twisted.web.client
+from twisted.internet import defer
+from twisted.internet.protocol import Protocol
+from twisted.python.failure import Failure
+from twisted.test.proto_helpers import MemoryReactor
+
+from synapse.api.room_versions import RoomVersions
+from synapse.server import HomeServer
+from synapse.types import JsonDict
+from synapse.util import Clock
+
+from tests.unittest import FederatingHomeserverTestCase
+
+
+class FederationClientTest(FederatingHomeserverTestCase):
+    def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
+        super().prepare(reactor, clock, homeserver)
+
+        # mock out the Agent used by the federation client, which is easier than
+        # catching the HTTPS connection and do the TLS stuff.
+        self._mock_agent = mock.create_autospec(twisted.web.client.Agent, spec_set=True)
+        homeserver.get_federation_http_client().agent = self._mock_agent
+
+    def test_get_room_state(self):
+        creator = f"@creator:{self.OTHER_SERVER_NAME}"
+        test_room_id = "!room_id"
+
+        # mock up some events to use in the response
+        create_event_dict = self.add_hashes_and_signatures(
+            {
+                "room_id": test_room_id,
+                "type": "m.room.create",
+                "state_key": "",
+                "sender": creator,
+                "content": {"creator": creator},
+                "prev_events": [],
+                "auth_events": [],
+                "origin_server_ts": 500,
+            }
+        )
+        member_event_dict = self.add_hashes_and_signatures(
+            {
+                "room_id": test_room_id,
+                "type": "m.room.member",
+                "sender": creator,
+                "state_key": creator,
+                "content": {"membership": "join"},
+                "prev_events": [],
+                "auth_events": [],
+                "origin_server_ts": 600,
+            }
+        )
+        pl_event_dict = self.add_hashes_and_signatures(
+            {
+                "room_id": test_room_id,
+                "type": "m.room.power_levels",
+                "sender": creator,
+                "state_key": "",
+                "content": {},
+                "prev_events": [],
+                "auth_events": [],
+                "origin_server_ts": 700,
+            }
+        )
+
+        # mock up the response, and have the agent return it
+        self._mock_agent.request.return_value = defer.succeed(
+            _mock_response(
+                {
+                    "pdus": [
+                        create_event_dict,
+                        member_event_dict,
+                        pl_event_dict,
+                    ],
+                    "auth_chain": [
+                        create_event_dict,
+                        member_event_dict,
+                    ],
+                }
+            )
+        )
+
+        # now fire off the request
+        state_resp, auth_resp = self.get_success(
+            self.hs.get_federation_client().get_room_state(
+                "yet_another_server",
+                test_room_id,
+                "event_id",
+                RoomVersions.V9,
+            )
+        )
+
+        # check the right call got made to the agent
+        self._mock_agent.request.assert_called_once_with(
+            b"GET",
+            b"matrix://yet_another_server/_matrix/federation/v1/state/%21room_id?event_id=event_id",
+            headers=mock.ANY,
+            bodyProducer=None,
+        )
+
+        # ... and that the response is correct.
+
+        # the auth_resp should be empty because all the events are also in state
+        self.assertEqual(auth_resp, [])
+
+        # all of the events should be returned in state_resp, though not necessarily
+        # in the same order. We just check the type on the assumption that if the type
+        # is right, so is the rest of the event.
+        self.assertCountEqual(
+            [e.type for e in state_resp],
+            ["m.room.create", "m.room.member", "m.room.power_levels"],
+        )
+
+
+def _mock_response(resp: JsonDict):
+    body = json.dumps(resp).encode("utf-8")
+
+    def deliver_body(p: Protocol):
+        p.dataReceived(body)
+        p.connectionLost(Failure(twisted.web.client.ResponseDone()))
+
+    response = mock.Mock(
+        code=200,
+        phrase=b"OK",
+        headers=twisted.web.client.Headers({"content-Type": ["application/json"]}),
+        length=len(body),
+        deliverBody=deliver_body,
+    )
+    mock.seal(response)
+    return response

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -51,7 +51,10 @@ from twisted.web.server import Request
 
 from synapse import events
 from synapse.api.constants import EventTypes, Membership
+from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersion
 from synapse.config.homeserver import HomeServerConfig
+from synapse.config.server import DEFAULT_ROOM_VERSION
+from synapse.crypto.event_signing import add_hashes_and_signatures
 from synapse.federation.transport.server import TransportLayerServer
 from synapse.http.server import JsonResource
 from synapse.http.site import SynapseRequest, SynapseSite
@@ -838,6 +841,24 @@ class FederatingHomeserverTestCase(HomeserverTestCase):
             custom_headers=custom_headers,
             client_ip=client_ip,
         )
+
+    def add_hashes_and_signatures(
+        self,
+        event_dict: JsonDict,
+        room_version: RoomVersion = KNOWN_ROOM_VERSIONS[DEFAULT_ROOM_VERSION],
+    ) -> JsonDict:
+        """Adds hashes and signatures to the given event dict
+
+        Returns:
+             The modified event dict, for convenience
+        """
+        add_hashes_and_signatures(
+            room_version,
+            event_dict,
+            signature_name=self.OTHER_SERVER_NAME,
+            signing_key=self.OTHER_SERVER_SIGNATURE_KEY,
+        )
+        return event_dict
 
 
 def _auth_header_for_request(


### PR DESCRIPTION
This is an endpoint that we have server-side support for, but no client-side support. It's going to be useful for resyncing partial-stated rooms, so let's introduce it.