### PR TITLE
Fix bug in `StateFilter.return_expanded()` and add some tests.

### DIFF
--- a/changelog.d/12016.misc
+++ b/changelog.d/12016.misc
@@ -1,0 +1,1 @@
+Fix bug in `StateFilter.return_expanded()` and add some tests.

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -204,13 +204,16 @@ class StateFilter:
         if get_all_members:
             # We want to return everything.
             return StateFilter.all()
-        else:
+        elif EventTypes.Member in self.types:
             # We want to return all non-members, but only particular
             # memberships
             return StateFilter(
                 types=frozendict({EventTypes.Member: self.types[EventTypes.Member]}),
                 include_others=True,
             )
+        else:
+            # We want to return all non-members
+            return _ALL_NON_MEMBER_STATE_FILTER
 
     def make_sql_filter_clause(self) -> Tuple[str, List[str]]:
         """Converts the filter to an SQL clause.
@@ -528,6 +531,9 @@ class StateFilter:
 
 
 _ALL_STATE_FILTER = StateFilter(types=frozendict(), include_others=True)
+_ALL_NON_MEMBER_STATE_FILTER = StateFilter(
+    types=frozendict({EventTypes.Member: frozenset()}), include_others=True
+)
 _NONE_STATE_FILTER = StateFilter(types=frozendict(), include_others=False)
 
 


### PR DESCRIPTION
If you rollback to just before the fix and run the tests, you'll see the error that gets hit:

```
  File "/home/rei/work/synapse/tests/storage/test_state.py", line 1086, in test_return_expanded
    StateFilter.freeze(
  File "/home/rei/work/synapse/synapse/storage/state.py", line 211, in return_expanded
    types=frozendict({EventTypes.Member: self.types[EventTypes.Member]}),
builtins.KeyError: 'm.room.member'
```

I suspect this hasn't actually ever been hit in production (hence the `misc` label) but I noticed
it was wrong when working on #10870.

