### PR TITLE
Fix 500 error with Postgres when looking backwards with the MSC3030 `/timestamp_to_event` endpoint

### DIFF
--- a/changelog.d/12024.bugfix
+++ b/changelog.d/12024.bugfix
@@ -1,0 +1,1 @@
+Fix 500 error with Postgres when looking backwards with the [MSC3030](https://github.com/matrix-org/matrix-doc/pull/3030) `/timestamp_to_event?dir=b` endpoint.

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -1854,7 +1854,7 @@ class EventsWorkerStore(SQLBaseStore):
             forward_edge_query = """
                 SELECT 1 FROM event_edges
                 /* Check to make sure the event referencing our event in question is not rejected */
-                LEFT JOIN rejections ON event_edges.event_id == rejections.event_id
+                LEFT JOIN rejections ON event_edges.event_id = rejections.event_id
                 WHERE
                     event_edges.room_id = ?
                     AND event_edges.prev_event_id = ?


### PR DESCRIPTION
Fix 500 error with Postgres when looking backwards with the MSC3030 `/timestamp_to_event` endpoint.

`==` is a valid comparison operator in SQLite but not in Postgres.

This wasn't caught in the [MSC3030 Complement tests](https://github.com/matrix-org/complement/pull/178) because they use SQLite, see https://github.com/matrix-org/complement/blob/18aa82f2635cb5f69d720adb4b6bb722debb7c47/dockerfiles/synapse/homeserver.yaml#L34-L35

### Sources

SQLite says:

> Equals can be either = or ==.
>
> *-- https://sqlite.org/lang_expr.html*

But for Postgres, https://www.postgresql.org/docs/8.2/functions-comparison.html, only lists `=`


### Example 500 error

Example Synapse 500 error when using `/_matrix/client/unstable/org.matrix.msc3030/rooms/!HBehERstyQBxyJDLfR:my.synapse.server/timestamp_to_event?ts=1644278400000&dir=b`:

```
2022-02-17 22:05:00,116 - synapse.http.server - 100 - ERROR - GET-14 - Failed handle request via 'TimestampLookupRestServlet': <XForwardedForRequest at 0x10e498eb0 method='GET' uri='/_matrix/client/unstable/org.matrix.msc3030/rooms/!HBehERstyQBxyJDLfR:my.synapse.server/timestamp_to_event?ts=1644451200000&dir=b' clientproto='HTTP/1.1' site='8008'>
Traceback (most recent call last):
  File "/Users/eric/Documents/github/element/synapse/synapse/http/server.py", line 269, in _async_render_wrapper
    callback_return = await self._async_render(request)
  File "/Users/eric/Documents/github/element/synapse/synapse/http/server.py", line 471, in _async_render
    callback_return = await raw_callback_return
  File "/Users/eric/Documents/github/element/synapse/synapse/rest/client/room.py", line 1134, in on_GET
    ) = await self.timestamp_lookup_handler.get_event_for_timestamp(
  File "/Users/eric/Documents/github/element/synapse/synapse/handlers/room.py", line 1308, in get_event_for_timestamp
    await self.store.is_event_next_to_forward_gap(local_event)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/events_worker.py", line 1891, in is_event_next_to_forward_gap
    return await self.db_pool.runInteraction(
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/database.py", line 743, in runInteraction
    result = await self.runWithConnection(
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/database.py", line 857, in runWithConnection
    return await make_deferred_yieldable(
  File "/Users/eric/Documents/github/element/synapse/env/lib/python3.9/site-packages/twisted/python/threadpool.py", line 238, in inContext
    result = inContext.theWork()  # type: ignore[attr-defined]
  File "/Users/eric/Documents/github/element/synapse/env/lib/python3.9/site-packages/twisted/python/threadpool.py", line 254, in <lambda>
    inContext.theWork = lambda: context.call(  # type: ignore[attr-defined]
  File "/Users/eric/Documents/github/element/synapse/env/lib/python3.9/site-packages/twisted/python/context.py", line 118, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/Users/eric/Documents/github/element/synapse/env/lib/python3.9/site-packages/twisted/python/context.py", line 83, in callWithContext
    return func(*args, **kw)
  File "/Users/eric/Documents/github/element/synapse/env/lib/python3.9/site-packages/twisted/enterprise/adbapi.py", line 293, in _runWithConnection
    compat.reraise(excValue, excTraceback)
  File "/Users/eric/Documents/github/element/synapse/env/lib/python3.9/site-packages/twisted/python/deprecate.py", line 298, in deprecatedFunction
    return function(*args, **kwargs)
  File "/Users/eric/Documents/github/element/synapse/env/lib/python3.9/site-packages/twisted/python/compat.py", line 404, in reraise
    raise exception.with_traceback(traceback)
  File "/Users/eric/Documents/github/element/synapse/env/lib/python3.9/site-packages/twisted/enterprise/adbapi.py", line 284, in _runWithConnection
    result = func(conn, *args, **kw)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/database.py", line 850, in inner_func
    return func(db_conn, *args, **kwargs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/database.py", line 609, in new_transaction
    r = func(cursor, *args, **kwargs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/events_worker.py", line 1884, in is_event_next_to_gap_txn
    txn.execute(forward_edge_query, (event.room_id, event.event_id))
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/database.py", line 310, in execute
    self._do_execute(self.txn.execute, sql, *args)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/database.py", line 343, in _do_execute
    return func(sql, *args)
psycopg2.errors.UndefinedFunction: operator does not exist: text == text
LINE 1: ...d */ LEFT JOIN rejections ON event_edges.event_id == rejecti...
                                                             ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
```

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
