### PR TITLE
Update the olddeps CI check to use an old version of markupsafe

### DIFF
--- a/changelog.d/12025.misc
+++ b/changelog.d/12025.misc
@@ -1,0 +1,1 @@
+Update the `olddeps` CI job to use an old version of `markupsafe`.

--- a/tox.ini
+++ b/tox.ini
@@ -124,6 +124,7 @@ usedevelop = false
 deps =
     Automat == 0.8.0
     lxml
+    markupsafe < 2.1
     {[base]deps}
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -124,6 +124,8 @@ usedevelop = false
 deps =
     Automat == 0.8.0
     lxml
+    # markupsafe 2.1 introduced a change that breaks Jinja 2.x. Since we depend on
+    # Jinja >= 2.9, it means this test suite will fail if markupsafe >= 2.1 is installed.
     markupsafe < 2.1
     {[base]deps}
 


### PR DESCRIPTION
Our olddeps check don't check for the oldest possible versions on _transitive_ dependencies. Markupsafe 2.1 was released recently, which breaks Jinja 2.x. So olddeps installs Jinja 2.9 (since it's the oldest version allowed) and markupsafe 2.1 (since it's the latest version of the transitive dep), which breaks everything.

See https://github.com/pallets/jinja/issues/1587