### PR TITLE
Add more tests for in-flight state query duplication.

### DIFF
--- a/changelog.d/12033.misc
+++ b/changelog.d/12033.misc
@@ -1,0 +1,1 @@
+Deduplicate in-flight requests in `_get_state_for_groups`.


### PR DESCRIPTION
Follows on from #10870.

I felt like a few more tests wouldn't hurt.

