### PR TITLE
Run `_handle_queued_pdus` as a background process

### DIFF
--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -559,7 +559,9 @@ class FederationHandler:
             # lots of requests for missing prev_events which we do actually
             # have. Hence we fire off the background task, but don't wait for it.
 
-            run_in_background(self._handle_queued_pdus, room_queue)
+            run_as_background_process(
+                "handle_queued_pdus", self._handle_queued_pdus, room_queue
+            )
 
     async def do_knock(
         self,


### PR DESCRIPTION
... to ensure it gets a proper log context, mostly.

(Background: any events that arrive over federation while a join is in progress  get stuck in a queue which is then processed once the join completes. `_handle_queued_pdus` processes those events.)