### PR TITLE
Tidy the building of sdists and wheels

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -91,17 +91,7 @@ jobs:
 
   build-sdist:
     name: "Build pypi distribution files"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install wheel
-      - run: |
-          python setup.py sdist bdist_wheel
-      - uses: actions/upload-artifact@v2
-        with:
-          name: python-dist
-          path: dist/*
+    uses: "matrix-org/backend-meta/.github/workflows/packaging.yml@v1"
 
   # if it's a tag, create a release and attach the artifacts to it
   attach-assets:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -7,7 +7,7 @@ on:
   # of things breaking (but only build one set of debs)
   pull_request:
   push:
-    branches: ["develop"]
+    branches: ["develop", "release-*"]
 
     # we do the full build on tags.
     tags: ["v*"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,24 +48,10 @@ jobs:
         env:
           PULL_REQUEST_NUMBER: ${{ github.event.number }}
 
-  lint-sdist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-      - run: pip install wheel
-      - run: python setup.py sdist bdist_wheel
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Python Distributions
-          path: dist/*
-
   # Dummy step to gate other tests on without repeating the whole list
   linting-done:
     if: ${{ !cancelled() }} # Run this even if prior jobs were skipped
-    needs: [lint, lint-crlf, lint-newsfile, lint-sdist]
+    needs: [lint, lint-crlf, lint-newsfile]
     runs-on: ubuntu-latest
     steps:
       - run: "true"
@@ -397,7 +383,6 @@ jobs:
       - lint
       - lint-crlf
       - lint-newsfile
-      - lint-sdist
       - trial
       - trial-olddeps
       - sytest

--- a/changelog.d/12051.misc
+++ b/changelog.d/12051.misc
@@ -1,0 +1,1 @@
+Tidy up GitHub Actions config which builds distributions for PyPI.


### PR DESCRIPTION
We seem to build sdists and wheel distributions in two places:

- `tests.yml`, on `develop`, ` release-*` and on PRs.
- `release-artifacts.yml`, on `develop`, `v.*` tags and on PRs.

In particular this means that we build these twice for all PRs, and twice on develop.

I propose that
- we stop build distributions in `tests.yml`.
- we trigger `release-artifacts.yml` on release branches. That means we'll now build debs and docker images on the release branch, not just on the release tag.

Additionally, I propose we make use of [the workflow in backend-meta](https://github.com/matrix-org/backend-meta/blob/main/.github/workflows/packaging.yml) to save a bit of yaml, and also make it slightly easier to switch over to poetry (#11537). The common workflow [uploads sdist and wheel with different display names](https://github.com/matrix-org/backend-meta/blob/2001ab8d60a922b0d1f48bd5f3b38765e9f74113/.github/workflows/packaging.yml#L31-L39), but the same filename---so I think the release process should be unaffected.