### PR TITLE
Bump the default room version to 9 per MSC3589.

### DIFF
--- a/changelog.d/12058.feature
+++ b/changelog.d/12058.feature
@@ -1,0 +1,1 @@
+Use room version 9 as the default room version (per [MSC3589](https://github.com/matrix-org/matrix-doc/pull/3589)).

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -163,7 +163,7 @@ presence:
 # For example, for room version 1, default_room_version should be set
 # to "1".
 #
-#default_room_version: "6"
+#default_room_version: "9"
 
 # The GC threshold parameters to pass to `gc.set_threshold`, if defined
 #

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -146,7 +146,7 @@ DEFAULT_IP_RANGE_BLACKLIST = [
     "fec0::/10",
 ]
 
-DEFAULT_ROOM_VERSION = "6"
+DEFAULT_ROOM_VERSION = "9"
 
 ROOM_COMPLEXITY_TOO_GREAT = (
     "Your homeserver is unable to join rooms this large or complex. "


### PR DESCRIPTION
[MSC3589](https://github.com/matrix-org/matrix-doc/pull/3589) passed FCP, so we can use version 9 as the default.

Fixes #11697.