### PR TITLE
Prune setup.cfg some more

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+# TODO: incorporate this into pyproject.toml if flake8 supports it in the future.
+# See https://github.com/PyCQA/flake8/issues/234
+[flake8]
+# see https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
+# for error codes. The ones we ignore are:
+#  W503: line break before binary operator
+#  W504: line break after binary operator
+#  E203: whitespace before ':' (which is contrary to pep8?)
+#  E731: do not assign a lambda expression, use a def
+#  E501: Line too long (black enforces this for us)
+ignore=W503,W504,E203,E731,E501

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -45,6 +45,7 @@ include book.toml
 include pyproject.toml
 recursive-include changelog.d *
 
+include .flake8
 prune .circleci
 prune .github
 prune .ci

--- a/changelog.d/12052.misc
+++ b/changelog.d/12052.misc
@@ -1,1 +1,1 @@
-Move `isort` configuration to `pyproject.toml`.
+Move configuration out of `setup.cfg`.

--- a/changelog.d/12059.misc
+++ b/changelog.d/12059.misc
@@ -1,0 +1,1 @@
+Move configuration out of `setup.cfg`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[trial]
-test_suite = tests
-
 [check-manifest]
 ignore =
     .git-blame-ignore-revs

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,12 +7,3 @@ ignore =
     pylint.cfg
     tox.ini
 
-[flake8]
-# see https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
-# for error codes. The ones we ignore are:
-#  W503: line break before binary operator
-#  W504: line break after binary operator
-#  E203: whitespace before ':' (which is contrary to pep8?)
-#  E731: do not assign a lambda expression, use a def
-#  E501: Line too long (black enforces this for us)
-ignore=W503,W504,E203,E731,E501


### PR DESCRIPTION
Similar to #12052: I want to move stuff away from setup.cfg where possible. However, this time I have an additional motivation. I've only been able to get `tox` and `poetry` to cooperate if `setup.cfg` and `setup.py` are nowhere to be seen. Otherwise, when `tox` invokes `pip`, the latter guesses we're in a setuptools project and tries to run `setup.py develop`, which fails.

Merging this will mean that only `check_manifest` config remains in setup.cfg. That isn't needed for poetry (it doesn't use a manifest file, but config in pyproject.toml). So we will soon be able to remove setup.cfg altogether.