### PR TITLE
Add module callbacks called for reacting to deactivation and profile update

### DIFF
--- a/changelog.d/12062.feature
+++ b/changelog.d/12062.feature
@@ -1,1 +1,1 @@
-Add module callbacks to react to user deactivations and profile updates.
+Add module callbacks to react to user deactivation status changes (i.e. deactivations and reactivations) and profile updates.

--- a/changelog.d/12062.feature
+++ b/changelog.d/12062.feature
@@ -1,0 +1,1 @@
+Add module callbacks to react to user deactivations and profile udpates.

--- a/changelog.d/12062.feature
+++ b/changelog.d/12062.feature
@@ -1,1 +1,1 @@
-Add module callbacks to react to user deactivations and profile udpates.
+Add module callbacks to react to user deactivations and profile updates.

--- a/docs/modules/third_party_rules_callbacks.md
+++ b/docs/modules/third_party_rules_callbacks.md
@@ -150,7 +150,7 @@ If multiple modules implement this callback, Synapse runs them all in order.
 
 ### `on_profile_update`
 
-_First introduced in Synapse v1.5X.0_
+_First introduced in Synapse v1.54.0_
 
 ```python
 async def on_profile_update(
@@ -185,7 +185,7 @@ If multiple modules implement this callback, Synapse runs them all in order.
 
 ### `on_user_deactivation_status_changed`
 
-_First introduced in Synapse v1.5X.0_
+_First introduced in Synapse v1.54.0_
 
 ```python
 async def on_user_deactivation_status_changed(

--- a/docs/modules/third_party_rules_callbacks.md
+++ b/docs/modules/third_party_rules_callbacks.md
@@ -166,8 +166,8 @@ deactivated (in which case their display name is set to an empty string (`""`) a
 avatar URL is set to `None`). The module is passed the Matrix ID of the user whose profile
 has been updated, their new profile, as well as a boolean that is `True` if the update
 was triggered by a server admin (and `False` otherwise). Note that this boolean is also
-`True` if the profile change happens as a result of the user logging through Single
-Sing-On, and if a server admin updates their own profile.
+`True` if the profile change happens as a result of the user logging in through Single
+Sign-On, or if a server admin updates their own profile.
 
 If multiple modules implement this callback, Synapse runs them all in order.
 

--- a/docs/modules/third_party_rules_callbacks.md
+++ b/docs/modules/third_party_rules_callbacks.md
@@ -165,15 +165,17 @@ Called after updating a local user's profile. The update can be triggered either
 user themselves or a server admin. The update can also be triggered by a user being
 deactivated (in which case their display name is set to an empty string (`""`) and the
 avatar URL is set to `None`). The module is passed the Matrix ID of the user whose profile
-has been updated, their new profile, as well as a boolean that is `True` if the update
-was triggered by a server admin (and `False` otherwise), and a boolean that is `True` if
-the update is a result of the user being deactivated. Note that the `by_admin` boolean is
-also `True` if the profile change happens as a result of the user logging in through
-Single Sign-On, or if a server admin updates their own profile.
+has been updated, their new profile, as well as a `by_admin` boolean that is `True` if the
+update was triggered by a server admin (and `False` otherwise), and a `deactivated`
+boolean that is `True` if the update is a result of the user being deactivated.
+
+Note that the `by_admin` boolean is also `True` if the profile change happens as a result
+of the user logging in through Single Sign-On, or if a server admin updates their own
+profile.
 
 Per-room profile changes do not trigger this callback to be called. Synapse administrators
 wishing this callback to be called on every profile change are encouraged to disable
-per-room profile globally using the `allow_per_room_profiles` configuration setting in
+per-room profiles globally using the `allow_per_room_profiles` configuration setting in
 Synapse's configuration file.
 This callback is not called when registering a user, even when setting it through the
 [`get_displayname_for_registration`](https://matrix-org.github.io/synapse/latest/modules/password_auth_provider_callbacks.html#get_displayname_for_registration)
@@ -181,18 +183,24 @@ module callback.
 
 If multiple modules implement this callback, Synapse runs them all in order.
 
-### `on_deactivation`
+### `on_user_deactivation_status_changed`
 
 _First introduced in Synapse v1.5X.0_
 
 ```python
-async def on_deactivation(user_id: str, by_admin: bool) -> None:
+async def on_user_deactivation_status_changed(
+    user_id: str, deactivated: bool, by_admin: bool
+) -> None:
 ```
 
-Called after deactivating a local user. The deactivation can be triggered either by the
-user themselves or a server admin. The module is passed the Matrix ID of the user that's
-been deactivated, as well as a boolean that is `True` if the deactivation was triggered
-by a server admin (and `False` otherwise).
+Called after deactivating a local user, or reactivating them through the admin API. The
+deactivation can be triggered either by the user themselves or a server admin. The module
+is passed the Matrix ID of the user whose status is changed, as well as a `deactivated`
+boolean that is `True` if the user is being deactivated and `False` if they're being
+reactivated, and a `by_admin` boolean that is `True` if the deactivation was triggered by
+a server admin (and `False` otherwise). This latter `by_admin` boolean is always `True`
+if the user is being reactivated, as this operation can only be performed through the
+admin API.
 
 If multiple modules implement this callback, Synapse runs them all in order.
 

--- a/docs/modules/third_party_rules_callbacks.md
+++ b/docs/modules/third_party_rules_callbacks.md
@@ -157,6 +157,7 @@ async def on_profile_update(
     user_id: str,
     new_profile: "synapse.module_api.ProfileInfo",
     by_admin: bool,
+    deactivation: bool,
 ) -> None:
 ```
 
@@ -165,9 +166,18 @@ user themselves or a server admin. The update can also be triggered by a user be
 deactivated (in which case their display name is set to an empty string (`""`) and the
 avatar URL is set to `None`). The module is passed the Matrix ID of the user whose profile
 has been updated, their new profile, as well as a boolean that is `True` if the update
-was triggered by a server admin (and `False` otherwise). Note that this boolean is also
-`True` if the profile change happens as a result of the user logging in through Single
-Sign-On, or if a server admin updates their own profile.
+was triggered by a server admin (and `False` otherwise), and a boolean that is `True` if
+the update is a result of the user being deactivated. Note that the `by_admin` boolean is
+also `True` if the profile change happens as a result of the user logging in through
+Single Sign-On, or if a server admin updates their own profile.
+
+Per-room profile changes do not trigger this callback to be called. Synapse administrators
+wishing this callback to be called on every profile change are encouraged to disable
+per-room profile globally using the `allow_per_room_profiles` configuration setting in
+Synapse's configuration file.
+This callback is not called when registering a user, even when setting it through the
+[`get_displayname_for_registration`](https://matrix-org.github.io/synapse/latest/modules/password_auth_provider_callbacks.html#get_displayname_for_registration)
+module callback.
 
 If multiple modules implement this callback, Synapse runs them all in order.
 

--- a/docs/modules/third_party_rules_callbacks.md
+++ b/docs/modules/third_party_rules_callbacks.md
@@ -148,6 +148,44 @@ deny an incoming event, see [`check_event_for_spam`](spam_checker_callbacks.md#c
 
 If multiple modules implement this callback, Synapse runs them all in order.
 
+### `on_profile_update`
+
+_First introduced in Synapse v1.5X.0_
+
+```python
+async def on_profile_update(
+    user_id: str,
+    new_profile: "synapse.module_api.ProfileInfo",
+    by_admin: bool,
+) -> None:
+```
+
+Called after updating a local user's profile. The update can be triggered either by the
+user themselves or a server admin. The update can also be triggered by a user being
+deactivated (in which case their display name is set to an empty string (`""`) and the
+avatar URL is set to `None`). The module is passed the Matrix ID of the user whose profile
+has been updated, their new profile, as well as a boolean that is `True` if the update
+was triggered by a server admin (and `False` otherwise). Note that this boolean is also
+`True` if the profile change happens as a result of the user logging through Single
+Sing-On, and if a server admin updates their own profile.
+
+If multiple modules implement this callback, Synapse runs them all in order.
+
+### `on_deactivation`
+
+_First introduced in Synapse v1.5X.0_
+
+```python
+async def on_deactivation(user_id: str, by_admin: bool) -> None:
+```
+
+Called after deactivating a local user. The deactivation can be triggered either by the
+user themselves or a server admin. The module is passed the Matrix ID of the user that's
+been deactivated, as well as a boolean that is `True` if the deactivation was triggered
+by a server admin (and `False` otherwise).
+
+If multiple modules implement this callback, Synapse runs them all in order.
+
 ## Example
 
 The example below is a module that implements the third-party rules callback

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -38,7 +38,7 @@ CHECK_VISIBILITY_CAN_BE_MODIFIED_CALLBACK = Callable[
     [str, StateMap[EventBase], str], Awaitable[bool]
 ]
 ON_NEW_EVENT_CALLBACK = Callable[[EventBase, StateMap[EventBase]], Awaitable]
-ON_PROFILE_UPDATE_CALLBACK = Callable[[str, ProfileInfo, bool], Awaitable]
+ON_PROFILE_UPDATE_CALLBACK = Callable[[str, ProfileInfo, bool, bool], Awaitable]
 ON_DEACTIVATION_CALLBACK = Callable[[str, bool], Awaitable]
 
 
@@ -382,7 +382,7 @@ class ThirdPartyEventRules:
         return state_events
 
     async def on_profile_update(
-        self, user_id: str, new_profile: ProfileInfo, by_admin: bool
+        self, user_id: str, new_profile: ProfileInfo, by_admin: bool, deactivation: bool
     ) -> None:
         """Called after the global profile of a user has been updated. Does not include
         per-room profile changes.
@@ -391,10 +391,11 @@ class ThirdPartyEventRules:
             user_id: The user whose profile was changed.
             new_profile: The updated profile for the user.
             by_admin: Whether the profile update was performed by a server admin.
+            deactivation: Whether this change was made while deactivating the user.
         """
         for callback in self._on_profile_update_callbacks:
             try:
-                await callback(user_id, new_profile, by_admin)
+                await callback(user_id, new_profile, by_admin, deactivation)
             except Exception as e:
                 logger.exception(
                     "Failed to run module API callback %s: %s", callback, e

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -405,7 +405,7 @@ class ThirdPartyEventRules:
 
         Args:
             user_id: The deactivated user.
-            by_admin: Whether the deactivation is performed by a server admin.
+            by_admin: Whether the deactivation was performed by a server admin.
         """
         for callback in self._on_deactivation_callbacks:
             try:

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -166,7 +166,11 @@ class DeactivateAccountHandler:
         await self.store.purge_account_data_for_user(user_id)
 
         # Let modules know the user has been deactivated.
-        await self._third_party_rules.on_deactivation(user_id, by_admin)
+        await self._third_party_rules.on_user_deactivation_status_changed(
+            user_id,
+            True,
+            by_admin,
+        )
 
         return identity_server_supports_unbinding
 
@@ -271,6 +275,10 @@ class DeactivateAccountHandler:
 
         # Mark the user as active.
         await self.store.set_user_deactivated_status(user_id, False)
+
+        await self._third_party_rules.on_user_deactivation_status_changed(
+            user_id, False, True
+        )
 
         # Add the user to the directory, if necessary. Note that
         # this must be done after the user is re-activated, because

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -38,6 +38,7 @@ class DeactivateAccountHandler:
         self._profile_handler = hs.get_profile_handler()
         self.user_directory_handler = hs.get_user_directory_handler()
         self._server_name = hs.hostname
+        self._third_party_rules = hs.get_third_party_event_rules()
 
         # Flag that indicates whether the process to part users from rooms is running
         self._user_parter_running = False
@@ -159,6 +160,9 @@ class DeactivateAccountHandler:
 
         # Remove account data (including ignored users and push rules).
         await self.store.purge_account_data_for_user(user_id)
+
+        # Let modules know the user has been deactivated.
+        await self._third_party_rules.on_deactivation(user_id, by_admin)
 
         return identity_server_supports_unbinding
 

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -136,9 +136,13 @@ class DeactivateAccountHandler:
         if erase_data:
             user = UserID.from_string(user_id)
             # Remove avatar URL from this user
-            await self._profile_handler.set_avatar_url(user, requester, "", by_admin)
+            await self._profile_handler.set_avatar_url(
+                user, requester, "", by_admin, deactivation=True
+            )
             # Remove displayname from this user
-            await self._profile_handler.set_displayname(user, requester, "", by_admin)
+            await self._profile_handler.set_displayname(
+                user, requester, "", by_admin, deactivation=True
+            )
 
             logger.info("Marking %s as erased", user_id)
             await self.store.mark_user_erased(user_id)

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -173,6 +173,7 @@ class ProfileHandler:
         requester: Requester,
         new_displayname: str,
         by_admin: bool = False,
+        deactivation: bool = False,
     ) -> None:
         """Set the displayname of a user
 
@@ -181,6 +182,7 @@ class ProfileHandler:
             requester: The user attempting to make this change.
             new_displayname: The displayname to give this user.
             by_admin: Whether this change was made by an administrator.
+            deactivation: Whether this change was made while deactivating the user.
         """
         if not self.hs.is_mine(target_user):
             raise SynapseError(400, "User is not hosted on this homeserver")
@@ -230,7 +232,7 @@ class ProfileHandler:
         )
 
         await self._third_party_rules.on_profile_update(
-            target_user.to_string(), profile, by_admin
+            target_user.to_string(), profile, by_admin, deactivation
         )
 
         await self._update_join_states(requester, target_user)
@@ -267,6 +269,7 @@ class ProfileHandler:
         requester: Requester,
         new_avatar_url: str,
         by_admin: bool = False,
+        deactivation: bool = False,
     ) -> None:
         """Set a new avatar URL for a user.
 
@@ -275,6 +278,7 @@ class ProfileHandler:
             requester: The user attempting to make this change.
             new_avatar_url: The avatar URL to give this user.
             by_admin: Whether this change was made by an administrator.
+            deactivation: Whether this change was made while deactivating the user.
         """
         if not self.hs.is_mine(target_user):
             raise SynapseError(400, "User is not hosted on this homeserver")
@@ -322,7 +326,7 @@ class ProfileHandler:
         )
 
         await self._third_party_rules.on_profile_update(
-            target_user.to_string(), profile, by_admin
+            target_user.to_string(), profile, by_admin, deactivation
         )
 
         await self._update_join_states(requester, target_user)

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -71,6 +71,8 @@ class ProfileHandler:
 
         self.server_name = hs.config.server.server_name
 
+        self._third_party_rules = hs.get_third_party_event_rules()
+
         if hs.config.worker.run_background_tasks:
             self.clock.looping_call(
                 self._update_remote_profile_cache, self.PROFILE_UPDATE_MS
@@ -227,6 +229,10 @@ class ProfileHandler:
             target_user.to_string(), profile
         )
 
+        await self._third_party_rules.on_profile_update(
+            target_user.to_string(), profile, by_admin
+        )
+
         await self._update_join_states(requester, target_user)
 
     async def get_avatar_url(self, target_user: UserID) -> Optional[str]:
@@ -313,6 +319,10 @@ class ProfileHandler:
         profile = await self.store.get_profileinfo(target_user.localpart)
         await self.user_directory_handler.handle_local_profile_change(
             target_user.to_string(), profile
+        )
+
+        await self._third_party_rules.on_profile_update(
+            target_user.to_string(), profile, by_admin
         )
 
         await self._update_join_states(requester, target_user)

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -145,6 +145,7 @@ __all__ = [
     "JsonDict",
     "EventBase",
     "StateMap",
+    "ProfileInfo",
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -15,12 +15,12 @@ import threading
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
 from unittest.mock import Mock
 
-from synapse.api.constants import EventTypes, Membership
+from synapse.api.constants import EventTypes, Membership, LoginType
 from synapse.api.errors import SynapseError
 from synapse.events import EventBase
 from synapse.events.third_party_rules import load_legacy_third_party_event_rules
 from synapse.rest import admin
-from synapse.rest.client import login, room
+from synapse.rest.client import login, room, profile, account
 from synapse.types import JsonDict, Requester, StateMap
 from synapse.util.frozenutils import unfreeze
 
@@ -80,6 +80,8 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
         admin.register_servlets,
         login.register_servlets,
         room.register_servlets,
+        profile.register_servlets,
+        account.register_servlets,
     ]
 
     def make_homeserver(self, reactor, clock):
@@ -530,3 +532,174 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
             },
             tok=self.tok,
         )
+
+    def test_on_profile_update(self):
+        """Tests that the on_profile_update module callback is correctly called on
+        profile update.
+        """
+        displayname = "Foo"
+        avatar_url = "mxc://matrix.org/oWQDvfewxmlRaRCkVbfetyEo"
+
+        # Register a mock callback.
+        m = Mock(return_value=make_awaitable(None))
+        self.hs.get_third_party_event_rules()._on_profile_update_callbacks.append(m)
+
+        # Change the display name.
+        channel = self.make_request(
+            "PUT",
+            "/_matrix/client/v3/profile/%s/displayname" % self.user_id,
+            {"displayname": displayname},
+            access_token=self.tok,
+        )
+        self.assertEqual(channel.code, 200, channel.json_body)
+
+        # Check that the callback has been called once for our user.
+        m.assert_called_once()
+        args = m.call_args[0]
+        self.assertEqual(args[0], self.user_id)
+
+        # Test that by_admin is False.
+        self.assertFalse(args[2])
+
+        # Check that we've got the right profile data.
+        profile_info = args[1]
+        self.assertEqual(profile_info.display_name, displayname)
+        self.assertIsNone(profile_info.avatar_url)
+
+        # Change the avatar.
+        channel = self.make_request(
+            "PUT",
+            "/_matrix/client/v3/profile/%s/avatar_url" % self.user_id,
+            {"avatar_url": avatar_url},
+            access_token=self.tok,
+        )
+        self.assertEqual(channel.code, 200, channel.json_body)
+
+        # Check that the callback has been called once for our user.
+        m.assert_called_once()
+        args = m.call_args[0]
+        self.assertEqual(args[0], self.user_id)
+
+        # Test that by_admin is False.
+        self.assertFalse(args[2])
+
+        # Check that we've got the right profile data.
+        profile_info = args[1]
+        self.assertEqual(profile_info.display_name, displayname)
+        self.assertEqual(
+            profile_info.avatar_url, avatar_url
+        )
+
+    def test_on_profile_update_admin(self):
+        """Tests that the on_profile_update module callback is correctly called on
+        profile update triggered by a server admin.
+        """
+        displayname = "Foo"
+        avatar_url = "mxc://matrix.org/oWQDvfewxmlRaRCkVbfetyEo"
+
+        # Register a mock callback.
+        m = Mock(return_value=make_awaitable(None))
+        self.hs.get_third_party_event_rules()._on_profile_update_callbacks.append(m)
+
+        # Register an admin user.
+        self.register_user("admin", "password", admin=True)
+        admin_tok = self.login("admin", "password")
+
+        # Change a user's profile.
+        channel = self.make_request(
+            "PUT",
+            "/_synapse/admin/v2/users/%s" % self.user_id,
+            {"displayname": displayname, "avatar_url": avatar_url},
+            access_token=admin_tok,
+        )
+        self.assertEqual(channel.code, 200, channel.json_body)
+
+        # Check that the callback has been called twice (since we update the display name
+        # and avatar separately).
+        self.assertEqual(m.call_count, 2)
+
+        # Get the arguments for the last call and check it's about the right user.
+        args = m.call_args[0]
+        self.assertEqual(args[0], self.user_id)
+
+        # Check that by_admin is True.
+        self.assertTrue(args[2])
+
+        # Check that we've got the right profile data.
+        profile_info = args[1]
+        self.assertEqual(profile_info.display_name, displayname)
+        self.assertEqual(
+            profile_info.avatar_url, avatar_url
+        )
+
+    def test_on_deactivation(self):
+        """Tests that the on_deactivation module callback is called correctly when
+        processing a user's deactivation.
+        """
+        # Register a mocked callback.
+        m = Mock(return_value=make_awaitable(None))
+        self.hs.get_third_party_event_rules()._on_deactivation_callbacks.append(m)
+
+        # Register a user that we'll deactivate.
+        user_id = self.register_user("altan", "password")
+        tok = self.login("altan", "password")
+
+        # Deactivate that user.
+        channel = self.make_request(
+            "POST",
+            "/_matrix/client/v3/account/deactivate",
+            {
+                "auth": {
+                    "type": LoginType.PASSWORD,
+                    "password": "password",
+                    "identifier": {
+                        "type": "m.id.user",
+                        "user": user_id,
+                    },
+                }
+            },
+            access_token=tok,
+        )
+        self.assertEqual(channel.code, 200, channel.json_body)
+
+        # Check that the mock was called once.
+        m.assert_called_once()
+        args = m.call_args[0]
+
+        # Check that the mock was called with the right user ID, and with a False
+        # by_admin flag.
+        self.assertEqual(args[0], user_id)
+        self.assertFalse(args[1])
+
+    def test_on_deactivation_admin(self):
+        """Tests that the on_deactivation module callback is called correctly when
+        processing a user's deactivation triggered by a server admin.
+        """
+        # Register a mock callback.
+        m = Mock(return_value=make_awaitable(None))
+        self.hs.get_third_party_event_rules()._on_deactivation_callbacks.append(m)
+
+        # Register an admin user.
+        self.register_user("admin", "password", admin=True)
+        admin_tok = self.login("admin", "password")
+
+        # Register a user that we'll deactivate.
+        user_id = self.register_user("altan", "password")
+
+        # Change a user's profile.
+        channel = self.make_request(
+            "PUT",
+            "/_synapse/admin/v2/users/%s" % user_id,
+            {"deactivated": True},
+            access_token=admin_tok,
+        )
+        self.assertEqual(channel.code, 200, channel.json_body)
+
+        # Check that the mock was called once.
+        m.assert_called_once()
+        args = m.call_args[0]
+
+        # Check that the mock was called with the right user ID, and with a True
+        # by_admin flag.
+        self.assertEqual(args[0], user_id)
+        self.assertTrue(args[1])

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -15,12 +15,12 @@ import threading
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
 from unittest.mock import Mock
 
-from synapse.api.constants import EventTypes, Membership, LoginType
+from synapse.api.constants import EventTypes, LoginType, Membership
 from synapse.api.errors import SynapseError
 from synapse.events import EventBase
 from synapse.events.third_party_rules import load_legacy_third_party_event_rules
 from synapse.rest import admin
-from synapse.rest.client import login, room, profile, account
+from synapse.rest.client import account, login, profile, room
 from synapse.types import JsonDict, Requester, StateMap
 from synapse.util.frozenutils import unfreeze
 
@@ -586,9 +586,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
         # Check that we've got the right profile data.
         profile_info = args[1]
         self.assertEqual(profile_info.display_name, displayname)
-        self.assertEqual(
-            profile_info.avatar_url, avatar_url
-        )
+        self.assertEqual(profile_info.avatar_url, avatar_url)
 
     def test_on_profile_update_admin(self):
         """Tests that the on_profile_update module callback is correctly called on
@@ -628,9 +626,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
         # Check that we've got the right profile data.
         profile_info = args[1]
         self.assertEqual(profile_info.display_name, displayname)
-        self.assertEqual(
-            profile_info.avatar_url, avatar_url
-        )
+        self.assertEqual(profile_info.avatar_url, avatar_url)
 
     def test_on_deactivation(self):
         """Tests that the on_deactivation module callback is called correctly when

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -576,7 +576,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
         self.assertEqual(channel.code, 200, channel.json_body)
 
         # Check that the callback has been called once for our user.
-        m.assert_called_once()
+        self.assertEqual(m.call_count, 2)
         args = m.call_args[0]
         self.assertEqual(args[0], self.user_id)
 

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -535,7 +535,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
 
     def test_on_profile_update(self):
         """Tests that the on_profile_update module callback is correctly called on
-        profile update.
+        profile updates.
         """
         displayname = "Foo"
         avatar_url = "mxc://matrix.org/oWQDvfewxmlRaRCkVbfetyEo"
@@ -590,7 +590,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
 
     def test_on_profile_update_admin(self):
         """Tests that the on_profile_update module callback is correctly called on
-        profile update triggered by a server admin.
+        profile updates triggered by a server admin.
         """
         displayname = "Foo"
         avatar_url = "mxc://matrix.org/oWQDvfewxmlRaRCkVbfetyEo"


### PR DESCRIPTION
Part of the Tchap mainlining work.

Adds 2 new module callbacks: `on_profile_update` and `on_deactivation`, which are called after a profile update and a deactivation, respectively.

Should be reviewable commit by commit.