### PR TITLE
Remove more references to `get_datastore`

### DIFF
--- a/changelog.d/12067.feature
+++ b/changelog.d/12067.feature
@@ -1,0 +1,1 @@
+Implement experimental support for [MSC3720](https://github.com/matrix-org/matrix-doc/pull/3720) (account status endpoints).

--- a/synapse/handlers/account.py
+++ b/synapse/handlers/account.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 class AccountHandler:
     def __init__(self, hs: "HomeServer"):
-        self._store = hs.get_datastore()
+        self._main_store = hs.get_datastores().main
         self._is_mine = hs.is_mine
         self._federation_client = hs.get_federation_client()
 
@@ -98,7 +98,7 @@ class AccountHandler:
         """
         status = {"exists": False}
 
-        userinfo = await self._store.get_userinfo_by_id(user_id.to_string())
+        userinfo = await self._main_store.get_userinfo_by_id(user_id.to_string())
 
         if userinfo is not None:
             status = {

--- a/synapse/rest/client/account.py
+++ b/synapse/rest/client/account.py
@@ -904,9 +904,6 @@ class AccountStatusRestServlet(RestServlet):
     def __init__(self, hs: "HomeServer"):
         super().__init__()
         self._auth = hs.get_auth()
-        self._store = hs.get_datastore()
-        self._is_mine = hs.is_mine
-        self._federation_client = hs.get_federation_client()
         self._account_handler = hs.get_account_handler()
 
     async def on_POST(self, request: SynapseRequest) -> Tuple[int, JsonDict]:

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -1119,7 +1119,9 @@ class AccountStatusTestCase(unittest.HomeserverTestCase):
         """Tests that the account status endpoint correctly reports a deactivated user."""
         user = self.register_user("someuser", "password")
         self.get_success(
-            self.hs.get_datastore().set_user_deactivated_status(user, deactivated=True)
+            self.hs.get_datastores().main.set_user_deactivated_status(
+                user, deactivated=True
+            )
         )
 
         self._test_status(


### PR DESCRIPTION
These were added in #12001, and were snuck in since #12031 was started.

Also a couple of other cleanups while we're in the area.