### PR TITLE
Properly failover for unknown endpoints from Conduit/Dendrite

### DIFF
--- a/changelog.d/12077.bugfix
+++ b/changelog.d/12077.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where Synapse would make additional failing requests over federation for missing data.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -617,7 +617,7 @@ class FederationClient(FederationBase):
         #
         # Dendrite returns a 404 (with no body); synapse returns a 400
         # with M_UNRECOGNISED.
-        return e.code == 404 or (
+        return (e.code == 404 and not e.response) or (
             e.code == 400 and synapse_error.errcode == Codes.UNRECOGNIZED
         )
 

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -1002,7 +1002,7 @@ class FederationClient(FederationBase):
             )
         except HttpResponseException as e:
             # If an error is received that is due to an unrecognised endpoint,
-            # fallback to the v1 endpoint. Otherwise consider it a legitmate error
+            # fallback to the v1 endpoint. Otherwise, consider it a legitimate error
             # and raise.
             if not self._is_unknown_endpoint(e):
                 raise
@@ -1071,7 +1071,7 @@ class FederationClient(FederationBase):
         except HttpResponseException as e:
             # If an error is received that is due to an unrecognised endpoint,
             # fallback to the v1 endpoint if the room uses old-style event IDs.
-            # Otherwise consider it a legitmate error and raise.
+            # Otherwise, consider it a legitimate error and raise.
             err = e.to_synapse_error()
             if self._is_unknown_endpoint(e, err):
                 if room_version.event_format != EventFormatVersions.V1:
@@ -1132,7 +1132,7 @@ class FederationClient(FederationBase):
             )
         except HttpResponseException as e:
             # If an error is received that is due to an unrecognised endpoint,
-            # fallback to the v1 endpoint. Otherwise consider it a legitmate error
+            # fallback to the v1 endpoint. Otherwise, consider it a legitimate error
             # and raise.
             if not self._is_unknown_endpoint(e):
                 raise
@@ -1458,8 +1458,8 @@ class FederationClient(FederationBase):
                 )
             except HttpResponseException as e:
                 # If an error is received that is due to an unrecognised endpoint,
-                # fallback to the unstable endpoint. Otherwise consider it a
-                # legitmate error and raise.
+                # fallback to the unstable endpoint. Otherwise, consider it a
+                # legitimate error and raise.
                 if not self._is_unknown_endpoint(e):
                     raise
 

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -615,11 +615,15 @@ class FederationClient(FederationBase):
             synapse_error = e.to_synapse_error()
         # There is no good way to detect an "unknown" endpoint.
         #
-        # Dendrite returns a 404 (with no body); synapse returns a 400
+        # Dendrite returns a 404 (with a body of "404 page not found");
+        # Conduit returns a 404 (with no body); and Synapse returns a 400
         # with M_UNRECOGNISED.
-        return (e.code == 404 and not e.response) or (
-            e.code == 400 and synapse_error.errcode == Codes.UNRECOGNIZED
-        )
+        #
+        # This needs to be rather specific as some endpoints truly do return 404
+        # errors.
+        return (
+            e.code == 404 and (not e.response or e.response == b"404 page not found")
+        ) or (e.code == 400 and synapse_error.errcode == Codes.UNRECOGNIZED)
 
     async def _try_destination_list(
         self,


### PR DESCRIPTION
Related to #11694.

There was a bug in the failover logic for finding "unknown endpoints" in that it considered any 404 an unknown endpoint. This isn't always accurate though since some federation endpoints actually return a 404 for missing objects.

Note that I wrote [MSC3743](https://github.com/matrix-org/matrix-doc/pull/3743) to make this behavior less...annoying to deal with. That MSC has some information about where the bodies of the 404s come from (pretty much Conduit and Dendrite).