### PR TITLE
Replace assertEquals with assertEqual.

### DIFF
--- a/changelog.d/12092.misc
+++ b/changelog.d/12092.misc
@@ -1,0 +1,1 @@
+User `assertEqual` instead of the deprecated `assertEquals` in test code.

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -71,7 +71,7 @@ class AuthTestCase(unittest.HomeserverTestCase):
         request.args[b"access_token"] = [self.test_token]
         request.requestHeaders.getRawHeaders = mock_getRawHeaders()
         requester = self.get_success(self.auth.get_user_by_req(request))
-        self.assertEquals(requester.user.to_string(), self.test_user)
+        self.assertEqual(requester.user.to_string(), self.test_user)
 
     def test_get_user_by_req_user_bad_token(self):
         self.store.get_user_by_access_token = simple_async_mock(None)
@@ -109,7 +109,7 @@ class AuthTestCase(unittest.HomeserverTestCase):
         request.args[b"access_token"] = [self.test_token]
         request.requestHeaders.getRawHeaders = mock_getRawHeaders()
         requester = self.get_success(self.auth.get_user_by_req(request))
-        self.assertEquals(requester.user.to_string(), self.test_user)
+        self.assertEqual(requester.user.to_string(), self.test_user)
 
     def test_get_user_by_req_appservice_valid_token_good_ip(self):
         from netaddr import IPSet
@@ -128,7 +128,7 @@ class AuthTestCase(unittest.HomeserverTestCase):
         request.args[b"access_token"] = [self.test_token]
         request.requestHeaders.getRawHeaders = mock_getRawHeaders()
         requester = self.get_success(self.auth.get_user_by_req(request))
-        self.assertEquals(requester.user.to_string(), self.test_user)
+        self.assertEqual(requester.user.to_string(), self.test_user)
 
     def test_get_user_by_req_appservice_valid_token_bad_ip(self):
         from netaddr import IPSet
@@ -195,7 +195,7 @@ class AuthTestCase(unittest.HomeserverTestCase):
         request.args[b"user_id"] = [masquerading_user_id]
         request.requestHeaders.getRawHeaders = mock_getRawHeaders()
         requester = self.get_success(self.auth.get_user_by_req(request))
-        self.assertEquals(
+        self.assertEqual(
             requester.user.to_string(), masquerading_user_id.decode("utf8")
         )
 
@@ -242,10 +242,10 @@ class AuthTestCase(unittest.HomeserverTestCase):
         request.args[b"org.matrix.msc3202.device_id"] = [masquerading_device_id]
         request.requestHeaders.getRawHeaders = mock_getRawHeaders()
         requester = self.get_success(self.auth.get_user_by_req(request))
-        self.assertEquals(
+        self.assertEqual(
             requester.user.to_string(), masquerading_user_id.decode("utf8")
         )
-        self.assertEquals(requester.device_id, masquerading_device_id.decode("utf8"))
+        self.assertEqual(requester.device_id, masquerading_device_id.decode("utf8"))
 
     @override_config({"experimental_features": {"msc3202_device_masquerading": True}})
     def test_get_user_by_req_appservice_valid_token_invalid_device_id(self):
@@ -275,8 +275,8 @@ class AuthTestCase(unittest.HomeserverTestCase):
         request.requestHeaders.getRawHeaders = mock_getRawHeaders()
 
         failure = self.get_failure(self.auth.get_user_by_req(request), AuthError)
-        self.assertEquals(failure.value.code, 400)
-        self.assertEquals(failure.value.errcode, Codes.EXCLUSIVE)
+        self.assertEqual(failure.value.code, 400)
+        self.assertEqual(failure.value.errcode, Codes.EXCLUSIVE)
 
     def test_get_user_by_req__puppeted_token__not_tracking_puppeted_mau(self):
         self.store.get_user_by_access_token = simple_async_mock(
@@ -309,7 +309,7 @@ class AuthTestCase(unittest.HomeserverTestCase):
         request.args[b"access_token"] = [self.test_token]
         request.requestHeaders.getRawHeaders = mock_getRawHeaders()
         self.get_success(self.auth.get_user_by_req(request))
-        self.assertEquals(self.store.insert_client_ip.call_count, 2)
+        self.assertEqual(self.store.insert_client_ip.call_count, 2)
 
     def test_get_user_from_macaroon(self):
         self.store.get_user_by_access_token = simple_async_mock(
@@ -369,9 +369,9 @@ class AuthTestCase(unittest.HomeserverTestCase):
         self.store.get_monthly_active_count = simple_async_mock(lots_of_users)
 
         e = self.get_failure(self.auth.check_auth_blocking(), ResourceLimitError)
-        self.assertEquals(e.value.admin_contact, self.hs.config.server.admin_contact)
-        self.assertEquals(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
-        self.assertEquals(e.value.code, 403)
+        self.assertEqual(e.value.admin_contact, self.hs.config.server.admin_contact)
+        self.assertEqual(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
+        self.assertEqual(e.value.code, 403)
 
         # Ensure does not throw an error
         self.store.get_monthly_active_count = simple_async_mock(small_number_of_users)
@@ -473,9 +473,9 @@ class AuthTestCase(unittest.HomeserverTestCase):
         self.auth_blocking._hs_disabled = True
         self.auth_blocking._hs_disabled_message = "Reason for being disabled"
         e = self.get_failure(self.auth.check_auth_blocking(), ResourceLimitError)
-        self.assertEquals(e.value.admin_contact, self.hs.config.server.admin_contact)
-        self.assertEquals(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
-        self.assertEquals(e.value.code, 403)
+        self.assertEqual(e.value.admin_contact, self.hs.config.server.admin_contact)
+        self.assertEqual(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
+        self.assertEqual(e.value.code, 403)
 
     def test_hs_disabled_no_server_notices_user(self):
         """Check that 'hs_disabled_message' works correctly when there is no
@@ -488,9 +488,9 @@ class AuthTestCase(unittest.HomeserverTestCase):
         self.auth_blocking._hs_disabled = True
         self.auth_blocking._hs_disabled_message = "Reason for being disabled"
         e = self.get_failure(self.auth.check_auth_blocking(), ResourceLimitError)
-        self.assertEquals(e.value.admin_contact, self.hs.config.server.admin_contact)
-        self.assertEquals(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
-        self.assertEquals(e.value.code, 403)
+        self.assertEqual(e.value.admin_contact, self.hs.config.server.admin_contact)
+        self.assertEqual(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
+        self.assertEqual(e.value.code, 403)
 
     def test_server_notices_mxid_special_cased(self):
         self.auth_blocking._hs_disabled = True

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -526,4 +526,4 @@ class FilteringTestCase(unittest.HomeserverTestCase):
 
         self.assertEqual(filter.get_filter_json(), user_filter_json)
 
-        self.assertRegexpMatches(repr(filter), r"<FilterCollection \{.*\}>")
+        self.assertRegex(repr(filter), r"<FilterCollection \{.*\}>")

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -364,7 +364,7 @@ class FilteringTestCase(unittest.HomeserverTestCase):
         )
 
         results = self.get_success(user_filter.filter_presence(events=events))
-        self.assertEquals(events, results)
+        self.assertEqual(events, results)
 
     def test_filter_presence_no_match(self):
         user_filter_json = {"presence": {"types": ["m.*"]}}
@@ -388,7 +388,7 @@ class FilteringTestCase(unittest.HomeserverTestCase):
         )
 
         results = self.get_success(user_filter.filter_presence(events=events))
-        self.assertEquals([], results)
+        self.assertEqual([], results)
 
     def test_filter_room_state_match(self):
         user_filter_json = {"room": {"state": {"types": ["m.*"]}}}
@@ -407,7 +407,7 @@ class FilteringTestCase(unittest.HomeserverTestCase):
         )
 
         results = self.get_success(user_filter.filter_room_state(events=events))
-        self.assertEquals(events, results)
+        self.assertEqual(events, results)
 
     def test_filter_room_state_no_match(self):
         user_filter_json = {"room": {"state": {"types": ["m.*"]}}}
@@ -428,7 +428,7 @@ class FilteringTestCase(unittest.HomeserverTestCase):
         )
 
         results = self.get_success(user_filter.filter_room_state(events))
-        self.assertEquals([], results)
+        self.assertEqual([], results)
 
     def test_filter_rooms(self):
         definition = {
@@ -444,7 +444,7 @@ class FilteringTestCase(unittest.HomeserverTestCase):
 
         filtered_room_ids = list(Filter(self.hs, definition).filter_rooms(room_ids))
 
-        self.assertEquals(filtered_room_ids, ["!allowed:example.com"])
+        self.assertEqual(filtered_room_ids, ["!allowed:example.com"])
 
     @unittest.override_config({"experimental_features": {"msc3440_enabled": True}})
     def test_filter_relations(self):
@@ -486,7 +486,7 @@ class FilteringTestCase(unittest.HomeserverTestCase):
                     Filter(self.hs, definition)._check_event_relations(events)
                 )
             )
-        self.assertEquals(filtered_events, events[1:])
+        self.assertEqual(filtered_events, events[1:])
 
     def test_add_filter(self):
         user_filter_json = {"room": {"state": {"types": ["m.*"]}}}
@@ -497,8 +497,8 @@ class FilteringTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertEquals(filter_id, 0)
-        self.assertEquals(
+        self.assertEqual(filter_id, 0)
+        self.assertEqual(
             user_filter_json,
             (
                 self.get_success(
@@ -524,6 +524,6 @@ class FilteringTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertEquals(filter.get_filter_json(), user_filter_json)
+        self.assertEqual(filter.get_filter_json(), user_filter_json)
 
         self.assertRegexpMatches(repr(filter), r"<FilterCollection \{.*\}>")

--- a/tests/api/test_ratelimiting.py
+++ b/tests/api/test_ratelimiting.py
@@ -14,19 +14,19 @@ class TestRatelimiter(unittest.HomeserverTestCase):
             limiter.can_do_action(None, key="test_id", _time_now_s=0)
         )
         self.assertTrue(allowed)
-        self.assertEquals(10.0, time_allowed)
+        self.assertEqual(10.0, time_allowed)
 
         allowed, time_allowed = self.get_success_or_raise(
             limiter.can_do_action(None, key="test_id", _time_now_s=5)
         )
         self.assertFalse(allowed)
-        self.assertEquals(10.0, time_allowed)
+        self.assertEqual(10.0, time_allowed)
 
         allowed, time_allowed = self.get_success_or_raise(
             limiter.can_do_action(None, key="test_id", _time_now_s=10)
         )
         self.assertTrue(allowed)
-        self.assertEquals(20.0, time_allowed)
+        self.assertEqual(20.0, time_allowed)
 
     def test_allowed_appservice_ratelimited_via_can_requester_do_action(self):
         appservice = ApplicationService(
@@ -45,19 +45,19 @@ class TestRatelimiter(unittest.HomeserverTestCase):
             limiter.can_do_action(as_requester, _time_now_s=0)
         )
         self.assertTrue(allowed)
-        self.assertEquals(10.0, time_allowed)
+        self.assertEqual(10.0, time_allowed)
 
         allowed, time_allowed = self.get_success_or_raise(
             limiter.can_do_action(as_requester, _time_now_s=5)
         )
         self.assertFalse(allowed)
-        self.assertEquals(10.0, time_allowed)
+        self.assertEqual(10.0, time_allowed)
 
         allowed, time_allowed = self.get_success_or_raise(
             limiter.can_do_action(as_requester, _time_now_s=10)
         )
         self.assertTrue(allowed)
-        self.assertEquals(20.0, time_allowed)
+        self.assertEqual(20.0, time_allowed)
 
     def test_allowed_appservice_via_can_requester_do_action(self):
         appservice = ApplicationService(
@@ -76,19 +76,19 @@ class TestRatelimiter(unittest.HomeserverTestCase):
             limiter.can_do_action(as_requester, _time_now_s=0)
         )
         self.assertTrue(allowed)
-        self.assertEquals(-1, time_allowed)
+        self.assertEqual(-1, time_allowed)
 
         allowed, time_allowed = self.get_success_or_raise(
             limiter.can_do_action(as_requester, _time_now_s=5)
         )
         self.assertTrue(allowed)
-        self.assertEquals(-1, time_allowed)
+        self.assertEqual(-1, time_allowed)
 
         allowed, time_allowed = self.get_success_or_raise(
             limiter.can_do_action(as_requester, _time_now_s=10)
         )
         self.assertTrue(allowed)
-        self.assertEquals(-1, time_allowed)
+        self.assertEqual(-1, time_allowed)
 
     def test_allowed_via_ratelimit(self):
         limiter = Ratelimiter(
@@ -246,7 +246,7 @@ class TestRatelimiter(unittest.HomeserverTestCase):
             limiter.can_do_action(None, key="test_id", n_actions=3, _time_now_s=0)
         )
         self.assertTrue(allowed)
-        self.assertEquals(10.0, time_allowed)
+        self.assertEqual(10.0, time_allowed)
 
         # Test that, after doing these 3 actions, we can't do any more action without
         # waiting.
@@ -254,7 +254,7 @@ class TestRatelimiter(unittest.HomeserverTestCase):
             limiter.can_do_action(None, key="test_id", n_actions=1, _time_now_s=0)
         )
         self.assertFalse(allowed)
-        self.assertEquals(10.0, time_allowed)
+        self.assertEqual(10.0, time_allowed)
 
         # Test that after waiting we can do only 1 action.
         allowed, time_allowed = self.get_success_or_raise(
@@ -269,7 +269,7 @@ class TestRatelimiter(unittest.HomeserverTestCase):
         self.assertTrue(allowed)
         # The time allowed is the current time because we could still repeat the action
         # once.
-        self.assertEquals(10.0, time_allowed)
+        self.assertEqual(10.0, time_allowed)
 
         allowed, time_allowed = self.get_success_or_raise(
             limiter.can_do_action(None, key="test_id", n_actions=2, _time_now_s=10)
@@ -277,7 +277,7 @@ class TestRatelimiter(unittest.HomeserverTestCase):
         self.assertFalse(allowed)
         # The time allowed doesn't change despite allowed being False because, while we
         # don't allow 2 actions, we could still do 1.
-        self.assertEquals(10.0, time_allowed)
+        self.assertEqual(10.0, time_allowed)
 
         # Test that after waiting a bit more we can do 2 actions.
         allowed, time_allowed = self.get_success_or_raise(
@@ -286,4 +286,4 @@ class TestRatelimiter(unittest.HomeserverTestCase):
         self.assertTrue(allowed)
         # The time allowed is the current time because we could still repeat the action
         # once.
-        self.assertEquals(20.0, time_allowed)
+        self.assertEqual(20.0, time_allowed)

--- a/tests/appservice/test_scheduler.py
+++ b/tests/appservice/test_scheduler.py
@@ -71,7 +71,7 @@ class ApplicationServiceSchedulerTransactionCtrlTestCase(unittest.TestCase):
             one_time_key_counts={},
             unused_fallback_keys={},
         )
-        self.assertEquals(0, len(self.txnctrl.recoverers))  # no recoverer made
+        self.assertEqual(0, len(self.txnctrl.recoverers))  # no recoverer made
         txn.complete.assert_called_once_with(self.store)  # txn completed
 
     def test_single_service_down(self):
@@ -97,8 +97,8 @@ class ApplicationServiceSchedulerTransactionCtrlTestCase(unittest.TestCase):
             one_time_key_counts={},
             unused_fallback_keys={},
         )
-        self.assertEquals(0, txn.send.call_count)  # txn not sent though
-        self.assertEquals(0, txn.complete.call_count)  # or completed
+        self.assertEqual(0, txn.send.call_count)  # txn not sent though
+        self.assertEqual(0, txn.complete.call_count)  # or completed
 
     def test_single_service_up_txn_not_sent(self):
         # Test: The AS is up and the txn is not sent. A Recoverer is made and
@@ -125,10 +125,10 @@ class ApplicationServiceSchedulerTransactionCtrlTestCase(unittest.TestCase):
             one_time_key_counts={},
             unused_fallback_keys={},
         )
-        self.assertEquals(1, self.recoverer_fn.call_count)  # recoverer made
-        self.assertEquals(1, self.recoverer.recover.call_count)  # and invoked
-        self.assertEquals(1, len(self.txnctrl.recoverers))  # and stored
-        self.assertEquals(0, txn.complete.call_count)  # txn not completed
+        self.assertEqual(1, self.recoverer_fn.call_count)  # recoverer made
+        self.assertEqual(1, self.recoverer.recover.call_count)  # and invoked
+        self.assertEqual(1, len(self.txnctrl.recoverers))  # and stored
+        self.assertEqual(0, txn.complete.call_count)  # txn not completed
         self.store.set_appservice_state.assert_called_once_with(
             service, ApplicationServiceState.DOWN  # service marked as down
         )
@@ -161,17 +161,17 @@ class ApplicationServiceSchedulerRecovererTestCase(unittest.TestCase):
 
         self.recoverer.recover()
         # shouldn't have called anything prior to waiting for exp backoff
-        self.assertEquals(0, self.store.get_oldest_unsent_txn.call_count)
+        self.assertEqual(0, self.store.get_oldest_unsent_txn.call_count)
         txn.send = simple_async_mock(True)
         txn.complete = simple_async_mock(None)
         # wait for exp backoff
         self.clock.advance_time(2)
-        self.assertEquals(1, txn.send.call_count)
-        self.assertEquals(1, txn.complete.call_count)
+        self.assertEqual(1, txn.send.call_count)
+        self.assertEqual(1, txn.complete.call_count)
         # 2 because it needs to get None to know there are no more txns
-        self.assertEquals(2, self.store.get_oldest_unsent_txn.call_count)
+        self.assertEqual(2, self.store.get_oldest_unsent_txn.call_count)
         self.callback.assert_called_once_with(self.recoverer)
-        self.assertEquals(self.recoverer.service, self.service)
+        self.assertEqual(self.recoverer.service, self.service)
 
     def test_recover_retry_txn(self):
         txn = Mock()
@@ -187,26 +187,26 @@ class ApplicationServiceSchedulerRecovererTestCase(unittest.TestCase):
         self.store.get_oldest_unsent_txn = Mock(side_effect=take_txn)
 
         self.recoverer.recover()
-        self.assertEquals(0, self.store.get_oldest_unsent_txn.call_count)
+        self.assertEqual(0, self.store.get_oldest_unsent_txn.call_count)
         txn.send = simple_async_mock(False)
         txn.complete = simple_async_mock(None)
         self.clock.advance_time(2)
-        self.assertEquals(1, txn.send.call_count)
-        self.assertEquals(0, txn.complete.call_count)
-        self.assertEquals(0, self.callback.call_count)
+        self.assertEqual(1, txn.send.call_count)
+        self.assertEqual(0, txn.complete.call_count)
+        self.assertEqual(0, self.callback.call_count)
         self.clock.advance_time(4)
-        self.assertEquals(2, txn.send.call_count)
-        self.assertEquals(0, txn.complete.call_count)
-        self.assertEquals(0, self.callback.call_count)
+        self.assertEqual(2, txn.send.call_count)
+        self.assertEqual(0, txn.complete.call_count)
+        self.assertEqual(0, self.callback.call_count)
         self.clock.advance_time(8)
-        self.assertEquals(3, txn.send.call_count)
-        self.assertEquals(0, txn.complete.call_count)
-        self.assertEquals(0, self.callback.call_count)
+        self.assertEqual(3, txn.send.call_count)
+        self.assertEqual(0, txn.complete.call_count)
+        self.assertEqual(0, self.callback.call_count)
         txn.send = simple_async_mock(True)  # successfully send the txn
         pop_txn = True  # returns the txn the first time, then no more.
         self.clock.advance_time(16)
-        self.assertEquals(1, txn.send.call_count)  # new mock reset call count
-        self.assertEquals(1, txn.complete.call_count)
+        self.assertEqual(1, txn.send.call_count)  # new mock reset call count
+        self.assertEqual(1, txn.complete.call_count)
         self.callback.assert_called_once_with(self.recoverer)
 
 
@@ -241,13 +241,13 @@ class ApplicationServiceSchedulerQueuerTestCase(unittest.HomeserverTestCase):
         self.scheduler.enqueue_for_appservice(service, events=[event2])
         self.scheduler.enqueue_for_appservice(service, events=[event3])
         self.txn_ctrl.send.assert_called_with(service, [event], [], [], None, None)
-        self.assertEquals(1, self.txn_ctrl.send.call_count)
+        self.assertEqual(1, self.txn_ctrl.send.call_count)
         # Resolve the send event: expect the queued events to be sent
         d.callback(service)
         self.txn_ctrl.send.assert_called_with(
             service, [event2, event3], [], [], None, None
         )
-        self.assertEquals(2, self.txn_ctrl.send.call_count)
+        self.assertEqual(2, self.txn_ctrl.send.call_count)
 
     def test_multiple_service_queues(self):
         # Tests that each service has its own queue, and that they don't block
@@ -281,7 +281,7 @@ class ApplicationServiceSchedulerQueuerTestCase(unittest.HomeserverTestCase):
         # service
         srv_2_defer.callback(srv2)
         self.txn_ctrl.send.assert_called_with(srv2, [srv_2_event2], [], [], None, None)
-        self.assertEquals(3, self.txn_ctrl.send.call_count)
+        self.assertEqual(3, self.txn_ctrl.send.call_count)
 
     def test_send_large_txns(self):
         srv_1_defer = defer.Deferred()
@@ -312,7 +312,7 @@ class ApplicationServiceSchedulerQueuerTestCase(unittest.HomeserverTestCase):
         self.txn_ctrl.send.assert_called_with(
             service, event_list[101:], [], [], None, None
         )
-        self.assertEquals(3, self.txn_ctrl.send.call_count)
+        self.assertEqual(3, self.txn_ctrl.send.call_count)
 
     def test_send_single_ephemeral_no_queue(self):
         # Expect the event to be sent immediately.
@@ -346,14 +346,14 @@ class ApplicationServiceSchedulerQueuerTestCase(unittest.HomeserverTestCase):
         self.scheduler.enqueue_for_appservice(service, ephemeral=event_list_2)
         self.scheduler.enqueue_for_appservice(service, ephemeral=event_list_3)
         self.txn_ctrl.send.assert_called_with(service, [], event_list_1, [], None, None)
-        self.assertEquals(1, self.txn_ctrl.send.call_count)
+        self.assertEqual(1, self.txn_ctrl.send.call_count)
         # Resolve txn_ctrl.send
         d.callback(service)
         # Expect the queued events to be sent
         self.txn_ctrl.send.assert_called_with(
             service, [], event_list_2 + event_list_3, [], None, None
         )
-        self.assertEquals(2, self.txn_ctrl.send.call_count)
+        self.assertEqual(2, self.txn_ctrl.send.call_count)
 
     def test_send_large_txns_ephemeral(self):
         d = defer.Deferred()
@@ -369,4 +369,4 @@ class ApplicationServiceSchedulerQueuerTestCase(unittest.HomeserverTestCase):
         )
         d.callback(service)
         self.txn_ctrl.send.assert_called_with(service, [], second_chunk, [], None, None)
-        self.assertEquals(2, self.txn_ctrl.send.call_count)
+        self.assertEqual(2, self.txn_ctrl.send.call_count)

--- a/tests/crypto/test_event_signing.py
+++ b/tests/crypto/test_event_signing.py
@@ -63,14 +63,14 @@ class EventSigningTestCase(unittest.TestCase):
 
         self.assertTrue(hasattr(event, "hashes"))
         self.assertIn("sha256", event.hashes)
-        self.assertEquals(
+        self.assertEqual(
             event.hashes["sha256"], "6tJjLpXtggfke8UxFhAKg82QVkJzvKOVOOSjUDK4ZSI"
         )
 
         self.assertTrue(hasattr(event, "signatures"))
         self.assertIn(HOSTNAME, event.signatures)
         self.assertIn(KEY_NAME, event.signatures["domain"])
-        self.assertEquals(
+        self.assertEqual(
             event.signatures[HOSTNAME][KEY_NAME],
             "2Wptgo4CwmLo/Y8B8qinxApKaCkBG2fjTWB7AbP5Uy+"
             "aIbygsSdLOFzvdDjww8zUVKCmI02eP9xtyJxc/cLiBA",
@@ -97,14 +97,14 @@ class EventSigningTestCase(unittest.TestCase):
 
         self.assertTrue(hasattr(event, "hashes"))
         self.assertIn("sha256", event.hashes)
-        self.assertEquals(
+        self.assertEqual(
             event.hashes["sha256"], "onLKD1bGljeBWQhWZ1kaP9SorVmRQNdN5aM2JYU2n/g"
         )
 
         self.assertTrue(hasattr(event, "signatures"))
         self.assertIn(HOSTNAME, event.signatures)
         self.assertIn(KEY_NAME, event.signatures["domain"])
-        self.assertEquals(
+        self.assertEqual(
             event.signatures[HOSTNAME][KEY_NAME],
             "Wm+VzmOUOz08Ds+0NTWb1d4CZrVsJSikkeRxh6aCcUw"
             "u6pNC78FunoD7KNWzqFn241eYHYMGCA5McEiVPdhzBA",

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -76,7 +76,7 @@ class FakeRequest:
 @logcontext_clean
 class KeyringTestCase(unittest.HomeserverTestCase):
     def check_context(self, val, expected):
-        self.assertEquals(getattr(current_context(), "request", None), expected)
+        self.assertEqual(getattr(current_context(), "request", None), expected)
         return val
 
     def test_verify_json_objects_for_server_awaits_previous_requests(self):
@@ -96,7 +96,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
         async def first_lookup_fetch(
             server_name: str, key_ids: List[str], minimum_valid_until_ts: int
         ) -> Dict[str, FetchKeyResult]:
-            # self.assertEquals(current_context().request.id, "context_11")
+            # self.assertEqual(current_context().request.id, "context_11")
             self.assertEqual(server_name, "server10")
             self.assertEqual(key_ids, [get_key_id(key1)])
             self.assertEqual(minimum_valid_until_ts, 0)
@@ -137,7 +137,7 @@ class KeyringTestCase(unittest.HomeserverTestCase):
         async def second_lookup_fetch(
             server_name: str, key_ids: List[str], minimum_valid_until_ts: int
         ) -> Dict[str, FetchKeyResult]:
-            # self.assertEquals(current_context().request.id, "context_12")
+            # self.assertEqual(current_context().request.id, "context_12")
             return {get_key_id(key1): FetchKeyResult(get_verify_key(key1), 100)}
 
         mock_fetcher.get_keys.reset_mock()

--- a/tests/events/test_utils.py
+++ b/tests/events/test_utils.py
@@ -395,7 +395,7 @@ class SerializeEventTestCase(unittest.TestCase):
         return serialize_event(ev, 1479807801915, only_event_fields=fields)
 
     def test_event_fields_works_with_keys(self):
-        self.assertEquals(
+        self.assertEqual(
             self.serialize(
                 MockEvent(sender="@alice:localhost", room_id="!foo:bar"), ["room_id"]
             ),
@@ -403,7 +403,7 @@ class SerializeEventTestCase(unittest.TestCase):
         )
 
     def test_event_fields_works_with_nested_keys(self):
-        self.assertEquals(
+        self.assertEqual(
             self.serialize(
                 MockEvent(
                     sender="@alice:localhost",
@@ -416,7 +416,7 @@ class SerializeEventTestCase(unittest.TestCase):
         )
 
     def test_event_fields_works_with_dot_keys(self):
-        self.assertEquals(
+        self.assertEqual(
             self.serialize(
                 MockEvent(
                     sender="@alice:localhost",
@@ -429,7 +429,7 @@ class SerializeEventTestCase(unittest.TestCase):
         )
 
     def test_event_fields_works_with_nested_dot_keys(self):
-        self.assertEquals(
+        self.assertEqual(
             self.serialize(
                 MockEvent(
                     sender="@alice:localhost",
@@ -445,7 +445,7 @@ class SerializeEventTestCase(unittest.TestCase):
         )
 
     def test_event_fields_nops_with_unknown_keys(self):
-        self.assertEquals(
+        self.assertEqual(
             self.serialize(
                 MockEvent(
                     sender="@alice:localhost",
@@ -458,7 +458,7 @@ class SerializeEventTestCase(unittest.TestCase):
         )
 
     def test_event_fields_nops_with_non_dict_keys(self):
-        self.assertEquals(
+        self.assertEqual(
             self.serialize(
                 MockEvent(
                     sender="@alice:localhost",
@@ -471,7 +471,7 @@ class SerializeEventTestCase(unittest.TestCase):
         )
 
     def test_event_fields_nops_with_array_keys(self):
-        self.assertEquals(
+        self.assertEqual(
             self.serialize(
                 MockEvent(
                     sender="@alice:localhost",
@@ -484,7 +484,7 @@ class SerializeEventTestCase(unittest.TestCase):
         )
 
     def test_event_fields_all_fields_if_empty(self):
-        self.assertEquals(
+        self.assertEqual(
             self.serialize(
                 MockEvent(
                     type="foo",

--- a/tests/federation/test_complexity.py
+++ b/tests/federation/test_complexity.py
@@ -50,7 +50,7 @@ class RoomComplexityTests(unittest.FederatingHomeserverTestCase):
         channel = self.make_signed_federation_request(
             "GET", "/_matrix/federation/unstable/rooms/%s/complexity" % (room_1,)
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         complexity = channel.json_body["v1"]
         self.assertTrue(complexity > 0, complexity)
 
@@ -62,7 +62,7 @@ class RoomComplexityTests(unittest.FederatingHomeserverTestCase):
         channel = self.make_signed_federation_request(
             "GET", "/_matrix/federation/unstable/rooms/%s/complexity" % (room_1,)
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         complexity = channel.json_body["v1"]
         self.assertEqual(complexity, 1.23)
 

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -59,7 +59,7 @@ class FederationServerTests(unittest.FederatingHomeserverTestCase):
             "/_matrix/federation/v1/get_missing_events/%s" % (room_1,),
             query_content,
         )
-        self.assertEquals(400, channel.code, channel.result)
+        self.assertEqual(400, channel.code, channel.result)
         self.assertEqual(channel.json_body["errcode"], "M_NOT_JSON")
 
 
@@ -125,7 +125,7 @@ class StateQueryTests(unittest.FederatingHomeserverTestCase):
         channel = self.make_signed_federation_request(
             "GET", "/_matrix/federation/v1/state/%s" % (room_1,)
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         self.assertEqual(
             channel.json_body["room_version"],
@@ -157,7 +157,7 @@ class StateQueryTests(unittest.FederatingHomeserverTestCase):
         channel = self.make_signed_federation_request(
             "GET", "/_matrix/federation/v1/state/%s" % (room_1,)
         )
-        self.assertEquals(403, channel.code, channel.result)
+        self.assertEqual(403, channel.code, channel.result)
         self.assertEqual(channel.json_body["errcode"], "M_FORBIDDEN")
 
 
@@ -189,7 +189,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
             f"/_matrix/federation/v1/make_join/{self._room_id}/{user_id}"
             f"?ver={DEFAULT_ROOM_VERSION}",
         )
-        self.assertEquals(channel.code, 200, channel.json_body)
+        self.assertEqual(channel.code, 200, channel.json_body)
         return channel.json_body
 
     def test_send_join(self):
@@ -209,7 +209,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
             f"/_matrix/federation/v2/send_join/{self._room_id}/x",
             content=join_event_dict,
         )
-        self.assertEquals(channel.code, 200, channel.json_body)
+        self.assertEqual(channel.code, 200, channel.json_body)
 
         # we should get complete room state back
         returned_state = [
@@ -266,7 +266,7 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
             f"/_matrix/federation/v2/send_join/{self._room_id}/x?org.matrix.msc3706.partial_state=true",
             content=join_event_dict,
         )
-        self.assertEquals(channel.code, 200, channel.json_body)
+        self.assertEqual(channel.code, 200, channel.json_body)
 
         # expect a reduced room state
         returned_state = [

--- a/tests/federation/transport/test_knocking.py
+++ b/tests/federation/transport/test_knocking.py
@@ -169,7 +169,7 @@ class KnockingStrippedStateEventHelperMixin(TestCase):
             self.assertIn(event_type, expected_room_state)
 
             # Check the state content matches
-            self.assertEquals(
+            self.assertEqual(
                 expected_room_state[event_type]["content"], event["content"]
             )
 
@@ -256,7 +256,7 @@ class FederationKnockingTestCase(
                 RoomVersions.V7.identifier,
             ),
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         # Note: We don't expect the knock membership event to be sent over federation as
         # part of the stripped room state, as the knocking homeserver already has that
@@ -266,11 +266,11 @@ class FederationKnockingTestCase(
         knock_event = channel.json_body["event"]
 
         # Check that the event has things we expect in it
-        self.assertEquals(knock_event["room_id"], room_id)
-        self.assertEquals(knock_event["sender"], fake_knocking_user_id)
-        self.assertEquals(knock_event["state_key"], fake_knocking_user_id)
-        self.assertEquals(knock_event["type"], EventTypes.Member)
-        self.assertEquals(knock_event["content"]["membership"], Membership.KNOCK)
+        self.assertEqual(knock_event["room_id"], room_id)
+        self.assertEqual(knock_event["sender"], fake_knocking_user_id)
+        self.assertEqual(knock_event["state_key"], fake_knocking_user_id)
+        self.assertEqual(knock_event["type"], EventTypes.Member)
+        self.assertEqual(knock_event["content"]["membership"], Membership.KNOCK)
 
         # Turn the event json dict into a proper event.
         # We won't sign it properly, but that's OK as we stub out event auth in `prepare`
@@ -294,7 +294,7 @@ class FederationKnockingTestCase(
             % (room_id, signed_knock_event.event_id),
             signed_knock_event_json,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         # Check that we got the stripped room state in return
         room_state_events = channel.json_body["knock_state_events"]

--- a/tests/federation/transport/test_server.py
+++ b/tests/federation/transport/test_server.py
@@ -26,7 +26,7 @@ class RoomDirectoryFederationTests(unittest.FederatingHomeserverTestCase):
             "GET",
             "/_matrix/federation/v1/publicRooms",
         )
-        self.assertEquals(403, channel.code)
+        self.assertEqual(403, channel.code)
 
     @override_config({"allow_public_rooms_over_federation": True})
     def test_open_public_room_list_over_federation(self):
@@ -37,4 +37,4 @@ class RoomDirectoryFederationTests(unittest.FederatingHomeserverTestCase):
             "GET",
             "/_matrix/federation/v1/publicRooms",
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -147,8 +147,8 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         self.mock_as_api.query_alias.assert_called_once_with(
             interested_service, room_alias_str
         )
-        self.assertEquals(result.room_id, room_id)
-        self.assertEquals(result.servers, servers)
+        self.assertEqual(result.room_id, room_id)
+        self.assertEqual(result.servers, servers)
 
     def test_get_3pe_protocols_no_appservices(self):
         self.mock_store.get_app_services.return_value = []
@@ -156,7 +156,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             defer.ensureDeferred(self.handler.get_3pe_protocols("my-protocol"))
         )
         self.mock_as_api.get_3pe_protocol.assert_not_called()
-        self.assertEquals(response, {})
+        self.assertEqual(response, {})
 
     def test_get_3pe_protocols_no_protocols(self):
         service = self._mkservice(False, [])
@@ -165,7 +165,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             defer.ensureDeferred(self.handler.get_3pe_protocols())
         )
         self.mock_as_api.get_3pe_protocol.assert_not_called()
-        self.assertEquals(response, {})
+        self.assertEqual(response, {})
 
     def test_get_3pe_protocols_protocol_no_response(self):
         service = self._mkservice(False, ["my-protocol"])
@@ -177,7 +177,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         self.mock_as_api.get_3pe_protocol.assert_called_once_with(
             service, "my-protocol"
         )
-        self.assertEquals(response, {})
+        self.assertEqual(response, {})
 
     def test_get_3pe_protocols_select_one_protocol(self):
         service = self._mkservice(False, ["my-protocol"])
@@ -191,7 +191,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         self.mock_as_api.get_3pe_protocol.assert_called_once_with(
             service, "my-protocol"
         )
-        self.assertEquals(
+        self.assertEqual(
             response, {"my-protocol": {"x-protocol-data": 42, "instances": []}}
         )
 
@@ -207,7 +207,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         self.mock_as_api.get_3pe_protocol.assert_called_once_with(
             service, "my-protocol"
         )
-        self.assertEquals(
+        self.assertEqual(
             response, {"my-protocol": {"x-protocol-data": 42, "instances": []}}
         )
 
@@ -222,7 +222,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             defer.ensureDeferred(self.handler.get_3pe_protocols())
         )
         self.mock_as_api.get_3pe_protocol.assert_called()
-        self.assertEquals(
+        self.assertEqual(
             response,
             {
                 "my-protocol": {"x-protocol-data": 42, "instances": []},
@@ -254,7 +254,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             defer.ensureDeferred(self.handler.get_3pe_protocols())
         )
         # It's expected that the second service's data doesn't appear in the response
-        self.assertEquals(
+        self.assertEqual(
             response,
             {
                 "my-protocol": {

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -63,7 +63,7 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
 
         result = self.get_success(self.handler.get_association(self.my_room))
 
-        self.assertEquals({"room_id": "!8765qwer:test", "servers": ["test"]}, result)
+        self.assertEqual({"room_id": "!8765qwer:test", "servers": ["test"]}, result)
 
     def test_get_remote_association(self):
         self.mock_federation.make_query.return_value = make_awaitable(
@@ -72,7 +72,7 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
 
         result = self.get_success(self.handler.get_association(self.remote_room))
 
-        self.assertEquals(
+        self.assertEqual(
             {"room_id": "!8765qwer:test", "servers": ["test", "remote"]}, result
         )
         self.mock_federation.make_query.assert_called_with(
@@ -94,7 +94,7 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
             self.handler.on_directory_query({"room_alias": "#your-room:test"})
         )
 
-        self.assertEquals({"room_id": "!8765asdf:test", "servers": ["test"]}, response)
+        self.assertEqual({"room_id": "!8765asdf:test", "servers": ["test"]}, response)
 
 
 class TestCreateAlias(unittest.HomeserverTestCase):
@@ -224,7 +224,7 @@ class TestDeleteAlias(unittest.HomeserverTestCase):
                 create_requester(self.test_user), self.room_alias
             )
         )
-        self.assertEquals(self.room_id, result)
+        self.assertEqual(self.room_id, result)
 
         # Confirm the alias is gone.
         self.get_failure(
@@ -243,7 +243,7 @@ class TestDeleteAlias(unittest.HomeserverTestCase):
                 create_requester(self.admin_user), self.room_alias
             )
         )
-        self.assertEquals(self.room_id, result)
+        self.assertEqual(self.room_id, result)
 
         # Confirm the alias is gone.
         self.get_failure(
@@ -269,7 +269,7 @@ class TestDeleteAlias(unittest.HomeserverTestCase):
                 create_requester(self.test_user), self.room_alias
             )
         )
-        self.assertEquals(self.room_id, result)
+        self.assertEqual(self.room_id, result)
 
         # Confirm the alias is gone.
         self.get_failure(
@@ -411,7 +411,7 @@ class TestCreateAliasACL(unittest.HomeserverTestCase):
             b"directory/room/%23test%3Atest",
             {"room_id": room_id},
         )
-        self.assertEquals(403, channel.code, channel.result)
+        self.assertEqual(403, channel.code, channel.result)
 
     def test_allowed(self):
         room_id = self.helper.create_room_as(self.user_id)
@@ -421,7 +421,7 @@ class TestCreateAliasACL(unittest.HomeserverTestCase):
             b"directory/room/%23unofficial_test%3Atest",
             {"room_id": room_id},
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
     def test_denied_during_creation(self):
         """A room alias that is not allowed should be rejected during creation."""
@@ -443,8 +443,8 @@ class TestCreateAliasACL(unittest.HomeserverTestCase):
             "GET",
             b"directory/room/%23unofficial_test%3Atest",
         )
-        self.assertEquals(200, channel.code, channel.result)
-        self.assertEquals(channel.json_body["room_id"], room_id)
+        self.assertEqual(200, channel.code, channel.result)
+        self.assertEqual(channel.json_body["room_id"], room_id)
 
 
 class TestCreatePublishedRoomACL(unittest.HomeserverTestCase):
@@ -572,7 +572,7 @@ class TestRoomListSearchDisabled(unittest.HomeserverTestCase):
         channel = self.make_request(
             "PUT", b"directory/list/room/%s" % (room_id.encode("ascii"),), b"{}"
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         self.room_list_handler = hs.get_room_list_handler()
         self.directory_handler = hs.get_directory_handler()
@@ -585,7 +585,7 @@ class TestRoomListSearchDisabled(unittest.HomeserverTestCase):
 
         # Room list is enabled so we should get some results
         channel = self.make_request("GET", b"publicRooms")
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         self.assertTrue(len(channel.json_body["chunk"]) > 0)
 
         self.room_list_handler.enable_room_list_search = False
@@ -593,7 +593,7 @@ class TestRoomListSearchDisabled(unittest.HomeserverTestCase):
 
         # Room list disabled so we should get no results
         channel = self.make_request("GET", b"publicRooms")
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         self.assertTrue(len(channel.json_body["chunk"]) == 0)
 
         # Room list disabled so we shouldn't be allowed to publish rooms
@@ -601,4 +601,4 @@ class TestRoomListSearchDisabled(unittest.HomeserverTestCase):
         channel = self.make_request(
             "PUT", b"directory/list/room/%s" % (room_id.encode("ascii"),), b"{}"
         )
-        self.assertEquals(403, channel.code, channel.result)
+        self.assertEqual(403, channel.code, channel.result)

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -61,11 +61,11 @@ class PresenceUpdateTestCase(unittest.HomeserverTestCase):
 
         self.assertTrue(persist_and_notify)
         self.assertTrue(state.currently_active)
-        self.assertEquals(new_state.state, state.state)
-        self.assertEquals(new_state.status_msg, state.status_msg)
-        self.assertEquals(state.last_federation_update_ts, now)
+        self.assertEqual(new_state.state, state.state)
+        self.assertEqual(new_state.status_msg, state.status_msg)
+        self.assertEqual(state.last_federation_update_ts, now)
 
-        self.assertEquals(wheel_timer.insert.call_count, 3)
+        self.assertEqual(wheel_timer.insert.call_count, 3)
         wheel_timer.insert.assert_has_calls(
             [
                 call(now=now, obj=user_id, then=new_state.last_active_ts + IDLE_TIMER),
@@ -104,11 +104,11 @@ class PresenceUpdateTestCase(unittest.HomeserverTestCase):
         self.assertFalse(persist_and_notify)
         self.assertTrue(federation_ping)
         self.assertTrue(state.currently_active)
-        self.assertEquals(new_state.state, state.state)
-        self.assertEquals(new_state.status_msg, state.status_msg)
-        self.assertEquals(state.last_federation_update_ts, now)
+        self.assertEqual(new_state.state, state.state)
+        self.assertEqual(new_state.status_msg, state.status_msg)
+        self.assertEqual(state.last_federation_update_ts, now)
 
-        self.assertEquals(wheel_timer.insert.call_count, 3)
+        self.assertEqual(wheel_timer.insert.call_count, 3)
         wheel_timer.insert.assert_has_calls(
             [
                 call(now=now, obj=user_id, then=new_state.last_active_ts + IDLE_TIMER),
@@ -149,11 +149,11 @@ class PresenceUpdateTestCase(unittest.HomeserverTestCase):
         self.assertFalse(persist_and_notify)
         self.assertTrue(federation_ping)
         self.assertTrue(state.currently_active)
-        self.assertEquals(new_state.state, state.state)
-        self.assertEquals(new_state.status_msg, state.status_msg)
-        self.assertEquals(state.last_federation_update_ts, now)
+        self.assertEqual(new_state.state, state.state)
+        self.assertEqual(new_state.status_msg, state.status_msg)
+        self.assertEqual(state.last_federation_update_ts, now)
 
-        self.assertEquals(wheel_timer.insert.call_count, 3)
+        self.assertEqual(wheel_timer.insert.call_count, 3)
         wheel_timer.insert.assert_has_calls(
             [
                 call(now=now, obj=user_id, then=new_state.last_active_ts + IDLE_TIMER),
@@ -191,11 +191,11 @@ class PresenceUpdateTestCase(unittest.HomeserverTestCase):
 
         self.assertTrue(persist_and_notify)
         self.assertFalse(state.currently_active)
-        self.assertEquals(new_state.state, state.state)
-        self.assertEquals(new_state.status_msg, state.status_msg)
-        self.assertEquals(state.last_federation_update_ts, now)
+        self.assertEqual(new_state.state, state.state)
+        self.assertEqual(new_state.status_msg, state.status_msg)
+        self.assertEqual(state.last_federation_update_ts, now)
 
-        self.assertEquals(wheel_timer.insert.call_count, 2)
+        self.assertEqual(wheel_timer.insert.call_count, 2)
         wheel_timer.insert.assert_has_calls(
             [
                 call(now=now, obj=user_id, then=new_state.last_active_ts + IDLE_TIMER),
@@ -227,10 +227,10 @@ class PresenceUpdateTestCase(unittest.HomeserverTestCase):
         self.assertFalse(persist_and_notify)
         self.assertFalse(federation_ping)
         self.assertFalse(state.currently_active)
-        self.assertEquals(new_state.state, state.state)
-        self.assertEquals(new_state.status_msg, state.status_msg)
+        self.assertEqual(new_state.state, state.state)
+        self.assertEqual(new_state.status_msg, state.status_msg)
 
-        self.assertEquals(wheel_timer.insert.call_count, 1)
+        self.assertEqual(wheel_timer.insert.call_count, 1)
         wheel_timer.insert.assert_has_calls(
             [
                 call(
@@ -259,10 +259,10 @@ class PresenceUpdateTestCase(unittest.HomeserverTestCase):
         )
 
         self.assertTrue(persist_and_notify)
-        self.assertEquals(new_state.state, state.state)
-        self.assertEquals(state.last_federation_update_ts, now)
+        self.assertEqual(new_state.state, state.state)
+        self.assertEqual(state.last_federation_update_ts, now)
 
-        self.assertEquals(wheel_timer.insert.call_count, 0)
+        self.assertEqual(wheel_timer.insert.call_count, 0)
 
     def test_online_to_idle(self):
         wheel_timer = Mock()
@@ -281,12 +281,12 @@ class PresenceUpdateTestCase(unittest.HomeserverTestCase):
         )
 
         self.assertTrue(persist_and_notify)
-        self.assertEquals(new_state.state, state.state)
-        self.assertEquals(state.last_federation_update_ts, now)
-        self.assertEquals(new_state.state, state.state)
-        self.assertEquals(new_state.status_msg, state.status_msg)
+        self.assertEqual(new_state.state, state.state)
+        self.assertEqual(state.last_federation_update_ts, now)
+        self.assertEqual(new_state.state, state.state)
+        self.assertEqual(new_state.status_msg, state.status_msg)
 
-        self.assertEquals(wheel_timer.insert.call_count, 1)
+        self.assertEqual(wheel_timer.insert.call_count, 1)
         wheel_timer.insert.assert_has_calls(
             [
                 call(
@@ -357,8 +357,8 @@ class PresenceTimeoutTestCase(unittest.TestCase):
         new_state = handle_timeout(state, is_mine=True, syncing_user_ids=set(), now=now)
 
         self.assertIsNotNone(new_state)
-        self.assertEquals(new_state.state, PresenceState.UNAVAILABLE)
-        self.assertEquals(new_state.status_msg, status_msg)
+        self.assertEqual(new_state.state, PresenceState.UNAVAILABLE)
+        self.assertEqual(new_state.status_msg, status_msg)
 
     def test_busy_no_idle(self):
         """
@@ -380,8 +380,8 @@ class PresenceTimeoutTestCase(unittest.TestCase):
         new_state = handle_timeout(state, is_mine=True, syncing_user_ids=set(), now=now)
 
         self.assertIsNotNone(new_state)
-        self.assertEquals(new_state.state, PresenceState.BUSY)
-        self.assertEquals(new_state.status_msg, status_msg)
+        self.assertEqual(new_state.state, PresenceState.BUSY)
+        self.assertEqual(new_state.status_msg, status_msg)
 
     def test_sync_timeout(self):
         user_id = "@foo:bar"
@@ -399,8 +399,8 @@ class PresenceTimeoutTestCase(unittest.TestCase):
         new_state = handle_timeout(state, is_mine=True, syncing_user_ids=set(), now=now)
 
         self.assertIsNotNone(new_state)
-        self.assertEquals(new_state.state, PresenceState.OFFLINE)
-        self.assertEquals(new_state.status_msg, status_msg)
+        self.assertEqual(new_state.state, PresenceState.OFFLINE)
+        self.assertEqual(new_state.status_msg, status_msg)
 
     def test_sync_online(self):
         user_id = "@foo:bar"
@@ -420,8 +420,8 @@ class PresenceTimeoutTestCase(unittest.TestCase):
         )
 
         self.assertIsNotNone(new_state)
-        self.assertEquals(new_state.state, PresenceState.ONLINE)
-        self.assertEquals(new_state.status_msg, status_msg)
+        self.assertEqual(new_state.state, PresenceState.ONLINE)
+        self.assertEqual(new_state.status_msg, status_msg)
 
     def test_federation_ping(self):
         user_id = "@foo:bar"
@@ -440,7 +440,7 @@ class PresenceTimeoutTestCase(unittest.TestCase):
         new_state = handle_timeout(state, is_mine=True, syncing_user_ids=set(), now=now)
 
         self.assertIsNotNone(new_state)
-        self.assertEquals(state, new_state)
+        self.assertEqual(state, new_state)
 
     def test_no_timeout(self):
         user_id = "@foo:bar"
@@ -477,8 +477,8 @@ class PresenceTimeoutTestCase(unittest.TestCase):
         )
 
         self.assertIsNotNone(new_state)
-        self.assertEquals(new_state.state, PresenceState.OFFLINE)
-        self.assertEquals(new_state.status_msg, status_msg)
+        self.assertEqual(new_state.state, PresenceState.OFFLINE)
+        self.assertEqual(new_state.status_msg, status_msg)
 
     def test_last_active(self):
         user_id = "@foo:bar"
@@ -497,7 +497,7 @@ class PresenceTimeoutTestCase(unittest.TestCase):
         new_state = handle_timeout(state, is_mine=True, syncing_user_ids=set(), now=now)
 
         self.assertIsNotNone(new_state)
-        self.assertEquals(state, new_state)
+        self.assertEqual(state, new_state)
 
 
 class PresenceHandlerTestCase(unittest.HomeserverTestCase):

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -65,7 +65,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
 
         displayname = self.get_success(self.handler.get_displayname(self.frank))
 
-        self.assertEquals("Frank", displayname)
+        self.assertEqual("Frank", displayname)
 
     def test_set_my_name(self):
         self.get_success(
@@ -74,7 +74,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertEquals(
+        self.assertEqual(
             (
                 self.get_success(
                     self.store.get_profile_displayname(self.frank.localpart)
@@ -90,7 +90,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertEquals(
+        self.assertEqual(
             (
                 self.get_success(
                     self.store.get_profile_displayname(self.frank.localpart)
@@ -118,7 +118,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             self.store.set_profile_displayname(self.frank.localpart, "Frank")
         )
 
-        self.assertEquals(
+        self.assertEqual(
             (
                 self.get_success(
                     self.store.get_profile_displayname(self.frank.localpart)
@@ -150,7 +150,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
 
         displayname = self.get_success(self.handler.get_displayname(self.alice))
 
-        self.assertEquals(displayname, "Alice")
+        self.assertEqual(displayname, "Alice")
         self.mock_federation.make_query.assert_called_with(
             destination="remote",
             query_type="profile",
@@ -172,7 +172,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertEquals({"displayname": "Caroline"}, response)
+        self.assertEqual({"displayname": "Caroline"}, response)
 
     def test_get_my_avatar(self):
         self.get_success(
@@ -182,7 +182,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
         )
         avatar_url = self.get_success(self.handler.get_avatar_url(self.frank))
 
-        self.assertEquals("http://my.server/me.png", avatar_url)
+        self.assertEqual("http://my.server/me.png", avatar_url)
 
     def test_set_my_avatar(self):
         self.get_success(
@@ -193,7 +193,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertEquals(
+        self.assertEqual(
             (self.get_success(self.store.get_profile_avatar_url(self.frank.localpart))),
             "http://my.server/pic.gif",
         )
@@ -207,7 +207,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertEquals(
+        self.assertEqual(
             (self.get_success(self.store.get_profile_avatar_url(self.frank.localpart))),
             "http://my.server/me.png",
         )
@@ -235,7 +235,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertEquals(
+        self.assertEqual(
             (self.get_success(self.store.get_profile_avatar_url(self.frank.localpart))),
             "http://my.server/me.png",
         )

--- a/tests/handlers/test_receipts.py
+++ b/tests/handlers/test_receipts.py
@@ -314,4 +314,4 @@ class ReceiptsTestCase(unittest.HomeserverTestCase):
     ):
         """Tests that the _filter_out_hidden returns the expected output"""
         filtered_events = self.event_source.filter_out_hidden(events, "@me:server.org")
-        self.assertEquals(filtered_events, expected_output)
+        self.assertEqual(filtered_events, expected_output)

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -167,7 +167,7 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
         result_user_id, result_token = self.get_success(
             self.get_or_create_user(requester, frank.localpart, "Frankie")
         )
-        self.assertEquals(result_user_id, user_id)
+        self.assertEqual(result_user_id, user_id)
         self.assertIsInstance(result_token, str)
         self.assertGreater(len(result_token), 20)
 
@@ -183,7 +183,7 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
         result_user_id, result_token = self.get_success(
             self.get_or_create_user(requester, local_part, None)
         )
-        self.assertEquals(result_user_id, user_id)
+        self.assertEqual(result_user_id, user_id)
         self.assertTrue(result_token is not None)
 
     @override_config({"limit_usage_by_mau": False})

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -69,7 +69,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             self.sync_handler.wait_for_sync_for_user(requester, sync_config),
             ResourceLimitError,
         )
-        self.assertEquals(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
+        self.assertEqual(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
 
         self.auth_blocking._hs_disabled = False
 
@@ -80,7 +80,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             self.sync_handler.wait_for_sync_for_user(requester, sync_config),
             ResourceLimitError,
         )
-        self.assertEquals(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
+        self.assertEqual(e.value.errcode, Codes.RESOURCE_LIMIT_EXCEEDED)
 
     def test_unknown_room_version(self):
         """
@@ -122,7 +122,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
             b"{}",
             tok,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         # The rooms should appear in the sync response.
         result = self.get_success(

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -156,7 +156,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
     def test_started_typing_local(self):
         self.room_members = [U_APPLE, U_BANANA]
 
-        self.assertEquals(self.event_source.get_current_key(), 0)
+        self.assertEqual(self.event_source.get_current_key(), 0)
 
         self.get_success(
             self.handler.started_typing(
@@ -169,13 +169,13 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
 
         self.on_new_event.assert_has_calls([call("typing_key", 1, rooms=[ROOM_ID])])
 
-        self.assertEquals(self.event_source.get_current_key(), 1)
+        self.assertEqual(self.event_source.get_current_key(), 1)
         events = self.get_success(
             self.event_source.get_new_events(
                 user=U_APPLE, from_key=0, limit=None, room_ids=[ROOM_ID], is_guest=False
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             events[0],
             [
                 {
@@ -220,7 +220,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
     def test_started_typing_remote_recv(self):
         self.room_members = [U_APPLE, U_ONION]
 
-        self.assertEquals(self.event_source.get_current_key(), 0)
+        self.assertEqual(self.event_source.get_current_key(), 0)
 
         channel = self.make_request(
             "PUT",
@@ -239,13 +239,13 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
 
         self.on_new_event.assert_has_calls([call("typing_key", 1, rooms=[ROOM_ID])])
 
-        self.assertEquals(self.event_source.get_current_key(), 1)
+        self.assertEqual(self.event_source.get_current_key(), 1)
         events = self.get_success(
             self.event_source.get_new_events(
                 user=U_APPLE, from_key=0, limit=None, room_ids=[ROOM_ID], is_guest=False
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             events[0],
             [
                 {
@@ -259,7 +259,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
     def test_started_typing_remote_recv_not_in_room(self):
         self.room_members = [U_APPLE, U_ONION]
 
-        self.assertEquals(self.event_source.get_current_key(), 0)
+        self.assertEqual(self.event_source.get_current_key(), 0)
 
         channel = self.make_request(
             "PUT",
@@ -278,7 +278,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
 
         self.on_new_event.assert_not_called()
 
-        self.assertEquals(self.event_source.get_current_key(), 0)
+        self.assertEqual(self.event_source.get_current_key(), 0)
         events = self.get_success(
             self.event_source.get_new_events(
                 user=U_APPLE,
@@ -288,8 +288,8 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
                 is_guest=False,
             )
         )
-        self.assertEquals(events[0], [])
-        self.assertEquals(events[1], 0)
+        self.assertEqual(events[0], [])
+        self.assertEqual(events[1], 0)
 
     @override_config({"send_federation": True})
     def test_stopped_typing(self):
@@ -302,7 +302,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
         self.handler._member_typing_until[member] = 1002000
         self.handler._room_typing[ROOM_ID] = {U_APPLE.to_string()}
 
-        self.assertEquals(self.event_source.get_current_key(), 0)
+        self.assertEqual(self.event_source.get_current_key(), 0)
 
         self.get_success(
             self.handler.stopped_typing(
@@ -332,13 +332,13 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
             try_trailing_slash_on_400=True,
         )
 
-        self.assertEquals(self.event_source.get_current_key(), 1)
+        self.assertEqual(self.event_source.get_current_key(), 1)
         events = self.get_success(
             self.event_source.get_new_events(
                 user=U_APPLE, from_key=0, limit=None, room_ids=[ROOM_ID], is_guest=False
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             events[0],
             [{"type": "m.typing", "room_id": ROOM_ID, "content": {"user_ids": []}}],
         )
@@ -346,7 +346,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
     def test_typing_timeout(self):
         self.room_members = [U_APPLE, U_BANANA]
 
-        self.assertEquals(self.event_source.get_current_key(), 0)
+        self.assertEqual(self.event_source.get_current_key(), 0)
 
         self.get_success(
             self.handler.started_typing(
@@ -360,7 +360,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
         self.on_new_event.assert_has_calls([call("typing_key", 1, rooms=[ROOM_ID])])
         self.on_new_event.reset_mock()
 
-        self.assertEquals(self.event_source.get_current_key(), 1)
+        self.assertEqual(self.event_source.get_current_key(), 1)
         events = self.get_success(
             self.event_source.get_new_events(
                 user=U_APPLE,
@@ -370,7 +370,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
                 is_guest=False,
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             events[0],
             [
                 {
@@ -385,7 +385,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
 
         self.on_new_event.assert_has_calls([call("typing_key", 2, rooms=[ROOM_ID])])
 
-        self.assertEquals(self.event_source.get_current_key(), 2)
+        self.assertEqual(self.event_source.get_current_key(), 2)
         events = self.get_success(
             self.event_source.get_new_events(
                 user=U_APPLE,
@@ -395,7 +395,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
                 is_guest=False,
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             events[0],
             [{"type": "m.typing", "room_id": ROOM_ID, "content": {"user_ids": []}}],
         )
@@ -414,7 +414,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
         self.on_new_event.assert_has_calls([call("typing_key", 3, rooms=[ROOM_ID])])
         self.on_new_event.reset_mock()
 
-        self.assertEquals(self.event_source.get_current_key(), 3)
+        self.assertEqual(self.event_source.get_current_key(), 3)
         events = self.get_success(
             self.event_source.get_new_events(
                 user=U_APPLE,
@@ -424,7 +424,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
                 is_guest=False,
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             events[0],
             [
                 {

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -1042,7 +1042,7 @@ class TestUserDirSearchDisabled(unittest.HomeserverTestCase):
             b'{"search_term":"user2"}',
             access_token=u1_token,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         self.assertTrue(len(channel.json_body["results"]) > 0)
 
         # Disable user directory and check search returns nothing
@@ -1053,5 +1053,5 @@ class TestUserDirSearchDisabled(unittest.HomeserverTestCase):
             b'{"search_term":"user2"}',
             access_token=u1_token,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         self.assertTrue(len(channel.json_body["results"]) == 0)

--- a/tests/http/federation/test_srv_resolver.py
+++ b/tests/http/federation/test_srv_resolver.py
@@ -65,9 +65,9 @@ class SrvResolverTestCase(unittest.TestCase):
 
         servers = self.successResultOf(test_d)
 
-        self.assertEquals(len(servers), 1)
-        self.assertEquals(servers, cache[service_name])
-        self.assertEquals(servers[0].host, host_name)
+        self.assertEqual(len(servers), 1)
+        self.assertEqual(servers, cache[service_name])
+        self.assertEqual(servers[0].host, host_name)
 
     @defer.inlineCallbacks
     def test_from_cache_expired_and_dns_fail(self):
@@ -88,8 +88,8 @@ class SrvResolverTestCase(unittest.TestCase):
 
         dns_client_mock.lookupService.assert_called_once_with(service_name)
 
-        self.assertEquals(len(servers), 1)
-        self.assertEquals(servers, cache[service_name])
+        self.assertEqual(len(servers), 1)
+        self.assertEqual(servers, cache[service_name])
 
     @defer.inlineCallbacks
     def test_from_cache(self):
@@ -114,8 +114,8 @@ class SrvResolverTestCase(unittest.TestCase):
 
         self.assertFalse(dns_client_mock.lookupService.called)
 
-        self.assertEquals(len(servers), 1)
-        self.assertEquals(servers, cache[service_name])
+        self.assertEqual(len(servers), 1)
+        self.assertEqual(servers, cache[service_name])
 
     @defer.inlineCallbacks
     def test_empty_cache(self):
@@ -144,8 +144,8 @@ class SrvResolverTestCase(unittest.TestCase):
 
         servers = yield defer.ensureDeferred(resolver.resolve_service(service_name))
 
-        self.assertEquals(len(servers), 0)
-        self.assertEquals(len(cache), 0)
+        self.assertEqual(len(servers), 0)
+        self.assertEqual(len(cache), 0)
 
     def test_disabled_service(self):
         """
@@ -201,6 +201,6 @@ class SrvResolverTestCase(unittest.TestCase):
 
         servers = self.successResultOf(resolve_d)
 
-        self.assertEquals(len(servers), 1)
-        self.assertEquals(servers, cache[service_name])
-        self.assertEquals(servers[0].host, b"host")
+        self.assertEqual(len(servers), 1)
+        self.assertEqual(servers, cache[service_name])
+        self.assertEqual(servers[0].host, b"host")

--- a/tests/replication/slave/storage/test_events.py
+++ b/tests/replication/slave/storage/test_events.py
@@ -59,7 +59,7 @@ class SlavedEventStoreTestCase(BaseSlavedStoreTestCase):
 
     def setUp(self):
         # Patch up the equality operator for events so that we can check
-        # whether lists of events match using assertEquals
+        # whether lists of events match using assertEqual
         self.unpatches = [patch__eq__(_EventInternalMetadata), patch__eq__(FrozenEvent)]
         return super().setUp()
 

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -1909,7 +1909,7 @@ class JoinAliasRoomTestCase(unittest.HomeserverTestCase):
             "/_matrix/client/r0/joined_rooms",
             access_token=self.second_tok,
         )
-        self.assertEquals(HTTPStatus.OK, channel.code, msg=channel.json_body)
+        self.assertEqual(HTTPStatus.OK, channel.code, msg=channel.json_body)
         self.assertEqual(self.public_room_id, channel.json_body["joined_rooms"][0])
 
     def test_join_private_room_if_not_member(self) -> None:
@@ -1957,7 +1957,7 @@ class JoinAliasRoomTestCase(unittest.HomeserverTestCase):
             "/_matrix/client/r0/joined_rooms",
             access_token=self.admin_user_tok,
         )
-        self.assertEquals(HTTPStatus.OK, channel.code, msg=channel.json_body)
+        self.assertEqual(HTTPStatus.OK, channel.code, msg=channel.json_body)
         self.assertEqual(private_room_id, channel.json_body["joined_rooms"][0])
 
         # Join user to room.
@@ -1980,7 +1980,7 @@ class JoinAliasRoomTestCase(unittest.HomeserverTestCase):
             "/_matrix/client/r0/joined_rooms",
             access_token=self.second_tok,
         )
-        self.assertEquals(HTTPStatus.OK, channel.code, msg=channel.json_body)
+        self.assertEqual(HTTPStatus.OK, channel.code, msg=channel.json_body)
         self.assertEqual(private_room_id, channel.json_body["joined_rooms"][0])
 
     def test_join_private_room_if_owner(self) -> None:
@@ -2010,7 +2010,7 @@ class JoinAliasRoomTestCase(unittest.HomeserverTestCase):
             "/_matrix/client/r0/joined_rooms",
             access_token=self.second_tok,
         )
-        self.assertEquals(HTTPStatus.OK, channel.code, msg=channel.json_body)
+        self.assertEqual(HTTPStatus.OK, channel.code, msg=channel.json_body)
         self.assertEqual(private_room_id, channel.json_body["joined_rooms"][0])
 
     def test_context_as_non_admin(self) -> None:
@@ -2044,7 +2044,7 @@ class JoinAliasRoomTestCase(unittest.HomeserverTestCase):
                 % (room_id, events[midway]["event_id"]),
                 access_token=tok,
             )
-            self.assertEquals(HTTPStatus.FORBIDDEN, channel.code, msg=channel.json_body)
+            self.assertEqual(HTTPStatus.FORBIDDEN, channel.code, msg=channel.json_body)
             self.assertEqual(Codes.FORBIDDEN, channel.json_body["errcode"])
 
     def test_context_as_admin(self) -> None:
@@ -2074,8 +2074,8 @@ class JoinAliasRoomTestCase(unittest.HomeserverTestCase):
             % (room_id, events[midway]["event_id"]),
             access_token=self.admin_user_tok,
         )
-        self.assertEquals(HTTPStatus.OK, channel.code, msg=channel.json_body)
-        self.assertEquals(
+        self.assertEqual(HTTPStatus.OK, channel.code, msg=channel.json_body)
+        self.assertEqual(
             channel.json_body["event"]["event_id"], events[midway]["event_id"]
         )
 

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -104,7 +104,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         client_secret = "foobar"
         session_id = self._request_token(email, client_secret)
 
-        self.assertEquals(len(self.email_attempts), 1)
+        self.assertEqual(len(self.email_attempts), 1)
         link = self._get_link_from_email()
 
         self._validate_token(link)
@@ -143,7 +143,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
             client_secret = "foobar"
             session_id = self._request_token(email, client_secret, ip)
 
-            self.assertEquals(len(self.email_attempts), 1)
+            self.assertEqual(len(self.email_attempts), 1)
             link = self._get_link_from_email()
 
             self._validate_token(link)
@@ -193,7 +193,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         client_secret = "foobar"
         session_id = self._request_token(email_passwort_reset, client_secret)
 
-        self.assertEquals(len(self.email_attempts), 1)
+        self.assertEqual(len(self.email_attempts), 1)
         link = self._get_link_from_email()
 
         self._validate_token(link)
@@ -230,7 +230,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         client_secret = "foobar"
         session_id = self._request_token(email, client_secret)
 
-        self.assertEquals(len(self.email_attempts), 1)
+        self.assertEqual(len(self.email_attempts), 1)
 
         # Attempt to reset password without clicking the link
         self._reset_password(new_password, session_id, client_secret, expected_code=401)
@@ -322,7 +322,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
             shorthand=False,
         )
 
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         # Now POST to the same endpoint, mimicking the same behaviour as clicking the
         # password reset confirm button
@@ -337,7 +337,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
             shorthand=False,
             content_is_form=True,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
     def _get_link_from_email(self):
         assert self.email_attempts, "No emails have been sent"
@@ -376,7 +376,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
                 },
             },
         )
-        self.assertEquals(expected_code, channel.code, channel.result)
+        self.assertEqual(expected_code, channel.code, channel.result)
 
 
 class DeactivateTestCase(unittest.HomeserverTestCase):
@@ -676,7 +676,7 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
         client_secret = "foobar"
         session_id = self._request_token(self.email, client_secret)
 
-        self.assertEquals(len(self.email_attempts), 1)
+        self.assertEqual(len(self.email_attempts), 1)
         link = self._get_link_from_email()
 
         self._validate_token(link)
@@ -780,7 +780,7 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
         client_secret = "foobar"
         session_id = self._request_token(self.email, client_secret)
 
-        self.assertEquals(len(self.email_attempts), 1)
+        self.assertEqual(len(self.email_attempts), 1)
 
         # Attempt to add email without clicking the link
         channel = self.make_request(
@@ -981,7 +981,7 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
         path = link.replace("https://example.com", "")
 
         channel = self.make_request("GET", path, shorthand=False)
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
     def _get_link_from_email(self):
         assert self.email_attempts, "No emails have been sent"
@@ -1010,7 +1010,7 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
         client_secret = "foobar"
         session_id = self._request_token(request_email, client_secret)
 
-        self.assertEquals(len(self.email_attempts) - previous_email_attempts, 1)
+        self.assertEqual(len(self.email_attempts) - previous_email_attempts, 1)
         link = self._get_link_from_email()
 
         self._validate_token(link)

--- a/tests/rest/client/test_events.py
+++ b/tests/rest/client/test_events.py
@@ -65,13 +65,13 @@ class EventStreamPermissionsTestCase(unittest.HomeserverTestCase):
         channel = self.make_request(
             "GET", "/events?access_token=%s" % ("invalid" + self.token,)
         )
-        self.assertEquals(channel.code, 401, msg=channel.result)
+        self.assertEqual(channel.code, 401, msg=channel.result)
 
         # valid token, expect content
         channel = self.make_request(
             "GET", "/events?access_token=%s&timeout=0" % (self.token,)
         )
-        self.assertEquals(channel.code, 200, msg=channel.result)
+        self.assertEqual(channel.code, 200, msg=channel.result)
         self.assertTrue("chunk" in channel.json_body)
         self.assertTrue("start" in channel.json_body)
         self.assertTrue("end" in channel.json_body)
@@ -89,10 +89,10 @@ class EventStreamPermissionsTestCase(unittest.HomeserverTestCase):
         channel = self.make_request(
             "GET", "/events?access_token=%s&timeout=0" % (self.token,)
         )
-        self.assertEquals(channel.code, 200, msg=channel.result)
+        self.assertEqual(channel.code, 200, msg=channel.result)
 
         # We may get a presence event for ourselves down
-        self.assertEquals(
+        self.assertEqual(
             0,
             len(
                 [
@@ -153,4 +153,4 @@ class GetEventsTestCase(unittest.HomeserverTestCase):
             "/events/" + event_id,
             access_token=self.token,
         )
-        self.assertEquals(channel.code, 200, msg=channel.result)
+        self.assertEqual(channel.code, 200, msg=channel.result)

--- a/tests/rest/client/test_filter.py
+++ b/tests/rest/client/test_filter.py
@@ -45,7 +45,7 @@ class FilterTestCase(unittest.HomeserverTestCase):
         self.assertEqual(channel.json_body, {"filter_id": "0"})
         filter = self.store.get_user_filter(user_localpart="apple", filter_id=0)
         self.pump()
-        self.assertEquals(filter.result, self.EXAMPLE_FILTER)
+        self.assertEqual(filter.result, self.EXAMPLE_FILTER)
 
     def test_add_filter_for_other_user(self):
         channel = self.make_request(
@@ -55,7 +55,7 @@ class FilterTestCase(unittest.HomeserverTestCase):
         )
 
         self.assertEqual(channel.result["code"], b"403")
-        self.assertEquals(channel.json_body["errcode"], Codes.FORBIDDEN)
+        self.assertEqual(channel.json_body["errcode"], Codes.FORBIDDEN)
 
     def test_add_filter_non_local_user(self):
         _is_mine = self.hs.is_mine
@@ -68,7 +68,7 @@ class FilterTestCase(unittest.HomeserverTestCase):
 
         self.hs.is_mine = _is_mine
         self.assertEqual(channel.result["code"], b"403")
-        self.assertEquals(channel.json_body["errcode"], Codes.FORBIDDEN)
+        self.assertEqual(channel.json_body["errcode"], Codes.FORBIDDEN)
 
     def test_get_filter(self):
         filter_id = defer.ensureDeferred(
@@ -83,7 +83,7 @@ class FilterTestCase(unittest.HomeserverTestCase):
         )
 
         self.assertEqual(channel.result["code"], b"200")
-        self.assertEquals(channel.json_body, self.EXAMPLE_FILTER)
+        self.assertEqual(channel.json_body, self.EXAMPLE_FILTER)
 
     def test_get_filter_non_existant(self):
         channel = self.make_request(
@@ -91,7 +91,7 @@ class FilterTestCase(unittest.HomeserverTestCase):
         )
 
         self.assertEqual(channel.result["code"], b"404")
-        self.assertEquals(channel.json_body["errcode"], Codes.NOT_FOUND)
+        self.assertEqual(channel.json_body["errcode"], Codes.NOT_FOUND)
 
     # Currently invalid params do not have an appropriate errcode
     # in errors.py

--- a/tests/rest/client/test_groups.py
+++ b/tests/rest/client/test_groups.py
@@ -30,8 +30,8 @@ class GroupsTestCase(unittest.HomeserverTestCase):
 
         # Alice creates a group
         channel = self.make_request("POST", "/create_group", {"localpart": "spqr"})
-        self.assertEquals(channel.code, 200, msg=channel.text_body)
-        self.assertEquals(channel.json_body, {"group_id": group_id})
+        self.assertEqual(channel.code, 200, msg=channel.text_body)
+        self.assertEqual(channel.json_body, {"group_id": group_id})
 
         # Bob creates a private room
         room_id = self.helper.create_room_as(self.room_creator_user_id, is_public=False)
@@ -45,12 +45,12 @@ class GroupsTestCase(unittest.HomeserverTestCase):
         channel = self.make_request(
             "PUT", f"/groups/{group_id}/admin/rooms/{room_id}", {}
         )
-        self.assertEquals(channel.code, 200, msg=channel.text_body)
-        self.assertEquals(channel.json_body, {})
+        self.assertEqual(channel.code, 200, msg=channel.text_body)
+        self.assertEqual(channel.json_body, {})
 
         # Alice now tries to retrieve the room list of the space.
         channel = self.make_request("GET", f"/groups/{group_id}/rooms")
-        self.assertEquals(channel.code, 200, msg=channel.text_body)
-        self.assertEquals(
+        self.assertEqual(channel.code, 200, msg=channel.text_body)
+        self.assertEqual(
             channel.json_body, {"chunk": [], "total_room_count_estimate": 0}
         )

--- a/tests/rest/client/test_login.py
+++ b/tests/rest/client/test_login.py
@@ -136,10 +136,10 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
             channel = self.make_request(b"POST", LOGIN_URL, params)
 
             if i == 5:
-                self.assertEquals(channel.result["code"], b"429", channel.result)
+                self.assertEqual(channel.result["code"], b"429", channel.result)
                 retry_after_ms = int(channel.json_body["retry_after_ms"])
             else:
-                self.assertEquals(channel.result["code"], b"200", channel.result)
+                self.assertEqual(channel.result["code"], b"200", channel.result)
 
         # Since we're ratelimiting at 1 request/min, retry_after_ms should be lower
         # than 1min.
@@ -154,7 +154,7 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
         }
         channel = self.make_request(b"POST", LOGIN_URL, params)
 
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
     @override_config(
         {
@@ -181,10 +181,10 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
             channel = self.make_request(b"POST", LOGIN_URL, params)
 
             if i == 5:
-                self.assertEquals(channel.result["code"], b"429", channel.result)
+                self.assertEqual(channel.result["code"], b"429", channel.result)
                 retry_after_ms = int(channel.json_body["retry_after_ms"])
             else:
-                self.assertEquals(channel.result["code"], b"200", channel.result)
+                self.assertEqual(channel.result["code"], b"200", channel.result)
 
         # Since we're ratelimiting at 1 request/min, retry_after_ms should be lower
         # than 1min.
@@ -199,7 +199,7 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
         }
         channel = self.make_request(b"POST", LOGIN_URL, params)
 
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
     @override_config(
         {
@@ -226,10 +226,10 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
             channel = self.make_request(b"POST", LOGIN_URL, params)
 
             if i == 5:
-                self.assertEquals(channel.result["code"], b"429", channel.result)
+                self.assertEqual(channel.result["code"], b"429", channel.result)
                 retry_after_ms = int(channel.json_body["retry_after_ms"])
             else:
-                self.assertEquals(channel.result["code"], b"403", channel.result)
+                self.assertEqual(channel.result["code"], b"403", channel.result)
 
         # Since we're ratelimiting at 1 request/min, retry_after_ms should be lower
         # than 1min.
@@ -244,7 +244,7 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
         }
         channel = self.make_request(b"POST", LOGIN_URL, params)
 
-        self.assertEquals(channel.result["code"], b"403", channel.result)
+        self.assertEqual(channel.result["code"], b"403", channel.result)
 
     @override_config({"session_lifetime": "24h"})
     def test_soft_logout(self) -> None:
@@ -252,8 +252,8 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
 
         # we shouldn't be able to make requests without an access token
         channel = self.make_request(b"GET", TEST_URL)
-        self.assertEquals(channel.result["code"], b"401", channel.result)
-        self.assertEquals(channel.json_body["errcode"], "M_MISSING_TOKEN")
+        self.assertEqual(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_MISSING_TOKEN")
 
         # log in as normal
         params = {
@@ -263,22 +263,22 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
         }
         channel = self.make_request(b"POST", LOGIN_URL, params)
 
-        self.assertEquals(channel.code, 200, channel.result)
+        self.assertEqual(channel.code, 200, channel.result)
         access_token = channel.json_body["access_token"]
         device_id = channel.json_body["device_id"]
 
         # we should now be able to make requests with the access token
         channel = self.make_request(b"GET", TEST_URL, access_token=access_token)
-        self.assertEquals(channel.code, 200, channel.result)
+        self.assertEqual(channel.code, 200, channel.result)
 
         # time passes
         self.reactor.advance(24 * 3600)
 
         # ... and we should be soft-logouted
         channel = self.make_request(b"GET", TEST_URL, access_token=access_token)
-        self.assertEquals(channel.code, 401, channel.result)
-        self.assertEquals(channel.json_body["errcode"], "M_UNKNOWN_TOKEN")
-        self.assertEquals(channel.json_body["soft_logout"], True)
+        self.assertEqual(channel.code, 401, channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_UNKNOWN_TOKEN")
+        self.assertEqual(channel.json_body["soft_logout"], True)
 
         #
         # test behaviour after deleting the expired device
@@ -290,17 +290,17 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
         # more requests with the expired token should still return a soft-logout
         self.reactor.advance(3600)
         channel = self.make_request(b"GET", TEST_URL, access_token=access_token)
-        self.assertEquals(channel.code, 401, channel.result)
-        self.assertEquals(channel.json_body["errcode"], "M_UNKNOWN_TOKEN")
-        self.assertEquals(channel.json_body["soft_logout"], True)
+        self.assertEqual(channel.code, 401, channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_UNKNOWN_TOKEN")
+        self.assertEqual(channel.json_body["soft_logout"], True)
 
         # ... but if we delete that device, it will be a proper logout
         self._delete_device(access_token_2, "kermit", "monkey", device_id)
 
         channel = self.make_request(b"GET", TEST_URL, access_token=access_token)
-        self.assertEquals(channel.code, 401, channel.result)
-        self.assertEquals(channel.json_body["errcode"], "M_UNKNOWN_TOKEN")
-        self.assertEquals(channel.json_body["soft_logout"], False)
+        self.assertEqual(channel.code, 401, channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_UNKNOWN_TOKEN")
+        self.assertEqual(channel.json_body["soft_logout"], False)
 
     def _delete_device(
         self, access_token: str, user_id: str, password: str, device_id: str
@@ -309,7 +309,7 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
         channel = self.make_request(
             b"DELETE", "devices/" + device_id, access_token=access_token
         )
-        self.assertEquals(channel.code, 401, channel.result)
+        self.assertEqual(channel.code, 401, channel.result)
         # check it's a UI-Auth fail
         self.assertEqual(
             set(channel.json_body.keys()),
@@ -332,7 +332,7 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
             access_token=access_token,
             content={"auth": auth},
         )
-        self.assertEquals(channel.code, 200, channel.result)
+        self.assertEqual(channel.code, 200, channel.result)
 
     @override_config({"session_lifetime": "24h"})
     def test_session_can_hard_logout_after_being_soft_logged_out(self) -> None:
@@ -343,20 +343,20 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
 
         # we should now be able to make requests with the access token
         channel = self.make_request(b"GET", TEST_URL, access_token=access_token)
-        self.assertEquals(channel.code, 200, channel.result)
+        self.assertEqual(channel.code, 200, channel.result)
 
         # time passes
         self.reactor.advance(24 * 3600)
 
         # ... and we should be soft-logouted
         channel = self.make_request(b"GET", TEST_URL, access_token=access_token)
-        self.assertEquals(channel.code, 401, channel.result)
-        self.assertEquals(channel.json_body["errcode"], "M_UNKNOWN_TOKEN")
-        self.assertEquals(channel.json_body["soft_logout"], True)
+        self.assertEqual(channel.code, 401, channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_UNKNOWN_TOKEN")
+        self.assertEqual(channel.json_body["soft_logout"], True)
 
         # Now try to hard logout this session
         channel = self.make_request(b"POST", "/logout", access_token=access_token)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
     @override_config({"session_lifetime": "24h"})
     def test_session_can_hard_logout_all_sessions_after_being_soft_logged_out(
@@ -369,20 +369,20 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
 
         # we should now be able to make requests with the access token
         channel = self.make_request(b"GET", TEST_URL, access_token=access_token)
-        self.assertEquals(channel.code, 200, channel.result)
+        self.assertEqual(channel.code, 200, channel.result)
 
         # time passes
         self.reactor.advance(24 * 3600)
 
         # ... and we should be soft-logouted
         channel = self.make_request(b"GET", TEST_URL, access_token=access_token)
-        self.assertEquals(channel.code, 401, channel.result)
-        self.assertEquals(channel.json_body["errcode"], "M_UNKNOWN_TOKEN")
-        self.assertEquals(channel.json_body["soft_logout"], True)
+        self.assertEqual(channel.code, 401, channel.result)
+        self.assertEqual(channel.json_body["errcode"], "M_UNKNOWN_TOKEN")
+        self.assertEqual(channel.json_body["soft_logout"], True)
 
         # Now try to hard log out all of the user's sessions
         channel = self.make_request(b"POST", "/logout/all", access_token=access_token)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
 
 @skip_unless(has_saml2 and HAS_OIDC, "Requires SAML2 and OIDC")
@@ -1129,7 +1129,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
             b"POST", LOGIN_URL, params, access_token=self.service.token
         )
 
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
     def test_login_appservice_user_bot(self) -> None:
         """Test that the appservice bot can use /login"""
@@ -1143,7 +1143,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
             b"POST", LOGIN_URL, params, access_token=self.service.token
         )
 
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
     def test_login_appservice_wrong_user(self) -> None:
         """Test that non-as users cannot login with the as token"""
@@ -1157,7 +1157,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
             b"POST", LOGIN_URL, params, access_token=self.service.token
         )
 
-        self.assertEquals(channel.result["code"], b"403", channel.result)
+        self.assertEqual(channel.result["code"], b"403", channel.result)
 
     def test_login_appservice_wrong_as(self) -> None:
         """Test that as users cannot login with wrong as token"""
@@ -1171,7 +1171,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
             b"POST", LOGIN_URL, params, access_token=self.another_service.token
         )
 
-        self.assertEquals(channel.result["code"], b"403", channel.result)
+        self.assertEqual(channel.result["code"], b"403", channel.result)
 
     def test_login_appservice_no_token(self) -> None:
         """Test that users must provide a token when using the appservice
@@ -1185,7 +1185,7 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
         }
         channel = self.make_request(b"POST", LOGIN_URL, params)
 
-        self.assertEquals(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.result["code"], b"401", channel.result)
 
 
 @skip_unless(HAS_OIDC, "requires OIDC")

--- a/tests/rest/client/test_profile.py
+++ b/tests/rest/client/test_profile.py
@@ -80,7 +80,7 @@ class ProfileTestCase(unittest.HomeserverTestCase):
 
     def test_get_displayname_other(self):
         res = self._get_displayname(self.other)
-        self.assertEquals(res, "Bob")
+        self.assertEqual(res, "Bob")
 
     def test_set_displayname_other(self):
         channel = self.make_request(

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -65,7 +65,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             b"POST", self.url + b"?access_token=i_am_an_app_service", request_data
         )
 
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
         det_data = {"user_id": user_id, "home_server": self.hs.hostname}
         self.assertDictContainsSubset(det_data, channel.json_body)
 
@@ -87,7 +87,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             b"POST", self.url + b"?access_token=i_am_an_app_service", request_data
         )
 
-        self.assertEquals(channel.result["code"], b"400", channel.result)
+        self.assertEqual(channel.result["code"], b"400", channel.result)
 
     def test_POST_appservice_registration_invalid(self):
         self.appservice = None  # no application service exists
@@ -98,21 +98,21 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             b"POST", self.url + b"?access_token=i_am_an_app_service", request_data
         )
 
-        self.assertEquals(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.result["code"], b"401", channel.result)
 
     def test_POST_bad_password(self):
         request_data = json.dumps({"username": "kermit", "password": 666})
         channel = self.make_request(b"POST", self.url, request_data)
 
-        self.assertEquals(channel.result["code"], b"400", channel.result)
-        self.assertEquals(channel.json_body["error"], "Invalid password")
+        self.assertEqual(channel.result["code"], b"400", channel.result)
+        self.assertEqual(channel.json_body["error"], "Invalid password")
 
     def test_POST_bad_username(self):
         request_data = json.dumps({"username": 777, "password": "monkey"})
         channel = self.make_request(b"POST", self.url, request_data)
 
-        self.assertEquals(channel.result["code"], b"400", channel.result)
-        self.assertEquals(channel.json_body["error"], "Invalid username")
+        self.assertEqual(channel.result["code"], b"400", channel.result)
+        self.assertEqual(channel.json_body["error"], "Invalid username")
 
     def test_POST_user_valid(self):
         user_id = "@kermit:test"
@@ -131,7 +131,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             "home_server": self.hs.hostname,
             "device_id": device_id,
         }
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
         self.assertDictContainsSubset(det_data, channel.json_body)
 
     @override_config({"enable_registration": False})
@@ -141,9 +141,9 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
 
         channel = self.make_request(b"POST", self.url, request_data)
 
-        self.assertEquals(channel.result["code"], b"403", channel.result)
-        self.assertEquals(channel.json_body["error"], "Registration has been disabled")
-        self.assertEquals(channel.json_body["errcode"], "M_FORBIDDEN")
+        self.assertEqual(channel.result["code"], b"403", channel.result)
+        self.assertEqual(channel.json_body["error"], "Registration has been disabled")
+        self.assertEqual(channel.json_body["errcode"], "M_FORBIDDEN")
 
     def test_POST_guest_registration(self):
         self.hs.config.key.macaroon_secret_key = "test"
@@ -152,7 +152,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
         channel = self.make_request(b"POST", self.url + b"?kind=guest", b"{}")
 
         det_data = {"home_server": self.hs.hostname, "device_id": "guest_device"}
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
         self.assertDictContainsSubset(det_data, channel.json_body)
 
     def test_POST_disabled_guest_registration(self):
@@ -160,8 +160,8 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
 
         channel = self.make_request(b"POST", self.url + b"?kind=guest", b"{}")
 
-        self.assertEquals(channel.result["code"], b"403", channel.result)
-        self.assertEquals(channel.json_body["error"], "Guest access is disabled")
+        self.assertEqual(channel.result["code"], b"403", channel.result)
+        self.assertEqual(channel.json_body["error"], "Guest access is disabled")
 
     @override_config({"rc_registration": {"per_second": 0.17, "burst_count": 5}})
     def test_POST_ratelimiting_guest(self):
@@ -170,16 +170,16 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             channel = self.make_request(b"POST", url, b"{}")
 
             if i == 5:
-                self.assertEquals(channel.result["code"], b"429", channel.result)
+                self.assertEqual(channel.result["code"], b"429", channel.result)
                 retry_after_ms = int(channel.json_body["retry_after_ms"])
             else:
-                self.assertEquals(channel.result["code"], b"200", channel.result)
+                self.assertEqual(channel.result["code"], b"200", channel.result)
 
         self.reactor.advance(retry_after_ms / 1000.0 + 1.0)
 
         channel = self.make_request(b"POST", self.url + b"?kind=guest", b"{}")
 
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
     @override_config({"rc_registration": {"per_second": 0.17, "burst_count": 5}})
     def test_POST_ratelimiting(self):
@@ -194,16 +194,16 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             channel = self.make_request(b"POST", self.url, request_data)
 
             if i == 5:
-                self.assertEquals(channel.result["code"], b"429", channel.result)
+                self.assertEqual(channel.result["code"], b"429", channel.result)
                 retry_after_ms = int(channel.json_body["retry_after_ms"])
             else:
-                self.assertEquals(channel.result["code"], b"200", channel.result)
+                self.assertEqual(channel.result["code"], b"200", channel.result)
 
         self.reactor.advance(retry_after_ms / 1000.0 + 1.0)
 
         channel = self.make_request(b"POST", self.url + b"?kind=guest", b"{}")
 
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
     @override_config({"registration_requires_token": True})
     def test_POST_registration_requires_token(self):
@@ -231,7 +231,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
 
         # Request without auth to get flows and session
         channel = self.make_request(b"POST", self.url, json.dumps(params))
-        self.assertEquals(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.result["code"], b"401", channel.result)
         flows = channel.json_body["flows"]
         # Synapse adds a dummy stage to differentiate flows where otherwise one
         # flow would be a subset of another flow.
@@ -249,7 +249,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
         }
         request_data = json.dumps(params)
         channel = self.make_request(b"POST", self.url, request_data)
-        self.assertEquals(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.result["code"], b"401", channel.result)
         completed = channel.json_body["completed"]
         self.assertCountEqual([LoginType.REGISTRATION_TOKEN], completed)
 
@@ -265,7 +265,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             "home_server": self.hs.hostname,
             "device_id": device_id,
         }
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
         self.assertDictContainsSubset(det_data, channel.json_body)
 
         # Check the `completed` counter has been incremented and pending is 0
@@ -276,8 +276,8 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
                 retcols=["pending", "completed"],
             )
         )
-        self.assertEquals(res["completed"], 1)
-        self.assertEquals(res["pending"], 0)
+        self.assertEqual(res["completed"], 1)
+        self.assertEqual(res["pending"], 0)
 
     @override_config({"registration_requires_token": True})
     def test_POST_registration_token_invalid(self):
@@ -295,23 +295,23 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             "session": session,
         }
         channel = self.make_request(b"POST", self.url, json.dumps(params))
-        self.assertEquals(channel.result["code"], b"401", channel.result)
-        self.assertEquals(channel.json_body["errcode"], Codes.MISSING_PARAM)
-        self.assertEquals(channel.json_body["completed"], [])
+        self.assertEqual(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.json_body["errcode"], Codes.MISSING_PARAM)
+        self.assertEqual(channel.json_body["completed"], [])
 
         # Test with non-string (invalid)
         params["auth"]["token"] = 1234
         channel = self.make_request(b"POST", self.url, json.dumps(params))
-        self.assertEquals(channel.result["code"], b"401", channel.result)
-        self.assertEquals(channel.json_body["errcode"], Codes.INVALID_PARAM)
-        self.assertEquals(channel.json_body["completed"], [])
+        self.assertEqual(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.json_body["errcode"], Codes.INVALID_PARAM)
+        self.assertEqual(channel.json_body["completed"], [])
 
         # Test with unknown token (invalid)
         params["auth"]["token"] = "1234"
         channel = self.make_request(b"POST", self.url, json.dumps(params))
-        self.assertEquals(channel.result["code"], b"401", channel.result)
-        self.assertEquals(channel.json_body["errcode"], Codes.UNAUTHORIZED)
-        self.assertEquals(channel.json_body["completed"], [])
+        self.assertEqual(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.json_body["errcode"], Codes.UNAUTHORIZED)
+        self.assertEqual(channel.json_body["completed"], [])
 
     @override_config({"registration_requires_token": True})
     def test_POST_registration_token_limit_uses(self):
@@ -354,7 +354,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
                 retcol="pending",
             )
         )
-        self.assertEquals(pending, 1)
+        self.assertEqual(pending, 1)
 
         # Check auth fails when using token with session2
         params2["auth"] = {
@@ -363,9 +363,9 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             "session": session2,
         }
         channel = self.make_request(b"POST", self.url, json.dumps(params2))
-        self.assertEquals(channel.result["code"], b"401", channel.result)
-        self.assertEquals(channel.json_body["errcode"], Codes.UNAUTHORIZED)
-        self.assertEquals(channel.json_body["completed"], [])
+        self.assertEqual(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.json_body["errcode"], Codes.UNAUTHORIZED)
+        self.assertEqual(channel.json_body["completed"], [])
 
         # Complete registration with session1
         params1["auth"]["type"] = LoginType.DUMMY
@@ -378,14 +378,14 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
                 retcols=["pending", "completed"],
             )
         )
-        self.assertEquals(res["pending"], 0)
-        self.assertEquals(res["completed"], 1)
+        self.assertEqual(res["pending"], 0)
+        self.assertEqual(res["completed"], 1)
 
         # Check auth still fails when using token with session2
         channel = self.make_request(b"POST", self.url, json.dumps(params2))
-        self.assertEquals(channel.result["code"], b"401", channel.result)
-        self.assertEquals(channel.json_body["errcode"], Codes.UNAUTHORIZED)
-        self.assertEquals(channel.json_body["completed"], [])
+        self.assertEqual(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.json_body["errcode"], Codes.UNAUTHORIZED)
+        self.assertEqual(channel.json_body["completed"], [])
 
     @override_config({"registration_requires_token": True})
     def test_POST_registration_token_expiry(self):
@@ -417,9 +417,9 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             "session": session,
         }
         channel = self.make_request(b"POST", self.url, json.dumps(params))
-        self.assertEquals(channel.result["code"], b"401", channel.result)
-        self.assertEquals(channel.json_body["errcode"], Codes.UNAUTHORIZED)
-        self.assertEquals(channel.json_body["completed"], [])
+        self.assertEqual(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.json_body["errcode"], Codes.UNAUTHORIZED)
+        self.assertEqual(channel.json_body["completed"], [])
 
         # Update token so it expires tomorrow
         self.get_success(
@@ -504,7 +504,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
                 retcol="result",
             )
         )
-        self.assertEquals(db_to_json(result2), token)
+        self.assertEqual(db_to_json(result2), token)
 
         # Delete both sessions (mimics expiry)
         self.get_success(
@@ -519,7 +519,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
                 retcol="pending",
             )
         )
-        self.assertEquals(pending, 0)
+        self.assertEqual(pending, 0)
 
     @override_config({"registration_requires_token": True})
     def test_POST_registration_token_session_expiry_deleted_token(self):
@@ -572,7 +572,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
 
     def test_advertised_flows(self):
         channel = self.make_request(b"POST", self.url, b"{}")
-        self.assertEquals(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.result["code"], b"401", channel.result)
         flows = channel.json_body["flows"]
 
         # with the stock config, we only expect the dummy flow
@@ -595,7 +595,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
     )
     def test_advertised_flows_captcha_and_terms_and_3pids(self):
         channel = self.make_request(b"POST", self.url, b"{}")
-        self.assertEquals(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.result["code"], b"401", channel.result)
         flows = channel.json_body["flows"]
 
         self.assertCountEqual(
@@ -627,7 +627,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
     )
     def test_advertised_flows_no_msisdn_email_required(self):
         channel = self.make_request(b"POST", self.url, b"{}")
-        self.assertEquals(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.result["code"], b"401", channel.result)
         flows = channel.json_body["flows"]
 
         # with the stock config, we expect all four combinations of 3pid
@@ -671,7 +671,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             b"register/email/requestToken",
             {"client_secret": "foobar", "email": email, "send_attempt": 1},
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         self.assertIsNotNone(channel.json_body.get("sid"))
 
@@ -694,9 +694,9 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             b"register/email/requestToken",
             {"client_secret": "foobar", "email": "email@@email", "send_attempt": 1},
         )
-        self.assertEquals(400, channel.code, channel.result)
+        self.assertEqual(400, channel.code, channel.result)
         # Check error to ensure that we're not erroring due to a bug in the test.
-        self.assertEquals(
+        self.assertEqual(
             channel.json_body,
             {"errcode": "M_UNKNOWN", "error": "Unable to parse email address"},
         )
@@ -707,8 +707,8 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             b"register/email/requestToken",
             {"client_secret": "foobar", "email": "email", "send_attempt": 1},
         )
-        self.assertEquals(400, channel.code, channel.result)
-        self.assertEquals(
+        self.assertEqual(400, channel.code, channel.result)
+        self.assertEqual(
             channel.json_body,
             {"errcode": "M_UNKNOWN", "error": "Unable to parse email address"},
         )
@@ -720,8 +720,8 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
             b"register/email/requestToken",
             {"client_secret": "foobar", "email": email, "send_attempt": 1},
         )
-        self.assertEquals(400, channel.code, channel.result)
-        self.assertEquals(
+        self.assertEqual(400, channel.code, channel.result)
+        self.assertEqual(
             channel.json_body,
             {"errcode": "M_UNKNOWN", "error": "Unable to parse email address"},
         )
@@ -745,7 +745,7 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
         # Check that /available correctly ignores the username provided despite the
         # username being already registered.
         channel = self.make_request("GET", "register/available?username=" + username)
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         # Test that when starting a UIA registration flow the request doesn't fail because
         # of a conflicting username
@@ -799,14 +799,14 @@ class AccountValidityTestCase(unittest.HomeserverTestCase):
         # endpoint.
         channel = self.make_request(b"GET", "/sync", access_token=tok)
 
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         self.reactor.advance(datetime.timedelta(weeks=1).total_seconds())
 
         channel = self.make_request(b"GET", "/sync", access_token=tok)
 
-        self.assertEquals(channel.result["code"], b"403", channel.result)
-        self.assertEquals(
+        self.assertEqual(channel.result["code"], b"403", channel.result)
+        self.assertEqual(
             channel.json_body["errcode"], Codes.EXPIRED_ACCOUNT, channel.result
         )
 
@@ -826,12 +826,12 @@ class AccountValidityTestCase(unittest.HomeserverTestCase):
         params = {"user_id": user_id}
         request_data = json.dumps(params)
         channel = self.make_request(b"POST", url, request_data, access_token=admin_tok)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         # The specific endpoint doesn't matter, all we need is an authenticated
         # endpoint.
         channel = self.make_request(b"GET", "/sync", access_token=tok)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
     def test_manual_expire(self):
         user_id = self.register_user("kermit", "monkey")
@@ -848,13 +848,13 @@ class AccountValidityTestCase(unittest.HomeserverTestCase):
         }
         request_data = json.dumps(params)
         channel = self.make_request(b"POST", url, request_data, access_token=admin_tok)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         # The specific endpoint doesn't matter, all we need is an authenticated
         # endpoint.
         channel = self.make_request(b"GET", "/sync", access_token=tok)
-        self.assertEquals(channel.result["code"], b"403", channel.result)
-        self.assertEquals(
+        self.assertEqual(channel.result["code"], b"403", channel.result)
+        self.assertEqual(
             channel.json_body["errcode"], Codes.EXPIRED_ACCOUNT, channel.result
         )
 
@@ -873,18 +873,18 @@ class AccountValidityTestCase(unittest.HomeserverTestCase):
         }
         request_data = json.dumps(params)
         channel = self.make_request(b"POST", url, request_data, access_token=admin_tok)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         # Try to log the user out
         channel = self.make_request(b"POST", "/logout", access_token=tok)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         # Log the user in again (allowed for expired accounts)
         tok = self.login("kermit", "monkey")
 
         # Try to log out all of the user's sessions
         channel = self.make_request(b"POST", "/logout/all", access_token=tok)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
 
 class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
@@ -959,7 +959,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         renewal_token = self.get_success(self.store.get_renewal_token_for_user(user_id))
         url = "/_matrix/client/unstable/account_validity/renew?token=%s" % renewal_token
         channel = self.make_request(b"GET", url)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         # Check that we're getting HTML back.
         content_type = channel.headers.getRawHeaders(b"Content-Type")
@@ -977,7 +977,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         # Move 1 day forward. Try to renew with the same token again.
         url = "/_matrix/client/unstable/account_validity/renew?token=%s" % renewal_token
         channel = self.make_request(b"GET", url)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         # Check that we're getting HTML back.
         content_type = channel.headers.getRawHeaders(b"Content-Type")
@@ -997,14 +997,14 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         # succeed.
         self.reactor.advance(datetime.timedelta(days=3).total_seconds())
         channel = self.make_request(b"GET", "/sync", access_token=tok)
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
     def test_renewal_invalid_token(self):
         # Hit the renewal endpoint with an invalid token and check that it behaves as
         # expected, i.e. that it responds with 404 Not Found and the correct HTML.
         url = "/_matrix/client/unstable/account_validity/renew?token=123"
         channel = self.make_request(b"GET", url)
-        self.assertEquals(channel.result["code"], b"404", channel.result)
+        self.assertEqual(channel.result["code"], b"404", channel.result)
 
         # Check that we're getting HTML back.
         content_type = channel.headers.getRawHeaders(b"Content-Type")
@@ -1028,7 +1028,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
             "/_matrix/client/unstable/account_validity/send_mail",
             access_token=tok,
         )
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         self.assertEqual(len(self.email_attempts), 1)
 
@@ -1103,7 +1103,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
             "/_matrix/client/unstable/account_validity/send_mail",
             access_token=tok,
         )
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         self.assertEqual(len(self.email_attempts), 1)
 
@@ -1183,8 +1183,8 @@ class RegistrationTokenValidityRestServletTestCase(unittest.HomeserverTestCase):
             b"GET",
             f"{self.url}?token={token}",
         )
-        self.assertEquals(channel.result["code"], b"200", channel.result)
-        self.assertEquals(channel.json_body["valid"], True)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.json_body["valid"], True)
 
     def test_GET_token_invalid(self):
         token = "1234"
@@ -1192,8 +1192,8 @@ class RegistrationTokenValidityRestServletTestCase(unittest.HomeserverTestCase):
             b"GET",
             f"{self.url}?token={token}",
         )
-        self.assertEquals(channel.result["code"], b"200", channel.result)
-        self.assertEquals(channel.json_body["valid"], False)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.json_body["valid"], False)
 
     @override_config(
         {"rc_registration_token_validity": {"per_second": 0.1, "burst_count": 5}}
@@ -1208,10 +1208,10 @@ class RegistrationTokenValidityRestServletTestCase(unittest.HomeserverTestCase):
             )
 
             if i == 5:
-                self.assertEquals(channel.result["code"], b"429", channel.result)
+                self.assertEqual(channel.result["code"], b"429", channel.result)
                 retry_after_ms = int(channel.json_body["retry_after_ms"])
             else:
-                self.assertEquals(channel.result["code"], b"200", channel.result)
+                self.assertEqual(channel.result["code"], b"200", channel.result)
 
         self.reactor.advance(retry_after_ms / 1000.0 + 1.0)
 
@@ -1219,4 +1219,4 @@ class RegistrationTokenValidityRestServletTestCase(unittest.HomeserverTestCase):
             b"GET",
             f"{self.url}?token={token}",
         )
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -69,7 +69,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         """
 
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", key="👍")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         event_id = channel.json_body["event_id"]
 
@@ -78,7 +78,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             "/rooms/%s/event/%s" % (self.room, event_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         self.assert_dict(
             {
@@ -103,7 +103,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             parent_id="foo",
             content={"body": "foo", "msgtype": "m.text"},
         )
-        self.assertEquals(400, channel.code, channel.json_body)
+        self.assertEqual(400, channel.code, channel.json_body)
 
         # Unless that event is referenced from another event!
         self.get_success(
@@ -123,7 +123,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             parent_id="foo",
             content={"body": "foo", "msgtype": "m.text"},
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
     def test_deny_invalid_room(self):
         """Test that we deny relations on non-existant events"""
@@ -136,15 +136,15 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         channel = self._send_relation(
             RelationTypes.ANNOTATION, "m.reaction", parent_id=parent_id, key="A"
         )
-        self.assertEquals(400, channel.code, channel.json_body)
+        self.assertEqual(400, channel.code, channel.json_body)
 
     def test_deny_double_react(self):
         """Test that we deny relations on membership events"""
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", key="a")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "a")
-        self.assertEquals(400, channel.code, channel.json_body)
+        self.assertEqual(400, channel.code, channel.json_body)
 
     def test_deny_forked_thread(self):
         """It is invalid to start a thread off a thread."""
@@ -154,7 +154,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             content={"msgtype": "m.text", "body": "foo"},
             parent_id=self.parent_id,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         parent_id = channel.json_body["event_id"]
 
         channel = self._send_relation(
@@ -163,16 +163,16 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             content={"msgtype": "m.text", "body": "foo"},
             parent_id=parent_id,
         )
-        self.assertEquals(400, channel.code, channel.json_body)
+        self.assertEqual(400, channel.code, channel.json_body)
 
     def test_basic_paginate_relations(self):
         """Tests that calling pagination API correctly the latest relations."""
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "a")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         first_annotation_id = channel.json_body["event_id"]
 
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "b")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         second_annotation_id = channel.json_body["event_id"]
 
         channel = self.make_request(
@@ -180,11 +180,11 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/_matrix/client/unstable/rooms/{self.room}/relations/{self.parent_id}?limit=1",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # We expect to get back a single pagination result, which is the latest
         # full relation event we sent above.
-        self.assertEquals(len(channel.json_body["chunk"]), 1, channel.json_body)
+        self.assertEqual(len(channel.json_body["chunk"]), 1, channel.json_body)
         self.assert_dict(
             {
                 "event_id": second_annotation_id,
@@ -195,7 +195,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         )
 
         # We also expect to get the original event (the id of which is self.parent_id)
-        self.assertEquals(
+        self.assertEqual(
             channel.json_body["original_event"]["event_id"], self.parent_id
         )
 
@@ -212,11 +212,11 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/{self.parent_id}?limit=1&org.matrix.msc3715.dir=f",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # We expect to get back a single pagination result, which is the earliest
         # full relation event we sent above.
-        self.assertEquals(len(channel.json_body["chunk"]), 1, channel.json_body)
+        self.assertEqual(len(channel.json_body["chunk"]), 1, channel.json_body)
         self.assert_dict(
             {
                 "event_id": first_annotation_id,
@@ -245,7 +245,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             channel = self._send_relation(
                 RelationTypes.ANNOTATION, "m.reaction", chr(ord("a") + idx)
             )
-            self.assertEquals(200, channel.code, channel.json_body)
+            self.assertEqual(200, channel.code, channel.json_body)
             expected_event_ids.append(channel.json_body["event_id"])
 
         prev_token = ""
@@ -260,7 +260,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 f"/_matrix/client/unstable/rooms/{self.room}/relations/{self.parent_id}?limit=1{from_token}",
                 access_token=self.user_token,
             )
-            self.assertEquals(200, channel.code, channel.json_body)
+            self.assertEqual(200, channel.code, channel.json_body)
 
             found_event_ids.extend(e["event_id"] for e in channel.json_body["chunk"])
             next_batch = channel.json_body.get("next_batch")
@@ -273,7 +273,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
         # We paginated backwards, so reverse
         found_event_ids.reverse()
-        self.assertEquals(found_event_ids, expected_event_ids)
+        self.assertEqual(found_event_ids, expected_event_ids)
 
         # Reset and try again, but convert the tokens to the legacy format.
         prev_token = ""
@@ -288,7 +288,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 f"/_matrix/client/unstable/rooms/{self.room}/relations/{self.parent_id}?limit=1{from_token}",
                 access_token=self.user_token,
             )
-            self.assertEquals(200, channel.code, channel.json_body)
+            self.assertEqual(200, channel.code, channel.json_body)
 
             found_event_ids.extend(e["event_id"] for e in channel.json_body["chunk"])
             next_batch = channel.json_body.get("next_batch")
@@ -301,12 +301,12 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
         # We paginated backwards, so reverse
         found_event_ids.reverse()
-        self.assertEquals(found_event_ids, expected_event_ids)
+        self.assertEqual(found_event_ids, expected_event_ids)
 
     def test_pagination_from_sync_and_messages(self):
         """Pagination tokens from /sync and /messages can be used to paginate /relations."""
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "A")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         annotation_id = channel.json_body["event_id"]
         # Send an event after the relation events.
         self.helper.send(self.room, body="Latest event", tok=self.user_token)
@@ -319,7 +319,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         channel = self.make_request(
             "GET", f"/sync?filter={filter}", access_token=self.user_token
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         room_timeline = channel.json_body["rooms"]["join"][self.room]["timeline"]
         sync_prev_batch = room_timeline["prev_batch"]
         self.assertIsNotNone(sync_prev_batch)
@@ -335,7 +335,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/rooms/{self.room}/messages?dir=b&limit=1",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         messages_end = channel.json_body["end"]
         self.assertIsNotNone(messages_end)
         # Ensure the relation event is not in the chunk returned from /messages.
@@ -355,7 +355,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 f"/_matrix/client/unstable/rooms/{self.room}/relations/{self.parent_id}?from={from_token}",
                 access_token=self.user_token,
             )
-            self.assertEquals(200, channel.code, channel.json_body)
+            self.assertEqual(200, channel.code, channel.json_body)
 
             # The relation should be in the returned chunk.
             self.assertIn(
@@ -386,7 +386,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 key=key,
                 access_token=access_tokens[idx],
             )
-            self.assertEquals(200, channel.code, channel.json_body)
+            self.assertEqual(200, channel.code, channel.json_body)
 
             idx += 1
             idx %= len(access_tokens)
@@ -404,7 +404,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 % (self.room, self.parent_id, from_token),
                 access_token=self.user_token,
             )
-            self.assertEquals(200, channel.code, channel.json_body)
+            self.assertEqual(200, channel.code, channel.json_body)
 
             self.assertEqual(len(channel.json_body["chunk"]), 1, channel.json_body)
 
@@ -425,7 +425,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             if not prev_token:
                 break
 
-        self.assertEquals(sent_groups, found_groups)
+        self.assertEqual(sent_groups, found_groups)
 
     def test_aggregation_pagination_within_group(self):
         """Test that we can paginate within an annotation group."""
@@ -449,14 +449,14 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 key="👍",
                 access_token=access_tokens[idx],
             )
-            self.assertEquals(200, channel.code, channel.json_body)
+            self.assertEqual(200, channel.code, channel.json_body)
             expected_event_ids.append(channel.json_body["event_id"])
 
             idx += 1
 
         # Also send a different type of reaction so that we test we don't see it
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", key="a")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         prev_token = ""
         found_event_ids: List[str] = []
@@ -473,7 +473,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 f"/m.reaction/{encoded_key}?limit=1{from_token}",
                 access_token=self.user_token,
             )
-            self.assertEquals(200, channel.code, channel.json_body)
+            self.assertEqual(200, channel.code, channel.json_body)
 
             self.assertEqual(len(channel.json_body["chunk"]), 1, channel.json_body)
 
@@ -489,7 +489,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
         # We paginated backwards, so reverse
         found_event_ids.reverse()
-        self.assertEquals(found_event_ids, expected_event_ids)
+        self.assertEqual(found_event_ids, expected_event_ids)
 
         # Reset and try again, but convert the tokens to the legacy format.
         prev_token = ""
@@ -506,7 +506,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 f"/m.reaction/{encoded_key}?limit=1{from_token}",
                 access_token=self.user_token,
             )
-            self.assertEquals(200, channel.code, channel.json_body)
+            self.assertEqual(200, channel.code, channel.json_body)
 
             self.assertEqual(len(channel.json_body["chunk"]), 1, channel.json_body)
 
@@ -522,21 +522,21 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
         # We paginated backwards, so reverse
         found_event_ids.reverse()
-        self.assertEquals(found_event_ids, expected_event_ids)
+        self.assertEqual(found_event_ids, expected_event_ids)
 
     def test_aggregation(self):
         """Test that annotations get correctly aggregated."""
 
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "a")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self._send_relation(
             RelationTypes.ANNOTATION, "m.reaction", "a", access_token=self.user2_token
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "b")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self.make_request(
             "GET",
@@ -544,9 +544,9 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             % (self.room, self.parent_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
-        self.assertEquals(
+        self.assertEqual(
             channel.json_body,
             {
                 "chunk": [
@@ -560,13 +560,13 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         """Test that annotations get correctly aggregated after a redaction."""
 
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "a")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         to_redact_event_id = channel.json_body["event_id"]
 
         channel = self._send_relation(
             RelationTypes.ANNOTATION, "m.reaction", "a", access_token=self.user2_token
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # Now lets redact one of the 'a' reactions
         channel = self.make_request(
@@ -575,7 +575,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             access_token=self.user_token,
             content={},
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self.make_request(
             "GET",
@@ -583,9 +583,9 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             % (self.room, self.parent_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
-        self.assertEquals(
+        self.assertEqual(
             channel.json_body,
             {"chunk": [{"type": "m.reaction", "key": "a", "count": 1}]},
         )
@@ -599,7 +599,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             % (self.room, self.parent_id, RelationTypes.REPLACE),
             access_token=self.user_token,
         )
-        self.assertEquals(400, channel.code, channel.json_body)
+        self.assertEqual(400, channel.code, channel.json_body)
 
     @unittest.override_config(
         {"experimental_features": {"msc3440_enabled": True, "msc3666_enabled": True}}
@@ -615,29 +615,29 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         """
         # Setup by sending a variety of relations.
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "a")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self._send_relation(
             RelationTypes.ANNOTATION, "m.reaction", "a", access_token=self.user2_token
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "b")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self._send_relation(RelationTypes.REFERENCE, "m.room.test")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         reply_1 = channel.json_body["event_id"]
 
         channel = self._send_relation(RelationTypes.REFERENCE, "m.room.test")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         reply_2 = channel.json_body["event_id"]
 
         channel = self._send_relation(RelationTypes.THREAD, "m.room.test")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self._send_relation(RelationTypes.THREAD, "m.room.test")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         thread_2 = channel.json_body["event_id"]
 
         def assert_bundle(event_json: JsonDict) -> None:
@@ -655,7 +655,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             )
 
             # Check the values of each field.
-            self.assertEquals(
+            self.assertEqual(
                 {
                     "chunk": [
                         {"type": "m.reaction", "key": "a", "count": 2},
@@ -665,12 +665,12 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 relations_dict[RelationTypes.ANNOTATION],
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 {"chunk": [{"event_id": reply_1}, {"event_id": reply_2}]},
                 relations_dict[RelationTypes.REFERENCE],
             )
 
-            self.assertEquals(
+            self.assertEqual(
                 2,
                 relations_dict[RelationTypes.THREAD].get("count"),
             )
@@ -701,7 +701,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/rooms/{self.room}/event/{self.parent_id}",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         assert_bundle(channel.json_body)
 
         # Request the room messages.
@@ -710,7 +710,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/rooms/{self.room}/messages?dir=b",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         assert_bundle(self._find_event_in_chunk(channel.json_body["chunk"]))
 
         # Request the room context.
@@ -719,12 +719,12 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/rooms/{self.room}/context/{self.parent_id}",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         assert_bundle(channel.json_body["event"])
 
         # Request sync.
         channel = self.make_request("GET", "/sync", access_token=self.user_token)
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         room_timeline = channel.json_body["rooms"]["join"][self.room]["timeline"]
         self.assertTrue(room_timeline["limited"])
         assert_bundle(self._find_event_in_chunk(room_timeline["events"]))
@@ -737,7 +737,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             content={"search_categories": {"room_events": {"search_term": "Hi"}}},
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         chunk = [
             result["result"]
             for result in channel.json_body["search_categories"]["room_events"][
@@ -751,42 +751,42 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         when directly requested.
         """
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", "a")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         annotation_id = channel.json_body["event_id"]
 
         # Annotate the annotation.
         channel = self._send_relation(
             RelationTypes.ANNOTATION, "m.reaction", "a", parent_id=annotation_id
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self.make_request(
             "GET",
             f"/rooms/{self.room}/event/{annotation_id}",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         self.assertIsNone(channel.json_body["unsigned"].get("m.relations"))
 
     def test_aggregation_get_event_for_thread(self):
         """Test that threads get bundled aggregations included when directly requested."""
         channel = self._send_relation(RelationTypes.THREAD, "m.room.test")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         thread_id = channel.json_body["event_id"]
 
         # Annotate the annotation.
         channel = self._send_relation(
             RelationTypes.ANNOTATION, "m.reaction", "a", parent_id=thread_id
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self.make_request(
             "GET",
             f"/rooms/{self.room}/event/{thread_id}",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
-        self.assertEquals(
+        self.assertEqual(200, channel.code, channel.json_body)
+        self.assertEqual(
             channel.json_body["unsigned"].get("m.relations"),
             {
                 RelationTypes.ANNOTATION: {
@@ -801,11 +801,11 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/_matrix/client/unstable/rooms/{self.room}/relations/{self.parent_id}?limit=1",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         self.assertEqual(len(channel.json_body["chunk"]), 1)
 
         thread_message = channel.json_body["chunk"][0]
-        self.assertEquals(
+        self.assertEqual(
             thread_message["unsigned"].get("m.relations"),
             {
                 RelationTypes.ANNOTATION: {
@@ -905,7 +905,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/_matrix/client/unstable/rooms/{room2}/relations/{parent_id}",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         self.assertEqual(channel.json_body["chunk"], [])
 
         # And when fetching aggregations.
@@ -914,7 +914,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/_matrix/client/unstable/rooms/{room2}/aggregations/{parent_id}",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         self.assertEqual(channel.json_body["chunk"], [])
 
         # And for bundled aggregations.
@@ -923,7 +923,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/rooms/{room2}/event/{parent_id}",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         self.assertNotIn("m.relations", channel.json_body["unsigned"])
 
     @unittest.override_config({"experimental_features": {"msc3666_enabled": True}})
@@ -936,7 +936,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             "m.room.message",
             content={"msgtype": "m.text", "body": "foo", "m.new_content": new_body},
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         edit_event_id = channel.json_body["event_id"]
 
@@ -958,8 +958,8 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/rooms/{self.room}/event/{self.parent_id}",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
-        self.assertEquals(channel.json_body["content"], new_body)
+        self.assertEqual(200, channel.code, channel.json_body)
+        self.assertEqual(channel.json_body["content"], new_body)
         assert_bundle(channel.json_body)
 
         # Request the room messages.
@@ -968,7 +968,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/rooms/{self.room}/messages?dir=b",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         assert_bundle(self._find_event_in_chunk(channel.json_body["chunk"]))
 
         # Request the room context.
@@ -977,7 +977,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/rooms/{self.room}/context/{self.parent_id}",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         assert_bundle(channel.json_body["event"])
 
         # Request sync, but limit the timeline so it becomes limited (and includes
@@ -988,7 +988,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         channel = self.make_request(
             "GET", f"/sync?filter={filter}", access_token=self.user_token
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         room_timeline = channel.json_body["rooms"]["join"][self.room]["timeline"]
         self.assertTrue(room_timeline["limited"])
         assert_bundle(self._find_event_in_chunk(room_timeline["events"]))
@@ -1001,7 +1001,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             content={"search_categories": {"room_events": {"search_term": "Hi"}}},
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         chunk = [
             result["result"]
             for result in channel.json_body["search_categories"]["room_events"][
@@ -1024,7 +1024,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 "m.new_content": {"msgtype": "m.text", "body": "First edit"},
             },
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         new_body = {"msgtype": "m.text", "body": "I've been edited!"}
         channel = self._send_relation(
@@ -1032,7 +1032,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             "m.room.message",
             content={"msgtype": "m.text", "body": "foo", "m.new_content": new_body},
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         edit_event_id = channel.json_body["event_id"]
 
@@ -1045,16 +1045,16 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 "m.new_content": {"msgtype": "m.text", "body": "Edit, but wrong type"},
             },
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         channel = self.make_request(
             "GET",
             "/rooms/%s/event/%s" % (self.room, self.parent_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
-        self.assertEquals(channel.json_body["content"], new_body)
+        self.assertEqual(channel.json_body["content"], new_body)
 
         relations_dict = channel.json_body["unsigned"].get("m.relations")
         self.assertIn(RelationTypes.REPLACE, relations_dict)
@@ -1076,7 +1076,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             "m.room.message",
             content={"msgtype": "m.text", "body": "A reply!"},
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         reply = channel.json_body["event_id"]
 
         new_body = {"msgtype": "m.text", "body": "I've been edited!"}
@@ -1086,7 +1086,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             content={"msgtype": "m.text", "body": "foo", "m.new_content": new_body},
             parent_id=reply,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         edit_event_id = channel.json_body["event_id"]
 
@@ -1095,7 +1095,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             "/rooms/%s/event/%s" % (self.room, reply),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # We expect to see the new body in the dict, as well as the reference
         # metadata sill intact.
@@ -1133,7 +1133,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             "m.room.message",
             content={"msgtype": "m.text", "body": "A threaded reply!"},
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         threaded_event_id = channel.json_body["event_id"]
 
         new_body = {"msgtype": "m.text", "body": "I've been edited!"}
@@ -1143,7 +1143,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             content={"msgtype": "m.text", "body": "foo", "m.new_content": new_body},
             parent_id=threaded_event_id,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # Fetch the thread root, to get the bundled aggregation for the thread.
         channel = self.make_request(
@@ -1151,7 +1151,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/rooms/{self.room}/event/{self.parent_id}",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # We expect that the edit message appears in the thread summary in the
         # unsigned relations section.
@@ -1161,9 +1161,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         thread_summary = relations_dict[RelationTypes.THREAD]
         self.assertIn("latest_event", thread_summary)
         latest_event_in_thread = thread_summary["latest_event"]
-        self.assertEquals(
-            latest_event_in_thread["content"]["body"], "I've been edited!"
-        )
+        self.assertEqual(latest_event_in_thread["content"]["body"], "I've been edited!")
 
     def test_edit_edit(self):
         """Test that an edit cannot be edited."""
@@ -1177,7 +1175,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 "m.new_content": new_body,
             },
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         edit_event_id = channel.json_body["event_id"]
 
         # Edit the edit event.
@@ -1191,7 +1189,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             },
             parent_id=edit_event_id,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # Request the original event.
         channel = self.make_request(
@@ -1199,9 +1197,9 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             "/rooms/%s/event/%s" % (self.room, self.parent_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         # The edit to the edit should be ignored.
-        self.assertEquals(channel.json_body["content"], new_body)
+        self.assertEqual(channel.json_body["content"], new_body)
 
         # The relations information should not include the edit to the edit.
         relations_dict = channel.json_body["unsigned"].get("m.relations")
@@ -1234,7 +1232,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
                 "m.new_content": {"msgtype": "m.text", "body": "First edit"},
             },
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # Check the relation is returned
         channel = self.make_request(
@@ -1243,10 +1241,10 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             % (self.room, original_event_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         self.assertIn("chunk", channel.json_body)
-        self.assertEquals(len(channel.json_body["chunk"]), 1)
+        self.assertEqual(len(channel.json_body["chunk"]), 1)
 
         # Redact the original event
         channel = self.make_request(
@@ -1256,7 +1254,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             access_token=self.user_token,
             content="{}",
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # Try to check for remaining m.replace relations
         channel = self.make_request(
@@ -1265,11 +1263,11 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             % (self.room, original_event_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # Check that no relations are returned
         self.assertIn("chunk", channel.json_body)
-        self.assertEquals(channel.json_body["chunk"], [])
+        self.assertEqual(channel.json_body["chunk"], [])
 
     def test_aggregations_redaction_prevents_access_to_aggregations(self):
         """Test that annotations of an event are redacted when the original event
@@ -1283,7 +1281,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         channel = self._send_relation(
             RelationTypes.ANNOTATION, "m.reaction", key="👍", parent_id=original_event_id
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # Redact the original
         channel = self.make_request(
@@ -1297,7 +1295,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             access_token=self.user_token,
             content="{}",
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # Check that aggregations returns zero
         channel = self.make_request(
@@ -1306,15 +1304,15 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             % (self.room, original_event_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         self.assertIn("chunk", channel.json_body)
-        self.assertEquals(channel.json_body["chunk"], [])
+        self.assertEqual(channel.json_body["chunk"], [])
 
     def test_unknown_relations(self):
         """Unknown relations should be accepted."""
         channel = self._send_relation("m.relation.test", "m.room.test")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         event_id = channel.json_body["event_id"]
 
         channel = self.make_request(
@@ -1323,18 +1321,18 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             % (self.room, self.parent_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
 
         # We expect to get back a single pagination result, which is the full
         # relation event we sent above.
-        self.assertEquals(len(channel.json_body["chunk"]), 1, channel.json_body)
+        self.assertEqual(len(channel.json_body["chunk"]), 1, channel.json_body)
         self.assert_dict(
             {"event_id": event_id, "sender": self.user_id, "type": "m.room.test"},
             channel.json_body["chunk"][0],
         )
 
         # We also expect to get the original event (the id of which is self.parent_id)
-        self.assertEquals(
+        self.assertEqual(
             channel.json_body["original_event"]["event_id"], self.parent_id
         )
 
@@ -1344,7 +1342,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             "/rooms/%s/event/%s" % (self.room, self.parent_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         self.assertNotIn("m.relations", channel.json_body["unsigned"])
 
         # But unknown relations can be directly queried.
@@ -1354,8 +1352,8 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             % (self.room, self.parent_id),
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
-        self.assertEquals(channel.json_body["chunk"], [])
+        self.assertEqual(200, channel.code, channel.json_body)
+        self.assertEqual(channel.json_body["chunk"], [])
 
     def _find_event_in_chunk(self, events: List[JsonDict]) -> JsonDict:
         """
@@ -1422,15 +1420,15 @@ class RelationsTestCase(unittest.HomeserverTestCase):
     def test_background_update(self):
         """Test the event_arbitrary_relations background update."""
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", key="👍")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         annotation_event_id_good = channel.json_body["event_id"]
 
         channel = self._send_relation(RelationTypes.ANNOTATION, "m.reaction", key="A")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         annotation_event_id_bad = channel.json_body["event_id"]
 
         channel = self._send_relation(RelationTypes.THREAD, "m.room.test")
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         thread_event_id = channel.json_body["event_id"]
 
         # Clean-up the table as if the inserts did not happen during event creation.
@@ -1450,8 +1448,8 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/_matrix/client/unstable/rooms/{self.room}/relations/{self.parent_id}?limit=10",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
-        self.assertEquals(
+        self.assertEqual(200, channel.code, channel.json_body)
+        self.assertEqual(
             [ev["event_id"] for ev in channel.json_body["chunk"]],
             [annotation_event_id_good],
         )
@@ -1475,7 +1473,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             f"/_matrix/client/unstable/rooms/{self.room}/relations/{self.parent_id}?limit=10",
             access_token=self.user_token,
         )
-        self.assertEquals(200, channel.code, channel.json_body)
+        self.assertEqual(200, channel.code, channel.json_body)
         self.assertCountEqual(
             [ev["event_id"] for ev in channel.json_body["chunk"]],
             [annotation_event_id_good, thread_event_id],

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -265,7 +265,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             found_event_ids.extend(e["event_id"] for e in channel.json_body["chunk"])
             next_batch = channel.json_body.get("next_batch")
 
-            self.assertNotEquals(prev_token, next_batch)
+            self.assertNotEqual(prev_token, next_batch)
             prev_token = next_batch
 
             if not prev_token:
@@ -293,7 +293,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             found_event_ids.extend(e["event_id"] for e in channel.json_body["chunk"])
             next_batch = channel.json_body.get("next_batch")
 
-            self.assertNotEquals(prev_token, next_batch)
+            self.assertNotEqual(prev_token, next_batch)
             prev_token = next_batch
 
             if not prev_token:
@@ -419,7 +419,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
             next_batch = channel.json_body.get("next_batch")
 
-            self.assertNotEquals(prev_token, next_batch)
+            self.assertNotEqual(prev_token, next_batch)
             prev_token = next_batch
 
             if not prev_token:
@@ -481,7 +481,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
             next_batch = channel.json_body.get("next_batch")
 
-            self.assertNotEquals(prev_token, next_batch)
+            self.assertNotEqual(prev_token, next_batch)
             prev_token = next_batch
 
             if not prev_token:
@@ -514,7 +514,7 @@ class RelationsTestCase(unittest.HomeserverTestCase):
 
             next_batch = channel.json_body.get("next_batch")
 
-            self.assertNotEquals(prev_token, next_batch)
+            self.assertNotEqual(prev_token, next_batch)
             prev_token = next_batch
 
             if not prev_token:

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -95,7 +95,7 @@ class RoomPermissionsTestCase(RoomBase):
         channel = self.make_request(
             "PUT", self.created_rmid_msg_path, b'{"msgtype":"m.text","body":"test msg"}'
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         # set topic for public room
         channel = self.make_request(
@@ -103,7 +103,7 @@ class RoomPermissionsTestCase(RoomBase):
             ("rooms/%s/state/m.room.topic" % self.created_public_rmid).encode("ascii"),
             b'{"topic":"Public Room Topic"}',
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         # auth as user_id now
         self.helper.auth_user_id = self.user_id
@@ -125,28 +125,28 @@ class RoomPermissionsTestCase(RoomBase):
             "/rooms/%s/send/m.room.message/mid2" % (self.uncreated_rmid,),
             msg_content,
         )
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
         # send message in created room not joined (no state), expect 403
         channel = self.make_request("PUT", send_msg_path(), msg_content)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
         # send message in created room and invited, expect 403
         self.helper.invite(
             room=self.created_rmid, src=self.rmcreator_id, targ=self.user_id
         )
         channel = self.make_request("PUT", send_msg_path(), msg_content)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
         # send message in created room and joined, expect 200
         self.helper.join(room=self.created_rmid, user=self.user_id)
         channel = self.make_request("PUT", send_msg_path(), msg_content)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         # send message in created room and left, expect 403
         self.helper.leave(room=self.created_rmid, user=self.user_id)
         channel = self.make_request("PUT", send_msg_path(), msg_content)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
     def test_topic_perms(self):
         topic_content = b'{"topic":"My Topic Name"}'
@@ -156,28 +156,28 @@ class RoomPermissionsTestCase(RoomBase):
         channel = self.make_request(
             "PUT", "/rooms/%s/state/m.room.topic" % self.uncreated_rmid, topic_content
         )
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
         channel = self.make_request(
             "GET", "/rooms/%s/state/m.room.topic" % self.uncreated_rmid
         )
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
         # set/get topic in created PRIVATE room not joined, expect 403
         channel = self.make_request("PUT", topic_path, topic_content)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
         channel = self.make_request("GET", topic_path)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
         # set topic in created PRIVATE room and invited, expect 403
         self.helper.invite(
             room=self.created_rmid, src=self.rmcreator_id, targ=self.user_id
         )
         channel = self.make_request("PUT", topic_path, topic_content)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
         # get topic in created PRIVATE room and invited, expect 403
         channel = self.make_request("GET", topic_path)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
         # set/get topic in created PRIVATE room and joined, expect 200
         self.helper.join(room=self.created_rmid, user=self.user_id)
@@ -185,25 +185,25 @@ class RoomPermissionsTestCase(RoomBase):
         # Only room ops can set topic by default
         self.helper.auth_user_id = self.rmcreator_id
         channel = self.make_request("PUT", topic_path, topic_content)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
         self.helper.auth_user_id = self.user_id
 
         channel = self.make_request("GET", topic_path)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
         self.assert_dict(json.loads(topic_content.decode("utf8")), channel.json_body)
 
         # set/get topic in created PRIVATE room and left, expect 403
         self.helper.leave(room=self.created_rmid, user=self.user_id)
         channel = self.make_request("PUT", topic_path, topic_content)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
         channel = self.make_request("GET", topic_path)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         # get topic in PUBLIC room, not joined, expect 403
         channel = self.make_request(
             "GET", "/rooms/%s/state/m.room.topic" % self.created_public_rmid
         )
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
         # set topic in PUBLIC room, not joined, expect 403
         channel = self.make_request(
@@ -211,7 +211,7 @@ class RoomPermissionsTestCase(RoomBase):
             "/rooms/%s/state/m.room.topic" % self.created_public_rmid,
             topic_content,
         )
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
     def _test_get_membership(
         self, room=None, members: Iterable = frozenset(), expect_code=None
@@ -219,7 +219,7 @@ class RoomPermissionsTestCase(RoomBase):
         for member in members:
             path = "/rooms/%s/state/m.room.member/%s" % (room, member)
             channel = self.make_request("GET", path)
-            self.assertEquals(expect_code, channel.code)
+            self.assertEqual(expect_code, channel.code)
 
     def test_membership_basic_room_perms(self):
         # === room does not exist ===
@@ -478,16 +478,16 @@ class RoomsMemberListTestCase(RoomBase):
     def test_get_member_list(self):
         room_id = self.helper.create_room_as(self.user_id)
         channel = self.make_request("GET", "/rooms/%s/members" % room_id)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
     def test_get_member_list_no_room(self):
         channel = self.make_request("GET", "/rooms/roomdoesnotexist/members")
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
     def test_get_member_list_no_permission(self):
         room_id = self.helper.create_room_as("@some_other_guy:red")
         channel = self.make_request("GET", "/rooms/%s/members" % room_id)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
     def test_get_member_list_no_permission_with_at_token(self):
         """
@@ -498,7 +498,7 @@ class RoomsMemberListTestCase(RoomBase):
 
         # first sync to get an at token
         channel = self.make_request("GET", "/sync")
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         sync_token = channel.json_body["next_batch"]
 
         # check that permission is denied for @sid1:red to get the
@@ -507,7 +507,7 @@ class RoomsMemberListTestCase(RoomBase):
             "GET",
             f"/rooms/{room_id}/members?at={sync_token}",
         )
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
     def test_get_member_list_no_permission_former_member(self):
         """
@@ -520,14 +520,14 @@ class RoomsMemberListTestCase(RoomBase):
 
         # check that the user can see the member list to start with
         channel = self.make_request("GET", "/rooms/%s/members" % room_id)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         # ban the user
         self.helper.change_membership(room_id, "@alice:red", self.user_id, "ban")
 
         # check the user can no longer see the member list
         channel = self.make_request("GET", "/rooms/%s/members" % room_id)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
     def test_get_member_list_no_permission_former_member_with_at_token(self):
         """
@@ -541,14 +541,14 @@ class RoomsMemberListTestCase(RoomBase):
 
         # sync to get an at token
         channel = self.make_request("GET", "/sync")
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         sync_token = channel.json_body["next_batch"]
 
         # check that the user can see the member list to start with
         channel = self.make_request(
             "GET", "/rooms/%s/members?at=%s" % (room_id, sync_token)
         )
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         # ban the user (Note: the user is actually allowed to see this event and
         # state so that they know they're banned!)
@@ -560,14 +560,14 @@ class RoomsMemberListTestCase(RoomBase):
 
         # now, with the original user, sync again to get a new at token
         channel = self.make_request("GET", "/sync")
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         sync_token = channel.json_body["next_batch"]
 
         # check the user can no longer see the updated member list
         channel = self.make_request(
             "GET", "/rooms/%s/members?at=%s" % (room_id, sync_token)
         )
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
     def test_get_member_list_mixed_memberships(self):
         room_creator = "@some_other_guy:red"
@@ -576,17 +576,17 @@ class RoomsMemberListTestCase(RoomBase):
         self.helper.invite(room=room_id, src=room_creator, targ=self.user_id)
         # can't see list if you're just invited.
         channel = self.make_request("GET", room_path)
-        self.assertEquals(403, channel.code, msg=channel.result["body"])
+        self.assertEqual(403, channel.code, msg=channel.result["body"])
 
         self.helper.join(room=room_id, user=self.user_id)
         # can see list now joined
         channel = self.make_request("GET", room_path)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         self.helper.leave(room=room_id, user=self.user_id)
         # can see old list once left
         channel = self.make_request("GET", room_path)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
 
 class RoomsCreateTestCase(RoomBase):
@@ -598,19 +598,19 @@ class RoomsCreateTestCase(RoomBase):
         # POST with no config keys, expect new room id
         channel = self.make_request("POST", "/createRoom", "{}")
 
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         self.assertTrue("room_id" in channel.json_body)
 
     def test_post_room_visibility_key(self):
         # POST with visibility config key, expect new room id
         channel = self.make_request("POST", "/createRoom", b'{"visibility":"private"}')
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         self.assertTrue("room_id" in channel.json_body)
 
     def test_post_room_custom_key(self):
         # POST with custom config keys, expect new room id
         channel = self.make_request("POST", "/createRoom", b'{"custom":"stuff"}')
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         self.assertTrue("room_id" in channel.json_body)
 
     def test_post_room_known_and_unknown_keys(self):
@@ -618,16 +618,16 @@ class RoomsCreateTestCase(RoomBase):
         channel = self.make_request(
             "POST", "/createRoom", b'{"visibility":"private","custom":"things"}'
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         self.assertTrue("room_id" in channel.json_body)
 
     def test_post_room_invalid_content(self):
         # POST with invalid content / paths, expect 400
         channel = self.make_request("POST", "/createRoom", b'{"visibili')
-        self.assertEquals(400, channel.code)
+        self.assertEqual(400, channel.code)
 
         channel = self.make_request("POST", "/createRoom", b'["hello"]')
-        self.assertEquals(400, channel.code)
+        self.assertEqual(400, channel.code)
 
     def test_post_room_invitees_invalid_mxid(self):
         # POST with invalid invitee, see https://github.com/matrix-org/synapse/issues/4088
@@ -635,7 +635,7 @@ class RoomsCreateTestCase(RoomBase):
         channel = self.make_request(
             "POST", "/createRoom", b'{"invite":["@alice:example.com "]}'
         )
-        self.assertEquals(400, channel.code)
+        self.assertEqual(400, channel.code)
 
     @unittest.override_config({"rc_invites": {"per_room": {"burst_count": 3}}})
     def test_post_room_invitees_ratelimit(self):
@@ -694,9 +694,9 @@ class RoomsCreateTestCase(RoomBase):
             "/createRoom",
             {},
         )
-        self.assertEquals(channel.code, 200, channel.json_body)
+        self.assertEqual(channel.code, 200, channel.json_body)
 
-        self.assertEquals(join_mock.call_count, 0)
+        self.assertEqual(join_mock.call_count, 0)
 
 
 class RoomTopicTestCase(RoomBase):
@@ -712,54 +712,54 @@ class RoomTopicTestCase(RoomBase):
     def test_invalid_puts(self):
         # missing keys or invalid json
         channel = self.make_request("PUT", self.path, "{}")
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", self.path, '{"_name":"bo"}')
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", self.path, '{"nao')
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request(
             "PUT", self.path, '[{"_name":"bo"},{"_name":"jill"}]'
         )
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", self.path, "text only")
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", self.path, "")
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         # valid key, wrong type
         content = '{"topic":["Topic name"]}'
         channel = self.make_request("PUT", self.path, content)
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
     def test_rooms_topic(self):
         # nothing should be there
         channel = self.make_request("GET", self.path)
-        self.assertEquals(404, channel.code, msg=channel.result["body"])
+        self.assertEqual(404, channel.code, msg=channel.result["body"])
 
         # valid put
         content = '{"topic":"Topic name"}'
         channel = self.make_request("PUT", self.path, content)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         # valid get
         channel = self.make_request("GET", self.path)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
         self.assert_dict(json.loads(content), channel.json_body)
 
     def test_rooms_topic_with_extra_keys(self):
         # valid put with extra keys
         content = '{"topic":"Seasons","subtopic":"Summer"}'
         channel = self.make_request("PUT", self.path, content)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         # valid get
         channel = self.make_request("GET", self.path)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
         self.assert_dict(json.loads(content), channel.json_body)
 
 
@@ -775,22 +775,22 @@ class RoomMemberStateTestCase(RoomBase):
         path = "/rooms/%s/state/m.room.member/%s" % (self.room_id, self.user_id)
         # missing keys or invalid json
         channel = self.make_request("PUT", path, "{}")
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", path, '{"_name":"bo"}')
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", path, '{"nao')
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", path, b'[{"_name":"bo"},{"_name":"jill"}]')
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", path, "text only")
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", path, "")
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         # valid keys, wrong types
         content = '{"membership":["%s","%s","%s"]}' % (
@@ -799,7 +799,7 @@ class RoomMemberStateTestCase(RoomBase):
             Membership.LEAVE,
         )
         channel = self.make_request("PUT", path, content.encode("ascii"))
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
     def test_rooms_members_self(self):
         path = "/rooms/%s/state/m.room.member/%s" % (
@@ -810,13 +810,13 @@ class RoomMemberStateTestCase(RoomBase):
         # valid join message (NOOP since we made the room)
         content = '{"membership":"%s"}' % Membership.JOIN
         channel = self.make_request("PUT", path, content.encode("ascii"))
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("GET", path, None)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         expected_response = {"membership": Membership.JOIN}
-        self.assertEquals(expected_response, channel.json_body)
+        self.assertEqual(expected_response, channel.json_body)
 
     def test_rooms_members_other(self):
         self.other_id = "@zzsid1:red"
@@ -828,11 +828,11 @@ class RoomMemberStateTestCase(RoomBase):
         # valid invite message
         content = '{"membership":"%s"}' % Membership.INVITE
         channel = self.make_request("PUT", path, content)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("GET", path, None)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
-        self.assertEquals(json.loads(content), channel.json_body)
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(json.loads(content), channel.json_body)
 
     def test_rooms_members_other_custom_keys(self):
         self.other_id = "@zzsid1:red"
@@ -847,11 +847,11 @@ class RoomMemberStateTestCase(RoomBase):
             "Join us!",
         )
         channel = self.make_request("PUT", path, content)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("GET", path, None)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
-        self.assertEquals(json.loads(content), channel.json_body)
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(json.loads(content), channel.json_body)
 
 
 class RoomInviteRatelimitTestCase(RoomBase):
@@ -937,7 +937,7 @@ class RoomJoinTestCase(RoomBase):
                 False,
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             callback_mock.call_args,
             expected_call_args,
             callback_mock.call_args,
@@ -955,7 +955,7 @@ class RoomJoinTestCase(RoomBase):
                 True,
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             callback_mock.call_args,
             expected_call_args,
             callback_mock.call_args,
@@ -1013,7 +1013,7 @@ class RoomJoinRatelimitTestCase(RoomBase):
         # Update the display name for the user.
         path = "/_matrix/client/r0/profile/%s/displayname" % self.user_id
         channel = self.make_request("PUT", path, {"displayname": "John Doe"})
-        self.assertEquals(channel.code, 200, channel.json_body)
+        self.assertEqual(channel.code, 200, channel.json_body)
 
         # Check that all the rooms have been sent a profile update into.
         for room_id in room_ids:
@@ -1023,10 +1023,10 @@ class RoomJoinRatelimitTestCase(RoomBase):
             )
 
             channel = self.make_request("GET", path)
-            self.assertEquals(channel.code, 200)
+            self.assertEqual(channel.code, 200)
 
             self.assertIn("displayname", channel.json_body)
-            self.assertEquals(channel.json_body["displayname"], "John Doe")
+            self.assertEqual(channel.json_body["displayname"], "John Doe")
 
     @unittest.override_config(
         {"rc_joins": {"local": {"per_second": 0.5, "burst_count": 3}}}
@@ -1047,7 +1047,7 @@ class RoomJoinRatelimitTestCase(RoomBase):
             # if all of these requests ended up joining the user to a room.
             for _ in range(4):
                 channel = self.make_request("POST", path % room_id, {})
-                self.assertEquals(channel.code, 200)
+                self.assertEqual(channel.code, 200)
 
     @unittest.override_config(
         {
@@ -1078,40 +1078,40 @@ class RoomMessagesTestCase(RoomBase):
         path = "/rooms/%s/send/m.room.message/mid1" % (urlparse.quote(self.room_id))
         # missing keys or invalid json
         channel = self.make_request("PUT", path, b"{}")
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", path, b'{"_name":"bo"}')
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", path, b'{"nao')
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", path, b'[{"_name":"bo"},{"_name":"jill"}]')
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", path, b"text only")
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         channel = self.make_request("PUT", path, b"")
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
     def test_rooms_messages_sent(self):
         path = "/rooms/%s/send/m.room.message/mid1" % (urlparse.quote(self.room_id))
 
         content = b'{"body":"test","msgtype":{"type":"a"}}'
         channel = self.make_request("PUT", path, content)
-        self.assertEquals(400, channel.code, msg=channel.result["body"])
+        self.assertEqual(400, channel.code, msg=channel.result["body"])
 
         # custom message types
         content = b'{"body":"test","msgtype":"test.custom.text"}'
         channel = self.make_request("PUT", path, content)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
         # m.text message type
         path = "/rooms/%s/send/m.room.message/mid2" % (urlparse.quote(self.room_id))
         content = b'{"body":"test2","msgtype":"m.text"}'
         channel = self.make_request("PUT", path, content)
-        self.assertEquals(200, channel.code, msg=channel.result["body"])
+        self.assertEqual(200, channel.code, msg=channel.result["body"])
 
 
 class RoomInitialSyncTestCase(RoomBase):
@@ -1125,10 +1125,10 @@ class RoomInitialSyncTestCase(RoomBase):
 
     def test_initial_sync(self):
         channel = self.make_request("GET", "/rooms/%s/initialSync" % self.room_id)
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
 
-        self.assertEquals(self.room_id, channel.json_body["room_id"])
-        self.assertEquals("join", channel.json_body["membership"])
+        self.assertEqual(self.room_id, channel.json_body["room_id"])
+        self.assertEqual("join", channel.json_body["membership"])
 
         # Room state is easier to assert on if we unpack it into a dict
         state = {}
@@ -1152,7 +1152,7 @@ class RoomInitialSyncTestCase(RoomBase):
             e["content"]["user_id"]: e for e in channel.json_body["presence"]
         }
         self.assertTrue(self.user_id in presence_by_user)
-        self.assertEquals("m.presence", presence_by_user[self.user_id]["type"])
+        self.assertEqual("m.presence", presence_by_user[self.user_id]["type"])
 
 
 class RoomMessageListTestCase(RoomBase):
@@ -1168,9 +1168,9 @@ class RoomMessageListTestCase(RoomBase):
         channel = self.make_request(
             "GET", "/rooms/%s/messages?access_token=x&from=%s" % (self.room_id, token)
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         self.assertTrue("start" in channel.json_body)
-        self.assertEquals(token, channel.json_body["start"])
+        self.assertEqual(token, channel.json_body["start"])
         self.assertTrue("chunk" in channel.json_body)
         self.assertTrue("end" in channel.json_body)
 
@@ -1179,9 +1179,9 @@ class RoomMessageListTestCase(RoomBase):
         channel = self.make_request(
             "GET", "/rooms/%s/messages?access_token=x&from=%s" % (self.room_id, token)
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         self.assertTrue("start" in channel.json_body)
-        self.assertEquals(token, channel.json_body["start"])
+        self.assertEqual(token, channel.json_body["start"])
         self.assertTrue("chunk" in channel.json_body)
         self.assertTrue("end" in channel.json_body)
 
@@ -2614,7 +2614,7 @@ class ThreepidInviteTestCase(unittest.HomeserverTestCase):
             },
             access_token=self.tok,
         )
-        self.assertEquals(channel.code, 200)
+        self.assertEqual(channel.code, 200)
 
         # Check that the callback was called with the right params.
         mock.assert_called_with(self.user_id, "email", email_to_invite, self.room_id)
@@ -2636,7 +2636,7 @@ class ThreepidInviteTestCase(unittest.HomeserverTestCase):
             },
             access_token=self.tok,
         )
-        self.assertEquals(channel.code, 403)
+        self.assertEqual(channel.code, 403)
 
         # Also check that it stopped before calling _make_and_store_3pid_invite.
         make_invite_mock.assert_called_once()

--- a/tests/rest/client/test_shadow_banned.py
+++ b/tests/rest/client/test_shadow_banned.py
@@ -96,7 +96,7 @@ class RoomTestCase(_ShadowBannedBase):
             {"id_server": "test", "medium": "email", "address": "test@test.test"},
             access_token=self.banned_access_token,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         # This should have raised an error earlier, but double check this wasn't called.
         identity_handler.lookup_3pid.assert_not_called()
@@ -110,7 +110,7 @@ class RoomTestCase(_ShadowBannedBase):
             {"visibility": "public", "invite": [self.other_user_id]},
             access_token=self.banned_access_token,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         room_id = channel.json_body["room_id"]
 
         # But the user wasn't actually invited.
@@ -165,7 +165,7 @@ class RoomTestCase(_ShadowBannedBase):
             {"new_version": "6"},
             access_token=self.banned_access_token,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         # A new room_id should be returned.
         self.assertIn("replacement_room", channel.json_body)
 
@@ -190,11 +190,11 @@ class RoomTestCase(_ShadowBannedBase):
             {"typing": True, "timeout": 30000},
             access_token=self.banned_access_token,
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
 
         # There should be no typing events.
         event_source = self.hs.get_event_sources().sources.typing
-        self.assertEquals(event_source.get_current_key(), 0)
+        self.assertEqual(event_source.get_current_key(), 0)
 
         # The other user can join and send typing events.
         self.helper.join(room_id, self.other_user_id, tok=self.other_access_token)
@@ -205,10 +205,10 @@ class RoomTestCase(_ShadowBannedBase):
             {"typing": True, "timeout": 30000},
             access_token=self.other_access_token,
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
 
         # These appear in the room.
-        self.assertEquals(event_source.get_current_key(), 1)
+        self.assertEqual(event_source.get_current_key(), 1)
         events = self.get_success(
             event_source.get_new_events(
                 user=UserID.from_string(self.other_user_id),
@@ -218,7 +218,7 @@ class RoomTestCase(_ShadowBannedBase):
                 is_guest=False,
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             events[0],
             [
                 {
@@ -257,7 +257,7 @@ class ProfileTestCase(_ShadowBannedBase):
             {"displayname": new_display_name},
             access_token=self.banned_access_token,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         self.assertEqual(channel.json_body, {})
 
         # The user's display name should be updated.
@@ -299,7 +299,7 @@ class ProfileTestCase(_ShadowBannedBase):
             {"membership": "join", "displayname": new_display_name},
             access_token=self.banned_access_token,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         self.assertIn("event_id", channel.json_body)
 
         # The display name in the room should not be changed.

--- a/tests/rest/client/test_shared_rooms.py
+++ b/tests/rest/client/test_shared_rooms.py
@@ -91,9 +91,9 @@ class UserSharedRoomsTest(unittest.HomeserverTestCase):
         # Check shared rooms from user1's perspective.
         # We should see the one room in common
         channel = self._get_shared_rooms(u1_token, u2)
-        self.assertEquals(200, channel.code, channel.result)
-        self.assertEquals(len(channel.json_body["joined"]), 1)
-        self.assertEquals(channel.json_body["joined"][0], room_id_one)
+        self.assertEqual(200, channel.code, channel.result)
+        self.assertEqual(len(channel.json_body["joined"]), 1)
+        self.assertEqual(channel.json_body["joined"][0], room_id_one)
 
         # Create another room and invite user2 to it
         room_id_two = self.helper.create_room_as(
@@ -104,8 +104,8 @@ class UserSharedRoomsTest(unittest.HomeserverTestCase):
 
         # Check shared rooms again. We should now see both rooms.
         channel = self._get_shared_rooms(u1_token, u2)
-        self.assertEquals(200, channel.code, channel.result)
-        self.assertEquals(len(channel.json_body["joined"]), 2)
+        self.assertEqual(200, channel.code, channel.result)
+        self.assertEqual(len(channel.json_body["joined"]), 2)
         for room_id_id in channel.json_body["joined"]:
             self.assertIn(room_id_id, [room_id_one, room_id_two])
 
@@ -125,18 +125,18 @@ class UserSharedRoomsTest(unittest.HomeserverTestCase):
 
         # Assert user directory is not empty
         channel = self._get_shared_rooms(u1_token, u2)
-        self.assertEquals(200, channel.code, channel.result)
-        self.assertEquals(len(channel.json_body["joined"]), 1)
-        self.assertEquals(channel.json_body["joined"][0], room)
+        self.assertEqual(200, channel.code, channel.result)
+        self.assertEqual(len(channel.json_body["joined"]), 1)
+        self.assertEqual(channel.json_body["joined"][0], room)
 
         self.helper.leave(room, user=u1, tok=u1_token)
 
         # Check user1's view of shared rooms with user2
         channel = self._get_shared_rooms(u1_token, u2)
-        self.assertEquals(200, channel.code, channel.result)
-        self.assertEquals(len(channel.json_body["joined"]), 0)
+        self.assertEqual(200, channel.code, channel.result)
+        self.assertEqual(len(channel.json_body["joined"]), 0)
 
         # Check user2's view of shared rooms with user1
         channel = self._get_shared_rooms(u2_token, u1)
-        self.assertEquals(200, channel.code, channel.result)
-        self.assertEquals(len(channel.json_body["joined"]), 0)
+        self.assertEqual(200, channel.code, channel.result)
+        self.assertEqual(len(channel.json_body["joined"]), 0)

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -237,10 +237,10 @@ class SyncTypingTests(unittest.HomeserverTestCase):
             typing_url % (room, other_user_id, other_access_token),
             b'{"typing": true, "timeout": 30000}',
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
 
         channel = self.make_request("GET", "/sync?access_token=%s" % (access_token,))
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         next_batch = channel.json_body["next_batch"]
 
         # Stop typing.
@@ -249,7 +249,7 @@ class SyncTypingTests(unittest.HomeserverTestCase):
             typing_url % (room, other_user_id, other_access_token),
             b'{"typing": false}',
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
 
         # Start typing.
         channel = self.make_request(
@@ -257,11 +257,11 @@ class SyncTypingTests(unittest.HomeserverTestCase):
             typing_url % (room, other_user_id, other_access_token),
             b'{"typing": true, "timeout": 30000}',
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
 
         # Should return immediately
         channel = self.make_request("GET", sync_url % (access_token, next_batch))
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         next_batch = channel.json_body["next_batch"]
 
         # Reset typing serial back to 0, as if the master had.
@@ -273,7 +273,7 @@ class SyncTypingTests(unittest.HomeserverTestCase):
         self.helper.send(room, body="There!", tok=other_access_token)
 
         channel = self.make_request("GET", sync_url % (access_token, next_batch))
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         next_batch = channel.json_body["next_batch"]
 
         # This should time out! But it does not, because our stream token is
@@ -281,7 +281,7 @@ class SyncTypingTests(unittest.HomeserverTestCase):
         # already seen) is new, since it's got a token above our new, now-reset
         # stream token.
         channel = self.make_request("GET", sync_url % (access_token, next_batch))
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
         next_batch = channel.json_body["next_batch"]
 
         # Clear the typing information, so that it doesn't think everything is
@@ -351,7 +351,7 @@ class SyncKnockTestCase(
             b"{}",
             self.knocker_tok,
         )
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         # We expect to see the knock event in the stripped room state later
         self.expected_room_state[EventTypes.Member] = {

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -139,7 +139,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
             {},
             access_token=self.tok,
         )
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         callback.assert_called_once()
 
@@ -157,7 +157,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
             {},
             access_token=self.tok,
         )
-        self.assertEquals(channel.result["code"], b"403", channel.result)
+        self.assertEqual(channel.result["code"], b"403", channel.result)
 
     def test_third_party_rules_workaround_synapse_errors_pass_through(self):
         """
@@ -193,7 +193,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
             access_token=self.tok,
         )
         # Check the error code
-        self.assertEquals(channel.result["code"], b"429", channel.result)
+        self.assertEqual(channel.result["code"], b"429", channel.result)
         # Check the JSON body has had the `nasty` key injected
         self.assertEqual(
             channel.json_body,
@@ -329,10 +329,10 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
             self.hs.get_module_api().create_and_send_event_into_room(event_dict)
         )
 
-        self.assertEquals(event.sender, self.user_id)
-        self.assertEquals(event.room_id, self.room_id)
-        self.assertEquals(event.type, "m.room.message")
-        self.assertEquals(event.content, content)
+        self.assertEqual(event.sender, self.user_id)
+        self.assertEqual(event.room_id, self.room_id)
+        self.assertEqual(event.type, "m.room.message")
+        self.assertEqual(event.content, content)
 
     @unittest.override_config(
         {

--- a/tests/rest/client/test_typing.py
+++ b/tests/rest/client/test_typing.py
@@ -72,9 +72,9 @@ class RoomTypingTestCase(unittest.HomeserverTestCase):
             "/rooms/%s/typing/%s" % (self.room_id, self.user_id),
             b'{"typing": true, "timeout": 30000}',
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
 
-        self.assertEquals(self.event_source.get_current_key(), 1)
+        self.assertEqual(self.event_source.get_current_key(), 1)
         events = self.get_success(
             self.event_source.get_new_events(
                 user=UserID.from_string(self.user_id),
@@ -84,7 +84,7 @@ class RoomTypingTestCase(unittest.HomeserverTestCase):
                 is_guest=False,
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             events[0],
             [
                 {
@@ -101,7 +101,7 @@ class RoomTypingTestCase(unittest.HomeserverTestCase):
             "/rooms/%s/typing/%s" % (self.room_id, self.user_id),
             b'{"typing": false}',
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
 
     def test_typing_timeout(self):
         channel = self.make_request(
@@ -109,19 +109,19 @@ class RoomTypingTestCase(unittest.HomeserverTestCase):
             "/rooms/%s/typing/%s" % (self.room_id, self.user_id),
             b'{"typing": true, "timeout": 30000}',
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
 
-        self.assertEquals(self.event_source.get_current_key(), 1)
+        self.assertEqual(self.event_source.get_current_key(), 1)
 
         self.reactor.advance(36)
 
-        self.assertEquals(self.event_source.get_current_key(), 2)
+        self.assertEqual(self.event_source.get_current_key(), 2)
 
         channel = self.make_request(
             "PUT",
             "/rooms/%s/typing/%s" % (self.room_id, self.user_id),
             b'{"typing": true, "timeout": 30000}',
         )
-        self.assertEquals(200, channel.code)
+        self.assertEqual(200, channel.code)
 
-        self.assertEquals(self.event_source.get_current_key(), 3)
+        self.assertEqual(self.event_source.get_current_key(), 3)

--- a/tests/rest/client/test_upgrade_room.py
+++ b/tests/rest/client/test_upgrade_room.py
@@ -65,7 +65,7 @@ class UpgradeRoomTest(unittest.HomeserverTestCase):
         Upgrading a room should work fine.
         """
         channel = self._upgrade_room()
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         self.assertIn("replacement_room", channel.json_body)
 
     def test_not_in_room(self):
@@ -77,7 +77,7 @@ class UpgradeRoomTest(unittest.HomeserverTestCase):
         roomless_token = self.login(roomless, "pass")
 
         channel = self._upgrade_room(roomless_token)
-        self.assertEquals(403, channel.code, channel.result)
+        self.assertEqual(403, channel.code, channel.result)
 
     def test_power_levels(self):
         """
@@ -85,7 +85,7 @@ class UpgradeRoomTest(unittest.HomeserverTestCase):
         """
         # The other user doesn't have the proper power level.
         channel = self._upgrade_room(self.other_token)
-        self.assertEquals(403, channel.code, channel.result)
+        self.assertEqual(403, channel.code, channel.result)
 
         # Increase the power levels so that this user can upgrade.
         power_levels = self.helper.get_state(
@@ -103,7 +103,7 @@ class UpgradeRoomTest(unittest.HomeserverTestCase):
 
         # The upgrade should succeed!
         channel = self._upgrade_room(self.other_token)
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
     def test_power_levels_user_default(self):
         """
@@ -111,7 +111,7 @@ class UpgradeRoomTest(unittest.HomeserverTestCase):
         """
         # The other user doesn't have the proper power level.
         channel = self._upgrade_room(self.other_token)
-        self.assertEquals(403, channel.code, channel.result)
+        self.assertEqual(403, channel.code, channel.result)
 
         # Increase the power levels so that this user can upgrade.
         power_levels = self.helper.get_state(
@@ -129,7 +129,7 @@ class UpgradeRoomTest(unittest.HomeserverTestCase):
 
         # The upgrade should succeed!
         channel = self._upgrade_room(self.other_token)
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
     def test_power_levels_tombstone(self):
         """
@@ -137,7 +137,7 @@ class UpgradeRoomTest(unittest.HomeserverTestCase):
         """
         # The other user doesn't have the proper power level.
         channel = self._upgrade_room(self.other_token)
-        self.assertEquals(403, channel.code, channel.result)
+        self.assertEqual(403, channel.code, channel.result)
 
         # Increase the power levels so that this user can upgrade.
         power_levels = self.helper.get_state(
@@ -155,7 +155,7 @@ class UpgradeRoomTest(unittest.HomeserverTestCase):
 
         # The upgrade should succeed!
         channel = self._upgrade_room(self.other_token)
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
 
         power_levels = self.helper.get_state(
             self.room_id,
@@ -197,7 +197,7 @@ class UpgradeRoomTest(unittest.HomeserverTestCase):
 
         # Upgrade the room!
         channel = self._upgrade_room(room_id=space_id)
-        self.assertEquals(200, channel.code, channel.result)
+        self.assertEqual(200, channel.code, channel.result)
         self.assertIn("replacement_room", channel.json_body)
 
         new_space_id = channel.json_body["replacement_room"]

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -94,7 +94,7 @@ class MediaStorageTests(unittest.HomeserverTestCase):
         self.assertTrue(os.path.exists(local_path))
 
         # Asserts the file is under the expected local cache directory
-        self.assertEquals(
+        self.assertEqual(
             os.path.commonprefix([self.primary_base_path, local_path]),
             self.primary_base_path,
         )

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -88,18 +88,18 @@ class HaveSeenEventsTestCase(unittest.HomeserverTestCase):
             res = self.get_success(
                 self.store.have_seen_events("room1", ["event10", "event19"])
             )
-            self.assertEquals(res, {"event10"})
+            self.assertEqual(res, {"event10"})
 
             # that should result in a single db query
-            self.assertEquals(ctx.get_resource_usage().db_txn_count, 1)
+            self.assertEqual(ctx.get_resource_usage().db_txn_count, 1)
 
         # a second lookup of the same events should cause no queries
         with LoggingContext(name="test") as ctx:
             res = self.get_success(
                 self.store.have_seen_events("room1", ["event10", "event19"])
             )
-            self.assertEquals(res, {"event10"})
-            self.assertEquals(ctx.get_resource_usage().db_txn_count, 0)
+            self.assertEqual(res, {"event10"})
+            self.assertEqual(ctx.get_resource_usage().db_txn_count, 0)
 
     def test_query_via_event_cache(self):
         # fetch an event into the event cache
@@ -108,8 +108,8 @@ class HaveSeenEventsTestCase(unittest.HomeserverTestCase):
         # looking it up should now cause no db hits
         with LoggingContext(name="test") as ctx:
             res = self.get_success(self.store.have_seen_events("room1", ["event10"]))
-            self.assertEquals(res, {"event10"})
-            self.assertEquals(ctx.get_resource_usage().db_txn_count, 0)
+            self.assertEqual(res, {"event10"})
+            self.assertEqual(ctx.get_resource_usage().db_txn_count, 0)
 
 
 class EventCacheTestCase(unittest.HomeserverTestCase):

--- a/tests/storage/test_appservice.py
+++ b/tests/storage/test_appservice.py
@@ -88,21 +88,21 @@ class ApplicationServiceStoreTestCase(unittest.HomeserverTestCase):
 
     def test_retrieve_unknown_service_token(self) -> None:
         service = self.store.get_app_service_by_token("invalid_token")
-        self.assertEquals(service, None)
+        self.assertEqual(service, None)
 
     def test_retrieval_of_service(self) -> None:
         stored_service = self.store.get_app_service_by_token(self.as_token)
         assert stored_service is not None
-        self.assertEquals(stored_service.token, self.as_token)
-        self.assertEquals(stored_service.id, self.as_id)
-        self.assertEquals(stored_service.url, self.as_url)
-        self.assertEquals(stored_service.namespaces[ApplicationService.NS_ALIASES], [])
-        self.assertEquals(stored_service.namespaces[ApplicationService.NS_ROOMS], [])
-        self.assertEquals(stored_service.namespaces[ApplicationService.NS_USERS], [])
+        self.assertEqual(stored_service.token, self.as_token)
+        self.assertEqual(stored_service.id, self.as_id)
+        self.assertEqual(stored_service.url, self.as_url)
+        self.assertEqual(stored_service.namespaces[ApplicationService.NS_ALIASES], [])
+        self.assertEqual(stored_service.namespaces[ApplicationService.NS_ROOMS], [])
+        self.assertEqual(stored_service.namespaces[ApplicationService.NS_USERS], [])
 
     def test_retrieval_of_all_services(self) -> None:
         services = self.store.get_app_services()
-        self.assertEquals(len(services), 3)
+        self.assertEqual(len(services), 3)
 
 
 class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
@@ -182,7 +182,7 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
     ) -> None:
         service = Mock(id="999")
         state = self.get_success(self.store.get_appservice_state(service))
-        self.assertEquals(None, state)
+        self.assertEqual(None, state)
 
     def test_get_appservice_state_up(
         self,
@@ -194,7 +194,7 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         state = self.get_success(
             defer.ensureDeferred(self.store.get_appservice_state(service))
         )
-        self.assertEquals(ApplicationServiceState.UP, state)
+        self.assertEqual(ApplicationServiceState.UP, state)
 
     def test_get_appservice_state_down(
         self,
@@ -210,7 +210,7 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         )
         service = Mock(id=self.as_list[1]["id"])
         state = self.get_success(self.store.get_appservice_state(service))
-        self.assertEquals(ApplicationServiceState.DOWN, state)
+        self.assertEqual(ApplicationServiceState.DOWN, state)
 
     def test_get_appservices_by_state_none(
         self,
@@ -218,7 +218,7 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         services = self.get_success(
             self.store.get_appservices_by_state(ApplicationServiceState.DOWN)
         )
-        self.assertEquals(0, len(services))
+        self.assertEqual(0, len(services))
 
     def test_set_appservices_state_down(
         self,
@@ -235,7 +235,7 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
                 (ApplicationServiceState.DOWN.value,),
             )
         )
-        self.assertEquals(service.id, rows[0][0])
+        self.assertEqual(service.id, rows[0][0])
 
     def test_set_appservices_state_multiple_up(
         self,
@@ -258,7 +258,7 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
                 (ApplicationServiceState.UP.value,),
             )
         )
-        self.assertEquals(service.id, rows[0][0])
+        self.assertEqual(service.id, rows[0][0])
 
     def test_create_appservice_txn_first(
         self,
@@ -270,9 +270,9 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
                 self.store.create_appservice_txn(service, events, [], [], {}, {})
             )
         )
-        self.assertEquals(txn.id, 1)
-        self.assertEquals(txn.events, events)
-        self.assertEquals(txn.service, service)
+        self.assertEqual(txn.id, 1)
+        self.assertEqual(txn.events, events)
+        self.assertEqual(txn.service, service)
 
     def test_create_appservice_txn_older_last_txn(
         self,
@@ -285,9 +285,9 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         txn = self.get_success(
             self.store.create_appservice_txn(service, events, [], [], {}, {})
         )
-        self.assertEquals(txn.id, 9646)
-        self.assertEquals(txn.events, events)
-        self.assertEquals(txn.service, service)
+        self.assertEqual(txn.id, 9646)
+        self.assertEqual(txn.events, events)
+        self.assertEqual(txn.service, service)
 
     def test_create_appservice_txn_up_to_date_last_txn(
         self,
@@ -298,9 +298,9 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         txn = self.get_success(
             self.store.create_appservice_txn(service, events, [], [], {}, {})
         )
-        self.assertEquals(txn.id, 9644)
-        self.assertEquals(txn.events, events)
-        self.assertEquals(txn.service, service)
+        self.assertEqual(txn.id, 9644)
+        self.assertEqual(txn.events, events)
+        self.assertEqual(txn.service, service)
 
     def test_create_appservice_txn_up_fuzzing(
         self,
@@ -322,9 +322,9 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         txn = self.get_success(
             self.store.create_appservice_txn(service, events, [], [], {}, {})
         )
-        self.assertEquals(txn.id, 9644)
-        self.assertEquals(txn.events, events)
-        self.assertEquals(txn.service, service)
+        self.assertEqual(txn.id, 9644)
+        self.assertEqual(txn.events, events)
+        self.assertEqual(txn.service, service)
 
     def test_complete_appservice_txn_first_txn(
         self,
@@ -346,8 +346,8 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
                 (service.id,),
             )
         )
-        self.assertEquals(1, len(res))
-        self.assertEquals(txn_id, res[0][0])
+        self.assertEqual(1, len(res))
+        self.assertEqual(txn_id, res[0][0])
 
         res = self.get_success(
             self.db_pool.runQuery(
@@ -357,7 +357,7 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
                 (txn_id,),
             )
         )
-        self.assertEquals(0, len(res))
+        self.assertEqual(0, len(res))
 
     def test_complete_appservice_txn_existing_in_state_table(
         self,
@@ -379,9 +379,9 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
                 (service.id,),
             )
         )
-        self.assertEquals(1, len(res))
-        self.assertEquals(txn_id, res[0][0])
-        self.assertEquals(ApplicationServiceState.UP.value, res[0][1])
+        self.assertEqual(1, len(res))
+        self.assertEqual(txn_id, res[0][0])
+        self.assertEqual(ApplicationServiceState.UP.value, res[0][1])
 
         res = self.get_success(
             self.db_pool.runQuery(
@@ -391,7 +391,7 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
                 (txn_id,),
             )
         )
-        self.assertEquals(0, len(res))
+        self.assertEqual(0, len(res))
 
     def test_get_oldest_unsent_txn_none(
         self,
@@ -399,7 +399,7 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         service = Mock(id=self.as_list[0]["id"])
 
         txn = self.get_success(self.store.get_oldest_unsent_txn(service))
-        self.assertEquals(None, txn)
+        self.assertEqual(None, txn)
 
     def test_get_oldest_unsent_txn(self) -> None:
         service = Mock(id=self.as_list[0]["id"])
@@ -416,9 +416,9 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         self.get_success(self._insert_txn(service.id, 12, other_events))
 
         txn = self.get_success(self.store.get_oldest_unsent_txn(service))
-        self.assertEquals(service, txn.service)
-        self.assertEquals(10, txn.id)
-        self.assertEquals(events, txn.events)
+        self.assertEqual(service, txn.service)
+        self.assertEqual(10, txn.id)
+        self.assertEqual(events, txn.events)
 
     def test_get_appservices_by_state_single(
         self,
@@ -433,8 +433,8 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         services = self.get_success(
             self.store.get_appservices_by_state(ApplicationServiceState.DOWN)
         )
-        self.assertEquals(1, len(services))
-        self.assertEquals(self.as_list[0]["id"], services[0].id)
+        self.assertEqual(1, len(services))
+        self.assertEqual(self.as_list[0]["id"], services[0].id)
 
     def test_get_appservices_by_state_multiple(
         self,
@@ -455,8 +455,8 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         services = self.get_success(
             self.store.get_appservices_by_state(ApplicationServiceState.DOWN)
         )
-        self.assertEquals(2, len(services))
-        self.assertEquals(
+        self.assertEqual(2, len(services))
+        self.assertEqual(
             {self.as_list[2]["id"], self.as_list[0]["id"]},
             {services[0].id, services[1].id},
         )
@@ -476,12 +476,12 @@ class ApplicationServiceStoreTypeStreamIds(unittest.HomeserverTestCase):
         value = self.get_success(
             self.store.get_type_stream_id_for_appservice(self.service, "read_receipt")
         )
-        self.assertEquals(value, 0)
+        self.assertEqual(value, 0)
 
         value = self.get_success(
             self.store.get_type_stream_id_for_appservice(self.service, "presence")
         )
-        self.assertEquals(value, 0)
+        self.assertEqual(value, 0)
 
     def test_get_type_stream_id_for_appservice_invalid_type(self) -> None:
         self.get_failure(

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -103,7 +103,7 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEquals("Value", value)
+        self.assertEqual("Value", value)
         self.mock_txn.execute.assert_called_with(
             "SELECT retcol FROM tablename WHERE keycol = ?", ["TheKey"]
         )
@@ -121,7 +121,7 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEquals({"colA": 1, "colB": 2, "colC": 3}, ret)
+        self.assertEqual({"colA": 1, "colB": 2, "colC": 3}, ret)
         self.mock_txn.execute.assert_called_with(
             "SELECT colA, colB, colC FROM tablename WHERE keycol = ?", ["TheKey"]
         )
@@ -154,7 +154,7 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEquals([{"colA": 1}, {"colA": 2}, {"colA": 3}], ret)
+        self.assertEqual([{"colA": 1}, {"colA": 2}, {"colA": 3}], ret)
         self.mock_txn.execute.assert_called_with(
             "SELECT colA FROM tablename WHERE keycol = ?", ["A set"]
         )

--- a/tests/storage/test_directory.py
+++ b/tests/storage/test_directory.py
@@ -31,7 +31,7 @@ class DirectoryStoreTestCase(HomeserverTestCase):
             )
         )
 
-        self.assertEquals(
+        self.assertEqual(
             ["#my-room:test"],
             (self.get_success(self.store.get_aliases_for_room(self.room.to_string()))),
         )

--- a/tests/storage/test_event_push_actions.py
+++ b/tests/storage/test_event_push_actions.py
@@ -57,7 +57,7 @@ class EventPushActionsStoreTestCase(HomeserverTestCase):
                     "", self.store._get_unread_counts_by_pos_txn, room_id, user_id, 0
                 )
             )
-            self.assertEquals(
+            self.assertEqual(
                 counts,
                 NotifCounts(
                     notify_count=noitf_count,

--- a/tests/storage/test_main.py
+++ b/tests/storage/test_main.py
@@ -38,12 +38,12 @@ class DataStoreTestCase(unittest.HomeserverTestCase):
             self.store.get_users_paginate(0, 10, name="bc", guests=False)
         )
 
-        self.assertEquals(1, total)
-        self.assertEquals(self.displayname, users.pop()["displayname"])
+        self.assertEqual(1, total)
+        self.assertEqual(self.displayname, users.pop()["displayname"])
 
         users, total = self.get_success(
             self.store.get_users_paginate(0, 10, name="BC", guests=False)
         )
 
-        self.assertEquals(1, total)
-        self.assertEquals(self.displayname, users.pop()["displayname"])
+        self.assertEqual(1, total)
+        self.assertEqual(self.displayname, users.pop()["displayname"])

--- a/tests/storage/test_profile.py
+++ b/tests/storage/test_profile.py
@@ -33,7 +33,7 @@ class ProfileStoreTestCase(unittest.HomeserverTestCase):
             self.store.set_profile_displayname(self.u_frank.localpart, "Frank")
         )
 
-        self.assertEquals(
+        self.assertEqual(
             "Frank",
             (
                 self.get_success(
@@ -60,7 +60,7 @@ class ProfileStoreTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertEquals(
+        self.assertEqual(
             "http://my.site/here",
             (
                 self.get_success(

--- a/tests/storage/test_registration.py
+++ b/tests/storage/test_registration.py
@@ -30,7 +30,7 @@ class RegistrationStoreTestCase(HomeserverTestCase):
     def test_register(self):
         self.get_success(self.store.register_user(self.user_id, self.pwhash))
 
-        self.assertEquals(
+        self.assertEqual(
             {
                 # TODO(paul): Surely this field should be 'user_id', not 'name'
                 "name": self.user_id,
@@ -131,7 +131,7 @@ class RegistrationStoreTestCase(HomeserverTestCase):
             ),
             ThreepidValidationError,
         )
-        self.assertEquals(e.value.msg, "Unknown session_id", e)
+        self.assertEqual(e.value.msg, "Unknown session_id", e)
 
         # Set the config setting to true.
         self.store._ignore_unknown_session_error = True
@@ -146,4 +146,4 @@ class RegistrationStoreTestCase(HomeserverTestCase):
             ),
             ThreepidValidationError,
         )
-        self.assertEquals(e.value.msg, "Validation token not found or has expired", e)
+        self.assertEqual(e.value.msg, "Validation token not found or has expired", e)

--- a/tests/storage/test_room.py
+++ b/tests/storage/test_room.py
@@ -104,7 +104,7 @@ class RoomEventsStoreTestCase(HomeserverTestCase):
             self.store.get_current_state(room_id=self.room.to_string())
         )
 
-        self.assertEquals(1, len(state))
+        self.assertEqual(1, len(state))
         self.assertObjectHasAttributes(
             {"type": "m.room.name", "room_id": self.room.to_string(), "name": name},
             state[0],
@@ -121,7 +121,7 @@ class RoomEventsStoreTestCase(HomeserverTestCase):
             self.store.get_current_state(room_id=self.room.to_string())
         )
 
-        self.assertEquals(1, len(state))
+        self.assertEqual(1, len(state))
         self.assertObjectHasAttributes(
             {"type": "m.room.topic", "room_id": self.room.to_string(), "topic": topic},
             state[0],

--- a/tests/storage/test_room_search.py
+++ b/tests/storage/test_room_search.py
@@ -53,7 +53,7 @@ class EventSearchInsertionTest(HomeserverTestCase):
         result = self.get_success(
             store.search_msgs([room_id], "hi bob", ["content.body"])
         )
-        self.assertEquals(result.get("count"), 1)
+        self.assertEqual(result.get("count"), 1)
         if isinstance(store.database_engine, PostgresEngine):
             self.assertIn("hi", result.get("highlights"))
             self.assertIn("bob", result.get("highlights"))
@@ -62,14 +62,14 @@ class EventSearchInsertionTest(HomeserverTestCase):
         result = self.get_success(
             store.search_msgs([room_id], "another", ["content.body"])
         )
-        self.assertEquals(result.get("count"), 1)
+        self.assertEqual(result.get("count"), 1)
         if isinstance(store.database_engine, PostgresEngine):
             self.assertIn("another", result.get("highlights"))
 
         # Check that search works for a search term that overlaps with the message
         # containing a null byte and an unrelated message.
         result = self.get_success(store.search_msgs([room_id], "hi", ["content.body"]))
-        self.assertEquals(result.get("count"), 2)
+        self.assertEqual(result.get("count"), 2)
         result = self.get_success(
             store.search_msgs([room_id], "hi alice", ["content.body"])
         )

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -55,7 +55,7 @@ class RoomMemberStoreTestCase(unittest.HomeserverTestCase):
             )
         )
 
-        self.assertEquals([self.room], [m.room_id for m in rooms_for_user])
+        self.assertEqual([self.room], [m.room_id for m in rooms_for_user])
 
     def test_count_known_servers(self):
         """

--- a/tests/test_distributor.py
+++ b/tests/test_distributor.py
@@ -48,7 +48,7 @@ class DistributorTestCase(unittest.TestCase):
             observers[0].assert_called_once_with("Go")
             observers[1].assert_called_once_with("Go")
 
-            self.assertEquals(mock_logger.warning.call_count, 1)
+            self.assertEqual(mock_logger.warning.call_count, 1)
             self.assertIsInstance(mock_logger.warning.call_args[0][0], str)
 
     def test_signal_prereg(self):

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -54,7 +54,7 @@ class TermsTestCase(unittest.HomeserverTestCase):
         request_data = json.dumps({"username": "kermit", "password": "monkey"})
         channel = self.make_request(b"POST", self.url, request_data)
 
-        self.assertEquals(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.result["code"], b"401", channel.result)
 
         self.assertTrue(channel.json_body is not None)
         self.assertIsInstance(channel.json_body["session"], str)
@@ -99,7 +99,7 @@ class TermsTestCase(unittest.HomeserverTestCase):
 
         # We don't bother checking that the response is correct - we'll leave that to
         # other tests. We just want to make sure we're on the right path.
-        self.assertEquals(channel.result["code"], b"401", channel.result)
+        self.assertEqual(channel.result["code"], b"401", channel.result)
 
         # Finish the UI auth for terms
         request_data = json.dumps(
@@ -117,7 +117,7 @@ class TermsTestCase(unittest.HomeserverTestCase):
         # We're interested in getting a response that looks like a successful
         # registration, not so much that the details are exactly what we want.
 
-        self.assertEquals(channel.result["code"], b"200", channel.result)
+        self.assertEqual(channel.result["code"], b"200", channel.result)
 
         self.assertTrue(channel.json_body is not None)
         self.assertIsInstance(channel.json_body["user_id"], str)

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -25,7 +25,7 @@ class MockClockTestCase(unittest.TestCase):
 
         self.clock.advance_time(20)
 
-        self.assertEquals(20, self.clock.time() - start_time)
+        self.assertEqual(20, self.clock.time() - start_time)
 
     def test_later(self):
         invoked = [0, 0]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -22,9 +22,9 @@ class UserIDTestCase(unittest.HomeserverTestCase):
     def test_parse(self):
         user = UserID.from_string("@1234abcd:test")
 
-        self.assertEquals("1234abcd", user.localpart)
-        self.assertEquals("test", user.domain)
-        self.assertEquals(True, self.hs.is_mine(user))
+        self.assertEqual("1234abcd", user.localpart)
+        self.assertEqual("test", user.domain)
+        self.assertEqual(True, self.hs.is_mine(user))
 
     def test_pase_empty(self):
         with self.assertRaises(SynapseError):
@@ -33,7 +33,7 @@ class UserIDTestCase(unittest.HomeserverTestCase):
     def test_build(self):
         user = UserID("5678efgh", "my.domain")
 
-        self.assertEquals(user.to_string(), "@5678efgh:my.domain")
+        self.assertEqual(user.to_string(), "@5678efgh:my.domain")
 
     def test_compare(self):
         userA = UserID.from_string("@userA:my.domain")
@@ -48,14 +48,14 @@ class RoomAliasTestCase(unittest.HomeserverTestCase):
     def test_parse(self):
         room = RoomAlias.from_string("#channel:test")
 
-        self.assertEquals("channel", room.localpart)
-        self.assertEquals("test", room.domain)
-        self.assertEquals(True, self.hs.is_mine(room))
+        self.assertEqual("channel", room.localpart)
+        self.assertEqual("test", room.domain)
+        self.assertEqual(True, self.hs.is_mine(room))
 
     def test_build(self):
         room = RoomAlias("channel", "my.domain")
 
-        self.assertEquals(room.to_string(), "#channel:my.domain")
+        self.assertEqual(room.to_string(), "#channel:my.domain")
 
     def test_validate(self):
         id_string = "#test:domain,test"

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -152,12 +152,12 @@ class TestCase(unittest.TestCase):
 
     def assertObjectHasAttributes(self, attrs, obj):
         """Asserts that the given object has each of the attributes given, and
-        that the value of each matches according to assertEquals."""
+        that the value of each matches according to assertEqual."""
         for key in attrs.keys():
             if not hasattr(obj, key):
                 raise AssertionError("Expected obj to have a '.%s'" % key)
             try:
-                self.assertEquals(attrs[key], getattr(obj, key))
+                self.assertEqual(attrs[key], getattr(obj, key))
             except AssertionError as e:
                 raise (type(e))(f"Assert error for '.{key}':") from e
 
@@ -169,7 +169,7 @@ class TestCase(unittest.TestCase):
             actual (dict): The test result. Extra keys will not be checked.
         """
         for key in required:
-            self.assertEquals(
+            self.assertEqual(
                 required[key], actual[key], msg="%s mismatch. %s" % (key, actual)
             )
 

--- a/tests/util/caches/test_deferred_cache.py
+++ b/tests/util/caches/test_deferred_cache.py
@@ -31,7 +31,7 @@ class DeferredCacheTestCase(TestCase):
         cache = DeferredCache("test")
         cache.prefill("foo", 123)
 
-        self.assertEquals(self.successResultOf(cache.get("foo")), 123)
+        self.assertEqual(self.successResultOf(cache.get("foo")), 123)
 
     def test_hit_deferred(self):
         cache = DeferredCache("test")

--- a/tests/util/caches/test_descriptors.py
+++ b/tests/util/caches/test_descriptors.py
@@ -434,8 +434,8 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
 
         a = A()
 
-        self.assertEquals((yield a.func("foo")), "foo")
-        self.assertEquals((yield a.func("bar")), "bar")
+        self.assertEqual((yield a.func("foo")), "foo")
+        self.assertEqual((yield a.func("bar")), "bar")
 
     @defer.inlineCallbacks
     def test_hit(self):
@@ -450,10 +450,10 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
         a = A()
         yield a.func("foo")
 
-        self.assertEquals(callcount[0], 1)
+        self.assertEqual(callcount[0], 1)
 
-        self.assertEquals((yield a.func("foo")), "foo")
-        self.assertEquals(callcount[0], 1)
+        self.assertEqual((yield a.func("foo")), "foo")
+        self.assertEqual(callcount[0], 1)
 
     @defer.inlineCallbacks
     def test_invalidate(self):
@@ -468,13 +468,13 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
         a = A()
         yield a.func("foo")
 
-        self.assertEquals(callcount[0], 1)
+        self.assertEqual(callcount[0], 1)
 
         a.func.invalidate(("foo",))
 
         yield a.func("foo")
 
-        self.assertEquals(callcount[0], 2)
+        self.assertEqual(callcount[0], 2)
 
     def test_invalidate_missing(self):
         class A:
@@ -499,7 +499,7 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
         for k in range(0, 12):
             yield a.func(k)
 
-        self.assertEquals(callcount[0], 12)
+        self.assertEqual(callcount[0], 12)
 
         # There must have been at least 2 evictions, meaning if we calculate
         # all 12 values again, we must get called at least 2 more times
@@ -525,8 +525,8 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
 
         a.func.prefill(("foo",), 456)
 
-        self.assertEquals(a.func("foo").result, 456)
-        self.assertEquals(callcount[0], 0)
+        self.assertEqual(a.func("foo").result, 456)
+        self.assertEqual(callcount[0], 0)
 
     @defer.inlineCallbacks
     def test_invalidate_context(self):
@@ -547,19 +547,19 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
         a = A()
         yield a.func2("foo")
 
-        self.assertEquals(callcount[0], 1)
-        self.assertEquals(callcount2[0], 1)
+        self.assertEqual(callcount[0], 1)
+        self.assertEqual(callcount2[0], 1)
 
         a.func.invalidate(("foo",))
         yield a.func("foo")
 
-        self.assertEquals(callcount[0], 2)
-        self.assertEquals(callcount2[0], 1)
+        self.assertEqual(callcount[0], 2)
+        self.assertEqual(callcount2[0], 1)
 
         yield a.func2("foo")
 
-        self.assertEquals(callcount[0], 2)
-        self.assertEquals(callcount2[0], 2)
+        self.assertEqual(callcount[0], 2)
+        self.assertEqual(callcount2[0], 2)
 
     @defer.inlineCallbacks
     def test_eviction_context(self):
@@ -581,22 +581,22 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
         yield a.func2("foo")
         yield a.func2("foo2")
 
-        self.assertEquals(callcount[0], 2)
-        self.assertEquals(callcount2[0], 2)
+        self.assertEqual(callcount[0], 2)
+        self.assertEqual(callcount2[0], 2)
 
         yield a.func2("foo")
-        self.assertEquals(callcount[0], 2)
-        self.assertEquals(callcount2[0], 2)
+        self.assertEqual(callcount[0], 2)
+        self.assertEqual(callcount2[0], 2)
 
         yield a.func("foo3")
 
-        self.assertEquals(callcount[0], 3)
-        self.assertEquals(callcount2[0], 2)
+        self.assertEqual(callcount[0], 3)
+        self.assertEqual(callcount2[0], 2)
 
         yield a.func2("foo")
 
-        self.assertEquals(callcount[0], 4)
-        self.assertEquals(callcount2[0], 3)
+        self.assertEqual(callcount[0], 4)
+        self.assertEqual(callcount2[0], 3)
 
     @defer.inlineCallbacks
     def test_double_get(self):
@@ -619,30 +619,30 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
 
         yield a.func2("foo")
 
-        self.assertEquals(callcount[0], 1)
-        self.assertEquals(callcount2[0], 1)
+        self.assertEqual(callcount[0], 1)
+        self.assertEqual(callcount2[0], 1)
 
         a.func2.invalidate(("foo",))
-        self.assertEquals(a.func2.cache.cache.del_multi.call_count, 1)
+        self.assertEqual(a.func2.cache.cache.del_multi.call_count, 1)
 
         yield a.func2("foo")
         a.func2.invalidate(("foo",))
-        self.assertEquals(a.func2.cache.cache.del_multi.call_count, 2)
+        self.assertEqual(a.func2.cache.cache.del_multi.call_count, 2)
 
-        self.assertEquals(callcount[0], 1)
-        self.assertEquals(callcount2[0], 2)
+        self.assertEqual(callcount[0], 1)
+        self.assertEqual(callcount2[0], 2)
 
         a.func.invalidate(("foo",))
-        self.assertEquals(a.func2.cache.cache.del_multi.call_count, 3)
+        self.assertEqual(a.func2.cache.cache.del_multi.call_count, 3)
         yield a.func("foo")
 
-        self.assertEquals(callcount[0], 2)
-        self.assertEquals(callcount2[0], 2)
+        self.assertEqual(callcount[0], 2)
+        self.assertEqual(callcount2[0], 2)
 
         yield a.func2("foo")
 
-        self.assertEquals(callcount[0], 2)
-        self.assertEquals(callcount2[0], 3)
+        self.assertEqual(callcount[0], 2)
+        self.assertEqual(callcount2[0], 3)
 
 
 class CachedListDescriptorTestCase(unittest.TestCase):

--- a/tests/util/test_expiring_cache.py
+++ b/tests/util/test_expiring_cache.py
@@ -26,8 +26,8 @@ class ExpiringCacheTestCase(unittest.HomeserverTestCase):
         cache = ExpiringCache("test", clock, max_len=1)
 
         cache["key"] = "value"
-        self.assertEquals(cache.get("key"), "value")
-        self.assertEquals(cache["key"], "value")
+        self.assertEqual(cache.get("key"), "value")
+        self.assertEqual(cache["key"], "value")
 
     def test_eviction(self):
         clock = MockClock()
@@ -35,13 +35,13 @@ class ExpiringCacheTestCase(unittest.HomeserverTestCase):
 
         cache["key"] = "value"
         cache["key2"] = "value2"
-        self.assertEquals(cache.get("key"), "value")
-        self.assertEquals(cache.get("key2"), "value2")
+        self.assertEqual(cache.get("key"), "value")
+        self.assertEqual(cache.get("key2"), "value2")
 
         cache["key3"] = "value3"
-        self.assertEquals(cache.get("key"), None)
-        self.assertEquals(cache.get("key2"), "value2")
-        self.assertEquals(cache.get("key3"), "value3")
+        self.assertEqual(cache.get("key"), None)
+        self.assertEqual(cache.get("key2"), "value2")
+        self.assertEqual(cache.get("key3"), "value3")
 
     def test_iterable_eviction(self):
         clock = MockClock()
@@ -51,15 +51,15 @@ class ExpiringCacheTestCase(unittest.HomeserverTestCase):
         cache["key2"] = [2, 3]
         cache["key3"] = [4, 5]
 
-        self.assertEquals(cache.get("key"), [1])
-        self.assertEquals(cache.get("key2"), [2, 3])
-        self.assertEquals(cache.get("key3"), [4, 5])
+        self.assertEqual(cache.get("key"), [1])
+        self.assertEqual(cache.get("key2"), [2, 3])
+        self.assertEqual(cache.get("key3"), [4, 5])
 
         cache["key4"] = [6, 7]
-        self.assertEquals(cache.get("key"), None)
-        self.assertEquals(cache.get("key2"), None)
-        self.assertEquals(cache.get("key3"), [4, 5])
-        self.assertEquals(cache.get("key4"), [6, 7])
+        self.assertEqual(cache.get("key"), None)
+        self.assertEqual(cache.get("key2"), None)
+        self.assertEqual(cache.get("key3"), [4, 5])
+        self.assertEqual(cache.get("key4"), [6, 7])
 
     def test_time_eviction(self):
         clock = MockClock()
@@ -69,13 +69,13 @@ class ExpiringCacheTestCase(unittest.HomeserverTestCase):
         clock.advance_time(0.5)
         cache["key2"] = 2
 
-        self.assertEquals(cache.get("key"), 1)
-        self.assertEquals(cache.get("key2"), 2)
+        self.assertEqual(cache.get("key"), 1)
+        self.assertEqual(cache.get("key2"), 2)
 
         clock.advance_time(0.9)
-        self.assertEquals(cache.get("key"), None)
-        self.assertEquals(cache.get("key2"), 2)
+        self.assertEqual(cache.get("key"), None)
+        self.assertEqual(cache.get("key2"), 2)
 
         clock.advance_time(1)
-        self.assertEquals(cache.get("key"), None)
-        self.assertEquals(cache.get("key2"), None)
+        self.assertEqual(cache.get("key"), None)
+        self.assertEqual(cache.get("key2"), None)

--- a/tests/util/test_logcontext.py
+++ b/tests/util/test_logcontext.py
@@ -17,7 +17,7 @@ from .. import unittest
 
 class LoggingContextTestCase(unittest.TestCase):
     def _check_test_key(self, value):
-        self.assertEquals(current_context().name, value)
+        self.assertEqual(current_context().name, value)
 
     def test_with_context(self):
         with LoggingContext("test"):

--- a/tests/util/test_lrucache.py
+++ b/tests/util/test_lrucache.py
@@ -27,37 +27,37 @@ class LruCacheTestCase(unittest.HomeserverTestCase):
     def test_get_set(self):
         cache = LruCache(1)
         cache["key"] = "value"
-        self.assertEquals(cache.get("key"), "value")
-        self.assertEquals(cache["key"], "value")
+        self.assertEqual(cache.get("key"), "value")
+        self.assertEqual(cache["key"], "value")
 
     def test_eviction(self):
         cache = LruCache(2)
         cache[1] = 1
         cache[2] = 2
 
-        self.assertEquals(cache.get(1), 1)
-        self.assertEquals(cache.get(2), 2)
+        self.assertEqual(cache.get(1), 1)
+        self.assertEqual(cache.get(2), 2)
 
         cache[3] = 3
 
-        self.assertEquals(cache.get(1), None)
-        self.assertEquals(cache.get(2), 2)
-        self.assertEquals(cache.get(3), 3)
+        self.assertEqual(cache.get(1), None)
+        self.assertEqual(cache.get(2), 2)
+        self.assertEqual(cache.get(3), 3)
 
     def test_setdefault(self):
         cache = LruCache(1)
-        self.assertEquals(cache.setdefault("key", 1), 1)
-        self.assertEquals(cache.get("key"), 1)
-        self.assertEquals(cache.setdefault("key", 2), 1)
-        self.assertEquals(cache.get("key"), 1)
+        self.assertEqual(cache.setdefault("key", 1), 1)
+        self.assertEqual(cache.get("key"), 1)
+        self.assertEqual(cache.setdefault("key", 2), 1)
+        self.assertEqual(cache.get("key"), 1)
         cache["key"] = 2  # Make sure overriding works.
-        self.assertEquals(cache.get("key"), 2)
+        self.assertEqual(cache.get("key"), 2)
 
     def test_pop(self):
         cache = LruCache(1)
         cache["key"] = 1
-        self.assertEquals(cache.pop("key"), 1)
-        self.assertEquals(cache.pop("key"), None)
+        self.assertEqual(cache.pop("key"), 1)
+        self.assertEqual(cache.pop("key"), None)
 
     def test_del_multi(self):
         cache = LruCache(4, cache_type=TreeCache)
@@ -66,23 +66,23 @@ class LruCacheTestCase(unittest.HomeserverTestCase):
         cache[("vehicles", "car")] = "vroom"
         cache[("vehicles", "train")] = "chuff"
 
-        self.assertEquals(len(cache), 4)
+        self.assertEqual(len(cache), 4)
 
-        self.assertEquals(cache.get(("animal", "cat")), "mew")
-        self.assertEquals(cache.get(("vehicles", "car")), "vroom")
+        self.assertEqual(cache.get(("animal", "cat")), "mew")
+        self.assertEqual(cache.get(("vehicles", "car")), "vroom")
         cache.del_multi(("animal",))
-        self.assertEquals(len(cache), 2)
-        self.assertEquals(cache.get(("animal", "cat")), None)
-        self.assertEquals(cache.get(("animal", "dog")), None)
-        self.assertEquals(cache.get(("vehicles", "car")), "vroom")
-        self.assertEquals(cache.get(("vehicles", "train")), "chuff")
+        self.assertEqual(len(cache), 2)
+        self.assertEqual(cache.get(("animal", "cat")), None)
+        self.assertEqual(cache.get(("animal", "dog")), None)
+        self.assertEqual(cache.get(("vehicles", "car")), "vroom")
+        self.assertEqual(cache.get(("vehicles", "train")), "chuff")
         # Man from del_multi say "Yes".
 
     def test_clear(self):
         cache = LruCache(1)
         cache["key"] = 1
         cache.clear()
-        self.assertEquals(len(cache), 0)
+        self.assertEqual(len(cache), 0)
 
     @override_config({"caches": {"per_cache_factors": {"mycache": 10}}})
     def test_special_size(self):
@@ -105,10 +105,10 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
         self.assertFalse(m.called)
 
         cache.set("key", "value2")
-        self.assertEquals(m.call_count, 1)
+        self.assertEqual(m.call_count, 1)
 
         cache.set("key", "value")
-        self.assertEquals(m.call_count, 1)
+        self.assertEqual(m.call_count, 1)
 
     def test_multi_get(self):
         m = Mock()
@@ -124,10 +124,10 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
         self.assertFalse(m.called)
 
         cache.set("key", "value2")
-        self.assertEquals(m.call_count, 1)
+        self.assertEqual(m.call_count, 1)
 
         cache.set("key", "value")
-        self.assertEquals(m.call_count, 1)
+        self.assertEqual(m.call_count, 1)
 
     def test_set(self):
         m = Mock()
@@ -140,10 +140,10 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
         self.assertFalse(m.called)
 
         cache.set("key", "value2")
-        self.assertEquals(m.call_count, 1)
+        self.assertEqual(m.call_count, 1)
 
         cache.set("key", "value")
-        self.assertEquals(m.call_count, 1)
+        self.assertEqual(m.call_count, 1)
 
     def test_pop(self):
         m = Mock()
@@ -153,13 +153,13 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
         self.assertFalse(m.called)
 
         cache.pop("key")
-        self.assertEquals(m.call_count, 1)
+        self.assertEqual(m.call_count, 1)
 
         cache.set("key", "value")
-        self.assertEquals(m.call_count, 1)
+        self.assertEqual(m.call_count, 1)
 
         cache.pop("key")
-        self.assertEquals(m.call_count, 1)
+        self.assertEqual(m.call_count, 1)
 
     def test_del_multi(self):
         m1 = Mock()
@@ -173,17 +173,17 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
         cache.set(("b", "1"), "value", callbacks=[m3])
         cache.set(("b", "2"), "value", callbacks=[m4])
 
-        self.assertEquals(m1.call_count, 0)
-        self.assertEquals(m2.call_count, 0)
-        self.assertEquals(m3.call_count, 0)
-        self.assertEquals(m4.call_count, 0)
+        self.assertEqual(m1.call_count, 0)
+        self.assertEqual(m2.call_count, 0)
+        self.assertEqual(m3.call_count, 0)
+        self.assertEqual(m4.call_count, 0)
 
         cache.del_multi(("a",))
 
-        self.assertEquals(m1.call_count, 1)
-        self.assertEquals(m2.call_count, 1)
-        self.assertEquals(m3.call_count, 0)
-        self.assertEquals(m4.call_count, 0)
+        self.assertEqual(m1.call_count, 1)
+        self.assertEqual(m2.call_count, 1)
+        self.assertEqual(m3.call_count, 0)
+        self.assertEqual(m4.call_count, 0)
 
     def test_clear(self):
         m1 = Mock()
@@ -193,13 +193,13 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
         cache.set("key1", "value", callbacks=[m1])
         cache.set("key2", "value", callbacks=[m2])
 
-        self.assertEquals(m1.call_count, 0)
-        self.assertEquals(m2.call_count, 0)
+        self.assertEqual(m1.call_count, 0)
+        self.assertEqual(m2.call_count, 0)
 
         cache.clear()
 
-        self.assertEquals(m1.call_count, 1)
-        self.assertEquals(m2.call_count, 1)
+        self.assertEqual(m1.call_count, 1)
+        self.assertEqual(m2.call_count, 1)
 
     def test_eviction(self):
         m1 = Mock(name="m1")
@@ -210,33 +210,33 @@ class LruCacheCallbacksTestCase(unittest.HomeserverTestCase):
         cache.set("key1", "value", callbacks=[m1])
         cache.set("key2", "value", callbacks=[m2])
 
-        self.assertEquals(m1.call_count, 0)
-        self.assertEquals(m2.call_count, 0)
-        self.assertEquals(m3.call_count, 0)
+        self.assertEqual(m1.call_count, 0)
+        self.assertEqual(m2.call_count, 0)
+        self.assertEqual(m3.call_count, 0)
 
         cache.set("key3", "value", callbacks=[m3])
 
-        self.assertEquals(m1.call_count, 1)
-        self.assertEquals(m2.call_count, 0)
-        self.assertEquals(m3.call_count, 0)
+        self.assertEqual(m1.call_count, 1)
+        self.assertEqual(m2.call_count, 0)
+        self.assertEqual(m3.call_count, 0)
 
         cache.set("key3", "value")
 
-        self.assertEquals(m1.call_count, 1)
-        self.assertEquals(m2.call_count, 0)
-        self.assertEquals(m3.call_count, 0)
+        self.assertEqual(m1.call_count, 1)
+        self.assertEqual(m2.call_count, 0)
+        self.assertEqual(m3.call_count, 0)
 
         cache.get("key2")
 
-        self.assertEquals(m1.call_count, 1)
-        self.assertEquals(m2.call_count, 0)
-        self.assertEquals(m3.call_count, 0)
+        self.assertEqual(m1.call_count, 1)
+        self.assertEqual(m2.call_count, 0)
+        self.assertEqual(m3.call_count, 0)
 
         cache.set("key1", "value", callbacks=[m1])
 
-        self.assertEquals(m1.call_count, 1)
-        self.assertEquals(m2.call_count, 0)
-        self.assertEquals(m3.call_count, 1)
+        self.assertEqual(m1.call_count, 1)
+        self.assertEqual(m2.call_count, 0)
+        self.assertEqual(m3.call_count, 1)
 
 
 class LruCacheSizedTestCase(unittest.HomeserverTestCase):
@@ -247,20 +247,20 @@ class LruCacheSizedTestCase(unittest.HomeserverTestCase):
         cache["key3"] = [3]
         cache["key4"] = [4]
 
-        self.assertEquals(cache["key1"], [0])
-        self.assertEquals(cache["key2"], [1, 2])
-        self.assertEquals(cache["key3"], [3])
-        self.assertEquals(cache["key4"], [4])
-        self.assertEquals(len(cache), 5)
+        self.assertEqual(cache["key1"], [0])
+        self.assertEqual(cache["key2"], [1, 2])
+        self.assertEqual(cache["key3"], [3])
+        self.assertEqual(cache["key4"], [4])
+        self.assertEqual(len(cache), 5)
 
         cache["key5"] = [5, 6]
 
-        self.assertEquals(len(cache), 4)
-        self.assertEquals(cache.get("key1"), None)
-        self.assertEquals(cache.get("key2"), None)
-        self.assertEquals(cache["key3"], [3])
-        self.assertEquals(cache["key4"], [4])
-        self.assertEquals(cache["key5"], [5, 6])
+        self.assertEqual(len(cache), 4)
+        self.assertEqual(cache.get("key1"), None)
+        self.assertEqual(cache.get("key2"), None)
+        self.assertEqual(cache["key3"], [3])
+        self.assertEqual(cache["key4"], [4])
+        self.assertEqual(cache["key5"], [5, 6])
 
     def test_zero_size_drop_from_cache(self) -> None:
         """Test that `drop_from_cache` works correctly with 0-sized entries."""

--- a/tests/util/test_treecache.py
+++ b/tests/util/test_treecache.py
@@ -23,61 +23,61 @@ class TreeCacheTestCase(unittest.TestCase):
         cache = TreeCache()
         cache[("a",)] = "A"
         cache[("b",)] = "B"
-        self.assertEquals(cache.get(("a",)), "A")
-        self.assertEquals(cache.get(("b",)), "B")
-        self.assertEquals(len(cache), 2)
+        self.assertEqual(cache.get(("a",)), "A")
+        self.assertEqual(cache.get(("b",)), "B")
+        self.assertEqual(len(cache), 2)
 
     def test_pop_onelevel(self):
         cache = TreeCache()
         cache[("a",)] = "A"
         cache[("b",)] = "B"
-        self.assertEquals(cache.pop(("a",)), "A")
-        self.assertEquals(cache.pop(("a",)), None)
-        self.assertEquals(cache.get(("b",)), "B")
-        self.assertEquals(len(cache), 1)
+        self.assertEqual(cache.pop(("a",)), "A")
+        self.assertEqual(cache.pop(("a",)), None)
+        self.assertEqual(cache.get(("b",)), "B")
+        self.assertEqual(len(cache), 1)
 
     def test_get_set_twolevel(self):
         cache = TreeCache()
         cache[("a", "a")] = "AA"
         cache[("a", "b")] = "AB"
         cache[("b", "a")] = "BA"
-        self.assertEquals(cache.get(("a", "a")), "AA")
-        self.assertEquals(cache.get(("a", "b")), "AB")
-        self.assertEquals(cache.get(("b", "a")), "BA")
-        self.assertEquals(len(cache), 3)
+        self.assertEqual(cache.get(("a", "a")), "AA")
+        self.assertEqual(cache.get(("a", "b")), "AB")
+        self.assertEqual(cache.get(("b", "a")), "BA")
+        self.assertEqual(len(cache), 3)
 
     def test_pop_twolevel(self):
         cache = TreeCache()
         cache[("a", "a")] = "AA"
         cache[("a", "b")] = "AB"
         cache[("b", "a")] = "BA"
-        self.assertEquals(cache.pop(("a", "a")), "AA")
-        self.assertEquals(cache.get(("a", "a")), None)
-        self.assertEquals(cache.get(("a", "b")), "AB")
-        self.assertEquals(cache.pop(("b", "a")), "BA")
-        self.assertEquals(cache.pop(("b", "a")), None)
-        self.assertEquals(len(cache), 1)
+        self.assertEqual(cache.pop(("a", "a")), "AA")
+        self.assertEqual(cache.get(("a", "a")), None)
+        self.assertEqual(cache.get(("a", "b")), "AB")
+        self.assertEqual(cache.pop(("b", "a")), "BA")
+        self.assertEqual(cache.pop(("b", "a")), None)
+        self.assertEqual(len(cache), 1)
 
     def test_pop_mixedlevel(self):
         cache = TreeCache()
         cache[("a", "a")] = "AA"
         cache[("a", "b")] = "AB"
         cache[("b", "a")] = "BA"
-        self.assertEquals(cache.get(("a", "a")), "AA")
+        self.assertEqual(cache.get(("a", "a")), "AA")
         popped = cache.pop(("a",))
-        self.assertEquals(cache.get(("a", "a")), None)
-        self.assertEquals(cache.get(("a", "b")), None)
-        self.assertEquals(cache.get(("b", "a")), "BA")
-        self.assertEquals(len(cache), 1)
+        self.assertEqual(cache.get(("a", "a")), None)
+        self.assertEqual(cache.get(("a", "b")), None)
+        self.assertEqual(cache.get(("b", "a")), "BA")
+        self.assertEqual(len(cache), 1)
 
-        self.assertEquals({"AA", "AB"}, set(iterate_tree_cache_entry(popped)))
+        self.assertEqual({"AA", "AB"}, set(iterate_tree_cache_entry(popped)))
 
     def test_clear(self):
         cache = TreeCache()
         cache[("a",)] = "A"
         cache[("b",)] = "B"
         cache.clear()
-        self.assertEquals(len(cache), 0)
+        self.assertEqual(len(cache), 0)
 
     def test_contains(self):
         cache = TreeCache()


### PR DESCRIPTION
I believe Python 3.10 warns about this by default now? Regardless we should use the non-deprecated alias.

This was done with:

```bash
$ sed -i '' "s/assertEquals/assertEqual/g" tests/**/*.py
$ ./scripts-dev/lint.sh
```

(Repeat the sed line for the various aliases at https://docs.python.org/3/library/unittest.html#deprecated-aliases)