### PR TITLE
Move experimental support for MSC3440 to /versions.

### DIFF
--- a/changelog.d/12099.misc
+++ b/changelog.d/12099.misc
@@ -1,0 +1,1 @@
+Move experimental support for [MSC3440](https://github.com/matrix-org/matrix-doc/pull/3440) to /versions.

--- a/synapse/rest/client/capabilities.py
+++ b/synapse/rest/client/capabilities.py
@@ -72,9 +72,6 @@ class CapabilitiesRestServlet(RestServlet):
                 "org.matrix.msc3244.room_capabilities"
             ] = MSC3244_CAPABILITIES
 
-        if self.config.experimental.msc3440_enabled:
-            response["capabilities"]["io.element.thread"] = {"enabled": True}
-
         if self.config.experimental.msc3720_enabled:
             response["capabilities"]["org.matrix.msc3720.account_status"] = {
                 "enabled": True,

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -99,6 +99,8 @@ class VersionsRestServlet(RestServlet):
                     "org.matrix.msc2716": self.config.experimental.msc2716_enabled,
                     # Adds support for jump to date endpoints (/timestamp_to_event) as per MSC3030
                     "org.matrix.msc3030": self.config.experimental.msc3030_enabled,
+                    # Adds support for thread relations, per MSC3440.
+                    "org.matrix.msc3440": self.config.experimental.msc3440_enabled,
                 },
             },
         )


### PR DESCRIPTION
Per changes to the MSC: [matrix-org/matrix-doc@`e640f6b` (#3440)](https://github.com/matrix-org/matrix-doc/pull/3440/commits/e640f6b95d828076003626d131c51a846be58e05).

