### PR TITLE
Advertise Python 3.10 support in setup.py

### DIFF
--- a/changelog.d/12111.misc
+++ b/changelog.d/12111.misc
@@ -1,0 +1,1 @@
+Advertise support for Python 3.10 in packaging files.

--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     scripts=["synctl"] + glob.glob("scripts/*"),
     cmdclass={"test": TestCommand},


### PR DESCRIPTION
This PR updates our classifiers defined in `setup.py` to advertise Synapse's support for Python 3.10.

I'm not entirely sure if this was omitted from https://github.com/matrix-org/synapse/issues/11780 on purpose or simply missed, but presenting it here for review.