### PR TITLE
Detox, part 1 of N

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - uses: actions/setup-python@v2
-      - run: pip install tox
+      - run: "pip install 'towncrier>=18.6.0rc1'"
       - run: scripts-dev/check-newsfragment
         env:
           PULL_REQUEST_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,12 +10,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-sampleconfig:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install -e .
+      - run: scripts-dev/generate_sample_config --check
+
   lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         toxenv:
-          - "check-sampleconfig"
           - "check_codestyle"
           - "check_isort"
           - "mypy"
@@ -51,7 +58,7 @@ jobs:
   # Dummy step to gate other tests on without repeating the whole list
   linting-done:
     if: ${{ !cancelled() }} # Run this even if prior jobs were skipped
-    needs: [lint, lint-crlf, lint-newsfile]
+    needs: [lint, lint-crlf, lint-newsfile, check-sampleconfig]
     runs-on: ubuntu-latest
     steps:
       - run: "true"

--- a/changelog.d/12119.misc
+++ b/changelog.d/12119.misc
@@ -1,0 +1,1 @@
+Move CI checks out of tox, to facilitate a move to using poetry.

--- a/changelog.d/12119.misc
+++ b/changelog.d/12119.misc
@@ -1,1 +1,1 @@
-Move CI checks out of tox, to facilitate a move to using poetry. NO FULLSTOP SHOULD TRIGGER CI TO FAIL
+Move CI checks out of tox, to facilitate a move to using poetry.

--- a/changelog.d/12119.misc
+++ b/changelog.d/12119.misc
@@ -1,1 +1,1 @@
-Move CI checks out of tox, to facilitate a move to using poetry.
+Move CI checks out of tox, to facilitate a move to using poetry. NO FULLSTOP SHOULD TRIGGER CI TO FAIL

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -49,7 +49,6 @@ modules:
 
 
 ## Server ##
-THIS SHOULD TRIGGER CI TO FAIL
 
 # The public-facing domain of the server
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -49,6 +49,7 @@ modules:
 
 
 ## Server ##
+THIS SHOULD TRIGGER CI TO FAIL
 
 # The public-facing domain of the server
 #

--- a/scripts-dev/check-newsfragment
+++ b/scripts-dev/check-newsfragment
@@ -35,7 +35,7 @@ CONTRIBUTING_GUIDE_TEXT="!! Please see the contributing guide for help writing y
 https://github.com/matrix-org/synapse/blob/develop/CONTRIBUTING.md#changelog"
 
 # If check-newsfragment returns a non-zero exit code, print the contributing guide and exit
-tox -qe check-newsfragment || (echo -e "$CONTRIBUTING_GUIDE_TEXT" >&2 && exit 1)
+python -m towncrier.check --compare-with=origin/develop || (echo -e "$CONTRIBUTING_GUIDE_TEXT" >&2 && exit 1)
 
 echo
 echo "--------------------------"

--- a/tox.ini
+++ b/tox.ini
@@ -168,13 +168,6 @@ commands =
 extras = lint
 commands = isort -c --df {[base]lint_targets}
 
-[testenv:check-newsfragment]
-skip_install = true
-usedevelop = false
-deps = towncrier>=18.6.0rc1
-commands =
-   python -m towncrier.check --compare-with=origin/develop
-
 [testenv:combine]
 skip_install = true
 usedevelop = false

--- a/tox.ini
+++ b/tox.ini
@@ -175,9 +175,6 @@ deps = towncrier>=18.6.0rc1
 commands =
    python -m towncrier.check --compare-with=origin/develop
 
-[testenv:check-sampleconfig]
-commands = {toxinidir}/scripts-dev/generate_sample_config --check
-
 [testenv:combine]
 skip_install = true
 usedevelop = false


### PR DESCRIPTION
As part of #11537 we are going to move away from tox.

This pulls out two linting steps from tox which refer to the `scripts` directory. Will be useful for #12118.