### PR TITLE
Make release script write correct no-op changelog

### DIFF
--- a/changelog.d/12127.misc
+++ b/changelog.d/12127.misc
@@ -1,0 +1,1 @@
+Update release script to insert the previous version when writing "No significant changes" line in the changelog.


### PR DESCRIPTION
As we want to include the previous version in the "No new changes..." string.
