### PR TITLE
Don't impose version checks on dev extras at runtime

### DIFF
--- a/changelog.d/12129.misc
+++ b/changelog.d/12129.misc
@@ -1,0 +1,1 @@
+Inspect application dependencies using `importlib.metadata` or its backport.

--- a/synapse/util/check_dependencies.py
+++ b/synapse/util/check_dependencies.py
@@ -106,8 +106,10 @@ def _dependencies_for_extra(extra: str) -> Iterable[Dependency]:
 
 def _not_installed(requirement: Requirement, extra: Optional[str] = None) -> str:
     if extra:
-        return f"Synapse {VERSION} needs {requirement.name} for {extra}, " \
-               f"but it is not installed"
+        return (
+            f"Synapse {VERSION} needs {requirement.name} for {extra}, "
+            f"but it is not installed"
+        )
     else:
         return f"Synapse {VERSION} needs {requirement.name}, but it is not installed"
 

--- a/synapse/util/check_dependencies.py
+++ b/synapse/util/check_dependencies.py
@@ -1,3 +1,17 @@
+#  Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 import logging
 from typing import Iterable, NamedTuple, Optional
 

--- a/synapse/util/check_dependencies.py
+++ b/synapse/util/check_dependencies.py
@@ -57,6 +57,7 @@ DEV_EXTRAS = {"lint", "mypy", "test", "dev"}
 RUNTIME_EXTRAS = (
     set(metadata.metadata(DISTRIBUTION_NAME).get_all("Provides-Extra")) - DEV_EXTRAS
 )
+VERSION = metadata.version(DISTRIBUTION_NAME)
 
 
 def _is_dev_dependency(req: Requirement) -> bool:
@@ -105,18 +106,24 @@ def _dependencies_for_extra(extra: str) -> Iterable[Dependency]:
 
 def _not_installed(requirement: Requirement, extra: Optional[str] = None) -> str:
     if extra:
-        return f"Need {requirement.name} for {extra}, but it is not installed"
+        return f"Synapse {VERSION} needs {requirement.name} for {extra}, " \
+               f"but it is not installed"
     else:
-        return f"Need {requirement.name}, but it is not installed"
+        return f"Synapse {VERSION} needs {requirement.name}, but it is not installed"
 
 
 def _incorrect_version(
     requirement: Requirement, got: str, extra: Optional[str] = None
 ) -> str:
     if extra:
-        return f"Need {requirement} for {extra}, but got {requirement.name}=={got}"
+        return (
+            f"Synapse {VERSION} needs {requirement} for {extra}, "
+            f"but got {requirement.name}=={got}"
+        )
     else:
-        return f"Need {requirement}, but got {requirement.name}=={got}"
+        return (
+            f"Synapse {VERSION} needs {requirement}, but got {requirement.name}=={got}"
+        )
 
 
 def check_requirements(extra: Optional[str] = None) -> None:
@@ -141,7 +148,7 @@ def check_requirements(extra: Optional[str] = None) -> None:
     elif extra in RUNTIME_EXTRAS:
         dependencies = _dependencies_for_extra(extra)
     else:
-        raise ValueError(f"Synapse does not provide the feature '{extra}'")
+        raise ValueError(f"Synapse {VERSION} does not provide the feature '{extra}'")
 
     deps_unfulfilled = []
     errors = []

--- a/synapse/util/check_dependencies.py
+++ b/synapse/util/check_dependencies.py
@@ -12,6 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+
+"""
+This module exposes a single function which checks synapse's dependencies are present
+and correctly versioned. It makes use of `importlib.metadata` to do so. The details
+are a bit murky: there's no easy way to get a map from "extras" to the packages they
+require. But this is probably just symptomatic of Python's package management.
+"""
+
 import logging
 from typing import Iterable, NamedTuple, Optional
 
@@ -23,6 +31,8 @@ try:
     from importlib import metadata
 except ImportError:
     import importlib_metadata as metadata  # type: ignore[no-redef]
+
+__all__ = ["check_requirements"]
 
 
 class DependencyException(Exception):

--- a/tests/util/test_check_dependencies.py
+++ b/tests/util/test_check_dependencies.py
@@ -92,4 +92,4 @@ class TestDependencyChecker(TestCase):
                 self.assertRaises(DependencyException, check_requirements, "cool-extra")
             with self.mock_installed_package(new):
                 # should not raise
-                check_requirements()
+                check_requirements("cool-extra")

--- a/tests/util/test_check_dependencies.py
+++ b/tests/util/test_check_dependencies.py
@@ -65,6 +65,23 @@ class TestDependencyChecker(TestCase):
                 # should not raise
                 check_requirements()
 
+    def test_checks_ignore_dev_dependencies(self) -> None:
+        """Bot generic and per-extra checks should ignore dev dependencies."""
+        with patch(
+            "synapse.util.check_dependencies.metadata.requires",
+            return_value=["dummypkg >= 1; extra == 'mypy'"],
+        ), patch("synapse.util.check_dependencies.RUNTIME_EXTRAS", {"cool-extra"}):
+            # We're testing that none of these calls raise.
+            with self.mock_installed_package(None):
+                check_requirements()
+                check_requirements("cool-extra")
+            with self.mock_installed_package(old):
+                check_requirements()
+                check_requirements("cool-extra")
+            with self.mock_installed_package(new):
+                check_requirements()
+                check_requirements("cool-extra")
+
     def test_generic_check_of_optional_dependency(self) -> None:
         """Complain if an optional package is old."""
         with patch(
@@ -85,7 +102,7 @@ class TestDependencyChecker(TestCase):
         with patch(
             "synapse.util.check_dependencies.metadata.requires",
             return_value=["dummypkg >= 1; extra == 'cool-extra'"],
-        ), patch("synapse.util.check_dependencies.EXTRAS", {"cool-extra"}):
+        ), patch("synapse.util.check_dependencies.RUNTIME_EXTRAS", {"cool-extra"}):
             with self.mock_installed_package(None):
                 self.assertRaises(DependencyException, check_requirements, "cool-extra")
             with self.mock_installed_package(old):


### PR DESCRIPTION
#12088 was causing @clokep trouble. The error message:

```
✗ python -m [synapse.app](http://synapse.app/).homeserver --config-path demo/etc/8080.config 
ERROR:root:Need matrix-common==1.0.0, but got matrix-common==1.1.0
ERROR:root:Need mypy==0.910; extra == "dev", but got mypy==0.931
ERROR:root:Need mypy-zope==0.3.2; extra == "dev", but got mypy-zope==0.3.5
ERROR:root:Need mypy==0.910; extra == "mypy", but got mypy==0.931
ERROR:root:Need mypy-zope==0.3.2; extra == "mypy", but got mypy-zope==0.3.5
Missing Requirements: "matrix-common", "mypy", "mypy-zope", "mypy", "mypy-zope"
To install run:
    pip install --upgrade --force "matrix-common" "mypy" "mypy-zope" "mypy" "mypy-zope"
```

The `matrix-common` is a well-meaning error. Patrick had the correct version on disk (presumably having upgraded it), but the metadata for synapse was not updated. This was fixed with `pip install -e .`. In the future, `poetry install` will take care of both updating dependencies and updating the editable installation's metadata.

The mypy ones are erroneous. We should be discard any requirements which are needed only for development. That's what this PR does.

I tested this with
- `pip install mypy == 0.910`
- demo/start.sh
  ```
  ~/workspace/synapse-plain/demo/8080 ~/workspace/synapse-plain
  ERROR:root:Need mypy==0.931; extra == "mypy", but got mypy==0.910
  Missing Requirements: "mypy"
  To install run:
      pip install --upgrade --force "mypy"
    ```
- apply patch, no more error.