### PR TITLE
Fix CI not attaching source distributions and wheels to the GitHub releases.

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -112,7 +112,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            python-dist/*
+            Sdist/*
+            Wheel/*
             debs.tar.xz
           # if it's not already published, keep the release as a draft.
           draft: true

--- a/changelog.d/12131.misc
+++ b/changelog.d/12131.misc
@@ -1,0 +1,1 @@
+Fix CI not attaching source distributions and wheels to the GitHub releases.


### PR DESCRIPTION
#12051 separated the wheels and sdist artifacts, but our GHA stuff was not set up to attach them to the GitHub releases with their new locations.
This hopefully fixes those. (They're used in the release script but 404ed this time around.)

See also: https://github.com/matrix-org/synapse/runs/5393252759?check_suite_focus=true#step:4:10


