### PR TITLE
Detox, part 2 of N

### DIFF
--- a/changelog.d/12152.misc
+++ b/changelog.d/12152.misc
@@ -1,0 +1,1 @@
+Prune unused jobs from `tox` config.

--- a/tox.ini
+++ b/tox.ini
@@ -158,32 +158,6 @@ commands =
 extras = lint
 commands = isort -c --df {[base]lint_targets}
 
-[testenv:combine]
-skip_install = true
-usedevelop = false
-deps =
-    coverage
-    pip>=10
-commands=
-    coverage combine
-    coverage report
-
-[testenv:cov-erase]
-skip_install = true
-usedevelop = false
-deps =
-    coverage
-commands=
-    coverage erase
-
-[testenv:cov-html]
-skip_install = true
-usedevelop = false
-deps =
-    coverage
-commands=
-    coverage html
-
 [testenv:mypy]
 deps =
     {[base]deps}


### PR DESCRIPTION
I've argued in #11537 that poetry and tox don't cooperate well at the
moment. (See also #12119.) Therefore I'm pruning away bits of `tox` to make the transition to poetry easier. This change removes the commands for `coverage`.

We don't use coverage in anger at the moment. It shouldn't be too hard to add `coverage` as a dev-dependency and reintroduce this if we really want it.