### PR TITLE
Add type hints for `ObservableDeferred` attributes

### DIFF
--- a/changelog.d/12159.misc
+++ b/changelog.d/12159.misc
@@ -1,0 +1,1 @@
+Add type hints for `ObservableDeferred` attributes.


### PR DESCRIPTION
While poking around `ObservableDeferred`, I noticed that my IDE didn't understand the types of its attributes.
This'll be likely due to the use of `object.__setattr__` to set them.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
