### PR TITLE
Reduce to-device queries for /sync.

### DIFF
--- a/changelog.d/12163.misc
+++ b/changelog.d/12163.misc
@@ -1,1 +1,1 @@
-Reduce number of DB queries made during processing of `/sync`. 
+Reduce number of DB queries made during processing of `/sync`.

--- a/changelog.d/12163.misc
+++ b/changelog.d/12163.misc
@@ -1,0 +1,1 @@
+Reduce number of DB queries made during processing of `/sync`. 

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -298,6 +298,9 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                 # This user has new messages sent to them. Query messages for them
                 user_ids_to_query.add(user_id)
 
+        if not user_ids_to_query:
+            return {}, to_stream_id
+
         def get_device_messages_txn(txn: LoggingTransaction):
             # Build a query to select messages from any of the given devices that
             # are between the given stream id bounds.


### PR DESCRIPTION
Right now we always hit the DB, even if the stream change cache reports that there are no new to-device messages for the users.