### PR TITLE
Relax version guard for packaging

### DIFF
--- a/changelog.d/12166.misc
+++ b/changelog.d/12166.misc
@@ -1,0 +1,1 @@
+Relax the version guard for "packaging" added in #12088.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -83,8 +83,8 @@ REQUIREMENTS = [
     # ijson 3.1.4 fixes a bug with "." in property names
     "ijson>=3.1.4",
     "matrix-common~=1.1.0",
-    # For runtime introspection of our dependencies
-    "packaging~=21.3",
+    # We need packaging.requirements.Requirement, added in 16.1.
+    "packaging>=16.1",
 ]
 
 CONDITIONAL_REQUIREMENTS = {


### PR DESCRIPTION
It’s just occurred to me that #12088 pulled in the “packaging” package (~=21.3). I pulled in the newest version I had at the time, and I didn’t check this with the packagers, sorry. (Also sorry to bring up the P-word again.)

I only use it for packaging.requirements.Requirements. Which was added in packaging 16.1: https://github.com/pypa/packaging/releases/tag/16.1

https://pkgs.org/download/python3-packaging suggests that the oldest version we care about is 17.1 in Ubuntu Bionic. So I think with this bound we're hunky dory.
