### PR TITLE
Make `parse_server_name` more consistent

### DIFF
--- a/changelog.d/12167.misc
+++ b/changelog.d/12167.misc
@@ -1,0 +1,1 @@
+Make the `parse_server_name` function more consistent.

--- a/synapse/util/stringutils.py
+++ b/synapse/util/stringutils.py
@@ -86,14 +86,17 @@ def parse_server_name(server_name: str) -> Tuple[str, Optional[int]]:
         ValueError if the server name could not be parsed.
     """
     try:
-        if server_name[-1] == "]":
+        if not server_name:
+            # Nothing provided
+            return "", None
+        elif server_name[-1] == "]":
             # ipv6 literal, hopefully
             return server_name, None
-
-        domain_port = server_name.rsplit(":", 1)
-        domain = domain_port[0]
-        port = int(domain_port[1]) if domain_port[1:] else None
-        return domain, port
+        elif ":" not in server_name:
+            # hostname only
+            return server_name, None
+        domain, port = server_name.rsplit(":", 1)
+        return domain, int(port) if port else None
     except Exception:
         raise ValueError("Invalid server name '%s'" % server_name)
 
@@ -123,6 +126,8 @@ def parse_and_validate_server_name(server_name: str) -> Tuple[str, Optional[int]
     # that nobody is sneaking IP literals in that look like hostnames, etc.
 
     # look for ipv6 literals
+    if not host:
+        raise ValueError(f"Server name '{server_name}' has an invalid format.")
     if host[0] == "[":
         if host[-1] != "]":
             raise ValueError("Mismatched [...] in server name '%s'" % (server_name,))

--- a/tests/util/test_stringutils.py
+++ b/tests/util/test_stringutils.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 from synapse.api.errors import SynapseError
-from synapse.util.stringutils import assert_valid_client_secret, base62_encode
+from synapse.util.stringutils import (
+    assert_valid_client_secret,
+    base62_encode,
+    parse_server_name,
+    parse_and_validate_server_name,
+)
 
 from .. import unittest
 
@@ -51,3 +56,39 @@ class StringUtilsTestCase(unittest.TestCase):
         self.assertEqual("10", base62_encode(62))
         self.assertEqual("1c", base62_encode(100))
         self.assertEqual("001c", base62_encode(100, minwidth=4))
+
+    def test_parse_server_name(self):
+        vals = [
+            ("localhost:80", ("localhost", 80)),
+            ("", ("", None)),
+            (":80", ("", 80)),
+            ("[::1]", ("[::1]", None)),
+            ("[::1]:80", ("[::1]", 80)),
+            ("[::1:80", ("[::1", 80)),
+        ]
+        for value, expected in vals:
+            self.assertEqual(parse_server_name(value), expected)
+
+    def test_valid_server_name(self):
+        valid_server_names = [
+            ("foo.bar.baz:80", ("foo.bar.baz", 80)),
+            ("[::1]:80", ("[::1]", 80)),
+            ("127.0.0.1:80", ("127.0.0.1", 80)),
+            ("foo.bar.baz", ("foo.bar.baz", None)),
+            ("[::1]", ("[::1]", None)),
+            ("127.0.0.1", ("127.0.0.1", None)),
+            ("localhost", ("localhost", None)),
+        ]
+        for name, expected in valid_server_names:
+            self.assertEqual(expected, parse_and_validate_server_name(name))
+
+    def test_invalid_server_name(self):
+        invalid_server_names = [
+            ("[::1:80", r"Mismatched \[\.\.\.\] in server name '\[::1:80'"),
+            ("", "Server name '' has an invalid format"),
+            ("[]:80", r"Server name '\[\]:80' is not a valid IPv6 address"),
+            (".baz:80", r"Server name '.baz:80' has an invalid format"),
+        ]
+        for server_name, regex in invalid_server_names:
+            with self.assertRaisesRegex(ValueError, regex):
+                parse_and_validate_server_name(server_name)


### PR DESCRIPTION
As mentionned in https://github.com/matrix-org/synapse/issues/12122,
the parse_server_name should act as a `server_name` splitter, while `parse_and_validate_server_name`
does the checks.