### PR TITLE
Purge room when all users have forgotten it

### DIFF
--- a/changelog.d/12170.bugfix
+++ b/changelog.d/12170.bugfix
@@ -1,3 +1,1 @@
-Purge a room completely when all local users have forgotten it.
-
-Contributed by @pingiun.
+Purge a room completely when all local users have forgotten it. Contributed by @pingiun.

--- a/changelog.d/12170.bugfix
+++ b/changelog.d/12170.bugfix
@@ -1,0 +1,1 @@
+Purge a room completely when all local users have forgotten it.

--- a/changelog.d/12170.bugfix
+++ b/changelog.d/12170.bugfix
@@ -1,1 +1,3 @@
 Purge a room completely when all local users have forgotten it.
+
+Contributed by @pingiun.

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -795,11 +795,11 @@ class RoomMemberWorkerStore(EventsWorkerStore):
 
     async def is_locally_forgotten_room(self, room_id: str) -> bool:
         sql = """
-            SELECT 1 FROM room_memberships
-            WHERE room_id = ?
-                AND user_id LIKE ?
-                AND forgotten != 1
-            LIMIT 1
+            SELECT count(*) FROM local_current_membership
+            INNER JOIN room_memberships USING (room_id, event_id)
+            WHERE 
+                room_id = ?
+                AND forgotten = 0;
         """
 
         rows = await self.db_pool.execute(


### PR DESCRIPTION
Somewhat adresses #4720, based on comment: https://github.com/matrix-org/synapse/issues/4720#issuecomment-671899124

This will only work for newly forgotten rooms, and only rooms that are completely forgotten by all users. This is not a general fix for people who want to remove rooms after some time and after they have been left by everyone.

Signed-off-by: Jelle Besseling <jelle@pingiun.com>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
