### PR TITLE
Skip attempt to get state at backwards-extremities

### DIFF
--- a/changelog.d/12173.misc
+++ b/changelog.d/12173.misc
@@ -1,0 +1,1 @@
+Avoid trying to calculate the state at outlier events.


### PR DESCRIPTION
We don't *have* the state at a backwards-extremity, so this is never going to do anything useful.

As part of my investigation, I stuck some debug in the middle of the code to see if it ever found a non-empty list of servers to fetch from, and ran it through sytest. It was never hit.

(part of my quest to sort out #12074)