### PR TITLE
Add `delay_cancellation` utility function

### DIFF
--- a/changelog.d/12180.misc
+++ b/changelog.d/12180.misc
@@ -1,0 +1,1 @@
+Add `delay_cancellation` utility function, which behaves like `stop_cancellation` but waits until the original `Deferred` resolves before raising a `CancelledError`.

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -686,11 +686,12 @@ def stop_cancellation(deferred: "defer.Deferred[T]") -> "defer.Deferred[T]":
             Synapse logcontext rules.
 
     Returns:
-        A new `Deferred`, which will contain the result of the original `Deferred`,
-        but will not propagate cancellation through to the original. When cancelled,
-        the new `Deferred` will fail with a `CancelledError` and will not follow the
-        Synapse logcontext rules. `make_deferred_yieldable` should be used to wrap
-        the new `Deferred`.
+        A new `Deferred`, which will contain the result of the original `Deferred`.
+        The new `Deferred` will not propagate cancellation through to the original.
+        When cancelled, the new `Deferred` will fail with a `CancelledError`.
+
+        The new `Deferred` will not follow the Synapse logcontext rules and should be
+        wrapped with `make_deferred_yieldable`.
     """
     new_deferred: defer.Deferred[T] = defer.Deferred()
     deferred.chainDeferred(new_deferred)

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -698,17 +698,15 @@ def stop_cancellation(deferred: "defer.Deferred[T]") -> "defer.Deferred[T]":
     return new_deferred
 
 
-def delay_cancellation(deferred: "defer.Deferred[T]", all: bool) -> "defer.Deferred[T]":
+def delay_cancellation(deferred: "defer.Deferred[T]") -> "defer.Deferred[T]":
     """Delay cancellation of a `Deferred` until it resolves.
 
     Has the same effect as `stop_cancellation`, but the returned `Deferred` will not
     resolve with a `CancelledError` until the original `Deferred` resolves.
 
     Args:
-        deferred: The `Deferred` to protect against cancellation. Must not follow the
-            Synapse logcontext rules if `all` is `False`.
-        all: `True` to delay multiple cancellations. `False` to delay only the first
-            cancellation.
+        deferred: The `Deferred` to protect against cancellation. May optionally follow
+            the Synapse logcontext rules.
 
     Returns:
         A new `Deferred`, which will contain the result of the original `Deferred`.
@@ -716,9 +714,9 @@ def delay_cancellation(deferred: "defer.Deferred[T]", all: bool) -> "defer.Defer
         When cancelled, the new `Deferred` will wait until the original `Deferred`
         resolves before failing with a `CancelledError`.
 
-        The new `Deferred` will only follow the Synapse logcontext rules if `all` is
-        `True` and `deferred` follows the Synapse logcontext rules. Otherwise the new
-        `Deferred` should be wrapped with `make_deferred_yieldable`.
+        The new `Deferred` will follow the Synapse logcontext rules if `deferred`
+        follows the Synapse logcontext rules. Otherwise the new `Deferred` should be
+        wrapped with `make_deferred_yieldable`.
     """
 
     def cancel_errback(failure: Failure) -> Union[Failure, "defer.Deferred[T]"]:
@@ -738,10 +736,9 @@ def delay_cancellation(deferred: "defer.Deferred[T]", all: bool) -> "defer.Defer
         delay_deferred: "defer.Deferred[T]" = defer.Deferred()
         deferred.chainDeferred(delay_deferred)
 
-        if all:
-            # Intercept cancellations recursively. Each cancellation will cause another
-            # `Deferred` to be inserted into the chain.
-            delay_deferred.addErrback(cancel_errback)
+        # Intercept cancellations recursively. Each cancellation will cause another
+        # `Deferred` to be inserted into the chain.
+        delay_deferred.addErrback(cancel_errback)
 
         # Override the result with the `CancelledError`.
         delay_deferred.addBoth(lambda _: failure)

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -696,3 +696,59 @@ def stop_cancellation(deferred: "defer.Deferred[T]") -> "defer.Deferred[T]":
     new_deferred: "defer.Deferred[T]" = defer.Deferred()
     deferred.chainDeferred(new_deferred)
     return new_deferred
+
+
+def delay_cancellation(deferred: "defer.Deferred[T]", all: bool) -> "defer.Deferred[T]":
+    """Delay cancellation of a `Deferred` until it resolves.
+
+    Has the same effect as `stop_cancellation`, but the returned `Deferred` will not
+    resolve with a `CancelledError` until the original `Deferred` resolves.
+
+    Args:
+        deferred: The `Deferred` to protect against cancellation. Must not follow the
+            Synapse logcontext rules if `all` is `False`.
+        all: `True` to delay multiple cancellations. `False` to delay only the first
+            cancellation.
+
+    Returns:
+        A new `Deferred`, which will contain the result of the original `Deferred`.
+        The new `Deferred` will not propagate cancellation through to the original.
+        When cancelled, the new `Deferred` will wait until the original `Deferred`
+        resolves before failing with a `CancelledError`.
+
+        The new `Deferred` will only follow the Synapse logcontext rules if `all` is
+        `True` and `deferred` follows the Synapse logcontext rules. Otherwise the new
+        `Deferred` should be wrapped with `make_deferred_yieldable`.
+    """
+
+    def cancel_errback(failure: Failure) -> Union[Failure, "defer.Deferred[T]"]:
+        """Insert another `Deferred` into the chain to delay cancellation.
+
+        Called when the original `Deferred` resolves or the new `Deferred` is
+        cancelled.
+        """
+        failure.trap(CancelledError)
+
+        if deferred.called and not deferred.paused:
+            # The `CancelledError` came from the original `Deferred`. Pass it through.
+            return failure
+
+        # Construct another `Deferred` that will only fail with the `CancelledError`
+        # once the original `Deferred` resolves.
+        delay_deferred: "defer.Deferred[T]" = defer.Deferred()
+        deferred.chainDeferred(delay_deferred)
+
+        if all:
+            # Intercept cancellations recursively. Each cancellation will cause another
+            # `Deferred` to be inserted into the chain.
+            delay_deferred.addErrback(cancel_errback)
+
+        # Override the result with the `CancelledError`.
+        delay_deferred.addBoth(lambda _: failure)
+
+        return delay_deferred
+
+    new_deferred: "defer.Deferred[T]" = defer.Deferred()
+    deferred.chainDeferred(new_deferred)
+    new_deferred.addErrback(cancel_errback)
+    return new_deferred

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -720,6 +720,9 @@ def delay_cancellation(deferred: "defer.Deferred[T]") -> "defer.Deferred[T]":
     """
 
     def handle_cancel(new_deferred: "defer.Deferred[T]") -> None:
+        # before the new deferred is cancelled, we `pause` it to stop the cancellation
+        # propagating. we then `unpause` it once the wrapped deferred completes, to
+        # propagate the exception.
         new_deferred.pause()
         new_deferred.errback(Failure(CancelledError()))
 

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -693,6 +693,6 @@ def stop_cancellation(deferred: "defer.Deferred[T]") -> "defer.Deferred[T]":
         The new `Deferred` will not follow the Synapse logcontext rules and should be
         wrapped with `make_deferred_yieldable`.
     """
-    new_deferred: defer.Deferred[T] = defer.Deferred()
+    new_deferred: "defer.Deferred[T]" = defer.Deferred()
     deferred.chainDeferred(new_deferred)
     return new_deferred

--- a/tests/util/test_async_helpers.py
+++ b/tests/util/test_async_helpers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import traceback
-from typing import Callable
 
 from parameterized import parameterized_class
 
@@ -319,16 +318,21 @@ class ConcurrentlyExecuteTest(TestCase):
 
 
 @parameterized_class(
-    ("wrap_deferred",),
-    [
-        (lambda _self, deferred: stop_cancellation(deferred),),
-        (lambda _self, deferred: delay_cancellation(deferred, all=True),),
-    ],
+    ("wrapper",),
+    [("stop_cancellation",), ("delay_cancellation",)],
 )
 class CancellationWrapperTests(TestCase):
     """Common tests for the `stop_cancellation` and `delay_cancellation` functions."""
 
-    wrap_deferred: Callable[[TestCase, "Deferred[str]"], "Deferred[str]"]
+    wrapper: str
+
+    def wrap_deferred(self, deferred: "Deferred[str]") -> "Deferred[str]":
+        if self.wrapper == "stop_cancellation":
+            return stop_cancellation(deferred)
+        elif self.wrapper == "delay_cancellation":
+            return delay_cancellation(deferred, all=True)
+        else:
+            raise ValueError(f"Unsupported wrapper type: {self.wrapper}")
 
     def test_succeed(self):
         """Test that the new `Deferred` receives the result."""

--- a/tests/util/test_async_helpers.py
+++ b/tests/util/test_async_helpers.py
@@ -462,7 +462,6 @@ class DelayCancellationTests(TestCase):
         self.assertEqual(SENTINEL_CONTEXT, current_context())
 
         d.cancel()
-        d.cancel()
 
         # Now unblock. `outer()` will consume the `CancelledError` and check the
         # logging context.


### PR DESCRIPTION
`delay_cancellation` behaves like `stop_cancellation` (#12106), except it
delays `CancelledError`s until the original `Deferred` resolves.
This is handy for unifying cleanup paths and ensuring that uncancelled
coroutines don't use finished logcontexts.

Comes from a suggestion by @erikjohnston.

As part of these changes I've ended up updating some of the `stop_cancellation` code and tests.

Generally useful for #3528.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
