### PR TITLE
Convert boolean event content to strings for push rule evaluation

### DIFF
--- a/changelog.d/12181.misc
+++ b/changelog.d/12181.misc
@@ -1,0 +1,1 @@
+Convert event content booleans to strings when evaluating push rules. Contributed by Nick @ Beeper.

--- a/synapse/push/push_rule_evaluator.py
+++ b/synapse/push/push_rule_evaluator.py
@@ -232,6 +232,8 @@ def _flatten_dict(
     if result is None:
         result = {}
     for key, value in d.items():
+        if isinstance(value, bool):
+            value = str(value)
         if isinstance(value, str):
             result[".".join(prefix + [key])] = value.lower()
         elif isinstance(value, Mapping):


### PR DESCRIPTION
Quick change so boolean event fields can be evaluated in push rules (as strings). Alternative could be a different matcher type (`event_match_boolean`) but that felt like overkill.

Signed of by Nick Mills-Barrett <nick@beeper.com>

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
