### PR TITLE
Allow modules to store already existing 3PID associations

### DIFF
--- a/changelog.d/12195.feature
+++ b/changelog.d/12195.feature
@@ -1,0 +1,1 @@
+Allow modules to store already existing 3PID associations.

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -659,7 +659,8 @@ class ModuleApi:
     def record_user_external_id(
         self, auth_provider_id: str, remote_user_id: str, registered_user_id: str
     ) -> defer.Deferred:
-        """Record a mapping from an external user id to a mxid
+        """Record a mapping between an external user id from a single sign-on provider
+        and a mxid.
 
         Added in Synapse v1.9.0.
 
@@ -1281,7 +1282,7 @@ class ModuleApi:
 
         The association must already exist on the remote identity server.
 
-        Added in Synapse v1.55.0.
+        Added in Synapse v1.56.0.
 
         Args:
             user_id: The user ID that's been associated with the 3PID.
@@ -1289,6 +1290,12 @@ class ModuleApi:
                 "email").
             address: The address of the 3PID.
             id_server: The identity server the 3PID association has been registered on.
+                This should only be the domain (or IP address, optionally with the port
+                number) for the identity server. This will be used to reach out to the
+                identity server using HTTPS (unless specified otherwise by Synapse's
+                configuration) when attempting to unbind the third-party identifier.
+
+
         """
         await self._store.add_user_bound_threepid(user_id, medium, address, id_server)
 

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -1274,6 +1274,24 @@ class ModuleApi:
         """
         await self._registration_handler.check_username(username)
 
+    async def store_remote_3pid_association(
+        self, user_id: str, medium: str, address: str, id_server: str
+    ) -> None:
+        """Stores an existing association between a user ID and a third-party identifier.
+
+        The association must already exist on the remote identity server.
+
+        Added in Synapse v1.55.0.
+
+        Args:
+            user_id: The user ID that's been associated with the 3PID.
+            medium: The medium of the 3PID (current supported values are "msisdn" and
+                "email").
+            address: The address of the 3PID.
+            id_server: The identity server the 3PID association has been registered on.
+        """
+        await self._store.add_user_bound_threepid(user_id, medium, address, id_server)
+
 
 class PublicRoomListManager:
     """Contains methods for adding to, removing from and querying whether a room


### PR DESCRIPTION
Part of the Tchap mainlining. On Tchap, users register with their work email address, which is automatically associated on Sydent using Sydent's internal API. These associations then need to be stored in Synapse's database. The idea is to move that into a module that implements [`on_user_registration`](https://matrix-org.github.io/synapse/latest/modules/account_validity_callbacks.html#on_user_registration), binds the 3pid, and then inserts the association into the database.

Ideally I would have copied over `add_user_bound_threepid` into the module, but it requires doing an upsert which isn't trivial from a module.