### PR TITLE
Retention test: avoid relying on state at purged events

### DIFF
--- a/changelog.d/12202.misc
+++ b/changelog.d/12202.misc
@@ -1,0 +1,1 @@
+Avoid trying to calculate the state at outlier events.


### PR DESCRIPTION
This test was relying on poking events which weren't in the database into `filter_events_for_client`, which is conflicting with my changes elsewhere.

The intention of the test is to see what happens when `filter_events_for_client` is called on events which should have expired, but are still in the db. So let's *actually* test that by leaving them in the db!