### PR TITLE
Fix a misleading comment in `check_events_for_spam`

### DIFF
--- a/changelog.d/12203.misc
+++ b/changelog.d/12203.misc
@@ -1,0 +1,1 @@
+Fix a misleading comment in the function `check_event_for_spam`.

--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -245,8 +245,8 @@ class SpamChecker:
         """Checks if a given event is considered "spammy" by this server.
 
         If the server considers an event spammy, then it will be rejected if
-        sent by a local user. If it is sent by a user on another server, then
-        users receive a blank event.
+        sent by a local user. If it is sent by a user on another server, the
+        event is soft-failed.
 
         Args:
             event: the event to be checked


### PR DESCRIPTION
Pursuant to this conversation on this issue: #3649. Once upon a time when spammy events were received over federation Synapse redacted them and sent them on. Now they are soft-failed. I have changed the docstring to reflect this. 