### PR TITLE
Note that contributors can sign off privately

### DIFF
--- a/changelog.d/12204.doc
+++ b/changelog.d/12204.doc
@@ -1,0 +1,1 @@
+Document that contributors can sign off privately by email.

--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -463,7 +463,7 @@ flag to `git commit`, which uses the name and email set in your
 If you would like to provide your legal name privately to the Matrix.org
 Foundation (instead of in a public commit or comment), you can do so
 by emailing your legal name and a link to the pull request to
-[dco@matrix.org](mailto:dco@matrix.org).
+[dco@matrix.org](mailto:dco@matrix.org?subject=Private%20sign%20off).
 It helps to include "sign off" or similar in the subject line. You will then
 be instructed further.
 

--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -458,6 +458,17 @@ Git allows you to add this signoff automatically when using the `-s`
 flag to `git commit`, which uses the name and email set in your
 `user.name` and `user.email` git configs.
 
+### Private Sign off
+
+If you would like to provide your legal name privately to the Matrix.org
+Foundation (instead of in a public commit or comment), you can do so
+by emailing your legal name and a link to the pull request to
+[dco@matrix.org](mailto:dco@matrix.org).
+It helps to include "sign off" or similar in the subject line. You will then
+be instructed further.
+
+Once private sign off is complete, doing so for future contributions will not
+be required.
 
 # 10. Turn feedback into better code.
 


### PR DESCRIPTION
Contributors can now sign off their contributions without revealing their legal name to the public.

This has existed for a little while now. It's time to write it down somewhere.