### PR TITLE
Implement a Jinja2 filter to extract localparts from email addresses

### DIFF
--- a/changelog.d/12212.feature
+++ b/changelog.d/12212.feature
@@ -1,0 +1,1 @@
+Add a new Jinja2 template filter to extract the local part of an email address.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1948,7 +1948,8 @@ saml2_config:
 #             localpart_template: Jinja2 template for the localpart of the MXID.
 #                 If this is not set, the user will be prompted to choose their
 #                 own username (see the documentation for the
-#                 'sso_auth_account_details.html' template).
+#                 'sso_auth_account_details.html' template). This template can
+#                 use the 'localpart_from_email' filter.
 #
 #             confirm_localpart: Whether to prompt the user to validate (or
 #                 change) the generated localpart (see the documentation for the

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -36,6 +36,13 @@ Turns a `mxc://` URL for media content into an HTTP(S) one using the homeserver'
 
 Example: `message.sender_avatar_url|mxc_to_http(32,32)`
 
+```python
+localpart_from_email(address: str) -> str
+```
+
+Returns the local part of an email address (e.g. `alice` in `alice@example.com`).
+
+Example: `user.email_address|localpart_from_email`
 
 ## Email templates
 

--- a/synapse/config/oidc.py
+++ b/synapse/config/oidc.py
@@ -183,7 +183,8 @@ class OIDCConfig(Config):
         #             localpart_template: Jinja2 template for the localpart of the MXID.
         #                 If this is not set, the user will be prompted to choose their
         #                 own username (see the documentation for the
-        #                 'sso_auth_account_details.html' template).
+        #                 'sso_auth_account_details.html' template). This template can
+        #                 use the 'localpart_from_email' filter.
         #
         #             confirm_localpart: Whether to prompt the user to validate (or
         #                 change) the generated localpart (see the documentation for the

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -45,6 +45,7 @@ from synapse.types import JsonDict, UserID, map_username_to_mxid_localpart
 from synapse.util import Clock, json_decoder
 from synapse.util.caches.cached_call import RetryOnExceptionCachedCall
 from synapse.util.macaroons import get_value_from_macaroon, satisfy_expiry
+from synapse.util.templates import _localpart_from_email_filter
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
@@ -1308,6 +1309,11 @@ def jinja_finalize(thing: Any) -> Any:
 
 
 env = Environment(finalize=jinja_finalize)
+env.filters.update(
+    {
+        "localpart_from_email": _localpart_from_email_filter,
+    }
+)
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)

--- a/synapse/util/templates.py
+++ b/synapse/util/templates.py
@@ -64,6 +64,7 @@ def build_jinja_env(
         {
             "format_ts": _format_ts_filter,
             "mxc_to_http": _create_mxc_to_http_filter(config.server.public_baseurl),
+            "localpart_from_email": _localpart_from_email_filter,
         }
     )
 
@@ -112,3 +113,7 @@ def _create_mxc_to_http_filter(
 
 def _format_ts_filter(value: int, format: str) -> str:
     return time.strftime(format, time.localtime(value / 1000))
+
+
+def _localpart_from_email_filter(address: str) -> str:
+    return address.rsplit("@", 1)[0]


### PR DESCRIPTION
When discussing config changes for https://github.com/matrix-org/synapse/issues/12205, we concluded that we want to use email address localparts. We don't have a filter for that currently, so this PR adds one:

```python
>>> from synapse.util.templates import _localpart_from_email_filter
>>> from jinja2.environment import Environment
>>> env = Environment()
>>> env.filters.update({"localpart_from_email": _localpart_from_email_filter})
>>> t = env.from_string("{{ email|localpart_from_email }}")
>>> t.render(email="foo@bar.com")
'foo'
>>> t.render(email="foo@bar.com@example.com")
'foo@bar.com'
>>> 
```
