### PR TITLE
docs/worker: add missing typing request location

### DIFF
--- a/changelog.d/12220.doc
+++ b/changelog.d/12220.doc
@@ -1,0 +1,1 @@
+add missing typing requests location

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -256,6 +256,9 @@ information.
     ^/_matrix/client/(api/v1|r0|v3|unstable)/join/
     ^/_matrix/client/(api/v1|r0|v3|unstable)/profile/
 
+    # Typing requests
+    ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/typing
+
     # Device requests
     ^/_matrix/client/(r0|v3|unstable)/sendToDevice/
 


### PR DESCRIPTION
@clokep we both missed and forgot something in the PR #12196. ;)
