### PR TITLE
Refactor relations tests

### DIFF
--- a/changelog.d/12232.misc
+++ b/changelog.d/12232.misc
@@ -1,0 +1,1 @@
+Refactor relations tests to improve code re-use.


### PR DESCRIPTION
This refactors the relations tests a bit:

* Moves out pagination tests to a separate class.
* Move the assertion of the response code into the `_send_relation` helper (which is used in like every test...)
* Moves some helpers into the base-class (note that this isn't terribly useful *in this PR*, but I plan to use them in a few different future PRs).

Mostly making this a separate PR since it is only refactoring and because I want these changes in multiple separate PRs (#12228 and the follow-on to #12227) and hoping it will help parallelize them.