### PR TITLE
Optimise `_update_client_ips_batch_txn` to batch together database operations.

### DIFF
--- a/changelog.d/12252.feature
+++ b/changelog.d/12252.feature
@@ -1,0 +1,1 @@
+Move `update_client_ip` background job from the main process to the background worker.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1856,11 +1856,6 @@ class DatabasePool:
                 f"{len(key_values)} key rows and {len(value_values)} value rows: should be the same number."
             )
 
-        # List of value names, then key names
-        allnames: List[str] = []
-        allnames.extend(value_names)
-        allnames.extend(key_names)
-
         # List of tuples of (value values, then key values)
         # (This matches the order of `allnames` and the order of the query)
         args = [tuple(x) + tuple(y) for x, y in zip(value_values, key_values)]

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     from synapse.server import HomeServer
 
 # python 3 does not have a maximum int value
-MAX_TXN_ID = 2 ** 63 - 1
+MAX_TXN_ID = 2**63 - 1
 
 logger = logging.getLogger(__name__)
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1280,7 +1280,8 @@ class DatabasePool:
             value_names: The value column names
             value_values: A list of each row's value column values.
                 Ignored if value_names is empty.
-            lock: True to lock the table when doing the upsert.
+            lock: True to lock the table when doing the upsert. Unused if the database engine
+            	supports native upserts.
         """
 
         # We can autocommit if we are going to use native upserts
@@ -1320,7 +1321,8 @@ class DatabasePool:
             value_names: The value column names
             value_values: A list of each row's value column values.
                 Ignored if value_names is empty.
-            lock: True to lock the table when doing the upsert.
+            lock: True to lock the table when doing the upsert. Unused if the database engine
+            	supports native upserts.
         """
         if self.engine.can_native_upsert and table not in self._unsafe_to_upsert_tables:
             return self.simple_upsert_many_txn_native_upsert(

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1360,11 +1360,17 @@ class DatabasePool:
         if not value_names:
             value_values = [() for x in range(len(key_values))]
 
+        if lock:
+            # Lock the table just once, to prevent it being done once per row.
+            # Note that, according to Postgres' documentation, once obtained,
+            # the lock is held for the remainder of the current transaction.
+            self.engine.lock_table(txn, "user_ips")
+
         for keyv, valv in zip(key_values, value_values):
             _keys = {x: y for x, y in zip(key_names, keyv)}
             _vals = {x: y for x, y in zip(value_names, valv)}
 
-            self.simple_upsert_txn_emulated(txn, table, _keys, _vals, lock=lock)
+            self.simple_upsert_txn_emulated(txn, table, _keys, _vals, lock=False)
 
     def simple_upsert_many_txn_native_upsert(
         self,

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1808,6 +1808,18 @@ class DatabasePool:
         value_values: Iterable[Iterable[Any]],
         desc: str,
     ) -> None:
+        """
+        Update, many times, using batching where possible.
+        If the keys don't match anything, nothing will be updated.
+
+        Args:
+            table: The table to update
+            key_names: The key column names.
+            key_values: A list of each row's key column values.
+            value_names: The names of value columns to update.
+            value_values: A list of each row's value column values.
+        """
+
         return await self.runInteraction(
             desc,
             self.simple_update_many_txn,
@@ -1829,9 +1841,10 @@ class DatabasePool:
     ) -> None:
         """
         Update, many times, using batching where possible.
+        If the keys don't match anything, nothing will be updated.
 
         Args:
-            table: The table to upsert into
+            table: The table to update
             key_names: The key column names.
             key_values: A list of each row's key column values.
             value_names: The names of value columns to update.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1857,7 +1857,7 @@ class DatabasePool:
             )
 
         # List of tuples of (value values, then key values)
-        # (This matches the order of `allnames` and the order of the query)
+        # (This matches the order needed for the query)
         args = [tuple(x) + tuple(y) for x, y in zip(value_values, key_values)]
 
         for ks, vs in zip(key_values, value_values):

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1281,7 +1281,7 @@ class DatabasePool:
             value_values: A list of each row's value column values.
                 Ignored if value_names is empty.
             lock: True to lock the table when doing the upsert. Unused if the database engine
-            	supports native upserts.
+                supports native upserts.
         """
 
         # We can autocommit if we are going to use native upserts
@@ -1322,7 +1322,7 @@ class DatabasePool:
             value_values: A list of each row's value column values.
                 Ignored if value_names is empty.
             lock: True to lock the table when doing the upsert. Unused if the database engine
-            	supports native upserts.
+                supports native upserts.
         """
         if self.engine.can_native_upsert and table not in self._unsafe_to_upsert_tables:
             return self.simple_upsert_many_txn_native_upsert(

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1792,6 +1792,25 @@ class DatabasePool:
 
         return txn.rowcount
 
+    async def simple_update_many(
+        self,
+        table: str,
+        key_names: Collection[str],
+        key_values: Collection[Iterable[Any]],
+        value_names: Collection[str],
+        value_values: Iterable[Iterable[Any]],
+        desc: str,
+    ) -> None:
+        return await self.runInteraction(
+            desc,
+            self.simple_update_many_txn,
+            table,
+            key_names,
+            key_values,
+            value_names,
+            value_values,
+        )
+
     @staticmethod
     def simple_update_many_txn(
         txn: LoggingTransaction,

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1288,7 +1288,7 @@ class DatabasePool:
             self.engine.can_native_upsert and table not in self._unsafe_to_upsert_tables
         )
 
-        return await self.runInteraction(
+        await self.runInteraction(
             desc,
             self.simple_upsert_many_txn,
             table,
@@ -1820,7 +1820,7 @@ class DatabasePool:
             value_values: A list of each row's value column values.
         """
 
-        return await self.runInteraction(
+        await self.runInteraction(
             desc,
             self.simple_update_many_txn,
             table,

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1818,7 +1818,7 @@ class DatabasePool:
         key_names: Collection[str],
         key_values: Collection[Iterable[Any]],
         value_names: Collection[str],
-        value_values: Iterable[Iterable[Any]],
+        value_values: Collection[Iterable[Any]],
     ) -> None:
         """
         Update, many times, using batching where possible.
@@ -1830,6 +1830,11 @@ class DatabasePool:
             value_names: The names of value columns to update.
             value_values: A list of each row's value column values.
         """
+
+        if len(value_values) != len(key_values):
+            raise ValueError(
+                f"{len(key_values)} key rows and {len(value_values)} value rows: should be the same number."
+            )
 
         # List of value names, then key names
         allnames: List[str] = []

--- a/synapse/storage/databases/main/client_ips.py
+++ b/synapse/storage/databases/main/client_ips.py
@@ -630,11 +630,6 @@ class ClientIpWorkerStore(ClientIpBackgroundUpdateStore, MonthlyActiveUsersWorke
             self._update_on_this_worker
         ), "This worker is not designated to update client IPs"
 
-        if "user_ips" in self.db_pool._unsafe_to_upsert_tables or (
-            not self.database_engine.can_native_upsert
-        ):
-            self.database_engine.lock_table(txn, "user_ips")
-
         # Keys and values for the `user_ips` upsert.
         user_ips_keys = []
         user_ips_values = []
@@ -661,7 +656,6 @@ class ClientIpWorkerStore(ClientIpBackgroundUpdateStore, MonthlyActiveUsersWorke
             key_values=user_ips_keys,
             value_names=("user_agent", "device_id", "last_seen"),
             value_values=user_ips_values,
-            lock=False,
         )
 
         if devices_values:

--- a/synapse/storage/databases/main/client_ips.py
+++ b/synapse/storage/databases/main/client_ips.py
@@ -634,25 +634,24 @@ class ClientIpWorkerStore(ClientIpBackgroundUpdateStore, MonthlyActiveUsersWorke
         ):
             self.database_engine.lock_table(txn, "user_ips")
 
-        def update_user_ips() -> None:
-            # Keys and values for the `user_ips` upsert.
-            keys = []
-            values = []
+        # Keys and values for the `user_ips` upsert.
+        user_ips_keys = []
+        user_ips_values = []
 
-            for entry in to_update.items():
-                (user_id, access_token, ip), (user_agent, device_id, last_seen) = entry
-                keys.append((user_id, access_token, ip))
-                values.append((user_agent, device_id, last_seen))
+        for entry in to_update.items():
+            (user_id, access_token, ip), (user_agent, device_id, last_seen) = entry
+            user_ips_keys.append((user_id, access_token, ip))
+            user_ips_values.append((user_agent, device_id, last_seen))
 
-            self.db_pool.simple_upsert_many_txn(
-                txn,
-                table="user_ips",
-                key_names=("user_id", "access_token", "ip"),
-                key_values=keys,
-                value_names=("user_agent", "device_id", "last_seen"),
-                value_values=values,
-                lock=False
-            )
+        self.db_pool.simple_upsert_many_txn(
+            txn,
+            table="user_ips",
+            key_names=("user_id", "access_token", "ip"),
+            key_values=user_ips_keys,
+            value_names=("user_agent", "device_id", "last_seen"),
+            value_values=user_ips_values,
+            lock=False,
+        )
 
         def update_devices() -> None:
             # Keys and values for the `devices` update.

--- a/synapse/storage/databases/main/client_ips.py
+++ b/synapse/storage/databases/main/client_ips.py
@@ -653,7 +653,7 @@ class ClientIpWorkerStore(ClientIpBackgroundUpdateStore, MonthlyActiveUsersWorke
                 key_values=keys,
                 value_names=value_columns,
                 value_values=values,
-                # TODO lock=False
+                lock=False
             )
 
         def update_devices() -> None:

--- a/synapse/storage/databases/main/client_ips.py
+++ b/synapse/storage/databases/main/client_ips.py
@@ -636,9 +636,7 @@ class ClientIpWorkerStore(ClientIpBackgroundUpdateStore, MonthlyActiveUsersWorke
 
         def update_user_ips() -> None:
             # Keys and values for the `user_ips` upsert.
-            key_columns = "user_id", "access_token", "ip"
             keys = []
-            value_columns = "user_agent", "device_id", "last_seen"
             values = []
 
             for entry in to_update.items():
@@ -649,18 +647,16 @@ class ClientIpWorkerStore(ClientIpBackgroundUpdateStore, MonthlyActiveUsersWorke
             self.db_pool.simple_upsert_many_txn(
                 txn,
                 table="user_ips",
-                key_names=key_columns,
+                key_names=("user_id", "access_token", "ip"),
                 key_values=keys,
-                value_names=value_columns,
+                value_names=("user_agent", "device_id", "last_seen"),
                 value_values=values,
                 lock=False
             )
 
         def update_devices() -> None:
             # Keys and values for the `devices` update.
-            key_columns = "user_id", "device_id"
             keys = []
-            value_columns = "user_agent", "last_seen", "ip"
             values = []
 
             for entry in to_update.items():
@@ -675,9 +671,9 @@ class ClientIpWorkerStore(ClientIpBackgroundUpdateStore, MonthlyActiveUsersWorke
             self.db_pool.simple_update_many_txn(
                 txn,
                 table="devices",
-                key_names=key_columns,
+                key_names=("user_id", "device_id"),
                 key_values=keys,
-                value_names=value_columns,
+                value_names=("user_agent", "last_seen", "ip"),
                 value_values=values,
             )
 

--- a/tests/storage/test__base.py
+++ b/tests/storage/test__base.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import secrets
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Generator, Tuple
 
 from twisted.test.proto_helpers import MemoryReactor
 

--- a/tests/storage/test__base.py
+++ b/tests/storage/test__base.py
@@ -24,7 +24,7 @@ from synapse.util import Clock
 from tests import unittest
 
 
-class UpsertManyTests(unittest.HomeserverTestCase):
+class UpdateUpsertManyTests(unittest.HomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.storage = hs.get_datastores().main
 
@@ -46,7 +46,7 @@ class UpsertManyTests(unittest.HomeserverTestCase):
             )
         )
 
-    def _dump_to_tuple(self) -> Generator[Tuple[int, str, str], None, None]:
+    def _dump_table_to_tuple(self) -> Generator[Tuple[int, str, str], None, None]:
         res = self.get_success(
             self.storage.db_pool.simple_select_list(
                 self.table_name, None, ["id, username, value"]
@@ -80,7 +80,7 @@ class UpsertManyTests(unittest.HomeserverTestCase):
 
         # Check results are what we expect
         self.assertEqual(
-            set(self._dump_to_tuple()),
+            set(self._dump_table_to_tuple()),
             {(1, "user1", "hello"), (2, "user2", "there")},
         )
 
@@ -102,6 +102,6 @@ class UpsertManyTests(unittest.HomeserverTestCase):
 
         # Check results are what we expect
         self.assertEqual(
-            set(self._dump_to_tuple()),
+            set(self._dump_table_to_tuple()),
             {(1, "user1", "hello"), (2, "user2", "bleb")},
         )

--- a/tests/storage/test__base.py
+++ b/tests/storage/test__base.py
@@ -46,9 +46,13 @@ class UpsertManyTests(unittest.HomeserverTestCase):
             )
         )
 
-    def _dump_to_tuple(
-        self, res: List[Dict[str, Any]]
-    ) -> Generator[Tuple[int, str, str], None, None]:
+    def _dump_to_tuple(self) -> Generator[Tuple[int, str, str], None, None]:
+        res = self.get_success(
+            self.storage.db_pool.simple_select_list(
+                self.table_name, None, ["id, username, value"]
+            )
+        )
+
         for i in res:
             yield (i["id"], i["username"], i["value"])
 
@@ -75,13 +79,8 @@ class UpsertManyTests(unittest.HomeserverTestCase):
         )
 
         # Check results are what we expect
-        res = self.get_success(
-            self.storage.db_pool.simple_select_list(
-                self.table_name, None, ["id, username, value"]
-            )
-        )
         self.assertEqual(
-            set(self._dump_to_tuple(res)),
+            set(self._dump_to_tuple()),
             {(1, "user1", "hello"), (2, "user2", "there")},
         )
 
@@ -102,12 +101,7 @@ class UpsertManyTests(unittest.HomeserverTestCase):
         )
 
         # Check results are what we expect
-        res = self.get_success(
-            self.storage.db_pool.simple_select_list(
-                self.table_name, None, ["id, username, value"]
-            )
-        )
         self.assertEqual(
-            set(self._dump_to_tuple(res)),
+            set(self._dump_to_tuple()),
             {(1, "user1", "hello"), (2, "user2", "bleb")},
         )


### PR DESCRIPTION
This easy optimisation was noticed in #10425 by anoa, and it seemed like the right time to implement these
(along with #12251). Not expecting super magical powers, but it might be a nice little improvement.

Depends on: #12251

