### PR TITLE
Reword 'Choose your user name' as 'Choose your account name' in the SSO registration template, in order to comply with SIWA guidelines.

### DIFF
--- a/changelog.d/12260.misc
+++ b/changelog.d/12260.misc
@@ -1,0 +1,1 @@
+Reword 'Choose your user name' as 'Choose your account name' in the SSO registration template, in order to comply with SIWA guidelines.

--- a/synapse/res/templates/sso_auth_account_details.html
+++ b/synapse/res/templates/sso_auth_account_details.html
@@ -130,7 +130,7 @@
   </head>
   <body>
     <header>
-      <h1>Choose your user name</h1>
+      <h1>Choose your account name</h1>
       <p>This is required to create your account on {{ server_name }}, and you can't change this later.</p>
     </header>
     <main>


### PR DESCRIPTION
Fixes #12259; enhances #12210 and addresses part of #12205.

