### PR TITLE
Re-enable concurrency on Complement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -377,7 +377,7 @@ jobs:
       # Run Complement
       - run: |
           set -o pipefail
-          go test -v -json -p 1 -tags synapse_blacklist,msc2403,msc2716,msc3030 ./tests/... 2>&1 | gotestfmt
+          go test -v -json -tags synapse_blacklist,msc2403,msc2716,msc3030 ./tests/... 2>&1 | gotestfmt
         shell: bash
         name: Run Complement Tests
         env:

--- a/changelog.d/12283.misc
+++ b/changelog.d/12283.misc
@@ -1,0 +1,1 @@
+Re-enable Complement concurrency in CI.


### PR DESCRIPTION
The issues which meant concurrency caused flakey tests has been resolved for over a month now without issue ( https://github.com/matrix-org/complement/pull/318 ) so it's safe to re-enable this for Synapse.

For context, this reduces the total time from ~9m 52s to ~8m 11s. Most of the savings are during the actual running of the tests, which has gone from 7m 20s to 5m 47s.
