### PR TITLE
Add a configuration option for rewriting base URLs when interacting with ISs

### DIFF
--- a/changelog.d/12284.feature
+++ b/changelog.d/12284.feature
@@ -1,0 +1,1 @@
+Add a configuration option for rewriting base URLs when interacting with identity servers from Synapse.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -539,6 +539,23 @@ templates:
   #
   #custom_template_directory: /path/to/custom/templates/
 
+# Base URLs to substitute when making requests to identity servers from Synapse.
+# This can be useful if an identity server exists under a different name or
+# address within an internal network than on the Internet.
+#
+# The first half of each line is the domain or address on which the identity
+# server is publicly accessible (without a protocol scheme) and the second half
+# is the base URL (i.e. protocol scheme and domain or address) to use for this
+# identity server.
+#
+# This list does not need to be exhaustive: if Synapse needs to send a request to
+# an identity server that isn't in this list it will just use its public name or
+# address.
+#
+#rewrite_identity_server_base_urls:
+#   public.example.com: http://public.int.example.com
+#   vip.example.com: http://vip.int.example.com
+
 
 # Message retention policy at the server level.
 #

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -676,6 +676,14 @@ class ServerConfig(Config):
         ):
             raise ConfigError("'custom_template_directory' must be a string")
 
+        self.identity_server_rewrite_map: Dict[str, str] = (
+            config.get("rewrite_identity_server_base_urls") or {}
+        )
+        if not isinstance(self.identity_server_rewrite_map, dict):
+            raise ConfigError(
+                "'rewrite_identity_server_base_urls' must be a dictionary"
+            )
+
     def has_tls_listener(self) -> bool:
         return any(listener.tls for listener in self.listeners)
 
@@ -1230,6 +1238,23 @@ class ServerConfig(Config):
           # information about using custom templates.
           #
           #custom_template_directory: /path/to/custom/templates/
+
+        # Base URLs to substitute when making requests to identity servers from Synapse.
+        # This can be useful if an identity server exists under a different name or
+        # address within an internal network than on the Internet.
+        #
+        # The first half of each line is the domain or address on which the identity
+        # server is publicly accessible (without a protocol scheme) and the second half
+        # is the base URL (i.e. protocol scheme and domain or address) to use for this
+        # identity server.
+        #
+        # This list does not need to be exhaustive: if Synapse needs to send a request to
+        # an identity server that isn't in this list it will just use its public name or
+        # address.
+        #
+        #rewrite_identity_server_base_urls:
+        #   public.example.com: http://public.int.example.com
+        #   vip.example.com: http://vip.int.example.com
         """
             % locals()
         )

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -87,8 +87,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-id_server_scheme = "https://"
-
 FIVE_MINUTES_IN_MS = 5 * 60 * 1000
 
 

--- a/tests/rest/client/test_identity.py
+++ b/tests/rest/client/test_identity.py
@@ -80,6 +80,7 @@ class IdentityTestCase(unittest.HomeserverTestCase):
                 }
             )
         )
+        mock_client.get_json = Mock(return_value=make_awaitable({}))
 
         self.hs.get_identity_handler().blacklisting_http_client = mock_client
 

--- a/tests/rest/client/test_identity.py
+++ b/tests/rest/client/test_identity.py
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from http import HTTPStatus
+from unittest.mock import Mock
 
 from twisted.test.proto_helpers import MemoryReactor
 
 import synapse.rest.admin
-from synapse.rest.client import login, room
+from synapse.http.client import SimpleHttpClient
+from synapse.rest.client import login, register, room
 from synapse.server import HomeServer
 from synapse.util import Clock
 
 from tests import unittest
+from tests.test_utils import make_awaitable
 
 
 class IdentityTestCase(unittest.HomeserverTestCase):
@@ -31,18 +33,55 @@ class IdentityTestCase(unittest.HomeserverTestCase):
         synapse.rest.admin.register_servlets_for_client_rest_resource,
         room.register_servlets,
         login.register_servlets,
+        register.register_servlets,
     ]
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
 
         config = self.default_config()
-        config["enable_3pid_lookup"] = False
         self.hs = self.setup_test_homeserver(config=config)
 
         return self.hs
 
+    @unittest.override_config({"enable_3pid_lookup": False})
     def test_3pid_lookup_disabled(self) -> None:
-        self.hs.config.registration.enable_3pid_lookup = False
+        self.register_user("kermit", "monkey")
+        tok = self.login("kermit", "monkey")
+
+        channel = self.make_request(b"POST", "/createRoom", b"{}", access_token=tok)
+        self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
+        room_id = channel.json_body["room_id"]
+
+        self._send_threepid_invite(
+            id_server="vip.example.com",
+            address="test@example.com",
+            room_id=room_id,
+            tok=tok,
+            expected_status=HTTPStatus.FORBIDDEN,
+        )
+
+    @unittest.override_config(
+        {
+            "rewrite_identity_server_base_urls": {
+                "vip.example.com": "http://vip-int.example.com",
+            }
+        }
+    )
+    def test_rewrite_is_base_url(self) -> None:
+        """Tests that base URLs for identity services are correctly rewritten."""
+        mock_client = Mock(spec=SimpleHttpClient)
+        mock_client.post_json_get_json = Mock(
+            return_value=make_awaitable(
+                {
+                    "token": "sometoken",
+                    "public_key": "somekey",
+                    "public_keys": [],
+                    "display_name": "foo",
+                }
+            )
+        )
+
+        self.hs.get_identity_handler().blacklisting_http_client = mock_client
 
         self.register_user("kermit", "monkey")
         tok = self.login("kermit", "monkey")
@@ -51,14 +90,55 @@ class IdentityTestCase(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
         room_id = channel.json_body["room_id"]
 
-        params = {
-            "id_server": "testis",
-            "medium": "email",
-            "address": "test@example.com",
-        }
-        request_data = json.dumps(params)
-        request_url = ("/rooms/%s/invite" % (room_id)).encode("ascii")
-        channel = self.make_request(
-            b"POST", request_url, request_data, access_token=tok
+        # Send a 3PID invite, and check that the base URL for the identity server has been
+        # correctly rewritten.
+        self._send_threepid_invite(
+            id_server="vip.example.com",
+            address="test@example.com",
+            room_id=room_id,
+            tok=tok,
+            expected_status=HTTPStatus.OK,
         )
-        self.assertEqual(channel.code, HTTPStatus.FORBIDDEN, channel.result)
+
+        mock_client.post_json_get_json.assert_called_once()
+        args = mock_client.post_json_get_json.call_args[0]
+
+        self.assertTrue(args[0].startswith("http://vip-int.example.com"))
+
+        # Send another 3PID invite, this time to an identity server that doesn't need
+        # rewriting, and check that the base URL hasn't been rewritten (apart from adding
+        # an HTTPS protocol scheme).
+        self._send_threepid_invite(
+            id_server="testis",
+            address="test@example.com",
+            room_id=room_id,
+            tok=tok,
+            expected_status=HTTPStatus.OK,
+        )
+
+        self.assertEqual(mock_client.post_json_get_json.call_count, 2)
+        args = mock_client.post_json_get_json.call_args[0]
+
+        self.assertTrue(args[0].startswith("https://testis"))
+
+    def _send_threepid_invite(
+        self, id_server: str, address: str, room_id: str, tok: str, expected_status: int
+    ) -> None:
+        """Try to send a 3PID invite into a room.
+
+        Args:
+            id_server: the identity server to use to store the invite.
+            address: the email address to send the invite to.
+            room_id: the room the invite is for.
+            tok: the access token to authenticate the request with.
+            expected_status: the expected HTTP status in the response to /invite.
+        """
+        params = {
+            "id_server": id_server,
+            "medium": "email",
+            "address": address,
+        }
+        channel = self.make_request(
+            b"POST", "/rooms/%s/invite" % (room_id,), params, access_token=tok
+        )
+        self.assertEqual(channel.code, expected_status, channel.result)


### PR DESCRIPTION
This work is happening in the context of the Tchap mainlining.

Identity servers are services that need to be accessible by both clients (lookups, associations, etc) and homeservers (storing 3PID invites). In the Tchap infra, for security reasons, any IS URL that doesn't need to be accessible to clients are firewalled off and only accessible via the internal network. Thus the URL (both address/hostname and protocol) to use isn't the same depending on whether the communication is happening from a client on the internet or a homeserver on the local network.

This change introduces a `rewrite_identity_server_base_urls` configuration setting allowing admins to provide a substitution maps for base URLs when to use by Synapse when interacting with identity services.