### PR TITLE
Do not consider events by ignored users for relations

### DIFF
--- a/changelog.d/12227.bugfix
+++ b/changelog.d/12227.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where events from ignored users were still considered for relations.

--- a/changelog.d/12227.misc
+++ b/changelog.d/12227.misc
@@ -1,1 +1,0 @@
-Refactor the relations endpoints to add a `RelationsHandler`.

--- a/changelog.d/12232.bugfix
+++ b/changelog.d/12232.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where events from ignored users were still considered for relations.

--- a/changelog.d/12232.misc
+++ b/changelog.d/12232.misc
@@ -1,1 +1,0 @@
-Refactor relations tests to improve code re-use.

--- a/changelog.d/12285.bugfix
+++ b/changelog.d/12285.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where events from ignored users were still considered for relations.


### PR DESCRIPTION
This is part of the last bit needed for #11753; we need to ensure that if a user ignores another user, their related events are properly ignored.

This PR (which is split from #12235) handles filtering events from an ignored user in `/relations`.

As #12235 is about to come a bit more complicated I figured it was worth while to separate this out to a separate PR since the diff is more self-contained.