### PR TITLE
Replace instances of deprecated `Jinja2.Markup` with `markupsafe.Markup`

### DIFF
--- a/changelog.d/12289.misc
+++ b/changelog.d/12289.misc
@@ -1,0 +1,1 @@
+Remove uses of the long-deprecated `Jinja2.Markup` which would prevent Synapse from starting with Jinja2 3.1.0 or above installed. This does not affect deployments of Synapse using our Docker images or Debian packages.

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, TypeVar
 
 import bleach
 import jinja2
+from markupsafe import Markup
 
 from synapse.api.constants import EventTypes, Membership, RoomTypes
 from synapse.api.errors import StoreError
@@ -867,7 +868,7 @@ class Mailer:
         )
 
 
-def safe_markup(raw_html: str) -> jinja2.Markup:
+def safe_markup(raw_html: str) -> Markup:
     """
     Sanitise a raw HTML string to a set of allowed tags and attributes, and linkify any bare URLs.
 
@@ -877,7 +878,7 @@ def safe_markup(raw_html: str) -> jinja2.Markup:
     Returns:
         A Markup object ready to safely use in a Jinja template.
     """
-    return jinja2.Markup(
+    return Markup(
         bleach.linkify(
             bleach.clean(
                 raw_html,
@@ -891,7 +892,7 @@ def safe_markup(raw_html: str) -> jinja2.Markup:
     )
 
 
-def safe_text(raw_text: str) -> jinja2.Markup:
+def safe_text(raw_text: str) -> Markup:
     """
     Sanitise text (escape any HTML tags), and then linkify any bare URLs.
 
@@ -901,7 +902,7 @@ def safe_text(raw_text: str) -> jinja2.Markup:
     Returns:
         A Markup object ready to safely use in a Jinja template.
     """
-    return jinja2.Markup(
+    return Markup(
         bleach.linkify(bleach.clean(raw_text, tags=[], attributes=[], strip=False))
     )
 

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -75,6 +75,7 @@ REQUIREMENTS = [
     "attrs>=19.2.0,!=21.1.0",
     "netaddr>=0.7.18",
     "Jinja2>=2.9",
+    "MarkupSafe<=3.0.0",
     "bleach>=1.4.3",
     # We use `ParamSpec`, which was added in `typing-extensions` 3.10.0.0.
     "typing-extensions>=3.10.0",

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -75,7 +75,7 @@ REQUIREMENTS = [
     "attrs>=19.2.0,!=21.1.0",
     "netaddr>=0.7.18",
     "Jinja2>=2.9",
-    "MarkupSafe<=3.0.0",
+    "MarkupSafe>=2.0",
     "bleach>=1.4.3",
     # We use `ParamSpec`, which was added in `typing-extensions` 3.10.0.0.
     "typing-extensions>=3.10.0",


### PR DESCRIPTION
The Jinja2 recently [removed](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0) the long-deprecated `Jinja2.Markup` property, instead advising callers to import `Markup` from the [markupsafe](https://pypi.org/project/MarkupSafe/) library directly.

This PR:

* Adds a direct dependency on MarkupSafe as we now import from it. Pinned to the currently major version of `2`.
* Replaces uses of `Jinja2.Markup` with `markupsafe.Markup`