### PR TITLE
Revert "Replace instances of deprecated `Jinja2.Markup` with `markupsafe.Markup`"

### DIFF
--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, TypeVar
 
 import bleach
 import jinja2
-from markupsafe import Markup
 
 from synapse.api.constants import EventTypes, Membership, RoomTypes
 from synapse.api.errors import StoreError
@@ -868,7 +867,7 @@ class Mailer:
         )
 
 
-def safe_markup(raw_html: str) -> Markup:
+def safe_markup(raw_html: str) -> jinja2.Markup:
     """
     Sanitise a raw HTML string to a set of allowed tags and attributes, and linkify any bare URLs.
 
@@ -878,7 +877,7 @@ def safe_markup(raw_html: str) -> Markup:
     Returns:
         A Markup object ready to safely use in a Jinja template.
     """
-    return Markup(
+    return jinja2.Markup(
         bleach.linkify(
             bleach.clean(
                 raw_html,
@@ -892,7 +891,7 @@ def safe_markup(raw_html: str) -> Markup:
     )
 
 
-def safe_text(raw_text: str) -> Markup:
+def safe_text(raw_text: str) -> jinja2.Markup:
     """
     Sanitise text (escape any HTML tags), and then linkify any bare URLs.
 
@@ -902,7 +901,7 @@ def safe_text(raw_text: str) -> Markup:
     Returns:
         A Markup object ready to safely use in a Jinja template.
     """
-    return Markup(
+    return jinja2.Markup(
         bleach.linkify(bleach.clean(raw_text, tags=[], attributes=[], strip=False))
     )
 

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -75,7 +75,6 @@ REQUIREMENTS = [
     "attrs>=19.2.0,!=21.1.0",
     "netaddr>=0.7.18",
     "Jinja2>=2.9",
-    "MarkupSafe>=2.0",
     "bleach>=1.4.3",
     # We use `ParamSpec`, which was added in `typing-extensions` 3.10.0.0.
     "typing-extensions>=3.10.0",


### PR DESCRIPTION
Reverts matrix-org/synapse#12289. Due to https://github.com/matrix-org/synapse/issues/12294.