### PR TITLE
Pin Jinja to <3.1.0

### DIFF
--- a/changelog.d/12297.misc
+++ b/changelog.d/12297.misc
@@ -1,0 +1,1 @@
+Pin Jinja to <3.1.0, as Synapse fails to start with Jinja 3.1.0.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -74,7 +74,8 @@ REQUIREMENTS = [
     # Note: 21.1.0 broke `/sync`, see #9936
     "attrs>=19.2.0,!=21.1.0",
     "netaddr>=0.7.18",
-    "Jinja2>=2.9",
+    # Jinja2 3.1.0 removes the deprecated jinja2.Markup class, which we rely on.
+    "Jinja2<3.1.0",
     "bleach>=1.4.3",
     # We use `ParamSpec`, which was added in `typing-extensions` 3.10.0.0.
     "typing-extensions>=3.10.0",


### PR DESCRIPTION
Pins [Jinja2](https://pypi.org/project/jinja2/) to <3.1.0, as 3.1.0 removed the deprecated `jinja2.Markup` class which we still rely on.

An alternative to https://github.com/matrix-org/synapse/pull/12289, which ended in https://github.com/matrix-org/synapse/issues/12294.