### PR TITLE
Enhance logging for inbound federation events

### DIFF
--- a/changelog.d/12301.misc
+++ b/changelog.d/12301.misc
@@ -1,0 +1,1 @@
+Enhance logging for inbound federation events.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -1092,7 +1092,7 @@ class FederationServer(FederationBase):
         # has started processing).
         while True:
             async with lock:
-                logger.info("handling received PDU: %s", event)
+                logger.info("handling received PDU in room %s: %s", room_id, event)
                 try:
                     with nested_logging_context(event.event_id):
                         await self._federation_event_handler.on_receive_pdu(


### PR DESCRIPTION
It is currently rather hard to see which rooms are causing inbound federation traffic. Add the room id to the logs.

Currently, this log line looks like:

```
2022-03-25 09:13:55,104 - synapse.federation.federation_server - 1096 - INFO - _process_incoming_pdus_in_room_inner-829556 - handling received PDU: <FrozenEventV3 event_id=$Hk4ESFnYBbj9Ph-6Lx3PD-obTuOWzndD2hNk7du_SCU, type=m.room.message, state_key=None, outlier=False>
```