### PR TITLE
Draft: Remove unused `auth_event_ids` argument plumbing

### DIFF
--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -782,7 +782,6 @@ class EventCreationHandler:
         event_dict: dict,
         allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
-        auth_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
         ratelimit: bool = True,
         txn_id: Optional[str] = None,
@@ -807,12 +806,6 @@ class EventCreationHandler:
                 The event IDs to use as the prev events.
                 Should normally be left as None to automatically request them
                 from the database.
-            auth_event_ids:
-                The event ids to use as the auth_events for the new event.
-                Should normally be left as None, which will cause them to be calculated
-                based on the room state at the prev_events.
-
-                If non-None, prev_event_ids must also be provided.
             state_event_ids:
                 The full state at a given event. This is used particularly by the MSC2716
                 /batch_send endpoint. One use case is with insertion events which float at
@@ -878,7 +871,6 @@ class EventCreationHandler:
                 txn_id=txn_id,
                 allow_no_prev_events=allow_no_prev_events,
                 prev_event_ids=prev_event_ids,
-                auth_event_ids=auth_event_ids,
                 state_event_ids=state_event_ids,
                 outlier=outlier,
                 historical=historical,

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -271,7 +271,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         membership: str,
         allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
-        auth_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
         txn_id: Optional[str] = None,
         ratelimit: bool = True,
@@ -295,10 +294,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 events should have a prev_event and we should only use this in special
                 cases like MSC2716.
             prev_event_ids: The event IDs to use as the prev events
-            auth_event_ids:
-                The event ids to use as the auth_events for the new event.
-                Should normally be left as None, which will cause them to be calculated
-                based on the room state at the prev_events.
             state_event_ids:
                 The full state at a given event. This is used particularly by the MSC2716
                 /batch_send endpoint. One use case is the historical `state_events_at_start`;
@@ -361,7 +356,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             txn_id=txn_id,
             allow_no_prev_events=allow_no_prev_events,
             prev_event_ids=prev_event_ids,
-            auth_event_ids=auth_event_ids,
             state_event_ids=state_event_ids,
             require_consent=require_consent,
             outlier=outlier,
@@ -465,7 +459,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         historical: bool = False,
         allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
-        auth_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
     ) -> Tuple[str, int]:
         """Update a user's membership in a room.
@@ -494,10 +487,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 events should have a prev_event and we should only use this in special
                 cases like MSC2716.
             prev_event_ids: The event IDs to use as the prev events
-            auth_event_ids:
-                The event ids to use as the auth_events for the new event.
-                Should normally be left as None, which will cause them to be calculated
-                based on the room state at the prev_events.
             state_event_ids:
                 The full state at a given event. This is used particularly by the MSC2716
                 /batch_send endpoint. One use case is the historical `state_events_at_start`;
@@ -544,7 +533,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                     historical=historical,
                     allow_no_prev_events=allow_no_prev_events,
                     prev_event_ids=prev_event_ids,
-                    auth_event_ids=auth_event_ids,
                     state_event_ids=state_event_ids,
                 )
 
@@ -567,7 +555,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         historical: bool = False,
         allow_no_prev_events: bool = False,
         prev_event_ids: Optional[List[str]] = None,
-        auth_event_ids: Optional[List[str]] = None,
         state_event_ids: Optional[List[str]] = None,
     ) -> Tuple[str, int]:
         """Helper for update_membership.
@@ -598,10 +585,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 events should have a prev_event and we should only use this in special
                 cases like MSC2716.
             prev_event_ids: The event IDs to use as the prev events
-            auth_event_ids:
-                The event ids to use as the auth_events for the new event.
-                Should normally be left as None, which will cause them to be calculated
-                based on the room state at the prev_events.
             state_event_ids:
                 The full state at a given event. This is used particularly by the MSC2716
                 /batch_send endpoint. One use case is the historical `state_events_at_start`;
@@ -736,7 +719,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 ratelimit=ratelimit,
                 allow_no_prev_events=allow_no_prev_events,
                 prev_event_ids=prev_event_ids,
-                auth_event_ids=auth_event_ids,
                 state_event_ids=state_event_ids,
                 content=content,
                 require_consent=require_consent,
@@ -961,7 +943,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             txn_id=txn_id,
             ratelimit=ratelimit,
             prev_event_ids=latest_event_ids,
-            auth_event_ids=auth_event_ids,
             state_event_ids=state_event_ids,
             content=content,
             require_consent=require_consent,


### PR DESCRIPTION
Remove unused `auth_event_ids` argument plumbing

Follow-up to https://github.com/matrix-org/synapse/pull/12083

Since we are now using the new `state_event_ids` parameter to do all of the heavy lifting.
We can remove any spots where we plumbed `auth_event_ids` just for MSC2716 things in
https://github.com/matrix-org/synapse/pull/9247/files.

Removing `auth_event_ids` from following functions:

 - `create_and_send_nonmember_event`
 - `_local_membership_update`
 - `update_membership`
 - `update_membership_locked`

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
