### PR TITLE
Improve type annotations for `execute_values`.

### DIFF
--- a/changelog.d/12311.misc
+++ b/changelog.d/12311.misc
@@ -1,0 +1,1 @@
+Improve type annotations for `execute_values`.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -324,16 +324,6 @@ class LoggingTransaction:
         "Strip newlines out of SQL so that the loggers in the DB are on one line"
         return " ".join(line.strip() for line in sql.splitlines() if line.strip())
 
-    # TODO(ParamSpec):
-    #     Once Mypy supports Concatenate, this could be written as
-    #     def _do_execute(
-    #         self,
-    #         func: Callable[Concatenate[str, P], R],
-    #         sql: str,
-    #         *args: P.args,
-    #         **kwargs: P.kwargs,
-    #     ) -> R:
-    #     so long as we also pass kwargs.
     def _do_execute(self, func: Callable[..., R], sql: str, *args: Any) -> R:
         sql = self._make_sql_one_line(sql)
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -290,7 +290,9 @@ class LoggingTransaction:
         if isinstance(self.database_engine, PostgresEngine):
             from psycopg2.extras import execute_batch
 
-            self._do_execute(lambda *x: execute_batch(self.txn, *x), sql, args)
+            self._do_execute(
+                lambda the_sql: execute_batch(self.txn, the_sql, args), sql
+            )
         else:
             self.executemany(sql, args)
 
@@ -307,11 +309,8 @@ class LoggingTransaction:
         from psycopg2.extras import execute_values
 
         return self._do_execute(
-            lambda the_sql, the_values: execute_values(
-                self.txn, the_sql, the_values, fetch=fetch
-            ),
+            lambda the_sql: execute_values(self.txn, the_sql, values, fetch=fetch),
             sql,
-            values,
         )
 
     def execute(self, sql: str, *args: Any) -> None:

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -295,7 +295,7 @@ class LoggingTransaction:
             self.executemany(sql, args)
 
     def execute_values(
-        self, sql: str, args: Iterable[Iterable[Any]], fetch: bool = True
+        self, sql: str, values: Iterable[Iterable[Any]], fetch: bool = True
     ) -> List[Tuple]:
         """Corresponds to psycopg2.extras.execute_values. Only available when
         using postgres.
@@ -307,11 +307,11 @@ class LoggingTransaction:
         from psycopg2.extras import execute_values
 
         return self._do_execute(
-            lambda the_sql, the_args: execute_values(
-                self.txn, the_sql, the_args, fetch=fetch
+            lambda the_sql, the_values: execute_values(
+                self.txn, the_sql, the_values, fetch=fetch
             ),
             sql,
-            args,
+            values,
         )
 
     def execute(self, sql: str, *args: Any) -> None:

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -326,6 +326,16 @@ class LoggingTransaction:
         "Strip newlines out of SQL so that the loggers in the DB are on one line"
         return " ".join(line.strip() for line in sql.splitlines() if line.strip())
 
+    # TODO(ParamSpec):
+    #     Once Mypy supports Concatenate, this could be written as
+    #     def _do_execute(
+    #         self,
+    #         func: Callable[Concatenate[str, P], R],
+    #         sql: str,
+    #         *args: P.args,
+    #         **kwargs: P.kwargs,
+    #     ) -> R:
+    #     so long as we also pass kwargs.
     def _do_execute(self, func: Callable[..., R], sql: str, *args: Any) -> R:
         sql = self._make_sql_one_line(sql)
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -294,7 +294,9 @@ class LoggingTransaction:
         else:
             self.executemany(sql, args)
 
-    def execute_values(self, sql: str, *args: Any, fetch: bool = True) -> List[Tuple]:
+    def execute_values(
+        self, sql: str, args: Iterable[Iterable[Any]], fetch: bool = True
+    ) -> List[Tuple]:
         """Corresponds to psycopg2.extras.execute_values. Only available when
         using postgres.
 
@@ -305,15 +307,11 @@ class LoggingTransaction:
         from psycopg2.extras import execute_values
 
         return self._do_execute(
-            # Type ignore: mypy is unhappy because if `x` is a 5-tuple, then there will
-            # be two values for `fetch`: one given positionally, and another given
-            # as a keyword argument. We might be able to fix this by
-            # - propagating the signature of psycopg2.extras.execute_values to this
-            #   function, or
-            # - changing `*args: Any` to `values: T` for some appropriate T.
-            lambda *x: execute_values(self.txn, *x, fetch=fetch),  # type: ignore[misc]
+            lambda the_sql, the_args: execute_values(
+                self.txn, the_sql, the_args, fetch=fetch
+            ),
             sql,
-            *args,
+            args,
         )
 
     def execute(self, sql: str, *args: Any) -> None:


### PR DESCRIPTION
Should be a commit-by-commit review.

This was something that I agreed to look into whilst I was in the area.
Turns out the `*args` was not necessary; there's only one arg here (an iterable of value rows).

I also added a comment to `_do_execute`, where we could improve the type annotations easily a little bit
once `ParamSpec` is more usable.

