### PR TITLE
Un-revert Jinja2 fix

### DIFF
--- a/changelog.d/12313.misc
+++ b/changelog.d/12313.misc
@@ -1,0 +1,1 @@
+Correctly import `Markup` from `MarkupSafe` instead of `Jinja2`.

--- a/changelog.d/12313.misc
+++ b/changelog.d/12313.misc
@@ -1,1 +1,1 @@
-Import `Markup` from `MarkupSafe` as importing it from `Jinja2` has been deprecated for some time and recently removed.
+Fix compatibility with the recently-released Jinja 3.1.

--- a/changelog.d/12313.misc
+++ b/changelog.d/12313.misc
@@ -1,1 +1,1 @@
-Correctly import `Markup` from `MarkupSafe` instead of `Jinja2`.
+Import `Markup` from `MarkupSafe` as importing it from `Jinja2` has been deprecated for some time and recently removed.

--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, TypeVar
 
 import bleach
 import jinja2
+from markupsafe import Markup
 
 from synapse.api.constants import EventTypes, Membership, RoomTypes
 from synapse.api.errors import StoreError
@@ -867,7 +868,7 @@ class Mailer:
         )
 
 
-def safe_markup(raw_html: str) -> jinja2.Markup:
+def safe_markup(raw_html: str) -> Markup:
     """
     Sanitise a raw HTML string to a set of allowed tags and attributes, and linkify any bare URLs.
 
@@ -877,7 +878,7 @@ def safe_markup(raw_html: str) -> jinja2.Markup:
     Returns:
         A Markup object ready to safely use in a Jinja template.
     """
-    return jinja2.Markup(
+    return Markup(
         bleach.linkify(
             bleach.clean(
                 raw_html,
@@ -891,7 +892,7 @@ def safe_markup(raw_html: str) -> jinja2.Markup:
     )
 
 
-def safe_text(raw_text: str) -> jinja2.Markup:
+def safe_text(raw_text: str) -> Markup:
     """
     Sanitise text (escape any HTML tags), and then linkify any bare URLs.
 
@@ -901,7 +902,7 @@ def safe_text(raw_text: str) -> jinja2.Markup:
     Returns:
         A Markup object ready to safely use in a Jinja template.
     """
-    return jinja2.Markup(
+    return Markup(
         bleach.linkify(bleach.clean(raw_text, tags=[], attributes=[], strip=False))
     )
 

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -77,7 +77,7 @@ REQUIREMENTS = [
     # Jinja 2.x is incompatible with MarkupSafe>=2.1. To ensure that admins do not
     # end up with a broken installation, with recent MarkupSafe but old Jinja, we
     # add a lower bound to the Jinja2 dependency.
-    "Jinja2~=3.0",
+    "Jinja2>=3.0",
     "bleach>=1.4.3",
     # We use `ParamSpec`, which was added in `typing-extensions` 3.10.0.0.
     "typing-extensions>=3.10.0",

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -74,7 +74,9 @@ REQUIREMENTS = [
     # Note: 21.1.0 broke `/sync`, see #9936
     "attrs>=19.2.0,!=21.1.0",
     "netaddr>=0.7.18",
-    # Jinja 2.x is incompatible with recent versions of MarkupSafe, on which it depends.
+    # Jinja 2.x is incompatible with MarkupSafe>=2.1. To ensure that admins do not
+    # end up with a broken installation, with recent MarkupSafe but old Jinja, we
+    # add a lower bound to the Jinja2 dependency.
     "Jinja2~=3.0",
     "bleach>=1.4.3",
     # We use `ParamSpec`, which was added in `typing-extensions` 3.10.0.0.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -74,8 +74,8 @@ REQUIREMENTS = [
     # Note: 21.1.0 broke `/sync`, see #9936
     "attrs>=19.2.0,!=21.1.0",
     "netaddr>=0.7.18",
-    # Jinja2 3.1.0 removes the deprecated jinja2.Markup class, which we rely on.
-    "Jinja2<3.1.0",
+    "Jinja2>=2.9",
+    "MarkupSafe>=2.0",
     "bleach>=1.4.3",
     # We use `ParamSpec`, which was added in `typing-extensions` 3.10.0.0.
     "typing-extensions>=3.10.0",

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -74,8 +74,7 @@ REQUIREMENTS = [
     # Note: 21.1.0 broke `/sync`, see #9936
     "attrs>=19.2.0,!=21.1.0",
     "netaddr>=0.7.18",
-    "Jinja2>=2.9",
-    "MarkupSafe>=2.0",
+    "Jinja2~=3.0",
     "bleach>=1.4.3",
     # We use `ParamSpec`, which was added in `typing-extensions` 3.10.0.0.
     "typing-extensions>=3.10.0",

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -74,6 +74,7 @@ REQUIREMENTS = [
     # Note: 21.1.0 broke `/sync`, see #9936
     "attrs>=19.2.0,!=21.1.0",
     "netaddr>=0.7.18",
+    # Jinja 2.x is incompatible with recent versions of MarkupSafe, on which it depends.
     "Jinja2~=3.0",
     "bleach>=1.4.3",
     # We use `ParamSpec`, which was added in `typing-extensions` 3.10.0.0.


### PR DESCRIPTION
* Reverts https://github.com/matrix-org/synapse/pull/12296
* Pins `Jinja2>=3.0`

Fixes https://github.com/matrix-org/synapse/issues/12294