### PR TITLE
Exclude outliers in `on_backfill_request`

### DIFF
--- a/changelog.d/12314.misc
+++ b/changelog.d/12314.misc
@@ -1,0 +1,1 @@
+Avoid trying to calculate the state at outlier events.


### PR DESCRIPTION
When we are processing a `/backfill` request from a remote server, exclude any
outliers from consideration early on. We can't return outliers anyway (since we
don't know the state at the outlier), and filtering them out earlier means that
we won't attempt to calculate the state for them.

part of my work on fixing #12074.