### PR TITLE
Room batch: fix up handling of unknown prev_event_ids

### DIFF
--- a/changelog.d/12316.misc
+++ b/changelog.d/12316.misc
@@ -1,0 +1,1 @@
+Avoid trying to calculate the state at outlier events.


### PR DESCRIPTION
Don't attempt to get the state at an unknown `prev_event_id`.

part of my work on fixing #12074.