### PR TITLE
Move warning of open registration to v1.56 upgrade notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,18 @@
 Synapse 1.56.0rc1 (2022-03-29)
 ==============================
 
+Synapse will now refuse to start up if open registration is enabled, in order to help reduce
+the number of homeservers that have accidentally left registration publicly accessible. These
+are increasingly used as vectors of attack for spam across the federation. If you would like
+to provide registration to anyone, consider adding [email](https://github.com/matrix-org/synapse/blob/8a519f8abc6de772167c2cca101d22ee2052fafc/docs/sample_config.yaml#L1285),
+[recaptcha](https://matrix-org.github.io/synapse/v1.56/CAPTCHA_SETUP.html)
+or [token-based verification](https://matrix-org.github.io/synapse/v1.56/usage/administration/admin_api/registration_tokens.html)
+in order to prevent automated registration from bad actors.
+
+This check can be disabled by setting the `enable_registration_without_verification` option in your
+homeserver configuration file. More details are available in the
+[upgrade notes](https://matrix-org.github.io/synapse/v1.56/upgrade.html#open-registration-without-verification-is-now-disabled-by-default).
+
 Features
 --------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,7 @@ Internal Changes
 - Rename `shared_rooms` to `mutual_rooms` ([MSC2666](https://github.com/matrix-org/matrix-doc/pull/2666)), as per proposal changes. ([\#12036](https://github.com/matrix-org/synapse/issues/12036))
 - Remove check on `update_user_directory` for shared rooms handler ([MSC2666](https://github.com/matrix-org/matrix-doc/pull/2666)), and update/expand documentation. ([\#12038](https://github.com/matrix-org/synapse/issues/12038))
 - Refactor `create_new_client_event` to use a new parameter, `state_event_ids`, which accurately describes the usage with [MSC2716](https://github.com/matrix-org/matrix-doc/pull/2716) instead of abusing `auth_event_ids`. ([\#12083](https://github.com/matrix-org/synapse/issues/12083), [\#12304](https://github.com/matrix-org/synapse/issues/12304))
-- Refuse to start if registration is enabled without email, captcha, or token-based verification unless the new config flag `enable_registration_without_verification` is set. ([\#12091](https://github.com/matrix-org/synapse/issues/12091))
+- Refuse to start if registration is enabled without email, captcha, or token-based verification unless the new config flag `enable_registration_without_verification` is set to `true`. ([\#12091](https://github.com/matrix-org/synapse/issues/12091))
 - Add tests for database transaction callbacks. ([\#12198](https://github.com/matrix-org/synapse/issues/12198))
 - Handle cancellation in `DatabasePool.runInteraction`. ([\#12199](https://github.com/matrix-org/synapse/issues/12199))
 - Add missing type hints for cache storage. ([\#12216](https://github.com/matrix-org/synapse/issues/12216))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,16 +1,15 @@
 Synapse 1.56.0rc1 (2022-03-29)
 ==============================
 
-Synapse will now refuse to start up if open registration is enabled, in order to help reduce
-the number of homeservers that have accidentally left registration publicly accessible. These
-are increasingly used as vectors of attack for spam across the federation. If you would like
+Synapse will now refuse to start up if open registration is enabled, in order to help mitigate
+abuse across the federation. If you would like
 to provide registration to anyone, consider adding [email](https://github.com/matrix-org/synapse/blob/8a519f8abc6de772167c2cca101d22ee2052fafc/docs/sample_config.yaml#L1285),
 [recaptcha](https://matrix-org.github.io/synapse/v1.56/CAPTCHA_SETUP.html)
-or [token-based verification](https://matrix-org.github.io/synapse/v1.56/usage/administration/admin_api/registration_tokens.html)
+or [token-based](https://matrix-org.github.io/synapse/v1.56/usage/administration/admin_api/registration_tokens.html) verification
 in order to prevent automated registration from bad actors.
 
 This check can be disabled by setting the `enable_registration_without_verification` option in your
-homeserver configuration file. More details are available in the
+homeserver configuration file to `true`. More details are available in the
 [upgrade notes](https://matrix-org.github.io/synapse/v1.56/upgrade.html#open-registration-without-verification-is-now-disabled-by-default).
 
 Features

--- a/changelog.d/12322.misc
+++ b/changelog.d/12322.misc
@@ -1,1 +1,1 @@
-Refuse to start if registration is enabled without email, captcha, or token-based verification unless new config flag `enable_registration_without_verification` is set.
+Refuse to start if registration is enabled without email, captcha, or token-based verification unless new config flag `enable_registration_without_verification` is set to `true`.

--- a/changelog.d/12322.misc
+++ b/changelog.d/12322.misc
@@ -1,0 +1,1 @@
+Refuse to start if registration is enabled without email, captcha, or token-based verification unless new config flag `enable_registration_without_verification` is set.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -87,6 +87,11 @@ process, for example:
 
 # Upgrading to v1.56.0
 
+## Open registration without verification is now disabled by default
+
+Synapse will refuse to start if registration is enabled without email, captcha, or token-based verification unless the new config
+flag `enable_registration_without_verification` is set to "true".
+
 ## Groups/communities feature has been deprecated
 
 The non-standard groups/communities feature in Synapse has been deprecated and will
@@ -107,12 +112,6 @@ the configuration file, is set to `true`. See the [PostgreSQL documentation](htt
 for more information and instructions on how to fix a database with incorrect values.
 
 # Upgrading to v1.55.0
-
-## Open registration without verification is now disabled by default
-
-Synapse will refuse to start if registration is enabled without email, captcha, or token-based verification unless the new config 
-flag `enable_registration_without_verification` is set to "true".
-
 
 ## `synctl` script has been moved
 


### PR DESCRIPTION
This was added in https://github.com/matrix-org/synapse/pull/12091, which was expected to land in the v1.55 release. However, it was first included in v1.56.0rc1, and thus the upgrade notes need to be moved to the right version section.

Uses the same changelog as https://github.com/matrix-org/synapse/pull/12091.