### PR TITLE
Allow non-member state sent in room batch to resolve for historic events (MSC2716)

### DIFF
--- a/changelog.d/12329.bugfix
+++ b/changelog.d/12329.bugfix
@@ -1,0 +1,1 @@
+Fix non-member state events not resolving for historical events when used in [MSC2716](https://github.com/matrix-org/matrix-spec-proposals/pull/2716) `/batch_send` `state_events_at_start`.

--- a/synapse/handlers/room_batch.py
+++ b/synapse/handlers/room_batch.py
@@ -156,8 +156,8 @@ class RoomBatchHandler:
     ) -> List[str]:
         """Takes all `state_events_at_start` event dictionaries and creates/persists
         them in a floating state event chain which don't resolve into the current room
-        state. They are floating because they reference no prev_events and are marked
-        as outliers which disconnects them from the normal DAG.
+        state. They are floating because they reference no prev_events which disconnects
+        them from the normal DAG.
 
         Args:
             state_events_at_start:
@@ -218,23 +218,18 @@ class RoomBatchHandler:
                     # The rest should hang off each other in a chain.
                     allow_no_prev_events=index == 0,
                     prev_event_ids=prev_event_ids_for_state_chain,
-                    # Since each state event is marked as an outlier, the
-                    # `EventContext.for_outlier()` won't have any `state_ids`
-                    # set and therefore can't derive any state even though the
-                    # prev_events are set. Also since the first event in the
-                    # state chain is floating with no `prev_events`, it can't
-                    # derive state from anywhere automatically. So we need to
-                    # set some state explicitly.
+                    # The first event in the state chain is floating with no
+                    # `prev_events` which means it can't derive state from
+                    # anywhere automatically. So we need to set some state
+                    # explicitly.
                     #
                     # Make sure to use a copy of this list because we modify it
                     # later in the loop here. Otherwise it will be the same
-                    # reference and also update in the event when we append later.
+                    # reference and also update in the event when we append
+                    # later.
                     state_event_ids=state_event_ids.copy(),
                 )
             else:
-                # TODO: Add some complement tests that adds state that is not member joins
-                # and will use this code path. Maybe we only want to support join state events
-                # and can get rid of this `else`?
                 (
                     event,
                     _,
@@ -248,13 +243,10 @@ class RoomBatchHandler:
                     # The rest should hang off each other in a chain.
                     allow_no_prev_events=index == 0,
                     prev_event_ids=prev_event_ids_for_state_chain,
-                    # Since each state event is marked as an outlier, the
-                    # `EventContext.for_outlier()` won't have any `state_ids`
-                    # set and therefore can't derive any state even though the
-                    # prev_events are set. Also since the first event in the
-                    # state chain is floating with no `prev_events`, it can't
-                    # derive state from anywhere automatically. So we need to
-                    # set some state explicitly.
+                    # The first event in the state chain is floating with no
+                    # `prev_events` which means it can't derive state from
+                    # anywhere automatically. So we need to set some state
+                    # explicitly.
                     #
                     # Make sure to use a copy of this list because we modify it
                     # later in the loop here. Otherwise it will be the same

--- a/synapse/handlers/room_batch.py
+++ b/synapse/handlers/room_batch.py
@@ -213,9 +213,6 @@ class RoomBatchHandler:
                     room_id=room_id,
                     action=membership,
                     content=event_dict["content"],
-                    # Mark as an outlier to disconnect it from the normal DAG
-                    # and not show up between batches of history.
-                    outlier=True,
                     historical=True,
                     # Only the first event in the state chain should be floating.
                     # The rest should hang off each other in a chain.
@@ -246,9 +243,6 @@ class RoomBatchHandler:
                         state_event["sender"], app_service_requester.app_service
                     ),
                     event_dict,
-                    # Mark as an outlier to disconnect it from the normal DAG
-                    # and not show up between batches of history.
-                    outlier=True,
                     historical=True,
                     # Only the first event in the state chain should be floating.
                     # The rest should hang off each other in a chain.


### PR DESCRIPTION
Allow non-member state sent in room batch to resolve for historic events. `/batch_send` `state_events_at_start`

Previously, non-member state didn't resolve because [`filter_events_for_client`](https://github.com/matrix-org/synapse/blob/e0bb2681340752f2716f1f386139ca37c53f26cd/synapse/visibility.py#L44) [filters out all `outlier` state](https://github.com/matrix-org/synapse/blob/e0bb2681340752f2716f1f386139ca37c53f26cd/synapse/visibility.py#L79-L81) except for out-of-band membership.

Part of https://github.com/matrix-org/synapse/issues/12110

Complement test: https://github.com/matrix-org/complement/pull/354

Part of [MSC2716](https://github.com/matrix-org/matrix-spec-proposals/pull/2716)



### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
