### PR TITLE
Nuke the tox `packaging` job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           - "check_codestyle"
           - "check_isort"
           - "mypy"
-          - "packaging"
 
     steps:
       - uses: actions/checkout@v2

--- a/changelog.d/12334.misc
+++ b/changelog.d/12334.misc
@@ -1,0 +1,1 @@
+Remove the `tox` packaging job: it will be redundant once #11537 lands.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = packaging, py37, py38, py39, py310, check_codestyle, check_isort
+envlist = py37, py38, py39, py310, check_codestyle, check_isort
 
 # we require tox>=2.3.2 for the fix to https://github.com/tox-dev/tox/issues/208
 minversion = 2.3.2
@@ -137,14 +137,6 @@ setenv =
     SYNAPSE_POSTGRES = 1
 commands =
     python -m synmark {posargs:}
-
-[testenv:packaging]
-skip_install = true
-usedevelop = false
-deps =
-    check-manifest
-commands =
-    check-manifest
 
 [testenv:check_codestyle]
 extras = lint


### PR DESCRIPTION
It only checks the manifest. Once #11537 lands there won't be a manifest
any more.