### PR TITLE
Ignore .envrc for direnv users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ __pycache__/
 /media_store/
 /uploads
 
+# For direnv users
+/.envrc
+
 # IDEs
 /.idea/
 /.ropeproject/

--- a/changelog.d/12335.misc
+++ b/changelog.d/12335.misc
@@ -1,0 +1,1 @@
+Ignore `.envrc` for `direnv` users.


### PR DESCRIPTION
`direnv` + either 
- `layout python` or 
- `layout poetry` with config as described in https://github.com/direnv/direnv/wiki/Python#poetry 

works well for me. Its configuration file is `.envrc`. I happen to know @reivilibre uses it too and finds is a pleasurable.

I haven't committed an `.envrc` file because I don't want to
introduce clutter for people who aren't using direnv, and because I
suppose in principle someone could choose to use a different layout.