### PR TITLE
Update mdbook to 0.4.17

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup mdbook
         uses: peaceiris/actions-mdbook@4b5ef36b314c2599664ca107bb8c02412548d79d # v1.1.14
         with:
-          mdbook-version: '0.4.9'
+          mdbook-version: '0.4.17'
 
       - name: Build the documentation
         # mdbook will only create an index.html if we're including docs/README.md in SUMMARY.md.

--- a/changelog.d/12339.doc
+++ b/changelog.d/12339.doc
@@ -1,0 +1,1 @@
+Upgrade the version of `mdbook` in CI to 0.4.17.


### PR DESCRIPTION
Update `mdbook` (the tool used to render the documentation website) to version 0.4.17. [Full changelog](https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-0417).

There's not really any particular reason, other than staying relatively up to date with our dependencies.

I've tested this version locally and all seems to work well.