### PR TITLE
docs: Don't render the table of contents on the print page

### DIFF
--- a/changelog.d/12340.doc
+++ b/changelog.d/12340.doc
@@ -1,0 +1,1 @@
+Fix rendering of the documentation site when using the 'print' feature.

--- a/docs/website_files/table-of-contents.js
+++ b/docs/website_files/table-of-contents.js
@@ -75,6 +75,20 @@ function setTocEntry() {
  * Populate sidebar on load
  */
 window.addEventListener('load', () => {
+    // Prevent rendering the table of contents of the "print book" page, as it
+    // will end up being rendered into the output (in a broken-looking way)
+
+    // Get the name of the current page (i.e. 'print.html')
+    const pageNameExtension = window.location.pathname.split('/').pop();
+
+    // Split off the extension (as '.../print' is also a valid page name), which
+    // should result in 'print'
+    const pageName = pageNameExtension.split('.')[0];
+    if (pageName === "print") {
+        // Don't render the table of contents on this page
+        return;
+    }
+
     // Only create table of contents if there is more than one header on the page
     if (headers.length <= 1) {
         return;


### PR DESCRIPTION
If you try to print our docs currently: https://matrix-org.github.io/synapse/v1.55/print.html

...you will presented with about 6 pages of page headers before you finally get to the actual content. This is due to our custom table-of-contents renderer rendering all page titles upon page load. This is very useful for most pages, but not the print page (which shows all contents in the entire book).

This PR exits the table-of-contents loading code early if it notices that it's running on the print page.