### PR TITLE
Disable groups/communities by default.

### DIFF
--- a/changelog.d/12344.removal
+++ b/changelog.d/12344.removal
@@ -1,0 +1,1 @@
+The groups/communities feature in Synapse has been disabled by default.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -85,6 +85,13 @@ process, for example:
     dpkg -i matrix-synapse-py3_1.3.0+stretch1_amd64.deb
     ```
 
+# Upgrading to v1.58.0
+
+## Groups/communities feature has been disabled by default
+
+The non-standard groups/communities feature in Synapse has been disabled by default
+and will be removed in Synapse v1.61.0.
+
 # Upgrading to v1.57.0
 
 ## Changes to database schema for application services

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -77,7 +77,7 @@ class ExperimentalConfig(Config):
         self.msc3720_enabled: bool = experimental.get("msc3720_enabled", False)
 
         # The deprecated groups feature.
-        self.groups_enabled: bool = experimental.get("groups_enabled", True)
+        self.groups_enabled: bool = experimental.get("groups_enabled", False)
 
         # MSC2654: Unread counts
         self.msc2654_enabled: bool = experimental.get("msc2654_enabled", False)

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -63,6 +63,7 @@ class DeleteGroupTestCase(unittest.HomeserverTestCase):
         self.other_user = self.register_user("user", "pass")
         self.other_user_token = self.login("user", "pass")
 
+    @unittest.override_config({"experimental_features": {"groups_enabled": True}})
     def test_delete_group(self) -> None:
         # Create a new group
         channel = self.make_request(


### PR DESCRIPTION
This is the next bit of #11584 -- disabling groups by default, but leaving the configuration flag there to enable it.

**Blocked until develop is on Synapse v1.58.0.**

Requires matrix-org/sytest#1233.