### PR TITLE
Default to `private` room visibility rather than `public` when a client does not specify one, according to spec.

### DIFF
--- a/changelog.d/12350.bugfix
+++ b/changelog.d/12350.bugfix
@@ -1,0 +1,1 @@
+Default to `private` room visibility rather than `public` when a client does not specify one, according to spec.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -771,7 +771,9 @@ class RoomCreationHandler:
                 % (user_id,),
             )
 
-        visibility = config.get("visibility", None)
+        # The spec says rooms should default to private visibility if
+        # `visibility` is not specified.
+        visibility = config.get("visibility", "private")
         is_public = visibility == "public"
 
         room_id = await self._generate_room_id(

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -292,7 +292,7 @@ class ModuleApiTestCase(HomeserverTestCase):
         # Create a user and room to play with
         user_id = self.register_user("kermit", "monkey")
         tok = self.login("kermit", "monkey")
-        room_id = self.helper.create_room_as(user_id, tok=tok)
+        room_id = self.helper.create_room_as(user_id, tok=tok, is_public=False)
 
         # The room should not currently be in the public rooms directory
         is_in_public_rooms = self.get_success(

--- a/tests/rest/client/utils.py
+++ b/tests/rest/client/utils.py
@@ -88,7 +88,7 @@ class RestHelper:
     def create_room_as(
         self,
         room_creator: Optional[str] = None,
-        is_public: Optional[bool] = None,
+        is_public: Optional[bool] = True,
         room_version: Optional[str] = None,
         tok: Optional[str] = None,
         expect_code: int = HTTPStatus.OK,
@@ -101,9 +101,12 @@ class RestHelper:
         Args:
             room_creator: The user ID to create the room with.
             is_public: If True, the `visibility` parameter will be set to
-                "public". If False, it will be set to "private". If left
-                unspecified, the server will set it to an appropriate default
-                (which should be "private" as per the CS spec).
+                "public". If False, it will be set to "private".
+                If None, doesn't specify the `visibility` parameter in which
+                case the server is supposed to make the room private according to
+                the CS API.
+                Defaults to public, since that is commonly needed in tests
+                for convenience where room privacy is not a problem.
             room_version: The room version to create the room as. Defaults to Synapse's
                 default room version.
             tok: The access token to use in the request.

--- a/tests/storage/test_cleanup_extrems.py
+++ b/tests/storage/test_cleanup_extrems.py
@@ -250,7 +250,9 @@ class CleanupExtremDummyEventsTestCase(HomeserverTestCase):
         self.user = UserID.from_string(self.register_user("user1", "password"))
         self.token1 = self.login("user1", "password")
         self.requester = create_requester(self.user)
-        info, _ = self.get_success(self.room_creator.create_room(self.requester, {}))
+        info, _ = self.get_success(
+            self.room_creator.create_room(self.requester, {"visibility": "public"})
+        )
         self.room_id = info["room_id"]
         self.event_creator = homeserver.get_event_creation_handler()
         homeserver.config.consent.user_consent_version = self.CONSENT_VERSION


### PR DESCRIPTION
Our tests pretty heavily depend on the broken behaviour, so I changed our test helper to default to creating public rooms rather than 'default' rooms, since I think that matches the casual style of most tests anyway.
(Tests are usually not too fussed about privacy rules and just want some users in a room!)

Should be a commit-by-commit review. Just a quick fix to #11498.

