### PR TITLE
Convert `Linearizer` tests from `inlineCallbacks` to async

### DIFF
--- a/changelog.d/12353.misc
+++ b/changelog.d/12353.misc
@@ -1,0 +1,1 @@
+Convert `Linearizer` tests from `inlineCallbacks` to async.

--- a/tests/util/test_linearizer.py
+++ b/tests/util/test_linearizer.py
@@ -122,7 +122,7 @@ class LinearizerTestCase(unittest.TestCase):
     def test_lots_of_queued_things(self) -> None:
         """Tests lots of fast things queued up behind a slow thing.
 
-        The stack should *not* explode when the fast thing completes.
+        The stack should *not* explode when the slow thing completes.
         """
         linearizer = Linearizer()
         key = ""

--- a/tests/util/test_linearizer.py
+++ b/tests/util/test_linearizer.py
@@ -26,6 +26,7 @@ from tests import unittest
 class LinearizerTestCase(unittest.TestCase):
     @defer.inlineCallbacks
     def test_linearizer(self):
+        """Tests that a task is queued up behind an earlier task."""
         linearizer = Linearizer()
 
         key = object()
@@ -44,6 +45,10 @@ class LinearizerTestCase(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_linearizer_is_queued(self):
+        """Tests `Linearizer.is_queued`.
+
+        Runs through the same scenario as `test_linearizer`.
+        """
         linearizer = Linearizer()
 
         key = object()
@@ -75,8 +80,10 @@ class LinearizerTestCase(unittest.TestCase):
         self.assertFalse(linearizer.is_queued(key))
 
     def test_lots_of_queued_things(self):
-        # we have one slow thing, and lots of fast things queued up behind it.
-        # it should *not* explode the stack.
+        """Tests lots of fast things queued up behind a slow thing.
+
+        The stack should *not* explode when the fast thing completes.
+        """
         linearizer = Linearizer()
 
         @defer.inlineCallbacks
@@ -97,6 +104,7 @@ class LinearizerTestCase(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_multiple_entries(self):
+        """Tests a `Linearizer` with a concurrency above 1."""
         limiter = Linearizer(max_count=3)
 
         key = object()
@@ -143,6 +151,7 @@ class LinearizerTestCase(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_cancellation(self):
+        """Tests cancellation while waiting for a `Linearizer`."""
         linearizer = Linearizer()
 
         key = object()

--- a/tests/util/test_linearizer.py
+++ b/tests/util/test_linearizer.py
@@ -13,17 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Hashable, Optional, Tuple
+from typing import Callable, Hashable, Tuple
 
 from twisted.internet import defer, reactor
 from twisted.internet.base import ReactorBase
 from twisted.internet.defer import CancelledError, Deferred
 
-from synapse.logging.context import (
-    LoggingContext,
-    current_context,
-    make_deferred_yieldable,
-)
+from synapse.logging.context import LoggingContext, current_context
 from synapse.util.async_helpers import Linearizer
 
 from tests import unittest
@@ -127,12 +123,10 @@ class LinearizerTestCase(unittest.TestCase):
         linearizer = Linearizer()
         key = ""
 
-        async def func(i: int, wait_for: Optional["Deferred[None]"] = None) -> None:
+        async def func(i: int) -> None:
             with LoggingContext("func(%s)" % i) as lc:
                 with (await linearizer.queue(key)):
                     self.assertEqual(current_context(), lc)
-                    if wait_for:
-                        await make_deferred_yieldable(wait_for)
 
                 self.assertEqual(current_context(), lc)
 

--- a/tests/util/test_linearizer.py
+++ b/tests/util/test_linearizer.py
@@ -212,6 +212,9 @@ class LinearizerTestCase(unittest.TestCase):
         self.failureResultOf(d2, CancelledError)
 
         # The third task should continue running.
-        self.assertTrue(acquired_d3.called)
+        self.assertTrue(
+            acquired_d3.called,
+            "Third task did not get the lock after the second task was cancelled",
+        )
         unblock3()
         self.successResultOf(d3)

--- a/tests/util/test_linearizer.py
+++ b/tests/util/test_linearizer.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Hashable, Tuple
+from typing import Callable, Hashable, Optional, Tuple
 
 from twisted.internet import defer, reactor
 from twisted.internet.base import ReactorBase
@@ -70,7 +70,7 @@ class LinearizerTestCase(unittest.TestCase):
         while reactor.getDelayedCalls():
             reactor.runUntilCurrent()
 
-    def test_linearizer(self):
+    def test_linearizer(self) -> None:
         """Tests that a task is queued up behind an earlier task."""
         linearizer = Linearizer()
 
@@ -88,7 +88,7 @@ class LinearizerTestCase(unittest.TestCase):
 
         unblock2()
 
-    def test_linearizer_is_queued(self):
+    def test_linearizer_is_queued(self) -> None:
         """Tests `Linearizer.is_queued`.
 
         Runs through the same scenario as `test_linearizer`.
@@ -119,7 +119,7 @@ class LinearizerTestCase(unittest.TestCase):
         unblock2()
         self.assertFalse(linearizer.is_queued(key))
 
-    def test_lots_of_queued_things(self):
+    def test_lots_of_queued_things(self) -> None:
         """Tests lots of fast things queued up behind a slow thing.
 
         The stack should *not* explode when the fast thing completes.
@@ -127,7 +127,7 @@ class LinearizerTestCase(unittest.TestCase):
         linearizer = Linearizer()
         key = ""
 
-        async def func(i, wait_for=None) -> None:
+        async def func(i: int, wait_for: Optional["Deferred[None]"] = None) -> None:
             with LoggingContext("func(%s)" % i) as lc:
                 with (await linearizer.queue(key)):
                     self.assertEqual(current_context(), lc)
@@ -144,7 +144,7 @@ class LinearizerTestCase(unittest.TestCase):
         unblock()
         self.successResultOf(d)
 
-    def test_multiple_entries(self):
+    def test_multiple_entries(self) -> None:
         """Tests a `Linearizer` with a concurrency above 1."""
         limiter = Linearizer(max_count=3)
 
@@ -185,7 +185,7 @@ class LinearizerTestCase(unittest.TestCase):
         self.assertTrue(acquired_d6)
         unblock6()
 
-    def test_cancellation(self):
+    def test_cancellation(self) -> None:
         """Tests cancellation while waiting for a `Linearizer`."""
         linearizer = Linearizer()
 


### PR DESCRIPTION
To fix #12114, it might be useful to convert the `Linearizer` from raw `Deferred`s to async. But first, we need to convert the tests.

Probably easier to review commit by commit. There's a commit in the middle that adds comments, so that the correspondence between `inlineCallbacks` and async code is clearer.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
