### PR TITLE
Fix a spec compliance issue where requests to the `/publicRooms` federation API would specify `limit` as a string.

### DIFF
--- a/changelog.d/12364.bugfix
+++ b/changelog.d/12364.bugfix
@@ -1,0 +1,1 @@
+Fix a spec compliance issue where requests to the `/publicRooms` federation API would specify `limit` as a string.

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -481,7 +481,7 @@ class TransportLayerClient:
             if third_party_instance_id:
                 data["third_party_instance_id"] = third_party_instance_id
             if limit:
-                data["limit"] = str(limit)
+                data["limit"] = limit
             if since_token:
                 data["since"] = since_token
 
@@ -509,7 +509,7 @@ class TransportLayerClient:
             if third_party_instance_id:
                 args["third_party_instance_id"] = (third_party_instance_id,)
             if limit:
-                args["limit"] = [str(limit)]
+                args["limit"] = [limit]
             if since_token:
                 args["since"] = [since_token]
 


### PR DESCRIPTION
Fixes the sending half of #10304.

Synapse is able to **accept** either strings or integers (and likely floats and bools ... sigh), but should really only emit spec-approved integers.

Enforcing this requirement on the receiving side is out of scope for this PR, but we might consider it someday, after giving enough time for Synapse versions to spread throughout the network.

