### PR TITLE
Allow specifying the Postgres database's port when running unit tests with Postgres.

### DIFF
--- a/changelog.d/12376.misc
+++ b/changelog.d/12376.misc
@@ -1,0 +1,1 @@
+Allow specifying the Postgres database's port when running unit tests with Postgres.

--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -206,9 +206,10 @@ To do so, [configure Postgres](../postgres.md) and run `trial` with the
 following environment variables matching your configuration:
 
 - `SYNAPSE_POSTGRES` to anything nonempty
-- `SYNAPSE_POSTGRES_HOST`
-- `SYNAPSE_POSTGRES_USER`
-- `SYNAPSE_POSTGRES_PASSWORD`
+- `SYNAPSE_POSTGRES_HOST` (optional if it's the default: UNIX socket)
+- `SYNAPSE_POSTGRES_PORT` (optional if it's the default: 5432)
+- `SYNAPSE_POSTGRES_USER` (optional if using a UNIX socket)
+- `SYNAPSE_POSTGRES_PASSWORD` (optional if using a UNIX socket)
 
 For example:
 
@@ -219,6 +220,13 @@ export SYNAPSE_POSTGRES_USER=postgres
 export SYNAPSE_POSTGRES_PASSWORD=mydevenvpassword
 trial
 ```
+
+You don't need to specify the host, user, port or password if your Postgres
+server is set to authenticate you over the UNIX socket (i.e. if the `psql` command
+works without further arguments).
+
+Your Postgres account needs to be able to create databases.
+
 
 ## Run the integration tests ([Sytest](https://github.com/matrix-org/sytest)).
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -76,6 +76,7 @@ from tests.utils import (
     POSTGRES_BASE_DB,
     POSTGRES_HOST,
     POSTGRES_PASSWORD,
+    POSTGRES_PORT,
     POSTGRES_USER,
     SQLITE_PERSIST_DB,
     USE_POSTGRES_FOR_TESTS,
@@ -747,6 +748,7 @@ def setup_test_homeserver(
                 "host": POSTGRES_HOST,
                 "password": POSTGRES_PASSWORD,
                 "user": POSTGRES_USER,
+                "port": POSTGRES_PORT,
                 "cp_min": 1,
                 "cp_max": 5,
             },
@@ -786,6 +788,7 @@ def setup_test_homeserver(
             database=POSTGRES_BASE_DB,
             user=POSTGRES_USER,
             host=POSTGRES_HOST,
+            port=POSTGRES_PORT,
             password=POSTGRES_PASSWORD,
         )
         db_conn.autocommit = True
@@ -833,6 +836,7 @@ def setup_test_homeserver(
                 database=POSTGRES_BASE_DB,
                 user=POSTGRES_USER,
                 host=POSTGRES_HOST,
+                port=POSTGRES_PORT,
                 password=POSTGRES_PASSWORD,
             )
             db_conn.autocommit = True

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,6 +35,11 @@ LEAVE_DB = os.environ.get("SYNAPSE_LEAVE_DB", False)
 POSTGRES_USER = os.environ.get("SYNAPSE_POSTGRES_USER", None)
 POSTGRES_HOST = os.environ.get("SYNAPSE_POSTGRES_HOST", None)
 POSTGRES_PASSWORD = os.environ.get("SYNAPSE_POSTGRES_PASSWORD", None)
+POSTGRES_PORT = (
+    int(os.environ["SYNAPSE_POSTGRES_PORT"])
+    if "SYNAPSE_POSTGRES_PORT" in os.environ
+    else None
+)
 POSTGRES_BASE_DB = "_synapse_unit_tests_base_%s" % (os.getpid(),)
 
 # When debugging a specific test, it's occasionally useful to write the
@@ -55,6 +60,7 @@ def setupdb():
         db_conn = db_engine.module.connect(
             user=POSTGRES_USER,
             host=POSTGRES_HOST,
+            port=POSTGRES_PORT,
             password=POSTGRES_PASSWORD,
             dbname=POSTGRES_DBNAME_FOR_INITIAL_CREATE,
         )
@@ -73,6 +79,7 @@ def setupdb():
             database=POSTGRES_BASE_DB,
             user=POSTGRES_USER,
             host=POSTGRES_HOST,
+            port=POSTGRES_PORT,
             password=POSTGRES_PASSWORD,
         )
         db_conn = LoggingDatabaseConnection(db_conn, db_engine, "tests")
@@ -83,6 +90,7 @@ def setupdb():
             db_conn = db_engine.module.connect(
                 user=POSTGRES_USER,
                 host=POSTGRES_HOST,
+                port=POSTGRES_PORT,
                 password=POSTGRES_PASSWORD,
                 dbname=POSTGRES_DBNAME_FOR_INITIAL_CREATE,
             )


### PR DESCRIPTION
Due to weirdness, my local dev machine has its Postgres UNIX socket specified as number 5433 rather than 5432,
so I need to be able to specify the port to run the tests locally.

This adds an environment variable to the tests that allows you to specify the Postgres port.

I also update the documentation and describe how to use this environment variable, as well as the fact that most of these
are optional if you're using a well-configured Postgres server with a UNIX socket, as is common on Debians/Ubuntus.

