### PR TITLE
Add opentracing spans to calls to external cache

### DIFF
--- a/changelog.d/12380.misc
+++ b/changelog.d/12380.misc
@@ -1,0 +1,1 @@
+Add opentracing spans to calls to external cache.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -289,6 +289,9 @@ class SynapseTags:
     # Uniqueish ID of a database transaction
     DB_TXN_ID = "db.txn_id"
 
+    # The name of the external cache
+    CACHE_NAME = "cache.name"
+
 
 class SynapseBaggage:
     FORCE_TRACING = "synapse-force-tracing"

--- a/synapse/replication/tcp/external_cache.py
+++ b/synapse/replication/tcp/external_cache.py
@@ -96,7 +96,7 @@ class ExternalCache:
 
         with opentracing.start_active_span(
             "ExternalCache.set",
-            tags={opentracing.SynapseTags: cache_name},
+            tags={opentracing.SynapseTags.CACHE_NAME: cache_name},
         ):
             with response_timer.labels("set").time():
                 return await make_deferred_yieldable(
@@ -115,7 +115,7 @@ class ExternalCache:
 
         with opentracing.start_active_span(
             "ExternalCache.get",
-            tags={opentracing.SynapseTags: cache_name},
+            tags={opentracing.SynapseTags.CACHE_NAME: cache_name},
         ):
             with response_timer.labels("get").time():
                 result = await make_deferred_yieldable(

--- a/synapse/replication/tcp/external_cache.py
+++ b/synapse/replication/tcp/external_cache.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from prometheus_client import Counter, Histogram
 
+from synapse.logging import opentracing
 from synapse.logging.context import make_deferred_yieldable
 from synapse.util import json_decoder, json_encoder
 
@@ -93,14 +94,15 @@ class ExternalCache:
 
         logger.debug("Caching %s %s: %r", cache_name, key, encoded_value)
 
-        with response_timer.labels("set").time():
-            return await make_deferred_yieldable(
-                self._redis_connection.set(
-                    self._get_redis_key(cache_name, key),
-                    encoded_value,
-                    pexpire=expiry_ms,
+        with opentracing.start_active_span("ExternalCache.set"):
+            with response_timer.labels("set").time():
+                return await make_deferred_yieldable(
+                    self._redis_connection.set(
+                        self._get_redis_key(cache_name, key),
+                        encoded_value,
+                        pexpire=expiry_ms,
+                    )
                 )
-            )
 
     async def get(self, cache_name: str, key: str) -> Optional[Any]:
         """Look up a key/value in the named cache."""
@@ -108,10 +110,11 @@ class ExternalCache:
         if self._redis_connection is None:
             return None
 
-        with response_timer.labels("get").time():
-            result = await make_deferred_yieldable(
-                self._redis_connection.get(self._get_redis_key(cache_name, key))
-            )
+        with opentracing.start_active_span("ExternalCache.get"):
+            with response_timer.labels("get").time():
+                result = await make_deferred_yieldable(
+                    self._redis_connection.get(self._get_redis_key(cache_name, key))
+                )
 
         logger.debug("Got cache result %s %s: %r", cache_name, key, result)
 

--- a/synapse/replication/tcp/external_cache.py
+++ b/synapse/replication/tcp/external_cache.py
@@ -94,7 +94,10 @@ class ExternalCache:
 
         logger.debug("Caching %s %s: %r", cache_name, key, encoded_value)
 
-        with opentracing.start_active_span("ExternalCache.set"):
+        with opentracing.start_active_span(
+            "ExternalCache.set",
+            tags={opentracing.SynapseTags: cache_name},
+        ):
             with response_timer.labels("set").time():
                 return await make_deferred_yieldable(
                     self._redis_connection.set(
@@ -110,7 +113,10 @@ class ExternalCache:
         if self._redis_connection is None:
             return None
 
-        with opentracing.start_active_span("ExternalCache.get"):
+        with opentracing.start_active_span(
+            "ExternalCache.get",
+            tags={opentracing.SynapseTags: cache_name},
+        ):
             with response_timer.labels("get").time():
                 result = await make_deferred_yieldable(
                     self._redis_connection.get(self._get_redis_key(cache_name, key))


### PR DESCRIPTION
I don't think redis is causing any issues, but we should be adding spans whenever we talk to an external service.