### PR TITLE
Add missing dependency on importlib_metadata

### DIFF
--- a/changelog.d/12384.misc
+++ b/changelog.d/12384.misc
@@ -1,0 +1,1 @@
+Make missing `importlib_metadata` dependency explicit.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1593,7 +1593,7 @@ url_preview = ["lxml"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "92465e65bef59c43c6112f332e5cf987740899801dbd34c19245db15b5c6362d"
+content-hash = "7ff6d982a9d6675cb595b216b23549ef1942d0e39cb91c97494ff6ed95a9e8d2"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,9 @@ ijson = ">=3.1.4"
 matrix-common = "~=1.1.0"
 # We need packaging.requirements.Requirement, added in 16.1.
 packaging = ">=16.1"
+# At the time of writing, we only use functions from the version `importlib.metadata`
+# which shipped in Python 3.8. This corresponds to version 1.4 of the backport.
+importlib_metadata = { version = ">=1.4", python = "<3.8" }
 
 
 # Optional Dependencies

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -89,6 +89,9 @@ REQUIREMENTS = [
     "matrix-common~=1.1.0",
     # We need packaging.requirements.Requirement, added in 16.1.
     "packaging>=16.1",
+    # At the time of writing, we only use functions from the version `importlib.metadata`
+    # which shipped in Python 3.8. This corresponds to version 1.4 of the backport.
+    "importlib_metadata>=1.4; python_version < 3.8",
 ]
 
 CONDITIONAL_REQUIREMENTS = {

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -91,7 +91,7 @@ REQUIREMENTS = [
     "packaging>=16.1",
     # At the time of writing, we only use functions from the version `importlib.metadata`
     # which shipped in Python 3.8. This corresponds to version 1.4 of the backport.
-    "importlib_metadata>=1.4; python_version < 3.8",
+    "importlib_metadata>=1.4",
 ]
 
 CONDITIONAL_REQUIREMENTS = {


### PR DESCRIPTION
Missed in #12088. We got away with it because we were indirectly
requiring it via other packages.

Without this change, we encounter pain in `poetry export`; and besides,
we should be explicit about our direct dependencies.
