### PR TITLE
Fix `synapse_event_persisted_position` metric

### DIFF
--- a/changelog.d/12390.bugfix
+++ b/changelog.d/12390.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.49.0 which caused the `synapse_event_persisted_position` metric to have invalid values.

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -197,9 +197,9 @@ class PersistEventsStore:
             )
             persist_event_counter.inc(len(events_and_contexts))
 
-            if stream < 0:
-                # backfilled events have negative stream orderings, so we don't
-                # want to set the event_persisted_position to that.
+            if not use_negative_stream_ordering:
+                # we don't want to set the event_persisted_position to a negative
+                # stream_ordering.
                 synapse.metrics.event_persisted_position.set(
                     events_and_contexts[-1][0].internal_metadata.stream_ordering
                 )


### PR DESCRIPTION
Fixes a bug introduced in #11417 where we would only included backfilled events
in `synapse_event_persisted_position`.