### PR TITLE
Resync state after partial-state join

### DIFF
--- a/changelog.d/12394.misc
+++ b/changelog.d/12394.misc
@@ -1,0 +1,1 @@
+Preparation for faster-room-join work: start a background process to resynchronise the room state after a room join.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -481,8 +481,8 @@ class FederationHandler:
             )
 
             if ret.partial_state:
-                # kick off the process of asynchronously fixing up the state for this
-                # room
+                # Kick off the process of asynchronously fetching the state for this
+                # room.
                 #
                 # TODO(faster_joins): pick this up again on restart
                 run_as_background_process(
@@ -1431,6 +1431,9 @@ class FederationHandler:
 
                 # we raced against more events arriving with partial state. Go round
                 # the loop again. We've already logged a warning, so no need for more.
+                # TODO(faster_joins): there is still a race here, whereby incoming events which raced 
+                #   with us will fail to be persisted after the call to `clear_partial_state_room` due to
+                #   having partial state.
                 continue
 
             events = await self.store.get_events_as_list(

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1431,7 +1431,7 @@ class FederationHandler:
 
                 # we raced against more events arriving with partial state. Go round
                 # the loop again. We've already logged a warning, so no need for more.
-                # TODO(faster_joins): there is still a race here, whereby incoming events which raced 
+                # TODO(faster_joins): there is still a race here, whereby incoming events which raced
                 #   with us will fail to be persisted after the call to `clear_partial_state_room` due to
                 #   having partial state.
                 continue

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -963,6 +963,21 @@ class PersistEventsStore:
                 values=to_insert,
             )
 
+    async def update_current_state(
+        self,
+        room_id: str,
+        state_delta: DeltaState,
+        stream_id: int,
+    ) -> None:
+        """Update the current state stored in the datatabase for the given room"""
+
+        await self.db_pool.runInteraction(
+            "update_current_state",
+            self._update_current_state_txn,
+            state_delta_by_room={room_id: state_delta},
+            stream_id=stream_id,
+        )
+
     def _update_current_state_txn(
         self,
         txn: LoggingTransaction,

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -1979,3 +1979,27 @@ class EventsWorkerStore(SQLBaseStore):
             desc="is_partial_state_event",
         )
         return result is not None
+
+    async def get_partial_state_events_batch(self, room_id: str) -> List[str]:
+        """Get a list of events in the given room that have partial state"""
+        return await self.db_pool.runInteraction(
+            "get_partial_state_events_batch",
+            self._get_partial_state_events_batch_txn,
+            room_id,
+        )
+
+    @staticmethod
+    def _get_partial_state_events_batch_txn(
+        txn: LoggingTransaction, room_id: str
+    ) -> List[str]:
+        txn.execute(
+            """\
+            SELECT event_id FROM partial_state_events AS pse
+                JOIN events USING (event_id)
+            WHERE pse.room_id = ?
+            ORDER BY events.stream_ordering
+            LIMIT 100
+            """,
+            (room_id,),
+        )
+        return [row[0] for row in txn]

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -1993,7 +1993,7 @@ class EventsWorkerStore(SQLBaseStore):
         txn: LoggingTransaction, room_id: str
     ) -> List[str]:
         txn.execute(
-            """\
+            """
             SELECT event_id FROM partial_state_events AS pse
                 JOIN events USING (event_id)
             WHERE pse.room_id = ?

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1079,7 +1079,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
 
     async def clear_partial_state_room(self, room_id: str) -> bool:
         # this can race with incoming events, so we watch out for FK errors.
-        # todo: this still doesn't completely fix the race, since the persist process
+        # TODO(faster_joins): this still doesn't completely fix the race, since the persist process
         #   is not atomic. I fear we need an application-level lock.
         try:
             await self.db_pool.runInteraction(
@@ -1087,7 +1087,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
             )
             return True
         except self.db_pool.engine.module.DatabaseError as e:
-            # todo: how do we distinguish between FK errors and other errors?
+            # TODO(faster_joins): how do we distinguish between FK errors and other errors?
             logger.warning(
                 "Exception while clearing lazy partial-state-room %s, retrying: %s",
                 room_id,

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -21,6 +21,7 @@ from synapse.api.constants import EventTypes, Membership
 from synapse.api.errors import NotFoundError, UnsupportedRoomVersionError
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersion
 from synapse.events import EventBase
+from synapse.events.snapshot import EventContext
 from synapse.storage._base import SQLBaseStore
 from synapse.storage.database import (
     DatabasePool,
@@ -353,6 +354,53 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
         )
 
         return {row["state_group"] for row in rows}
+
+    async def update_state_for_partial_state_event(
+        self,
+        event: EventBase,
+        context: EventContext,
+    ) -> None:
+        """Update the state group for a partial state event"""
+        await self.db_pool.runInteraction(
+            "update_state_for_partial_state_event",
+            self._update_state_for_partial_state_event_txn,
+            event,
+            context,
+        )
+
+    def _update_state_for_partial_state_event_txn(
+        self,
+        txn,
+        event: EventBase,
+        context: EventContext,
+    ):
+        # we shouldn't have any outliers here
+        assert not event.internal_metadata.is_outlier()
+
+        # anything that was rejected should have the same state as its
+        # predecessor.
+        if context.rejected:
+            assert context.state_group == context.state_group_before_event
+
+        self.db_pool.simple_update_txn(
+            txn,
+            table="event_to_state_groups",
+            keyvalues={"event_id": event.event_id},
+            updatevalues={"state_group": context.state_group},
+        )
+
+        self.db_pool.simple_delete_one_txn(
+            txn,
+            table="partial_state_events",
+            keyvalues={"event_id": event.event_id},
+        )
+
+        # TODO: need to do something about workers here
+        txn.call_after(
+            self._get_state_group_for_event.prefill,
+            (event.event_id,),
+            context.state_group,
+        )
 
 
 class MainStateBackgroundUpdateStore(RoomMemberWorkerStore):

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -395,7 +395,7 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
             keyvalues={"event_id": event.event_id},
         )
 
-        # TODO: need to do something about workers here
+        # TODO(faster_joins): need to do something about workers here
         txn.call_after(
             self._get_state_group_for_event.prefill,
             (event.event_id,),


### PR DESCRIPTION
We work through all the events with partial state, updating the state at each of them. Once it's done, we recalculate the state for the whole room, and then mark the room as having complete state.

I'm afraid this doesn't really have any tests yet. I do have some Complement tests, but they need more bits of this to land.

Part of #11249, and a follow-up to #12012.