### PR TITLE
Remove the unstable event field for `/send_join` per MSC3083.

### DIFF
--- a/changelog.d/12395.misc
+++ b/changelog.d/12395.misc
@@ -1,0 +1,1 @@
+Remove an unstable identifier from [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083).

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -687,8 +687,6 @@ class FederationServer(FederationBase):
         time_now = self._clock.time_msec()
         event_json = event.get_pdu_json(time_now)
         resp = {
-            # TODO Remove the unstable prefix when servers have updated.
-            "org.matrix.msc3083.v2.event": event_json,
             "event": event_json,
             "state": [p.get_pdu_json(time_now) for p in state_events],
             "auth_chain": [p.get_pdu_json(time_now) for p in auth_chain_events],

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -1379,16 +1379,6 @@ class SendJoinParser(ByteParser[SendJoinResponse]):
                 prefix + "auth_chain.item",
                 use_float=True,
             ),
-            # TODO Remove the unstable prefix when servers have updated.
-            #
-            # By re-using the same event dictionary this will cause the parsing of
-            # org.matrix.msc3083.v2.event and event to stomp over each other.
-            # Generally this should be fine.
-            ijson.kvitems_coro(
-                _event_parser(self._response.event_dict),
-                prefix + "org.matrix.msc3083.v2.event",
-                use_float=True,
-            ),
             ijson.kvitems_coro(
                 _event_parser(self._response.event_dict),
                 prefix + "event",


### PR DESCRIPTION
Fixes #11345 which goes into more detail about this, but I think we can drop support for the unstable identifier in `send_join` responses from MSC3083, which was erroneously used for a bit after stabilization.

The stable identifier was added in Synapse v1.49.0; the unstable identifiers were added in Synapse v1.41.0; so 1.41.0 - 1.48.0 are potentially of concern? Of those I only see any significant set of servers on 1.42.0.