### PR TITLE
Remove the unstable identifier from MSC3288.

### DIFF
--- a/changelog.d/12398.misc
+++ b/changelog.d/12398.misc
@@ -1,0 +1,1 @@
+Remove support for the unstable identifiers specified in [MSC3288](https://github.com/matrix-org/matrix-doc/pull/3288).

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -858,8 +858,6 @@ class IdentityHandler:
 
         if room_type is not None:
             invite_config["room_type"] = room_type
-            # TODO The unstable field is deprecated and should be removed in the future.
-            invite_config["org.matrix.msc3288.room_type"] = room_type
 
         # If a custom web client location is available, include it in the request.
         if self._web_client_location:


### PR DESCRIPTION
Fixes #11113.

Sydent since v2.5.0 has supported the stable identifier. This was released November 2021.