### PR TITLE
Narrow the `importlib_metadata` dependency

### DIFF
--- a/changelog.d/12400.misc
+++ b/changelog.d/12400.misc
@@ -1,0 +1,1 @@
+Make missing `importlib_metadata` dependency explicit.

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -91,7 +91,7 @@ REQUIREMENTS = [
     "packaging>=16.1",
     # At the time of writing, we only use functions from the version `importlib.metadata`
     # which shipped in Python 3.8. This corresponds to version 1.4 of the backport.
-    "importlib_metadata>=1.4",
+    "importlib_metadata>=1.4 ; python_version < '3.8'",
 ]
 
 CONDITIONAL_REQUIREMENTS = {


### PR DESCRIPTION
`pyproject.toml` already has the version guard. I struggled to work out
how to reproduce this guard under setuptools in #12384. But I really
should have persisted there; without this, poetry and setuptools
generate different sets of requirements. That means a poetry-installed
Synapse on a 3.8+ interpreter will fail the runtime dependency checks.