### PR TITLE
Poetry: select olddeps using `poetry`

### DIFF
--- a/.ci/scripts/test_old_deps.sh
+++ b/.ci/scripts/test_old_deps.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# this script is run by GitHub Actions in a plain `focal` container; it installs the
-# minimal requirements for tox and hands over to the py3-old tox environment.
+# this script is run by GitHub Actions in a plain `focal` container; it
+# - installs the minimal system requirements, and poetry;
+# - patches the project definition file to refer to old versions only;
+# - creates a venv with these old versions using poetry; and finally
+# - invokes `trial` to run the tests with old deps.
 
 # Prevent tzdata from asking for user input
 export DEBIAN_FRONTEND=noninteractive
@@ -9,12 +12,57 @@ set -ex
 
 apt-get update
 apt-get install -y \
-        python3 python3-dev python3-pip python3-venv \
-        libxml2-dev libxslt-dev xmlsec1 zlib1g-dev tox libjpeg-dev libwebp-dev
+        python3 python3-dev python3-pip python3-venv pipx \
+        libxml2-dev libxslt-dev xmlsec1 zlib1g-dev libjpeg-dev libwebp-dev
 
 export LANG="C.UTF-8"
 
 # Prevent virtualenv from auto-updating pip to an incompatible version
 export VIRTUALENV_NO_DOWNLOAD=1
 
-exec tox -e py3-old
+# I'd prefer to use something like this
+#   https://github.com/python-poetry/poetry/issues/3527
+#   https://github.com/pypa/pip/issues/8085
+# rather than this sed script. But that's an Opinion.
+
+# patch the project definitions in-place
+# replace all lower bounds with exact bounds
+# but make the pyopenssl 17.0, which can work against an
+# OpenSSL 1.1 compiled cryptography (as older ones don't compile on Travis).
+# delete all lines referring to psycopg2 --- so no testing of postgres support
+# Omit systemd: we're not logging to journal here.
+
+sed -i-backup \
+   -e "s/[~>]=/==/g" \
+   -e "/psycopg2/d" \
+   -e 's/pyOpenSSL = "==16.0.0"/pyOpenSSL = "==17.0.0"/' \
+   -e '/psycopg2/d' \
+   -e '/systemd/d' \
+   pyproject.toml
+
+# Use poetry to do the installation. This ensures that the versions are all mutually
+# compatible (as far the package metadata declares, anyway); pip's package resolver
+# is more lax.
+#
+# Rather than `poetry install --no-dev`, we drop all dev dependencies from the
+# toml file. This means we don't have to ensure compatibility between old deps and
+# dev tools.
+
+pip install --user toml
+
+REMOVE_DEV_DEPENDENCIES="
+import toml
+with open('pyproject.toml', 'r') as f:
+    data = toml.loads(f.read())
+
+del data['tool']['poetry']['dev-dependencies']
+
+with open('pyproject.toml', 'w') as f:
+    toml.dump(data, f)
+"
+python3 -c "$REMOVE_DEV_DEPENDENCIES"
+
+pipx install poetry==1.1.12
+~/.local/bin/poetry lock
+~/.local/bin/poetry install -E "all test"
+~/.local/bin/poetry run trial -j2 tests

--- a/.ci/scripts/test_old_deps.sh
+++ b/.ci/scripts/test_old_deps.sh
@@ -69,7 +69,7 @@ with open('pyproject.toml', 'w') as f:
 python3 -c "$REMOVE_DEV_DEPENDENCIES"
 
 echo "::group::Patched pyproject.toml"
-diff -u pyproject.toml-backup pyproject.toml
+cat pyproject.toml
 echo "::endgroup::"
 
 pipx install poetry==1.1.12

--- a/.ci/scripts/test_old_deps.sh
+++ b/.ci/scripts/test_old_deps.sh
@@ -38,7 +38,7 @@ export VIRTUALENV_NO_DOWNLOAD=1
 # `python = "^3.7"` to `python = "==3.7", which would mean we fail because olddeps
 # runs on 3.8 (#12343).
 
-sed -i-backup \
+sed -i \
    -e "s/[~>]=/==/g" \
    -e "/psycopg2/d" \
    -e 's/pyOpenSSL = "==16.0.0"/pyOpenSSL = "==17.0.0"/' \

--- a/.ci/scripts/test_old_deps.sh
+++ b/.ci/scripts/test_old_deps.sh
@@ -77,4 +77,4 @@ echo "::endgroup::"
 pipx install poetry==1.1.12
 ~/.local/bin/poetry lock
 ~/.local/bin/poetry install -E "all test"
-~/.local/bin/poetry run trial -j2 tests
+~/.local/bin/poetry run trial --jobs=2 tests

--- a/.ci/scripts/test_old_deps.sh
+++ b/.ci/scripts/test_old_deps.sh
@@ -32,10 +32,12 @@ export VIRTUALENV_NO_DOWNLOAD=1
 # - Delete all lines referring to psycopg2 --- so no testing of postgres support.
 # - Omit systemd: we're not logging to journal here.
 
-# TODO: also replace caret bounds, see https://python-poetry.org/docs/dependency-specification/#version-constraints
-# We don't use these yet, but IIRC they are the default bound used when you `poetry add`.
+# TODO: we should also replace caret bounds, see
+#    https://python-poetry.org/docs/dependency-specification/#version-constraints
+# We don't use these yet, but they are the default bound used when you `poetry add` from
+# the commandline, rather than editing pyproject.toml directly.
 # The sed expression 's/\^/==/g' ought to do the trick. But it would also change
-# `python = "^3.7"` to `python = "==3.7", which would mean we fail because olddeps
+# `python = "^3.7"` to `python = "==3.7"`, which would mean we fail because olddeps
 # runs on 3.8 (#12343).
 
 sed -i-backup \

--- a/.ci/scripts/test_old_deps.sh
+++ b/.ci/scripts/test_old_deps.sh
@@ -25,12 +25,18 @@ export VIRTUALENV_NO_DOWNLOAD=1
 #   https://github.com/pypa/pip/issues/8085
 # rather than this sed script. But that's an Opinion.
 
-# patch the project definitions in-place
-# replace all lower bounds with exact bounds
-# but make the pyopenssl 17.0, which can work against an
-# OpenSSL 1.1 compiled cryptography (as older ones don't compile on Travis).
-# delete all lines referring to psycopg2 --- so no testing of postgres support
-# Omit systemd: we're not logging to journal here.
+# Patch the project definitions in-place:
+# - Replace all lower and tilde bounds with exact bounds
+# - Make the pyopenssl 17.0, which can work against an
+#   OpenSSL 1.1 compiled cryptography (as older ones don't compile on Travis).
+# - Delete all lines referring to psycopg2 --- so no testing of postgres support.
+# - Omit systemd: we're not logging to journal here.
+
+# TODO: also replace caret bounds, see https://python-poetry.org/docs/dependency-specification/#version-constraints
+# We don't use these yet, but IIRC they are the default bound used when you `poetry add`.
+# The sed expression 's/\^/==/g' ought to do the trick. But it would also change
+# `python = "^3.7"` to `python = "==3.7", which would mean we fail because olddeps
+# runs on 3.8 (#12343).
 
 sed -i-backup \
    -e "s/[~>]=/==/g" \

--- a/.ci/scripts/test_old_deps.sh
+++ b/.ci/scripts/test_old_deps.sh
@@ -62,6 +62,10 @@ with open('pyproject.toml', 'w') as f:
 "
 python3 -c "$REMOVE_DEV_DEPENDENCIES"
 
+echo "::group::Patched pyproject.toml"
+diff -u pyproject.toml-backup pyproject.toml
+echo "::endgroup::"
+
 pipx install poetry==1.1.12
 ~/.local/bin/poetry lock
 ~/.local/bin/poetry install -E "all test"

--- a/.ci/scripts/test_old_deps.sh
+++ b/.ci/scripts/test_old_deps.sh
@@ -27,8 +27,8 @@ export VIRTUALENV_NO_DOWNLOAD=1
 
 # Patch the project definitions in-place:
 # - Replace all lower and tilde bounds with exact bounds
-# - Make the pyopenssl 17.0, which can work against an
-#   OpenSSL 1.1 compiled cryptography (as older ones don't compile on Travis).
+# - Make the pyopenssl 17.0, which is the oldest version that works with
+#   a `cryptography` compiled against OpenSSL 1.1.
 # - Delete all lines referring to psycopg2 --- so no testing of postgres support.
 # - Omit systemd: we're not logging to journal here.
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,18 +128,18 @@ jobs:
           || true
 
   trial-olddeps:
+    # Note: sqlite only; no postgres
     if: ${{ !cancelled() && !failure() }} # Allow previous steps to be skipped, but not fail
-    needs: linting-done
+#    needs: linting-done
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Test with old deps
         uses: docker://ubuntu:focal # For old python and sqlite
+        # Note: focal seems to be using 3.8, but the oldest is 3.7?
         with:
           workdir: /github/workspace
           entrypoint: .ci/scripts/test_old_deps.sh
-        env:
-          TRIAL_FLAGS: "--jobs=2"
       - name: Dump logs
         # Logs are most useful when the command fails, always include them.
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,7 +130,7 @@ jobs:
   trial-olddeps:
     # Note: sqlite only; no postgres
     if: ${{ !cancelled() && !failure() }} # Allow previous steps to be skipped, but not fail
-#    needs: linting-done
+    needs: linting-done
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,6 +137,7 @@ jobs:
       - name: Test with old deps
         uses: docker://ubuntu:focal # For old python and sqlite
         # Note: focal seems to be using 3.8, but the oldest is 3.7?
+        # See https://github.com/matrix-org/synapse/issues/12343
         with:
           workdir: /github/workspace
           entrypoint: .ci/scripts/test_old_deps.sh

--- a/changelog.d/12407.misc
+++ b/changelog.d/12407.misc
@@ -1,0 +1,1 @@
+Run the olddeps CI job using Poetry.

--- a/tox.ini
+++ b/tox.ini
@@ -105,29 +105,7 @@ commands =
 # )
 usedevelop=true
 
-# A test suite for the oldest supported versions of Python libraries, to catch
-# any uses of APIs not available in them.
-[testenv:py3-old]
-skip_install = true
-usedevelop = false
-deps =
-    Automat == 0.8.0
-    lxml
-    # markupsafe 2.1 introduced a change that breaks Jinja 2.x. Since we depend on
-    # Jinja >= 2.9, it means this test suite will fail if markupsafe >= 2.1 is installed.
-    markupsafe < 2.1
-    {[base]deps}
 
-commands =
-    # Make all greater-thans equals so we test the oldest version of our direct
-    # dependencies, but make the pyopenssl 17.0, which can work against an
-    # OpenSSL 1.1 compiled cryptography (as older ones don't compile on Travis).
-    /bin/sh -c 'python -m synapse.python_dependencies | sed -e "s/>=/==/g" -e "/psycopg2/d" -e "s/pyopenssl==16.0.0/pyopenssl==17.0.0/" | xargs -d"\n" pip install'
-
-    # Install Synapse itself. This won't update any libraries.
-    pip install -e ".[test]"
-
-    {[testenv]commands}
 
 [testenv:benchmark]
 deps =


### PR DESCRIPTION
There are a few moving parts here.

- Once we ditch setup.py we'll need to patch the dependencies in pyproject.toml to maintain this CI job.
- If we were using poetry-core as our PEP 517 build system, it would suffice to `pip install .[all,test]`. But we're gradually transitioning to that; setuptools remains the build system for now.
- Therefore use the "full" poetry to _lock_ an olddeps environment and run using `poetry run`.