### PR TITLE
Do not add groups to sync results if disabled.

### DIFF
--- a/changelog.d/12408.misc
+++ b/changelog.d/12408.misc
@@ -1,0 +1,1 @@
+Do not include groups in the sync response when disabled.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1155,8 +1155,9 @@ class SyncHandler:
                 await self.store.get_e2e_unused_fallback_key_types(user_id, device_id)
             )
 
-        logger.debug("Fetching group data")
-        await self._generate_sync_entry_for_groups(sync_result_builder)
+        if self.hs_config.experimental.groups_enabled:
+            logger.debug("Fetching group data")
+            await self._generate_sync_entry_for_groups(sync_result_builder)
 
         num_events = 0
 

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -301,14 +301,13 @@ class SyncRestServlet(RestServlet):
         if archived:
             response["rooms"][Membership.LEAVE] = archived
 
-        # By the time we get here groups is no longer optional.
-        assert sync_result.groups is not None
-        if sync_result.groups.join:
-            response["groups"][Membership.JOIN] = sync_result.groups.join
-        if sync_result.groups.invite:
-            response["groups"][Membership.INVITE] = sync_result.groups.invite
-        if sync_result.groups.leave:
-            response["groups"][Membership.LEAVE] = sync_result.groups.leave
+        if sync_result.groups is not None:
+            if sync_result.groups.join:
+                response["groups"][Membership.JOIN] = sync_result.groups.join
+            if sync_result.groups.invite:
+                response["groups"][Membership.INVITE] = sync_result.groups.invite
+            if sync_result.groups.leave:
+                response["groups"][Membership.LEAVE] = sync_result.groups.leave
 
         return response
 


### PR DESCRIPTION
This was missed in #12200 -- if we disable groups/communities we should stop returning them as part of sync results.