### PR TITLE
Stop maintaining a list of lint targets

### DIFF
--- a/changelog.d/12420.misc
+++ b/changelog.d/12420.misc
@@ -1,0 +1,1 @@
+Stop maintaining a list of lint targets.

--- a/docs/code_style.md
+++ b/docs/code_style.md
@@ -24,7 +24,7 @@ pip install -e ".[lint,mypy]"
     functionality) with:
 
     ```sh
-    black . --exclude="\.tox|build|env"
+    black .
     ```
 
 -   **flake8**
@@ -35,7 +35,7 @@ pip install -e ".[lint,mypy]"
     Check all application and test code with:
 
     ```sh
-    flake8 synapse tests
+    flake8 .
     ```
 
 -   **isort**
@@ -46,10 +46,8 @@ pip install -e ".[lint,mypy]"
     Auto-fix imports with:
 
     ```sh
-    isort -rc synapse tests
+    isort .
     ```
-
-    `-rc` means to recursively search the given directories.
 
 It's worth noting that modern IDEs and text editors can run these tools
 automatically on save. It may be worth looking into whether this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,24 +36,9 @@
 
 [tool.black]
 target-version = ['py37', 'py38', 'py39', 'py310']
-exclude = '''
-
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.tox
-    | \.venv
-    | \.env
-    | env
-    | _build
-    | _trial_temp.*
-    | build
-    | dist
-    | debian
-  )/
-)
-'''
+# black ignores everything in .gitignore by default, see
+# https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html#gitignore
+# Use `extend-exclude` if you want to exclude something in addition to this.
 
 [tool.isort]
 line_length = 88
@@ -65,6 +50,7 @@ known_twisted = ["twisted", "OpenSSL"]
 multi_line_output = 3
 include_trailing_comma = true
 combine_as_imports = true
+skip_gitignore = true
 
 [tool.poetry]
 name = "matrix-synapse"

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -80,13 +80,7 @@ else
   # then lint everything!
   if [[ -z ${files+x} ]]; then
     # Lint all source code files and directories
-    # Note: this list aims to mirror the one in tox.ini
-      files=(
-          "synapse" "docker" "tests"
-          # annoyingly, black doesn't find these so we have to list them
-          "scripts-dev"
-          "contrib" "setup.py" "synmark" "stubs" ".ci"
-      )
+      files=( "." )
   fi
 fi
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
     pip>=10
 
 # directories/files we run the linters on.
-# if you update this list, make sure to do the same in scripts-dev/lint.sh
+# TODO: this is now out of date; we will remove as part of poetry migration.
 lint_targets =
     setup.py
     synapse


### PR DESCRIPTION
instead, configure the tools to find sensible targets.

Pulled out from #12337; part (but not all) of
e53e99edba7ccda8319ebd4fe832637cbe9261cc. Related: #12107.