### PR TITLE
Implement MSC2815: allow room moderators to view redacted event content

### DIFF
--- a/changelog.d/12427.feature
+++ b/changelog.d/12427.feature
@@ -1,0 +1,1 @@
+Implement [MSC2815](https://github.com/matrix-org/matrix-spec-proposals/pull/2815) to allow room moderators to view redacted event content. Contributed by @tulir.

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -485,7 +485,7 @@ class RequestSendFailed(RuntimeError):
         self.can_retry = can_retry
 
 
-class UnredactedContentDeleted(SynapseError):
+class UnredactedContentDeletedError(SynapseError):
     def __init__(self, content_keep_ms: Optional[int] = None):
         super().__init__(
             404,

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -79,6 +79,8 @@ class Codes:
     UNABLE_AUTHORISE_JOIN = "M_UNABLE_TO_AUTHORISE_JOIN"
     UNABLE_TO_GRANT_JOIN = "M_UNABLE_TO_GRANT_JOIN"
 
+    UNREDACTED_CONTENT_DELETED = "FI.MAU.MSC2815_UNREDACTED_CONTENT_DELETED"
+
 
 class CodeMessageException(RuntimeError):
     """An exception with integer code and message string attributes.
@@ -481,6 +483,22 @@ class RequestSendFailed(RuntimeError):
         )
         self.inner_exception = inner_exception
         self.can_retry = can_retry
+
+
+class UnredactedContentDeleted(SynapseError):
+    def __init__(self, content_keep_ms: Optional[int] = None):
+        super().__init__(
+            404,
+            "The content for that event has already been erased from the database",
+            errcode=Codes.UNREDACTED_CONTENT_DELETED,
+        )
+        self.content_keep_ms = content_keep_ms
+
+    def error_dict(self) -> "JsonDict":
+        extra = {}
+        if self.content_keep_ms is not None:
+            extra = {"fi.mau.msc2815.content_keep_ms": self.content_keep_ms}
+        return cs_error(self.msg, self.errcode, **extra)
 
 
 def cs_error(msg: str, code: str = Codes.UNKNOWN, **kwargs: Any) -> "JsonDict":

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -81,3 +81,6 @@ class ExperimentalConfig(Config):
 
         # MSC2654: Unread counts
         self.msc2654_enabled: bool = experimental.get("msc2654_enabled", False)
+
+        # MSC2815 (allow room moderators to view redacted event content)
+        self.msc2815_enabled: bool = experimental.get("msc2815_enabled", False)

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -651,13 +651,14 @@ class RoomEventServlet(RestServlet):
         self._relations_handler = hs.get_relations_handler()
         self.auth = hs.get_auth()
         self.content_keep_ms = hs.config.server.redaction_retention_period
+        self.msc2815_enabled = hs.config.experimental.msc2815_enabled
 
     async def on_GET(
         self, request: SynapseRequest, room_id: str, event_id: str
     ) -> Tuple[int, JsonDict]:
         requester = await self.auth.get_user_by_req(request, allow_guest=True)
 
-        include_unredacted_content = (
+        include_unredacted_content = self.msc2815_enabled and (
             parse_string(
                 request,
                 "fi.mau.msc2815.include_unredacted_content",

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -30,7 +30,7 @@ from synapse.api.errors import (
     MissingClientTokenError,
     ShadowBanError,
     SynapseError,
-    UnredactedContentDeleted,
+    UnredactedContentDeletedError,
 )
 from synapse.api.filtering import Filter
 from synapse.events.utils import format_event_for_client_v2
@@ -705,7 +705,7 @@ class RoomEventServlet(RestServlet):
             if include_unredacted_content and await self._store.have_censored_event(
                 event_id
             ):
-                raise UnredactedContentDeleted(self.content_keep_ms)
+                raise UnredactedContentDeletedError(self.content_keep_ms)
 
             # Ensure there are bundled aggregations available.
             aggregations = await self._relations_handler.get_bundled_aggregations(

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -102,6 +102,8 @@ class VersionsRestServlet(RestServlet):
                     # Adds support for thread relations, per MSC3440.
                     "org.matrix.msc3440": self.config.experimental.msc3440_enabled,
                     "org.matrix.msc3440.stable": True,  # TODO: remove when "v1.3" is added above
+                    # Allows moderators to fetch redacted event content as described in MSC2815
+                    "fi.mau.msc2815": self.config.experimental.msc2815_enabled,
                 },
             },
         )

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -303,6 +303,15 @@ class EventsWorkerStore(SQLBaseStore):
             desc="get_received_ts",
         )
 
+    async def have_censored_event(self, event_id: str) -> Optional[bool]:
+        return await self.db_pool.simple_select_one_onecol(
+            table="redactions",
+            keyvalues={"redacts": event_id},
+            retcol="have_censored",
+            desc="get_have_censored",
+            allow_none=True,
+        )
+
     # Inform mypy that if allow_none is False (the default) then get_event
     # always returns an EventBase.
     @overload

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -303,14 +303,23 @@ class EventsWorkerStore(SQLBaseStore):
             desc="get_received_ts",
         )
 
-    async def have_censored_event(self, event_id: str) -> Optional[bool]:
-        return await self.db_pool.simple_select_one_onecol(
+    async def have_censored_event(self, event_id: str) -> bool:
+        """Check if an event has been censored, i.e. if the content of the event has been erased
+        from the database due to a redaction.
+
+        Args:
+            event_id: The event ID that was redacted.
+
+        Returns:
+            True if the event has been censored, False otherwise.
+        """
+        censored_redactions_list = await self.db_pool.simple_select_onecol(
             table="redactions",
             keyvalues={"redacts": event_id},
             retcol="have_censored",
             desc="get_have_censored",
-            allow_none=True,
         )
+        return any(censored_redactions_list)
 
     # Inform mypy that if allow_none is False (the default) then get_event
     # always returns an EventBase.


### PR DESCRIPTION
This pull request implements the query parameter described in MSC2815 to allow room moderators and server admins to get the original content of redacted events using the `/rooms/{roomId}/event/{eventId}` endpoint.

Signed-off-by: Tulir Asokan <tulir@maunium.net>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
