### PR TITLE
Run lints under poetry in CI; remove lint tox jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,19 +20,13 @@ jobs:
       - run: scripts-dev/config-lint.sh
 
   lint:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toxenv:
-          - "check_codestyle"
-          - "check_isort"
-          - "mypy"
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install tox
-      - run: tox -e ${{ matrix.toxenv }}
+    # This does a vanilla `poetry install` - no extras. I'm slightly anxious
+    # that we might skip some typechecks on code that uses extras. However,
+    # I think the right way to fix this is to mark any extras needed for
+    # typechecking as development dependencies. To detect this, we ought to
+    # turn up mypy's strictness: disallow unknown imports and be accept fewer
+    # uses of `Any`.
+    uses: "matrix-org/backend-meta/.github/workflows/python-poetry-ci.yml@v1"
 
   lint-crlf:
     runs-on: ubuntu-latest

--- a/changelog.d/12434.misc
+++ b/changelog.d/12434.misc
@@ -1,0 +1,1 @@
+Run lints under poetry in CI, and remove corresponding tox lint jobs.

--- a/poetry.lock
+++ b/poetry.lock
@@ -717,7 +717,7 @@ test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock 
 
 [[package]]
 name = "prometheus-client"
-version = "0.13.1"
+version = "0.14.0"
 description = "Python client for the Prometheus monitoring system."
 category = "main"
 optional = false
@@ -2225,8 +2225,8 @@ platformdirs = [
     {file = "platformdirs-2.5.1.tar.gz", hash = "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d"},
 ]
 prometheus-client = [
-    {file = "prometheus_client-0.13.1-py3-none-any.whl", hash = "sha256:357a447fd2359b0a1d2e9b311a0c5778c330cfbe186d880ad5a6b39884652316"},
-    {file = "prometheus_client-0.13.1.tar.gz", hash = "sha256:ada41b891b79fca5638bd5cfe149efa86512eaa55987893becd2c6d8d0a5dfc5"},
+    {file = "prometheus_client-0.14.0-py3-none-any.whl", hash = "sha256:f4aba3fdd1735852049f537c1f0ab177159b7ab76f271ecc4d2f45aa2a1d01f2"},
+    {file = "prometheus_client-0.14.0.tar.gz", hash = "sha256:8f7a922dd5455ad524b6ba212ce8eb2b4b05e073f4ec7218287f88b1cac34750"},
 ]
 psycopg2 = [
     {file = "psycopg2-2.9.3-cp310-cp310-win32.whl", hash = "sha256:083707a696e5e1c330af2508d8fab36f9700b26621ccbcb538abe22e15485362"},

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, check_codestyle, check_isort
+envlist = py37, py38, py39, py310
 
 # we require tox>=2.3.2 for the fix to https://github.com/tox-dev/tox/issues/208
 minversion = 2.3.2
@@ -31,20 +31,6 @@ deps =
     # we also need a semi-recent version of pip, because old ones fail to
     # install the "enum34" dependency of cryptography.
     pip>=10
-
-# directories/files we run the linters on.
-# TODO: this is now out of date; we will remove as part of poetry migration.
-lint_targets =
-    setup.py
-    synapse
-    tests
-    # annoyingly, black doesn't find these so we have to list them
-    scripts-dev
-    stubs
-    contrib
-    synmark
-    .ci
-    docker
 
 # default settings for all tox environments
 [testenv]
@@ -138,18 +124,3 @@ setenv =
 commands =
     python -m synmark {posargs:}
 
-[testenv:check_codestyle]
-extras = lint
-commands =
-    python -m black --check --diff {[base]lint_targets}
-    flake8 {[base]lint_targets} {env:PEP8SUFFIX:}
-
-[testenv:check_isort]
-extras = lint
-commands = isort -c --df {[base]lint_targets}
-
-[testenv:mypy]
-deps =
-    {[base]deps}
-extras = all,mypy
-commands = mypy


### PR DESCRIPTION
Pulled out from #12337.

- We don't recommend tox in `code_style.md`
- After #12107 it's much easier for black, isort and flake8 to find the
  scripts we want them to lint; we don't need to maintain `lint_targets`
  in the tox config. See also #12420.