### PR TITLE
Specify tls extra for Twisted dependency.

### DIFF
--- a/changelog.d/12444.misc
+++ b/changelog.d/12444.misc
@@ -1,0 +1,1 @@
+Explicitly specify the `tls` extra for Twisted dependency.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1593,7 +1593,7 @@ url_preview = ["lxml"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "7ff6d982a9d6675cb595b216b23549ef1942d0e39cb91c97494ff6ed95a9e8d2"
+content-hash = "786fbd4aa9a7714db5cee018cfc2a820b47d2aea60e8d84d6056854f8c1d1683"
 
 [metadata.files]
 appdirs = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1587,13 +1587,13 @@ redis = ["txredisapi", "hiredis"]
 saml2 = ["pysaml2"]
 sentry = ["sentry-sdk"]
 systemd = ["systemd-python"]
-test = ["parameterized"]
+test = ["parameterized", "idna"]
 url_preview = ["lxml"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "786fbd4aa9a7714db5cee018cfc2a820b47d2aea60e8d84d6056854f8c1d1683"
+content-hash = "964ad29eaf7fd02749a4e735818f3bc0ba729c2f4b9e3213f0daa02643508b16"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ canonicaljson = ">=1.4.0"
 # we use the type definitions added in signedjson 1.1.
 signedjson = ">=1.1.0"
 PyNaCl = ">=1.2.1"
-idna = ">=2.5"
 # validating SSL certs for IP addresses requires service_identity 18.1.
 service-identity = ">=18.1.0"
 # Twisted 18.9 introduces some logger improvements that the structured
@@ -180,6 +179,7 @@ txredisapi = { version = ">=1.4.7", optional = true }
 hiredis = { version = "*", optional = true }
 Pympler = { version = "*", optional = true }
 parameterized = { version = ">=0.7.4", optional = true }
+idna = { version = ">=2.5", optional = true }
 
 [tool.poetry.extras]
 # NB: Packages that should be part of `pip install matrix-synapse[all]` need to be specified
@@ -201,7 +201,7 @@ jwt = ["pyjwt"]
 redis = ["txredisapi", "hiredis"]
 # Required to use experimental `caches.track_memory_usage` config option.
 cache_memory = ["pympler"]
-test = ["parameterized"]
+test = ["parameterized", "idna"]
 
 # The duplication here is awful. I hate hate hate hate hate it. However, for now I want
 # to ensure you can still `pip install matrix-synapse[all]` like today. Two motivations:
@@ -266,6 +266,7 @@ types-setuptools = ">=57.4.0"
 # parameterized<0.7.4 can create classes with names that would normally be invalid
 # identifiers. trial really does not like this when running with multiple workers.
 parameterized = ">=0.7.4"
+idna = ">=2.5"
 
 # The following are used by the release script
 click = "==8.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ idna = ">=2.5"
 service-identity = ">=18.1.0"
 # Twisted 18.9 introduces some logger improvements that the structured
 # logger utilises
-Twisted = ">=18.9.0"
+Twisted = {extras = ["tls"], version = ">=18.9.0"}
 treq = ">=15.1"
 # Twisted has required pyopenssl 16.0 since about Twisted 16.6.
 pyOpenSSL = ">=16.0.0"

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ CONDITIONAL_REQUIREMENTS["mypy"] = [
 # Tests assume that all optional dependencies are installed.
 #
 # parameterized_class decorator was introduced in parameterized 0.7.0
-CONDITIONAL_REQUIREMENTS["test"] = ["parameterized>=0.7.0"]
+CONDITIONAL_REQUIREMENTS["test"] = ["parameterized>=0.7.0", "idna>=2.5"]
 
 CONDITIONAL_REQUIREMENTS["dev"] = (
     CONDITIONAL_REQUIREMENTS["lint"]

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -55,7 +55,7 @@ REQUIREMENTS = [
     "service_identity>=18.1.0",
     # Twisted 18.9 introduces some logger improvements that the structured
     # logger utilises
-    "Twisted>=18.9.0",
+    "Twisted[tls]>=18.9.0",
     "treq>=15.1",
     # Twisted has required pyopenssl 16.0 since about Twisted 16.6.
     "pyopenssl>=16.0.0",

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -50,7 +50,6 @@ REQUIREMENTS = [
     # we use the type definitions added in signedjson 1.1.
     "signedjson>=1.1.0",
     "pynacl>=1.2.1",
-    "idna>=2.5",
     # validating SSL certs for IP addresses requires service_identity 18.1.
     "service_identity>=18.1.0",
     # Twisted 18.9 introduces some logger improvements that the structured


### PR DESCRIPTION
It was already pulled in for us by `treq`, but we should be explicit
that we do use the `tls` functionality of Twisted directly.