### PR TITLE
Rename Mutual Rooms `unstable_features` flag to match MSC

### DIFF
--- a/changelog.d/12445.misc
+++ b/changelog.d/12445.misc
@@ -1,0 +1,1 @@
+Change Mutual Rooms' `unstable_features` flag to match MSC iteration (now; `uk.half-shot.msc2666.mutual_rooms`).

--- a/changelog.d/12445.misc
+++ b/changelog.d/12445.misc
@@ -1,1 +1,1 @@
-Change Mutual Rooms' `unstable_features` flag to match MSC iteration (now; `uk.half-shot.msc2666.mutual_rooms`).
+Change Mutual Rooms' `unstable_features` flag to `uk.half-shot.msc2666.mutual_rooms` which matches the current MSC iteration.

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -86,7 +86,7 @@ class VersionsRestServlet(RestServlet):
                     # Implements additional endpoints as described in MSC2432
                     "org.matrix.msc2432": True,
                     # Implements additional endpoints as described in MSC2666
-                    "uk.half-shot.msc2666": True,
+                    "uk.half-shot.msc2666.mutual_rooms": True,
                     # Whether new rooms will be set to encrypted or not (based on presets).
                     "io.element.e2ee_forced.public": self.e2ee_forced_public,
                     "io.element.e2ee_forced.private": self.e2ee_forced_private,


### PR DESCRIPTION
Altering the MSCs implementation as per [this MSC commit](https://github.com/matrix-org/matrix-spec-proposals/pull/2666/commits/591d3e55c97c9d4d92144e62cbcd8f868a96578b)

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`