### PR TITLE
Update documentation to reflect that `run_background_tasks_on` is no longer experimental.

### DIFF
--- a/changelog.d/12451.doc
+++ b/changelog.d/12451.doc
@@ -1,1 +1,1 @@
-Update documentation to reflect that `run_background_tasks_on` is no longer experimental.
+Update documentation to reflect that both the `run_background_tasks_on` option and the options for moving stream writers off of the main process are no longer experimental.

--- a/changelog.d/12451.doc
+++ b/changelog.d/12451.doc
@@ -1,0 +1,1 @@
+Update documentation to reflect that `run_background_tasks_on` is no longer experimental.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -343,9 +343,9 @@ effects of bursts of events from that bridge on events sent by normal users.
 
 #### Stream writers
 
-Additionally, there is *experimental* support for moving writing of specific
-streams (such as events) off of the main process to a particular worker. (This
-is only supported with Redis-based replication.)
+Additionally, the writing of specific streams (such as events) can be moved off
+of the main process to a particular worker.
+(This is only supported with Redis-based replication.)
 
 To enable this, the worker must have a HTTP replication listener configured,
 have a `worker_name` and be listed in the `instance_map` config. The same worker

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -422,7 +422,7 @@ the stream writer for the `presence` stream:
 
 #### Background tasks
 
-There is also *experimental* support for moving background tasks to a separate
+There is also support for moving background tasks to a separate
 worker. Background tasks are run periodically or started via replication. Exactly
 which tasks are configured to run depends on your Synapse configuration (e.g. if
 stats is enabled).


### PR DESCRIPTION
We've been running them on m.org for a long time; asking around, it seems like it's just been forgotten about :).
