### PR TITLE
fix type annotation in `get_stream_id_for_event_txn`

### DIFF
--- a/changelog.d/12470.misc
+++ b/changelog.d/12470.misc
@@ -1,0 +1,1 @@
+Changed type annotation of `StreamWorkerStore.get_stream_id_for_event_txn` from `int` to `Optional[int]` to be consistent with the parameter `allow_none`

--- a/changelog.d/12470.misc
+++ b/changelog.d/12470.misc
@@ -1,1 +1,1 @@
-Changed type annotation of `StreamWorkerStore.get_stream_id_for_event_txn` from `int` to `Optional[int]` to be consistent with the parameter `allow_none`
+Changed type annotation of `StreamWorkerStore.get_stream_id_for_event_txn` from `int` to `Optional[int]` to be consistent with the parameter `allow_none`.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1560,6 +1560,21 @@ class DatabasePool:
     ) -> Optional[Any]:
         ...
 
+    @overload
+    @classmethod
+    def simple_select_one_onecol_txn(
+        cls,
+        txn: LoggingTransaction,
+        table: str,
+        keyvalues: Dict[str, Any],
+        retcol: str,
+        allow_none: bool = False,
+    ) -> Optional[int]:
+        ret = cls.simple_select_one_onecol_txn(cls, txn, table=table, keyvalues=keyvalues, retcol=retcol, allow_none=allow_none)
+        if ret:
+            return int(ret)
+        return ret
+
     @classmethod
     def simple_select_one_onecol_txn(
         cls,

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -191,7 +191,7 @@ class EventPushActionsWorkerStore(SQLBaseStore):
         stream_ordering = None
 
         if last_read_event_id is not None:
-            stream_ordering = self.get_stream_id_for_event_txn(  # type: ignore[attr-defined]
+            stream_ordering = self.get_stream_id_for_event_txn(
                 txn,
                 last_read_event_id,
                 allow_none=True,
@@ -209,7 +209,7 @@ class EventPushActionsWorkerStore(SQLBaseStore):
                 retcol="event_id",
             )
 
-            stream_ordering = self.get_stream_id_for_event_txn(txn, event_id)  # type: ignore[attr-defined]
+            stream_ordering = self.get_stream_id_for_event_txn(txn, event_id)
 
         return self._get_unread_counts_by_pos_txn(
             txn, room_id, user_id, stream_ordering

--- a/synapse/storage/databases/main/stream.py
+++ b/synapse/storage/databases/main/stream.py
@@ -806,8 +806,8 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
         self,
         txn: LoggingTransaction,
         event_id: str,
-        allow_none=False,
-    ) -> int:
+        allow_none: bool = False,
+    ) -> Optional[int]:
         return self.db_pool.simple_select_one_onecol_txn(
             txn=txn,
             table="events",


### PR DESCRIPTION
Fixes: #12437 
`StreamWorkerStore.get_stream_id_for_event_txn` now has return type `Optional[int]` which is consistent with the `NoneType` when `allow_none=True`.


Signed-off-by: Gautam Kumar Giri <personal.gautamgiri@gmail.com>


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
