### PR TITLE
Add CI job to act as a canary for testing against latest dependencies

### DIFF
--- a/.ci/latest_deps_build_failed_issue_template.md
+++ b/.ci/latest_deps_build_failed_issue_template.md
@@ -1,0 +1,4 @@
+---
+title: CI run against latest deps is failing
+---
+See https://github.com/{{env.GITHUB_REPOSITORY}}/actions/runs/{{env.GITHUB_RUN_ID}}

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: matrix-org/setup-python-poetry@v1
         with:
           python-version: "3.x"
+          poetry-version: "1.2.0b1"
       # Dump installed versions for debugging.
       - run: poetry run pip list > before.txt
       # Upgrade all runtime dependencies only. This is intended to mimic a fresh

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -39,19 +39,18 @@ jobs:
           python-version: "3.x"
       # Dump installed versions for debugging.
       - run: poetry run pip list > before.txt
-      # Work out which packages we want pip to upgrade. We use sed to strip out the
-      # version numbers from `poetry export`'s output.
-      - run: >-
-          poetry export --extras all --without-hashes
-          | sed -Ee 's/^([^=]+)==[^;]+/\1/'
-          > requirements.txt
-      # Upgrade all runtime dependencies to their latest version. This is intended to
-      # mimic a fresh `pip install matrix-synapse[all]` as closely as possible.
-      - run: poetry run pip install --upgrade --upgrade-strategy eager -r requirements.txt
-      # Dump the changes for confirmation and debugging.
-      - run: poetry run pip list | tee after.txt
-      - run: diff -u before.txt after.txt || true
-      # Now we can finally typecheck.
+      # Upgrade all runtime dependencies only. This is intended to mimic a fresh
+      # `pip install matrix-synapse[all]` as closely as possible.
+      # AFAICS this will update transitive dependencies. E.g. try
+      #     pip install requests==2.24.0 idna==2.8
+      #     pip install --upgrade --upgrade-strategy eager requests
+      # The second command should update both requests and idna.
+      - run: poetry run pip install .[all] --upgrade --upgrade-strategy eager
+      # Doing the above makes mypy not process its list of ignores for some reason.
+      # I think this is because the above does a normal install of matrix-synapse rather
+      # than an editable install. We workaround this by uninstalling matrix-synapse.
+      - run: poetry run pip uninstall matrix-synapse
+      - run: poetry run pip list > after.txt && (diff -u before.txt after.txt || true)
       - run: poetry run mypy
   trial:
     runs-on: ubuntu-latest

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -41,15 +41,7 @@ jobs:
       - run: poetry run pip list > before.txt
       # Upgrade all runtime dependencies only. This is intended to mimic a fresh
       # `pip install matrix-synapse[all]` as closely as possible.
-      # AFAICS this will update transitive dependencies. E.g. try
-      #     pip install requests==2.24.0 idna==2.8
-      #     pip install --upgrade --upgrade-strategy eager requests
-      # The second command should update both requests and idna.
-      - run: poetry run pip install .[all] --upgrade --upgrade-strategy eager
-      # Doing the above makes mypy not process its list of ignores for some reason.
-      # I think this is because the above does a normal install of matrix-synapse rather
-      # than an editable install. We workaround this by uninstalling matrix-synapse.
-      - run: poetry run pip uninstall -y matrix-synapse
+      - run: poetry update --no-dev
       - run: poetry run pip list > after.txt && (diff -u before.txt after.txt || true)
       - run: poetry run mypy
   trial:

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -33,15 +33,36 @@ jobs:
 
   trial:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - database: "sqlite"
+          - database: "postgres"
+            postgres-version: "14"
 
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get -qq install xmlsec1
+      - name: Set up PostgreSQL ${{ matrix.postgres-version }}
+        if: ${{ matrix.postgres-version }}
+        run: |
+          docker run -d -p 5432:5432 \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
+            postgres:${{ matrix.postgres-version }}
       - uses: actions/setup-python@v2
         with:
           python-version: "3.x"
-      - run: trial --jobs 2 tests
-
+      - name: Await PostgreSQL
+        if: ${{ matrix.postgres-version }}
+        timeout-minutes: 2
+        run: until pg_isready -h localhost; do sleep 1; done
+      - run: trial --jobs=2 tests
+        env:
+          SYNAPSE_POSTGRES: ${{ matrix.database == 'postgres' || '' }}
+          SYNAPSE_POSTGRES_HOST: localhost
+          SYNAPSE_POSTGRES_USER: postgres
+          SYNAPSE_POSTGRES_PASSWORD: postgres
       - name: Dump logs
         # Logs are most useful when the command fails, always include them.
         if: ${{ always() }}
@@ -54,6 +75,7 @@ jobs:
           -exec cat {} \;
           -exec echo "::endgroup::" \;
           || true
+
 
 #  sytest:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -38,9 +38,9 @@ jobs:
         with:
           python-version: "3.x"
       # Lacking a `pip install --upgrade-literally-everything` option, concoct our own.
-      - run: "poetry run pip freeze | cut -d' ' -f 1 | xargs pip install --upgrade --upgrade-strategy eager"
+      - run: "poetry run pip freeze | cut -d' ' -f 1 | xargs poetry run pip install --upgrade --upgrade-strategy eager"
       # Dump installed versions for debugging
-      - run: pip freeze
+      - run: poetry run pip freeze
       - run: poetry run mypy
   trial:
     runs-on: ubuntu-latest

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Ensure systest runs `pip install`
+      - name: Ensure sytest runs `pip install`
         # Delete the lockfile so sytest will `pip install` rather than `poetry install`
         run: rm /src/poetry.lock
         working-directory: /src

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -1,7 +1,7 @@
-# People who are freshly `pip install`ing from the wheels we publish to PyPI will pull
-# in the latest versions of all dependencies. We used to do this in our CI runs, which
-# would detect any incompatibilities due to new package releases. Now that we use the
-# locked poetry environment, we don't have advance notice of these breakages.defaults:
+# People who are freshly `pip install`ing from PyPI will pull in the latest versions of all
+# dependencies. Since most CI runs are against the locked poetry environment, run
+# specifically against the latest dependencies to know if there's an upcoming breaking
+# change.
 #
 # To plug that hole, this job is a canary which periodically
 # - checks out develop,

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -37,13 +37,13 @@ jobs:
       - uses: matrix-org/setup-python-poetry@v1
         with:
           python-version: "3.x"
-      # Lacking a `pip install --upgrade-literally-everything` option, concoct our own.
-      # Ensure that we only invoke `pip install` once with at most 1000 package names
-      # by passing `-x -n 1000` to `xargs`. This ensures that pip resolves all
-      # dependencies together.
-      - run: "poetry run pip freeze | cut -d' ' -f 1 | xargs -x -n 1000 poetry run pip install --upgrade --upgrade-strategy eager"
-      # Dump installed versions for debugging
-      - run: poetry run pip freeze
+      # Dump installed versions for debugging.
+      - run: poetry run pip freeze > before.txt
+      # Upgrade all runtime dependencies only. This is intended to mimic a fresh
+      # `pip install matrix-synapse[all]` as closely as possible.
+      - run: poetry run pip install .[all] --upgrade --upgrade-strategy eager
+      - run: poetry run pip freeze | tee after.txt
+      - run: diff -u before.txt after.txt || true
       - run: poetry run mypy
   trial:
     runs-on: ubuntu-latest

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -41,15 +41,17 @@ jobs:
       - run: poetry run pip freeze > before.txt
       # Upgrade all runtime dependencies only. This is intended to mimic a fresh
       # `pip install matrix-synapse[all]` as closely as possible.
-      # AFAICS this will update transitive dependencies. E.g. try
-      #     pip install requests==2.24.0 idna==2.8
-      #     pip install --upgrade --upgrade-strategy eager requests
-      # The second command should update both requests and idna.
-      - run: poetry run pip install .[all] --upgrade --upgrade-strategy eager
+      # Notes:
+      # - AFAICS this will update transitive dependencies. E.g. try
+      #       pip install requests==2.24.0 idna==2.8
+      #       pip install --upgrade --upgrade-strategy eager requests
+      #   The second command should update both `requests` and `idna`.
+      - run: >-
+          poetry export --extras all 
+          | cut -d '=' -f1
+          | xargs poetry run pip install --upgrade --upgrade-strategy eager
       - run: poetry run pip freeze | tee after.txt
       - run: diff -u before.txt after.txt || true
-      - run: ls -alth
-      - run: cat mypy.ini
       - run: poetry run mypy
   trial:
     runs-on: ubuntu-latest

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -38,20 +38,20 @@ jobs:
         with:
           python-version: "3.x"
       # Dump installed versions for debugging.
-      - run: poetry run pip freeze > before.txt
-      # Upgrade all runtime dependencies only. This is intended to mimic a fresh
-      # `pip install matrix-synapse[all]` as closely as possible.
-      # Notes:
-      # - AFAICS this will update transitive dependencies. E.g. try
-      #       pip install requests==2.24.0 idna==2.8
-      #       pip install --upgrade --upgrade-strategy eager requests
-      #   The second command should update both `requests` and `idna`.
+      - run: poetry run pip list > before.txt
+      # Work out which packages we want pip to upgrade. We use sed to strip out the
+      # version numbers from `poetry export`'s output.
       - run: >-
-          poetry export --extras all 
-          | cut -d '=' -f1
-          | xargs poetry run pip install --upgrade --upgrade-strategy eager
-      - run: poetry run pip freeze | tee after.txt
+          poetry export --extras all --without-hashes
+          | sed -Ee 's/^([^=]+)==[^;]+/\1/'
+          > requirements.txt
+      # Upgrade all runtime dependencies to their latest version. This is intended to
+      # mimic a fresh `pip install matrix-synapse[all]` as closely as possible.
+      - run: poetry run pip install --upgrade --upgrade-strategy eager -r requirements.txt
+      # Dump the changes for confirmation and debugging.
+      - run: poetry run pip list | tee after.txt
       - run: diff -u before.txt after.txt || true
+      # Now we can finally typecheck.
       - run: poetry run mypy
   trial:
     runs-on: ubuntu-latest

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ matrix.postgres-version }}
         timeout-minutes: 2
         run: until pg_isready -h localhost; do sleep 1; done
-      - run: trial --jobs=2 tests
+      - run: python -m trial --jobs=2 tests
         env:
           SYNAPSE_POSTGRES: ${{ matrix.database == 'postgres' || '' }}
           SYNAPSE_POSTGRES_HOST: localhost

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -134,10 +134,14 @@ jobs:
             /logs/results.tap
             /logs/**/*.log*
 
+
+  # TODO: run complement (as with twisted trunk, see #12473).
+
   # open an issue if the build fails, so we know about it.
 #  open-issue:
 #    if: failure()
 #    needs:
+#      # TODO: should mypy be included here? It feels more brittle than the other two.
 #      - mypy
 #      - trial
 #      - sytest
@@ -151,4 +155,4 @@ jobs:
 #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #        with:
 #          update_existing: true
-#          filename: .ci/twisted_trunk_build_failed_issue_template.md
+#          filename: .ci/latest_deps_build_failed_issue_template.md

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -84,14 +84,30 @@ jobs:
       image: matrixdotorg/sytest-synapse:testing
       volumes:
         - ${{ github.workspace }}:/src
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sytest-tag: focal
+
+          - sytest-tag: focal
+            postgres: postgres
+            workers: workers
+            redis: redis
+    env:
+      POSTGRES: ${{ matrix.postgres && 1}}
+      WORKERS: ${{ matrix.workers && 1 }}
+      REDIS: ${{ matrix.redis && 1 }}
+      BLACKLIST: ${{ matrix.workers && 'synapse-blacklist-with-workers' }}
 
     steps:
       - uses: actions/checkout@v2
       - name: Ensure systest runs `pip install`
-        run: |
-          # Delete the lockfile so sytest will `pip install` rather than `poetry install`
-          rm /src/poetry.lock
+        # Delete the lockfile so sytest will `pip install` rather than `poetry install`
+        run: rm /src/poetry.lock
         working-directory: /src
+      - name: Prepare test blacklist
+        run: cat sytest-blacklist .ci/worker-blacklist > synapse-blacklist-with-workers
       - name: Run SyTest
         run: /bootstrap.sh synapse
         working-directory: /src

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -1,13 +1,12 @@
-# People who are freshly `pip install`ing from PyPI will pull in the latest versions of all
-# dependencies. Since most CI runs are against the locked poetry environment, run
-# specifically against the latest dependencies to know if there's an upcoming breaking
-# change.
+# People who are freshly `pip install`ing from PyPI will pull in the latest versions of
+# dependencies which match the broad requirements. Since most CI runs are against
+# the locked poetry environment, run specifically against the latest dependencies to
+# know if there's an upcoming breaking change.
 #
-# To plug that hole, this job is a canary which periodically
+# As an overview this workflow:
 # - checks out develop,
-# - pip installs from source (building a wheel locally using `poetry-core`,
-#   and `pip install`ing from that), and
-# - runs test suites against that checkout.
+# - installs from source, pulling in the dependencies like a fresh `pip install` would, and 
+# - runs mypy and test suites in that checkout.
 #
 # Based on the twisted trunk CI job.
 

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -27,10 +27,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-# TODO: do we want a mypy job? The mypy-only dependencies aren't exposed as extras, so
-# we would need to do some poetry shenanigans here.
-#  mypy:
-
+  # TODO(dmr): I'm not sure if we want to run mypy here, nor if mypy failures should
+  # merit an issue.
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # The dev dependencies aren't exposed in the wheel metadata (at least with current
+      # poetry-core versions). So we'll have to be dirty: `poetry install` to get the
+      # dev deps, then upgrade them in situ with pip.
+      - uses: matrix-org/setup-python-poetry@v1
+        with:
+          python-version: "3.x"
+      # Lacking a `pip install --upgrade-literally-everything` option, concoct our own.
+      - run: "poetry run pip freeze | cut -d' ' -f 1 | xargs echo pip install --upgrade --upgrade-strategy eager"
+      - run: poetry run mypy
   trial:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ matrix.postgres-version }}
         timeout-minutes: 2
         run: until pg_isready -h localhost; do sleep 1; done
-      - run: python -m trial --jobs=2 tests
+      - run: python -m twisted.trial --jobs=2 tests
         env:
           SYNAPSE_POSTGRES: ${{ matrix.database == 'postgres' || '' }}
           SYNAPSE_POSTGRES_HOST: localhost

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -32,8 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # The dev dependencies aren't exposed in the wheel metadata (at least with current
-      # poetry-core versions). So we'll have to be dirty: `poetry install` to get the
-      # dev deps, then upgrade them in situ with pip.
+      # poetry-core versions), so we install with poetry.
       - uses: matrix-org/setup-python-poetry@v1
         with:
           python-version: "3.x"

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -27,8 +27,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # TODO(dmr): I'm not sure if we want to run mypy here, nor if mypy failures should
-  # merit an issue.
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -15,10 +15,6 @@ name: Latest dependencies
 on:
   schedule:
     - cron: 0 7 * * *
-  pull_request:
-    branches: [dmr/poetry-wheel-ci]
-  push:
-    branches: [dmr/poetry-wheel-ci]
   workflow_dispatch:
 
 concurrency:
@@ -139,21 +135,22 @@ jobs:
   # TODO: run complement (as with twisted trunk, see #12473).
 
   # open an issue if the build fails, so we know about it.
-#  open-issue:
-#    if: failure()
-#    needs:
-#      # TODO: should mypy be included here? It feels more brittle than the other two.
-#      - mypy
-#      - trial
-#      - sytest
-#
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: JasonEtco/create-an-issue@5d9504915f79f9cc6d791934b8ef34f2353dd74d # v2.5.0, 2020-12-06
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          update_existing: true
-#          filename: .ci/latest_deps_build_failed_issue_template.md
+  open-issue:
+    if: failure()
+    needs:
+      # TODO: should mypy be included here? It feels more brittle than the other two.
+      - mypy
+      - trial
+      - sytest
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@5d9504915f79f9cc6d791934b8ef34f2353dd74d # v2.5.0, 2020-12-06
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          update_existing: true
+          filename: .ci/latest_deps_build_failed_issue_template.md
+

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -53,6 +53,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.x"
+      - run: pip install -e .[all,test]
       - name: Await PostgreSQL
         if: ${{ matrix.postgres-version }}
         timeout-minutes: 2

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -41,6 +41,10 @@ jobs:
       - run: poetry run pip freeze > before.txt
       # Upgrade all runtime dependencies only. This is intended to mimic a fresh
       # `pip install matrix-synapse[all]` as closely as possible.
+      # AFAICS this will update transitive dependencies. E.g. try
+      #     pip install requests==2.24.0 idna==2.8
+      #     pip install --upgrade --upgrade-strategy eager requests
+      # The second command should update both requests and idna.
       - run: poetry run pip install .[all] --upgrade --upgrade-strategy eager
       - run: poetry run pip freeze | tee after.txt
       - run: diff -u before.txt after.txt || true

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -40,7 +40,9 @@ jobs:
         with:
           python-version: "3.x"
       # Lacking a `pip install --upgrade-literally-everything` option, concoct our own.
-      - run: "poetry run pip freeze | cut -d' ' -f 1 | xargs echo pip install --upgrade --upgrade-strategy eager"
+      - run: "poetry run pip freeze | cut -d' ' -f 1 | xargs pip install --upgrade --upgrade-strategy eager"
+      # Dump installed versions for debugging
+      - run: pip freeze
       - run: poetry run mypy
   trial:
     runs-on: ubuntu-latest

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -1,0 +1,113 @@
+# People who are freshly `pip install`ing from the wheels we publish to PyPI will pull
+# in the latest versions of all dependencies. We used to do this in our CI runs, which
+# would detect any incompatibilities due to new package releases. Now that we use the
+# locked poetry environment, we don't have advance notice of these breakages.defaults:
+#
+# To plug that hole, this job is a canary which periodically
+# - checks out develop,
+# - pip installs from source (building a wheel locally using `poetry-core`,
+#   and `pip install`ing from that), and
+# - runs test suites against that checkout.
+#
+# Based on the twisted trunk CI job.
+
+name: Latest dependencies
+
+on:
+  schedule:
+    - cron: 0 7 * * *
+  pull_request:
+    branches:
+      - dmr/poetry-wheel-ci
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+# TODO: do we want a mypy job? The mypy-only dependencies aren't exposed as extras, so
+# we would need to do some poetry shenanigans here.
+#  mypy:
+
+  trial:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt-get -qq install xmlsec1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - run: trial --jobs 2 tests
+
+      - name: Dump logs
+        # Logs are most useful when the command fails, always include them.
+        if: ${{ always() }}
+        # Note: Dumps to workflow logs instead of using actions/upload-artifact
+        #       This keeps logs colocated with failing jobs
+        #       It also ignores find's exit code; this is a best effort affair
+        run: >-
+          find _trial_temp -name '*.log'
+          -exec echo "::group::{}" \;
+          -exec cat {} \;
+          -exec echo "::endgroup::" \;
+          || true
+
+#  sytest:
+#    runs-on: ubuntu-latest
+#    container:
+#      image: matrixdotorg/sytest-synapse:testing
+#      volumes:
+#        - ${{ github.workspace }}:/src
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Patch dependencies
+#        # Note: The poetry commands want to create a virtualenv in /src/.venv/,
+#        #       but the sytest-synapse container expects it to be in /venv/.
+#        #       We symlink it before running poetry so that poetry actually
+#        #       ends up installing to `/venv`.
+#        run: |
+#          ln -s -T /venv /src/.venv
+#          poetry remove twisted
+#          poetry add --extras tls git+https://github.com/twisted/twisted.git#trunk
+#          poetry install --no-interaction --extras "all test"
+#        working-directory: /src
+#      - name: Run SyTest
+#        run: /bootstrap.sh synapse
+#        working-directory: /src
+#        env:
+#          # Use offline mode to avoid reinstalling the pinned version of
+#          # twisted.
+#          OFFLINE: 1
+#      - name: Summarise results.tap
+#        if: ${{ always() }}
+#        run: /sytest/scripts/tap_to_gha.pl /logs/results.tap
+#      - name: Upload SyTest logs
+#        uses: actions/upload-artifact@v2
+#        if: ${{ always() }}
+#        with:
+#          name: Sytest Logs - ${{ job.status }} - (${{ join(matrix.*, ', ') }})
+#          path: |
+#            /logs/results.tap
+#            /logs/**/*.log*
+
+  # open an issue if the build fails, so we know about it.
+#  open-issue:
+#    if: failure()
+#    needs:
+#      - mypy
+#      - trial
+#      - sytest
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: JasonEtco/create-an-issue@5d9504915f79f9cc6d791934b8ef34f2353dd74d # v2.5.0, 2020-12-06
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          update_existing: true
+#          filename: .ci/twisted_trunk_build_failed_issue_template.md

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -49,7 +49,7 @@ jobs:
       # Doing the above makes mypy not process its list of ignores for some reason.
       # I think this is because the above does a normal install of matrix-synapse rather
       # than an editable install. We workaround this by uninstalling matrix-synapse.
-      - run: poetry run pip uninstall matrix-synapse
+      - run: poetry run pip uninstall -y matrix-synapse
       - run: poetry run pip list > after.txt && (diff -u before.txt after.txt || true)
       - run: poetry run mypy
   trial:

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -78,44 +78,34 @@ jobs:
           || true
 
 
-#  sytest:
-#    runs-on: ubuntu-latest
-#    container:
-#      image: matrixdotorg/sytest-synapse:testing
-#      volumes:
-#        - ${{ github.workspace }}:/src
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Patch dependencies
-#        # Note: The poetry commands want to create a virtualenv in /src/.venv/,
-#        #       but the sytest-synapse container expects it to be in /venv/.
-#        #       We symlink it before running poetry so that poetry actually
-#        #       ends up installing to `/venv`.
-#        run: |
-#          ln -s -T /venv /src/.venv
-#          poetry remove twisted
-#          poetry add --extras tls git+https://github.com/twisted/twisted.git#trunk
-#          poetry install --no-interaction --extras "all test"
-#        working-directory: /src
-#      - name: Run SyTest
-#        run: /bootstrap.sh synapse
-#        working-directory: /src
-#        env:
-#          # Use offline mode to avoid reinstalling the pinned version of
-#          # twisted.
-#          OFFLINE: 1
-#      - name: Summarise results.tap
-#        if: ${{ always() }}
-#        run: /sytest/scripts/tap_to_gha.pl /logs/results.tap
-#      - name: Upload SyTest logs
-#        uses: actions/upload-artifact@v2
-#        if: ${{ always() }}
-#        with:
-#          name: Sytest Logs - ${{ job.status }} - (${{ join(matrix.*, ', ') }})
-#          path: |
-#            /logs/results.tap
-#            /logs/**/*.log*
+  sytest:
+    runs-on: ubuntu-latest
+    container:
+      image: matrixdotorg/sytest-synapse:testing
+      volumes:
+        - ${{ github.workspace }}:/src
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Ensure systest runs `pip install`
+        run: |
+          # Delete the lockfile so sytest will `pip install` rather than `poetry install`
+          rm /src/poetry.lock
+        working-directory: /src
+      - name: Run SyTest
+        run: /bootstrap.sh synapse
+        working-directory: /src
+      - name: Summarise results.tap
+        if: ${{ always() }}
+        run: /sytest/scripts/tap_to_gha.pl /logs/results.tap
+      - name: Upload SyTest logs
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: Sytest Logs - ${{ job.status }} - (${{ join(matrix.*, ', ') }})
+          path: |
+            /logs/results.tap
+            /logs/**/*.log*
 
   # open an issue if the build fails, so we know about it.
 #  open-issue:

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -48,6 +48,8 @@ jobs:
       - run: poetry run pip install .[all] --upgrade --upgrade-strategy eager
       - run: poetry run pip freeze | tee after.txt
       - run: diff -u before.txt after.txt || true
+      - run: ls -alth
+      - run: cat mypy.ini
       - run: poetry run mypy
   trial:
     runs-on: ubuntu-latest

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -38,7 +38,10 @@ jobs:
         with:
           python-version: "3.x"
       # Lacking a `pip install --upgrade-literally-everything` option, concoct our own.
-      - run: "poetry run pip freeze | cut -d' ' -f 1 | xargs poetry run pip install --upgrade --upgrade-strategy eager"
+      # Ensure that we only invoke `pip install` once with at most 1000 package names
+      # by passing `-x -n 1000` to `xargs`. This ensures that pip resolves all
+      # dependencies together.
+      - run: "poetry run pip freeze | cut -d' ' -f 1 | xargs -x -n 1000 poetry run pip install --upgrade --upgrade-strategy eager"
       # Dump installed versions for debugging
       - run: poetry run pip freeze
       - run: poetry run mypy

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -17,8 +17,9 @@ on:
   schedule:
     - cron: 0 7 * * *
   pull_request:
-    branches:
-      - dmr/poetry-wheel-ci
+    branches: [dmr/poetry-wheel-ci]
+  push:
+    branches: [dmr/poetry-wheel-ci]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.x"
-      - run: pip install -e .[all,test]
+      - run: pip install .[all,test]
       - name: Await PostgreSQL
         if: ${{ matrix.postgres-version }}
         timeout-minutes: 2

--- a/changelog.d/12472.misc
+++ b/changelog.d/12472.misc
@@ -1,0 +1,1 @@
+Add a CI job which tests Synapse against the latest version of all dependencies.


### PR DESCRIPTION
Our old CI used to be this canary on every job. Now we are using poetry, we'll be using locked versions everywhere and so won't see problems coming from fresh `pip install matrix-synapse[all]` installations. Introduce this new job to try and cover that gap.

Based on the twisted trunk job. Runs an hour before the Twisted trunk job does. 

Not fully sure if mypy is appropriate here, see comments in the diff.