### PR TITLE
MSC2246 async uploads

### DIFF
--- a/changelog.d/12484.feature
+++ b/changelog.d/12484.feature
@@ -1,0 +1,1 @@
+Experimental support for asynchronous uploads as defined by [MSC2246](https://github.com/matrix-org/matrix-spec-proposals/pull/2246). Contributed by @sumnerevans at Beeper.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -964,6 +964,10 @@ log_config: "CONFDIR/SERVERNAME.log.config"
 #rc_third_party_invite:
 #  per_second: 0.2
 #  burst_count: 10
+#
+#rc_media_create:
+#  per_second: 10
+#  burst_count: 50
 
 # Ratelimiting settings for incoming federation
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1038,6 +1038,11 @@ media_store_path: "DATADIR/media_store"
 #
 #max_image_pixels: 32M
 
+# How long to wait before expiring created media IDs when MSC2246 support is
+# enabled.
+#
+#unused_expiration_time: 1m
+
 # Whether to generate new thumbnails on the fly to precisely match
 # the resolution requested by the client. If true then whenever
 # a new resolution is requested by the client the server will

--- a/synapse/api/urls.py
+++ b/synapse/api/urls.py
@@ -29,9 +29,7 @@ FEDERATION_V2_PREFIX = FEDERATION_PREFIX + "/v2"
 FEDERATION_UNSTABLE_PREFIX = FEDERATION_PREFIX + "/unstable"
 STATIC_PREFIX = "/_matrix/static"
 SERVER_KEY_V2_PREFIX = "/_matrix/key/v2"
-MEDIA_R0_PREFIX = "/_matrix/media/r0"
-MEDIA_V3_PREFIX = "/_matrix/media/v3"
-LEGACY_MEDIA_PREFIX = "/_matrix/media/v1"
+MEDIA_PREFIX = "/_matrix/media"
 
 
 class ConsentURIBuilder:

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -27,9 +27,7 @@ from synapse.api.errors import HttpResponseException, RequestSendFailed, Synapse
 from synapse.api.urls import (
     CLIENT_API_PREFIX,
     FEDERATION_PREFIX,
-    LEGACY_MEDIA_PREFIX,
-    MEDIA_R0_PREFIX,
-    MEDIA_V3_PREFIX,
+    MEDIA_PREFIX,
     SERVER_KEY_V2_PREFIX,
 )
 from synapse.app import _base
@@ -338,9 +336,7 @@ class GenericWorkerServer(HomeServer):
 
                         resources.update(
                             {
-                                MEDIA_R0_PREFIX: media_repo,
-                                MEDIA_V3_PREFIX: media_repo,
-                                LEGACY_MEDIA_PREFIX: media_repo,
+                                MEDIA_PREFIX: media_repo,
                                 "/_synapse/admin": admin_resource,
                             }
                         )

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -30,9 +30,7 @@ from synapse import events
 from synapse.api.urls import (
     CLIENT_API_PREFIX,
     FEDERATION_PREFIX,
-    LEGACY_MEDIA_PREFIX,
-    MEDIA_R0_PREFIX,
-    MEDIA_V3_PREFIX,
+    MEDIA_PREFIX,
     SERVER_KEY_V2_PREFIX,
     STATIC_PREFIX,
 )
@@ -245,13 +243,7 @@ class SynapseHomeServer(HomeServer):
         if name in ["media", "federation", "client"]:
             if self.config.server.enable_media_repo:
                 media_repo = self.get_media_repository_resource()
-                resources.update(
-                    {
-                        MEDIA_R0_PREFIX: media_repo,
-                        MEDIA_V3_PREFIX: media_repo,
-                        LEGACY_MEDIA_PREFIX: media_repo,
-                    }
-                )
+                resources[MEDIA_PREFIX] = media_repo
             elif name == "media":
                 raise ConfigError(
                     "'media' resource conflicts with enable_media_repo=False"

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -84,3 +84,6 @@ class ExperimentalConfig(Config):
 
         # MSC3772: A push rule for mutual relations.
         self.msc3772_enabled: bool = experimental.get("msc3772_enabled", False)
+
+        # MSC2246 (async media uploads)
+        self.msc2246_enabled: bool = experimental.get("msc2246_enabled", False)

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -144,6 +144,12 @@ class RatelimitConfig(Config):
             },
         )
 
+        # Ratelimit create media requests:
+        self.rc_media_create = RateLimitConfig(
+            config.get("rc_media_create", {}),
+            defaults={"per_second": 10, "burst_count": 50},
+        )
+
     def generate_config_section(self, **kwargs: Any) -> str:
         return """\
         ## Ratelimiting ##
@@ -234,6 +240,10 @@ class RatelimitConfig(Config):
         #rc_third_party_invite:
         #  per_second: 0.2
         #  burst_count: 10
+        #
+        #rc_media_create:
+        #  per_second: 10
+        #  burst_count: 50
 
         # Ratelimiting settings for incoming federation
         #

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -117,6 +117,10 @@ class ContentRepositoryConfig(Config):
         self.max_image_pixels = self.parse_size(config.get("max_image_pixels", "32M"))
         self.max_spider_size = self.parse_size(config.get("max_spider_size", "10M"))
 
+        self.unused_expiration_time = self.parse_duration(
+            config.get("unused_expiration_time", "1m")
+        )
+
         self.media_store_path = self.ensure_directory(
             config.get("media_store_path", "media_store")
         )
@@ -291,6 +295,11 @@ class ContentRepositoryConfig(Config):
         # Maximum number of pixels that will be thumbnailed
         #
         #max_image_pixels: 32M
+
+        # How long to wait before expiring created media IDs when MSC2246 support is
+        # enabled.
+        #
+        #unused_expiration_time: 1m
 
         # Whether to generate new thumbnails on the fly to precisely match
         # the resolution requested by the client. If true then whenever

--- a/synapse/rest/media/v1/_base.py
+++ b/synapse/rest/media/v1/_base.py
@@ -49,6 +49,8 @@ TEXT_CONTENT_TYPES = [
     "text/xml",
 ]
 
+DEFAULT_MSC2246_DELAY = 20_000
+
 
 def parse_media_id(request: Request) -> Tuple[str, str, Optional[str]]:
     """Parses the server name, media ID and optional file name from the request URI

--- a/synapse/rest/media/v1/create_resource.py
+++ b/synapse/rest/media/v1/create_resource.py
@@ -1,0 +1,84 @@
+# Copyright 2014-2016 OpenMarket Ltd
+# Copyright 2020-2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import TYPE_CHECKING
+
+from synapse.api.errors import LimitExceededError
+from synapse.api.ratelimiting import Ratelimiter
+from synapse.http.server import DirectServeJsonResource, respond_with_json
+from synapse.http.site import SynapseRequest
+
+if TYPE_CHECKING:
+    from synapse.rest.media.v1.media_repository import MediaRepository
+    from synapse.server import HomeServer
+
+
+logger = logging.getLogger(__name__)
+
+
+class CreateResource(DirectServeJsonResource):
+    isLeaf = True
+
+    def __init__(self, hs: "HomeServer", media_repo: "MediaRepository"):
+        super().__init__()
+
+        self.media_repo = media_repo
+        self.clock = hs.get_clock()
+        self.auth = hs.get_auth()
+
+        # A rate limiter for creating new media IDs.
+        self._create_media_rate_limiter = Ratelimiter(
+            store=hs.get_datastores().main,
+            clock=self.clock,
+            rate_hz=hs.config.ratelimiting.rc_media_create.per_second,
+            burst_count=hs.config.ratelimiting.rc_media_create.burst_count,
+        )
+
+    async def _async_render_OPTIONS(self, request: SynapseRequest) -> None:
+        respond_with_json(request, 200, {}, send_cors=True)
+
+    async def _async_render_POST(self, request: SynapseRequest) -> None:
+        requester = await self.auth.get_user_by_req(request)
+
+        # If the create media requests for the user are over the limit, drop
+        # them.
+        allowed, time_allowed = await self._create_media_rate_limiter.can_do_action(
+            requester
+        )
+        if not allowed:
+            time_now_s = self.clock.time()
+            raise LimitExceededError(
+                retry_after_ms=int(1000 * (time_allowed - time_now_s))
+            )
+
+        content_uri, unused_expires_at = await self.media_repo.create_media_id(
+            requester.user
+        )
+
+        logger.info(
+            "Created Media URI %r that if unused will expire at %d",
+            content_uri,
+            unused_expires_at,
+        )
+        respond_with_json(
+            request,
+            200,
+            {
+                "content_uri": content_uri,
+                "unused_expires_at": unused_expires_at,
+            },
+            send_cors=True,
+        )

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -18,7 +18,7 @@ import os
 import shutil
 from enum import Enum
 from io import BytesIO
-from typing import IO, TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 import twisted.internet.error
 import twisted.web.http
@@ -32,13 +32,14 @@ from synapse.api.errors import (
     NotFoundError,
     RequestSendFailed,
     SynapseError,
+    cs_error,
 )
 from synapse.config._base import ConfigError
 from synapse.config.repository import ThumbnailRequirement
+from synapse.http.server import respond_with_json
 from synapse.http.site import SynapseRequest
 from synapse.logging.context import defer_to_thread
 from synapse.metrics.background_process_metrics import run_as_background_process
-from synapse.rest.media.v1.create_resource import CreateResource
 from synapse.types import UserID
 from synapse.util.async_helpers import Linearizer
 from synapse.util.retryutils import NotRetryingDestination
@@ -53,6 +54,7 @@ from ._base import (
     respond_with_responder,
 )
 from .config_resource import MediaConfigResource
+from .create_resource import CreateResource
 from .download_resource import DownloadResource
 from .filepath import MediaFilePaths
 from .media_storage import MediaStorage
@@ -318,8 +320,64 @@ class MediaRepository:
 
         return "mxc://%s/%s" % (self.server_name, media_id)
 
+    def respond_not_yet_uploaded(self, request: SynapseRequest) -> None:
+        not_uploaded_error = cs_error(
+            "Media has not been uploaded yet",
+            code="FI.MAU.MSC2246_NOT_YET_UPLOADED",
+            retry_after_ms=5_000,
+        )
+        respond_with_json(request, 404, not_uploaded_error, send_cors=True)
+
+    async def get_local_media_info(
+        self, request: SynapseRequest, media_id: str, max_stall_ms: int
+    ) -> Optional[Dict[str, Any]]:
+        """Gets the info dictionary for given local media ID. If the media has
+        not been uploaded yet, this function will wait up to ``max_stall_ms``
+        milliseconds for the media to be uploaded.
+
+        Args:
+            request: The incoming request.
+            media_id: The media ID of the content. (This is the same as
+                the file_id for local content.)
+            max_stall_ms: the maximum number of milliseconds to wait for the
+                media to be uploaded.
+
+        Returns:
+            Either the info dictionary for the given local media ID or
+            ``None``. If ``None``, then no further processing is necessary as
+            this function will send the necessary JSON response.
+        """
+        wait_until = self.clock.time_msec() + max_stall_ms
+        while True:
+            # Get the info for the media
+            media_info = await self.store.get_local_media(media_id)
+            if not media_info:
+                respond_404(request)
+                return None
+
+            if media_info["quarantined_by"]:
+                logger.info("Media is quarantined")
+                respond_404(request)
+                return None
+
+            # The file has been uploaded, so stop looping
+            if media_info.get("media_length") is not None:
+                return media_info
+
+            if self.clock.time_msec() >= wait_until:
+                break
+
+            await self.clock.sleep(0.5)
+
+        self.respond_not_yet_uploaded(request)
+        return None
+
     async def get_local_media(
-        self, request: SynapseRequest, media_id: str, name: Optional[str]
+        self,
+        request: SynapseRequest,
+        media_id: str,
+        name: Optional[str],
+        max_stall_ms: int,
     ) -> None:
         """Responds to requests for local media, if exists, or returns 404.
 
@@ -329,13 +387,14 @@ class MediaRepository:
                 the file_id for local content.)
             name: Optional name that, if specified, will be used as
                 the filename in the Content-Disposition header of the response.
+            max_stall_ms: the maximum number of milliseconds to wait for the
+                media to be uploaded.
 
         Returns:
             Resolves once a response has successfully been written to request
         """
-        media_info = await self.store.get_local_media(media_id)
-        if not media_info or media_info["quarantined_by"]:
-            respond_404(request)
+        media_info = await self.get_local_media_info(request, media_id, max_stall_ms)
+        if not media_info:
             return
 
         self.mark_recently_accessed(None, media_id)
@@ -360,6 +419,7 @@ class MediaRepository:
         server_name: str,
         media_id: str,
         name: Optional[str],
+        max_stall_ms: int,
     ) -> None:
         """Respond to requests for remote media.
 
@@ -369,6 +429,8 @@ class MediaRepository:
             media_id: The media ID of the content (as defined by the remote server).
             name: Optional name that, if specified, will be used as
                 the filename in the Content-Disposition header of the response.
+            max_stall_ms: the maximum number of milliseconds to wait for the
+                media to be uploaded.
 
         Returns:
             Resolves once a response has successfully been written to request
@@ -383,14 +445,12 @@ class MediaRepository:
 
         # We linearize here to ensure that we don't try and download remote
         # media multiple times concurrently
-        key = (server_name, media_id)
-        async with self.remote_media_linearizer.queue(key):
+        async with self.remote_media_linearizer.queue((server_name, media_id)):
             responder, media_info = await self._get_remote_media_impl(
-                server_name, media_id
+                server_name, media_id, max_stall_ms
             )
 
-        # We deliberately stream the file outside the lock
-        if responder:
+        if responder and media_info:
             media_type = media_info["media_type"]
             media_length = media_info["media_length"]
             upload_name = name if name else media_info["upload_name"]
@@ -398,18 +458,24 @@ class MediaRepository:
                 request, responder, media_type, media_length, upload_name
             )
         else:
-            respond_404(request)
+            self.respond_not_yet_uploaded(request)
+            return
 
-    async def get_remote_media_info(self, server_name: str, media_id: str) -> dict:
+    async def get_remote_media_info(
+        self, server_name: str, media_id: str, max_stall_ms: int
+    ) -> Optional[dict]:
         """Gets the media info associated with the remote file, downloading
         if necessary.
 
         Args:
             server_name: Remote server_name where the media originated.
             media_id: The media ID of the content (as defined by the remote server).
+            max_stall_ms: the maximum number of milliseconds to wait for the
+                media to be uploaded.
 
         Returns:
-            The media info of the file
+            The media info of the file or ``None`` if the media wasn't uploaded
+            in time.
         """
         if (
             self.federation_domain_whitelist is not None
@@ -419,10 +485,9 @@ class MediaRepository:
 
         # We linearize here to ensure that we don't try and download remote
         # media multiple times concurrently
-        key = (server_name, media_id)
-        async with self.remote_media_linearizer.queue(key):
+        async with self.remote_media_linearizer.queue((server_name, media_id)):
             responder, media_info = await self._get_remote_media_impl(
-                server_name, media_id
+                server_name, media_id, max_stall_ms
             )
 
         # Ensure we actually use the responder so that it releases resources
@@ -433,7 +498,7 @@ class MediaRepository:
         return media_info
 
     async def _get_remote_media_impl(
-        self, server_name: str, media_id: str
+        self, server_name: str, media_id: str, max_stall_ms: int
     ) -> Tuple[Optional[Responder], dict]:
         """Looks for media in local cache, if not there then attempt to
         download from remote server.
@@ -442,6 +507,8 @@ class MediaRepository:
             server_name (str): Remote server_name where the media originated.
             media_id (str): The media ID of the content (as defined by the
                 remote server).
+            max_stall_ms: the maximum number of milliseconds to wait for the
+                media to be uploaded.
 
         Returns:
             A tuple of responder and the media info of the file.
@@ -472,8 +539,7 @@ class MediaRepository:
 
         try:
             media_info = await self._download_remote_file(
-                server_name,
-                media_id,
+                server_name, media_id, max_stall_ms
             )
         except SynapseError:
             raise
@@ -506,6 +572,7 @@ class MediaRepository:
         self,
         server_name: str,
         media_id: str,
+        max_stall_ms: int,
     ) -> dict:
         """Attempt to download the remote file from the given server name,
         using the given file_id as the local id.
@@ -515,7 +582,8 @@ class MediaRepository:
             media_id: The media ID of the content (as defined by the
                 remote server). This is different than the file_id, which is
                 locally generated.
-            file_id: Local file ID
+            max_stall_ms: the maximum number of milliseconds to wait for the
+                media to be uploaded.
 
         Returns:
             The media info of the file.
@@ -539,7 +607,8 @@ class MediaRepository:
                         # tell the remote server to 404 if it doesn't
                         # recognise the server_name, to make sure we don't
                         # end up with a routing loop.
-                        "allow_remote": "false"
+                        "allow_remote": "false",
+                        "fi.mau.msc2246.max_stall_ms": str(max_stall_ms),
                     },
                 )
             except RequestSendFailed as e:

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -37,6 +37,7 @@ from synapse.config.repository import ThumbnailRequirement
 from synapse.http.site import SynapseRequest
 from synapse.logging.context import defer_to_thread
 from synapse.metrics.background_process_metrics import run_as_background_process
+from synapse.rest.media.v1.create_resource import CreateResource
 from synapse.types import UserID
 from synapse.util.async_helpers import Linearizer
 from synapse.util.retryutils import NotRetryingDestination
@@ -84,6 +85,7 @@ class MediaRepository:
         self.store = hs.get_datastores().main
         self.max_upload_size = hs.config.media.max_upload_size
         self.max_image_pixels = hs.config.media.max_image_pixels
+        self.unused_expiration_time = hs.config.media.unused_expiration_time
 
         Thumbnailer.set_limits(self.max_image_pixels)
 
@@ -180,6 +182,27 @@ class MediaRepository:
             self.recently_accessed_remotes.add((server_name, media_id))
         else:
             self.recently_accessed_locals.add(media_id)
+
+    async def create_media_id(self, auth_user: UserID) -> Tuple[str, int]:
+        """Create and store a media ID for a local user and return the mxc URL
+
+        Args:
+            auth_user: The user_id of the uploader
+
+        Returns:
+            The mxc url of the stored content
+        """
+        media_id = random_string(24)
+        now = self.clock.time_msec()
+        # After the configured amount of time, don't allow the upload to start.
+        unused_expires_at = now + self.unused_expiration_time
+        await self.store.store_local_media_id(
+            media_id=media_id,
+            time_now_ms=now,
+            user_id=auth_user,
+            unused_expires_at=unused_expires_at,
+        )
+        return f"mxc://{self.server_name}/{media_id}", unused_expires_at
 
     async def create_content(
         self,
@@ -1043,6 +1066,20 @@ class MediaVersion(Enum):
     UNSTABLE = b"unstable"
 
 
+class MSC2246MediaRepositoryResource(Resource):
+    """Media creation and asynchronous uploading.
+
+    This resource implements MSC2246
+    https://github.com/matrix-org/matrix-spec-proposals/pull/2246
+    """
+
+    def __init__(self, hs: "HomeServer"):
+        super().__init__()
+        media_repo = hs.get_media_repository()
+
+        self.putChild(b"create", CreateResource(hs, media_repo))
+
+
 class VersionedMediaRepositoryResource(Resource):
     """File uploading and downloading.
 
@@ -1107,6 +1144,9 @@ class VersionedMediaRepositoryResource(Resource):
                 PreviewUrlResource(hs, media_repo, media_repo.media_storage),
             )
         self.putChild(b"config", MediaConfigResource(hs))
+
+        if version == MediaVersion.UNSTABLE and hs.config.experimental.msc2246_enabled:
+            self.putChild(b"fi.mau.msc2246", MSC2246MediaRepositoryResource(hs))
 
 
 class MediaRepositoryResource(Resource):

--- a/synapse/rest/media/v1/upload_resource.py
+++ b/synapse/rest/media/v1/upload_resource.py
@@ -42,7 +42,6 @@ class UploadResource(DirectServeJsonResource):
         self.server_name = hs.hostname
         self.auth = hs.get_auth()
         self.max_upload_size = hs.config.media.max_upload_size
-        self.clock = hs.get_clock()
 
     async def _async_render_OPTIONS(self, request: SynapseRequest) -> None:
         respond_with_json(request, 200, {}, send_cors=True)

--- a/synapse/rest/media/v1/upload_resource.py
+++ b/synapse/rest/media/v1/upload_resource.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging
-from typing import IO, TYPE_CHECKING, Dict, List, Optional
+from typing import IO, TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from synapse.api.errors import Codes, SynapseError
 from synapse.http.server import DirectServeJsonResource, respond_with_json
@@ -22,32 +22,40 @@ from synapse.http.servlet import parse_bytes_from_args
 from synapse.http.site import SynapseRequest
 from synapse.rest.media.v1.media_storage import SpamMediaException
 
+from ._base import parse_media_id
+
 if TYPE_CHECKING:
     from synapse.rest.media.v1.media_repository import MediaRepository
     from synapse.server import HomeServer
 
 logger = logging.getLogger(__name__)
 
+# The name of the lock to use when uploading media.
+_UPLOAD_MEDIA_LOCK_NAME = "upload_media"
+
 
 class UploadResource(DirectServeJsonResource):
     isLeaf = True
 
-    def __init__(self, hs: "HomeServer", media_repo: "MediaRepository"):
+    def __init__(
+        self,
+        hs: "HomeServer",
+        media_repo: "MediaRepository",
+        enable_async_uploads: bool,
+    ):
         super().__init__()
 
+        self.enable_async_uploads = enable_async_uploads
         self.media_repo = media_repo
         self.filepaths = media_repo.filepaths
         self.store = hs.get_datastores().main
-        self.clock = hs.get_clock()
         self.server_name = hs.hostname
         self.auth = hs.get_auth()
         self.max_upload_size = hs.config.media.max_upload_size
 
-    async def _async_render_OPTIONS(self, request: SynapseRequest) -> None:
-        respond_with_json(request, 200, {}, send_cors=True)
-
-    async def _async_render_POST(self, request: SynapseRequest) -> None:
-        requester = await self.auth.get_user_by_req(request)
+    def _get_file_metadata(
+        self, request: SynapseRequest
+    ) -> Tuple[int, Optional[str], str]:
         raw_content_length = request.getHeader("Content-Length")
         if raw_content_length is None:
             raise SynapseError(msg="Request must specify a Content-Length", code=400)
@@ -90,6 +98,15 @@ class UploadResource(DirectServeJsonResource):
         #     disposition = headers.getRawHeaders(b"Content-Disposition")[0]
         # TODO(markjh): parse content-dispostion
 
+        return content_length, upload_name, media_type
+
+    async def _async_render_OPTIONS(self, request: SynapseRequest) -> None:
+        respond_with_json(request, 200, {}, send_cors=True)
+
+    async def _async_render_POST(self, request: SynapseRequest) -> None:
+        requester = await self.auth.get_user_by_req(request)
+        content_length, upload_name, media_type = self._get_file_metadata(request)
+
         try:
             content: IO = request.content  # type: ignore
             content_uri = await self.media_repo.create_content(
@@ -103,3 +120,51 @@ class UploadResource(DirectServeJsonResource):
         logger.info("Uploaded content with URI %r", content_uri)
 
         respond_with_json(request, 200, {"content_uri": content_uri}, send_cors=True)
+
+    async def _async_render_PUT(self, request: SynapseRequest) -> None:
+        if not self.enable_async_uploads:
+            raise SynapseError(
+                405,
+                "Asynchronous uploads are not enabled on this homeserver",
+                errcode=Codes.UNRECOGNIZED,
+            )
+
+        requester = await self.auth.get_user_by_req(request)
+        server_name, media_id, _ = parse_media_id(request)
+
+        if server_name != self.server_name:
+            raise SynapseError(
+                404,
+                "Non-local server name specified",
+                errcode=Codes.NOT_FOUND,
+            )
+
+        lock = await self.store.try_acquire_lock(_UPLOAD_MEDIA_LOCK_NAME, media_id)
+        if not lock:
+            raise SynapseError(
+                409,
+                "Media ID is is locked and cannot be uploaded to",
+                errcode="FI.MAU.MSC2246_CANNOT_OVERWRITE_MEDIA",
+            )
+
+        async with lock:
+            await self.media_repo.verify_can_upload(media_id, requester.user)
+            content_length, upload_name, media_type = self._get_file_metadata(request)
+
+            try:
+                content: IO = request.content  # type: ignore
+                await self.media_repo.update_content(
+                    media_id,
+                    media_type,
+                    upload_name,
+                    content,
+                    content_length,
+                    requester.user,
+                )
+            except SpamMediaException:
+                # For uploading of media we want to respond with a 400, instead of
+                # the default 404, as that would just be confusing.
+                raise SynapseError(400, "Bad content")
+
+            logger.info("Uploaded content to URI %r", media_id)
+            respond_with_json(request, 200, {}, send_cors=True)

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -161,6 +161,9 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
     async def get_local_media(self, media_id: str) -> Optional[Dict[str, Any]]:
         """Get the metadata for a local piece of media
 
+        Args:
+            media_id: the media ID to retrieve information for
+
         Returns:
             None if the media_id doesn't exist.
         """
@@ -176,6 +179,7 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
                 "url_cache",
                 "safe_from_quarantine",
                 "user_id",
+                "unused_expires_at",
             ),
             allow_none=True,
             desc="get_local_media",

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -302,6 +302,24 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
             "get_local_media_before", _get_local_media_before_txn
         )
 
+    async def store_local_media_id(
+        self,
+        media_id: str,
+        time_now_ms: int,
+        user_id: UserID,
+        unused_expires_at: int,
+    ) -> None:
+        await self.db_pool.simple_insert(
+            "local_media_repository",
+            {
+                "media_id": media_id,
+                "created_ts": time_now_ms,
+                "user_id": user_id.to_string(),
+                "unused_expires_at": unused_expires_at,
+            },
+            desc="store_local_media_id",
+        )
+
     async def store_local_media(
         self,
         media_id: str,

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -175,6 +175,7 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
                 "quarantined_by",
                 "url_cache",
                 "safe_from_quarantine",
+                "user_id",
             ),
             allow_none=True,
             desc="get_local_media",
@@ -342,6 +343,30 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
                 "url_cache": url_cache,
             },
             desc="store_local_media",
+        )
+
+    async def update_local_media(
+        self,
+        media_id: str,
+        media_type: str,
+        upload_name: Optional[str],
+        media_length: int,
+        user_id: UserID,
+        url_cache: Optional[str] = None,
+    ) -> None:
+        await self.db_pool.simple_update_one(
+            "local_media_repository",
+            keyvalues={
+                "user_id": user_id.to_string(),
+                "media_id": media_id,
+            },
+            updatevalues={
+                "media_type": media_type,
+                "upload_name": upload_name,
+                "media_length": media_length,
+                "url_cache": url_cache,
+            },
+            desc="update_local_media",
         )
 
     async def mark_local_media_as_safe(self, media_id: str, safe: bool = True) -> None:

--- a/synapse/storage/schema/main/delta/68/06_msc2246_add_unused_expires_at_for_media.sql
+++ b/synapse/storage/schema/main/delta/68/06_msc2246_add_unused_expires_at_for_media.sql
@@ -1,0 +1,20 @@
+/* Copyright 2022 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Add new colums to the `local_media_repository` to keep track of when the
+-- media ID must be used by. This is to support MSC2246 async uploads.
+
+ALTER TABLE local_media_repository
+  ADD COLUMN unused_expires_at BIGINT DEFAULT NULL;

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -65,7 +65,9 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
             The channel for the *client* request and the *outbound* request for
             the media which the caller should respond to.
         """
-        resource = hs.get_media_repository_resource().children[b"download"]
+        resource = (
+            hs.get_media_repository_resource().children[b"r0"].children[b"download"]
+        )
         channel = make_request(
             self.reactor,
             FakeSite(resource, self.reactor),

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -61,8 +61,8 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         # Allow for uploading and downloading to/from the media repo
         self.media_repo = hs.get_media_repository_resource()
-        self.download_resource = self.media_repo.children[b"download"]
-        self.upload_resource = self.media_repo.children[b"upload"]
+        self.download_resource = self.media_repo.children[b"v3"].children[b"download"]
+        self.upload_resource = self.media_repo.children[b"v3"].children[b"upload"]
 
     def _ensure_quarantined(
         self, admin_user_tok: str, server_and_media_id: str

--- a/tests/rest/admin/test_media.py
+++ b/tests/rest/admin/test_media.py
@@ -123,8 +123,8 @@ class DeleteMediaByIDTestCase(unittest.HomeserverTestCase):
         Tests that delete a media is successfully
         """
 
-        download_resource = self.media_repo.children[b"download"]
-        upload_resource = self.media_repo.children[b"upload"]
+        download_resource = self.media_repo.children[b"v3"].children[b"download"]
+        upload_resource = self.media_repo.children[b"v3"].children[b"upload"]
 
         # Upload some media into the room
         response = self.helper.upload_media(
@@ -562,7 +562,7 @@ class DeleteMediaByDateSizeTestCase(unittest.HomeserverTestCase):
         """
         Create a media and return media_id and server_and_media_id
         """
-        upload_resource = self.media_repo.children[b"upload"]
+        upload_resource = self.media_repo.children[b"v3"].children[b"upload"]
 
         # Upload some media into the room
         response = self.helper.upload_media(
@@ -586,7 +586,7 @@ class DeleteMediaByDateSizeTestCase(unittest.HomeserverTestCase):
         """
         Try to access a media and check the result
         """
-        download_resource = self.media_repo.children[b"download"]
+        download_resource = self.media_repo.children[b"v3"].children[b"download"]
 
         media_id = server_and_media_id.split("/")[1]
         local_path = self.filepaths.local_media_filepath(media_id)
@@ -641,7 +641,7 @@ class QuarantineMediaByIDTestCase(unittest.HomeserverTestCase):
         self.admin_user_tok = self.login("admin", "pass")
 
         # Create media
-        upload_resource = media_repo.children[b"upload"]
+        upload_resource = media_repo.children[b"v3"].children[b"upload"]
 
         # Upload some media into the room
         response = self.helper.upload_media(
@@ -778,7 +778,7 @@ class ProtectMediaByIDTestCase(unittest.HomeserverTestCase):
         self.admin_user_tok = self.login("admin", "pass")
 
         # Create media
-        upload_resource = media_repo.children[b"upload"]
+        upload_resource = media_repo.children[b"v3"].children[b"upload"]
 
         # Upload some media into the room
         response = self.helper.upload_media(

--- a/tests/rest/admin/test_statistics.py
+++ b/tests/rest/admin/test_statistics.py
@@ -511,7 +511,7 @@ class UserMediaStatisticsTestCase(unittest.HomeserverTestCase):
             user_token: Access token of the user
             number_media: Number of media to be created for the user
         """
-        upload_resource = self.media_repo.children[b"upload"]
+        upload_resource = self.media_repo.children[b"v3"].children[b"upload"]
         for _ in range(number_media):
             # Upload some media into the room
             self.helper.upload_media(

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -3243,8 +3243,8 @@ class UserMediaRestTestCase(unittest.HomeserverTestCase):
         Returns:
             The ID of the newly created media.
         """
-        upload_resource = self.media_repo.children[b"upload"]
-        download_resource = self.media_repo.children[b"download"]
+        upload_resource = self.media_repo.children[b"v3"].children[b"upload"]
+        download_resource = self.media_repo.children[b"v3"].children[b"download"]
 
         # Upload some media into the room
         response = self.helper.upload_media(

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -253,8 +253,8 @@ class MediaRepoTests(unittest.HomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
 
         media_resource = hs.get_media_repository_resource()
-        self.download_resource = media_resource.children[b"download"]
-        self.thumbnail_resource = media_resource.children[b"thumbnail"]
+        self.download_resource = media_resource.children[b"v3"].children[b"download"]
+        self.thumbnail_resource = media_resource.children[b"v3"].children[b"thumbnail"]
         self.store = hs.get_datastores().main
         self.media_repo = hs.get_media_repository()
 
@@ -605,8 +605,8 @@ class SpamCheckerTestCase(unittest.HomeserverTestCase):
 
         # Allow for uploading and downloading to/from the media repo
         self.media_repo = hs.get_media_repository_resource()
-        self.download_resource = self.media_repo.children[b"download"]
-        self.upload_resource = self.media_repo.children[b"upload"]
+        self.download_resource = self.media_repo.children[b"v3"].children[b"download"]
+        self.upload_resource = self.media_repo.children[b"v3"].children[b"upload"]
 
         load_legacy_spam_checkers(hs)
 

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -280,7 +280,13 @@ class MediaRepoTests(unittest.HomeserverTestCase):
         self.assertEqual(
             self.fetches[0][2], "/_matrix/media/r0/download/" + self.media_id
         )
-        self.assertEqual(self.fetches[0][3], {"allow_remote": "false"})
+        self.assertEqual(
+            self.fetches[0][3],
+            {
+                "allow_remote": "false",
+                "fi.mau.msc2246.max_stall_ms": "20000",
+            },
+        )
 
         headers = {
             b"Content-Length": [b"%d" % (len(self.test_image.data))],

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -120,7 +120,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
 
         self.media_repo = hs.get_media_repository_resource()
-        self.preview_url = self.media_repo.children[b"preview_url"]
+        self.preview_url = self.media_repo.children[b"v3"].children[b"preview_url"]
 
         self.lookups: Dict[str, Any] = {}
 
@@ -162,7 +162,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://matrix.org",
+            "v3/preview_url?url=http://matrix.org",
             shorthand=False,
             await_result=False,
         )
@@ -186,7 +186,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         # Check the cache returns the correct response
         channel = self.make_request(
-            "GET", "preview_url?url=http://matrix.org", shorthand=False
+            "GET", "v3/preview_url?url=http://matrix.org", shorthand=False
         )
 
         # Check the cache response has the same content
@@ -202,7 +202,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         # Check the database cache returns the correct response
         channel = self.make_request(
-            "GET", "preview_url?url=http://matrix.org", shorthand=False
+            "GET", "v3/preview_url?url=http://matrix.org", shorthand=False
         )
 
         # Check the cache response has the same content
@@ -224,7 +224,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://matrix.org",
+            "v3/preview_url?url=http://matrix.org",
             shorthand=False,
             await_result=False,
         )
@@ -254,7 +254,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://matrix.org",
+            "v3/preview_url?url=http://matrix.org",
             shorthand=False,
             await_result=False,
         )
@@ -290,7 +290,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://matrix.org",
+            "v3/preview_url?url=http://matrix.org",
             shorthand=False,
             await_result=False,
         )
@@ -331,7 +331,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://matrix.org",
+            "v3/preview_url?url=http://matrix.org",
             shorthand=False,
             await_result=False,
         )
@@ -366,7 +366,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://matrix.org",
+            "v3/preview_url?url=http://matrix.org",
             shorthand=False,
             await_result=False,
         )
@@ -399,7 +399,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://example.com",
+            "v3/preview_url?url=http://example.com",
             shorthand=False,
             await_result=False,
         )
@@ -428,7 +428,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.lookups["example.com"] = [(IPv4Address, "192.168.1.1")]
 
         channel = self.make_request(
-            "GET", "preview_url?url=http://example.com", shorthand=False
+            "GET", "v3/preview_url?url=http://example.com", shorthand=False
         )
 
         # No requests made.
@@ -449,7 +449,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.lookups["example.com"] = [(IPv4Address, "1.1.1.2")]
 
         channel = self.make_request(
-            "GET", "preview_url?url=http://example.com", shorthand=False
+            "GET", "v3/preview_url?url=http://example.com", shorthand=False
         )
 
         self.assertEqual(channel.code, 502)
@@ -466,7 +466,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         Blacklisted IP addresses, accessed directly, are not spidered.
         """
         channel = self.make_request(
-            "GET", "preview_url?url=http://192.168.1.1", shorthand=False
+            "GET", "v3/preview_url?url=http://192.168.1.1", shorthand=False
         )
 
         # No requests made.
@@ -485,7 +485,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         Blacklisted IP ranges, accessed directly, are not spidered.
         """
         channel = self.make_request(
-            "GET", "preview_url?url=http://1.1.1.2", shorthand=False
+            "GET", "v3/preview_url?url=http://1.1.1.2", shorthand=False
         )
 
         self.assertEqual(channel.code, 403)
@@ -506,7 +506,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://example.com",
+            "v3/preview_url?url=http://example.com",
             shorthand=False,
             await_result=False,
         )
@@ -542,7 +542,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         ]
 
         channel = self.make_request(
-            "GET", "preview_url?url=http://example.com", shorthand=False
+            "GET", "v3/preview_url?url=http://example.com", shorthand=False
         )
         self.assertEqual(channel.code, 502)
         self.assertEqual(
@@ -562,7 +562,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         ]
 
         channel = self.make_request(
-            "GET", "preview_url?url=http://example.com", shorthand=False
+            "GET", "v3/preview_url?url=http://example.com", shorthand=False
         )
 
         # No requests made.
@@ -583,7 +583,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         self.lookups["example.com"] = [(IPv6Address, "2001:800::1")]
 
         channel = self.make_request(
-            "GET", "preview_url?url=http://example.com", shorthand=False
+            "GET", "v3/preview_url?url=http://example.com", shorthand=False
         )
 
         self.assertEqual(channel.code, 502)
@@ -600,7 +600,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         OPTIONS returns the OPTIONS.
         """
         channel = self.make_request(
-            "OPTIONS", "preview_url?url=http://example.com", shorthand=False
+            "OPTIONS", "v3/preview_url?url=http://example.com", shorthand=False
         )
         self.assertEqual(channel.code, 200)
         self.assertEqual(channel.json_body, {})
@@ -614,7 +614,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         # Build and make a request to the server
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://example.com",
+            "v3/preview_url?url=http://example.com",
             shorthand=False,
             await_result=False,
         )
@@ -672,7 +672,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            f"preview_url?{query_params}",
+            f"v3/preview_url?{query_params}",
             shorthand=False,
         )
         self.pump()
@@ -693,7 +693,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://matrix.org",
+            "v3/preview_url?url=http://matrix.org",
             shorthand=False,
             await_result=False,
         )
@@ -730,7 +730,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://twitter.com/matrixdotorg/status/12345",
+            "v3/preview_url?url=http://twitter.com/matrixdotorg/status/12345",
             shorthand=False,
             await_result=False,
         )
@@ -790,7 +790,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://twitter.com/matrixdotorg/status/12345",
+            "v3/preview_url?url=http://twitter.com/matrixdotorg/status/12345",
             shorthand=False,
             await_result=False,
         )
@@ -834,7 +834,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://www.hulu.com/watch/12345",
+            "v3/preview_url?url=http://www.hulu.com/watch/12345",
             shorthand=False,
             await_result=False,
         )
@@ -892,7 +892,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://www.twitter.com/matrixdotorg/status/12345",
+            "v3/preview_url?url=http://www.twitter.com/matrixdotorg/status/12345",
             shorthand=False,
             await_result=False,
         )
@@ -975,7 +975,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=http://cdn.twitter.com/matrixdotorg",
+            "v3/preview_url?url=http://cdn.twitter.com/matrixdotorg",
             shorthand=False,
             await_result=False,
         )
@@ -1017,7 +1017,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         # Check fetching
         channel = self.make_request(
             "GET",
-            f"download/{host}/{media_id}",
+            f"v3/download/{host}/{media_id}",
             shorthand=False,
             await_result=False,
         )
@@ -1030,7 +1030,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            f"download/{host}/{media_id}",
+            f"v3/download/{host}/{media_id}",
             shorthand=False,
             await_result=False,
         )
@@ -1065,7 +1065,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         # Check fetching
         channel = self.make_request(
             "GET",
-            f"thumbnail/{host}/{media_id}?width=32&height=32&method=scale",
+            f"v3/thumbnail/{host}/{media_id}?width=32&height=32&method=scale",
             shorthand=False,
             await_result=False,
         )
@@ -1083,7 +1083,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            f"thumbnail/{host}/{media_id}?width=32&height=32&method=scale",
+            f"v3/thumbnail/{host}/{media_id}?width=32&height=32&method=scale",
             shorthand=False,
             await_result=False,
         )
@@ -1135,7 +1135,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=" + bad_url,
+            "v3/preview_url?url=" + bad_url,
             shorthand=False,
             await_result=False,
         )
@@ -1144,7 +1144,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         channel = self.make_request(
             "GET",
-            "preview_url?url=" + good_url,
+            "v3/preview_url?url=" + good_url,
             shorthand=False,
             await_result=False,
         )


### PR DESCRIPTION
Implements [MSC2246](https://github.com/matrix-org/matrix-spec-proposals/pull/2246) by @tulir.

Note to reviewer: in general, you should be able to go commit-by-commit through this, but there are quite a few fixes at the end of the commit log since rebasing was getting difficult.

### Outstanding questions:

- [x] ~Updating the content of an existing MXC URI must be atomic. Right now, it is not. I'm using `LockStore`, but there appears to be a bug (see https://github.com/matrix-org/synapse/pull/12484#issuecomment-1116286459).~

  ~Blocked by https://github.com/matrix-org/synapse/pull/12832~

- [x] ~Should the `?fi.mau.msc2246.max_stall_ms` do anything when MSC2246 support is not enabled on the homeserver? My concern is that in the interim period when some homeservers have this enabled and some don't, that users could have a bad experience retrieving media over federation.~ (Decision: default to 20000ms)

- [x] ~Where is the best place to put tests for this. Should I create both unit tests and sytest tests?~ Not going to test this for now, since not in spec.

- [x] ~There's one failing sytest test. I tried to look at the logs, but I couldn't really understand what the problem was. If anyone has any suggestions on how to debug, please let me know.~ (Test has been fixed)

- [x] ~Where should the `unused_expires_at` config option be placed? (See first comment below)~

### Sign-off

Signed-off-by: Sumner Evans <sumner@beeper.com>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
