### PR TITLE
Fix Jinja templating error when generating thumbnail URLs.

### DIFF
--- a/changelog.d/12510.bugfix
+++ b/changelog.d/12510.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where the image thumbanils embedded into email notifications were broken.

--- a/synapse/res/templates/notif.html
+++ b/synapse/res/templates/notif.html
@@ -30,7 +30,7 @@
                     {%- elif message.msgtype == "m.notice" %}
                         {{ message.body_text_html }}
                     {%- elif message.msgtype == "m.image" and message.image_url %}
-                        <img src="{{ message.image_url|mxc_to_http(640, 480, scale) }}" />
+                        <img src="{{ message.image_url|mxc_to_http(640, 480, 'scale') }}" />
                     {%- elif message.msgtype == "m.file" %}
                         <span class="filename">{{ message.body_text_plain }}</span>
                     {%- else %}


### PR DESCRIPTION
Fixes #12506

`scale` in the template was referring to a non-existent variable, so Jinja replaces it with `""`, which causes a blank value in the resulting HTTP URL. Putting single quotes around it allows the true string value of `"scale"` to be used.