### PR TITLE
Include version 0.2.0 of the Synapse LDAP Auth Provider module in the Docker image.

### DIFF
--- a/changelog.d/12512.docker
+++ b/changelog.d/12512.docker
@@ -1,0 +1,1 @@
+Include version 0.2.0 of the Synapse LDAP Auth Provider module in the Docker image.

--- a/poetry.lock
+++ b/poetry.lock
@@ -558,16 +558,19 @@ test = ["tox", "twisted", "aiounittest"]
 
 [[package]]
 name = "matrix-synapse-ldap3"
-version = "0.1.5"
+version = "0.2.0"
 description = "An LDAP3 auth provider for Synapse"
 category = "main"
 optional = true
-python-versions = "*"
+python-versions = ">=3.7"
 
 [package.dependencies]
 ldap3 = ">=2.8"
-service_identity = "*"
+service-identity = "*"
 Twisted = ">=15.1.0"
+
+[package.extras]
+dev = ["matrix-synapse", "tox", "ldaptor", "mypy (==0.910)", "types-setuptools", "black (==21.9b0)", "flake8 (==4.0.1)", "isort (==5.9.3)"]
 
 [[package]]
 name = "mccabe"
@@ -2084,7 +2087,8 @@ matrix-common = [
     {file = "matrix_common-1.1.0.tar.gz", hash = "sha256:a8238748afc2b37079818367fed5156f355771b07c8ff0a175934f47e0ff3276"},
 ]
 matrix-synapse-ldap3 = [
-    {file = "matrix-synapse-ldap3-0.1.5.tar.gz", hash = "sha256:9fdf8df7c8ec756642aa0fea53b31c0b2f1924f70d7f049a2090b523125456fe"},
+    {file = "matrix-synapse-ldap3-0.2.0.tar.gz", hash = "sha256:91a0715b43a41ec3033244174fca20846836da98fda711fb01687f7199eecd2e"},
+    {file = "matrix_synapse_ldap3-0.2.0-py3-none-any.whl", hash = "sha256:0128ca7c3058987adc2e8a88463bb46879915bfd3d373309632813b353e30f9f"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},


### PR DESCRIPTION
The v1.56.0 image included v0.2.0 whereas the v1.57.0 image included v0.1.5, which broke homeservers that are using it with the generic module API.

Issue likely introduced by https://github.com/matrix-org/synapse/pull/12385/files?

Fixes https://github.com/matrix-org/matrix-synapse-ldap3/issues/162.

We'll want to release a patch release with this.

