### PR TITLE
Remove leftover references to setup.py

### DIFF
--- a/changelog.d/12514.misc
+++ b/changelog.d/12514.misc
@@ -1,0 +1,1 @@
+Use poetry-core instead of setuptools to build wheels.

--- a/mypy.ini
+++ b/mypy.ini
@@ -233,8 +233,8 @@ disallow_untyped_defs = True
 ;; The `typeshed` project maintains stubs here:
 ;;     https://github.com/python/typeshed/tree/master/stubs
 ;; and for each package `foo` there's a corresponding `types-foo` package on PyPI,
-;; which we can pull in as a dev dependency by adding to `setup.py`'s
-;; `CONDITIONAL_REQUIREMENTS["mypy"]` list.
+;; which we can pull in as a dev dependency by adding to `pyproject.toml`'s
+;; `[tool.poetry.dev-dependencies]` list.
 
 [mypy-authlib.*]
 ignore_missing_imports = True

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -91,7 +91,7 @@ else
       files=(
           "synapse" "docker" "tests"
           "scripts-dev"
-          "contrib" "setup.py" "synmark" "stubs" ".ci"
+          "contrib" "synmark" "stubs" ".ci"
       )
   fi
 fi


### PR DESCRIPTION
Missed in #12478.

In particular this fixes running the linter script on `develop`.
