### PR TITLE
MSC3202: Fix device_unused_fallback_keys -> device_unused_fallback_key_types

### DIFF
--- a/changelog.d/12520.bugfix
+++ b/changelog.d/12520.bugfix
@@ -1,0 +1,1 @@
+Fix a bug in the implementation of MSC3202 where Synapse would use the field name `device_unused_fallback_keys`, rather than `device_unused_fallback_key_types`.

--- a/synapse/appservice/__init__.py
+++ b/synapse/appservice/__init__.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 #   user ID -> {device ID -> {algorithm -> count}}
 TransactionOneTimeKeyCounts = Dict[str, Dict[str, Dict[str, int]]]
 
-# Type for the `device_unused_fallback_keys` field in an appservice transaction
+# Type for the `device_unused_fallback_key_types` field in an appservice transaction
 #   user ID -> {device ID -> [algorithm]}
 TransactionUnusedFallbackKeys = Dict[str, Dict[str, List[str]]]
 

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -278,7 +278,7 @@ class ApplicationServiceApi(SimpleHttpClient):
                 ] = one_time_key_counts
             if unused_fallback_keys:
                 body[
-                    "org.matrix.msc3202.device_unused_fallback_keys"
+                    "org.matrix.msc3202.device_unused_fallback_key_types"
                 ] = unused_fallback_keys
             if device_list_summary:
                 body["org.matrix.msc3202.device_lists"] = {


### PR DESCRIPTION
Having tried to test this feature out with the matrix-bot-sdk, I noticed that the MSC called for `device_unused_fallback_key_types` but Synapse was sending a `device_unused_fallback_keys` field instead. The bot-sdk seems to concur with the MSC, so I think we should probably fix this in Synapse.