### PR TITLE
Optimise backfill calculation

### DIFF
--- a/changelog.d/12522.bugfix
+++ b/changelog.d/12522.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 0.99.3 which could cause Synapse to consume large amounts of RAM when back-paginating in a large room.

--- a/changelog.d/12522.misc
+++ b/changelog.d/12522.misc
@@ -1,0 +1,1 @@
+Optimise room backfill, to reduce memory usage.

--- a/changelog.d/12522.misc
+++ b/changelog.d/12522.misc
@@ -1,1 +1,0 @@
-Optimise room backfill, to reduce memory usage.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -311,8 +311,8 @@ class FederationHandler:
 
             forward_event_ids = await self.store.get_successor_events([bp.event_id])
 
-            extremities_events = await self.store.get_events(
-                forward_event_ids,
+            extremities_events = await self.store.get_events_as_list(
+                successor_event_ids,
                 redact_behaviour=EventRedactBehaviour.AS_IS,
                 get_prev_content=False,
             )
@@ -322,7 +322,7 @@ class FederationHandler:
             filtered_extremities = await filter_events_for_server(
                 self.storage,
                 self.server_name,
-                list(extremities_events.values()),
+                extremities_events,
                 redact=False,
                 check_history_visibility_only=True,
             )

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -162,7 +162,7 @@ class FederationHandler:
             await self.store.get_oldest_event_ids_with_depth_in_room(room_id)
         )
 
-        insertion_events_to_be_backfilled: Dict[str, int] = {}
+        insertion_events_to_be_backfilled: List[Tuple[str, int]] = []
         if self.hs.config.experimental.msc2716_enabled:
             insertion_events_to_be_backfilled = (
                 await self.store.get_insertion_event_backward_extremities_in_room(
@@ -183,8 +183,8 @@ class FederationHandler:
         # start with the most recent (ie, max depth), so let's sort the list.
         sorted_extremeties_tuple: List[Tuple[str, int]] = sorted(
             itertools.chain(
-                oldest_events_with_depth.items(),
-                insertion_events_to_be_backfilled.items(),
+                oldest_events_with_depth,
+                insertion_events_to_be_backfilled,
             ),
             key=lambda e: -int(e[1]),
         )

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -179,60 +179,6 @@ class FederationHandler:
             logger.debug("Not backfilling as no extremeties found.")
             return False
 
-        # We only want to paginate if we can actually see the events we'll get,
-        # as otherwise we'll just spend a lot of resources to get redacted
-        # events.
-        #
-        # We do this by filtering all the backwards extremities and seeing if
-        # any remain. Given we don't have the extremity events themselves, we
-        # need to actually check the events that reference them.
-        #
-        # *Note*: the spec wants us to keep backfilling until we reach the start
-        # of the room in case we are allowed to see some of the history. However
-        # in practice that causes more issues than its worth, as a) its
-        # relatively rare for there to be any visible history and b) even when
-        # there is its often sufficiently long ago that clients would stop
-        # attempting to paginate before backfill reached the visible history.
-        #
-        # TODO: If we do do a backfill then we should filter the backwards
-        #   extremities to only include those that point to visible portions of
-        #   history.
-        #
-        # TODO: Correctly handle the case where we are allowed to see the
-        #   forward event but not the backward extremity, e.g. in the case of
-        #   initial join of the server where we are allowed to see the join
-        #   event but not anything before it. This would require looking at the
-        #   state *before* the event, ignoring the special casing certain event
-        #   types have.
-
-        forward_event_ids = await self.store.get_successor_events(
-            list(oldest_events_with_depth)
-        )
-
-        extremities_events = await self.store.get_events(
-            forward_event_ids,
-            redact_behaviour=EventRedactBehaviour.AS_IS,
-            get_prev_content=False,
-        )
-
-        # We set `check_history_visibility_only` as we might otherwise get false
-        # positives from users having been erased.
-        filtered_extremities = await filter_events_for_server(
-            self.storage,
-            self.server_name,
-            list(extremities_events.values()),
-            redact=False,
-            check_history_visibility_only=True,
-        )
-        logger.debug(
-            "_maybe_backfill_inner: filtered_extremities %s", filtered_extremities
-        )
-
-        if not filtered_extremities and not insertion_events_to_be_backfilled:
-            return False
-
-        # TODO: insertion_events_to_be_backfilled is currently skipping the filtered_extremities checks
-
         # we now have a list of potential places to backpaginate from. We prefer to
         # start with the most recent (ie, max depth), so let's sort the list.
         sorted_extremeties_tuple: List[Tuple[str, int]] = sorted(
@@ -291,6 +237,60 @@ class FederationHandler:
         # relevant events.
         if filtered_sorted_extremeties_tuple:
             sorted_extremeties_tuple = filtered_sorted_extremeties_tuple
+
+        # We only want to paginate if we can actually see the events we'll get,
+        # as otherwise we'll just spend a lot of resources to get redacted
+        # events.
+        #
+        # We do this by filtering all the backwards extremities and seeing if
+        # any remain. Given we don't have the extremity events themselves, we
+        # need to actually check the events that reference them.
+        #
+        # *Note*: the spec wants us to keep backfilling until we reach the start
+        # of the room in case we are allowed to see some of the history. However
+        # in practice that causes more issues than its worth, as a) its
+        # relatively rare for there to be any visible history and b) even when
+        # there is its often sufficiently long ago that clients would stop
+        # attempting to paginate before backfill reached the visible history.
+        #
+        # TODO: If we do do a backfill then we should filter the backwards
+        #   extremities to only include those that point to visible portions of
+        #   history.
+        #
+        # TODO: Correctly handle the case where we are allowed to see the
+        #   forward event but not the backward extremity, e.g. in the case of
+        #   initial join of the server where we are allowed to see the join
+        #   event but not anything before it. This would require looking at the
+        #   state *before* the event, ignoring the special casing certain event
+        #   types have.
+
+        forward_event_ids = await self.store.get_successor_events(
+            list(oldest_events_with_depth)
+        )
+
+        extremities_events = await self.store.get_events(
+            forward_event_ids,
+            redact_behaviour=EventRedactBehaviour.AS_IS,
+            get_prev_content=False,
+        )
+
+        # We set `check_history_visibility_only` as we might otherwise get false
+        # positives from users having been erased.
+        filtered_extremities = await filter_events_for_server(
+            self.storage,
+            self.server_name,
+            list(extremities_events.values()),
+            redact=False,
+            check_history_visibility_only=True,
+        )
+        logger.debug(
+            "_maybe_backfill_inner: filtered_extremities %s", filtered_extremities
+        )
+
+        if not filtered_extremities and not insertion_events_to_be_backfilled:
+            return False
+
+        # TODO: insertion_events_to_be_backfilled is currently skipping the filtered_extremities checks
 
         # We don't want to specify too many extremities as it causes the backfill
         # request URI to be too long.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -313,9 +313,7 @@ class FederationHandler:
             if bp.type == _BackfillPointType.INSERTION_PONT:
                 event_ids_to_check = [bp.event_id]
             else:
-                event_ids_to_check = await self.store.get_successor_events(
-                    [bp.event_id]
-                )
+                event_ids_to_check = await self.store.get_successor_events(bp.event_id)
 
             events_to_check = await self.store.get_events_as_list(
                 event_ids_to_check,

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -285,8 +285,9 @@ class FederationHandler:
         # any remain.
         #
         # Doing this filtering can be expensive (we load the full state for the room
-        # at each of the sucessor events), so we check them one at a time until we find
-        # enough good ones, and then stop.
+        # at each of the backfill points, or (worse) their successors), so we check 
+        # the backfill points one at a time until we find enough good ones, and then
+        # stop.
         #
         # *Note*: the spec wants us to keep backfilling until we reach the start
         # of the room in case we are allowed to see some of the history. However

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -20,7 +20,7 @@ import itertools
 import logging
 from enum import Enum
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
 
 import attr
 from signedjson.key import decode_verify_key_bytes
@@ -294,7 +294,7 @@ class FederationHandler:
         # there is it's often sufficiently long ago that clients would stop
         # attempting to paginate before backfill reached the visible history.
 
-        extremities_to_request: Set[str] = set()
+        extremities_to_request: List[str] = []
         for bp in sorted_backfill_points:
             if len(extremities_to_request) >= 5:
                 break
@@ -330,7 +330,7 @@ class FederationHandler:
                 check_history_visibility_only=True,
             )
             if filtered_extremities:
-                extremities_to_request.add(bp.event_id)
+                extremities_to_request.append(bp.event_id)
             else:
                 logger.debug(
                     "_maybe_backfill_inner: skipping extremity %s as it would not be visible",

--- a/synapse/handlers/room_batch.py
+++ b/synapse/handlers/room_batch.py
@@ -54,7 +54,7 @@ class RoomBatchHandler:
         # it has a larger `depth` but before the successor event because the `stream_ordering`
         # is negative before the successor event.
         successor_event_ids = await self.store.get_successor_events(
-            [most_recent_prev_event_id]
+            most_recent_prev_event_id
         )
 
         # If we can't find any successor events, then it's a forward extremity of

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1296,21 +1296,18 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
         event_results.reverse()
         return event_results
 
-    async def get_successor_events(self, event_ids: Iterable[str]) -> List[str]:
-        """Fetch all events that have the given events as a prev event
+    async def get_successor_events(self, event_id: str) -> List[str]:
+        """Fetch all events that have the given event as a prev event
 
         Args:
-            event_ids: The events to use as the previous events.
+            event_id: The event to search for as a prev_event.
         """
-        rows = await self.db_pool.simple_select_many_batch(
+        return await self.db_pool.simple_select_onecol(
             table="event_edges",
-            column="prev_event_id",
-            iterable=event_ids,
-            retcols=("event_id",),
+            keyvalues={"prev_event_id": event_id},
+            retcol="event_id",
             desc="get_successor_events",
         )
-
-        return [row["event_id"] for row in rows]
 
     @wrap_as_background_process("delete_old_forward_extrem_cache")
     async def _delete_old_forward_extrem_cache(self) -> None:

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -419,6 +419,13 @@ async def _event_to_memberships(
         return {}
 
     # for each event, get the event_ids of the membership state at those events.
+    #
+    # TODO: this means that we request the entire membership list. If there  are only
+    #   one or two users on this server, and the room is huge, this is very wasteful
+    #   (it means more db work, and churns the *stateGroupMembersCache*).
+    #   It might be that we could extend StateFilter to specify "give me keys matching
+    #   *:<server_name>", to avoid this.
+
     event_to_state_ids = await storage.state.get_state_ids_for_events(
         frozenset(e.event_id for e in events),
         state_filter=StateFilter.from_types(types=((EventTypes.Member, None),)),


### PR DESCRIPTION
Try to avoid an OOM by checking fewer extremities.

Generally this is a big rewrite of `_maybe_backfill`, to try and fix some of the TODOs and other problems in it. It's best reviewed commit-by-commit.

Fixes: #12523 