### PR TITLE
Add option to enable token registration without requiring 3pids

### DIFF
--- a/changelog.d/12526.feature
+++ b/changelog.d/12526.feature
@@ -1,0 +1,1 @@
+Add new `registration_token_without_3pids` configuration option to allow registrations via token without needing to verify a 3pid.

--- a/changelog.d/12526.feature
+++ b/changelog.d/12526.feature
@@ -1,1 +1,1 @@
-Add new `registration_token_without_3pids` configuration option to allow registrations via token without needing to verify a 3pid.
+Add new `enable_registration_token_3pid_bypass` configuration option to allow registrations via token as an alternative to verifying a 3pid.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1323,6 +1323,16 @@ oembed:
 #
 #registration_requires_token: true
 
+# Allow users to submit a token during registration without requiring them to complete any
+# 3pid steps.
+# Tokens can be managed using the admin API:
+# https://matrix-org.github.io/synapse/latest/usage/administration/admin_api/registration_tokens.html
+# Note that `enable_registration` must be set to `true`.
+# Disabling this option will not delete any tokens previously generated.
+# Defaults to false. Uncomment the following to require tokens:
+#
+#registration_token_without_3pid: false
+
 # If set, allows registration of standard or admin accounts by anyone who
 # has the shared secret, even if registration is otherwise disabled.
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1323,15 +1323,11 @@ oembed:
 #
 #registration_requires_token: true
 
-# Allow users to submit a token during registration without requiring them to complete any
-# 3pid steps.
-# Tokens can be managed using the admin API:
-# https://matrix-org.github.io/synapse/latest/usage/administration/admin_api/registration_tokens.html
-# Note that `enable_registration` must be set to `true`.
-# Disabling this option will not delete any tokens previously generated.
-# Defaults to false. Uncomment the following to require tokens:
+# Allow users to submit a token during registration to bypass any required 3pid
+# steps configured in `registrations_require_3pid`.
+# Defaults to false, requiring that registration tokens (if enabled) complete a 3pid flow.
 #
-#registration_token_without_3pid: false
+#enable_registration_token_3pid_bypass: false
 
 # If set, allows registration of standard or admin accounts by anyone who
 # has the shared secret, even if registration is otherwise disabled.

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -43,6 +43,9 @@ class RegistrationConfig(Config):
         self.registration_requires_token = config.get(
             "registration_requires_token", False
         )
+        self.registration_token_without_3pids = config.get(
+            "registration_token_without_3pids", False
+        )
         self.registration_shared_secret = config.get("registration_shared_secret")
 
         self.bcrypt_rounds = config.get("bcrypt_rounds", 12)
@@ -308,6 +311,16 @@ class RegistrationConfig(Config):
         # Defaults to false. Uncomment the following to require tokens:
         #
         #registration_requires_token: true
+
+        # Allow users to submit a token during registration without requiring them to complete any
+        # 3pid steps.
+        # Tokens can be managed using the admin API:
+        # https://matrix-org.github.io/synapse/latest/usage/administration/admin_api/registration_tokens.html
+        # Note that `enable_registration` must be set to `true`.
+        # Disabling this option will not delete any tokens previously generated.
+        # Defaults to false. Uncomment the following to require tokens:
+        #
+        #registration_token_without_3pid: false
 
         # If set, allows registration of standard or admin accounts by anyone who
         # has the shared secret, even if registration is otherwise disabled.

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -43,8 +43,8 @@ class RegistrationConfig(Config):
         self.registration_requires_token = config.get(
             "registration_requires_token", False
         )
-        self.registration_token_without_3pids = config.get(
-            "registration_token_without_3pids", False
+        self.enable_registration_token_3pid_bypasss = config.get(
+            "enable_registration_token_3pid_bypasss", False
         )
         self.registration_shared_secret = config.get("registration_shared_secret")
 
@@ -312,15 +312,11 @@ class RegistrationConfig(Config):
         #
         #registration_requires_token: true
 
-        # Allow users to submit a token during registration without requiring them to complete any
-        # 3pid steps.
-        # Tokens can be managed using the admin API:
-        # https://matrix-org.github.io/synapse/latest/usage/administration/admin_api/registration_tokens.html
-        # Note that `enable_registration` must be set to `true`.
-        # Disabling this option will not delete any tokens previously generated.
-        # Defaults to false. Uncomment the following to require tokens:
+        # Allow users to submit a token during registration to bypass any required 3pid
+        # steps configured in `registrations_require_3pid`.
+        # Defaults to false, requiring that registration tokens (if enabled) complete a 3pid flow.
         #
-        #registration_token_without_3pid: false
+        #enable_registration_token_3pid_bypass: false
 
         # If set, allows registration of standard or admin accounts by anyone who
         # has the shared secret, even if registration is otherwise disabled.

--- a/synapse/handlers/ui_auth/checkers.py
+++ b/synapse/handlers/ui_auth/checkers.py
@@ -256,7 +256,7 @@ class RegistrationTokenAuthChecker(UserInteractiveAuthChecker):
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
         self.hs = hs
-        self._enabled = bool(hs.config.registration.registration_requires_token)
+        self._enabled = bool(hs.config.registration.registration_requires_token) or bool(hs.config.registration.registration_token_without_3pids)
         self.store = hs.get_datastores().main
 
     def is_enabled(self) -> bool:

--- a/synapse/handlers/ui_auth/checkers.py
+++ b/synapse/handlers/ui_auth/checkers.py
@@ -256,7 +256,9 @@ class RegistrationTokenAuthChecker(UserInteractiveAuthChecker):
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
         self.hs = hs
-        self._enabled = bool(hs.config.registration.registration_requires_token) or bool(hs.config.registration.registration_token_without_3pids)
+        self._enabled = bool(
+            hs.config.registration.registration_requires_token
+        ) or bool(hs.config.registration.registration_token_without_3pids)
         self.store = hs.get_datastores().main
 
     def is_enabled(self) -> bool:

--- a/synapse/handlers/ui_auth/checkers.py
+++ b/synapse/handlers/ui_auth/checkers.py
@@ -258,7 +258,7 @@ class RegistrationTokenAuthChecker(UserInteractiveAuthChecker):
         self.hs = hs
         self._enabled = bool(
             hs.config.registration.registration_requires_token
-        ) or bool(hs.config.registration.registration_token_without_3pids)
+        ) or bool(hs.config.registration.enable_registration_token_3pid_bypasss)
         self.store = hs.get_datastores().main
 
     def is_enabled(self) -> bool:

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -948,7 +948,6 @@ def _calculate_registration_flows(
         for flow in flows:
             flow.insert(0, LoginType.RECAPTCHA)
 
-
     return flows
 
 

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -929,6 +929,15 @@ def _calculate_registration_flows(
         # always let users provide both MSISDN & email
         flows.append([LoginType.MSISDN, LoginType.EMAIL_IDENTITY])
 
+    # Prepend registration token to all flows if we're requiring a token
+    if config.registration.registration_requires_token:
+        for flow in flows:
+            flow.insert(0, LoginType.REGISTRATION_TOKEN)
+
+    # Add a flow that doesn't require any 3pids, if the config requests it.
+    if config.registration.registration_token_without_3pids:
+        flows.append([LoginType.REGISTRATION_TOKEN])
+
     # Prepend m.login.terms to all flows if we're requiring consent
     if config.consent.user_consent_at_registration:
         for flow in flows:
@@ -939,10 +948,6 @@ def _calculate_registration_flows(
         for flow in flows:
             flow.insert(0, LoginType.RECAPTCHA)
 
-    # Prepend registration token to all flows if we're requiring a token
-    if config.registration.registration_requires_token:
-        for flow in flows:
-            flow.insert(0, LoginType.REGISTRATION_TOKEN)
 
     return flows
 

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -929,13 +929,8 @@ def _calculate_registration_flows(
         # always let users provide both MSISDN & email
         flows.append([LoginType.MSISDN, LoginType.EMAIL_IDENTITY])
 
-    # Prepend registration token to all flows if we're requiring a token
-    if config.registration.registration_requires_token:
-        for flow in flows:
-            flow.insert(0, LoginType.REGISTRATION_TOKEN)
-
     # Add a flow that doesn't require any 3pids, if the config requests it.
-    if config.registration.registration_token_without_3pids:
+    if config.registration.enable_registration_token_3pid_bypasss:
         flows.append([LoginType.REGISTRATION_TOKEN])
 
     # Prepend m.login.terms to all flows if we're requiring consent
@@ -947,6 +942,12 @@ def _calculate_registration_flows(
     if config.captcha.enable_registration_captcha:
         for flow in flows:
             flow.insert(0, LoginType.RECAPTCHA)
+
+    # Prepend registration token to all flows if we're requiring a token
+    if config.registration.registration_requires_token:
+        for flow in flows:
+            if LoginType.REGISTRATION_TOKEN not in flow:
+                flow.insert(0, LoginType.REGISTRATION_TOKEN)
 
     return flows
 


### PR DESCRIPTION
This PR attempts to add a second flow for token registration which does not require 3pid validation to succeed, *regardless* of the configuration of `registrations_require_3pid`. The requirement is that we would like to be able to offer tokens that allow users to sign up for a homeserver without having to jump through a email / msidn verification flow.

I'm not a massive fan of the config flag that I have come up with, and I'm a little worried this feels like adding another layer upon an already complicated configuration system (and at this point, does it just become easier to allow advanced users to craft their own registration flows?). That said, I think the idea of having temporal tokens that allow users to bypass registration requirements could be a useful thing, so it's worth figuring out the best configuration option for it. 