### PR TITLE
Add an index to config manual 

### DIFF
--- a/changelog.d/12527.doc
+++ b/changelog.d/12527.doc
@@ -1,0 +1,2 @@
+Add an index to the configuration manual.
+

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -64,7 +64,49 @@ apply if you want your config file to be read properly. A few helpful things to 
   In addition, each setting has an example of its usage, with the proper indentation
   shown. 
 
-  
+## Index
+[Modules](#modules)
+
+[Server](#server)
+
+[Homeserver Blocking](#homeserver-blocking)
+
+[TLS](#tls)
+
+[Federation](#federation)
+
+[Caching](#caching)
+
+[Database](#database)
+
+[Logging](#logging)
+
+[Ratelimiting](#ratelimiting)
+
+[Media Store](#media-store)
+
+[Captcha](#captcha)
+
+[TURN](#turn)
+
+[Registration](#registration)
+
+[API Configuration](#api-configuration)
+
+[Signing Keys](#signing-keys)
+
+[Single Sign On Integration](#single-sign-on-integration)
+
+[Push](#push)
+
+[Rooms](#rooms)
+
+[Opentracing](#opentracing)
+
+[Workers](#workers)
+
+[Background Updates](#background-updates)
+
 ## Modules
 
 Server admins can expand Synapse's functionality with external modules.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -64,7 +64,7 @@ apply if you want your config file to be read properly. A few helpful things to 
   In addition, each setting has an example of its usage, with the proper indentation
   shown. 
 
-## Index
+## Contents
 [Modules](#modules)
 
 [Server](#server)


### PR DESCRIPTION
Adds an index for the config manual so users can jump to headers. Note that this may end up being temporary as the the lack of an index could also be fixed in the website code, but for now this is the quickest and easiest way to fix this and the manual is not really usable without an index.  