### PR TITLE
Docs/admin_api: Correct typo in device deletion JSON

### DIFF
--- a/changelog.d/12533.doc
+++ b/changelog.d/12533.doc
@@ -1,0 +1,1 @@
+Remove extraneous comma in users_admin_api device deletion section so example JSON is actually valid and working. Contributed by @olmari.

--- a/changelog.d/12533.doc
+++ b/changelog.d/12533.doc
@@ -1,1 +1,1 @@
-Remove extraneous comma in users_admin_api device deletion section so example JSON is actually valid and working. Contributed by @olmari.
+Remove extraneous comma in User Admin API's device deletion section so that the example JSON is actually valid and works. Contributed by @olmari.

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -804,7 +804,7 @@ POST /_synapse/admin/v2/users/<user_id>/delete_devices
   "devices": [
     "QBUAZIFURK",
     "AUIECTSRND"
-  ],
+  ]
 }
 ```
 


### PR DESCRIPTION
Remove extraneous comma in users_admin_api device deletion section so example JSON is actually valid and working.

Signed-off-by: Sami Olmari <sami@olmari.fi>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
