### PR TITLE
Add default_power_level_content_override config option.

### DIFF
--- a/changelog.d/12535.feature
+++ b/changelog.d/12535.feature
@@ -1,0 +1,1 @@
+Add default_power_level_content_override config option.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2449,6 +2449,22 @@ push:
 #
 #encryption_enabled_by_default_for_room_type: invite
 
+# Override the default power levels for rooms created on this server, per
+# room creation preset.
+#
+# Useful if you know that your users need special permissions in rooms
+# that they create (e.g. to send particular types of state events without
+# needing an elevated power level).  This takes the same shape as the
+# `power_level_content_override` parameter in the /createRoom API, but
+# is applied before that parameter.
+#
+# This is something of a workaround in the absence of MSC3779 or MSC3761.
+#
+#default_power_level_content_override:
+#   private_chat: null
+#   trusted_private_chat: null
+#   public_chat: null
+
 
 # Uncomment to allow non-server-admin users to create groups on this server
 #

--- a/synapse/config/room.py
+++ b/synapse/config/room.py
@@ -63,6 +63,19 @@ class RoomConfig(Config):
                 "Invalid value for encryption_enabled_by_default_for_room_type"
             )
 
+        self.default_power_level_content_override = config.get(
+            "default_power_level_content_override",
+            None,
+        )
+        if self.default_power_level_content_override is not None:
+            for preset in self.default_power_level_content_override:
+                if preset not in vars(RoomCreationPreset).values():
+                    raise ConfigError(
+                        "Unrecognised room preset %s in default_power_level_content_override"
+                        % preset
+                    )
+                # We validate the actual overrides when we try to apply them.
+
     def generate_config_section(self, **kwargs: Any) -> str:
         return """\
         ## Rooms ##
@@ -83,4 +96,20 @@ class RoomConfig(Config):
         # will also not affect rooms created by other servers.
         #
         #encryption_enabled_by_default_for_room_type: invite
+
+        # Override the default power levels for rooms created on this server, per
+        # room creation preset.
+        #
+        # Useful if you know that your users need special permissions in rooms
+        # that they create (e.g. to send particular types of state events without
+        # needing an elevated power level).  This takes the same shape as the
+        # `power_level_content_override` parameter in the /createRoom API, but
+        # is applied before that parameter.
+        #
+        # This is something of a workaround in the absence of MSC3779 or MSC3761.
+        #
+        #default_power_level_content_override:
+        #   private_chat: null
+        #   trusted_private_chat: null
+        #   public_chat: null
         """

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1046,6 +1046,18 @@ class RoomCreationHandler:
             if power_level_content_override:
                 power_level_content.update(power_level_content_override)
 
+            # override default_power_level_content_override for this room preset, if any
+            default_power_level_content_override = (
+                self.config.room.default_power_level_content_override
+            )
+            if (
+                default_power_level_content_override
+                and default_power_level_content_override.get(preset_config)
+            ):
+                power_level_content.update(
+                    default_power_level_content_override.get(preset_config)
+                )
+
             last_sent_stream_id = await send(
                 etype=EventTypes.PowerLevels, content=power_level_content
             )


### PR DESCRIPTION
Lets you override the default power levels for rooms created on this server, per
room creation preset.

Useful if you know that your users need special permissions in rooms
that they create (e.g. to send particular types of state events without
needing an elevated power level).  This takes the same shape as the
power_level_content_override parameter in the /createRoom API, but
is applied before that parameter.

This is something of a workaround in the absence of MSC3779 or MSC3761.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
