### PR TITLE
Move from `pkg_resources` to `importlib.resources`

### DIFF
--- a/changelog.d/12542.misc
+++ b/changelog.d/12542.misc
@@ -1,0 +1,1 @@
+Move from `pkg_resources` to `importlib.resources`.

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -126,7 +126,8 @@ class Config:
 
         # Get the path to the default Synapse template directory
         ref = importlib.resources.files("synapse") / "res/templates"
-        self.default_template_dir = importlib.resources.as_file(ref)
+        with importlib.resources.as_file(ref) as path:
+            self.default_template_dir = path
 
     @staticmethod
     def parse_size(value: Union[str, int]) -> int:

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -16,6 +16,7 @@
 
 import argparse
 import errno
+import importlib
 import os
 from collections import OrderedDict
 from hashlib import sha256
@@ -35,7 +36,6 @@ from typing import (
 
 import attr
 import jinja2
-import pkg_resources
 import yaml
 
 from synapse.util.templates import _create_mxc_to_http_filter, _format_ts_filter
@@ -125,9 +125,8 @@ class Config:
         self.root = root_config
 
         # Get the path to the default Synapse template directory
-        self.default_template_dir = pkg_resources.resource_filename(
-            "synapse", "res/templates"
-        )
+        ref = importlib.resources.files("synapse") / "res/templates"
+        self.default_template_dir = importlib.resources.as_file(ref)
 
     @staticmethod
     def parse_size(value: Union[str, int]) -> int:

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -125,9 +125,8 @@ class Config:
         self.root = root_config
 
         # Get the path to the default Synapse template directory
-        ref = importlib.resources.files("synapse") / "res/templates"
-        with importlib.resources.as_file(ref) as path:
-            self.default_template_dir = path
+        with importlib.resources.path("synapse", "") as path:
+            self.default_template_dir = path / "res/templates"
 
     @staticmethod
     def parse_size(value: Union[str, int]) -> int:

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -318,7 +318,7 @@ class RootConfig:
             try:
                 conf = config_class(self)
             except Exception as e:
-                raise Exception("Failed making %s: %r" % (config_class.section, e))
+                raise Exception("Failed making %s" % config_class.section) from e
             setattr(self, config_class.section, conf)
 
     def invoke_all(

--- a/synapse/config/oembed.py
+++ b/synapse/config/oembed.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib
 import json
 import re
 from typing import Any, Dict, Iterable, List, Optional, Pattern
 from urllib import parse as urlparse
 
 import attr
-import pkg_resources
 
 from synapse.types import JsonDict
 
@@ -58,7 +58,9 @@ class OembedConfig(Config):
         # Whether to use the packaged providers.json file.
         if not oembed_config.get("disable_default_providers") or False:
             providers = json.load(
-                pkg_resources.resource_stream("synapse", "res/providers.json")
+                importlib.resources.files("synapse")
+                .joinpath("res/providers.json")
+                .open("rb")
             )
             yield from self._parse_and_validate_provider(
                 providers, config_path=("oembed",)

--- a/synapse/config/oembed.py
+++ b/synapse/config/oembed.py
@@ -57,14 +57,12 @@ class OembedConfig(Config):
         """
         # Whether to use the packaged providers.json file.
         if not oembed_config.get("disable_default_providers") or False:
-            providers = json.load(
-                importlib.resources.files("synapse")
-                .joinpath("res/providers.json")
-                .open("rb")
-            )
-            yield from self._parse_and_validate_provider(
-                providers, config_path=("oembed",)
-            )
+            with importlib.resources.path("synapse", "") as path:
+                with path.joinpath("res/providers.json").open() as strm:
+                    providers = json.load(strm)
+                    yield from self._parse_and_validate_provider(
+                        providers, config_path=("oembed",)
+                    )
 
         # The JSON files which includes additional provider information.
         for i, file in enumerate(oembed_config.get("additional_providers") or []):

--- a/synapse/handlers/send_email.py
+++ b/synapse/handlers/send_email.py
@@ -19,7 +19,7 @@ from email.mime.text import MIMEText
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Optional
 
-from pkg_resources import parse_version
+from packaging.version import Version
 
 import twisted
 from twisted.internet.defer import Deferred
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_is_old_twisted = parse_version(twisted.__version__) < parse_version("21")
+_is_old_twisted = Version(twisted.__version__) < Version("21")
 
 
 class _NoTLSESMTPSender(ESMTPSender):

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import email.message
+import importlib.resources
 import os
 from typing import Dict, List, Sequence, Tuple
 
 import attr
-import pkg_resources
 
 from twisted.internet.defer import Deferred
 
@@ -49,9 +49,6 @@ class EmailPusherTests(HomeserverTestCase):
         config = self.default_config()
         config["email"] = {
             "enable_notifs": True,
-            "template_dir": os.path.abspath(
-                pkg_resources.resource_filename("synapse", "res/templates")
-            ),
             "expiry_template_html": "notice_expiry.html",
             "expiry_template_text": "notice_expiry.txt",
             "notif_template_html": "notif_mail.html",
@@ -67,6 +64,10 @@ class EmailPusherTests(HomeserverTestCase):
         }
         config["public_baseurl"] = "http://aaa"
         config["start_pushers"] = True
+
+        ref = importlib.resources.files("synapse") / "res/templates"
+        with importlib.resources.as_file(ref) as path:
+            config["template_dir"] = os.path.abspath(path)
 
         hs = self.setup_test_homeserver(config=config)
 

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib.resources
 import json
 import os
 import re
 from email.parser import Parser
 from typing import Any, Dict, List, Optional, Union
 from unittest.mock import Mock
-
-import pkg_resources
 
 from twisted.internet.interfaces import IReactorTCP
 from twisted.test.proto_helpers import MemoryReactor
@@ -54,9 +53,6 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         # Email config.
         config["email"] = {
             "enable_notifs": False,
-            "template_dir": os.path.abspath(
-                pkg_resources.resource_filename("synapse", "res/templates")
-            ),
             "smtp_host": "127.0.0.1",
             "smtp_port": 20,
             "require_transport_security": False,
@@ -65,6 +61,10 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
             "notif_from": "test@example.com",
         }
         config["public_baseurl"] = "https://example.com"
+
+        ref = importlib.resources.files("synapse") / "res/templates"
+        with importlib.resources.as_file(ref) as path:
+            config["template_dir"] = os.path.abspath(path)
 
         hs = self.setup_test_homeserver(config=config)
 
@@ -591,9 +591,6 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
         # Email config.
         config["email"] = {
             "enable_notifs": False,
-            "template_dir": os.path.abspath(
-                pkg_resources.resource_filename("synapse", "res/templates")
-            ),
             "smtp_host": "127.0.0.1",
             "smtp_port": 20,
             "require_transport_security": False,
@@ -602,6 +599,10 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
             "notif_from": "test@example.com",
         }
         config["public_baseurl"] = "https://example.com"
+
+        ref = importlib.resources.files("synapse") / "res/templates"
+        with importlib.resources.as_file(ref) as path:
+            config["template_dir"] = os.path.abspath(path)
 
         self.hs = self.setup_test_homeserver(config=config)
 

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -14,11 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import datetime
+import importlib.resources
 import json
 import os
 from typing import Any, Dict, List, Tuple
-
-import pkg_resources
 
 from twisted.test.proto_helpers import MemoryReactor
 
@@ -924,9 +923,6 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
 
         config["email"] = {
             "enable_notifs": True,
-            "template_dir": os.path.abspath(
-                pkg_resources.resource_filename("synapse", "res/templates")
-            ),
             "expiry_template_html": "notice_expiry.html",
             "expiry_template_text": "notice_expiry.txt",
             "notif_template_html": "notif_mail.html",
@@ -938,6 +934,10 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
             "smtp_pass": None,
             "notif_from": "test@example.com",
         }
+
+        ref = importlib.resources.files("synapse") / "res/templates"
+        with importlib.resources.as_file(ref) as path:
+            config["template_dir"] = os.path.abspath(path)
 
         self.hs = self.setup_test_homeserver(config=config)
 


### PR DESCRIPTION
Resolves #12508 

The issue also states that `setuptools` needs to be removed as a dev dependency. However, in `tox.ini`, there's comments explaining that it is required by another library. Is this comment outdated? 

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
