### PR TITLE
Build packages for Ubuntu 22.04

### DIFF
--- a/changelog.d/12543.misc
+++ b/changelog.d/12543.misc
@@ -1,0 +1,1 @@
+Build debian packages for Ubuntu 22.04 "Jammy Jellyfish".

--- a/scripts-dev/build_debian_packages.py
+++ b/scripts-dev/build_debian_packages.py
@@ -26,6 +26,7 @@ DISTS = (
     "debian:sid",
     "ubuntu:focal",  # 20.04 LTS (our EOL forced by Py38 on 2024-10-14)
     "ubuntu:impish",  # 21.10  (EOL 2022-07)
+    "ubuntu:jammy",  # 22.04 LTS (EOL 2027-04)
 )
 
 DESC = """\


### PR DESCRIPTION
As the title states. Fixes #12430, also note https://github.com/matrix-org/pkg-repo-configs/pull/11. I saw no problems building this locally so hopefully this is good to go. 