### PR TITLE
Comment out dodgy log-kv

### DIFF
--- a/changelog.d/12554.bugfix
+++ b/changelog.d/12554.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.58.0rc1 where the main process could consume excessive amounts of CPU and memory handling sentry logging failures.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -683,9 +683,12 @@ class DeviceHandler(DeviceWorkerHandler):
                             self.federation_sender.send_device_messages(
                                 host, immediate=False
                             )
-                            log_kv(
-                                {"message": "sent device update to host", "host": host}
-                            )
+                            # TODO: when called, this isn't in a logging context.
+                            # This leads to log spam, sentry event spam, and massive
+                            # memory usage. See #12552.
+                            # log_kv(
+                            #     {"message": "sent device update to host", "host": host}
+                            # )
 
                     if current_stream_id != stream_id:
                         # Clear the set of hosts we've already sent to as we're


### PR DESCRIPTION
Mitigation for #12552.

Tested in-place on matrix.org. We are still seeing high CPU usage, but now Synapse is making forward progress doing work rather than spending time being unable to handle logging/sentry errors correctly.