### PR TITLE
Fix sending opentracing contexts to remote servers

### DIFF
--- a/changelog.d/12555.bugfix
+++ b/changelog.d/12555.bugfix
@@ -1,0 +1,1 @@
+Fix sending opentracing contexts to whitelisted remote servers with device lists updates. Broken in v1.58.0rc1.

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -1776,7 +1776,17 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
 
         def get_uncoverted_outbound_room_pokes_txn(txn):
             txn.execute(sql, (limit,))
-            return txn.fetchall()
+
+            return [
+                (
+                    user_id,
+                    device_id,
+                    room_id,
+                    stream_id,
+                    db_to_json(opentracing_context),
+                )
+                for user_id, device_id, room_id, stream_id, opentracing_context in txn
+            ]
 
         return await self.db_pool.runInteraction(
             "get_uncoverted_outbound_room_pokes", get_uncoverted_outbound_room_pokes_txn


### PR DESCRIPTION
This was broken by #12365