### PR TITLE
Mark remote device list updates as already handled

### DIFF
--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -505,8 +505,9 @@ class DeviceHandler(DeviceWorkerHandler):
             "device_list_key", position, users={user_id}, rooms=room_ids
         )
 
-        # We may need to do some processing asynchronously.
-        self._handle_new_device_update_async()
+        # We may need to do some processing asynchronously for local user IDs.
+        if self.hs.is_mine_id(user_id):
+            self._handle_new_device_update_async()
 
     async def notify_user_signature_update(
         self, from_user_id: str, user_ids: List[str]

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -1748,7 +1748,8 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
                     device_id,
                     room_id,
                     stream_id,
-                    False,
+                    # We only need to calculate outbound pokes for local users
+                    not self.hs.is_mine_id(user_id),
                     encoded_context,
                 )
                 for room_id in room_ids


### PR DESCRIPTION
We don't bother caclulating outbound pokes for remote device list
updates, so we shouldn't mark them as needing to be handled by the
`_handle_new_device_update_async` background job.


This shouldn't change any behaviour, as we already filter out remote users when handling new device updates, but does mean we don't have to pull out each row and mark them as handled.