### PR TITLE
Exclude OOB memberships from the federation sender

### DIFF
--- a/changelog.d/12570.bugfix
+++ b/changelog.d/12570.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.57 which could cause `Failed to calculate hosts in room` errors to be logged for outbound federation.

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -213,10 +213,17 @@ class _EventInternalMetadata:
         return self.outlier
 
     def is_out_of_band_membership(self) -> bool:
-        """Whether this is an out of band membership, like an invite or an invite
-        rejection. This is needed as those events are marked as outliers, but
-        they still need to be processed as if they're new events (e.g. updating
-        invite state in the database, relaying to clients, etc).
+        """Whether this event is an out-of-band membership.
+
+        OOB memberships are a special case of outlier events: they are membership events
+        for federated rooms that we aren't full members. Examples include invites
+        received over federation, and rejections for such invites.
+
+        The concept of an OOB membership is needed because these events need to be
+        processed as if they're new regular events (e.g. updating membership state in
+        the database, relaying to clients via /sync, etc) despite being outliers.
+
+        See also https://matrix-org.github.io/synapse/develop/development/room-dag-concepts.html#out-of-band-membership-events.
 
         (Added in synapse 0.99.0, so may be unreliable for events received before that)
         """

--- a/synapse/federation/sender/__init__.py
+++ b/synapse/federation/sender/__init__.py
@@ -363,12 +363,13 @@ class FederationSender(AbstractFederationSender):
                     #     will have a `sender` on a different server, so will be
                     #     skipped by the "is_mine" test above anyway.
                     #
-                    # (2) rejections of invites to federated rooms. These are normally
-                    #     created via federation (in which case the remote server is
-                    #     responsible for sending out the rejection). If that fails,
+                    # (2) rejections of invites to federated rooms - either remotely
+                    #     or locally generated. (Such rejections are normally
+                    #     created via federation, in which case the remote server is
+                    #     responsible for sending out the rejection. If that fails,
                     #     we'll create a leave event locally, but that's only really
                     #     for the benefit of the invited user - we don't have enough
-                    #     information to send it out over federation.
+                    #     information to send it out over federation).
                     #
                     # (2a) rescinded knocks. These are identical to rejected invites.
                     #
@@ -381,6 +382,11 @@ class FederationSender(AbstractFederationSender):
                     # OOB memberships are always(?) outliers anyway, so if we *don't*
                     # ignore them, we'll get an exception further down when we try to
                     # fetch the membership list for the room.
+                    #
+                    # Arguably, we could equivalently ignore all outliers here, since
+                    # in theory the only way for an outlier with a local `sender` to
+                    # exist is by being an OOB membership (via one of (2), (2a) or (3)
+                    # above).
                     #
                     if event.internal_metadata.is_out_of_band_membership():
                         return


### PR DESCRIPTION
As the comment says, there is no need to process such events, and indeed we need to avoid doing so.

Fixes #12509.