### PR TITLE
Allow unused ignores in "bleeding edge" CI

### DIFF
--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           python-version: "3.x"
           poetry-version: "1.2.0b1"
+          extras: "all"
       # Dump installed versions for debugging.
       - run: poetry run pip list > before.txt
       # Upgrade all runtime dependencies only. This is intended to mimic a fresh

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -38,6 +38,8 @@ jobs:
       # `pip install matrix-synapse[all]` as closely as possible.
       - run: poetry update --no-dev
       - run: poetry run pip list > after.txt && (diff -u before.txt after.txt || true)
+      - name: Remove warn_unused_ignores from mypy config
+        run: sed '/warn_unused_ignores = True/d' -i mypy.ini
       - run: poetry run mypy
   trial:
     runs-on: ubuntu-latest

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -24,6 +24,8 @@ jobs:
           poetry remove twisted
           poetry add --extras tls git+https://github.com/twisted/twisted.git#trunk
           poetry install --no-interaction --extras "all test"
+      - name: Remove warn_unused_ignores from mypy config
+        run: sed '/warn_unused_ignores = True/d' -i mypy.ini
       - run: poetry run mypy
 
   trial:

--- a/changelog.d/12576.misc
+++ b/changelog.d/12576.misc
@@ -1,0 +1,1 @@
+Allow unused `#type: ignore` comments in bleeding edge CI jobs.


### PR DESCRIPTION
Where "bleeding edge" means the Twisted Trunk and Latest Deps jobs.

Follow up from #12531.
Resolves #12574.

Accidentally commited directly to develop: ce6ecdd4b4939fd99418bc949b40c01d39480489, f282d5fc1185dde3f9ec31c49b630cff962545d7, 5a320baa45b8e826e52bdd6cadadfad727ab0357. Reverted in 5d3509dfda607323892f1cc96d7421612816e803.