### PR TITLE
Improve comments and error messages around access tokens.

### DIFF
--- a/changelog.d/12577.misc
+++ b/changelog.d/12577.misc
@@ -1,0 +1,1 @@
+Improve comments and error messages around access tokens.

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -417,7 +417,8 @@ class Auth:
         """
 
         if rights == "access":
-            # first look in the database
+            # First look in the database to see if the access token is present
+            # as an opaque token.
             r = await self.store.get_user_by_access_token(token)
             if r:
                 valid_until_ms = r.valid_until_ms
@@ -434,7 +435,8 @@ class Auth:
 
                 return r
 
-        # otherwise it needs to be a valid macaroon
+        # If the token isn't found in the database, then it could still be a
+        # macaroon, so we check that here.
         try:
             user_id, guest = self._parse_and_validate_macaroon(token, rights)
 
@@ -482,8 +484,14 @@ class Auth:
             TypeError,
             ValueError,
         ) as e:
-            logger.warning("Invalid macaroon in auth: %s %s", type(e), e)
-            raise InvalidClientTokenError("Invalid macaroon passed.")
+            logger.warning(
+                "Invalid access token in auth: %s %s. (Neither a known token nor a valid macaroon.)",
+                type(e),
+                e,
+            )
+            raise InvalidClientTokenError(
+                "Invalid access token passed. (Neither a known token nor a valid macaroon.)"
+            )
 
     def _parse_and_validate_macaroon(
         self, token: str, rights: str = "access"
@@ -504,10 +512,9 @@ class Auth:
         try:
             macaroon = pymacaroons.Macaroon.deserialize(token)
         except Exception:  # deserialize can throw more-or-less anything
-            # doesn't look like a macaroon: treat it as an opaque token which
-            # must be in the database.
-            # TODO: it would be nice to get rid of this, but apparently some
-            # people use access tokens which aren't macaroons
+            # The access token doesn't look like a macaroon.
+            # In that case, we assume it's an opaque token which must be in the
+            # database.
             raise _InvalidMacaroonException()
 
         try:

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -489,9 +489,7 @@ class Auth:
                 type(e),
                 e,
             )
-            raise InvalidClientTokenError(
-                "Invalid access token passed. (Neither a known token nor a valid macaroon.)"
-            )
+            raise InvalidClientTokenError("Invalid access token passed.")
 
     def _parse_and_validate_macaroon(
         self, token: str, rights: str = "access"

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -485,7 +485,7 @@ class Auth:
             ValueError,
         ) as e:
             logger.warning(
-                "Invalid access token in auth: %s %s. (Neither a known token nor a valid macaroon.)",
+                "Invalid access token in auth: %s %s.",
                 type(e),
                 e,
             )

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -513,8 +513,6 @@ class Auth:
             macaroon = pymacaroons.Macaroon.deserialize(token)
         except Exception:  # deserialize can throw more-or-less anything
             # The access token doesn't look like a macaroon.
-            # In that case, we assume it's an opaque token which must be in the
-            # database.
             raise _InvalidMacaroonException()
 
         try:


### PR DESCRIPTION
Fixes #10964.

This commentary was confusing without the historical context (the comments are still roughly in a state where macaroons were the new thing, but now they're the old thing and opaque tokens are back in fashion!).
Especially notable was that 'Invalid macaroon passed.' is completely obscure to a client developer; customers have asked what this means!!

