### PR TITLE
Improve the docstrings for the receipts store.

### DIFF
--- a/changelog.d/12581.misc
+++ b/changelog.d/12581.misc
@@ -1,0 +1,1 @@
+Improve docstrings for the receipts store.

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -176,7 +176,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
         self, user_id: str, receipt_type: str
     ) -> Dict[str, str]:
         """
-        Fetch the event IDs for the latest receipt sent by the given user.
+        Fetch the event IDs for the latest receipts sent by the given user.
 
         Args:
             user_id: The user to fetch receipts for.

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -180,7 +180,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
 
         Args:
             user_id: The user to fetch receipts for.
-            receipt_type: The receipt types to fetch.
+            receipt_type: The receipt type to fetch.
 
         Returns:
             A map of room ID to the event ID of the latest receipt for that room.

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -134,7 +134,8 @@ class ReceiptsWorkerStore(SQLBaseStore):
             receipt_type: The receipt type to fetch.
 
         Returns:
-            A list of dictionaries of the user ID and event ID of the latest receipt for each user.
+            A list of dictionaries, one for each user ID. Each dictionary
+            contains a user ID and the event ID of that user's latest receipt.
         """
         return await self.db_pool.simple_select_list(
             table="receipts_linearized",

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -201,7 +201,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
         self, user_id: str, receipt_type: str
     ) -> JsonDict:
         """
-Fetch receipts for all rooms that the given user is joined to.
+        Fetch receipts for all rooms that the given user is joined to.
 
         Args:
             user_id: The user to fetch receipts for.

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -176,7 +176,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
         self, user_id: str, receipt_type: str
     ) -> Dict[str, str]:
         """
-        Fetch the event IDs for the latest receipt in all rooms with the given receipt type.
+        Fetch the event IDs for the latest receipt sent by the given user.
 
         Args:
             user_id: The user to fetch receipts for.
@@ -184,6 +184,9 @@ class ReceiptsWorkerStore(SQLBaseStore):
 
         Returns:
             A map of room ID to the event ID of the latest receipt for that room.
+
+            If the user has not sent a receipt to a room then it will not appear
+            in the returned dictionary.
         """
         rows = await self.db_pool.simple_select_list(
             table="receipts_linearized",

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -122,7 +122,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
         receipts = await self.get_receipts_for_room(room_id, ReceiptTypes.READ)
         return {r["user_id"] for r in receipts}
 
-    @cached(num_args=2)
+    @cached()
     async def get_receipts_for_room(
         self, room_id: str, receipt_type: str
     ) -> List[Dict[str, Any]]:
@@ -143,7 +143,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
             desc="get_receipts_for_room",
         )
 
-    @cached(num_args=3)
+    @cached()
     async def get_last_receipt_event_id_for_user(
         self, user_id: str, room_id: str, receipt_type: str
     ) -> Optional[str]:
@@ -170,7 +170,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
             allow_none=True,
         )
 
-    @cached(num_args=2)
+    @cached()
     async def get_receipts_for_user(
         self, user_id: str, receipt_type: str
     ) -> Dict[str, str]:
@@ -283,7 +283,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
 
         return await self._get_linearized_receipts_for_room(room_id, to_key, from_key)
 
-    @cached(num_args=3, tree=True)
+    @cached(tree=True)
     async def _get_linearized_receipts_for_room(
         self, room_id: str, to_key: int, from_key: Optional[int] = None
     ) -> List[JsonDict]:

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -156,7 +156,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
             receipt_type: The receipt type to fetch.
 
         Returns:
-            The event ID of the latest receipt, if one exists.
+            The event ID of the latest receipt, if one exists; otherwise `None`.
         """
         return await self.db_pool.simple_select_one_onecol(
             table="receipts_linearized",
@@ -197,7 +197,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
         self, user_id: str, receipt_type: str
     ) -> JsonDict:
         """
-        Fetch receipts in all rooms for a user.
+Fetch receipts for all rooms that the given user is joined to.
 
         Args:
             user_id: The user to fetch receipts for.


### PR DESCRIPTION
This is split out of #12168 in an effort to reduce that diff / make it more obvious what is changing in that PR.

This has two changes in it:

* Adds/corrects docstrings.
* Removes useless `num_args` parameter to `@cached()` (it defaults to all args).