### PR TITLE
Add ability to cancel disconnected requests to `SynapseRequest`

### DIFF
--- a/changelog.d/12588.misc
+++ b/changelog.d/12588.misc
@@ -1,1 +1,1 @@
-Add `@cancellable` decorator, for use on endpoint methods that can be cancelled when clients disconnect.
+Add ability to cancel disconnected requests to `SynapseRequest`.

--- a/changelog.d/12588.misc
+++ b/changelog.d/12588.misc
@@ -1,0 +1,1 @@
+Add `@cancellable` decorator, for use on endpoint methods that can be cancelled when clients disconnect.

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Generator, Optional, Tuple, Union
 import attr
 from zope.interface import implementer
 
+from twisted.internet.defer import Deferred
 from twisted.internet.interfaces import IAddress, IReactorTime
 from twisted.python.failure import Failure
 from twisted.web.http import HTTPChannel
@@ -90,6 +91,13 @@ class SynapseRequest(Request):
 
         # we can't yet create the logcontext, as we don't know the method.
         self.logcontext: Optional[LoggingContext] = None
+
+        # The `Deferred` to cancel if the client disconnects early. Expected to be set
+        # by `Resource.render`.
+        self.render_deferred: Optional["Deferred[None]"] = None
+        # A boolean indicating whether `_render_deferred` should be cancelled if the
+        # client disconnects early. Expected to be set during `Resource.render`.
+        self.is_render_cancellable = False
 
         global _next_request_seq
         self.request_seq = _next_request_seq
@@ -357,7 +365,20 @@ class SynapseRequest(Request):
                     {"event": "client connection lost", "reason": str(reason.value)}
                 )
 
-            if not self._is_processing:
+            if self._is_processing:
+                if self.is_render_cancellable:
+                    if self.render_deferred is not None:
+                        # Throw a cancellation into the request processing, in the hope
+                        # that it will finish up sooner than it normally would.
+                        # The `self.processing()` context manager will call
+                        # `_finished_processing()` when done.
+                        self.render_deferred.cancel()
+                    else:
+                        logger.error(
+                            "Connection from client lost, but have no Deferred to "
+                            "cancel even though the request is marked as cancellable."
+                        )
+            else:
                 self._finished_processing()
 
     def _started_processing(self, servlet_name: str) -> None:

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -372,7 +372,8 @@ class SynapseRequest(Request):
                         # that it will finish up sooner than it normally would.
                         # The `self.processing()` context manager will call
                         # `_finished_processing()` when done.
-                        self.render_deferred.cancel()
+                        with PreserveLoggingContext():
+                            self.render_deferred.cancel()
                     else:
                         logger.error(
                             "Connection from client lost, but have no Deferred to "


### PR DESCRIPTION
Part of a larger series of commits: #12583
See the linked PR for usage of the new attributes.

---

In #12583:

`render_deferred` is set in `_AsyncResource.render` in `synapse/http/server.py`.

`is_render_cancellable` is more tricky and gets set in `_AsyncResource._async_render`, `JsonResource._async_render` (`synapse/http/server.py`) and `ReplicationEndpoint._check_auth_and_handle` (`synapse/replication/http/_base.py`)

...because in Synapse, we have 5 ways of defining async HTTP endpoints:
* `RestServlet` subclasses with `on_$METHOD` methods
* `BaseFederationServlet` subclasses with `on_$METHOD` methods
* `ReplicationEndpoint` subclasses with a `_handle_request` implementation
* `DirectServe{Html,Json}Resource` subclasses with `_async_render_$METHOD` methods

All of these get invoked indirectly by `_AsyncResource.render`, which starts the async processing.
`DirectServeHtmlResource` and `DirectServeJsonResource` inherit from `_AsyncResource` directly, while the rest register themselves using `register_paths` on a `JsonResource`, which inherits from `_AsyncResource`.