### PR TITLE
Explicitly define enabled flake8 errors and warnings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,10 @@
 #  E731: do not assign a lambda expression, use a def
 #  E501: Line too long (black enforces this for us)
 ignore=W503,W504,E203,E731,E501
+
+# Default + Enabled flake8 error codes:
+#  E/W: pycodestyle errors and warnings
+#    F: PyFlakes lintings
+#  C90: complexity (mccabe)
+#    B: Bugbear
+select=E,F,W,C90,B

--- a/.flake8
+++ b/.flake8
@@ -10,7 +10,11 @@
 #  E501: Line too long (black enforces this for us)
 ignore=W503,W504,E203,E731,E501
 
-# Default + Enabled flake8 error codes:
+# Here we explicitly specify the error codes we *do* lint for.
+# This includes the default flake8 (E,W,F,C90) and default bugbear (B) codes.
+# Note: This excludes B90 (opinionated bugbear lints), which would need to be
+#  added here explicitly to be included.
+# Codes and their origins:
 #  E/W: pycodestyle errors and warnings
 #    F: PyFlakes lints
 #  C90: complexity (mccabe)

--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,7 @@ ignore=W503,W504,E203,E731,E501
 
 # Default + Enabled flake8 error codes:
 #  E/W: pycodestyle errors and warnings
-#    F: PyFlakes lintings
+#    F: PyFlakes lints
 #  C90: complexity (mccabe)
 #    B: Bugbear
 select=E,F,W,C90,B

--- a/changelog.d/12600.misc
+++ b/changelog.d/12600.misc
@@ -1,0 +1,1 @@
+Explicitly select the `flake8` lints used.

--- a/changelog.d/12600.misc
+++ b/changelog.d/12600.misc
@@ -1,1 +1,1 @@
-Explicitly select the `flake8` lints used.
+Specify and explicitly select which flake8 lint categories are used.


### PR DESCRIPTION
Closes https://github.com/matrix-org/synapse/issues/9366 either way or the other.

I think #9366 has existed for quite some time now, the last action being to enable `B90`, a set of opinionated lints.

However, this was blocked by having all flake8 lints be explicitly defined (using `select=`), as there is no way to "add" a lint code to check. `B90` being optional required this.

This PR could unblock that effort, but I'd want to petition this anyway, as I think now it'd be a good time to look at this again with fresh eyes.

If this PR goes through, I might make an issue about adding `B90`, discussing the pros and cons of those lints.

---

The advantages of doing this would be;
- Having a clear set of lints (as flake8 defaults are hard to find[1]), which could help resolve "is this enabled or not?" questions when adding flake8 plugins in the future.
- Being able to add optional lints (such as `B90`) easily.

Disadvantages would be;
- Flake8 can change its default set of lints inbetween versions, and this would override it.
  - Note that this would only apply if they'd be adding a whole new category, currently it just selects `E`, `W`, and `F`, which are all already the categories flake8 operate in. Any new lints would most likely be added to those, and automatically included here.

[1]: Currently the only way to find flake8 defaults are to run `flake8` with verbose on, and watching a line where it tells about overriding a set of defaults. Here I copied that list as it was per flake8 `4.0.1`.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
  
`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`
