### PR TITLE
Bump Synapse minimum Python version to 3.7.1

### DIFF
--- a/changelog.d/12613.removal
+++ b/changelog.d/12613.removal
@@ -1,0 +1,1 @@
+Synapse now requires at least Python 3.7.1 (up from 3.7.0), for compatibility with the latest Twisted trunk.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1561,8 +1561,8 @@ url_preview = ["lxml"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "3825cef058b8c9f520ef4b7acb92519be95db9a663a61c2e89a5fe431ed55655"
+python-versions = "^3.7.1"
+content-hash = "2bda1a7cfc8cc02832b4a7d16bf7e1615cb05e0639bdb30688aadf692d851942"
 
 [metadata.files]
 attrs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ synapse_review_recent_signups = "synapse._scripts.review_recent_signups:main"
 update_synapse_database = "synapse._scripts.update_synapse_database:main"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.7.1"
 
 # Mandatory Dependencies
 # ----------------------


### PR DESCRIPTION
Discussed in #synapse-dev last week.

This is presumably a minimum CPython version; I don't
think the abstract language has point releases.

Resolves #12575.