### PR TITLE
Disable device name lookup over federation by default

### DIFF
--- a/changelog.d/12616.misc
+++ b/changelog.d/12616.misc
@@ -1,0 +1,1 @@
+Prevent remote homeservers from requesting local user device names by default.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -710,8 +710,8 @@ retention:
 #allow_profile_lookup_over_federation: false
 
 # Uncomment to allow device display name lookup over federation. By default, the
-# Federation API prevents other homeservers from obtaining device display names of
-# users on this homeserver. Defaults to 'false'.
+# Federation API prevents other homeservers from obtaining the display names of
+# user devices on this homeserver. Defaults to 'false'.
 #
 #allow_device_name_lookup_over_federation: true
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -709,11 +709,11 @@ retention:
 #
 #allow_profile_lookup_over_federation: false
 
-# Uncomment to disable device display name lookup over federation. By default, the
-# Federation API allows other homeservers to obtain device display names of any user
-# on this homeserver. Defaults to 'true'.
+# Uncomment to allow device display name lookup over federation. By default, the
+# Federation API prevents other homeservers from obtaining device display names of
+# users on this homeserver. Defaults to 'false'.
 #
-#allow_device_name_lookup_over_federation: false
+#allow_device_name_lookup_over_federation: true
 
 
 ## Caching ##

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -89,6 +89,17 @@ process, for example:
     dpkg -i matrix-synapse-py3_1.3.0+stretch1_amd64.deb
     ```
 
+# Upgrading to v1.59.0
+
+## Device name lookup over federation has been disabled by default
+
+The names of user devices are no longer visible to users on other homeservers by default.
+Device IDs are unaffected, as these are necessary to facilitate end-to-end encryption.
+
+To re-enable this functionality, set the
+[`allow_device_name_lookup_over_federation`](https://matrix-org.github.io/synapse/v1.59/usage/configuration/config_documentation.html#federation)
+homeserver config option to `true`.
+
 # Upgrading to v1.58.0
 
 ## Groups/communities feature has been disabled by default

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1035,13 +1035,13 @@ allow_profile_lookup_over_federation: false
 ---
 Config option: `allow_device_name_lookup_over_federation`
 
-Set this option to false to disable device display name lookup over federation. By default, the
-Federation API allows other homeservers to obtain device display names of any user
+Set this option to true to allow device display name lookup over federation. By default, the
+Federation API prevents other homeservers from obtaining the display names of any user devices
 on this homeserver.
 
 Example configuration:
 ```yaml
-allow_device_name_lookup_over_federation: false
+allow_device_name_lookup_over_federation: true
 ```
 ---
 ## Caching ##

--- a/synapse/config/federation.py
+++ b/synapse/config/federation.py
@@ -82,8 +82,8 @@ class FederationConfig(Config):
         #allow_profile_lookup_over_federation: false
 
         # Uncomment to allow device display name lookup over federation. By default, the
-        # Federation API prevents other homeservers from obtaining device display names of
-        # users on this homeserver. Defaults to 'false'.
+        # Federation API prevents other homeservers from obtaining the display names of
+        # user devices on this homeserver. Defaults to 'false'.
         #
         #allow_device_name_lookup_over_federation: true
         """

--- a/synapse/config/federation.py
+++ b/synapse/config/federation.py
@@ -46,7 +46,7 @@ class FederationConfig(Config):
         )
 
         self.allow_device_name_lookup_over_federation = config.get(
-            "allow_device_name_lookup_over_federation", True
+            "allow_device_name_lookup_over_federation", False
         )
 
     def generate_config_section(self, **kwargs: Any) -> str:
@@ -81,11 +81,11 @@ class FederationConfig(Config):
         #
         #allow_profile_lookup_over_federation: false
 
-        # Uncomment to disable device display name lookup over federation. By default, the
-        # Federation API allows other homeservers to obtain device display names of any user
-        # on this homeserver. Defaults to 'true'.
+        # Uncomment to allow device display name lookup over federation. By default, the
+        # Federation API prevents other homeservers from obtaining device display names of
+        # users on this homeserver. Defaults to 'false'.
         #
-        #allow_device_name_lookup_over_federation: false
+        #allow_device_name_lookup_over_federation: true
         """
 
 


### PR DESCRIPTION
Closes https://github.com/matrix-org/synapse/issues/12414.

This PR sets the default value of `allow_device_name_lookup_over_federation` to `false`, such that device names are not available to remote users unless explicitly enabled by the homeserver admin. This does not affect device IDs (i.e. XCJKDEM).

