### PR TITLE
Add `mau_appservice_trial_days` config

### DIFF
--- a/changelog.d/12619.feature
+++ b/changelog.d/12619.feature
@@ -1,1 +1,1 @@
-Add new `enable_registration_token_3pid_bypass` configuration option to specify a different trial period for users registered via an appservice.
+Add new `mau_appservice_trial_days` configuration option to specify a different trial period for users registered via an appservice.

--- a/changelog.d/12619.feature
+++ b/changelog.d/12619.feature
@@ -1,0 +1,1 @@
+Add new `enable_registration_token_3pid_bypass` configuration option to specify a different trial period for users registered via an appservice.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -416,6 +416,9 @@ manhole_settings:
 #limit_usage_by_mau: false
 #max_mau_value: 50
 #mau_trial_days: 2
+#mau_appservice_trial_days:
+#  "appservice-id": 1
+#
 #mau_limit_alerting: false
 
 # If enabled, the metrics for the number of monthly active users will

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -407,6 +407,10 @@ manhole_settings:
 # sign up in a short space of time never to return after their initial
 # session.
 #
+# 'mau_appservice_trial_days' is similar to the above, but applies a different
+# trial number depending on the appservice ID registered to the user. A value
+# of 0 means no trial days are applied.
+#
 # 'mau_limit_alerting' is a means of limiting client side alerting
 # should the mau limit be reached. This is useful for small instances
 # where the admin has 5 mau seats (say) for 5 specific people and no
@@ -416,10 +420,9 @@ manhole_settings:
 #limit_usage_by_mau: false
 #max_mau_value: 50
 #mau_trial_days: 2
+#mau_limit_alerting: false
 #mau_appservice_trial_days:
 #  "appservice-id": 1
-#
-#mau_limit_alerting: false
 
 # If enabled, the metrics for the number of monthly active users will
 # be populated, however no one will be limited. If limit_usage_by_mau

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -407,6 +407,11 @@ manhole_settings:
 # sign up in a short space of time never to return after their initial
 # session.
 #
+# The option `mau_appservice_trial_days` is similar to `mau_trial_days`, but
+# applies a different trial number if the user was registered by an appservice.
+# A value of 0 means no trial days are applied. Appservices not listed in this
+# dictionary use the value of `mau_trial_days` instead.
+#
 # 'mau_limit_alerting' is a means of limiting client side alerting
 # should the mau limit be reached. This is useful for small instances
 # where the admin has 5 mau seats (say) for 5 specific people and no
@@ -417,6 +422,8 @@ manhole_settings:
 #max_mau_value: 50
 #mau_trial_days: 2
 #mau_limit_alerting: false
+#mau_appservice_trial_days:
+#  "appservice-id": 1
 
 # If enabled, the metrics for the number of monthly active users will
 # be populated, however no one will be limited. If limit_usage_by_mau
@@ -1322,6 +1329,12 @@ oembed:
 # Defaults to false. Uncomment the following to require tokens:
 #
 #registration_requires_token: true
+
+# Allow users to submit a token during registration to bypass any required 3pid
+# steps configured in `registrations_require_3pid`.
+# Defaults to false, requiring that registration tokens (if enabled) complete a 3pid flow.
+#
+#enable_registration_token_3pid_bypass: false
 
 # If set, allows registration of standard or admin accounts by anyone who
 # has the shared secret, even if registration is otherwise disabled.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -407,10 +407,6 @@ manhole_settings:
 # sign up in a short space of time never to return after their initial
 # session.
 #
-# 'mau_appservice_trial_days' is similar to the above, but applies a different
-# trial number depending on the appservice ID registered to the user. A value
-# of 0 means no trial days are applied.
-#
 # 'mau_limit_alerting' is a means of limiting client side alerting
 # should the mau limit be reached. This is useful for small instances
 # where the admin has 5 mau seats (say) for 5 specific people and no
@@ -421,8 +417,6 @@ manhole_settings:
 #max_mau_value: 50
 #mau_trial_days: 2
 #mau_limit_alerting: false
-#mau_appservice_trial_days:
-#  "appservice-id": 1
 
 # If enabled, the metrics for the number of monthly active users will
 # be populated, however no one will be limited. If limit_usage_by_mau
@@ -1328,12 +1322,6 @@ oembed:
 # Defaults to false. Uncomment the following to require tokens:
 #
 #registration_requires_token: true
-
-# Allow users to submit a token during registration to bypass any required 3pid
-# steps configured in `registrations_require_3pid`.
-# Defaults to false, requiring that registration tokens (if enabled) complete a 3pid flow.
-#
-#enable_registration_token_3pid_bypass: false
 
 # If set, allows registration of standard or admin accounts by anyone who
 # has the shared secret, even if registration is otherwise disabled.

--- a/docs/sample_log_config.yaml
+++ b/docs/sample_log_config.yaml
@@ -62,13 +62,6 @@ loggers:
         # information such as access tokens.
         level: INFO
 
-    twisted:
-        # We send the twisted logging directly to the file handler,
-        # to work around https://github.com/matrix-org/synapse/issues/3471
-        # when using "buffer" logger. Use "console" to log to stderr instead.
-        handlers: [file]
-        propagate: false
-
 root:
     level: INFO
 

--- a/docs/sample_log_config.yaml
+++ b/docs/sample_log_config.yaml
@@ -62,6 +62,13 @@ loggers:
         # information such as access tokens.
         level: INFO
 
+    twisted:
+        # We send the twisted logging directly to the file handler,
+        # to work around https://github.com/matrix-org/synapse/issues/3471
+        # when using "buffer" logger. Use "console" to log to stderr instead.
+        handlers: [file]
+        propagate: false
+
 root:
     level: INFO
 

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -627,6 +627,20 @@ Example configuration:
 mau_trial_days: 5
 ```
 ---
+Config option: `mau_appservice_trial_days`
+
+The option `mau_appservice_trial_days` is similar to `mau_trial_days`, but applies a different
+trial number if the user was registered by an appservice. A value
+of 0 means no trial days are applied. Appservices not listed in this dictionary
+use the value of `mau_trial_days` instead.
+
+Example configuration:
+```yaml
+mau_appservice_trial_days: 
+  my_appservice_id: 3
+  another_appservice_id: 6
+```
+---
 Config option: `mau_limit_alerting`
 
 The option `mau_limit_alerting` is a means of limiting client-side alerting

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -1106,9 +1106,10 @@ class ServerConfig(Config):
         # sign up in a short space of time never to return after their initial
         # session.
         #
-        # 'mau_appservice_trial_days' is similar to the above, but applies a different
-        # trial number depending on the appservice ID registered to the user. A value
-        # of 0 means no trial days are applied.
+        # The option `mau_appservice_trial_days` is similar to `mau_trial_days`, but
+        # applies a different trial number if the user was registered by an appservice.
+        # A value of 0 means no trial days are applied. Appservices not listed in this
+        # dictionary use the value of `mau_trial_days` instead.
         #
         # 'mau_limit_alerting' is a means of limiting client side alerting
         # should the mau limit be reached. This is useful for small instances

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -1109,7 +1109,6 @@ class ServerConfig(Config):
         # 'mau_appservice_trial_days' is similar to the above, but applies a different
         # trial number depending on the appservice ID registered to the user. A value
         # of 0 means no trial days are applied.
-        # 
         #
         # 'mau_limit_alerting' is a means of limiting client side alerting
         # should the mau limit be reached. This is useful for small instances

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -413,6 +413,7 @@ class ServerConfig(Config):
         )
 
         self.mau_trial_days = config.get("mau_trial_days", 0)
+        self.mau_appservice_trial_days = config.get("mau_appservice_trial_days", {})
         self.mau_limit_alerting = config.get("mau_limit_alerting", True)
 
         # How long to keep redacted events in the database in unredacted form
@@ -1105,6 +1106,11 @@ class ServerConfig(Config):
         # sign up in a short space of time never to return after their initial
         # session.
         #
+        # 'mau_appservice_trial_days' is similar to the above, but applies a different
+        # trial number depending on the appservice ID registered to the user. A value
+        # of 0 means no trial days are applied.
+        # 
+        #
         # 'mau_limit_alerting' is a means of limiting client side alerting
         # should the mau limit be reached. This is useful for small instances
         # where the admin has 5 mau seats (say) for 5 specific people and no
@@ -1115,6 +1121,8 @@ class ServerConfig(Config):
         #max_mau_value: 50
         #mau_trial_days: 2
         #mau_limit_alerting: false
+        #mau_appservice_trial_days:
+        #  "appservice-id": 1
 
         # If enabled, the metrics for the number of monthly active users will
         # be populated, however no one will be limited. If limit_usage_by_mau

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -215,7 +215,8 @@ class RegistrationWorkerStore(CacheInvalidationWorkerStore):
 
     async def is_trial_user(self, user_id: str) -> bool:
         """Checks if user is in the "trial" period, i.e. within the first
-        N days of registration defined by `mau_trial_days` config
+        N days of registration defined by `mau_trial_days` config or the
+        `mau_appservice_trial_days` config.
 
         Args:
             user_id: The user to check for trial status.
@@ -226,7 +227,8 @@ class RegistrationWorkerStore(CacheInvalidationWorkerStore):
             return False
 
         now = self._clock.time_msec()
-        trial_duration_ms = self.config.server.mau_trial_days * 24 * 60 * 60 * 1000
+        days = self.config.mau_appservice_trial_days.get(info["appservice_id"], self.config.mau_trial_days)
+        trial_duration_ms = days * 24 * 60 * 60 * 1000
         is_trial = (now - info["creation_ts"] * 1000) < trial_duration_ms
         return is_trial
 

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -227,7 +227,9 @@ class RegistrationWorkerStore(CacheInvalidationWorkerStore):
             return False
 
         now = self._clock.time_msec()
-        days = self.config.mau_appservice_trial_days.get(info["appservice_id"], self.config.mau_trial_days)
+        days = self.config.mau_appservice_trial_days.get(
+            info["appservice_id"], self.config.mau_trial_days
+        )
         trial_duration_ms = days * 24 * 60 * 60 * 1000
         is_trial = (now - info["creation_ts"] * 1000) < trial_duration_ms
         return is_trial

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -227,8 +227,8 @@ class RegistrationWorkerStore(CacheInvalidationWorkerStore):
             return False
 
         now = self._clock.time_msec()
-        days = self.config.mau_appservice_trial_days.get(
-            info["appservice_id"], self.config.mau_trial_days
+        days = self.config.server.mau_appservice_trial_days.get(
+            info["appservice_id"], self.config.server.mau_trial_days
         )
         trial_duration_ms = days * 24 * 60 * 60 * 1000
         is_trial = (now - info["creation_ts"] * 1000) < trial_duration_ms

--- a/tests/test_mau.py
+++ b/tests/test_mau.py
@@ -243,9 +243,7 @@ class TestMauLimit(unittest.HomeserverTestCase):
 
         # Create and sync so that the MAU counts get updated
         token1 = self.create_user("kermit1")
-        self.do_sync_for_user(token1)
         token2 = self.create_user("kermit2")
-        self.do_sync_for_user(token2)
 
         # Cheekily add an application service that we use to register a new user
         # with.
@@ -272,22 +270,24 @@ class TestMauLimit(unittest.HomeserverTestCase):
         )
 
         token3 = self.create_user("as_kermit3", token=as_token_1, appservice=True)
-        self.do_sync_for_user(token3)
         token4 = self.create_user("as_kermit4", token=as_token_2, appservice=True)
-        self.do_sync_for_user(token4)
 
         # Advance time by a day to include the first appservice
-        self.reactor.advance(24 * 60 * 60)
+        self.reactor.advance(24 * 60 * 61)
+        self.do_sync_for_user(token3)
         count = self.store.get_monthly_active_count()
         self.assertEqual(1, self.successResultOf(count))
 
         # Advance time by a day to include the next appservice
-        self.reactor.advance(24 * 60 * 60)
+        self.reactor.advance(24 * 60 * 61)
+        self.do_sync_for_user(token4)
         count = self.store.get_monthly_active_count()
         self.assertEqual(2, self.successResultOf(count))
 
         # Advance time by 2 days to include the native users
-        self.reactor.advance(2 * 24 * 60 * 60)
+        self.reactor.advance(2 * 24 * 60 * 61)
+        self.do_sync_for_user(token1)
+        self.do_sync_for_user(token2)
         count = self.store.get_monthly_active_count()
         self.assertEqual(4, self.successResultOf(count))
 

--- a/tests/test_mau.py
+++ b/tests/test_mau.py
@@ -229,7 +229,12 @@ class TestMauLimit(unittest.HomeserverTestCase):
         self.reactor.advance(100)
         self.assertEqual(2, self.successResultOf(count))
 
-    @override_config({"mau_trial_days": 3, "mau_appservice_trial_days": {"SomeASID": 1, "AnotherASID": 2}})
+    @override_config(
+        {
+            "mau_trial_days": 3,
+            "mau_appservice_trial_days": {"SomeASID": 1, "AnotherASID": 2},
+        }
+    )
     def test_as_trial_days(self):
         """Test that application services can still create users when the MAU
         limit has been reached. This only works when application service
@@ -258,7 +263,7 @@ class TestMauLimit(unittest.HomeserverTestCase):
         as_token_2 = "foobartoken2"
         self.store.services_cache.append(
             ApplicationService(
-                token=as_token,
+                token=as_token_2,
                 hostname=self.hs.hostname,
                 id="AnotherASID",
                 sender="@as_sender_2:test",
@@ -282,10 +287,9 @@ class TestMauLimit(unittest.HomeserverTestCase):
         self.assertEqual(2, self.successResultOf(count))
 
         # Advance time by 2 days to include the native users
-        self.reactor.advance(2 *24 * 60 * 60)
+        self.reactor.advance(2 * 24 * 60 * 60)
         count = self.store.get_monthly_active_count()
         self.assertEqual(4, self.successResultOf(count))
-
 
     def create_user(self, localpart, token=None, appservice=False):
         request_data = {


### PR DESCRIPTION
The intention here is to hold appservice users to a different trial duration to regular users, for instance tracking them immediately rather than delayed at the same rate as other users. This should be a "free" check, because `is_trial_user` already pulls this information anyway.