### PR TITLE
Update `replication.md` with info on TCP module structure

### DIFF
--- a/changelog.d/12621.doc
+++ b/changelog.d/12621.doc
@@ -1,3 +1,2 @@
 Add information about the TCP replication module to docs.
 
-

--- a/changelog.d/12621.doc
+++ b/changelog.d/12621.doc
@@ -1,2 +1,1 @@
 Add information about the TCP replication module to docs.
-

--- a/changelog.d/12621.doc
+++ b/changelog.d/12621.doc
@@ -1,2 +1,3 @@
-Add information about the TCP replication module to docs. 
+Add information about the TCP replication module to docs.
+
 

--- a/changelog.d/12621.doc
+++ b/changelog.d/12621.doc
@@ -1,0 +1,2 @@
+Add information about the TCP replication module to docs. 
+

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -35,3 +35,8 @@ See [the TCP replication documentation](tcp_replication.md).
 There are read-only version of the synapse storage layer in
 `synapse/replication/slave/storage` that use the response of the
 replication API to invalidate their caches.
+
+### The TCP Replication Module
+Information about how the tcp replication module is structured, including how
+the classes interact, can be found in
+`synapse/replication/tcp/__init__.py`

--- a/synapse/replication/tcp/__init__.py
+++ b/synapse/replication/tcp/__init__.py
@@ -15,7 +15,7 @@
 """This module implements the TCP replication protocol used by synapse to
 communicate between the master process and its workers (when they're enabled).
 
-Further details can be found in docs/tcp_replication.rst
+Further details can be found in docs/tcp_replication.md
 
 
 Structure of the module:


### PR DESCRIPTION
As the title states. I came across the comment in `synapse/replication/tcp/__init__.py` by accident and thought it might be useful to give a little more visibility to it. 