### PR TITLE
Drop triple s from enable_registration_token_3pid_bypass

### DIFF
--- a/changelog.d/12639.bugfix
+++ b/changelog.d/12639.bugfix
@@ -1,0 +1,1 @@
+Add new `enable_registration_token_3pid_bypass` configuration option to allow registrations via token as an alternative to verifying a 3pid.

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -43,8 +43,8 @@ class RegistrationConfig(Config):
         self.registration_requires_token = config.get(
             "registration_requires_token", False
         )
-        self.enable_registration_token_3pid_bypasss = config.get(
-            "enable_registration_token_3pid_bypasss", False
+        self.enable_registration_token_3pid_bypass = config.get(
+            "enable_registration_token_3pid_bypass", False
         )
         self.registration_shared_secret = config.get("registration_shared_secret")
 

--- a/synapse/handlers/ui_auth/checkers.py
+++ b/synapse/handlers/ui_auth/checkers.py
@@ -258,7 +258,7 @@ class RegistrationTokenAuthChecker(UserInteractiveAuthChecker):
         self.hs = hs
         self._enabled = bool(
             hs.config.registration.registration_requires_token
-        ) or bool(hs.config.registration.enable_registration_token_3pid_bypasss)
+        ) or bool(hs.config.registration.enable_registration_token_3pid_bypass)
         self.store = hs.get_datastores().main
 
     def is_enabled(self) -> bool:

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -930,7 +930,7 @@ def _calculate_registration_flows(
         flows.append([LoginType.MSISDN, LoginType.EMAIL_IDENTITY])
 
     # Add a flow that doesn't require any 3pids, if the config requests it.
-    if config.registration.enable_registration_token_3pid_bypasss:
+    if config.registration.enable_registration_token_3pid_bypass:
         flows.append([LoginType.REGISTRATION_TOKEN])
 
     # Prepend m.login.terms to all flows if we're requiring consent


### PR DESCRIPTION
This typo appeared in half the code in #12526, I think it's safe to fix this since it was never part of a release.