### PR TITLE
Include extra dependency groups 'systemd' and 'cache_memory' in debian packages

### DIFF
--- a/changelog.d/12640.misc
+++ b/changelog.d/12640.misc
@@ -1,0 +1,1 @@
+Re-include python dependencies from the `systemd` and `cache_memory` extras package groups in the Debian packages, after they were accidentally removed.

--- a/changelog.d/12640.misc
+++ b/changelog.d/12640.misc
@@ -1,1 +1,0 @@
-Re-include python dependencies from the `systemd` and `cache_memory` extras package groups in the Debian packages, after they were accidentally removed.

--- a/debian/build_virtualenv
+++ b/debian/build_virtualenv
@@ -37,7 +37,12 @@ python3 -m venv "$TEMP_VENV"
 source "$TEMP_VENV/bin/activate"
 pip install -U pip
 pip install poetry==1.2.0b1
-poetry export --extras all --extras test -o exported_requirements.txt
+poetry export \
+    --extras all \
+    --extras test \
+    --extras systemd \
+    --extras cache_memory \
+    -o exported_requirements.txt
 deactivate
 rm -rf "$TEMP_VENV"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 matrix-synapse-py3 (1.58.0+nmu1) UNRELEASED; urgency=medium
 
-  * Re-include python dependencies from the `systemd` and `cache_memory` extras package groups.
+  * Include python dependencies from the `systemd` and `cache_memory` extras package groups, which
+    were incorrectly omitted from the 1.58.0 package.
 
  -- Synapse Packaging team <packages@matrix.org>  Thu, 05 May 2022 12:26:36 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+matrix-synapse-py3 (1.58.0+nmu1) UNRELEASED; urgency=medium
+
+  * Re-include python dependencies from the `systemd` and `cache_memory` extras package groups.
+
+ -- Synapse Packaging team <packages@matrix.org>  Thu, 05 May 2022 12:26:36 +0100
+
 matrix-synapse-py3 (1.58.0) stable; urgency=medium
 
   * New Synapse release 1.58.0.


### PR DESCRIPTION
Fixes #12631.

The `systemd` and `cache_memory` extra package groups contain python dependencies that are necessary for using all available options of the base distribution of Synapse in debian packages.

`systemd` provides the `systemd-python` package which is required for logging to the systemd journal, whereas `cache_memory` provides the `pympler` package, which is required for the `caches.track_memory_usage` homeserver config option.

These dependencies were available before the poetry changeover, where [they seem to have gone missing](https://github.com/matrix-org/synapse/issues/12631#issuecomment-1118418265). This PR adds these extras groups back.

Merging to the `release-v1.58` branch with the intention of including this in a v1.58.1 release.

---

I'm not sure if we also need to add the `cache_memory` extras group to the following line?

https://github.com/matrix-org/synapse/blob/0d8d59542abb99412f6b578350e765aa050df4c0/debian/build_virtualenv#L62