### PR TITLE
Move `pympler` back into the `all` extras

### DIFF
--- a/changelog.d/12652.misc
+++ b/changelog.d/12652.misc
@@ -1,0 +1,1 @@
+Move `pympler` back in to the `all` extras.

--- a/debian/build_virtualenv
+++ b/debian/build_virtualenv
@@ -41,7 +41,6 @@ poetry export \
     --extras all \
     --extras test \
     --extras systemd \
-    --extras cache_memory \
     -o exported_requirements.txt
 deactivate
 rm -rf "$TEMP_VENV"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+matrix-synapse-py3 (1.58.2) UNRELEASED; urgency=medium
+
+  * Adjust how the `exported-requirements.txt` file is generated as part of
+    the process of building these packages. This affects the package
+    maintainers only; end-users are unaffected.
+
+ -- Synapse Packaging team <packages@matrix.org>  Fri, 06 May 2022 13:49:29 +0100
+
 matrix-synapse-py3 (1.58.1) stable; urgency=medium
 
   * Include python dependencies from the `systemd` and `cache_memory` extras package groups, which

--- a/poetry.lock
+++ b/poetry.lock
@@ -1546,7 +1546,7 @@ docs = ["sphinx", "repoze.sphinx.autointerface"]
 test = ["zope.i18nmessageid", "zope.testing", "zope.testrunner"]
 
 [extras]
-all = ["matrix-synapse-ldap3", "psycopg2", "psycopg2cffi", "psycopg2cffi-compat", "pysaml2", "authlib", "lxml", "sentry-sdk", "jaeger-client", "opentracing", "pyjwt", "txredisapi", "hiredis"]
+all = ["matrix-synapse-ldap3", "psycopg2", "psycopg2cffi", "psycopg2cffi-compat", "pysaml2", "authlib", "lxml", "sentry-sdk", "jaeger-client", "opentracing", "pyjwt", "txredisapi", "hiredis", "Pympler"]
 cache_memory = ["Pympler"]
 jwt = ["pyjwt"]
 matrix-synapse-ldap3 = ["matrix-synapse-ldap3"]
@@ -1563,7 +1563,7 @@ url_preview = ["lxml"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "f24699464828ac1a63f1034b4a18c841ef585737b9a802fd8311836444f1d702"
+content-hash = "eebc9e1d720e2e866f5fddda98ce83d858949a6fdbe30c7e5aef4cf9d17be498"
 
 [metadata.files]
 attrs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,10 +231,11 @@ all = [
     "jaeger-client", "opentracing",
     # jwt
     "pyjwt",
-    #redis
-    "txredisapi", "hiredis"
+    # redis
+    "txredisapi", "hiredis",
+    # cache_memory
+    "pympler",
     # omitted:
-    #   - cache_memory: this is an experimental option
     #   - test: it's useful to have this separate from dev deps in the olddeps job
     #   - systemd: this is a system-based requirement
 ]


### PR DESCRIPTION
Undoes a change I made in #12381. I can't fully remember my reasoning,
but this changed the contents of the debian packages in a backwards
incompatible way. We're not aware of anyone who's been bitten by this,
but we still want to fix it.

To the reviewer: please be convinced that the debian packages will still
contain pympler after this change.
