### PR TITLE
Prevent memory leak from reoccurring when presence is disabled.

### DIFF
--- a/changelog.d/12656.misc
+++ b/changelog.d/12656.misc
@@ -1,0 +1,1 @@
+Prevent memory leak from reoccurring when presence is disabled.


### PR DESCRIPTION
When presence was disabled in Synapse <v1.58.0 (fixed by #12213) there was a small memory leak where the sync code would call `set_state` and insert items into the wheel timer, but would then never read *from* the wheel timer, causing a memory leak.