### PR TITLE
Fix docs on how to run specific Complement tests after recent `complement.sh` change

### DIFF
--- a/changelog.d/12664.doc
+++ b/changelog.d/12664.doc
@@ -1,0 +1,1 @@
+Fix docs on how to run specific Complement tests using the `complement.sh` test runner.

--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -270,13 +270,13 @@ COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh
 To run a specific test file, you can pass the test name at the end of the command. The name passed comes from the naming structure in your Complement tests. If you're unsure of the name, you can do a full run and copy it from the test output:
 
 ```sh
-COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh TestBackfillingHistory
+COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -run TestImportHistoricalMessages
 ```
 
 To run a specific test, you can specify the whole name structure:
 
 ```sh
-COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh TestBackfillingHistory/parallel/Backfilled_historical_events_resolve_with_proper_state_in_correct_order
+COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -run TestImportHistoricalMessages/parallel/Historical_events_resolve_in_the_correct_order
 ```
 
 


### PR DESCRIPTION
Fix docs on how to run specific Complement tests after recent `complement.sh` change

The behavior changed in [#12404](https://github.com/matrix-org/synapse/pull/12404#discussion_r867307790) which removed the automatic insertion of `-run` for test regex.

❌ If you tried using the old method of supplying a test regex with the new behavior, you'd run into the following behavior and tests aren't run:

```sh
$ COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS=1 COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh TestImportHistoricalMessages
...

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Images built; running complement
package TestImportHistoricalMessages is not in GOROOT (/Users/eric/.gvm/gos/go1.18/src/TestImportHistoricalMessages)
```

✅ The new expected way to run specific Complement tests looks like:

```sh
$ COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS=1 COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -run TestImportHistoricalMessages
...

--- PASS: TestImportHistoricalMessages (24.90s)
...
PASS
ok  	github.com/matrix-org/complement/tests	29.618s
```


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
