### PR TITLE
Fix inconsistent spelling of 'UNRECOGNIZED' when refering to endpoints

### DIFF
--- a/changelog.d/12665.misc
+++ b/changelog.d/12665.misc
@@ -1,1 +1,1 @@
-Fix spelling of UNRECOGNIZED
+Fix spelling of `M_UNRECOGNIZED` in comments.

--- a/changelog.d/12665.misc
+++ b/changelog.d/12665.misc
@@ -1,0 +1,1 @@
+Fix spelling of UNRECOGNIZED

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -1006,7 +1006,7 @@ class FederationClient(FederationBase):
                 content=pdu.get_pdu_json(time_now),
             )
         except HttpResponseException as e:
-            # If an error is received that is due to an unrecognized endpoint,
+            # If an error is received that is due to an unrecognised endpoint,
             # fallback to the v1 endpoint. Otherwise, consider it a legitimate error
             # and raise.
             if not self._is_unknown_endpoint(e):
@@ -1074,7 +1074,7 @@ class FederationClient(FederationBase):
                 },
             )
         except HttpResponseException as e:
-            # If an error is received that is due to an unrecognized endpoint,
+            # If an error is received that is due to an unrecognised endpoint,
             # fallback to the v1 endpoint if the room uses old-style event IDs.
             # Otherwise, consider it a legitimate error and raise.
             err = e.to_synapse_error()
@@ -1136,7 +1136,7 @@ class FederationClient(FederationBase):
                 content=pdu.get_pdu_json(time_now),
             )
         except HttpResponseException as e:
-            # If an error is received that is due to an unrecognized endpoint,
+            # If an error is received that is due to an unrecognised endpoint,
             # fallback to the v1 endpoint. Otherwise, consider it a legitimate error
             # and raise.
             if not self._is_unknown_endpoint(e):
@@ -1407,7 +1407,7 @@ class FederationClient(FederationBase):
                     suggested_only=suggested_only,
                 )
             except HttpResponseException as e:
-                # If an error is received that is due to an unrecognized endpoint,
+                # If an error is received that is due to an unrecognised endpoint,
                 # fallback to the unstable endpoint. Otherwise, consider it a
                 # legitimate error and raise.
                 if not self._is_unknown_endpoint(e):

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -618,7 +618,7 @@ class FederationClient(FederationBase):
         #
         # Dendrite returns a 404 (with a body of "404 page not found");
         # Conduit returns a 404 (with no body); and Synapse returns a 400
-        # with M_UNRECOGNISED.
+        # with M_UNRECOGNIZED.
         #
         # This needs to be rather specific as some endpoints truly do return 404
         # errors.
@@ -1006,7 +1006,7 @@ class FederationClient(FederationBase):
                 content=pdu.get_pdu_json(time_now),
             )
         except HttpResponseException as e:
-            # If an error is received that is due to an unrecognised endpoint,
+            # If an error is received that is due to an unrecognized endpoint,
             # fallback to the v1 endpoint. Otherwise, consider it a legitimate error
             # and raise.
             if not self._is_unknown_endpoint(e):
@@ -1074,7 +1074,7 @@ class FederationClient(FederationBase):
                 },
             )
         except HttpResponseException as e:
-            # If an error is received that is due to an unrecognised endpoint,
+            # If an error is received that is due to an unrecognized endpoint,
             # fallback to the v1 endpoint if the room uses old-style event IDs.
             # Otherwise, consider it a legitimate error and raise.
             err = e.to_synapse_error()
@@ -1136,7 +1136,7 @@ class FederationClient(FederationBase):
                 content=pdu.get_pdu_json(time_now),
             )
         except HttpResponseException as e:
-            # If an error is received that is due to an unrecognised endpoint,
+            # If an error is received that is due to an unrecognized endpoint,
             # fallback to the v1 endpoint. Otherwise, consider it a legitimate error
             # and raise.
             if not self._is_unknown_endpoint(e):
@@ -1407,7 +1407,7 @@ class FederationClient(FederationBase):
                     suggested_only=suggested_only,
                 )
             except HttpResponseException as e:
-                # If an error is received that is due to an unrecognised endpoint,
+                # If an error is received that is due to an unrecognized endpoint,
                 # fallback to the unstable endpoint. Otherwise, consider it a
                 # legitimate error and raise.
                 if not self._is_unknown_endpoint(e):


### PR DESCRIPTION
"M_UNRECOGNIZED" is the errcode used by in the protocol.

https://github.com/matrix-org/synapse/blob/3a8ee229112697b02b876299869d7511474ecf92/synapse/api/errors.py#L34

Signed-off-by: Valentin Lorentz <progval+git@progval.net>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). N/A
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
