### PR TITLE
Use `Concatenate` to annotate `do_execute`

### DIFF
--- a/changelog.d/12666.misc
+++ b/changelog.d/12666.misc
@@ -1,0 +1,1 @@
+Use `Concatenate` to better annotate `_do_execute`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ netaddr = ">=0.7.18"
 # add a lower bound to the Jinja2 dependency.
 Jinja2 = ">=3.0"
 bleach = ">=1.4.3"
-# We use `ParamSpec`, which was added in `typing-extensions` 3.10.0.0.
+# We use `ParamSpec` and `Concatenate`, which were added in `typing-extensions` 3.10.0.0.
 typing-extensions = ">=3.10.0"
 # We enforce that we have a `cryptography` version that bundles an `openssl`
 # with the latest security patches.


### PR DESCRIPTION
I'm not sure this gives us a huge amount of type safety, see this
comment:
https://github.com/matrix-org/synapse/issues/12312#issuecomment-1120289915

In any case, it's a nice bit of practice with `ParamSpec`.

On the face of it, resolves #12312. But as per the linked comment above, I'm not sure if we want to consider that done.