### PR TITLE
Move methods into PushRuleEvaluatorForEvent.

### DIFF
--- a/changelog.d/12677.misc
+++ b/changelog.d/12677.misc
@@ -1,0 +1,1 @@
+Refactor functions to on `PushRuleEvaluatorForEvent`.

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -208,8 +208,6 @@ class BulkPushRuleEvaluator:
             event, len(room_members), sender_power_level, power_levels
         )
 
-        condition_cache: Dict[str, bool] = {}
-
         # If the event is not a state event check if any users ignore the sender.
         if not event.is_state():
             ignorers = await self.store.ignored_by(event.sender)
@@ -248,7 +246,7 @@ class BulkPushRuleEvaluator:
                     continue
 
                 matches = evaluator.check_conditions(
-                    rule["conditions"], uid, display_name, condition_cache
+                    rule["conditions"], uid, display_name
                 )
                 if matches:
                     actions = [x for x in rule["actions"] if x != "dont_notify"]

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -247,8 +247,8 @@ class BulkPushRuleEvaluator:
                 if "enabled" in rule and not rule["enabled"]:
                     continue
 
-                matches = _condition_checker(
-                    evaluator, rule["conditions"], uid, display_name, condition_cache
+                matches = evaluator.check_conditions(
+                    rule["conditions"], uid, display_name, condition_cache
                 )
                 if matches:
                     actions = [x for x in rule["actions"] if x != "dont_notify"]
@@ -265,32 +265,6 @@ class BulkPushRuleEvaluator:
             actions_by_user,
             count_as_unread,
         )
-
-
-def _condition_checker(
-    evaluator: PushRuleEvaluatorForEvent,
-    conditions: List[dict],
-    uid: str,
-    display_name: Optional[str],
-    cache: Dict[str, bool],
-) -> bool:
-    for cond in conditions:
-        _cache_key = cond.get("_cache_key", None)
-        if _cache_key:
-            res = cache.get(_cache_key, None)
-            if res is False:
-                return False
-            elif res is True:
-                continue
-
-        res = evaluator.matches(cond, uid, display_name)
-        if _cache_key:
-            cache[_cache_key] = bool(res)
-
-        if not res:
-            return False
-
-    return True
 
 
 MemberMap = Dict[str, Optional[EventIdMembership]]

--- a/synapse/push/push_rule_evaluator.py
+++ b/synapse/push/push_rule_evaluator.py
@@ -223,7 +223,7 @@ class PushRuleEvaluatorForEvent:
 
             return _glob_matches(pattern, body, word_boundary=True)
         else:
-            haystack = self._get_value(condition["key"])
+            haystack = self._value_cache.get(condition["key"], None)
             if haystack is None:
                 return False
 
@@ -255,9 +255,6 @@ class PushRuleEvaluatorForEvent:
             regex_cache[(display_name, False, True)] = r
 
         return bool(r.search(body))
-
-    def _get_value(self, dotted_key: str) -> Optional[str]:
-        return self._value_cache.get(dotted_key, None)
 
 
 # Caches (string, is_glob, word_boundary) -> regex for push. See _glob_matches

--- a/synapse/push/push_rule_evaluator.py
+++ b/synapse/push/push_rule_evaluator.py
@@ -129,17 +129,16 @@ class PushRuleEvaluatorForEvent:
         # Maps strings of e.g. 'content.body' -> event["content"]["body"]
         self._value_cache = _flatten_dict(event)
 
+        # Maps cache keys to final values.
+        self._condition_cache: Dict[str, bool] = {}
+
     def check_conditions(
-        self,
-        conditions: List[dict],
-        uid: str,
-        display_name: Optional[str],
-        cache: Dict[str, bool],
+        self, conditions: List[dict], uid: str, display_name: Optional[str]
     ) -> bool:
         for cond in conditions:
             _cache_key = cond.get("_cache_key", None)
             if _cache_key:
-                res = cache.get(_cache_key, None)
+                res = self._condition_cache.get(_cache_key, None)
                 if res is False:
                     return False
                 elif res is True:
@@ -147,7 +146,7 @@ class PushRuleEvaluatorForEvent:
 
             res = self.matches(cond, uid, display_name)
             if _cache_key:
-                cache[_cache_key] = bool(res)
+                self._condition_cache[_cache_key] = bool(res)
 
             if not res:
                 return False

--- a/synapse/push/push_rule_evaluator.py
+++ b/synapse/push/push_rule_evaluator.py
@@ -135,6 +135,17 @@ class PushRuleEvaluatorForEvent:
     def check_conditions(
         self, conditions: List[dict], uid: str, display_name: Optional[str]
     ) -> bool:
+        """
+        Returns true if a user's conditions/user ID/display name match the event.
+
+        Args:
+            conditions: The user's conditions to match.
+            uid: The user's MXID.
+            display_name: The display name.
+
+        Returns:
+             True if all conditions match the event, False otherwise.
+        """
         for cond in conditions:
             _cache_key = cond.get("_cache_key", None)
             if _cache_key:
@@ -156,6 +167,17 @@ class PushRuleEvaluatorForEvent:
     def matches(
         self, condition: Dict[str, Any], user_id: str, display_name: Optional[str]
     ) -> bool:
+        """
+        Returns true if a user's condition/user ID/display name match the event.
+
+        Args:
+            condition: The user's condition to match.
+            uid: The user's MXID.
+            display_name: The display name, or None if there is not one.
+
+        Returns:
+             True if the condition matches the event, False otherwise.
+        """
         if condition["kind"] == "event_match":
             return self._event_match(condition, user_id)
         elif condition["kind"] == "contains_display_name":
@@ -170,6 +192,16 @@ class PushRuleEvaluatorForEvent:
             return True
 
     def _event_match(self, condition: dict, user_id: str) -> bool:
+        """
+        Check an "event_match" push rule condition.
+
+        Args:
+            condition: The "event_match" push rule condition to match.
+            user_id: The user's MXID.
+
+        Returns:
+             True if the condition matches the event, False otherwise.
+        """
         pattern = condition.get("pattern", None)
 
         if not pattern:
@@ -198,6 +230,15 @@ class PushRuleEvaluatorForEvent:
             return _glob_matches(pattern, haystack)
 
     def _contains_display_name(self, display_name: Optional[str]) -> bool:
+        """
+        Check an "event_match" push rule condition.
+
+        Args:
+            display_name: The display name, or None if there is not one.
+
+        Returns:
+             True if the display name is found in the event body, False otherwise.
+        """
         if not display_name:
             return False
 

--- a/synapse/push/push_rule_evaluator.py
+++ b/synapse/push/push_rule_evaluator.py
@@ -129,6 +129,31 @@ class PushRuleEvaluatorForEvent:
         # Maps strings of e.g. 'content.body' -> event["content"]["body"]
         self._value_cache = _flatten_dict(event)
 
+    def check_conditions(
+        self,
+        conditions: List[dict],
+        uid: str,
+        display_name: Optional[str],
+        cache: Dict[str, bool],
+    ) -> bool:
+        for cond in conditions:
+            _cache_key = cond.get("_cache_key", None)
+            if _cache_key:
+                res = cache.get(_cache_key, None)
+                if res is False:
+                    return False
+                elif res is True:
+                    continue
+
+            res = self.matches(cond, uid, display_name)
+            if _cache_key:
+                cache[_cache_key] = bool(res)
+
+            if not res:
+                return False
+
+        return True
+
     def matches(
         self, condition: Dict[str, Any], user_id: str, display_name: Optional[str]
     ) -> bool:


### PR DESCRIPTION
It was quite confusing to me that we had some floating variables / functions which operate on a `PushRuleEvaluatorForEvent` instance. It seems clearer to move them onto the class.

Also adds some docstrings.

Tangentially related to #12551.