### PR TITLE
Capture the `Deferred` for request cancellation in `_AsyncResource`

### DIFF
--- a/changelog.d/12694.misc
+++ b/changelog.d/12694.misc
@@ -1,0 +1,1 @@
+Capture the `Deferred` for request cancellation in `_AsyncResource`.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -344,7 +344,9 @@ class _AsyncResource(resource.Resource, metaclass=abc.ABCMeta):
 
     def render(self, request: SynapseRequest) -> int:
         """This gets called by twisted every time someone sends us a request."""
-        defer.ensureDeferred(self._async_render_wrapper(request))
+        request.render_deferred = defer.ensureDeferred(
+            self._async_render_wrapper(request)
+        )
         return NOT_DONE_YET
 
     @wrap_async_request_handler

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -96,7 +96,8 @@ class SynapseRequest(Request):
         # `is_render_cancellable` is set. Expected to be set by `Resource.render`.
         self.render_deferred: Optional["Deferred[None]"] = None
         # A boolean indicating whether `render_deferred` should be cancelled if the
-        # client disconnects early. Expected to be set during `Resource.render`.
+        # client disconnects early. Expected to be set by the coroutine started by
+        # `Resource.render`, if rendering is asynchronous.
         self.is_render_cancellable = False
 
         global _next_request_seq

--- a/synapse/http/site.py
+++ b/synapse/http/site.py
@@ -92,10 +92,10 @@ class SynapseRequest(Request):
         # we can't yet create the logcontext, as we don't know the method.
         self.logcontext: Optional[LoggingContext] = None
 
-        # The `Deferred` to cancel if the client disconnects early. Expected to be set
-        # by `Resource.render`.
+        # The `Deferred` to cancel if the client disconnects early and
+        # `is_render_cancellable` is set. Expected to be set by `Resource.render`.
         self.render_deferred: Optional["Deferred[None]"] = None
-        # A boolean indicating whether `_render_deferred` should be cancelled if the
+        # A boolean indicating whether `render_deferred` should be cancelled if the
         # client disconnects early. Expected to be set during `Resource.render`.
         self.is_render_cancellable = False
 


### PR DESCRIPTION
All async request processing goes through `_AsyncResource`, so this is
the only place where a `Deferred` needs to be captured for cancellation.

Unfortunately, the same isn't true for determining whether a request
can be cancelled. Each of `RestServlet`, `BaseFederationServlet`,
`DirectServe{Html,Json}Resource` and `ReplicationEndpoint` have
different wrappers around the method doing the request handling and they
all need to be handled separately.

Signed-off-by: Sean Quah <seanq@element.io>

----

Part of a larger series of commits: #12583

We finally set the `is_render_cancellable` flag in:
  * 46cdb4bd0746df6aad0b2408beb35b38b5a94c18 for `DirectServe{Html,Json}Resource`
  * 2326bbf0999e99b57dafcebd966dd9bd942c52a2 for `RestServlet` and `BaseFederationServlet`
  * 62d3b915a5eb110b36e75107d77dd161305bf7e9 for `ReplicationEndpoint`

which will come in 3 future PRs.