### PR TITLE
Uniformize spam-checker API, part 1: the `Code` enum.

### DIFF
--- a/changelog.d/12703.misc
+++ b/changelog.d/12703.misc
@@ -1,1 +1,1 @@
-Introduce a string enum `Code` to replace the namespace class `Codes`.
+Convert namespace class `Codes` into a string enum.

--- a/changelog.d/12703.misc
+++ b/changelog.d/12703.misc
@@ -1,0 +1,1 @@
+Introduce a string enum `Code` to replace the namespace class `Codes`.

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -31,7 +31,7 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Code(str, Enum):
+class Codes(str, Enum):
     """
     All known error codes, as an enum of strings.
     """
@@ -91,11 +91,6 @@ class Code(str, Enum):
     UNABLE_TO_GRANT_JOIN = "M_UNABLE_TO_GRANT_JOIN"
 
     UNREDACTED_CONTENT_DELETED = "FI.MAU.MSC2815_UNREDACTED_CONTENT_DELETED"
-
-
-# `Codes` used to be a namespace for codes. This is now replaced
-# with the enum `Code` but we maintain it for backwards compatibility.
-Codes = Code
 
 
 class CodeMessageException(RuntimeError):

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -17,6 +17,7 @@
 
 import logging
 import typing
+from enum import Enum
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Union
 
@@ -30,7 +31,17 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Codes:
+class Code(str, Enum):
+    """
+    All known error codes, as an enum of strings.
+    """
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
+        return repr(self.value)
+
     UNRECOGNIZED = "M_UNRECOGNIZED"
     UNAUTHORIZED = "M_UNAUTHORIZED"
     FORBIDDEN = "M_FORBIDDEN"
@@ -80,6 +91,11 @@ class Codes:
     UNABLE_TO_GRANT_JOIN = "M_UNABLE_TO_GRANT_JOIN"
 
     UNREDACTED_CONTENT_DELETED = "FI.MAU.MSC2815_UNREDACTED_CONTENT_DELETED"
+
+
+# `Codes` used to be a namespace for codes. This is now replaced
+# with the enum `Code` but we maintain it for backwards compatibility.
+Codes = Code
 
 
 class CodeMessageException(RuntimeError):
@@ -265,7 +281,9 @@ class UnrecognizedRequestError(SynapseError):
     """An error indicating we don't understand the request you're trying to make"""
 
     def __init__(
-        self, msg: str = "Unrecognized request", errcode: str = Codes.UNRECOGNIZED
+        self,
+        msg: str = "Unrecognized request",
+        errcode: str = Codes.UNRECOGNIZED,
     ):
         super().__init__(400, msg, errcode)
 

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -36,12 +36,6 @@ class Codes(str, Enum):
     All known error codes, as an enum of strings.
     """
 
-    def __str__(self) -> str:
-        return self.value
-
-    def __repr__(self) -> str:
-        return repr(self.value)
-
     UNRECOGNIZED = "M_UNRECOGNIZED"
     UNAUTHORIZED = "M_UNAUTHORIZED"
     FORBIDDEN = "M_FORBIDDEN"


### PR DESCRIPTION
This PR is part of an ongoing refactoring to make the spam-checker API more powerful and more uniform.

In this PR, we introduce a string enum `Code` that regroups all known error codes. This will help us progressively replace some string-typing in error codes by strong typing. In particular, this is necessary for the ongoing refactoring.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
