### PR TITLE
Always try to invite the user when creating a server notice room

### DIFF
--- a/changelog.d/12704.bugfix
+++ b/changelog.d/12704.bugfix
@@ -1,1 +1,1 @@
-Fix a bug introduced in Synapse 1.30.0 which caused invites new server notice rooms to not be sent out if the notice was triggered by the homeserver's monthly active users limit being reached.
+Fix a bug introduced in Synapse 1.30.0 where invites to new server notice rooms would not be sent out if the notice was triggered by the homeserver's monthly active users limit being reached.

--- a/changelog.d/12704.bugfix
+++ b/changelog.d/12704.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.30.0 which caused invites new server notice rooms to not be sent out if the notice was triggered by the homeserver's monthly active users limit being reached.

--- a/synapse/server_notices/server_notices_manager.py
+++ b/synapse/server_notices/server_notices_manager.py
@@ -66,7 +66,6 @@ class ServerNoticesManager:
             txn_id: The transaction ID.
         """
         room_id = await self.get_or_create_notice_room_for_user(user_id)
-        await self.maybe_invite_user_to_room(user_id, room_id)
 
         assert self.server_notices_mxid is not None
         requester = create_requester(
@@ -90,8 +89,28 @@ class ServerNoticesManager:
         )
         return event
 
-    @cached()
     async def get_or_create_notice_room_for_user(self, user_id: str) -> str:
+        """Get the room for notices for a given user
+
+        If we have not yet created a notice room for this user, create it, but don't
+        invite the user to it.
+
+        Also checks if the user needs to be invited into the room, and invites them if
+        necessary.
+
+        Args:
+            user_id: complete user id for the user we want a room for
+
+        Returns:
+            room id of notice room.
+        """
+
+        room_id = await self._get_or_create_notice_room_for_user(user_id)
+        await self.maybe_invite_user_to_room(user_id, room_id)
+        return room_id
+
+    @cached()
+    async def _get_or_create_notice_room_for_user(self, user_id: str) -> str:
         """Get the room for notices for a given user
 
         If we have not yet created a notice room for this user, create it, but don't


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/12686

`get_or_create_notice_room_for_user` sounds like something that should also invite the user as part of the room's creation. In fact, a previous incarnation of it did. This means that the code interacting with it might make this assumption and miss calling `maybe_invite_user_to_room`, which means the user is never invited and new rooms are constantly created.

Introduced in https://github.com/matrix-org/synapse/pull/7199