### PR TITLE
Complain if a federation endpoint has the `@cancellable` flag

### DIFF
--- a/changelog.d/12705.misc
+++ b/changelog.d/12705.misc
@@ -1,0 +1,1 @@
+Complain if a federation endpoint has the `@cancellable` flag, since some of the wrapper code may not handle cancellation correctly yet.

--- a/synapse/federation/transport/server/_base.py
+++ b/synapse/federation/transport/server/_base.py
@@ -376,6 +376,8 @@ class BaseFederationServlet:
             if is_method_cancellable(code):
                 # The wrapper added by `self._wrap` will inherit the cancellable flag,
                 # but the wrapper itself does not support cancellation yet.
+                # Once resolved, the cancellation tests in
+                # `tests/federation/transport/server/test__base.py` can be re-enabled.
                 raise Exception(
                     f"{self.__class__.__name__}.on_{method} has been marked as "
                     "cancellable, but federation servlets do not support cancellation "

--- a/tests/federation/transport/server/test__base.py
+++ b/tests/federation/transport/server/test__base.py
@@ -59,6 +59,8 @@ class BaseFederationServletCancellationTests(
 ):
     """Tests for `BaseFederationServlet` cancellation."""
 
+    skip = "`BaseFederationServlet` does not support cancellation yet."
+
     path = f"{CancellableFederationServlet.PREFIX}{CancellableFederationServlet.PATH}"
 
     def create_test_resource(self):


### PR DESCRIPTION
`BaseFederationServlet` wraps its endpoints in a bunch of async code
that has not been vetted for compatibility with cancellation.
Fail CI if a `@cancellable` flag is applied to a federation endpoint.

----

Follows on from #12699, where cancellation for `BaseFederationServlet`s came for free.
This is the last PR broken out from #12583.

Many thanks to everyone who has been involved in reviewing the PR series!
