### PR TITLE
Fix reference to the wrong symbol in the media admin api docs

### DIFF
--- a/changelog.d/12715.doc
+++ b/changelog.d/12715.doc
@@ -1,0 +1,1 @@
+Fix a typo in the Media Admin API documentation.

--- a/docs/admin_api/media_admin_api.md
+++ b/docs/admin_api/media_admin_api.md
@@ -289,7 +289,7 @@ POST /_synapse/admin/v1/purge_media_cache?before_ts=<unix_timestamp_in_ms>
 
 URL Parameters
 
-* `unix_timestamp_in_ms`: string representing a positive integer - Unix timestamp in milliseconds.
+* `before_ts`: string representing a positive integer - Unix timestamp in milliseconds.
 All cached media that was last accessed before this timestamp will be removed.
 
 Response:


### PR DESCRIPTION
`unix_timestamp_in_ms` refers to an example in the docs, not the actual query parameter's name.