### PR TITLE
URL preview cache expiry logs: INFO -> DEBUG, text clarifications

### DIFF
--- a/changelog.d/12720.misc
+++ b/changelog.d/12720.misc
@@ -1,0 +1,1 @@
+Drop the logging level of status messages for the URL preview cache expiry job from INFO to DEBUG.


### PR DESCRIPTION
Noticed while working on a separate feature in the area.

This commit:

* Moves some not-very-info-worthy log lines related to the URL preview cache expiry background job from INFO to DEBUG.
* Clarifies the text of some log lines to mention that they related to URL preview cache expiry.

Slightly helps with https://github.com/matrix-org/synapse/issues/8021.