### PR TITLE
Fix push for m.read events

### DIFF
--- a/changelog.d/12721.bugfix
+++ b/changelog.d/12721.bugfix
@@ -1,0 +1,1 @@
+Fix push to dismiss notifications when read on another client. Contributed by @SpiritCroc @ Beeper.

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -405,7 +405,7 @@ class HttpPusher(Pusher):
         rejected = []
         if "rejected" in resp:
             rejected = resp["rejected"]
-        else:
+        if not rejected:
             self.badge_count_last_call = badge
         return rejected
 


### PR DESCRIPTION
badge_count_last_call was never set to non-zero values when the response for push
notifications included a "rejected" key which mapped to an empty list.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>