### PR TITLE
Downgrade some OIDC exceptions to warnings

### DIFF
--- a/changelog.d/12723.misc
+++ b/changelog.d/12723.misc
@@ -1,0 +1,1 @@
+Downgrade some OIDC errors to warnings in the logs, to reduce the noise of Sentry reports.

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -220,11 +220,11 @@ class OidcHandler:
                 session, state
             )
         except (MacaroonInitException, MacaroonDeserializationException, KeyError) as e:
-            logger.exception("Invalid session for OIDC callback")
+            logger.warning("Invalid session for OIDC callback: %s", e)
             self._sso_handler.render_error(request, "invalid_session", str(e))
             return
         except MacaroonInvalidSignatureException as e:
-            logger.exception("Could not verify session for OIDC callback")
+            logger.warning("Could not verify session for OIDC callback: %s", e)
             self._sso_handler.render_error(request, "mismatching_session", str(e))
             return
 
@@ -827,7 +827,7 @@ class OidcProvider:
             logger.debug("Exchanging OAuth2 code for a token")
             token = await self._exchange_code(code)
         except OidcError as e:
-            logger.exception("Could not exchange OAuth2 code")
+            logger.warning("Could not exchange OAuth2 code: %s", e)
             self._sso_handler.render_error(request, e.error, e.error_description)
             return
 

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -220,7 +220,7 @@ class OidcHandler:
                 session, state
             )
         except (MacaroonInitException, MacaroonDeserializationException, KeyError) as e:
-            logger.warning("Invalid session for OIDC callback: %s", e)
+            logger.exception("Invalid session for OIDC callback")
             self._sso_handler.render_error(request, "invalid_session", str(e))
             return
         except MacaroonInvalidSignatureException as e:


### PR DESCRIPTION
This means we won't get tracebacks reported to Sentry.

There are other `logger.exception` and `logger.error` calls in this
file. I tried to only target errors that

- show up a lot in Sentry
- don't sound like our fault
- are still reported to the end-user by other means.

I erred on the side of caution and included the error's string representation in the logged warning.

I know very little about open ID etc, so would appreciate sanity checking from a responsible adult.

Closes #12707.