### PR TITLE
Add config options for media retention

### DIFF
--- a/changelog.d/12732.feature
+++ b/changelog.d/12732.feature
@@ -1,0 +1,1 @@
+Add new `media_retention` options to the homeserver config for routinely cleaning up non-recently accessed media.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1043,43 +1043,6 @@ media_store_path: "DATADIR/media_store"
 #    height: 600
 #    method: scale
 
-# Configure media retention settings. Media will be purged if it
-# has not been accessed in at least this amount of time. If the
-# media has never been accessed, the media's creation time is used
-# instead. Both thumbnails and the original media will be removed.
-#
-# Media is 'accessed' when loaded in a room in a client, or
-# otherwise downloaded by a local or remote user.
-#
-# Purging the media will be the carried out by the media worker
-# (whichever worker has the 'enable_media_repo' homeserver config
-# option enabled). This may be the main process.
-#
-media_retention:
-    # Whether media retention settings should apply. Defaults to
-    # false.
-    #
-    # Uncomment to enable media retention on this homeserver.
-    #
-    #enabled: true
-
-    # How long to keep local media since its last access. Local
-    # media that is removed will be permanently deleted.
-    #
-    # If this option is not set, local media will not have a
-    # retention policy applied.
-    #
-    #local_media_lifetime: 30d
-
-    # How long to keep downloaded remote media since its last
-    # access. Remote media will be downloaded again from the
-    # originating server on demand.
-    #
-    # If this option is not set, remote media will not have a
-    # retention policy applied.
-    #
-    remote_media_lifetime: 7d
-
 # Is the preview URL API enabled?
 #
 # 'false' by default: uncomment the following to enable it (and specify a

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1045,11 +1045,15 @@ media_store_path: "DATADIR/media_store"
 
 # Configure media retention settings. Media will be purged if it
 # has not been accessed in at least this amount of time. If the
-# media has never been access, the media's creation time is used
+# media has never been accessed, the media's creation time is used
 # instead. Both thumbnails and the original media will be removed.
 #
 # Media is 'accessed' when loaded in a room in a client, or
 # otherwise downloaded by a local or remote user.
+#
+# Purging the media will be the carried out by the media worker
+# (whichever worker has the 'enable_media_repo' homeserver config
+# option enabled). This may be the main process.
 #
 media_retention:
     # Whether media retention settings should apply. Defaults to

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1043,6 +1043,39 @@ media_store_path: "DATADIR/media_store"
 #    height: 600
 #    method: scale
 
+# Configure media retention settings. Media will be purged if it
+# has not been accessed in at least this amount of time. If the
+# media has never been access, the media's creation time is used
+# instead. Both thumbnails and the original media will be removed.
+#
+# Media is 'accessed' when loaded in a room in a client, or
+# otherwise downloaded by a local or remote user.
+#
+media_retention:
+    # Whether media retention settings should apply. Defaults to
+    # false.
+    #
+    # Uncomment to enable media retention on this homeserver.
+    #
+    #enabled: true
+
+    # How long to keep local media since its last access. Local
+    # media that is removed will be permanently deleted.
+    #
+    # If this option is not set, local media will not have a
+    # retention policy applied.
+    #
+    #local_media_lifetime: 30d
+
+    # How long to keep downloaded remote media since its last
+    # access. Remote media will be downloaded again from the
+    # originating server on demand.
+    #
+    # If this option is not set, remote media will not have a
+    # retention policy applied.
+    #
+    remote_media_lifetime: 7d
+
 # Is the preview URL API enabled?
 #
 # 'false' by default: uncomment the following to enable it (and specify a

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1522,13 +1522,12 @@ Purging media files will be the carried out by the media worker
 (that is, the worker that has the `enable_media_repo` homeserver config
 option set to 'true'). This may be the main process.
 
-The `media_retention.enabled` option globally controls whether media
-retention is enabled.
-
 The `media_retention.purge_period` option dictates how often Synapse should
 scan and purge media to be removed according to the configured thresholds.
 For example, if set to "6h", Synapse will check every 6 hours for media
-that can be purged. The default value is "24h" meaning 24 hours.
+that can be purged. The default value is "24h" meaning 24 hours. Synapse
+will not regularly check for media to purge if no other media retention
+options are set.
 
 The `media_retention.local_media_lifetime` and
 `media_retention.remote_media_lifetime` config options control whether

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1407,7 +1407,7 @@ federation_rr_transactions_per_room_per_second: 40
 ```
 ---
 ## Media Store ##
-Config options relating to Synapse media store.
+Config options related to Synapse's media store.
 
 ---
 Config option: `enable_media_repo` 
@@ -1511,6 +1511,37 @@ thumbnail_sizes:
     height: 600
     method: scale
 ```
+---
+Config option: `media_retention`
+
+Controls whether local media and entries in the remote media cache
+(media that is downloaded from other homeservers) should be removed
+under certain conditions, typically for the purpose of saving space.
+
+Purging media files will be the carried out by the media worker
+(that is, the worker that has the `enable_media_repo` homeserver config
+option set to 'true'). This may be the main process.
+
+The `media_retention.enabled` option globally controls whether media
+retention is enabled.
+
+The `media_retention.local_media_lifetime` and
+`media_retention.remote_media_lifetime` config options control whether
+media will be purged if it has not been accessed in a given amount of
+time. Note that media is 'accessed' when loaded in a room in a client, or
+otherwise downloaded by a local or remote user. If the media has never
+been accessed, the media's creation time is used instead. Both thumbnails
+and the original media will be removed. If either of these options are unset,
+then media of that type will not be purged.
+
+Example configuration:
+```yaml
+media_retention:
+    enabled: true
+    local_media_lifetime: 30d
+    remote_media_lifetime: 7d
+```
+---
 Config option: `url_preview_enabled`
 
 This setting determines whether the preview URL API is enabled.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1525,6 +1525,11 @@ option set to 'true'). This may be the main process.
 The `media_retention.enabled` option globally controls whether media
 retention is enabled.
 
+The `media_retention.purge_period` option dictates how often Synapse should
+scan and purge media to be removed according to the configured thresholds.
+For example, if set to "6h", Synapse will check every 6 hours for media
+that can be purged. The default value is "24h" meaning 24 hours.
+
 The `media_retention.local_media_lifetime` and
 `media_retention.remote_media_lifetime` config options control whether
 media will be purged if it has not been accessed in a given amount of
@@ -1538,6 +1543,7 @@ Example configuration:
 ```yaml
 media_retention:
     enabled: true
+    purge_period: 24h
     local_media_lifetime: 30d
     remote_media_lifetime: 7d
 ```

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1522,13 +1522,6 @@ Purging media files will be the carried out by the media worker
 (that is, the worker that has the `enable_media_repo` homeserver config
 option set to 'true'). This may be the main process.
 
-The `media_retention.purge_period` option dictates how often Synapse should
-scan and purge media to be removed according to the configured thresholds.
-For example, if set to "6h", Synapse will check every 6 hours for media
-that can be purged. The default value is "24h" meaning 24 hours. Synapse
-will not regularly check for media to purge if no other media retention
-options are set.
-
 The `media_retention.local_media_lifetime` and
 `media_retention.remote_media_lifetime` config options control whether
 media will be purged if it has not been accessed in a given amount of
@@ -1541,7 +1534,6 @@ then media of that type will not be purged.
 Example configuration:
 ```yaml
 media_retention:
-    purge_period: 7d
     local_media_lifetime: 90d
     remote_media_lifetime: 14d
 ```

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1541,7 +1541,6 @@ then media of that type will not be purged.
 Example configuration:
 ```yaml
 media_retention:
-    enabled: true
     purge_period: 7d
     local_media_lifetime: 90d
     remote_media_lifetime: 14d

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1542,9 +1542,9 @@ Example configuration:
 ```yaml
 media_retention:
     enabled: true
-    purge_period: 24h
-    local_media_lifetime: 30d
-    remote_media_lifetime: 7d
+    purge_period: 7d
+    local_media_lifetime: 90d
+    remote_media_lifetime: 14d
 ```
 ---
 Config option: `url_preview_enabled`

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -306,43 +306,6 @@ class ContentRepositoryConfig(Config):
         #thumbnail_sizes:
 %(formatted_thumbnail_sizes)s
 
-        # Configure media retention settings. Media will be purged if it
-        # has not been accessed in at least this amount of time. If the
-        # media has never been accessed, the media's creation time is used
-        # instead. Both thumbnails and the original media will be removed.
-        #
-        # Media is 'accessed' when loaded in a room in a client, or
-        # otherwise downloaded by a local or remote user.
-        #
-        # Purging the media will be the carried out by the media worker
-        # (whichever worker has the 'enable_media_repo' homeserver config
-        # option enabled). This may be the main process.
-        #
-        media_retention:
-            # Whether media retention settings should apply. Defaults to
-            # false.
-            #
-            # Uncomment to enable media retention on this homeserver.
-            #
-            #enabled: true
-
-            # How long to keep local media since its last access. Local
-            # media that is removed will be permanently deleted.
-            #
-            # If this option is not set, local media will not have a
-            # retention policy applied.
-            #
-            #local_media_lifetime: 30d
-
-            # How long to keep downloaded remote media since its last
-            # access. Remote media will be downloaded again from the
-            # originating server on demand.
-            #
-            # If this option is not set, remote media will not have a
-            # retention policy applied.
-            #
-            remote_media_lifetime: 7d
-
         # Is the preview URL API enabled?
         #
         # 'false' by default: uncomment the following to enable it (and specify a

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -308,11 +308,15 @@ class ContentRepositoryConfig(Config):
 
         # Configure media retention settings. Media will be purged if it
         # has not been accessed in at least this amount of time. If the
-        # media has never been access, the media's creation time is used
+        # media has never been accessed, the media's creation time is used
         # instead. Both thumbnails and the original media will be removed.
         #
         # Media is 'accessed' when loaded in a room in a client, or
         # otherwise downloaded by a local or remote user.
+        #
+        # Purging the media will be the carried out by the media worker
+        # (whichever worker has the 'enable_media_repo' homeserver config
+        # option enabled). This may be the main process.
         #
         media_retention:
             # Whether media retention settings should apply. Defaults to

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -226,6 +226,10 @@ class ContentRepositoryConfig(Config):
         media_retention = config.get("media_retention") or {}
         self.media_retention_enabled = media_retention.get("enabled", False)
 
+        self.media_retention_purge_period = self.parse_duration(
+            media_retention.get("purge_period", "24h")
+        )
+
         self.media_retention_local_media_lifetime_ms = None
         local_media_lifetime = media_retention.get("local_media_lifetime")
         if local_media_lifetime is not None:

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -225,10 +225,6 @@ class ContentRepositoryConfig(Config):
 
         media_retention = config.get("media_retention") or {}
 
-        self.media_retention_purge_period = self.parse_duration(
-            media_retention.get("purge_period", "24h")
-        )
-
         self.media_retention_local_media_lifetime_ms = None
         local_media_lifetime = media_retention.get("local_media_lifetime")
         if local_media_lifetime is not None:

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -223,6 +223,23 @@ class ContentRepositoryConfig(Config):
                 "url_preview_accept_language"
             ) or ["en"]
 
+        media_retention = config.get("media_retention") or {}
+        self.media_retention_enabled = media_retention.get("enabled", False)
+
+        self.media_retention_local_media_lifetime_ms = None
+        local_media_lifetime = media_retention.get("local_media_lifetime")
+        if local_media_lifetime is not None:
+            self.media_retention_local_media_lifetime_ms = self.parse_duration(
+                local_media_lifetime
+            )
+
+        self.media_retention_remote_media_lifetime_ms = None
+        remote_media_lifetime = media_retention.get("remote_media_lifetime")
+        if remote_media_lifetime is not None:
+            self.media_retention_remote_media_lifetime_ms = self.parse_duration(
+                remote_media_lifetime
+            )
+
     def generate_config_section(self, data_dir_path: str, **kwargs: Any) -> str:
         assert data_dir_path is not None
         media_store = os.path.join(data_dir_path, "media_store")
@@ -288,6 +305,39 @@ class ContentRepositoryConfig(Config):
         #
         #thumbnail_sizes:
 %(formatted_thumbnail_sizes)s
+
+        # Configure media retention settings. Media will be purged if it
+        # has not been accessed in at least this amount of time. If the
+        # media has never been access, the media's creation time is used
+        # instead. Both thumbnails and the original media will be removed.
+        #
+        # Media is 'accessed' when loaded in a room in a client, or
+        # otherwise downloaded by a local or remote user.
+        #
+        media_retention:
+            # Whether media retention settings should apply. Defaults to
+            # false.
+            #
+            # Uncomment to enable media retention on this homeserver.
+            #
+            #enabled: true
+
+            # How long to keep local media since its last access. Local
+            # media that is removed will be permanently deleted.
+            #
+            # If this option is not set, local media will not have a
+            # retention policy applied.
+            #
+            #local_media_lifetime: 30d
+
+            # How long to keep downloaded remote media since its last
+            # access. Remote media will be downloaded again from the
+            # originating server on demand.
+            #
+            # If this option is not set, remote media will not have a
+            # retention policy applied.
+            #
+            remote_media_lifetime: 7d
 
         # Is the preview URL API enabled?
         #

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -224,7 +224,6 @@ class ContentRepositoryConfig(Config):
             ) or ["en"]
 
         media_retention = config.get("media_retention") or {}
-        self.media_retention_enabled = media_retention.get("enabled", False)
 
         self.media_retention_purge_period = self.parse_duration(
             media_retention.get("purge_period", "24h")

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -68,9 +68,6 @@ logger = logging.getLogger(__name__)
 # How often to run the background job to update the "recently accessed"
 # attribute of local and remote media.
 UPDATE_RECENTLY_ACCESSED_TS = 60 * 1000  # 1 minute
-# How often to run the background job that purges local and remote media
-# according to the configured media retention rules.
-APPLY_MEDIA_RETENTION_RULES_PERIOD_MS = 60 * 60 * 1000  # 1 hour
 
 
 class MediaRepository:
@@ -136,11 +133,11 @@ class MediaRepository:
         )
 
         if hs.config.media.media_retention_enabled:
-            # Run the background job to apply media retention rules every
-            # $APPLY_MEDIA_RETENTION_RULES_PERIOD_MS milliseconds.
+            # Run the background job to apply media retention rules routinely,
+            # with the duration between runs dictated by the homeserver config.
             self.clock.looping_call(
                 self._start_apply_media_retention_rules,
-                APPLY_MEDIA_RETENTION_RULES_PERIOD_MS,
+                hs.config.media.media_retention_purge_period,
             )
 
     def _start_update_recently_accessed(self) -> Deferred:

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -68,6 +68,9 @@ logger = logging.getLogger(__name__)
 # How often to run the background job to update the "recently accessed"
 # attribute of local and remote media.
 UPDATE_RECENTLY_ACCESSED_TS = 60 * 1000  # 1 minute
+# How often to run the background job to check for local and remote media
+# that should be purged according to the configured media retention settings.
+MEDIA_RETENTION_CHECK_PERIOD_MS = 60 * 60 * 1000  # 1 hour
 
 
 class MediaRepository:
@@ -141,7 +144,7 @@ class MediaRepository:
             # with the duration between runs dictated by the homeserver config.
             self.clock.looping_call(
                 self._start_apply_media_retention_rules,
-                hs.config.media.media_retention_purge_period,
+                MEDIA_RETENTION_CHECK_PERIOD_MS,
             )
 
     def _start_update_recently_accessed(self) -> Deferred:

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -132,7 +132,11 @@ class MediaRepository:
             hs.config.media.media_retention_remote_media_lifetime_ms
         )
 
-        if hs.config.media.media_retention_enabled:
+        # Check whether local or remote media retention is configured
+        if (
+            hs.config.media.media_retention_local_media_lifetime_ms is not None
+            or hs.config.media.media_retention_remote_media_lifetime_ms is not None
+        ):
             # Run the background job to apply media retention rules routinely,
             # with the duration between runs dictated by the homeserver config.
             self.clock.looping_call(

--- a/synapse/rest/media/v1/media_repository.py
+++ b/synapse/rest/media/v1/media_repository.py
@@ -866,9 +866,6 @@ class MediaRepository:
         """
         Purge old local and remote media according to the media retention rules
         defined in the homeserver config.
-
-        Raises:
-            ...
         """
         # Purge remote media
         if self._media_retention_remote_media_lifetime_ms is not None:

--- a/tests/rest/media/test_media_retention.py
+++ b/tests/rest/media/test_media_retention.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Matrix.org Foundation C.I.C.
+# Copyright 2022 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/rest/media/test_media_retention.py
+++ b/tests/rest/media/test_media_retention.py
@@ -1,0 +1,238 @@
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+from typing import Iterable, Optional, Tuple
+
+from twisted.test.proto_helpers import MemoryReactor
+
+from synapse.rest import admin
+from synapse.rest.client import login, register, room
+from synapse.server import HomeServer
+from synapse.types import UserID
+from synapse.util import Clock
+
+from tests import unittest
+from tests.unittest import override_config
+from tests.utils import MockClock
+
+
+class MediaRetentionTestCase(unittest.HomeserverTestCase):
+
+    ONE_DAY_IN_MS = 24 * 60 * 60 * 1000
+    THIRTY_DAYS_IN_MS = 30 * ONE_DAY_IN_MS
+
+    servlets = [
+        room.register_servlets,
+        login.register_servlets,
+        register.register_servlets,
+        admin.register_servlets_for_client_rest_resource,
+    ]
+
+    def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
+        # We need to be able to test advancing time in the homeserver, so we
+        # replace the test homeserver's default clock with a MockClock, which
+        # supports advancing time.
+        return self.setup_test_homeserver(clock=MockClock())
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.remote_server_name = "remote.homeserver"
+        self.store = hs.get_datastores().main
+
+        # Create a user to upload media with
+        test_user_id = self.register_user("alice", "password")
+
+        # Inject media (3 images each; recently accessed, old access, never accessed)
+        # into both the local store and the remote cache
+        media_repository = hs.get_media_repository()
+        test_media_content = b"example string"
+
+        def _create_media_and_set_last_accessed(
+            last_accessed_ms: Optional[int],
+        ) -> str:
+            # "Upload" some media to the local media store
+            mxc_uri = self.get_success(
+                media_repository.create_content(
+                    media_type="text/plain",
+                    upload_name=None,
+                    content=io.BytesIO(test_media_content),
+                    content_length=len(test_media_content),
+                    auth_user=UserID.from_string(test_user_id),
+                )
+            )
+
+            media_id = mxc_uri.split("/")[-1]
+
+            # Set the last recently accessed time for this media
+            if last_accessed_ms is not None:
+                self.get_success(
+                    self.store.update_cached_last_access_time(
+                        local_media=(media_id,),
+                        remote_media=(),
+                        time_ms=last_accessed_ms,
+                    )
+                )
+
+            return media_id
+
+        def _cache_remote_media_and_set_last_accessed(
+            media_id: str, last_accessed_ms: Optional[int]
+        ) -> str:
+            # Pretend to cache some remote media
+            self.get_success(
+                self.store.store_cached_remote_media(
+                    origin=self.remote_server_name,
+                    media_id=media_id,
+                    media_type="text/plain",
+                    media_length=1,
+                    time_now_ms=clock.time_msec(),
+                    upload_name="testfile.txt",
+                    filesystem_id="abcdefg12345",
+                )
+            )
+
+            # Set the last recently accessed time for this media
+            if last_accessed_ms is not None:
+                self.get_success(
+                    hs.get_datastores().main.update_cached_last_access_time(
+                        local_media=(),
+                        remote_media=((self.remote_server_name, media_id),),
+                        time_ms=last_accessed_ms,
+                    )
+                )
+
+            return media_id
+
+        # Start with the local media store
+        self.local_recently_accessed_media = _create_media_and_set_last_accessed(
+            self.THIRTY_DAYS_IN_MS
+        )
+        self.local_not_recently_accessed_media = _create_media_and_set_last_accessed(
+            self.ONE_DAY_IN_MS
+        )
+        self.local_never_accessed_media = _create_media_and_set_last_accessed(None)
+
+        # And now the remote media store
+        self.remote_recently_accessed_media = _cache_remote_media_and_set_last_accessed(
+            "a", self.THIRTY_DAYS_IN_MS
+        )
+        self.remote_not_recently_accessed_media = (
+            _cache_remote_media_and_set_last_accessed("b", self.ONE_DAY_IN_MS)
+        )
+        # Remote media will always have a "last accessed" attribute, as it would not
+        # be fetched from the remote homeserver unless instigated by a user.
+
+    @override_config(
+        {
+            "media_retention": {
+                # Enable retention for local media
+                "local_media_lifetime": "30d"
+                # Cached remote media should not be purged
+            }
+        }
+    )
+    def test_local_media_retention(self) -> None:
+        """
+        Tests that local media that have not been accessed recently is purged, while
+        cached remote media is unaffected.
+        """
+        # Advance 31 days (in seconds)
+        self.reactor.advance(31 * 24 * 60 * 60)
+
+        # Check that media has been correctly purged.
+        # Local media accessed <30 days ago should still exist.
+        # Remote media should be unaffected.
+        self._assert_if_mxc_uris_purged(
+            purged=[
+                (
+                    self.hs.config.server.server_name,
+                    self.local_not_recently_accessed_media,
+                ),
+                (self.hs.config.server.server_name, self.local_never_accessed_media),
+            ],
+            not_purged=[
+                (self.hs.config.server.server_name, self.local_recently_accessed_media),
+                (self.remote_server_name, self.remote_recently_accessed_media),
+                (self.remote_server_name, self.remote_not_recently_accessed_media),
+            ],
+        )
+
+    @override_config(
+        {
+            "media_retention": {
+                # Enable retention for cached remote media
+                "remote_media_lifetime": "30d"
+                # Local media should not be purged
+            }
+        }
+    )
+    def test_remote_media_cache_retention(self) -> None:
+        """
+        Tests that entries from the remote media cache that have not been accessed
+        recently is purged, while local media is unaffected.
+        """
+        # Advance 31 days (in seconds)
+        self.reactor.advance(31 * 24 * 60 * 60)
+
+        # Check that media has been correctly purged.
+        # Local media should be unaffected.
+        # Remote media accessed <30 days ago should still exist.
+        self._assert_if_mxc_uris_purged(
+            purged=[
+                (self.remote_server_name, self.remote_not_recently_accessed_media),
+            ],
+            not_purged=[
+                (self.remote_server_name, self.remote_recently_accessed_media),
+                (self.hs.config.server.server_name, self.local_recently_accessed_media),
+                (
+                    self.hs.config.server.server_name,
+                    self.local_not_recently_accessed_media,
+                ),
+                (self.hs.config.server.server_name, self.local_never_accessed_media),
+            ],
+        )
+
+    def _assert_if_mxc_uris_purged(
+        self, purged: Iterable[Tuple[str, str]], not_purged: Iterable[Tuple[str, str]]
+    ) -> None:
+        def _assert_mxc_uri_purge_state(
+            server_name: str, media_id: str, expect_purged: bool
+        ) -> None:
+            """Given an MXC URI, assert whether it has been purged or not."""
+            if server_name == self.hs.config.server.server_name:
+                found_media_dict = self.get_success(
+                    self.store.get_local_media(media_id)
+                )
+            else:
+                found_media_dict = self.get_success(
+                    self.store.get_cached_remote_media(server_name, media_id)
+                )
+
+            mxc_uri = f"mxc://{server_name}/{media_id}"
+
+            if expect_purged:
+                self.assertIsNone(
+                    found_media_dict, msg=f"{mxc_uri} unexpectedly not purged"
+                )
+            else:
+                self.assertIsNotNone(
+                    found_media_dict,
+                    msg=f"{mxc_uri} unexpectedly purged",
+                )
+
+        # Assert that the given MXC URIs have either been correctly purged or not.
+        for server_name, media_id in purged:
+            _assert_mxc_uri_purge_state(server_name, media_id, expect_purged=True)
+        for server_name, media_id in not_purged:
+            _assert_mxc_uri_purge_state(server_name, media_id, expect_purged=False)


### PR DESCRIPTION
Closes https://github.com/matrix-org/synapse/issues/6832.

Adds configuration options for automatically removing media if it hasn't been accessed (either locally or remotely) after a certain period of time. This is managed by an hourly background job that searches the database for old media according to the configured lifetimes, removing the files from disk if any is found.

TODO:

- [x] unit tests
    - [x] Test purging media with an old last_accessed date, and that recently accessed media is not affected
    - [x] Test purging media with no last_accessed date, but an old creation date, and that recently created media is not affected

Questions:

* ~~Do we apply any jitter to our background jobs? Otherwise I feel that a lot is going to happen 1hr after your start your homeserver.~~ I don't think we do. However, the period is now configurable with the default being every 24 hours. This is also not really a problem to consider in this PR.