### PR TITLE
Tidy up and type-hint the database engine modules

### DIFF
--- a/changelog.d/12734.misc
+++ b/changelog.d/12734.misc
@@ -1,0 +1,1 @@
+Tidy up and type-hint the database engine modules.

--- a/mypy.ini
+++ b/mypy.ini
@@ -232,6 +232,9 @@ disallow_untyped_defs = True
 [mypy-synapse.storage.databases.main.user_erasure_store]
 disallow_untyped_defs = True
 
+[mypy-synapse.storage.engines.*]
+disallow_untyped_defs = True
+
 [mypy-synapse.storage.prepare_database]
 disallow_untyped_defs = True
 

--- a/synapse/storage/engines/__init__.py
+++ b/synapse/storage/engines/__init__.py
@@ -11,25 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any, Mapping
 
 from ._base import BaseDatabaseEngine, IncorrectDatabaseSetup
 from .postgres import PostgresEngine
 from .sqlite import Sqlite3Engine
 
 
-def create_engine(database_config) -> BaseDatabaseEngine:
+def create_engine(database_config: Mapping[str, Any]) -> BaseDatabaseEngine:
     name = database_config["name"]
 
     if name == "sqlite3":
-        import sqlite3
-
-        return Sqlite3Engine(sqlite3, database_config)
+        return Sqlite3Engine(database_config)
 
     if name == "psycopg2":
-        # Note that psycopg2cffi-compat provides the psycopg2 module on pypy.
-        import psycopg2
-
-        return PostgresEngine(psycopg2, database_config)
+        return PostgresEngine(database_config)
 
     raise RuntimeError("Unsupported database engine '%s'" % (name,))
 

--- a/synapse/storage/engines/_base.py
+++ b/synapse/storage/engines/_base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import abc
 from enum import IntEnum
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Mapping, Optional, TypeVar
 
 from synapse.storage.types import Connection, Cursor, DBAPI2Module
 
@@ -35,7 +35,7 @@ ConnectionType = TypeVar("ConnectionType", bound=Connection)
 
 
 class BaseDatabaseEngine(Generic[ConnectionType], metaclass=abc.ABCMeta):
-    def __init__(self, module: DBAPI2Module):
+    def __init__(self, module: DBAPI2Module, config: Mapping[str, Any]):
         self.module = module
 
     @property

--- a/synapse/storage/engines/_base.py
+++ b/synapse/storage/engines/_base.py
@@ -102,12 +102,12 @@ class BaseDatabaseEngine(Generic[ConnectionType], metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def in_transaction(self, conn: Connection) -> bool:
+    def in_transaction(self, conn: ConnectionType) -> bool:
         """Whether the connection is currently in a transaction."""
         ...
 
     @abc.abstractmethod
-    def attempt_to_set_autocommit(self, conn: Connection, autocommit: bool):
+    def attempt_to_set_autocommit(self, conn: ConnectionType, autocommit: bool):
         """Attempt to set the connections autocommit mode.
 
         When True queries are run outside of transactions.
@@ -119,7 +119,7 @@ class BaseDatabaseEngine(Generic[ConnectionType], metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def attempt_to_set_isolation_level(
-        self, conn: Connection, isolation_level: Optional[int]
+        self, conn: ConnectionType, isolation_level: Optional[int]
     ):
         """Attempt to set the connections isolation level.
 

--- a/synapse/storage/engines/_base.py
+++ b/synapse/storage/engines/_base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import abc
 from enum import IntEnum
-from typing import Any, Generic, Mapping, Optional, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from synapse.storage.types import Connection
 
@@ -32,7 +32,7 @@ ConnectionType = TypeVar("ConnectionType", bound=Connection)
 
 
 class BaseDatabaseEngine(Generic[ConnectionType], metaclass=abc.ABCMeta):
-    def __init__(self, module, database_config: Mapping[str, Any]):
+    def __init__(self, module):
         self.module = module
 
     @property

--- a/synapse/storage/engines/_base.py
+++ b/synapse/storage/engines/_base.py
@@ -15,7 +15,7 @@ import abc
 from enum import IntEnum
 from typing import Generic, Optional, TypeVar
 
-from synapse.storage.types import Connection
+from synapse.storage.types import Connection, DBAPI2Module
 
 
 class IsolationLevel(IntEnum):
@@ -32,7 +32,7 @@ ConnectionType = TypeVar("ConnectionType", bound=Connection)
 
 
 class BaseDatabaseEngine(Generic[ConnectionType], metaclass=abc.ABCMeta):
-    def __init__(self, module):
+    def __init__(self, module: DBAPI2Module):
         self.module = module
 
     @property

--- a/synapse/storage/engines/_base.py
+++ b/synapse/storage/engines/_base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import abc
 from enum import IntEnum
-from typing import Generic, Optional, TypeVar
+from typing import Any, Generic, Mapping, Optional, TypeVar
 
 from synapse.storage.types import Connection
 
@@ -32,7 +32,7 @@ ConnectionType = TypeVar("ConnectionType", bound=Connection)
 
 
 class BaseDatabaseEngine(Generic[ConnectionType], metaclass=abc.ABCMeta):
-    def __init__(self, module, database_config: dict):
+    def __init__(self, module, database_config: Mapping[str, Any]):
         self.module = module
 
     @property

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -32,7 +32,7 @@ class PostgresEngine(BaseDatabaseEngine["psycopg2.connection"]):
     def __init__(self, database_config: Mapping[str, Any]):
         import psycopg2.extensions
 
-        super().__init__(psycopg2, database_config)
+        super().__init__(psycopg2)
         psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 
         # Disables passing `bytes` to txn.execute, c.f. #6186. If you do

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -35,7 +35,7 @@ class PostgresEngine(BaseDatabaseEngine["psycopg2.connection"]):
     def __init__(self, database_config: Mapping[str, Any]):
         import psycopg2.extensions
 
-        super().__init__(psycopg2)
+        super().__init__(psycopg2, database_config)
         psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 
         # Disables passing `bytes` to txn.execute, c.f. #6186. If you do

--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -23,7 +23,7 @@ from synapse.storage.types import Connection
 
 class Sqlite3Engine(BaseDatabaseEngine[sqlite3.Connection]):
     def __init__(self, database_config: Mapping[str, Any]):
-        super().__init__(sqlite3, database_config)
+        super().__init__(sqlite3)
 
         database = database_config.get("args", {}).get("database")
         self._is_in_memory = database in (

--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 class Sqlite3Engine(BaseDatabaseEngine[sqlite3.Connection]):
     def __init__(self, database_config: Mapping[str, Any]):
-        super().__init__(sqlite3)
+        super().__init__(sqlite3, database_config)
 
         database = database_config.get("args", {}).get("database")
         self._is_in_memory = database in (

--- a/synapse/storage/types.py
+++ b/synapse/storage/types.py
@@ -94,3 +94,23 @@ class Connection(Protocol):
         traceback: Optional[TracebackType],
     ) -> Optional[bool]:
         ...
+
+
+class DBAPI2Module(Protocol):
+    """The module-level attributes that we use from PEP 249.
+
+    This is NOT a comprehensive stub for the entire DBAPI2."""
+
+    __name__: str
+
+    Warning: Type[Exception]
+    Error: Type[Exception]
+    DatabaseError: Type[Exception]
+    OperationalError: Type[Exception]
+    IntegrityError: Type[Exception]
+
+    def connect(self, **parameters: object) -> Connection:
+        ...
+
+
+__all__ = ["Cursor", "Connection", "DBAPI2Module"]

--- a/synapse/storage/types.py
+++ b/synapse/storage/types.py
@@ -103,11 +103,61 @@ class DBAPI2Module(Protocol):
 
     __name__: str
 
+    # Exceptions. See https://peps.python.org/pep-0249/#exceptions
+
+    # For our specific drivers:
+    # - Python's sqlite3 module doesn't contains the same descriptions as the
+    #   DBAPI2 spec, see https://docs.python.org/3/library/sqlite3.html#exceptions
+    # - Psycopg2 maps every Postgres error code onto a unique exception class which
+    #   extends from this heirarchy. See
+    #     https://docs.python.org/3/library/sqlite3.html?highlight=sqlite3#exceptions
+    #     https://www.postgresql.org/docs/current/errcodes-appendix.html#ERRCODES-TABLE
     Warning: Type[Exception]
     Error: Type[Exception]
+
+    # Errors are divided into InterfaceErrors (something went wrong in the DB driver)
+    # and DatabaseErrors (something went wrong in the DB). These are both subclasses of
+    # Error, but we can't currently express this in type annotations due to
+    # https://github.com/python/mypy/issues/8397
+    InterfaceError: Type[Exception]
     DatabaseError: Type[Exception]
+
+    # Everything below is a subclass of `DatabaseError`.
+
+    # Roughly: the DB rejected a nonsensical value. Examples:
+    # - integer too big for its data type
+    # - invalid date time format
+    # - strings containing null code points
+    DataError: Type[Exception]
+
+    # Roughly: something went wrong in the DB, but it's not within the application
+    # programmer's control. Examples:
+    # - we failed to establish connection to the DB
+    # - we lost connection to the DB
+    # - deadlock detected
+    # - serialisation failure
+    # - the DB ran out of resources (storage, ram, connections...)
+    # - the DB encountered an error from the OS
     OperationalError: Type[Exception]
+
+    # Roughly: you've given the DB data which breaks a rule you asked it to enforce.
+    # Examples:
+    # - Stop, criminal scum! You violated the foreign key constraint
+    # - Also check constraints, non-null constraints, etc.
     IntegrityError: Type[Exception]
+
+    # Roughly: something went wrong within the DB server itself.
+    InternalError: Type[Exception]
+
+    # Roughly: your application did something silly that you need to fix. Examples:
+    # - You don't have permissions to do something.
+    # - You tried to create a table with duplicate column names.
+    # - You tried to use a reserved name.
+    # - You referred to a column that doesn't exist.
+    ProgrammingError: Type[Exception]
+
+    # Roughly: you've tried to do something that this DB doesn't support.
+    NotSupportedError: Type[Exception]
 
     def connect(self, **parameters: object) -> Connection:
         ...

--- a/synapse/storage/types.py
+++ b/synapse/storage/types.py
@@ -109,54 +109,54 @@ class DBAPI2Module(Protocol):
     # - Python's sqlite3 module doesn't contains the same descriptions as the
     #   DBAPI2 spec, see https://docs.python.org/3/library/sqlite3.html#exceptions
     # - Psycopg2 maps every Postgres error code onto a unique exception class which
-    #   extends from this heirarchy. See
+    #   extends from this hierarchy. See
     #     https://docs.python.org/3/library/sqlite3.html?highlight=sqlite3#exceptions
     #     https://www.postgresql.org/docs/current/errcodes-appendix.html#ERRCODES-TABLE
     Warning: Type[Exception]
     Error: Type[Exception]
 
-    # Errors are divided into InterfaceErrors (something went wrong in the DB driver)
-    # and DatabaseErrors (something went wrong in the DB). These are both subclasses of
-    # Error, but we can't currently express this in type annotations due to
-    # https://github.com/python/mypy/issues/8397
+    # Errors are divided into `InterfaceError`s (something went wrong in the database
+    # driver) and `DatabaseError`s (something went wrong in the database). These are
+    # both subclasses of `Error`, but we can't currently express this in type
+    # annotations due to https://github.com/python/mypy/issues/8397
     InterfaceError: Type[Exception]
     DatabaseError: Type[Exception]
 
     # Everything below is a subclass of `DatabaseError`.
 
-    # Roughly: the DB rejected a nonsensical value. Examples:
-    # - integer too big for its data type
-    # - invalid date time format
-    # - strings containing null code points
+    # Roughly: the database rejected a nonsensical value. Examples:
+    # - An integer was too big for its data type.
+    # - An invalid date time was provided.
+    # - A string contained a null code point.
     DataError: Type[Exception]
 
-    # Roughly: something went wrong in the DB, but it's not within the application
+    # Roughly: something went wrong in the database, but it's not within the application
     # programmer's control. Examples:
-    # - we failed to establish connection to the DB
-    # - we lost connection to the DB
-    # - deadlock detected
-    # - serialisation failure
-    # - the DB ran out of resources (storage, ram, connections...)
-    # - the DB encountered an error from the OS
-    OperationalError: Type[Exception]
+    # - We failed to establish a connection to the database.
+    # - The connection to the database was lost.
+    # - A deadlock was detected.
+    # - A serialisation failure occurred.
+    # - The database ran out of resources, such as storage, memory, connections, etc.
+    # - The database encountered an error from the operating system.
+OperationalError: Type[Exception]
 
-    # Roughly: you've given the DB data which breaks a rule you asked it to enforce.
+    # Roughly: we've given the database data which breaks a rule we asked it to enforce.
     # Examples:
     # - Stop, criminal scum! You violated the foreign key constraint
     # - Also check constraints, non-null constraints, etc.
     IntegrityError: Type[Exception]
 
-    # Roughly: something went wrong within the DB server itself.
+    # Roughly: something went wrong within the database server itself.
     InternalError: Type[Exception]
 
-    # Roughly: your application did something silly that you need to fix. Examples:
-    # - You don't have permissions to do something.
-    # - You tried to create a table with duplicate column names.
-    # - You tried to use a reserved name.
-    # - You referred to a column that doesn't exist.
+    # Roughly: the application did something silly that needs to be fixed. Examples:
+    # - We don't have permissions to do something.
+    # - We tried to create a table with duplicate column names.
+    # - We tried to use a reserved name.
+    # - We referred to a column that doesn't exist.
     ProgrammingError: Type[Exception]
 
-    # Roughly: you've tried to do something that this DB doesn't support.
+    # Roughly: we've tried to do something that this database doesn't support.
     NotSupportedError: Type[Exception]
 
     def connect(self, **parameters: object) -> Connection:

--- a/synapse/storage/types.py
+++ b/synapse/storage/types.py
@@ -138,7 +138,7 @@ class DBAPI2Module(Protocol):
     # - A serialisation failure occurred.
     # - The database ran out of resources, such as storage, memory, connections, etc.
     # - The database encountered an error from the operating system.
-OperationalError: Type[Exception]
+    OperationalError: Type[Exception]
 
     # Roughly: we've given the database data which breaks a rule we asked it to enforce.
     # Examples:


### PR DESCRIPTION
A Friday indulgence.

We tell the engines which module to use as a database driver. I wanted to change this because a) it seems weird, and b) my secret ulterior motive is to add yet more type coverage to Synapse.

Closes #12724.