### PR TITLE
Remove any NULL characters from remote displaynames before updating user directory

### DIFF
--- a/changelog.d/12743.bugfix
+++ b/changelog.d/12743.bugfix
@@ -1,0 +1,2 @@
+Fix a long-standing bug wherein remote display names or avatar URLs containing null bytes caused updating the user directory to fail resulting in high CPU on the main process. Contributed 
+by Nick @ Beeper.

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -465,9 +465,6 @@ class UserDirectoryHandler(StateDeltasHandler):
         prev_name = prev_event.content.get("displayname")
         new_name = event.content.get("displayname")
 
-        # Replace any NULL characters in the name as these cannot be stored in the database
-        new_name = new_name.replace("\x00", "\uFFFD")
-
         # If the new name is an unexpected form, do not update the directory.
         if not isinstance(new_name, str):
             new_name = prev_name

--- a/synapse/handlers/user_directory.py
+++ b/synapse/handlers/user_directory.py
@@ -464,6 +464,10 @@ class UserDirectoryHandler(StateDeltasHandler):
 
         prev_name = prev_event.content.get("displayname")
         new_name = event.content.get("displayname")
+
+        # Replace any NULL characters in the name as these cannot be stored in the database
+        new_name = new_name.replace("\x00", "\uFFFD")
+
         # If the new name is an unexpected form, do not update the directory.
         if not isinstance(new_name, str):
             new_name = prev_name

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -47,6 +47,7 @@ from synapse.storage.database import (
 from synapse.storage.databases.main.events_worker import EventCacheEntry
 from synapse.storage.databases.main.search import SearchEntry
 from synapse.storage.engines.postgres import PostgresEngine
+from synapse.storage.util import non_null_str_or_none
 from synapse.storage.util.id_generators import AbstractStreamIdGenerator
 from synapse.storage.util.sequence import SequenceGenerator
 from synapse.types import JsonDict, StateMap, get_domain_from_id
@@ -1727,9 +1728,6 @@ class PersistEventsStore:
                 for backfilled events because backfilled events in the past do
                 not affect the current local state.
         """
-
-        def non_null_str_or_none(val: Any) -> Optional[str]:
-            return val if isinstance(val, str) and "\u0000" not in val else None
 
         self.db_pool.simple_insert_many_txn(
             txn,

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -42,6 +42,7 @@ from synapse.storage.database import (
 from synapse.storage.databases.main.state import StateFilter
 from synapse.storage.databases.main.state_deltas import StateDeltasStore
 from synapse.storage.engines import PostgresEngine, Sqlite3Engine
+from synapse.storage.util import non_null_str_or_none
 from synapse.types import (
     JsonDict,
     UserProfile,
@@ -470,10 +471,8 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         Update or add a user's profile in the user directory.
         """
         # If the display name or avatar URL are unexpected types, overwrite them.
-        if not isinstance(display_name, str):
-            display_name = None
-        if not isinstance(avatar_url, str):
-            avatar_url = None
+        display_name = non_null_str_or_none(display_name)
+        avatar_url = non_null_str_or_none(avatar_url)
 
         def _update_profile_in_user_dir_txn(txn: LoggingTransaction) -> None:
             self.db_pool.simple_upsert_txn(

--- a/synapse/storage/util/__init__.py
+++ b/synapse/storage/util/__init__.py
@@ -11,3 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from typing import Any, Optional
+
+
+def non_null_str_or_none(val: Any) -> Optional[str]:
+    return val if isinstance(val, str) and "\u0000" not in val else None


### PR DESCRIPTION
An event that looks like this:

```json
{
    "content":
    {
        "displayname": "\u0001VERSION\u0001\u0000",
        "membership": "join"
    }
}
```

Causes an exception updating the user directory table `A string literal cannot contain NUL (0x00) characters` which never passes and just keeps retrying consuming a lot of CPU on main.

Is this the right fix?

Signed off by Nick (nick@beeper.com)

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
