### PR TITLE
add SpamChecker callback for silently dropping inbound federated events

### DIFF
--- a/changelog.d/12744.feature
+++ b/changelog.d/12744.feature
@@ -1,0 +1,1 @@
+Add a `drop_federated_event` callback to `SpamChecker` to disregard inbound federated events before they take up much processing power, in an emergency.

--- a/docs/modules/spam_checker_callbacks.md
+++ b/docs/modules/spam_checker_callbacks.md
@@ -249,6 +249,24 @@ callback returns `False`, Synapse falls through to the next one. The value of th
 callback that does not return `False` will be used. If this happens, Synapse will not call
 any of the subsequent implementations of this callback.
 
+### `drop_federated_event`
+
+_First introduced in Synapse v1.?.?_
+
+```python
+async def drop_federated_event(event: "synapse.events.EventBase") -> bool
+```
+
+Called when checking whether a remote server can federate an event with us. **Returning
+`True` from this function will silently drop a federated event and split-brain our view
+of a room's DAG, and thus you shouldn't use this callback unless you know what you are
+doing.**
+
+If multiple modules implement this callback, they will be considered in order. If a
+callback returns `False`, Synapse falls through to the next one. The value of the first
+callback that does not return `False` will be used. If this happens, Synapse will not call
+any of the subsequent implementations of this callback.
+
 ## Example
 
 The example below is a module that implements the spam checker callback

--- a/docs/modules/spam_checker_callbacks.md
+++ b/docs/modules/spam_checker_callbacks.md
@@ -251,7 +251,7 @@ any of the subsequent implementations of this callback.
 
 ### `drop_federated_event`
 
-_First introduced in Synapse v1.?.?_
+_First introduced in Synapse v1.60.0_
 
 ```python
 async def drop_federated_event(event: "synapse.events.EventBase") -> bool

--- a/docs/modules/spam_checker_callbacks.md
+++ b/docs/modules/spam_checker_callbacks.md
@@ -249,12 +249,12 @@ callback returns `False`, Synapse falls through to the next one. The value of th
 callback that does not return `False` will be used. If this happens, Synapse will not call
 any of the subsequent implementations of this callback.
 
-### `drop_federated_event`
+### `should_drop_federated_event`
 
 _First introduced in Synapse v1.60.0_
 
 ```python
-async def drop_federated_event(event: "synapse.events.EventBase") -> bool
+async def should_drop_federated_event(event: "synapse.events.EventBase") -> bool
 ```
 
 Called when checking whether a remote server can federate an event with us. **Returning

--- a/docs/spam_checker.md
+++ b/docs/spam_checker.md
@@ -32,6 +32,7 @@ well as some specific methods:
 * `check_username_for_spam`
 * `check_registration_for_spam`
 * `check_media_file_for_spam`
+* `drop_federated_event`
 
 The details of each of these methods (as well as their inputs and outputs)
 are documented in the `synapse.events.spamcheck.SpamChecker` class.
@@ -86,6 +87,10 @@ class ExampleSpamChecker:
 
     async def check_media_file_for_spam(self, file_wrapper, file_info):
         return False  # allow all media
+
+
+    async def drop_federated_event(self, foo):
+        return False  # don't silently drop any inbound federated events
 ```
 
 ## Configuration

--- a/docs/spam_checker.md
+++ b/docs/spam_checker.md
@@ -32,7 +32,6 @@ well as some specific methods:
 * `check_username_for_spam`
 * `check_registration_for_spam`
 * `check_media_file_for_spam`
-* `should_drop_federated_event`
 
 The details of each of these methods (as well as their inputs and outputs)
 are documented in the `synapse.events.spamcheck.SpamChecker` class.
@@ -87,10 +86,6 @@ class ExampleSpamChecker:
 
     async def check_media_file_for_spam(self, file_wrapper, file_info):
         return False  # allow all media
-
-
-    async def should_drop_federated_event(self, foo):
-        return False  # don't silently drop any inbound federated events
 ```
 
 ## Configuration

--- a/docs/spam_checker.md
+++ b/docs/spam_checker.md
@@ -32,7 +32,7 @@ well as some specific methods:
 * `check_username_for_spam`
 * `check_registration_for_spam`
 * `check_media_file_for_spam`
-* `drop_federated_event`
+* `should_drop_federated_event`
 
 The details of each of these methods (as well as their inputs and outputs)
 are documented in the `synapse.events.spamcheck.SpamChecker` class.
@@ -89,7 +89,7 @@ class ExampleSpamChecker:
         return False  # allow all media
 
 
-    async def drop_federated_event(self, foo):
+    async def should_drop_federated_event(self, foo):
         return False  # don't silently drop any inbound federated events
 ```
 

--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -97,7 +97,6 @@ def load_legacy_spam_checkers(hs: "synapse.server.HomeServer") -> None:
     # which name appears in this set, we'll want to register it.
     spam_checker_methods = {
         "check_event_for_spam",
-        "drop_federated_event",
         "user_may_invite",
         "user_may_create_room",
         "user_may_create_room_alias",

--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -44,7 +44,7 @@ CHECK_EVENT_FOR_SPAM_CALLBACK = Callable[
     ["synapse.events.EventBase"],
     Awaitable[Union[bool, str]],
 ]
-DROP_FEDERATED_EVENT_CALLBACK = Callable[
+SHOULD_DROP_FEDERATED_EVENT_CALLBACK = Callable[
     ["synapse.events.EventBase"],
     Awaitable[Union[bool, str]],
 ]
@@ -173,7 +173,9 @@ class SpamChecker:
         self.clock = hs.get_clock()
 
         self._check_event_for_spam_callbacks: List[CHECK_EVENT_FOR_SPAM_CALLBACK] = []
-        self._drop_federated_event_callbacks: List[DROP_FEDERATED_EVENT_CALLBACK] = []
+        self._should_drop_federated_event_callbacks: List[
+            SHOULD_DROP_FEDERATED_EVENT_CALLBACK
+        ] = []
         self._user_may_join_room_callbacks: List[USER_MAY_JOIN_ROOM_CALLBACK] = []
         self._user_may_invite_callbacks: List[USER_MAY_INVITE_CALLBACK] = []
         self._user_may_send_3pid_invite_callbacks: List[
@@ -197,7 +199,9 @@ class SpamChecker:
     def register_callbacks(
         self,
         check_event_for_spam: Optional[CHECK_EVENT_FOR_SPAM_CALLBACK] = None,
-        drop_federated_event: Optional[DROP_FEDERATED_EVENT_CALLBACK] = None,
+        should_drop_federated_event: Optional[
+            SHOULD_DROP_FEDERATED_EVENT_CALLBACK
+        ] = None,
         user_may_join_room: Optional[USER_MAY_JOIN_ROOM_CALLBACK] = None,
         user_may_invite: Optional[USER_MAY_INVITE_CALLBACK] = None,
         user_may_send_3pid_invite: Optional[USER_MAY_SEND_3PID_INVITE_CALLBACK] = None,
@@ -216,8 +220,10 @@ class SpamChecker:
         if check_event_for_spam is not None:
             self._check_event_for_spam_callbacks.append(check_event_for_spam)
 
-        if drop_federated_event is not None:
-            self._drop_federated_event_callbacks.append(drop_federated_event)
+        if should_drop_federated_event is not None:
+            self._should_drop_federated_event_callbacks.append(
+                should_drop_federated_event
+            )
 
         if user_may_join_room is not None:
             self._user_may_join_room_callbacks.append(user_may_join_room)
@@ -278,7 +284,7 @@ class SpamChecker:
 
         return False
 
-    async def drop_federated_event(
+    async def should_drop_federated_event(
         self, event: "synapse.events.EventBase"
     ) -> Union[bool, str]:
         """Checks if a given federated event is considered "spammy" by this
@@ -293,7 +299,7 @@ class SpamChecker:
         Returns:
             True if the event should be silently dropped
         """
-        for callback in self._drop_federated_event_callbacks:
+        for callback in self._should_drop_federated_event_callbacks:
             with Measure(
                 self.clock, "{}.{}".format(callback.__module__, callback.__qualname__)
             ):

--- a/synapse/events/spamcheck.py
+++ b/synapse/events/spamcheck.py
@@ -44,6 +44,10 @@ CHECK_EVENT_FOR_SPAM_CALLBACK = Callable[
     ["synapse.events.EventBase"],
     Awaitable[Union[bool, str]],
 ]
+DROP_FEDERATED_EVENT_CALLBACK = Callable[
+    ["synapse.events.EventBase"],
+    Awaitable[Union[bool, str]],
+]
 USER_MAY_JOIN_ROOM_CALLBACK = Callable[[str, str, bool], Awaitable[bool]]
 USER_MAY_INVITE_CALLBACK = Callable[[str, str, str], Awaitable[bool]]
 USER_MAY_SEND_3PID_INVITE_CALLBACK = Callable[[str, str, str, str], Awaitable[bool]]
@@ -93,6 +97,7 @@ def load_legacy_spam_checkers(hs: "synapse.server.HomeServer") -> None:
     # which name appears in this set, we'll want to register it.
     spam_checker_methods = {
         "check_event_for_spam",
+        "drop_federated_event",
         "user_may_invite",
         "user_may_create_room",
         "user_may_create_room_alias",
@@ -168,6 +173,7 @@ class SpamChecker:
         self.clock = hs.get_clock()
 
         self._check_event_for_spam_callbacks: List[CHECK_EVENT_FOR_SPAM_CALLBACK] = []
+        self._drop_federated_event_callbacks: List[DROP_FEDERATED_EVENT_CALLBACK] = []
         self._user_may_join_room_callbacks: List[USER_MAY_JOIN_ROOM_CALLBACK] = []
         self._user_may_invite_callbacks: List[USER_MAY_INVITE_CALLBACK] = []
         self._user_may_send_3pid_invite_callbacks: List[
@@ -191,6 +197,7 @@ class SpamChecker:
     def register_callbacks(
         self,
         check_event_for_spam: Optional[CHECK_EVENT_FOR_SPAM_CALLBACK] = None,
+        drop_federated_event: Optional[DROP_FEDERATED_EVENT_CALLBACK] = None,
         user_may_join_room: Optional[USER_MAY_JOIN_ROOM_CALLBACK] = None,
         user_may_invite: Optional[USER_MAY_INVITE_CALLBACK] = None,
         user_may_send_3pid_invite: Optional[USER_MAY_SEND_3PID_INVITE_CALLBACK] = None,
@@ -208,6 +215,9 @@ class SpamChecker:
         """Register callbacks from module for each hook."""
         if check_event_for_spam is not None:
             self._check_event_for_spam_callbacks.append(check_event_for_spam)
+
+        if drop_federated_event is not None:
+            self._drop_federated_event_callbacks.append(drop_federated_event)
 
         if user_may_join_room is not None:
             self._user_may_join_room_callbacks.append(user_may_join_room)
@@ -259,6 +269,31 @@ class SpamChecker:
             will be used as the error message returned to the user.
         """
         for callback in self._check_event_for_spam_callbacks:
+            with Measure(
+                self.clock, "{}.{}".format(callback.__module__, callback.__qualname__)
+            ):
+                res: Union[bool, str] = await delay_cancellation(callback(event))
+            if res:
+                return res
+
+        return False
+
+    async def drop_federated_event(
+        self, event: "synapse.events.EventBase"
+    ) -> Union[bool, str]:
+        """Checks if a given federated event is considered "spammy" by this
+        server.
+
+        If the server considers an event spammy, it will be silently dropped,
+        and in doing so will split-brain our view of the room's DAG.
+
+        Args:
+            event: the event to be checked
+
+        Returns:
+            True if the event should be silently dropped
+        """
+        for callback in self._drop_federated_event_callbacks:
             with Measure(
                 self.clock, "{}.{}".format(callback.__module__, callback.__qualname__)
             ):

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -1039,10 +1039,18 @@ class FederationServer(FederationBase):
                 pdu.room_id, room_version, lock, origin, pdu
             )
 
-    async def _get_next_valid_staged_event_for_room(
+    async def _get_next_nonspam_staged_event_for_room(
         self, room_id: str, room_version: RoomVersion
     ) -> Optional[Tuple[str, EventBase]]:
-        """Return the first non-spam event from staging queue."""
+        """Fetch the first non-spam event from staging queue.
+
+        Args:
+            room_id: the room to fetch the first non-spam event in.
+            room_version: the version of the room.
+
+        Returns:
+            The first non-spam event in that room.
+        """
 
         while True:
             # We need to do this check outside the lock to avoid a race between
@@ -1143,7 +1151,7 @@ class FederationServer(FederationBase):
                         (self._clock.time_msec() - received_ts) / 1000
                     )
 
-            next = await self._get_next_valid_staged_event_for_room(
+            next = await self._get_next_nonspam_staged_event_for_room(
                 room_id, room_version
             )
 

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -1020,7 +1020,7 @@ class FederationServer(FederationBase):
         except SynapseError as e:
             raise FederationError("ERROR", e.code, e.msg, affected=pdu.event_id)
 
-        if await self._spam_checker.drop_federated_event(pdu):
+        if await self._spam_checker.should_drop_federated_event(pdu):
             logger.warning(
                 "Unstaged federated event contains spam, dropping %s", pdu.event_id
             )
@@ -1129,7 +1129,7 @@ class FederationServer(FederationBase):
 
                 origin, event = next
 
-                if await self._spam_checker.drop_federated_event(event):
+                if await self._spam_checker.should_drop_federated_event(event):
                     logger.warning(
                         "Staged federated event contains spam, dropping %s",
                         event.event_id,

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -47,7 +47,7 @@ from synapse.events.spamcheck import (
     CHECK_MEDIA_FILE_FOR_SPAM_CALLBACK,
     CHECK_REGISTRATION_FOR_SPAM_CALLBACK,
     CHECK_USERNAME_FOR_SPAM_CALLBACK,
-    DROP_FEDERATED_EVENT_CALLBACK,
+    SHOULD_DROP_FEDERATED_EVENT_CALLBACK,
     USER_MAY_CREATE_ROOM_ALIAS_CALLBACK,
     USER_MAY_CREATE_ROOM_CALLBACK,
     USER_MAY_INVITE_CALLBACK,
@@ -235,7 +235,9 @@ class ModuleApi:
         self,
         *,
         check_event_for_spam: Optional[CHECK_EVENT_FOR_SPAM_CALLBACK] = None,
-        drop_federated_event: Optional[DROP_FEDERATED_EVENT_CALLBACK] = None,
+        should_drop_federated_event: Optional[
+            SHOULD_DROP_FEDERATED_EVENT_CALLBACK
+        ] = None,
         user_may_join_room: Optional[USER_MAY_JOIN_ROOM_CALLBACK] = None,
         user_may_invite: Optional[USER_MAY_INVITE_CALLBACK] = None,
         user_may_send_3pid_invite: Optional[USER_MAY_SEND_3PID_INVITE_CALLBACK] = None,
@@ -256,7 +258,7 @@ class ModuleApi:
         """
         return self._spam_checker.register_callbacks(
             check_event_for_spam=check_event_for_spam,
-            drop_federated_event=drop_federated_event,
+            should_drop_federated_event=should_drop_federated_event,
             user_may_join_room=user_may_join_room,
             user_may_invite=user_may_invite,
             user_may_send_3pid_invite=user_may_send_3pid_invite,

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -47,6 +47,7 @@ from synapse.events.spamcheck import (
     CHECK_MEDIA_FILE_FOR_SPAM_CALLBACK,
     CHECK_REGISTRATION_FOR_SPAM_CALLBACK,
     CHECK_USERNAME_FOR_SPAM_CALLBACK,
+    DROP_FEDERATED_EVENT_CALLBACK,
     USER_MAY_CREATE_ROOM_ALIAS_CALLBACK,
     USER_MAY_CREATE_ROOM_CALLBACK,
     USER_MAY_INVITE_CALLBACK,
@@ -234,6 +235,7 @@ class ModuleApi:
         self,
         *,
         check_event_for_spam: Optional[CHECK_EVENT_FOR_SPAM_CALLBACK] = None,
+        drop_federated_event: Optional[DROP_FEDERATED_EVENT_CALLBACK] = None,
         user_may_join_room: Optional[USER_MAY_JOIN_ROOM_CALLBACK] = None,
         user_may_invite: Optional[USER_MAY_INVITE_CALLBACK] = None,
         user_may_send_3pid_invite: Optional[USER_MAY_SEND_3PID_INVITE_CALLBACK] = None,
@@ -254,6 +256,7 @@ class ModuleApi:
         """
         return self._spam_checker.register_callbacks(
             check_event_for_spam=check_event_for_spam,
+            drop_federated_event=drop_federated_event,
             user_may_join_room=user_may_join_room,
             user_may_invite=user_may_invite,
             user_may_send_3pid_invite=user_may_send_3pid_invite,


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

### esoterica

something to be very careful about in a feature like this is correctly expressing the danger of such a callback. ignoring a federated event splitbrains our view of the DAG and thus people shouldn't use this if they don't know what they're doing; i chose `drop_federated_event()` for this, but I could see there being better options.