### PR TITLE
Add index to cache invalidations

### DIFF
--- a/changelog.d/12747.bugfix
+++ b/changelog.d/12747.bugfix
@@ -1,0 +1,1 @@
+Fix database performance problem for large servers with lots of workers.

--- a/changelog.d/12747.bugfix
+++ b/changelog.d/12747.bugfix
@@ -1,1 +1,1 @@
-Fix database performance problem for large servers with lots of workers.
+Fix poor database performance when reading the cache invalidation stream for large servers with lots of workers.

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -62,6 +62,7 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
             index_name="cache_invalidation_stream_by_instance_instance_index",
             table="cache_invalidation_stream_by_instance",
             columns=("instance_name", "stream_id"),
+            psql_only=True,  # The table is only on postgres DBs.
         )
 
     async def get_all_updated_caches(

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -57,6 +57,13 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
 
         self._instance_name = hs.get_instance_name()
 
+        self.db_pool.updates.register_background_index_update(
+            update_name="cache_invalidation_index_by_instance",
+            index_name="cache_invalidation_stream_by_instance_instance_index",
+            table="cache_invalidation_stream_by_instance",
+            columns=("instance_name", "stream_id"),
+        )
+
     async def get_all_updated_caches(
         self, instance_name: str, last_id: int, current_id: int, limit: int
     ) -> Tuple[List[Tuple[int, tuple]], int, bool]:

--- a/synapse/storage/schema/main/delta/69/02cache_invalidation_index.sql
+++ b/synapse/storage/schema/main/delta/69/02cache_invalidation_index.sql
@@ -1,0 +1,18 @@
+/* Copyright 2022 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Background update to clear the inboxes of hidden and deleted devices.
+INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
+  (6902, 'cache_invalidation_index_by_instance', '{}');


### PR DESCRIPTION
For workers that rarely write to the cache the `get_all_updated_caches`
query can become expensive if the worker falls behind when reading the
cache.
