### PR TITLE
Switch the 'Configuration' link in the docs homepage to the config manual

### DIFF
--- a/changelog.d/12748.doc
+++ b/changelog.d/12748.doc
@@ -1,0 +1,1 @@
+Link to the configuration manual from the welcome page of the documentation.

--- a/docs/welcome_and_overview.md
+++ b/docs/welcome_and_overview.md
@@ -11,13 +11,13 @@ This documentation covers topics for **installation**, **configuration** and
 
 * Learn how to [install](setup/installation.md) and
   [configure](usage/configuration/config_documentation.md) your own instance, perhaps with [Single
-  Sign-On](usage/configuration/user_authentication/index.html).
+  Sign-On](usage/configuration/user_authentication/README.md).
 
 * See how to [upgrade](upgrade.md) between Synapse versions.
 
 * Administer your instance using the [Admin
-  API](usage/administration/admin_api/index.html), installing [pluggable
-  modules](modules/index.html), or by accessing the [manhole](manhole.md).
+  API](usage/administration/admin_api/README.md), installing [pluggable
+  modules](modules/index.md), or by accessing the [manhole](manhole.md).
 
 * Learn how to [read log lines](usage/administration/request_log.md), configure
   [logging](usage/configuration/logging_sample_config.md) or set up [structured
@@ -50,7 +50,7 @@ following documentation:
   issue](https://github.com/matrix-org/synapse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 * Understand [how Synapse is
-  built](development/internal_documentation/index.html), how to [migrate
+  built](development/internal_documentation/README.md), how to [migrate
   database schemas](development/database_schema.md), learn about
   [federation](federate.md) and how to [set up a local
   federation](federate.md#running-a-demo-federation-of-synapses) for development.

--- a/docs/welcome_and_overview.md
+++ b/docs/welcome_and_overview.md
@@ -11,13 +11,13 @@ This documentation covers topics for **installation**, **configuration** and
 
 * Learn how to [install](setup/installation.md) and
   [configure](usage/configuration/config_documentation.md) your own instance, perhaps with [Single
-  Sign-On](usage/configuration/user_authentication/README.md).
+  Sign-On](usage/configuration/user_authentication/index.html).
 
 * See how to [upgrade](upgrade.md) between Synapse versions.
 
 * Administer your instance using the [Admin
-  API](usage/administration/admin_api/README.md), installing [pluggable
-  modules](modules/index.md), or by accessing the [manhole](manhole.md).
+  API](usage/administration/admin_api/index.html), installing [pluggable
+  modules](modules/index.html), or by accessing the [manhole](manhole.md).
 
 * Learn how to [read log lines](usage/administration/request_log.md), configure
   [logging](usage/configuration/logging_sample_config.md) or set up [structured
@@ -50,7 +50,7 @@ following documentation:
   issue](https://github.com/matrix-org/synapse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 * Understand [how Synapse is
-  built](development/internal_documentation/README.md), how to [migrate
+  built](development/internal_documentation/index.html), how to [migrate
   database schemas](development/database_schema.md), learn about
   [federation](federate.md) and how to [set up a local
   federation](federate.md#running-a-demo-federation-of-synapses) for development.

--- a/docs/welcome_and_overview.md
+++ b/docs/welcome_and_overview.md
@@ -7,7 +7,7 @@ team.
 ## Installing and using Synapse
 
 This documentation covers topics for **installation**, **configuration** and
-**maintainence** of your Synapse process:
+**maintenance** of your Synapse process:
 
 * Learn how to [install](setup/installation.md) and
   [configure](usage/configuration/config_documentation.md) your own instance, perhaps with [Single
@@ -65,7 +65,7 @@ following documentation:
 
 Want to help keep Synapse going but don't know how to code? Synapse is a
 [Matrix.org Foundation](https://matrix.org) project. Consider becoming a
-supportor on [Liberapay](https://liberapay.com/matrixdotorg),
+supporter on [Liberapay](https://liberapay.com/matrixdotorg),
 [Patreon](https://patreon.com/matrixdotorg) or through
 [PayPal](https://paypal.me/matrixdotorg) via a one-time donation.
 

--- a/docs/welcome_and_overview.md
+++ b/docs/welcome_and_overview.md
@@ -10,7 +10,7 @@ This documentation covers topics for **installation**, **configuration** and
 **maintainence** of your Synapse process:
 
 * Learn how to [install](setup/installation.md) and
-  [configure](usage/configuration/index.html) your own instance, perhaps with [Single
+  [configure](usage/configuration/config_documentation.md) your own instance, perhaps with [Single
   Sign-On](usage/configuration/user_authentication/index.html).
 
 * See how to [upgrade](upgrade.md) between Synapse versions.


### PR DESCRIPTION
As the config manual is probably where people actually want to be when looking to configure their homeserver.

I also fixed a bunch of `*.html` links on this page - they should be links to the markdown instead. mdbook will then translate these to `*.html` when the book is built. As well as a couple typos.

Recommended to review commit-by-small-amount-of-commits.