### PR TITLE
Fix typo in name of 'run_background_tasks_on' option in config manual

### DIFF
--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3454,7 +3454,7 @@ stream_writers:
   typing: worker1
 ```
 ---
-Config option: `run_background_task_on`
+Config option: `run_background_tasks_on`
 
 The worker that is used to run background tasks (e.g. cleaning up expired
 data). If not provided this defaults to the main process.


### PR DESCRIPTION
run_background_task_on -> run_background_task**s**_on

Mostly making this PR for posterity. I don't think it needs review.