### PR TITLE
Discard null-containing strings before updating the user directory

### DIFF
--- a/changelog.d/12762.misc
+++ b/changelog.d/12762.misc
@@ -1,0 +1,1 @@
+Fix a long-standing bug where the user directory background process would fail to make forward progress if a user included a null codepoint in their display name or avatar.

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -109,10 +109,10 @@ class RoomStateEventRestServlet(TransactionRestServlet):
         self.auth = hs.get_auth()
 
     def register(self, http_server: HttpServer) -> None:
-        # /room/$roomid/state/$eventtype
+        # /rooms/$roomid/state/$eventtype
         no_state_key = "/rooms/(?P<room_id>[^/]*)/state/(?P<event_type>[^/]*)$"
 
-        # /room/$roomid/state/$eventtype/$statekey
+        # /rooms/$roomid/state/$eventtype/$statekey
         state_key = (
             "/rooms/(?P<room_id>[^/]*)/state/"
             "(?P<event_type>[^/]*)/(?P<state_key>[^/]*)$"

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -52,6 +52,7 @@ from synapse.storage.util.sequence import SequenceGenerator
 from synapse.types import JsonDict, StateMap, get_domain_from_id
 from synapse.util import json_encoder
 from synapse.util.iterutils import batch_iter, sorted_topologically
+from synapse.util.stringutils import non_null_str_or_none
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
@@ -1727,9 +1728,6 @@ class PersistEventsStore:
                 for backfilled events because backfilled events in the past do
                 not affect the current local state.
         """
-
-        def non_null_str_or_none(val: Any) -> Optional[str]:
-            return val if isinstance(val, str) and "\u0000" not in val else None
 
         self.db_pool.simple_insert_many_txn(
             txn,

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -29,6 +29,7 @@ from typing import (
 from typing_extensions import TypedDict
 
 from synapse.api.errors import StoreError
+from synapse.util.stringutils import non_null_str_or_none
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
@@ -469,11 +470,9 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         """
         Update or add a user's profile in the user directory.
         """
-        # If the display name or avatar URL are unexpected types, overwrite them.
-        if not isinstance(display_name, str):
-            display_name = None
-        if not isinstance(avatar_url, str):
-            avatar_url = None
+        # If the display name or avatar URL are unexpected types, replace with None.
+        display_name = non_null_str_or_none(display_name)
+        avatar_url = non_null_str_or_none(avatar_url)
 
         def _update_profile_in_user_dir_txn(txn: LoggingTransaction) -> None:
             self.db_pool.simple_upsert_txn(

--- a/synapse/util/stringutils.py
+++ b/synapse/util/stringutils.py
@@ -16,7 +16,7 @@ import itertools
 import re
 import secrets
 import string
-from typing import Iterable, Optional, Tuple
+from typing import Any, Iterable, Optional, Tuple
 
 from netaddr import valid_ipv6
 
@@ -247,3 +247,7 @@ def base62_encode(num: int, minwidth: int = 1) -> str:
     # pad to minimum width
     pad = "0" * (minwidth - len(res))
     return pad + res
+
+
+def non_null_str_or_none(val: Any) -> Optional[str]:
+    return val if isinstance(val, str) and "\u0000" not in val else None

--- a/synapse/util/stringutils.py
+++ b/synapse/util/stringutils.py
@@ -250,4 +250,8 @@ def base62_encode(num: int, minwidth: int = 1) -> str:
 
 
 def non_null_str_or_none(val: Any) -> Optional[str]:
+    """Check that the arg is a string containing no null (U+0000) codepoints.
+
+    If so, returns the given string unmodified; otherwise, returns None.
+    """
     return val if isinstance(val, str) and "\u0000" not in val else None

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -1007,6 +1007,35 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         self.assertEqual(in_public, {(bob, room1), (bob, room2)})
         self.assertEqual(in_private, set())
 
+    def test_ignore_display_names_with_null_codepoints(self) -> None:
+        MXC_DUMMY = "mxc://dummy"
+
+        # Alice creates a public room.
+        alice = self.register_user("alice", "pass")
+        alice_token = self.login(alice, "pass")
+
+        # Alice has a user directory entry to start with.
+        self.assertIn(
+            alice,
+            self.get_success(self.user_dir_helper.get_profiles_in_user_directory()),
+        )
+
+        # Alice changes her name to include a null codepoint.
+        self.get_success(
+            self.hs.get_user_directory_handler().handle_local_profile_change(
+                alice,
+                ProfileInfo(
+                    display_name="abcd\u0000efgh",
+                    avatar_url=MXC_DUMMY,
+                ),
+            )
+        )
+        # Alice's profile should be updated with the new avatar, but no display name.
+        self.assertEqual(
+            self.get_success(self.user_dir_helper.get_profiles_in_user_directory()),
+            {alice: ProfileInfo(display_name=None, avatar_url=MXC_DUMMY)},
+        )
+
 
 class TestUserDirSearchDisabled(unittest.HomeserverTestCase):
     servlets = [

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -1012,7 +1012,6 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
 
         # Alice creates a public room.
         alice = self.register_user("alice", "pass")
-        alice_token = self.login(alice, "pass")
 
         # Alice has a user directory entry to start with.
         self.assertIn(


### PR DESCRIPTION
Fixes #12755.
Closes #12743.

I tested the new test case (8c977edec) without the fix and reproduced a postgres error for my troubles.

```
Traceback (most recent call last):
  File "/home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-YNqvS2_4-py3.10/lib/python3.10/site-packages/twisted/internet/defer.py", line 700, in errback
    self._startRunCallbacks(fail)
  File "/home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-YNqvS2_4-py3.10/lib/python3.10/site-packages/twisted/internet/defer.py", line 763, in _startRunCallbacks
    self._runCallbacks()
  File "/home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-YNqvS2_4-py3.10/lib/python3.10/site-packages/twisted/internet/defer.py", line 857, in _runCallbacks
    current.result = callback(  # type: ignore[misc]
  File "/home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-YNqvS2_4-py3.10/lib/python3.10/site-packages/twisted/internet/defer.py", line 1750, in gotResult
    current_context.run(_inlineCallbacks, r, gen, status)
--- <exception caught here> ---
  File "/home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-YNqvS2_4-py3.10/lib/python3.10/site-packages/twisted/internet/defer.py", line 1656, in _inlineCallbacks
    result = current_context.run(
  File "/home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-YNqvS2_4-py3.10/lib/python3.10/site-packages/twisted/python/failure.py", line 514, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/home/dmr/workspace/synapse/synapse/handlers/user_directory.py", line 136, in handle_local_profile_change
    await self.store.update_profile_in_user_dir(
  File "/home/dmr/workspace/synapse/synapse/storage/databases/main/user_directory.py", line 522, in update_profile_in_user_dir
    await self.db_pool.runInteraction(
  File "/home/dmr/workspace/synapse/synapse/storage/database.py", line 832, in runInteraction
    return await delay_cancellation(_runInteraction())
  File "/home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-YNqvS2_4-py3.10/lib/python3.10/site-packages/twisted/internet/defer.py", line 1656, in _inlineCallbacks
    result = current_context.run(
  File "/home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-YNqvS2_4-py3.10/lib/python3.10/site-packages/twisted/python/failure.py", line 514, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/home/dmr/workspace/synapse/synapse/storage/database.py", line 804, in _runInteraction
    result = await self.runWithConnection(
  File "/home/dmr/workspace/synapse/synapse/storage/database.py", line 927, in runWithConnection
    return await make_deferred_yieldable(
  File "/home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-YNqvS2_4-py3.10/lib/python3.10/site-packages/twisted/internet/defer.py", line 857, in _runCallbacks
    current.result = callback(  # type: ignore[misc]
  File "/home/dmr/workspace/synapse/tests/server.py", line 491, in <lambda>
    d.addCallback(lambda x: function(*args, **kwargs))
  File "/home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-YNqvS2_4-py3.10/lib/python3.10/site-packages/twisted/enterprise/adbapi.py", line 282, in _runWithConnection
    result = func(conn, *args, **kw)
  File "/home/dmr/workspace/synapse/synapse/storage/database.py", line 920, in inner_func
    return func(db_conn, *args, **kwargs)
  File "/home/dmr/workspace/synapse/synapse/storage/database.py", line 668, in new_transaction
    r = func(cursor, *args, **kwargs)
  File "/home/dmr/workspace/synapse/synapse/storage/databases/main/user_directory.py", line 479, in _update_profile_in_user_dir_txn
    self.db_pool.simple_upsert_txn(
  File "/home/dmr/workspace/synapse/synapse/storage/database.py", line 1168, in simple_upsert_txn
    return self.simple_upsert_txn_native_upsert(
  File "/home/dmr/workspace/synapse/synapse/storage/database.py", line 1294, in simple_upsert_txn_native_upsert
    txn.execute(sql, list(allvalues.values()))
  File "/home/dmr/workspace/synapse/synapse/storage/database.py", line 350, in execute
    self._do_execute(self.txn.execute, sql, *args)
  File "/home/dmr/workspace/synapse/synapse/storage/database.py", line 392, in _do_execute
    return func(sql, *args, **kwargs)
builtins.ValueError: A string literal cannot contain NUL (0x00) characters.
```

It's not strictly the same as the traceback in the linked issue: that handles an incoming profile change; we force a local change. But both pass through `update_profile_in_user_dir`, which contains the fix.