### PR TITLE
Add missing user_dir endpoint from the generic worker documentation

### DIFF
--- a/changelog.d/12773.doc
+++ b/changelog.d/12773.doc
@@ -1,1 +1,1 @@
-Add missing user directory endpoint from the generic worker documentation.
+Add missing user directory endpoint from the generic worker documentation. Contributed by @olmari.

--- a/changelog.d/12773.doc
+++ b/changelog.d/12773.doc
@@ -1,0 +1,1 @@
+Add missing user directory endpoint from the generic worker documentation.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -251,7 +251,7 @@ information.
     # Presence requests
     ^/_matrix/client/(api/v1|r0|v3|unstable)/presence/
 
-    # User directory queries
+    # User directory search requests
     ^/_matrix/client/(r0|v3|unstable)/user_directory/search$
 
 Additionally, the following REST endpoints can be handled for GET requests:

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -447,10 +447,6 @@ Specify its name in the shared configuration as follows:
 update_user_directory_from_worker: worker_name
 ```
 
-It can handle REST endpoint matching the following regular expression:
-
-    ^/_matrix/client/(r0|v3|unstable)/user_directory/search$
-
 This work cannot be load-balanced; please ensure the main process is restarted
 after setting this option in the shared configuration!
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -251,6 +251,8 @@ information.
     # Presence requests
     ^/_matrix/client/(api/v1|r0|v3|unstable)/presence/
 
+    # User directory queries
+    ^/_matrix/client/(r0|v3|unstable)/user_directory/search$
 
 Additionally, the following REST endpoints can be handled for GET requests:
 
@@ -444,6 +446,10 @@ Specify its name in the shared configuration as follows:
 ```yaml
 update_user_directory_from_worker: worker_name
 ```
+
+It can handle REST endpoint matching the following regular expression:
+
+    ^/_matrix/client/(r0|v3|unstable)/user_directory/search$
 
 This work cannot be load-balanced; please ensure the main process is restarted
 after setting this option in the shared configuration!

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -450,6 +450,14 @@ update_user_directory_from_worker: worker_name
 This work cannot be load-balanced; please ensure the main process is restarted
 after setting this option in the shared configuration!
 
+User directory updates allow REST endpoints matching the following regular
+expressions to work:
+
+    ^/_matrix/client/(r0|v3|unstable)/user_directory/search$
+
+The above endpoints can be routed to any worker, though you may choose to route
+it to the chosen user directory worker.
+
 This style of configuration supersedes the legacy `synapse.app.user_dir`
 worker application type.
 


### PR DESCRIPTION
Fixes #12768 

Signed-off-by: Sami Olmari <sami@olmari.fi>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
