### PR TITLE
make handling of federation Authorization header (more) compliant with RFC7230

### DIFF
--- a/changelog.d/12774.misc
+++ b/changelog.d/12774.misc
@@ -1,0 +1,1 @@
+Make handling of federation Authorization header (more) compliant with RFC7230.

--- a/synapse/federation/transport/server/_base.py
+++ b/synapse/federation/transport/server/_base.py
@@ -176,7 +176,9 @@ def _parse_auth_header(header_bytes: bytes) -> Tuple[str, str, str, Optional[str
 
         def strip_quotes(value: str) -> str:
             if value.startswith('"'):
-                return re.sub("\\\\(.)", lambda matchobj: matchobj.group(1), value[1:-1])
+                return re.sub(
+                    "\\\\(.)", lambda matchobj: matchobj.group(1), value[1:-1]
+                )
             else:
                 return value
 

--- a/synapse/federation/transport/server/_base.py
+++ b/synapse/federation/transport/server/_base.py
@@ -169,14 +169,14 @@ def _parse_auth_header(header_bytes: bytes) -> Tuple[str, str, str, Optional[str
     """
     try:
         header_str = header_bytes.decode("utf-8")
-        params = header_str.split(" ")[1].split(",")
+        params = re.split(" +", header_str)[1].split(",")
         param_dict: Dict[str, str] = {
-            k: v for k, v in [param.split("=", maxsplit=1) for param in params]
+            k.lower(): v for k, v in [param.split("=", maxsplit=1) for param in params]
         }
 
         def strip_quotes(value: str) -> str:
             if value.startswith('"'):
-                return value[1:-1]
+                return re.sub("\\\\(.)", lambda matchobj: matchobj.group(1), value[1:-1])
             else:
                 return value
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -747,7 +747,7 @@ class MatrixFederationHttpClient:
         for key, sig in request["signatures"][self.server_name].items():
             auth_headers.append(
                 (
-                    'X-Matrix origin=%s,key="%s",sig="%s",destination="%s"'
+                    'X-Matrix origin="%s",key="%s",sig="%s",destination="%s"'
                     % (
                         self.server_name,
                         key,


### PR DESCRIPTION
main differences are:
- values with delimiters (such as colons) should be quoted, so always quote the origin, since it could contain a colon followed by a port number
- should allow more than one space after "X-Matrix"
- quoted values with backslash-escaped characters should be unescaped
- names should be case insensitive