### PR TITLE
Update configuration manual to document size-related suffixes

### DIFF
--- a/changelog.d/12777.doc
+++ b/changelog.d/12777.doc
@@ -1,0 +1,2 @@
+Update configuration manual documentation to document size-related suffixes.
+

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -25,10 +25,10 @@ messages from the database after 5 minutes, rather than 5 months.
 
 In addition, configuration options referring to size use the following suffixes:
 
-* `M` = MiB, or 1048576 bytes
+* `M` = MiB, or 1,048,576 bytes
 * `K` = KiB, or 1024 bytes 
 
-For example, setting `max_avatar_size: 10M` means that Synapse will not accept files larger than 10485760 bytes
+For example, setting `max_avatar_size: 10M` means that Synapse will not accept files larger than 10,485,760 bytes
 for a user avatar. 
 
 ### YAML 

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -25,10 +25,10 @@ messages from the database after 5 minutes, rather than 5 months.
 
 In addition, configuration options referring to size use the following suffixes:
 
-* `M` = MB, or 1048576 bytes
-* `K` = KB, or 1024 bytes 
+* `M` = MiB, or 1048576 bytes
+* `K` = KiB, or 1024 bytes 
 
-For example, setting `max_avatar_size: 10M` means that Synapse will not accept files larger than 10MB
+For example, setting `max_avatar_size: 10M` means that Synapse will not accept files larger than 10485760 bytes
 for a user avatar. 
 
 ### YAML 

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -23,6 +23,14 @@ followed by a letter. Letters have the following meanings:
 For example, setting `redaction_retention_period: 5m` would remove redacted
 messages from the database after 5 minutes, rather than 5 months.
 
+In addition, configuration options referring to size use the following suffixes:
+
+* `M` = MB, or 1048576 bytes
+* `K` = KB, or 1024 bytes 
+
+For example, setting `max_avatar_size: 10M` means that Synapse will not accept files larger than 10MB
+for a user avatar. 
+
 ### YAML 
 The configuration file is a [YAML](https://yaml.org/) file, which means that certain syntax rules
 apply if you want your config file to be read properly. A few helpful things to know:


### PR DESCRIPTION
As the title states. Currently this is documented in the media repo section of the documentation, this PR adds it to the beginning of the manual with the time-related suffixes are documented. 

Fixes #12757