### PR TITLE
Give a meaningful error message when a client tries to create a room with an invalid alias localpart.

### DIFF
--- a/changelog.d/12779.bugfix
+++ b/changelog.d/12779.bugfix
@@ -1,0 +1,1 @@
+Give a meaningful error message when a client tries to create a room with an invalid alias localpart.

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -71,6 +71,9 @@ class DirectoryHandler:
             if wchar in room_alias.localpart:
                 raise SynapseError(400, "Invalid characters in room alias")
 
+        if ":" in room_alias.localpart:
+            raise SynapseError(400, "Invalid character in room alias localpart: ':'.")
+
         if not self.hs.is_mine(room_alias):
             raise SynapseError(400, "Room alias must be local")
             # TODO(erikj): Change this.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -751,6 +751,21 @@ class RoomCreationHandler:
                 if wchar in config["room_alias_name"]:
                     raise SynapseError(400, "Invalid characters in room alias")
 
+            if ":" in config["room_alias_name"]:
+                # Prevent someone from trying to pass in a full alias here.
+                # Note that it's permissible for a room alias to have multiple
+                # hash symbols at the start (notably bridged over from IRC, too),
+                # but the first colon in the alias is defined to separate the local
+                # part from the server name.
+                # (remember server names can contain port numbers, also separated
+                # by a colon. But under no circumstances should the local part be
+                # allowed to contain a colon!)
+                raise SynapseError(
+                    400,
+                    "':' is not permitted in the room alias name. "
+                    "Please note this expects a local part — 'wombat', not '#wombat:example.com'.",
+                )
+
             room_alias = RoomAlias(config["room_alias_name"], self.hs.hostname)
             mapping = await self.store.get_association_from_room_alias(room_alias)
 


### PR DESCRIPTION
This situation happened because someone was using an SDK that didn't make it very clear that `room_alias_name` was supposed to be a **localpart**.

In this case, they passed e.g. `#wombat:matrix.org` as the localpart and then Synapse wound up returning 502 Bad Gateway (which confused Cloudflare to return a page saying that Synapse was down, rather than passing through the error message).
(I'm not entirely sure why; possibly whilst trying to resolve the alias to check it doesn't exist?)

This is a quick drive-by fix to make Synapse not entertain the idea of trying to create `##wombat:matrix.org:matrix.org` (whilst creating a room), instead opting to give a more helpful error to a confused client developer.

Note that `##wombat:matrix.org` appears to be in order; apparently LiberaChat uses that to bridge ##wombat channels from their side. So this doesn't prevent you from starting your localpart with a hash.

The [grammar for room aliases](https://spec.matrix.org/v1.2/appendices/#room-aliases) is a little bit vague, unfortunately, but I think this change is less evil than giving a highly confusing 502 Bad Gateway error...