### PR TITLE
Do not keep going if there are 5 back-to-back background update failures.

### DIFF
--- a/changelog.d/12781.misc
+++ b/changelog.d/12781.misc
@@ -1,0 +1,1 @@
+Do not keep going if there are 5 back-to-back background update failures.

--- a/synapse/storage/background_updates.py
+++ b/synapse/storage/background_updates.py
@@ -282,12 +282,20 @@ class BackgroundUpdater:
 
         self._running = True
 
+        back_to_back_failures = 0
+
         try:
             logger.info("Starting background schema updates")
             while self.enabled:
                 try:
                     result = await self.do_next_background_update(sleep)
+                    back_to_back_failures = 0
                 except Exception:
+                    back_to_back_failures += 1
+                    if back_to_back_failures >= 5:
+                        raise RuntimeError(
+                            "5 back-to-back background update failures; aborting."
+                        )
                     logger.exception("Error doing update")
                 else:
                     if result:


### PR DESCRIPTION
Fixes #12780 — see that issue for context.

Up for debate whether this is a fair solution or not.

At least it makes tests fail rather than hang (personally confirmed).

