### PR TITLE
Fix federation in demo scripts.

### DIFF
--- a/changelog.d/12783.misc
+++ b/changelog.d/12783.misc
@@ -1,0 +1,1 @@
+Fix federation when using the demo scripts.

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -12,6 +12,7 @@ export PYTHONPATH
 
 echo "$PYTHONPATH"
 
+# Create servers which listen on HTTP at 808x and HTTPS at 848x.
 for port in 8080 8081 8082; do
     echo "Starting server on port $port... "
 
@@ -19,10 +20,12 @@ for port in 8080 8081 8082; do
     mkdir -p demo/$port
     pushd demo/$port || exit
 
-    # Generate the configuration for the homeserver at localhost:848x.
+    # Generate the configuration for the homeserver at localhost:848x, note that
+    # the homeserver name needs to match the HTTPS listening port for federation
+    # to properly work..
     python3 -m synapse.app.homeserver \
         --generate-config \
-        --server-name "localhost:$port" \
+        --server-name "localhost:$https_port" \
         --config-path "$port.config" \
         --report-stats no
 

--- a/docs/development/demo.md
+++ b/docs/development/demo.md
@@ -5,7 +5,7 @@
 Requires you to have a [Synapse development environment setup](https://matrix-org.github.io/synapse/develop/development/contributing_guide.html#4-install-the-dependencies).
 
 The demo setup allows running three federation Synapse servers, with server
-names `localhost:8080`, `localhost:8081`, and `localhost:8082`.
+names `localhost:8480`, `localhost:8481`, and `localhost:8482`.
 
 You can access them via any Matrix client over HTTP at `localhost:8080`,
 `localhost:8081`, and `localhost:8082` or over HTTPS at `localhost:8480`,
@@ -20,9 +20,10 @@ and the servers are configured in a highly insecure way, including:
 The servers are configured to store their data under `demo/8080`, `demo/8081`, and
 `demo/8082`. This includes configuration, logs, SQLite databases, and media.
 
-Note that when joining a public room on a different HS via "#foo:bar.net", then
-you are (in the current impl) joining a room with room_id "foo". This means that
-it won't work if your HS already has a room with that name.
+Note that when joining a public room on a different homeserver via "#foo:bar.net",
+then you are (in the current implementation) joining a room with room_id "foo".
+This means that it won't work if your homeserver already has a room with that
+name.
 
 ## Using the demo scripts
 


### PR DESCRIPTION
This fixes a regression from #12143 where I broke federation between the homeservers created by the demo scripts.

I had changed the server names to use the HTTP listening port, instead of the HTTPS listening port, which meant that federation (which always uses TLS) broke.

This reverts that change, which adds the annoyance back that you would generally connect to the homeserver over HTTP at e.g. `localhost:8080`, but end up with an MXID at the HTTPS address: `localhost:8480`.