### PR TITLE
Fix YAML parsing error in `url_preview_accept_language`

### DIFF
--- a/changelog.d/12785.doc
+++ b/changelog.d/12785.doc
@@ -1,0 +1,1 @@
+Fix invalid YAML syntax in the example documentation for the `url_preview_accept_language` config option.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1679,10 +1679,10 @@ Defaults to "en".
 Example configuration:
 ```yaml
  url_preview_accept_language:
-   - en-UK
-   - en-US;q=0.9
-   - fr;q=0.8
-   - *;q=0.7
+   - 'en-UK'
+   - 'en-US;q=0.9'
+   - 'fr;q=0.8'
+   - '*;q=0.7'
 ```
 ----
 Config option: `oembed`

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1194,7 +1194,7 @@ For more information on using Synapse with Postgres,
 see [here](../../postgres.md).
 
 Example SQLite configuration:
-```
+```yaml
 database:
   name: sqlite3
   args:
@@ -1202,7 +1202,7 @@ database:
 ```
 
 Example Postgres configuration:
-```
+```yaml
 database:
   name: psycopg2
   txn_limit: 10000


### PR DESCRIPTION
You cannot start a block in YAML with `*`. Otherwise a YAML parser may spit out:

```
did not find expected alphabetic or numeric character while scanning an alias
```

Also add some missing `yaml`s to codeblocks.