### PR TITLE
Simplify untyped-defs config in mypy.ini

### DIFF
--- a/changelog.d/12790.misc
+++ b/changelog.d/12790.misc
@@ -1,0 +1,1 @@
+Simplify `disallow_untyped_defs` config in `mypy.ini`.

--- a/mypy.ini
+++ b/mypy.ini
@@ -104,6 +104,8 @@ disallow_untyped_defs = False
 
 [mypy-synapse.metrics._reactor_metrics]
 disallow_untyped_defs = False
+# This module imports select.epoll. That exists on Linux, but doesn't on macOS.
+# See https://github.com/matrix-org/synapse/pull/11771.
 warn_unused_ignores = False
 
 [mypy-synapse.util.caches.treecache]

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,7 @@ warn_unreachable = True
 warn_unused_ignores = True
 local_partial_types = True
 no_implicit_optional = True
+disallow_untyped_defs = True
 
 files =
   docker/,
@@ -86,177 +87,35 @@ exclude = (?x)
    |tests/utils.py
    )$
 
-[mypy-synapse._scripts.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.api.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.app.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.appservice.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.config.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.crypto.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.event_auth]
-disallow_untyped_defs = True
-
-[mypy-synapse.events.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.federation.*]
-disallow_untyped_defs = True
-
 [mypy-synapse.federation.transport.client]
 disallow_untyped_defs = False
 
-[mypy-synapse.groups.*]
-disallow_untyped_defs = True
+[mypy-synapse.http.client]
+disallow_untyped_defs = False
 
-[mypy-synapse.handlers.*]
-disallow_untyped_defs = True
+[mypy-synapse.http.matrixfederationclient]
+disallow_untyped_defs = False
 
-[mypy-synapse.http.federation.*]
-disallow_untyped_defs = True
+[mypy-synapse.logging.opentracing]
+disallow_untyped_defs = False
 
-[mypy-synapse.http.connectproxyclient]
-disallow_untyped_defs = True
-
-[mypy-synapse.http.proxyagent]
-disallow_untyped_defs = True
-
-[mypy-synapse.http.request_metrics]
-disallow_untyped_defs = True
-
-[mypy-synapse.http.server]
-disallow_untyped_defs = True
-
-[mypy-synapse.logging._remote]
-disallow_untyped_defs = True
-
-[mypy-synapse.logging.context]
-disallow_untyped_defs = True
-
-[mypy-synapse.logging.formatter]
-disallow_untyped_defs = True
-
-[mypy-synapse.logging.handlers]
-disallow_untyped_defs = True
-
-[mypy-synapse.metrics.*]
-disallow_untyped_defs = True
+[mypy-synapse.logging.scopecontextmanager]
+disallow_untyped_defs = False
 
 [mypy-synapse.metrics._reactor_metrics]
-# This module imports select.epoll. That exists on Linux, but doesn't on macOS.
-# See https://github.com/matrix-org/synapse/pull/11771.
+disallow_untyped_defs = False
 warn_unused_ignores = False
 
-[mypy-synapse.module_api.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.notifier]
-disallow_untyped_defs = True
-
-[mypy-synapse.push.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.replication.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.rest.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.server_notices.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.state.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.background_updates]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.account_data]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.client_ips]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.directory]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.e2e_room_keys]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.end_to_end_keys]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.event_push_actions]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.events_bg_updates]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.events_worker]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.room]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.room_batch]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.profile]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.stats]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.state_deltas]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.stream]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.transactions]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.databases.main.user_erasure_store]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.engines.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.prepare_database]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.persist_events]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.state]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.types]
-disallow_untyped_defs = True
-
-[mypy-synapse.storage.util.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.streams.*]
-disallow_untyped_defs = True
-
-[mypy-synapse.types]
-disallow_untyped_defs = True
-
-[mypy-synapse.util.*]
-disallow_untyped_defs = True
-
 [mypy-synapse.util.caches.treecache]
+disallow_untyped_defs = False
+
+[mypy-synapse.server]
+disallow_untyped_defs = False
+
+[mypy-synapse.storage.database]
+disallow_untyped_defs = False
+
+[mypy-tests.*]
 disallow_untyped_defs = False
 
 [mypy-tests.handlers.test_user_directory]


### PR DESCRIPTION
Bask in _the glory_

Arguably:

Closes #11302.

#11315 remains, but that was somewhat contravertial and has now bitrotted.