### PR TITLE
Close providers.json stream when the json is loaded

### DIFF
--- a/changelog.d/12794.bugfix
+++ b/changelog.d/12794.bugfix
@@ -1,0 +1,1 @@
+Properly close `providers.json` file when the resource is loaded. Contributed by @arkamar.

--- a/changelog.d/12794.bugfix
+++ b/changelog.d/12794.bugfix
@@ -1,1 +1,1 @@
-Properly close `providers.json` file when the resource is loaded. Contributed by @arkamar.
+Fix a bug introduced in 1.43.0 where a file (`providers.json`) was never closed. Contributed by @arkamar.

--- a/synapse/config/oembed.py
+++ b/synapse/config/oembed.py
@@ -57,9 +57,9 @@ class OembedConfig(Config):
         """
         # Whether to use the packaged providers.json file.
         if not oembed_config.get("disable_default_providers") or False:
-            providers = json.load(
-                pkg_resources.resource_stream("synapse", "res/providers.json")
-            )
+            with pkg_resources.resource_stream("synapse", "res/providers.json") as s:
+                providers = json.load(s)
+
             yield from self._parse_and_validate_provider(
                 providers, config_path=("oembed",)
             )


### PR DESCRIPTION
I noticed lots of `synapse/config/oembed.py:60: ResourceWarning: unclosed file <_io.BufferedReader name='synapse/res/providers.json'>` warnings when I ran tests in `v1.59.1` and earlier versions. It should be possible to reproduce it with following command (I used python 3.9)
```sh
python -m unittest -v tests/unittest.py
```
which outputs
```
runTest (tests.unittest.FederatingHomeserverTestCase)
If no C{methodName} argument is passed to the constructor, L{run} will ... ok
synapse/config/oembed.py:60: ResourceWarning: unclosed file <_io.BufferedReader name='synapse/res/providers.json'>
  providers = json.load(
runTest (tests.unittest.HomeserverTestCase)
If no C{methodName} argument is passed to the constructor, L{run} will ... ok
synapse/config/oembed.py:60: ResourceWarning: unclosed file <_io.BufferedReader name='synapse/res/providers.json'>
  providers = json.load(
runTest (tests.unittest.TestCase)
If no C{methodName} argument is passed to the constructor, L{run} will ... ok

----------------------------------------------------------------------
Ran 3 tests in 3.127s

OK
```
#### Fix

The file is properly closed when the `providers.json` resource is loaded with the `with` statement.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
