### PR TITLE
Send `USER_IP` commands on a different Redis channel, in order to reduce traffic to workers that do not process these commands.

### DIFF
--- a/changelog.d/12672.feature
+++ b/changelog.d/12672.feature
@@ -1,0 +1,1 @@
+Send `USER_IP` commands on a different Redis channel, in order to reduce traffic to workers that do not process these commands.

--- a/changelog.d/12672.misc
+++ b/changelog.d/12672.misc
@@ -1,1 +1,0 @@
-Lay some foundation work to allow workers to only subscribe to some kinds of messages, reducing replication traffic.

--- a/changelog.d/12809.feature
+++ b/changelog.d/12809.feature
@@ -1,0 +1,1 @@
+Send `USER_IP` commands on a different Redis channel, in order to reduce traffic to workers that do not process these commands.

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -58,6 +58,15 @@ class Command(metaclass=abc.ABCMeta):
         # by default, we just use the command name.
         return self.NAME
 
+    def redis_channel_name(self, prefix: str) -> str:
+        """
+        Returns the Redis channel name upon which to publish this command.
+
+        Args:
+            prefix: The prefix for the channel.
+        """
+        return prefix
+
 
 SC = TypeVar("SC", bound="_SimpleCommand")
 
@@ -394,6 +403,9 @@ class UserIpCommand(Command):
             f"UserIpCommand({self.user_id!r}, .., {self.ip!r}, "
             f"{self.user_agent!r}, {self.device_id!r}, {self.last_seen})"
         )
+
+    def redis_channel_name(self, prefix: str) -> str:
+        return f"{prefix}/USER_IP"
 
 
 class RemoteServerUpCommand(_SimpleCommand):

--- a/synapse/replication/tcp/redis.py
+++ b/synapse/replication/tcp/redis.py
@@ -221,10 +221,10 @@ class RedisSubscriber(txredisapi.SubscriberProtocol):
         # remote instances.
         tcp_outbound_commands_counter.labels(cmd.NAME, "redis").inc()
 
+        channel_name = cmd.redis_channel_name(self.synapse_stream_prefix)
+
         await make_deferred_yieldable(
-            self.synapse_outbound_redis_connection.publish(
-                self.synapse_stream_prefix, encoded_string
-            )
+            self.synapse_outbound_redis_connection.publish(channel_name, encoded_string)
         )
 
 


### PR DESCRIPTION
Fixes #12460.

I will note that I confirmed the tests complain if there is a mistake in the channel name, so we are confirming that the messages are making it across.


