### PR TITLE
Fix Complement `TestCanRegisterAdmin` with workers, by adding Complement's shared registration secret.

### DIFF
--- a/changelog.d/12819.misc
+++ b/changelog.d/12819.misc
@@ -1,0 +1,1 @@
+Add Complement's shared registration secret to the Complement worker image. This fixes tests that depend on it.

--- a/docker/complement/conf-workers/workers-shared.yaml
+++ b/docker/complement/conf-workers/workers-shared.yaml
@@ -5,6 +5,12 @@ enable_registration: true
 enable_registration_without_verification: true
 bcrypt_rounds: 4
 
+## Registration ##
+
+# Needed by Complement to register admin users
+# DO NOT USE in a production configuration! This should be a random secret.
+registration_shared_secret: complement
+
 ## Federation ##
 
 # trust certs signed by Complement's CA


### PR DESCRIPTION
`TestCanRegisterAdmin` is fixed as a result, though a couple of others look admin registration-related and therefore might be fixed too.

Cross-ref: https://github.com/matrix-org/complement/blob/64517973539750c3a006dec14f13b4fb82de0b66/internal/client/client.go#L26-L28