### PR TITLE
Fix media thumbnails being unusable before the index had been added in the background.

### DIFF
--- a/changelog.d/12823.bugfix
+++ b/changelog.d/12823.bugfix
@@ -1,1 +1,1 @@
-Fix media thumbnails being unusable before the index had been added in the background.
+Fix a bug, introduced in Synapse 1.21.0, that led to media thumbnails being unusable before the index has been added in the background.

--- a/changelog.d/12823.bugfix
+++ b/changelog.d/12823.bugfix
@@ -1,0 +1,1 @@
+Fix media thumbnails being unusable before the index had been added in the background.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -90,6 +90,8 @@ UNIQUE_INDEX_BACKGROUND_UPDATES = {
     "device_lists_remote_extremeties": "device_lists_remote_extremeties_unique_idx",
     "device_lists_remote_cache": "device_lists_remote_cache_unique_idx",
     "event_search": "event_search_event_id_idx",
+    "local_media_repository_thumbnails": "local_media_repository_thumbnails_method_idx",
+    "remote_media_cache_thumbnails": "remote_media_repository_thumbnails_method_idx",
 }
 
 


### PR DESCRIPTION
Fixes #12798.

I don't think we would have noticed this if not for Complement tripping up on it :-).

This is necessary because upserts require a unique index.
These unique indices are introduced in the background by https://github.com/matrix-org/synapse/blob/b76f1a4d5f918def1f643910939b80e9e035e07f/synapse/storage/databases/main/media_repository.py#L85-L112

