### PR TITLE
Add a windows->unix file endings commit to git blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@ aff1eb7c671b0a3813407321d2702ec46c71fa56
 
 # Update black to 20.8b1 (#9381).
 0a00b7ff14890987f09112a2ae696c61001e6cf1
+
+# Convert tests/rest/admin/test_room.py to unix file endings (#7953).
+c4268e3da64f1abb5b31deaeb5769adb6510c0a7


### PR DESCRIPTION
This PR adds https://github.com/matrix-org/synapse/pull/7953 to the git blame revision blacklist (which prevents the associated commit appearing when using git blames).

A relatively small commit, but one that did get in the way today. I don't think this one is very useful when viewing blames.

Not sure if this one needs a changelog entry?