### PR TITLE
Make sure `prev_ids` defaults to empty list

### DIFF
--- a/changelog.d/12829.bugfix
+++ b/changelog.d/12829.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug where device list updates over federation would fail if they
+were not a list. Contributed by Carl Bordum Hansen.

--- a/changelog.d/12829.bugfix
+++ b/changelog.d/12829.bugfix
@@ -1,2 +1,1 @@
-Fixed a bug where device list updates over federation would fail if they
-were not a list. Contributed by Carl Bordum Hansen.
+Fix a bug where we did not correctly handle invalid device list updates over federation. Contributed by Carl Bordum Hansen.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -763,6 +763,10 @@ class DeviceListUpdater:
         device_id = edu_content.pop("device_id")
         stream_id = str(edu_content.pop("stream_id"))  # They may come as ints
         prev_ids = edu_content.pop("prev_id", [])
+        if not isinstance(prev_ids, list):
+            raise SynapseError(
+                400, "Device list update had an invalid 'prev_ids' field"
+            )
         prev_ids = [str(p) for p in prev_ids]  # They may come as ints
 
         if get_domain_from_id(user_id) != origin:


### PR DESCRIPTION
While this change seems a bit strange, I was seeing TypeErrors on my
homeserver because someone is sending device lists where they explicitly
set `"prev_id": null` which causes the next list comprehension to fail.

Signed-off-by: Carl Bordum Hansen <carl@bordum.dk>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
