### PR TITLE
LockStore: fix acquiring a lock via `LockStore.try_acquire_lock`

### DIFF
--- a/changelog.d/12832.bugfix
+++ b/changelog.d/12832.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug which allowed multiple async operations to access database locks concurrently. Contributed by @sumnerevans @ Beeper.

--- a/synapse/storage/databases/main/lock.py
+++ b/synapse/storage/databases/main/lock.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 from types import TracebackType
-from typing import TYPE_CHECKING, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Optional, Set, Tuple, Type
 from weakref import WeakValueDictionary
 
 from twisted.internet.interfaces import IReactorCore
@@ -84,6 +84,8 @@ class LockStore(SQLBaseStore):
             self._on_shutdown,
         )
 
+        self._acquiring_locks: Set[Tuple[str, str]] = set()
+
     @wrap_as_background_process("LockStore._on_shutdown")
     async def _on_shutdown(self) -> None:
         """Called when the server is shutting down"""
@@ -99,6 +101,21 @@ class LockStore(SQLBaseStore):
         logger.info("Dropped locks due to shutdown")
 
     async def try_acquire_lock(self, lock_name: str, lock_key: str) -> Optional["Lock"]:
+        """Try to acquire a lock for the given name/key. Will return an async
+        context manager if the lock is successfully acquired, which *must* be
+        used (otherwise the lock will leak).
+        """
+        if (lock_name, lock_key) in self._acquiring_locks:
+            return None
+        try:
+            self._acquiring_locks.add((lock_name, lock_key))
+            return await self._try_acquire_lock(lock_name, lock_key)
+        finally:
+            self._acquiring_locks.discard((lock_name, lock_key))
+
+    async def _try_acquire_lock(
+        self, lock_name: str, lock_key: str
+    ) -> Optional["Lock"]:
         """Try to acquire a lock for the given name/key. Will return an async
         context manager if the lock is successfully acquired, which *must* be
         used (otherwise the lock will leak).


### PR DESCRIPTION
This PR fixes acquiring a lock via `LockStore.try_acquire_lock` which is currently broken.

* Adds a test that demonstrates the issue. See https://github.com/matrix-org/synapse/pull/12484#issuecomment-1116286459
* Adds a `Linearizer` to `LockStore` to make the test pass.

Outstanding questions:

- [x] ~This change causes a regression in `LockTestCase.test_drop` and I'm not quite sure what to do about it. It's not obvious where the error is coming from (seems to be in the internals of `twisted` which seems concerning):~

<details><summary>old error</summary>

```
$ trial tests.storage.databases.main.test_lock
tests.storage.databases.main.test_lock
  LockTestCase
    test_acquire_contention ...                                            [OK]
    test_drop ...                                                       [ERROR]
    test_maintain_lock ...                                                 [OK]
    test_shutdown ...                                                      [OK]
    test_simple_lock ...                                                   [OK]
    test_timeout_lock ...                                                  [OK]

===============================================================================
[ERROR]
Traceback (most recent call last):
  File "/home/sumner/projects/beeper/.venv/lib/python3.9/site-packages/twisted/internet/defer.py", line 1660, in _inlineCallbacks
    result = current_context.run(gen.send, result)
builtins.RuntimeError: cannot reuse already awaited coroutine

tests.storage.databases.main.test_lock.LockTestCase.test_drop
-------------------------------------------------------------------------------
Ran 6 tests in 5.219s

FAILED (errors=1, successes=5)
```

</details>

### Note to Reviewer

If you checkout the branch at the commit where I add the initial test case, and run the test, it will fail.

```
$ trial tests.storage.databases.main.test_lock 
```

After fast-forwarding to the HEAD of the branch, running the same tests will pass.

### Sign-off

```
Signed-off-by: Sumner Evans <sumner@beeper.com>
```

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
