### PR TITLE
Fix ambiguous column name that would prevent use of MSC2716 History Import when using Postgres as a database.

### DIFF
--- a/changelog.d/12843.bugfix
+++ b/changelog.d/12843.bugfix
@@ -1,0 +1,1 @@
+Fix ambiguous column name that would prevent use of MSC2716 History Import when using Postgres as a database.

--- a/changelog.d/12843.bugfix
+++ b/changelog.d/12843.bugfix
@@ -1,1 +1,1 @@
-Fix ambiguous column name that would prevent use of MSC2716 History Import when using Postgres as a database.
+Fix bug where servers using a Postgres database would fail to backfill from an insertion event when MSC2716 is enabled (`experimental_features.msc2716_enabled`).

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1057,7 +1057,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
             INNER JOIN batch_events AS c
             ON i.next_batch_id = c.batch_id
             /* Get the depth of the batch start event from the events table */
-            INNER JOIN events AS e USING (event_id)
+            INNER JOIN events AS e ON c.event_id = e.event_id
             /* Find an insertion event which matches the given event_id */
             WHERE i.event_id = ?
             LIMIT ?


### PR DESCRIPTION
Fixes #12825.

@MadLittleMods I'd like to request your eyes to check this is what you intended.
It matches my reading of the surrounding commentary, but SQLite's query plan would have used `i` according to some experimentation!
Complement tests pass with *either* `c` or `i` so weren't much use in discerning the two :/.
