### PR TITLE
Pin poetry.core in Docker images

### DIFF
--- a/changelog.d/12853.docker
+++ b/changelog.d/12853.docker
@@ -1,0 +1,1 @@
+Fix the docker file after a dependency update.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,17 +45,11 @@ RUN \
 
 # We install poetry in its own build stage to avoid its dependencies conflicting with
 # synapse's dependencies.
-# We use a specific commit from poetry's master branch instead of our usual 1.1.12,
-# to incorporate fixes to some bugs in `poetry export`. This commit corresponds to
-#    https://github.com/python-poetry/poetry/pull/5156 and
-#    https://github.com/python-poetry/poetry/issues/5141 ;
-# without it, we generate a requirements.txt with incorrect environment markers,
-# which causes necessary packages to be omitted when we `pip install`.
 #
 # NB: In poetry 1.2 `poetry export` will be moved into a plugin; we'll need to also
 # pip install poetry-plugin-export (https://github.com/python-poetry/poetry-plugin-export).
 RUN --mount=type=cache,target=/root/.cache/pip \
-  pip install --user git+https://github.com/python-poetry/poetry.git@fb13b3a676f476177f7937ffa480ee5cff9a90a5
+  pip install --user "poetry==1.1.3"
 
 WORKDIR /synapse
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,8 @@ RUN \
  apt-get update && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
 
+# We install poetry in its own build stage to avoid its dependencies conflicting with
+# synapse's dependencies.
 # We use a specific commit from poetry's master branch instead of our usual 1.1.12,
 # to incorporate fixes to some bugs in `poetry export`. This commit corresponds to
 #    https://github.com/python-poetry/poetry/pull/5156 and

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,13 +43,17 @@ RUN \
  apt-get update && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
 
-# We install poetry in its own build stage to avoid its dependencies conflicting with
-# synapse's dependencies.
+# We use a specific commit from poetry's master branch instead of our usual 1.1.12,
+# to incorporate fixes to some bugs in `poetry export`. This commit corresponds to
+#    https://github.com/python-poetry/poetry/pull/5156 and
+#    https://github.com/python-poetry/poetry/issues/5141 ;
+# without it, we generate a requirements.txt with incorrect environment markers,
+# which causes necessary packages to be omitted when we `pip install`.
 #
 # NB: In poetry 1.2 `poetry export` will be moved into a plugin; we'll need to also
 # pip install poetry-plugin-export (https://github.com/python-poetry/poetry-plugin-export).
 RUN --mount=type=cache,target=/root/.cache/pip \
-  pip install --user "poetry==1.1.13"
+  pip install --user "poetry-core==1.1.0a7" "git+https://github.com/python-poetry/poetry.git@fb13b3a676f476177f7937ffa480ee5cff9a90a5"
 
 WORKDIR /synapse
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN \
 # NB: In poetry 1.2 `poetry export` will be moved into a plugin; we'll need to also
 # pip install poetry-plugin-export (https://github.com/python-poetry/poetry-plugin-export).
 RUN --mount=type=cache,target=/root/.cache/pip \
-  pip install --user "poetry==1.1.3"
+  pip install --user "poetry==1.1.13"
 
 WORKDIR /synapse
 


### PR DESCRIPTION
I *think* this should fix the docker images. It's unclear as to why, though a beta `poetry.core` package was released yesterday, and we don't pin the version of *that* 

Fixes #12854