### PR TITLE
Fixes to MSC3787 implementation

### DIFF
--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -45,7 +45,7 @@ docker build -t matrixdotorg/synapse -f "docker/Dockerfile" .
 
 extra_test_args=()
 
-test_tags="synapse_blacklist,msc2716,msc3030"
+test_tags="synapse_blacklist,msc2716,msc3030,msc3787"
 
 # If we're using workers, modify the docker files slightly.
 if [[ -n "$WORKERS" ]]; then

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -662,7 +662,7 @@ class RoomSummaryHandler:
         # The API doesn't return the room version so assume that a
         # join rule of knock is valid.
         if (
-            room.get("join_rules") in (JoinRules.PUBLIC, JoinRules.KNOCK)
+            room.get("join_rules") in (JoinRules.PUBLIC, JoinRules.KNOCK, JoinRules.KNOCK_RESTRICTED)
             or room.get("world_readable") is True
         ):
             return True


### PR DESCRIPTION
Missed in #12623.

Should hopefully run against https://github.com/matrix-org/complement/pull/367, which is using https://github.com/matrix-org/gomatrixserverlib/pull/310.

