### PR TITLE
Correct annotation of `_iterate_over_text`

### DIFF
--- a/changelog.d/12860.misc
+++ b/changelog.d/12860.misc
@@ -1,0 +1,1 @@
+Correct a type annotation in the URL preview source code.

--- a/synapse/rest/media/v1/preview_html.py
+++ b/synapse/rest/media/v1/preview_html.py
@@ -281,7 +281,7 @@ def parse_html_description(tree: "etree.Element") -> Optional[str]:
 
 
 def _iterate_over_text(
-    tree: "etree.Element", *tags_to_ignore: Iterable[Union[str, "etree.Comment"]]
+    tree: "etree.Element", *tags_to_ignore: Union[str, "etree.Comment"]
 ) -> Generator[str, None, None]:
     """Iterate over the tree returning text nodes in a depth first fashion,
     skipping text nodes inside certain tags.


### PR DESCRIPTION
`*args: T` means that `args: Tuple[T, ...]` within the function body.

I don't think this makes much sense because lxml doesn't come with any
type annotations out of the box.
