### PR TITLE
Add the `batch_send` endpoint to generic workers

### DIFF
--- a/changelog.d/12868.misc
+++ b/changelog.d/12868.misc
@@ -1,2 +1,1 @@
 Enable the `batch_send` endpoint on synapse worker processes. Contributed by Nick @ Beeper.
-

--- a/changelog.d/12868.misc
+++ b/changelog.d/12868.misc
@@ -1,0 +1,2 @@
+Enable the `batch_send` endpoint on synapse worker processes. Contributed by Nick @ Beeper.
+

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -158,6 +158,7 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
             "^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/(join|invite|leave|ban|unban|kick)$",
             "^/_matrix/client/(api/v1|r0|v3|unstable)/join/",
             "^/_matrix/client/(api/v1|r0|v3|unstable)/profile/",
+            "^/_matrix/client/(v1|unstable/org.matrix.msc2716)/rooms/.*/batch_send",
         ],
         "shared_extra_conf": {},
         "worker_extra_conf": "",

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -206,6 +206,7 @@ information.
     ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/members$
     ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/state$
     ^/_matrix/client/(v1|unstable/org.matrix.msc2946)/rooms/.*/hierarchy$
+    ^/_matrix/client/(v1|unstable/org.matrix.msc2716)/rooms/.*/batch_send$
     ^/_matrix/client/unstable/im.nheko.summary/rooms/.*/summary$
     ^/_matrix/client/(r0|v3|unstable)/account/3pid$
     ^/_matrix/client/(r0|v3|unstable)/devices$

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -78,6 +78,7 @@ from synapse.rest.client import (
     read_marker,
     receipts,
     room,
+    room_batch,
     room_keys,
     sendtodevice,
     sync,
@@ -308,6 +309,7 @@ class GenericWorkerServer(HomeServer):
                     room.register_servlets(self, resource, is_worker=True)
                     room.register_deprecated_servlets(self, resource)
                     initial_sync.register_servlets(self, resource)
+                    room_batch.register_servlets(self, resource)
                     room_keys.register_servlets(self, resource)
                     tags.register_servlets(self, resource)
                     account_data.register_servlets(self, resource)


### PR DESCRIPTION
I believe this should be safe, just as general room event sending is safe on worker instances. Another thing that can be pulled off main.

Signed off by Nick @ Beeper.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
