### PR TITLE
Don't create empty AS txns when the AS is down

### DIFF
--- a/changelog.d/12869.misc
+++ b/changelog.d/12869.misc
@@ -1,0 +1,1 @@
+Don't generate empty AS transactions when the AS is flagged as down. Contributed by Nick @ Beeper.

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -384,6 +384,11 @@ class _TransactionController:
             device_list_summary: The device list summary to include in the transaction.
         """
         try:
+            service_is_up = await self._is_service_up(service)
+            # Don't create empty txns when in recovery mode (ephemeral events are dropped)
+            if not service_is_up and not events:
+                return
+
             txn = await self.store.create_appservice_txn(
                 service=service,
                 events=events,
@@ -393,7 +398,6 @@ class _TransactionController:
                 unused_fallback_keys=unused_fallback_keys or {},
                 device_list_summary=device_list_summary or DeviceListUpdates(),
             )
-            service_is_up = await self._is_service_up(service)
             if service_is_up:
                 sent = await txn.send(self.as_api)
                 if sent:


### PR DESCRIPTION
Leftover fix/performance improvement we made a few weeks back to workaround an issue with the `get_latest_as_txn` query running slowly (we've not figured that out yet!).

Signed off by Nick @ Beeper.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
