### PR TITLE
Add stricter JSON type annotations to the Module API's account data manager.

### DIFF
--- a/changelog.d/12874.misc
+++ b/changelog.d/12874.misc
@@ -1,0 +1,1 @@
+Add stricter JSON type annotations to the Module API's account data manager.

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -112,6 +112,7 @@ from synapse.storage.databases.main.roommember import ProfileInfo
 from synapse.storage.state import StateFilter
 from synapse.types import (
     DomainSpecificString,
+    FrozenJsonDict,
     JsonDict,
     JsonMapping,
     Requester,
@@ -1498,7 +1499,9 @@ class AccountDataManager:
                 f"{user_id} is not local to this homeserver; can't access account data for remote users."
             )
 
-    async def get_global(self, user_id: str, data_type: str) -> Optional[JsonMapping]:
+    async def get_global(
+        self, user_id: str, data_type: str
+    ) -> Optional[FrozenJsonDict]:
         """
         Gets some global account data, of a specified type, for the specified user.
 

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -82,18 +82,26 @@ JsonSerializable = object
 # used for some basic sanity checking in e.g. module API return values.
 # Bottom out at `object` so that the caller knows they aren't getting any more
 # checking; they can always use casts if necessary.
-_FrozenJson1 = Union[str, int, float, None, frozendict[str, object], Tuple[object, ...]]
+
+_FrozenJson1 = Union[
+    str, int, float, None, "frozendict[str, object]", Tuple[object, ...]
+]
 _FrozenJson2 = Union[
-    str, int, float, None, frozendict[str, _FrozenJson1], Tuple[_FrozenJson1, ...]
+    str, int, float, None, "frozendict[str, _FrozenJson1]", Tuple[_FrozenJson1, ...]
 ]
 _FrozenJson3 = Union[
-    str, int, float, None, frozendict[str, _FrozenJson2], Tuple[_FrozenJson2, ...]
+    str, int, float, None, "frozendict[str, _FrozenJson2]", Tuple[_FrozenJson2, ...]
 ]
 
 # FrozenJson supports JSON-like data, but only using frozen data structures.
 # (frozendicts instead of dicts and tuples instead of lists)
 FrozenJson = _FrozenJson3
-FrozenJsonDict = frozendict[str, _FrozenJson3]
+if TYPE_CHECKING:
+    # frozendict isn't subscriptable.
+
+    FrozenJsonDict = frozendict[str, _FrozenJson3]
+else:
+    FrozenJsonDict = frozendict[str, Any]
 
 
 # Note that this seems to require inheriting *directly* from Interface in order

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -77,6 +77,25 @@ JsonMapping = Mapping[str, Any]
 JsonSerializable = object
 
 
+# Mypy doesn't support recursive type definitions, so unroll one manually a few
+# times. This makes this alias not entirely general-purpose, but it can be
+# used for some basic sanity checking in e.g. module API return values.
+# Bottom out at `object` so that the caller knows they aren't getting any more
+# checking; they can always use casts if necessary.
+_FrozenJson1 = Union[str, int, float, None, frozendict[str, object], Tuple[object, ...]]
+_FrozenJson2 = Union[
+    str, int, float, None, frozendict[str, _FrozenJson1], Tuple[_FrozenJson1, ...]
+]
+_FrozenJson3 = Union[
+    str, int, float, None, frozendict[str, _FrozenJson2], Tuple[_FrozenJson2, ...]
+]
+
+# FrozenJson supports JSON-like data, but only using frozen data structures.
+# (frozendicts instead of dicts and tuples instead of lists)
+FrozenJson = _FrozenJson3
+FrozenJsonDict = frozendict[str, _FrozenJson3]
+
+
 # Note that this seems to require inheriting *directly* from Interface in order
 # for mypy-zope to realize it is an interface.
 class ISynapseReactor(


### PR DESCRIPTION
This would have caught an issue in the auto-accept invitation module.

Considering we don't have integration tests for modules, it would really make me happy to see better type coverage in modules.

I first tried the heinous hack that is https://github.com/python/typing/issues/182#issuecomment-899624078 but it severely confused Mypy.


