### PR TITLE
Close `ijson` coroutines ourselves instead of letting the GC close them

### DIFF
--- a/changelog.d/12875.bugfix
+++ b/changelog.d/12875.bugfix
@@ -1,0 +1,1 @@
+Explicitly close `ijson` coroutines once we are done with them, instead of leaving the garbage collector to close them.

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -225,6 +225,7 @@ async def _handle_response(
     if max_response_size is None:
         max_response_size = MAX_RESPONSE_SIZE
 
+    finished = False
     try:
         check_content_type_is(response.headers, parser.CONTENT_TYPE)
 
@@ -233,6 +234,7 @@ async def _handle_response(
 
         length = await make_deferred_yieldable(d)
 
+        finished = True
         value = parser.finish()
     except BodyExceededMaxSize as e:
         # The response was too big.
@@ -283,6 +285,15 @@ async def _handle_response(
             e,
         )
         raise
+    finally:
+        if not finished:
+            # There was an exception and we didn't `finish()` the parse.
+            # Let the parser know that it can free up any resources.
+            try:
+                parser.finish()
+            except Exception:
+                # Ignore any additional exceptions.
+                pass
 
     time_taken_secs = reactor.seconds() - start_ms / 1000
 


### PR DESCRIPTION
Hopefully this means that exceptions raised due to truncated JSON
get a sensible logging context and stack.

Signed-off-by: Sean Quah <seanq@matrix.org>

-------

On matrix.org sentry, we are seeing a lot of `Exception ignored in: <generator object utf8_encoder at 0x7f87c9b1ccf0>` errors without a proper stack trace or logging context.

Digging into the logs, we find something like:
```
2022-05-25 05:15:16,092 - twisted - 279 - ERROR - sentinel - Exception ignored in: <generator object utf8_encoder at 0x7ff6c944b6d0>
2022-05-25 05:15:16,093 - twisted - 279 - ERROR - sentinel - Traceback (most recent call last):
2022-05-25 05:15:16,095 - twisted - 279 - ERROR - sentinel -   File "/.../site-packages/ijson/backends/python.py", line 46, in utf8_encoder
2022-05-25 05:15:16,098 - twisted - 279 - ERROR - sentinel -     target.close()
2022-05-25 05:15:16,099 - twisted - 279 - ERROR - sentinel -   File "/.../site-packages/ijson/backends/python.py", line 116, in Lexer
2022-05-25 05:15:16,100 - twisted - 279 - ERROR - sentinel -     target.send(EOF)
2022-05-25 05:15:16,101 - twisted - 279 - ERROR - sentinel -   File "/.../site-packages/ijson/backends/python.py", line 161, in parse_value
2022-05-25 05:15:16,102 - twisted - 279 - ERROR - sentinel -     raise common.IncompleteJSONError('Incomplete JSON content')
2022-05-25 05:15:16,103 - twisted - 279 - ERROR - sentinel - ijson.common.IncompleteJSONError: Incomplete JSON content
2022-05-25 05:15:16,104 - twisted - 279 - ERROR - sentinel - Exception ignored in: <generator object utf8_encoder at 0x7ff614ca97b0>
2022-05-25 05:15:16,105 - twisted - 279 - ERROR - sentinel - Traceback (most recent call last):
2022-05-25 05:15:16,106 - twisted - 279 - ERROR - sentinel -   File "/.../site-packages/ijson/backends/python.py", line 46, in utf8_encoder
2022-05-25 05:15:16,107 - twisted - 279 - ERROR - sentinel -     target.close()
2022-05-25 05:15:16,108 - twisted - 279 - ERROR - sentinel -   File "/.../site-packages/ijson/backends/python.py", line 116, in Lexer
2022-05-25 05:15:16,110 - twisted - 279 - ERROR - sentinel -     target.send(EOF)
2022-05-25 05:15:16,111 - twisted - 279 - ERROR - sentinel -   File "/.../site-packages/ijson/backends/python.py", line 161, in parse_value
2022-05-25 05:15:16,112 - twisted - 279 - ERROR - sentinel -     raise common.IncompleteJSONError('Incomplete JSON content')
2022-05-25 05:15:16,113 - twisted - 279 - ERROR - sentinel - ijson.common.IncompleteJSONError: Incomplete JSON content
```

Which I think is happening when Python garbage collects / frees `ijson` coroutines and throws a `GeneratorExit` into them.
So let's call `close()` ourselves to have the exception raised upfront.

Note that the `ijson` examples all include an explicit `close()` call:
https://pypi.org/project/ijson/#push-interfaces