### PR TITLE
Avoid attempting to delete push actions for remote users.

### DIFF
--- a/changelog.d/12879.misc
+++ b/changelog.d/12879.misc
@@ -1,0 +1,1 @@
+Avoid running queries which will never result in deletions.

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -223,7 +223,7 @@ class PerDestinationQueue:
         """Marks that the destination has new data to send, without starting a
         new transaction.
 
-        If a transaction loop is already in progress then a new transcation will
+        If a transaction loop is already in progress then a new transaction will
         be attempted when the current one finishes.
         """
 

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -938,7 +938,7 @@ class EventPushActionsWorkerStore(SQLBaseStore):
         users can still get a list of recent highlights.
 
         Args:
-            txn: The transcation
+            txn: The transaction
             room_id: Room ID to delete from
             user_id: user ID to delete for
             stream_ordering: The lowest stream ordering which will

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -673,8 +673,11 @@ class ReceiptsWorkerStore(SQLBaseStore):
             lock=False,
         )
 
+        # When updating a local users read receipt, remove any push actions
+        # which resulted from the receipt's event and all earlier events.
         if (
-            receipt_type in (ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE)
+            self.hs.is_mine_id(user_id)
+            and receipt_type in (ReceiptTypes.READ, ReceiptTypes.READ_PRIVATE)
             and stream_ordering is not None
         ):
             self._remove_old_push_actions_before_txn(  # type: ignore[attr-defined]

--- a/synapse/storage/persist_events.py
+++ b/synapse/storage/persist_events.py
@@ -313,7 +313,7 @@ class EventsPersistenceStorage:
             List of events persisted, the current position room stream position.
             The list of events persisted may not be the same as those passed in
             if they were deduplicated due to an event already existing that
-            matched the transcation ID; the existing event is returned in such
+            matched the transaction ID; the existing event is returned in such
             a case.
         """
         partitioned: Dict[str, List[Tuple[EventBase, EventContext]]] = {}


### PR DESCRIPTION
I was poking at the receipts code and noticed that we unconditionally call `_remove_old_push_actions_before_txn` for any read or private read receipt. This [deletes things from `event_push_actions` and `event_push_summary`](https://github.com/matrix-org/synapse/blob/de6e2bc986170605c9500395008fd0129aaea0c1/synapse/storage/databases/main/event_push_actions.py#L930-L974), but those tables only have entries for local users. We can skip those deletes which will never find any users.

These tables both have indexes on them such that the queries are both probably "instant", but if we can avoid the round-trip to the database, creating a transaction, etc. that's a nice win.

(Also fixes some spelling of "transaction" in a few spots.)