### PR TITLE
Add an option allowing users to use their password to reauthenticate even though password authentication is disabled.

### DIFF
--- a/changelog.d/12883.feature
+++ b/changelog.d/12883.feature
@@ -1,0 +1,1 @@
+Add an option allowing users to use their password to log in or reauthenticate even though password authentication is disabled.

--- a/changelog.d/12883.feature
+++ b/changelog.d/12883.feature
@@ -1,1 +1,1 @@
-Add an option allowing users to use their password to log in or reauthenticate even though password authentication is disabled.
+Add an option allowing users to use their password to reauthenticate for privileged actions even though password login is disabled.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2192,7 +2192,9 @@ sso:
 
 
 password_config:
-   # Uncomment to disable password login
+   # Uncomment to disable password login.
+   # Set to `only_for_reauth` to permit reauthentication for users that
+   # have passwords and are already logged in.
    #
    #enabled: false
 

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -2873,6 +2873,9 @@ Use this setting to enable password-based logins.
 
 This setting has the following sub-options:
 * `enabled`: Defaults to true.
+   Set to false to disable password authentication.
+   Set to `only_for_reauth` to allow users with existing passwords to use them
+   to log in and reauthenticate, whilst preventing new users from setting passwords.
 * `localdb_enabled`: Set to false to disable authentication against the local password
    database. This is ignored if `enabled` is false, and is only useful
    if you have other `password_providers`. Defaults to true. 

--- a/synapse/config/auth.py
+++ b/synapse/config/auth.py
@@ -30,13 +30,16 @@ class AuthConfig(Config):
             password_config = {}
 
         passwords_enabled = password_config.get("enabled", True)
-        self.password_enabled = passwords_enabled
         # 'only_for_reauth' allows users who have previously set a password to use it,
         # even though passwords would otherwise be disabled.
-        self.password_enabled_for_reauth = passwords_enabled == "only_for_reauth"
+        passwords_for_reauth_only = passwords_enabled == "only_for_reauth"
 
-        if self.password_enabled_for_reauth:
-            self.password_enabled = False
+        self.password_enabled_for_login = (
+            passwords_enabled and not passwords_for_reauth_only
+        )
+        self.password_enabled_for_reauth = (
+            passwords_for_reauth_only or passwords_enabled
+        )
 
         self.password_localdb_enabled = password_config.get("localdb_enabled", True)
         self.password_pepper = password_config.get("pepper", "")

--- a/synapse/config/auth.py
+++ b/synapse/config/auth.py
@@ -57,7 +57,9 @@ class AuthConfig(Config):
     def generate_config_section(self, **kwargs: Any) -> str:
         return """\
         password_config:
-           # Uncomment to disable password login
+           # Uncomment to disable password login.
+           # Set to `only_for_reauth` to permit reauthentication for users that
+           # have passwords and are already logged in.
            #
            #enabled: false
 

--- a/synapse/config/auth.py
+++ b/synapse/config/auth.py
@@ -29,7 +29,15 @@ class AuthConfig(Config):
         if password_config is None:
             password_config = {}
 
-        self.password_enabled = password_config.get("enabled", True)
+        passwords_enabled = password_config.get("enabled", True)
+        self.password_enabled = passwords_enabled
+        # 'only_for_reauth' allows users who have previously set a password to use it,
+        # even though passwords would otherwise be disabled.
+        self.password_enabled_for_reauth = passwords_enabled == "only_for_reauth"
+
+        if self.password_enabled_for_reauth:
+            self.password_enabled = False
+
         self.password_localdb_enabled = password_config.get("localdb_enabled", True)
         self.password_pepper = password_config.get("pepper", "")
 

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -22,6 +23,7 @@ from twisted.web.resource import Resource
 import synapse.rest.admin
 from synapse.api.constants import LoginType
 from synapse.handlers.ui_auth.checkers import UserInteractiveAuthChecker
+from synapse.rest import admin
 from synapse.rest.client import account, auth, devices, login, logout, register
 from synapse.rest.synapse.client import build_synapse_client_resource_tree
 from synapse.server import HomeServer
@@ -33,7 +35,7 @@ from tests import unittest
 from tests.handlers.test_oidc import HAS_OIDC
 from tests.rest.client.utils import TEST_OIDC_CONFIG
 from tests.server import FakeChannel
-from tests.unittest import override_config, skip_unless
+from tests.unittest import HomeserverTestCase, override_config, skip_unless
 
 
 class DummyRecaptchaChecker(UserInteractiveAuthChecker):
@@ -1079,3 +1081,28 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
         # and no refresh token
         self.assertEqual(_table_length("access_tokens"), 0)
         self.assertEqual(_table_length("refresh_tokens"), 0)
+
+
+class PasswordReauthTestCase(HomeserverTestCase):
+    servlets = [admin.register_servlets, login.register_servlets]
+
+    @override_config({"password_config": {"enabled": "only_for_reauth"}})
+    def test_password_reauth_succeeds_with_setting(self) -> None:
+        """
+        A user can re-authenticate using a previously-set password if
+        'only_for_reauth' is set.
+        """
+        user_id = self.register_user("christina", "verysecret")
+        self.login(user_id, "verysecret")
+
+    @override_config({"password_config": {"enabled": False}})
+    def test_password_reauth_fails_if_disabled(self) -> None:
+        user_id = self.register_user("christina", "verysecret")
+
+        body = {"type": "m.login.password", "user": user_id, "password": "verysecret"}
+        channel = self.make_request(
+            "POST",
+            "/_matrix/client/r0/login",
+            json.dumps(body).encode("utf8"),
+        )
+        self.assertEqual(channel.code, 400, channel.result)


### PR DESCRIPTION
Fixes #12844.

This splits up the use of passwords *for login* and *for reauthentication (for privileged operations, e.g. deleting devices, setting cross-signing keys, ...)*.

Registration is unaffected.