### PR TITLE
Improve URL previews by not including the content of media tags in the generated description.

### DIFF
--- a/changelog.d/12887.misc
+++ b/changelog.d/12887.misc
@@ -1,0 +1,1 @@
+Improve URL previews by not including the content of media tags in the generated description.

--- a/synapse/rest/media/v1/preview_html.py
+++ b/synapse/rest/media/v1/preview_html.py
@@ -246,7 +246,9 @@ def parse_html_description(tree: "etree.Element") -> Optional[str]:
 
     Grabs any text nodes which are inside the <body/> tag, unless they are within
     an HTML5 semantic markup tag (<header/>, <nav/>, <aside/>, <footer/>), or
-    if they are within a <script/> or <style/> tag.
+    if they are within a <script/>, <svg/> or <style/> tag, or if they are within
+    a tag whose content is usually only shown to old browsers
+    (<iframe/>, <video/>, <canvas/>, <picture/>).
 
     This is a very very very coarse approximation to a plain text render of the page.
 
@@ -268,6 +270,12 @@ def parse_html_description(tree: "etree.Element") -> Optional[str]:
         "script",
         "noscript",
         "style",
+        "svg",
+        "iframe",
+        "video",
+        "canvas",
+        "img",
+        "picture",
         etree.Comment,
     )
 


### PR DESCRIPTION
Many of these tags aren't intended to be text for human consumption, or if they are, the content is only shown to older browsers that don't understand them and so they usually
just say silly things like 'Upgrade your browser!!'.

