### PR TITLE
Clean-up some receipts code

### DIFF
--- a/changelog.d/12888.misc
+++ b/changelog.d/12888.misc
@@ -1,0 +1,1 @@
+Refactor receipt linearization code.

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -761,22 +761,6 @@ class ReceiptsWorkerStore(SQLBaseStore):
             now - event_ts,
         )
 
-        await self.insert_graph_receipt(room_id, receipt_type, user_id, event_ids, data)
-
-        max_persisted_id = self._receipts_id_gen.get_current_token()
-
-        return stream_id, max_persisted_id
-
-    async def insert_graph_receipt(
-        self,
-        room_id: str,
-        receipt_type: str,
-        user_id: str,
-        event_ids: List[str],
-        data: JsonDict,
-    ) -> None:
-        assert self._can_write_to_receipts
-
         await self.db_pool.runInteraction(
             "insert_graph_receipt",
             self._insert_graph_receipt_txn,
@@ -786,6 +770,10 @@ class ReceiptsWorkerStore(SQLBaseStore):
             event_ids,
             data,
         )
+
+        max_persisted_id = self._receipts_id_gen.get_current_token()
+
+        return stream_id, max_persisted_id
 
     def _insert_graph_receipt_txn(
         self,

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -689,6 +689,21 @@ class ReceiptsWorkerStore(SQLBaseStore):
     def _graph_to_linear(
         self, txn: LoggingTransaction, room_id: str, event_ids: List[str]
     ) -> str:
+        """
+        Generate a linearized event from a list of events (i.e. a list of forward
+        extremities in the room).
+
+        This should allow for calculation of the correct read receipt even if
+        servers have different event ordering.
+
+        Args:
+            txn: The transaction
+            room_id: The room ID the events are in.
+            event_ids: The list of event IDs to linearize.
+
+        Returns:
+            The linearized event ID.
+        """
         # TODO: Make this better.
         clause, args = make_in_list_sql_clause(
             self.database_engine, "event_id", event_ids

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -597,7 +597,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
 
         return super().process_replication_rows(stream_name, instance_name, token, rows)
 
-    def insert_linearized_receipt_txn(
+    def _insert_linearized_receipt_txn(
         self,
         txn: LoggingTransaction,
         room_id: str,
@@ -740,7 +740,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
         async with self._receipts_id_gen.get_next() as stream_id:  # type: ignore[attr-defined]
             event_ts = await self.db_pool.runInteraction(
                 "insert_linearized_receipt",
-                self.insert_linearized_receipt_txn,
+                self._insert_linearized_receipt_txn,
                 room_id,
                 receipt_type,
                 user_id,
@@ -779,7 +779,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
 
         await self.db_pool.runInteraction(
             "insert_graph_receipt",
-            self.insert_graph_receipt_txn,
+            self._insert_graph_receipt_txn,
             room_id,
             receipt_type,
             user_id,
@@ -787,7 +787,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
             data,
         )
 
-    def insert_graph_receipt_txn(
+    def _insert_graph_receipt_txn(
         self,
         txn: LoggingTransaction,
         room_id: str,


### PR DESCRIPTION
I was poking at this code a few times and there's some bits that annoy me / confuse me about it:

* Properly marks private methods as private.
* Add some docstrings.
* Rejigger some useless / inline methods.
