### PR TITLE
Rework stream token to stop caring about groups.

### DIFF
--- a/synapse/streams/events.py
+++ b/synapse/streams/events.py
@@ -54,7 +54,6 @@ class EventSources:
         push_rules_key = self.store.get_max_push_rules_stream_id()
         to_device_key = self.store.get_to_device_stream_token()
         device_list_key = self.store.get_device_stream_token()
-        groups_key = self.store.get_group_stream_token()
 
         token = StreamToken(
             room_key=self.sources.room.get_current_key(),
@@ -65,7 +64,8 @@ class EventSources:
             push_rules_key=push_rules_key,
             to_device_key=to_device_key,
             device_list_key=device_list_key,
-            groups_key=groups_key,
+            # Groups key is unused.
+            groups_key=0,
         )
         return token
 

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -691,6 +691,7 @@ class StreamToken:
     push_rules_key: int
     to_device_key: int
     device_list_key: int
+    # Note that the groups key is no longer used and may have bogus values.
     groups_key: int
 
     _SEPARATOR = "_"
@@ -722,6 +723,9 @@ class StreamToken:
                 str(self.push_rules_key),
                 str(self.to_device_key),
                 str(self.device_list_key),
+                # Note that the groups key is no longer used, but it is still
+                # serialized so that there will not be confusion in the future
+                # if additional tokens are added.
                 str(self.groups_key),
             ]
         )


### PR DESCRIPTION
Follow-on to #12553, #12558, and #12563 (split out of #12499, part of #11584), in this PR we rework the `StreamToken` class to stop caring about the `group` key.

Mostly just replication and datastores left after this.