### PR TITLE
pynacl purge and some questions about it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ unpaddedbase64 = ">=2.1.0"
 canonicaljson = ">=1.4.0"
 # we use the type definitions added in signedjson 1.1.
 signedjson = ">=1.1.0"
-PyNaCl = ">=1.2.1"
 # validating SSL certs for IP addresses requires service_identity 18.1.
 service-identity = ">=18.1.0"
 # Twisted 18.9 introduces some logger improvements that the structured

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -19,8 +19,8 @@ import attr
 import canonicaljson
 import signedjson.key
 import signedjson.sign
-from nacl.signing import SigningKey
 from signedjson.key import encode_verify_key_base64, get_verify_key
+from signedjson.types import SigningKey
 
 from twisted.internet import defer
 from twisted.internet.defer import Deferred, ensureDeferred


### PR DESCRIPTION
Partially addresses #12325 

I have no idea on how to purge the `tests/crypto/test_event_signing.py`, as it contains the seed which signedjson does not seem to directly support. I'm open to suggestions on how to proceed with this one.

There is also mention in `contrib/cmdclient/console.py` that is impossible to remove with current implementation of signedjson, and is not tested at all, so I did not touch that as well. 

I could open PRs in signedjson that addresses the missing functionalities and leave this PR hanging for the time being. Project maintainers, please advise on how to proceed with this one, thank you.
