### PR TITLE
Don't return `end` from `/messages` if there are no more events

### DIFF
--- a/changelog.d/12903.bugfix
+++ b/changelog.d/12903.bugfix
@@ -1,1 +1,1 @@
-Do not return end attribute when there are no more events
+Do not return end attribute when there are no more events.

--- a/changelog.d/12903.bugfix
+++ b/changelog.d/12903.bugfix
@@ -1,0 +1,1 @@
+Do not return end attribute when there are no more events

--- a/changelog.d/12903.bugfix
+++ b/changelog.d/12903.bugfix
@@ -1,1 +1,1 @@
-Do not return end attribute when there are no more events.
+Fix a long-standing bug which caused the `/messages` endpoint to return an incorrect `end` attribute when there were no more events. Contributed by @Vetchu.

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -515,8 +515,10 @@ class PaginationHandler:
 
             next_token = from_token.copy_and_replace(StreamKeyType.ROOM, next_key)
 
-        # if no events are returned from pagination
-        # do not return end - there's no need for further queries
+        # if no events are returned from pagination, that implies
+        # we have reached the end of the available events.
+        # In that case we do not return end, to tell the client
+        # there is no need for further queries.
         if not events:
             return {
                 "chunk": [],

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -527,7 +527,6 @@ class PaginationHandler:
             return {
                 "chunk": [],
                 "start": await from_token.to_string(self.store),
-                "end": await next_token.to_string(self.store),
             }
 
         state = None


### PR DESCRIPTION
Fixes #12102.

Judging by this [comment](https://github.com/matrix-org/matrix-spec-proposals/issues/2251#issuecomment-932821615) and the [spec](https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3roomsroomidmessages) this should fix the issue.

I'm not sure if end should be null if this was the last chunk of information but was non empty, but I do not know if it is possible to check if there are no more events in `next_token`.

Signed-off-by: Jacek Kuśnierz <kusnierz@protonmail.com>