### PR TITLE
Fix `get_metadata_for_events`

### DIFF
--- a/changelog.d/12904.misc
+++ b/changelog.d/12904.misc
@@ -1,0 +1,1 @@
+Pull out less state when handling gaps in room DAG.

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -167,8 +167,8 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
             )
 
             sql = f"""
-                SELECT e.event_id, e.room_id, e.type, e.state_key FROM events AS e
-                LEFT JOIN state_events USING (event_id)
+                SELECT e.event_id, e.room_id, e.type, se.state_key FROM events AS e
+                LEFT JOIN state_events se USING (event_id)
                 WHERE {clause}
             """
 


### PR DESCRIPTION
This method was introduced in #12852. It is using the `state_key` column from
the `events` table, which is not (yet) reliable (see #11496).