### PR TITLE
Stop reading from `event_edges.room_id`.

### DIFF
--- a/changelog.d/12914.misc
+++ b/changelog.d/12914.misc
@@ -1,0 +1,1 @@
+Preparation for database schema simplifications: stop reading from `event_edges.room_id`.

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1325,9 +1325,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
         while front and len(event_results) < limit:
             new_front = set()
             for event_id in front:
-                txn.execute(
-                    query, (event_id, limit - len(event_results))
-                )
+                txn.execute(query, (event_id, limit - len(event_results)))
 
                 new_results = {t[0] for t in txn} - seen_events
 

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1326,7 +1326,6 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
             new_front = set()
             for event_id in front:
                 txn.execute(query, (event_id, limit - len(event_results)))
-
                 new_results = {t[0] for t in txn} - seen_events
 
                 new_front |= new_results

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1318,7 +1318,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
 
         query = (
             "SELECT prev_event_id FROM event_edges "
-            "WHERE event_id = ? AND is_state = ? "
+            "WHERE event_id = ? AND NOT is_state "
             "LIMIT ?"
         )
 
@@ -1326,7 +1326,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
             new_front = set()
             for event_id in front:
                 txn.execute(
-                    query, (room_id, event_id, False, limit - len(event_results))
+                    query, (event_id, limit - len(event_results))
                 )
 
                 new_results = {t[0] for t in txn} - seen_events

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1318,7 +1318,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
 
         query = (
             "SELECT prev_event_id FROM event_edges "
-            "WHERE room_id = ? AND event_id = ? AND is_state = ? "
+            "WHERE event_id = ? AND is_state = ? "
             "LIMIT ?"
         )
 

--- a/synapse/storage/schema/__init__.py
+++ b/synapse/storage/schema/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SCHEMA_VERSION = 70  # remember to update the list below when updating
+SCHEMA_VERSION = 71  # remember to update the list below when updating
 """Represents the expectations made by the codebase about the database schema
 
 This should be incremented whenever the codebase changes its requirements on the
@@ -67,6 +67,9 @@ Changes in SCHEMA_VERSION = 69:
 
 Changes in SCHEMA_VERSION = 70:
     - event_reference_hashes is no longer written to.
+
+Changes in SCHEMA_VERSION = 71:
+    - event_edges.room_id is no longer read from.
 """
 
 


### PR DESCRIPTION
A first step for #12892, and another go at #3613. `event_edges.room_id` is implied by the event id, so there is no need to join on the room id.