### PR TITLE
Document the Synapse version of a new module API method

### DIFF
--- a/changelog.d/12917.feature
+++ b/changelog.d/12917.feature
@@ -1,0 +1,1 @@
+Add storage and module API methods to get monthly active users (and their corresponding appservices) within an optionally specified time range.

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -1149,7 +1149,10 @@ class ModuleApi:
             )
 
     async def sleep(self, seconds: float) -> None:
-        """Sleeps for the given number of seconds."""
+        """Sleeps for the given number of seconds.
+
+        Added in Synapse v1.49.0.
+        """
 
         await self._clock.sleep(seconds)
 
@@ -1434,6 +1437,8 @@ class ModuleApi:
     ) -> List[Tuple[str, str]]:
         """Generates list of monthly active users and their services.
         Please see corresponding storage docstring for more details.
+
+        Added in Synapse v1.61.0.
 
         Arguments:
             start_timestamp: If specified, only include users that were first active


### PR DESCRIPTION
Looks like this got missed in https://github.com/matrix-org/synapse/pull/12838

Also did `sleep` which I've probably missed when I documented the other existing methods.