### PR TITLE
Improve logging when signature checks fail

### DIFF
--- a/changelog.d/12925.misc
+++ b/changelog.d/12925.misc
@@ -1,0 +1,1 @@
+Improve the logging when signature checks on events fail.

--- a/synapse/federation/federation_base.py
+++ b/synapse/federation/federation_base.py
@@ -72,17 +72,13 @@ class FederationBase:
         Returns:
               * the original event if the checks pass
               * a redacted version of the event (if the signature
-                matched but the hash did not)
+                matched but the hash did not). In this case a warning will be logged.
 
         Raises:
-              SynapseError if the signature check failed.
+          InvalidEventSignatureError if the signature check failed. Nothing
+             will be logged in this case.
         """
-        try:
-            await _check_sigs_on_pdu(self.keyring, room_version, pdu)
-        except InvalidEventSignatureError as e:
-            errmsg = f"event id {pdu.event_id}: {e}"
-            logger.warning("%s", errmsg)
-            raise SynapseError(403, errmsg, Codes.FORBIDDEN)
+        await _check_sigs_on_pdu(self.keyring, room_version, pdu)
 
         if not check_event_content_hash(pdu):
             # let's try to distinguish between failures because the event was

--- a/synapse/federation/federation_base.py
+++ b/synapse/federation/federation_base.py
@@ -97,7 +97,7 @@ class FederationBase:
             if set(redacted_event.keys()) == set(pdu.keys()) and set(
                 redacted_event.content.keys()
             ) == set(pdu.content.keys()):
-                logger.info(
+                logger.debug(
                     "Event %s seems to have been redacted; using our redacted copy",
                     pdu.event_id,
                 )


### PR DESCRIPTION
Attempts to log less useless stuff, and give clearer warnings about what's going on when there are genuine fails.

Review commit-by-commit.