### PR TITLE
Fix complement tests using the wrong path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -372,7 +372,7 @@ jobs:
       # Attempt to check out the same branch of Complement as the PR. If it
       # doesn't exist, fallback to HEAD.
       - name: Checkout complement
-        run: .ci/scripts/checkout_complement.sh
+        run: synapse/.ci/scripts/checkout_complement.sh
 
       - run: |
           set -o pipefail

--- a/changelog.d/12933.misc
+++ b/changelog.d/12933.misc
@@ -1,1 +1,1 @@
-Fix Complement (develop only) test suite using the wrong path for `checkout_complement.sh`.
+Test Synapse against Complement with workers.

--- a/changelog.d/12933.misc
+++ b/changelog.d/12933.misc
@@ -1,0 +1,1 @@
+Fix Complement (develop only) test suite using the wrong path for `checkout_complement.sh`.


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
