### PR TITLE
Add Cross-Origin-Resource-Policy header to thumbnail and download media endpoints

### DIFF
--- a/changelog.d/12944.misc
+++ b/changelog.d/12944.misc
@@ -1,0 +1,1 @@
+Add `Cross-Origin-Resource-Policy: cross-origin` header to content repository's thumbnail and download endpoints.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -927,6 +927,16 @@ def set_cors_headers(request: Request) -> None:
         b"X-Requested-With, Content-Type, Authorization, Date",
     )
 
+def set_corp_headers(request: Request) -> None:
+    """Set the CORP headers so that javascript running in a web browsers can
+    embed the resource returned from this request when their client requires
+    the `Cross-Origin-Embedder-Policy: require-corp` header.
+
+    Args:
+        request: The http request to add the CORP header to.
+    """
+    request.setHeader(b"Cross-Origin-Resource-Policy", b"cross-origin")
+
 
 def respond_with_html(request: Request, code: int, html: str) -> None:
     """

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -937,7 +937,6 @@ def set_corp_headers(request: Request) -> None:
     """
     request.setHeader(b"Cross-Origin-Resource-Policy", b"cross-origin")
 
-
 def respond_with_html(request: Request, code: int, html: str) -> None:
     """
     Wraps `respond_with_html_bytes` by first encoding HTML from a str to UTF-8 bytes.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -927,6 +927,7 @@ def set_cors_headers(request: Request) -> None:
         b"X-Requested-With, Content-Type, Authorization, Date",
     )
 
+
 def set_corp_headers(request: Request) -> None:
     """Set the CORP headers so that javascript running in a web browsers can
     embed the resource returned from this request when their client requires
@@ -936,6 +937,7 @@ def set_corp_headers(request: Request) -> None:
         request: The http request to add the CORP header to.
     """
     request.setHeader(b"Cross-Origin-Resource-Policy", b"cross-origin")
+
 
 def respond_with_html(request: Request, code: int, html: str) -> None:
     """

--- a/synapse/rest/media/v1/download_resource.py
+++ b/synapse/rest/media/v1/download_resource.py
@@ -15,7 +15,11 @@
 import logging
 from typing import TYPE_CHECKING
 
-from synapse.http.server import DirectServeJsonResource, set_cors_headers, set_corp_headers
+from synapse.http.server import (
+    DirectServeJsonResource,
+    set_corp_headers,
+    set_cors_headers,
+)
 from synapse.http.servlet import parse_boolean
 from synapse.http.site import SynapseRequest
 

--- a/synapse/rest/media/v1/download_resource.py
+++ b/synapse/rest/media/v1/download_resource.py
@@ -15,7 +15,7 @@
 import logging
 from typing import TYPE_CHECKING
 
-from synapse.http.server import DirectServeJsonResource, set_cors_headers
+from synapse.http.server import DirectServeJsonResource, set_cors_headers, set_corp_headers
 from synapse.http.servlet import parse_boolean
 from synapse.http.site import SynapseRequest
 
@@ -38,6 +38,7 @@ class DownloadResource(DirectServeJsonResource):
 
     async def _async_render_GET(self, request: SynapseRequest) -> None:
         set_cors_headers(request)
+        set_corp_headers(request)
         request.setHeader(
             b"Content-Security-Policy",
             b"sandbox;"

--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -18,7 +18,11 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from synapse.api.errors import SynapseError
-from synapse.http.server import DirectServeJsonResource, set_cors_headers, set_corp_headers
+from synapse.http.server import (
+    DirectServeJsonResource,
+    set_corp_headers,
+    set_cors_headers,
+)
 from synapse.http.servlet import parse_integer, parse_string
 from synapse.http.site import SynapseRequest
 from synapse.rest.media.v1.media_storage import MediaStorage

--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -18,7 +18,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from synapse.api.errors import SynapseError
-from synapse.http.server import DirectServeJsonResource, set_cors_headers
+from synapse.http.server import DirectServeJsonResource, set_cors_headers, set_corp_headers
 from synapse.http.servlet import parse_integer, parse_string
 from synapse.http.site import SynapseRequest
 from synapse.rest.media.v1.media_storage import MediaStorage
@@ -58,6 +58,7 @@ class ThumbnailResource(DirectServeJsonResource):
 
     async def _async_render_GET(self, request: SynapseRequest) -> None:
         set_cors_headers(request)
+        set_corp_headers(request)
         server_name, media_id, _ = parse_media_id(request)
         width = parse_integer(request, "width", required=True)
         height = parse_integer(request, "height", required=True)

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -481,6 +481,12 @@ class MediaRepoTests(unittest.HomeserverTestCase):
 
         if expected_found:
             self.assertEqual(channel.code, 200)
+
+            self.assertEqual(
+                channel.headers.getRawHeaders(b"Cross-Origin-Resource-Policy"),
+                [b"cross-origin"],
+            )
+            
             if expected_body is not None:
                 self.assertEqual(
                     channel.result["body"], expected_body, channel.result["body"]
@@ -547,6 +553,20 @@ class MediaRepoTests(unittest.HomeserverTestCase):
         self.assertEqual(
             headers.getRawHeaders(b"X-Robots-Tag"),
             [b"noindex, nofollow, noarchive, noimageindex"],
+        )
+
+    def test_cross_origin_resource_policy_header(self) -> None:
+        """
+        Test that the Cross-Origin-Resource-Policy header is set to "cross-origin"
+        allowing web clients to embed media from the downloads API.
+        """
+        channel = self._req(b"inline; filename=out" + self.test_image.extension)
+
+        headers = channel.headers
+
+        self.assertEqual(
+            headers.getRawHeaders(b"Cross-Origin-Resource-Policy"),
+            [b"cross-origin"],
         )
 
 

--- a/tests/rest/media/v1/test_media_storage.py
+++ b/tests/rest/media/v1/test_media_storage.py
@@ -486,7 +486,7 @@ class MediaRepoTests(unittest.HomeserverTestCase):
                 channel.headers.getRawHeaders(b"Cross-Origin-Resource-Policy"),
                 [b"cross-origin"],
             )
-            
+
             if expected_body is not None:
                 self.assertEqual(
                     channel.result["body"], expected_body, channel.result["body"]


### PR DESCRIPTION
This PR is an implementation of [MSC3828](https://github.com/matrix-org/matrix-spec-proposals/pull/3828) which adds the `Cross-Origin-Resource-Policy: cross-origin` header to the media repository's thumbnail and download endpoints. This is a required header for web-based Matrix clients which use features like `SharedArrayBuffer` which requires the `Cross-Origin-Embedder-Policy: require-corp` header be set.