### PR TITLE
Do not break URL previews if an image 404s

### DIFF
--- a/changelog.d/12950.bugfix
+++ b/changelog.d/12950.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where a URL preview would break if the image failed to download.


### PR DESCRIPTION
Fixes #5298.

If we fail to download an image (i.e. due to a 404), or are unable to process that image. We should still return *something* for the URL preview.
