### PR TITLE
Use READ COMMITTED isolation level when inserting read receipts

### DIFF
--- a/changelog.d/12957.misc
+++ b/changelog.d/12957.misc
@@ -1,0 +1,1 @@
+Use lower isolation level when inserting read receipts to avoid serialization errors. Contributed by Nick @ Beeper.

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -29,13 +29,14 @@ from typing import (
 from synapse.api.constants import EduTypes, ReceiptTypes
 from synapse.replication.slave.storage._slaved_id_tracker import SlavedIdTracker
 from synapse.replication.tcp.streams import ReceiptsStream
-from synapse.storage._base import SQLBaseStore, IsolationLevel, db_to_json, make_in_list_sql_clause
+from synapse.storage._base import SQLBaseStore, db_to_json, make_in_list_sql_clause
 from synapse.storage.database import (
     DatabasePool,
     LoggingDatabaseConnection,
     LoggingTransaction,
 )
 from synapse.storage.engines import PostgresEngine
+from synapse.storage.engines._base import IsolationLevel
 from synapse.storage.util.id_generators import (
     AbstractStreamIdTracker,
     MultiWriterIdGenerator,


### PR DESCRIPTION
This is by far the greatest cause of serialisation errors in our instance. Read committed is actually beneficial here because we check for a receipt with greater stream order, and checking the very latest data at select time is better than the data at transaction start time (I think :)).

Signed off by Nick @ Beeper

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
