### PR TITLE
Reduce amount of state we pull out when attempting to send catchup PDUs.

### DIFF
--- a/changelog.d/12963.misc
+++ b/changelog.d/12963.misc
@@ -1,0 +1,1 @@
+Reduce amount of state we pull out when attempting to send catchup PDUs.

--- a/changelog.d/12963.misc
+++ b/changelog.d/12963.misc
@@ -1,1 +1,1 @@
-Reduce amount of state we pull out when attempting to send catchup PDUs.
+Reduce the amount of state we pull from the DB.


### PR DESCRIPTION
Currently we pull out all hosts in the room for each event we want to send to check that the server is allowed to see the event, even for public rooms. Instead, let's use `filter_events_for_server` which does the right thing.