### PR TITLE
Fix a stale comment in get_room_version_id_txn.

### DIFF
--- a/changelog.d/12969.misc
+++ b/changelog.d/12969.misc
@@ -1,0 +1,1 @@
+Fix an inaccurate comment.

--- a/synapse/storage/databases/main/state.py
+++ b/synapse/storage/databases/main/state.py
@@ -127,13 +127,8 @@ class StateGroupWorkerStore(EventsWorkerStore, SQLBaseStore):
             NotFoundError: if the room is unknown
         """
 
-        # First we try looking up room version from the database, but for old
-        # rooms we might not have added the room version to it yet so we fall
-        # back to previous behaviour and look in current state events.
-        #
         # We really should have an entry in the rooms table for every room we
-        # care about, but let's be a bit paranoid (at least while the background
-        # update is happening) to avoid breaking existing rooms.
+        # care about, but let's be a bit paranoid.
         room_version = self.db_pool.simple_select_one_onecol_txn(
             txn,
             table="rooms",


### PR DESCRIPTION
This comment was originally added in #6729 and then modified in #10245 to stop checking the create event (and only depend on the data in `rooms.room_version`. The comment lies though and says it falls back to the create event.

A combination of #6847/#7070 made it so that all nulls are filled in, but as far as I can see the column is still nullable though it seems that, so not sure if this change was on purpose.