### PR TITLE
Prevent breaking old sqlite's when media retention is enabled

### DIFF
--- a/changelog.d/12977.feature
+++ b/changelog.d/12977.feature
@@ -1,0 +1,1 @@
+Add new `media_retention` options to the homeserver config for routinely cleaning up non-recently accessed media.

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -327,7 +327,7 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
         if include_protected_media is False:
             # Do not include media that has been protected from quarantine
             sql += """
-                AND safe_from_quarantine = false
+                AND NOT safe_from_quarantine
             """
 
         def _get_local_media_ids_txn(txn: LoggingTransaction) -> List[str]:


### PR DESCRIPTION
Addresses https://github.com/matrix-org/synapse/pull/12972#discussion_r891058932.

Includes the same changelog as https://github.com/matrix-org/synapse/pull/12972 as it fixes a bug in the implementation.