### PR TITLE
Extend the release script to automatically push a new SyTest branch, rather than having that be a manual process.

### DIFF
--- a/changelog.d/12978.misc
+++ b/changelog.d/12978.misc
@@ -1,0 +1,1 @@
+Extend the release script to automatically push a new SyTest branch, rather than having that be a manual process.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -215,9 +215,7 @@ def prepare() -> None:
         # as well push it now (and only when we create a release branch;
         # not on subsequent RCs or full releases).
         if click.confirm("Push new SyTest branch?", default=True):
-            sytest_repo.git.push(
-                "-u", sytest_repo.remote().name, sytest_repo.active_branch.name
-            )
+            sytest_repo.git.push("-u", sytest_repo.remote().name, release_branch_name)
 
     # Switch to the release branch and ensure it's up to date.
     synapse_repo.git.checkout(release_branch_name)

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -95,7 +95,7 @@ def prepare() -> None:
     synapse_repo = get_repo_and_check_clean_checkout()
     sytest_repo = get_repo_and_check_clean_checkout("../sytest", "sytest")
 
-    click.secho("Updating git repo...")
+    click.secho("Updating Synapse and Sytest git repos...")
     synapse_repo.remote().fetch()
     sytest_repo.remote().fetch()
 


### PR DESCRIPTION
This is a typically error-prone part of our process, so it seems to make sense to try and automate it.

Should be a commit-by-commit review.

Unfortunately I haven't tested it myself yet, since I already did it :/.

Marking as a release blocker to try and give someone the idea that they should try it before creating the branch themselves.
It will only create the branch if it's also responsible for creating the branch on Synapse, **so you need to disregard the wiki instructions a bit and just run it straight on develop**.
(You probably need to make a copy of the script outside of the tree first, or you'll get told off for having a dirty tree)