### PR TITLE
Stop depending on `room_id` to be returned for children state in the hierarchy response.

### DIFF
--- a/changelog.d/12991.bugfix
+++ b/changelog.d/12991.bugfix
@@ -1,0 +1,2 @@
+Fix a bug where non-standard information was required when requesting the `/hierarchy` API over federation. Introduced 
+in Synapse v1.41.0.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -1642,10 +1642,6 @@ def _validate_hierarchy_event(d: JsonDict) -> None:
     if not isinstance(event_type, str):
         raise ValueError("Invalid event: 'event_type' must be a str")
 
-    room_id = d.get("room_id")
-    if not isinstance(room_id, str):
-        raise ValueError("Invalid event: 'room_id' must be a str")
-
     state_key = d.get("state_key")
     if not isinstance(state_key, str):
         raise ValueError("Invalid event: 'state_key' must be a str")

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -178,7 +178,7 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
             result_room_ids.append(result_room["room_id"])
             result_children_ids.append(
                 [
-                    (cs["room_id"], cs["state_key"])
+                    (result_room["room_id"], cs["state_key"])
                     for cs in result_room["children_state"]
                 ]
             )


### PR DESCRIPTION
This was missed during work for #10946, we should not be returning a `room_id` for each item in the return `children_state` field. Unfortunately we validate that it is there and a string when fetching over federation, thus we can't just remove it.