### PR TITLE
Fix-up the graph scripts

### DIFF
--- a/changelog.d/13013.misc
+++ b/changelog.d/13013.misc
@@ -1,0 +1,1 @@
+Modernize the `contrib/graph/` scripts.

--- a/contrib/graph/graph.py
+++ b/contrib/graph/graph.py
@@ -1,11 +1,3 @@
-import argparse
-import cgi
-import datetime
-import json
-
-import pydot
-import urllib2
-
 # Copyright 2014-2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,12 +12,24 @@ import urllib2
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
+import cgi
+import datetime
+import json
+
+import pydot
+import urllib2
+
 
 def make_name(pdu_id, origin):
     return "%s@%s" % (pdu_id, origin)
 
 
 def make_graph(pdus, room, filename_prefix):
+    """
+    Generate a dot and SVG file for a graph of events in the room based on the
+    topological ordering by querying a homeserver.
+    """
     pdu_map = {}
     node_map = {}
 

--- a/contrib/graph/graph.py
+++ b/contrib/graph/graph.py
@@ -16,16 +16,17 @@ import argparse
 import cgi
 import datetime
 import json
+from typing import List
 
 import pydot
 import urllib2
 
 
-def make_name(pdu_id, origin):
+def make_name(pdu_id: str, origin: str) -> str:
     return "%s@%s" % (pdu_id, origin)
 
 
-def make_graph(pdus, room, filename_prefix):
+def make_graph(pdus: List[dict], room: str, filename_prefix: str) -> None:
     """
     Generate a dot and SVG file for a graph of events in the room based on the
     topological ordering by querying a homeserver.
@@ -115,7 +116,7 @@ def make_graph(pdus, room, filename_prefix):
     graph.write_svg("%s.svg" % filename_prefix, prog="dot")
 
 
-def get_pdus(host, room):
+def get_pdus(host: str, room: str) -> List[dict]:
     transaction = json.loads(
         urllib2.urlopen(
             "http://%s/_matrix/federation/v1/context/%s/" % (host, room)

--- a/contrib/graph/graph.py
+++ b/contrib/graph/graph.py
@@ -16,10 +16,10 @@ import argparse
 import cgi
 import datetime
 import json
+import urllib.request
 from typing import List
 
 import pydot
-import urllib2
 
 
 def make_name(pdu_id: str, origin: str) -> str:
@@ -118,7 +118,7 @@ def make_graph(pdus: List[dict], room: str, filename_prefix: str) -> None:
 
 def get_pdus(host: str, room: str) -> List[dict]:
     transaction = json.loads(
-        urllib2.urlopen(
+        urllib.request.urlopen(
             "http://%s/_matrix/federation/v1/context/%s/" % (host, room)
         ).read()
     )

--- a/contrib/graph/graph.py
+++ b/contrib/graph/graph.py
@@ -23,7 +23,7 @@ import pydot
 
 
 def make_name(pdu_id: str, origin: str) -> str:
-    return "%s@%s" % (pdu_id, origin)
+    return f"{pdu_id}@{origin}"
 
 
 def make_graph(pdus: List[dict], filename_prefix: str) -> None:
@@ -119,7 +119,7 @@ def make_graph(pdus: List[dict], filename_prefix: str) -> None:
 def get_pdus(host: str, room: str) -> List[dict]:
     transaction = json.loads(
         urllib.request.urlopen(
-            "http://%s/_matrix/federation/v1/context/%s/" % (host, room)
+            f"http://{host}/_matrix/federation/v1/context/{room}/"
         ).read()
     )
 

--- a/contrib/graph/graph.py
+++ b/contrib/graph/graph.py
@@ -26,7 +26,7 @@ def make_name(pdu_id: str, origin: str) -> str:
     return "%s@%s" % (pdu_id, origin)
 
 
-def make_graph(pdus: List[dict], room: str, filename_prefix: str) -> None:
+def make_graph(pdus: List[dict], filename_prefix: str) -> None:
     """
     Generate a dot and SVG file for a graph of events in the room based on the
     topological ordering by querying a homeserver.
@@ -146,4 +146,4 @@ if __name__ == "__main__":
 
     pdus = get_pdus(host, room)
 
-    make_graph(pdus, room, prefix)
+    make_graph(pdus, prefix)

--- a/contrib/graph/graph2.py
+++ b/contrib/graph/graph2.py
@@ -14,8 +14,8 @@
 
 
 import argparse
-import cgi
 import datetime
+import html
 import json
 import sqlite3
 
@@ -88,7 +88,7 @@ def make_graph(db_name: str, room_id: str, file_prefix: str, limit: int) -> None
             "name": event.event_id,
             "type": event.type,
             "state_key": event.get("state_key", None),
-            "content": cgi.escape(content, quote=True),
+            "content": html.escape(content, quote=True),
             "time": t,
             "depth": event.depth,
             "state_group": state_group,

--- a/contrib/graph/graph2.py
+++ b/contrib/graph/graph2.py
@@ -112,7 +112,7 @@ def make_graph(db_name: str, room_id: str, file_prefix: str, limit: int) -> None
             try:
                 end_node = node_map[prev_id]
             except Exception:
-                end_node = pydot.Node(name=prev_id, label="<<b>%s</b>>" % (prev_id,))
+                end_node = pydot.Node(name=prev_id, label=f"<<b>{prev_id}</b>>")
 
                 node_map[prev_id] = end_node
                 graph.add_node(end_node)
@@ -124,7 +124,7 @@ def make_graph(db_name: str, room_id: str, file_prefix: str, limit: int) -> None
         if len(event_ids) <= 1:
             continue
 
-        cluster = pydot.Cluster(str(group), label="<State Group: %s>" % (str(group),))
+        cluster = pydot.Cluster(str(group), label=f"<State Group: {str(group)}>")
 
         for event_id in event_ids:
             cluster.add_node(node_map[event_id])

--- a/contrib/graph/graph2.py
+++ b/contrib/graph/graph2.py
@@ -25,7 +25,7 @@ from synapse.events import FrozenEvent
 from synapse.util.frozenutils import unfreeze
 
 
-def make_graph(db_name, room_id, file_prefix, limit):
+def make_graph(db_name: str, room_id: str, file_prefix: str, limit: int) -> None:
     """
     Generate a dot and SVG file for a graph of events in the room based on the
     topological ordering by reading from a Synapse SQLite database.

--- a/contrib/graph/graph2.py
+++ b/contrib/graph/graph2.py
@@ -26,6 +26,10 @@ from synapse.util.frozenutils import unfreeze
 
 
 def make_graph(db_name, room_id, file_prefix, limit):
+    """
+    Generate a dot and SVG file for a graph of events in the room based on the
+    topological ordering by reading from a Synapse SQLite database.
+    """
     conn = sqlite3.connect(db_name)
 
     sql = (
@@ -126,7 +130,7 @@ def make_graph(db_name, room_id, file_prefix, limit):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Generate a PDU graph for a given room by talking "
-        "to the given homeserver to get the list of PDUs. \n"
+        "to the given a Synapse SQLite file to get the list of PDUs. \n"
         "Requires pydot."
     )
     parser.add_argument(

--- a/contrib/graph/graph2.py
+++ b/contrib/graph/graph2.py
@@ -138,7 +138,7 @@ def make_graph(db_name: str, room_id: str, file_prefix: str, limit: int) -> None
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Generate a PDU graph for a given room by talking "
-        "to the given a Synapse SQLite file to get the list of PDUs. \n"
+        "to the given Synapse SQLite file to get the list of PDUs. \n"
         "Requires pydot."
     )
     parser.add_argument(

--- a/contrib/graph/graph3.py
+++ b/contrib/graph/graph3.py
@@ -115,7 +115,7 @@ def make_graph(file_name: str, file_prefix: str, limit: int) -> None:
             try:
                 end_node = node_map[prev_id]
             except Exception:
-                end_node = pydot.Node(name=prev_id, label="<<b>%s</b>>" % (prev_id,))
+                end_node = pydot.Node(name=prev_id, label=f"<<b>{prev_id}</b>>")
 
                 node_map[prev_id] = end_node
                 graph.add_node(end_node)

--- a/contrib/graph/graph3.py
+++ b/contrib/graph/graph3.py
@@ -24,7 +24,7 @@ from synapse.events import make_event_from_dict
 from synapse.util.frozenutils import unfreeze
 
 
-def make_graph(file_name: str, room_id: str, file_prefix: str, limit: int) -> None:
+def make_graph(file_name: str, file_prefix: str, limit: int) -> None:
     """
     Generate a dot and SVG file for a graph of events in the room based on the
     topological ordering by reading line-delimited JSON from a file.
@@ -149,8 +149,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("-l", "--limit", help="Only retrieve the last N events.")
     parser.add_argument("event_file")
-    parser.add_argument("room")
 
     args = parser.parse_args()
 
-    make_graph(args.event_file, args.room, args.prefix, args.limit)
+    make_graph(args.event_file, args.prefix, args.limit)

--- a/contrib/graph/graph3.py
+++ b/contrib/graph/graph3.py
@@ -1,13 +1,3 @@
-import argparse
-import cgi
-import datetime
-
-import pydot
-import simplejson as json
-
-from synapse.events import FrozenEvent
-from synapse.util.frozenutils import unfreeze
-
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +12,22 @@ from synapse.util.frozenutils import unfreeze
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
+import cgi
+import datetime
+
+import pydot
+import simplejson as json
+
+from synapse.events import FrozenEvent
+from synapse.util.frozenutils import unfreeze
+
 
 def make_graph(file_name, room_id, file_prefix, limit):
+    """
+    Generate a dot and SVG file for a graph of events in the room based on the
+    topological ordering by reading line-delimited JSON from a file.
+    """
     print("Reading lines")
     with open(file_name) as f:
         lines = f.readlines()

--- a/contrib/graph/graph3.py
+++ b/contrib/graph/graph3.py
@@ -23,7 +23,7 @@ from synapse.events import FrozenEvent
 from synapse.util.frozenutils import unfreeze
 
 
-def make_graph(file_name, room_id, file_prefix, limit):
+def make_graph(file_name: str, room_id: str, file_prefix: str, limit: int) -> None:
     """
     Generate a dot and SVG file for a graph of events in the room based on the
     topological ordering by reading line-delimited JSON from a file.

--- a/contrib/graph/graph3.py
+++ b/contrib/graph/graph3.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import argparse
-import cgi
 import datetime
+import html
+import json
 
 import pydot
-import simplejson as json
 
 from synapse.events import FrozenEvent
 from synapse.util.frozenutils import unfreeze
@@ -70,8 +70,8 @@ def make_graph(file_name: str, room_id: str, file_prefix: str, limit: int) -> No
             content.append(
                 "<b>%s</b>: %s,"
                 % (
-                    cgi.escape(key, quote=True).encode("ascii", "xmlcharrefreplace"),
-                    cgi.escape(value, quote=True).encode("ascii", "xmlcharrefreplace"),
+                    html.escape(key, quote=True).encode("ascii", "xmlcharrefreplace"),
+                    html.escape(value, quote=True).encode("ascii", "xmlcharrefreplace"),
                 )
             )
 


### PR DESCRIPTION
I had a need to run the `graph2` script and get it running on Python 3. The changes were straightforward to make to all 3 files so I went ahead and did that.

Note that `graph.py` still won't run, the API it calls doesn't exist on homeservers (and I cannot find a reference to it ever existing).

Should be reviewable commit-by-commit.