### PR TITLE
Remove redundant `room_version` object from event auth functions

### DIFF
--- a/changelog.d/13017.misc
+++ b/changelog.d/13017.misc
@@ -1,0 +1,1 @@
+Remove redundant `room_version` parameters from event auth functions.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -113,7 +113,6 @@ def validate_event_for_room_version(event: "EventBase") -> None:
 
 
 def check_auth_rules_for_event(
-    room_version_obj: RoomVersion,
     event: "EventBase",
     auth_events: Iterable["EventBase"],
 ) -> None:
@@ -132,7 +131,6 @@ def check_auth_rules_for_event(
        a bunch of other tests.
 
     Args:
-        room_version_obj: the version of the room
         event: the event being checked.
         auth_events: the room state to check the events against.
 
@@ -201,7 +199,10 @@ def check_auth_rules_for_event(
             raise AuthError(403, "This room has been marked as unfederatable.")
 
     # 4. If type is m.room.aliases
-    if event.type == EventTypes.Aliases and room_version_obj.special_case_aliases_auth:
+    if (
+        event.type == EventTypes.Aliases
+        and event.room_version.special_case_aliases_auth
+    ):
         # 4a. If event has no state_key, reject
         if not event.is_state():
             raise AuthError(403, "Alias event must be a state event")
@@ -221,7 +222,7 @@ def check_auth_rules_for_event(
 
     # 5. If type is m.room.membership
     if event.type == EventTypes.Member:
-        _is_membership_change_allowed(room_version_obj, event, auth_dict)
+        _is_membership_change_allowed(event.room_version, event, auth_dict)
         logger.debug("Allowing! %s", event)
         return
 
@@ -243,17 +244,17 @@ def check_auth_rules_for_event(
     _can_send_event(event, auth_dict)
 
     if event.type == EventTypes.PowerLevels:
-        _check_power_levels(room_version_obj, event, auth_dict)
+        _check_power_levels(event.room_version, event, auth_dict)
 
     if event.type == EventTypes.Redaction:
-        check_redaction(room_version_obj, event, auth_dict)
+        check_redaction(event.room_version, event, auth_dict)
 
     if (
         event.type == EventTypes.MSC2716_INSERTION
         or event.type == EventTypes.MSC2716_BATCH
         or event.type == EventTypes.MSC2716_MARKER
     ):
-        check_historical(room_version_obj, event, auth_dict)
+        check_historical(event.room_version, event, auth_dict)
 
     logger.debug("Allowing! %s", event)
 

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -45,9 +45,7 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def validate_event_for_room_version(
-    room_version_obj: RoomVersion, event: "EventBase"
-) -> None:
+def validate_event_for_room_version(event: "EventBase") -> None:
     """Ensure that the event complies with the limits, and has the right signatures
 
     NB: does not *validate* the signatures - it assumes that any signatures present
@@ -60,12 +58,10 @@ def validate_event_for_room_version(
     NB: This is used to check events that have been received over federation. As such,
     it can only enforce the checks specified in the relevant room version, to avoid
     a split-brain situation where some servers accept such events, and others reject
-    them.
-
-    TODO: consider moving this into EventValidator
+    them. See also EventValidator, which contains extra checks which are applied only to
+    locally-generated events.
 
     Args:
-        room_version_obj: the version of the room which contains this event
         event: the event to be checked
 
     Raises:
@@ -103,7 +99,7 @@ def validate_event_for_room_version(
             raise AuthError(403, "Event not signed by sending server")
 
     is_invite_via_allow_rule = (
-        room_version_obj.msc3083_join_rules
+        event.room_version.msc3083_join_rules
         and event.type == EventTypes.Member
         and event.membership == Membership.JOIN
         and EventContentFields.AUTHORISING_USER in event.content

--- a/synapse/events/validator.py
+++ b/synapse/events/validator.py
@@ -35,6 +35,10 @@ class EventValidator:
     def validate_new(self, event: EventBase, config: HomeServerConfig) -> None:
         """Validates the event has roughly the right format
 
+        Suitable for checking a locally-created event. It has stricter checks than
+        is appropriate for an event received over federation (for which, see
+        event_auth.validate_event_for_room_version)
+
         Args:
             event: The event to validate.
             config: The homeserver's configuration.

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -48,7 +48,6 @@ class EventAuthHandler:
 
     async def check_auth_rules_from_context(
         self,
-        room_version_obj: RoomVersion,
         event: EventBase,
         context: EventContext,
     ) -> None:

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -55,7 +55,7 @@ class EventAuthHandler:
         """Check an event passes the auth rules at its own auth events"""
         auth_event_ids = event.auth_event_ids()
         auth_events_by_id = await self._store.get_events(auth_event_ids)
-        check_auth_rules_for_event(room_version_obj, event, auth_events_by_id.values())
+        check_auth_rules_for_event(event, auth_events_by_id.values())
 
     def compute_auth_events(
         self,

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -799,9 +799,7 @@ class FederationHandler:
 
         # The remote hasn't signed it yet, obviously. We'll do the full checks
         # when we get the event back in `on_send_join_request`
-        await self._event_auth_handler.check_auth_rules_from_context(
-            room_version, event, context
-        )
+        await self._event_auth_handler.check_auth_rules_from_context(event, context)
         return event
 
     async def on_invite_request(
@@ -972,9 +970,7 @@ class FederationHandler:
         try:
             # The remote hasn't signed it yet, obviously. We'll do the full checks
             # when we get the event back in `on_send_leave_request`
-            await self._event_auth_handler.check_auth_rules_from_context(
-                room_version_obj, event, context
-            )
+            await self._event_auth_handler.check_auth_rules_from_context(event, context)
         except AuthError as e:
             logger.warning("Failed to create new leave %r because %s", event, e)
             raise e
@@ -1033,9 +1029,7 @@ class FederationHandler:
         try:
             # The remote hasn't signed it yet, obviously. We'll do the full checks
             # when we get the event back in `on_send_knock_request`
-            await self._event_auth_handler.check_auth_rules_from_context(
-                room_version_obj, event, context
-            )
+            await self._event_auth_handler.check_auth_rules_from_context(event, context)
         except AuthError as e:
             logger.warning("Failed to create new knock %r because %s", event, e)
             raise e
@@ -1208,7 +1202,7 @@ class FederationHandler:
             try:
                 validate_event_for_room_version(event)
                 await self._event_auth_handler.check_auth_rules_from_context(
-                    room_version_obj, event, context
+                    event, context
                 )
             except AuthError as e:
                 logger.warning("Denying new third party invite %r because %s", event, e)
@@ -1259,9 +1253,7 @@ class FederationHandler:
 
         try:
             validate_event_for_room_version(event)
-            await self._event_auth_handler.check_auth_rules_from_context(
-                room_version_obj, event, context
-            )
+            await self._event_auth_handler.check_auth_rules_from_context(event, context)
         except AuthError as e:
             logger.warning("Denying third party invite %r because %s", event, e)
             raise e

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1206,7 +1206,7 @@ class FederationHandler:
             event.internal_metadata.send_on_behalf_of = self.hs.hostname
 
             try:
-                validate_event_for_room_version(room_version_obj, event)
+                validate_event_for_room_version(event)
                 await self._event_auth_handler.check_auth_rules_from_context(
                     room_version_obj, event, context
                 )
@@ -1258,7 +1258,7 @@ class FederationHandler:
         )
 
         try:
-            validate_event_for_room_version(room_version_obj, event)
+            validate_event_for_room_version(event)
             await self._event_auth_handler.check_auth_rules_from_context(
                 room_version_obj, event, context
             )

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1453,7 +1453,7 @@ class FederationEventHandler:
 
                 context = EventContext.for_outlier(self._storage_controllers)
                 try:
-                    validate_event_for_room_version(room_version_obj, event)
+                    validate_event_for_room_version(event)
                     check_auth_rules_for_event(room_version_obj, event, auth)
                 except AuthError as e:
                     logger.warning("Rejecting %r because %s", event, e)
@@ -1501,7 +1501,7 @@ class FederationEventHandler:
         room_version_obj = KNOWN_ROOM_VERSIONS[room_version]
 
         try:
-            validate_event_for_room_version(room_version_obj, event)
+            validate_event_for_room_version(event)
         except AuthError as e:
             logger.warning("While validating received event %r: %s", event, e)
             # TODO: use a different rejected reason here?

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1428,9 +1428,6 @@ class FederationEventHandler:
             allow_rejected=True,
         )
 
-        room_version = await self._store.get_room_version_id(room_id)
-        room_version_obj = KNOWN_ROOM_VERSIONS[room_version]
-
         def prep(event: EventBase) -> Optional[Tuple[EventBase, EventContext]]:
             with nested_logging_context(suffix=event.event_id):
                 auth = []
@@ -1454,7 +1451,7 @@ class FederationEventHandler:
                 context = EventContext.for_outlier(self._storage_controllers)
                 try:
                     validate_event_for_room_version(event)
-                    check_auth_rules_for_event(room_version_obj, event, auth)
+                    check_auth_rules_for_event(event, auth)
                 except AuthError as e:
                     logger.warning("Rejecting %r because %s", event, e)
                     context.rejected = RejectedReason.AUTH_ERROR
@@ -1497,9 +1494,6 @@ class FederationEventHandler:
         assert not event.internal_metadata.outlier
 
         # first of all, check that the event itself is valid.
-        room_version = await self._store.get_room_version_id(event.room_id)
-        room_version_obj = KNOWN_ROOM_VERSIONS[room_version]
-
         try:
             validate_event_for_room_version(event)
         except AuthError as e:
@@ -1519,7 +1513,7 @@ class FederationEventHandler:
 
         # ... and check that the event passes auth at those auth events.
         try:
-            check_auth_rules_for_event(room_version_obj, event, claimed_auth_events)
+            check_auth_rules_for_event(event, claimed_auth_events)
         except AuthError as e:
             logger.warning(
                 "While checking auth of %r against auth_events: %s", event, e
@@ -1567,9 +1561,7 @@ class FederationEventHandler:
             auth_events_for_auth = calculated_auth_event_map
 
         try:
-            check_auth_rules_for_event(
-                room_version_obj, event, auth_events_for_auth.values()
-            )
+            check_auth_rules_for_event(event, auth_events_for_auth.values())
         except AuthError as e:
             logger.warning("Failed auth resolution for %r because %s", event, e)
             context.rejected = RejectedReason.AUTH_ERROR
@@ -1669,7 +1661,7 @@ class FederationEventHandler:
         )
 
         try:
-            check_auth_rules_for_event(room_version_obj, event, current_auth_events)
+            check_auth_rules_for_event(event, current_auth_events)
         except AuthError as e:
             logger.warning(
                 "Soft-failing %r (from %s) because %s",

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1297,7 +1297,7 @@ class EventCreationHandler:
             assert event.content["membership"] == Membership.LEAVE
         else:
             try:
-                validate_event_for_room_version(room_version_obj, event)
+                validate_event_for_room_version(event)
                 await self._event_auth_handler.check_auth_rules_from_context(
                     room_version_obj, event, context
                 )

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -42,7 +42,7 @@ from synapse.api.errors import (
     SynapseError,
     UnsupportedRoomVersionError,
 )
-from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersions
+from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
 from synapse.api.urls import ConsentURIBuilder
 from synapse.event_auth import validate_event_for_room_version
 from synapse.events import EventBase, relation_from_event
@@ -1273,23 +1273,6 @@ class EventCreationHandler:
                 )
                 return prev_event
 
-        if event.is_state() and (event.type, event.state_key) == (
-            EventTypes.Create,
-            "",
-        ):
-            room_version_id = event.content.get(
-                "room_version", RoomVersions.V1.identifier
-            )
-            maybe_room_version_obj = KNOWN_ROOM_VERSIONS.get(room_version_id)
-            if not maybe_room_version_obj:
-                raise UnsupportedRoomVersionError(
-                    "Attempt to create a room with unsupported room version %s"
-                    % (room_version_id,)
-                )
-            room_version_obj = maybe_room_version_obj
-        else:
-            room_version_obj = await self.store.get_room_version(event.room_id)
-
         if event.internal_metadata.is_out_of_band_membership():
             # the only sort of out-of-band-membership events we expect to see here are
             # invite rejections and rescinded knocks that we have generated ourselves.
@@ -1299,7 +1282,7 @@ class EventCreationHandler:
             try:
                 validate_event_for_room_version(event)
                 await self._event_auth_handler.check_auth_rules_from_context(
-                    room_version_obj, event, context
+                    event, context
                 )
             except AuthError as err:
                 logger.warning("Denying new event %r because %s", event, err)

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -226,10 +226,9 @@ class RoomCreationHandler:
                 },
             },
         )
-        old_room_version = await self.store.get_room_version(old_room_id)
         validate_event_for_room_version(tombstone_event)
         await self._event_auth_handler.check_auth_rules_from_context(
-            old_room_version, tombstone_event, tombstone_context
+            tombstone_event, tombstone_context
         )
 
         # Upgrade the room

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -227,7 +227,7 @@ class RoomCreationHandler:
             },
         )
         old_room_version = await self.store.get_room_version(old_room_id)
-        validate_event_for_room_version(old_room_version, tombstone_event)
+        validate_event_for_room_version(tombstone_event)
         await self._event_auth_handler.check_auth_rules_from_context(
             old_room_version, tombstone_event, tombstone_context
         )

--- a/synapse/state/v1.py
+++ b/synapse/state/v1.py
@@ -30,7 +30,7 @@ from typing import (
 from synapse import event_auth
 from synapse.api.constants import EventTypes
 from synapse.api.errors import AuthError
-from synapse.api.room_versions import RoomVersion, RoomVersions
+from synapse.api.room_versions import RoomVersion
 from synapse.events import EventBase
 from synapse.types import MutableStateMap, StateMap
 
@@ -331,7 +331,6 @@ def _resolve_auth_events(
         try:
             # The signatures have already been checked at this point
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V1,
                 event,
                 auth_events.values(),
             )
@@ -349,7 +348,6 @@ def _resolve_normal_events(
         try:
             # The signatures have already been checked at this point
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V1,
                 event,
                 auth_events.values(),
             )

--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -547,7 +547,6 @@ async def _iterative_auth_checks(
 
         try:
             event_auth.check_auth_rules_for_event(
-                room_version,
                 event,
                 auth_events.values(),
             )

--- a/tests/test_event_auth.py
+++ b/tests/test_event_auth.py
@@ -38,7 +38,6 @@ class EventAuthTestCase(unittest.TestCase):
 
         # creator should be able to send state
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V9,
             _random_state_event(RoomVersions.V9, creator),
             auth_events,
         )
@@ -55,7 +54,6 @@ class EventAuthTestCase(unittest.TestCase):
         self.assertRaises(
             AuthError,
             event_auth.check_auth_rules_for_event,
-            RoomVersions.V9,
             _random_state_event(RoomVersions.V9, creator),
             auth_events,
         )
@@ -66,7 +64,6 @@ class EventAuthTestCase(unittest.TestCase):
         self.assertRaises(
             AuthError,
             event_auth.check_auth_rules_for_event,
-            RoomVersions.V9,
             _random_state_event(RoomVersions.V9, creator),
             auth_events,
         )
@@ -86,7 +83,6 @@ class EventAuthTestCase(unittest.TestCase):
 
         # creator should be able to send state
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V1,
             _random_state_event(RoomVersions.V1, creator),
             auth_events,
         )
@@ -95,7 +91,6 @@ class EventAuthTestCase(unittest.TestCase):
         self.assertRaises(
             AuthError,
             event_auth.check_auth_rules_for_event,
-            RoomVersions.V1,
             _random_state_event(RoomVersions.V1, joiner),
             auth_events,
         )
@@ -125,14 +120,12 @@ class EventAuthTestCase(unittest.TestCase):
         self.assertRaises(
             AuthError,
             event_auth.check_auth_rules_for_event,
-            RoomVersions.V1,
             _random_state_event(RoomVersions.V1, pleb),
             auth_events,
         ),
 
         # king should be able to send state
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V1,
             _random_state_event(RoomVersions.V1, king),
             auth_events,
         )
@@ -148,7 +141,6 @@ class EventAuthTestCase(unittest.TestCase):
 
         # creator should be able to send aliases
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V1,
             _alias_event(RoomVersions.V1, creator),
             auth_events,
         )
@@ -156,7 +148,6 @@ class EventAuthTestCase(unittest.TestCase):
         # Reject an event with no state key.
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V1,
                 _alias_event(RoomVersions.V1, creator, state_key=""),
                 auth_events,
             )
@@ -164,14 +155,12 @@ class EventAuthTestCase(unittest.TestCase):
         # If the domain of the sender does not match the state key, reject.
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V1,
                 _alias_event(RoomVersions.V1, creator, state_key="test.com"),
                 auth_events,
             )
 
         # Note that the member does *not* need to be in the room.
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V1,
             _alias_event(RoomVersions.V1, other),
             auth_events,
         )
@@ -187,19 +176,16 @@ class EventAuthTestCase(unittest.TestCase):
 
         # creator should be able to send aliases
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V6,
             _alias_event(RoomVersions.V6, creator),
             auth_events,
         )
 
         # No particular checks are done on the state key.
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V6,
             _alias_event(RoomVersions.V6, creator, state_key=""),
             auth_events,
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V6,
             _alias_event(RoomVersions.V6, creator, state_key="test.com"),
             auth_events,
         )
@@ -207,7 +193,6 @@ class EventAuthTestCase(unittest.TestCase):
         # Per standard auth rules, the member must be in the room.
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V6,
                 _alias_event(RoomVersions.V6, other),
                 auth_events,
             )
@@ -235,14 +220,12 @@ class EventAuthTestCase(unittest.TestCase):
 
         # on room V1, pleb should be able to modify the notifications power level.
         if allow_modification:
-            event_auth.check_auth_rules_for_event(room_version, pl_event, auth_events)
+            event_auth.check_auth_rules_for_event(pl_event, auth_events)
 
         else:
             # But an MSC2209 room rejects this change.
             with self.assertRaises(AuthError):
-                event_auth.check_auth_rules_for_event(
-                    room_version, pl_event, auth_events
-                )
+                event_auth.check_auth_rules_for_event(pl_event, auth_events)
 
     def test_join_rules_public(self):
         """
@@ -261,7 +244,6 @@ class EventAuthTestCase(unittest.TestCase):
 
         # Check join.
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V6,
             _join_event(RoomVersions.V6, pleb),
             auth_events.values(),
         )
@@ -269,7 +251,6 @@ class EventAuthTestCase(unittest.TestCase):
         # A user cannot be force-joined to a room.
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V6,
                 _member_event(RoomVersions.V6, pleb, "join", sender=creator),
                 auth_events.values(),
             )
@@ -280,7 +261,6 @@ class EventAuthTestCase(unittest.TestCase):
         )
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V6,
                 _join_event(RoomVersions.V6, pleb),
                 auth_events.values(),
             )
@@ -290,7 +270,6 @@ class EventAuthTestCase(unittest.TestCase):
             RoomVersions.V6, pleb, "leave"
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V6,
             _join_event(RoomVersions.V6, pleb),
             auth_events.values(),
         )
@@ -300,7 +279,6 @@ class EventAuthTestCase(unittest.TestCase):
             RoomVersions.V6, pleb, "join"
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V6,
             _join_event(RoomVersions.V6, pleb),
             auth_events.values(),
         )
@@ -310,7 +288,6 @@ class EventAuthTestCase(unittest.TestCase):
             RoomVersions.V6, pleb, "invite", sender=creator
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V6,
             _join_event(RoomVersions.V6, pleb),
             auth_events.values(),
         )
@@ -333,7 +310,6 @@ class EventAuthTestCase(unittest.TestCase):
         # A join without an invite is rejected.
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V6,
                 _join_event(RoomVersions.V6, pleb),
                 auth_events.values(),
             )
@@ -341,7 +317,6 @@ class EventAuthTestCase(unittest.TestCase):
         # A user cannot be force-joined to a room.
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V6,
                 _member_event(RoomVersions.V6, pleb, "join", sender=creator),
                 auth_events.values(),
             )
@@ -352,7 +327,6 @@ class EventAuthTestCase(unittest.TestCase):
         )
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V6,
                 _join_event(RoomVersions.V6, pleb),
                 auth_events.values(),
             )
@@ -363,7 +337,6 @@ class EventAuthTestCase(unittest.TestCase):
         )
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V6,
                 _join_event(RoomVersions.V6, pleb),
                 auth_events.values(),
             )
@@ -373,7 +346,6 @@ class EventAuthTestCase(unittest.TestCase):
             RoomVersions.V6, pleb, "join"
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V6,
             _join_event(RoomVersions.V6, pleb),
             auth_events.values(),
         )
@@ -383,7 +355,6 @@ class EventAuthTestCase(unittest.TestCase):
             RoomVersions.V6, pleb, "invite", sender=creator
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V6,
             _join_event(RoomVersions.V6, pleb),
             auth_events.values(),
         )
@@ -406,7 +377,6 @@ class EventAuthTestCase(unittest.TestCase):
 
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V6,
                 _join_event(RoomVersions.V6, pleb),
                 auth_events.values(),
             )
@@ -444,7 +414,6 @@ class EventAuthTestCase(unittest.TestCase):
             },
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V8,
             authorised_join_event,
             auth_events.values(),
         )
@@ -461,7 +430,6 @@ class EventAuthTestCase(unittest.TestCase):
             RoomVersions.V8, "@inviter:foo.test"
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V8,
             _join_event(
                 RoomVersions.V8,
                 pleb,
@@ -475,7 +443,6 @@ class EventAuthTestCase(unittest.TestCase):
         # A join which is missing an authorised server is rejected.
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V8,
                 _join_event(RoomVersions.V8, pleb),
                 auth_events.values(),
             )
@@ -489,7 +456,6 @@ class EventAuthTestCase(unittest.TestCase):
         )
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V8,
                 _join_event(
                     RoomVersions.V8,
                     pleb,
@@ -504,7 +470,6 @@ class EventAuthTestCase(unittest.TestCase):
         # *would* be valid, but is sent be a different user.)
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V8,
                 _member_event(
                     RoomVersions.V8,
                     pleb,
@@ -523,7 +488,6 @@ class EventAuthTestCase(unittest.TestCase):
         )
         with self.assertRaises(AuthError):
             event_auth.check_auth_rules_for_event(
-                RoomVersions.V8,
                 authorised_join_event,
                 auth_events.values(),
             )
@@ -533,7 +497,6 @@ class EventAuthTestCase(unittest.TestCase):
             RoomVersions.V8, pleb, "leave"
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V8,
             authorised_join_event,
             auth_events.values(),
         )
@@ -544,7 +507,6 @@ class EventAuthTestCase(unittest.TestCase):
             RoomVersions.V8, pleb, "join"
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V8,
             _join_event(RoomVersions.V8, pleb),
             auth_events.values(),
         )
@@ -555,7 +517,6 @@ class EventAuthTestCase(unittest.TestCase):
             RoomVersions.V8, pleb, "invite", sender=creator
         )
         event_auth.check_auth_rules_for_event(
-            RoomVersions.V8,
             _join_event(RoomVersions.V8, pleb),
             auth_events.values(),
         )


### PR DESCRIPTION
`validate_event_for_room_version` and `check_auth_rules_for_event` both take a dedicated `room_version` parameter, which is redundant because it is the same as  `event.room_version`.

Apart from simplifying the interface, this also means we can get rid of a few `store.get_room_version` calls.

The parameter was added in #4482 (though the code has evolved a lot since then), but it's been redundant since #6875 gave events their own room version property. 

Should be reviewable commit-by-commit.