### PR TITLE
Type annotations in `synapse.databases.main.devices`

### DIFF
--- a/changelog.d/13025.misc
+++ b/changelog.d/13025.misc
@@ -1,0 +1,1 @@
+Add type annotations to `synapse.storage.databases.main.devices`.

--- a/mypy.ini
+++ b/mypy.ini
@@ -27,7 +27,6 @@ exclude = (?x)
   ^(
    |synapse/storage/databases/__init__.py
    |synapse/storage/databases/main/cache.py
-   |synapse/storage/databases/main/devices.py
    |synapse/storage/schema/
 
    |tests/api/test_auth.py

--- a/synapse/replication/slave/storage/devices.py
+++ b/synapse/replication/slave/storage/devices.py
@@ -19,13 +19,12 @@ from synapse.replication.slave.storage._slaved_id_tracker import SlavedIdTracker
 from synapse.replication.tcp.streams._base import DeviceListsStream, UserSignatureStream
 from synapse.storage.database import DatabasePool, LoggingDatabaseConnection
 from synapse.storage.databases.main.devices import DeviceWorkerStore
-from synapse.storage.databases.main.end_to_end_keys import EndToEndKeyWorkerStore
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
 
 
-class SlavedDeviceStore(EndToEndKeyWorkerStore, DeviceWorkerStore, BaseSlavedStore):
+class SlavedDeviceStore(DeviceWorkerStore, BaseSlavedStore):
     def __init__(
         self,
         database: DatabasePool,

--- a/synapse/storage/databases/main/__init__.py
+++ b/synapse/storage/databases/main/__init__.py
@@ -197,6 +197,7 @@ class DataStore(
         self._min_stream_order_on_start = self.get_room_min_stream_ordering()
 
     def get_device_stream_token(self) -> int:
+        # TODO: shouldn't this be moved to `DeviceWorkerStore`?
         return self._device_list_id_gen.get_current_token()
 
     async def get_users(self) -> List[JsonDict]:

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -1899,7 +1899,6 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
                 [],
             )
 
-        # is a StreamIdGenerator, or SlavedDataStore where it is a SlavedIdTracker.
         async with self._device_list_id_gen.get_next_mult(len(hosts)) as stream_ids:  # type: ignore[attr-defined]
             return await self.db_pool.runInteraction(
                 "add_device_list_outbound_pokes",

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -603,7 +603,7 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
             txn=txn,
             table="device_lists_outbound_last_success",
             key_names=("destination", "user_id"),
-            key_values=tuple((destination, user_id) for user_id, _ in rows),
+            key_values=[destination, user_id) for user_id, _ in rows],
             value_names=("stream_id",),
             value_values=((stream_id,) for _, stream_id in rows),
         )

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -791,6 +791,9 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
             """
 
             # Query device changes with a batch of users at a time
+            # Assertion for mypy's benefit; see also
+            # https://mypy.readthedocs.io/en/stable/common_issues.html#narrowing-and-inner-functions
+            assert user_ids_to_check is not None
             for chunk in batch_iter(user_ids_to_check, 100):
                 clause, args = make_in_list_sql_clause(
                     txn.database_engine, "user_id", chunk

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -860,7 +860,9 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
         if last_id == current_id:
             return [], current_id, False
 
-        def _get_all_device_list_changes_for_remotes(txn):
+        def _get_all_device_list_changes_for_remotes(
+            txn: Cursor,
+        ) -> Tuple[List[Tuple[int, tuple]], int, bool]:
             # This query Does The Right Thing where it'll correctly apply the
             # bounds to the inner queries.
             sql = """

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -44,6 +44,8 @@ from synapse.storage.database import (
     LoggingTransaction,
     make_tuple_comparison_clause,
 )
+from synapse.storage.databases.main.end_to_end_keys import EndToEndKeyWorkerStore
+from synapse.storage.types import Cursor
 from synapse.types import JsonDict, get_verify_key_from_cross_signing_key
 from synapse.util import json_decoder, json_encoder
 from synapse.util.caches.descriptors import cached, cachedList
@@ -65,7 +67,7 @@ DROP_DEVICE_LIST_STREAMS_NON_UNIQUE_INDEXES = (
 BG_UPDATE_REMOVE_DUP_OUTBOUND_POKES = "remove_dup_outbound_pokes"
 
 
-class DeviceWorkerStore(SQLBaseStore):
+class DeviceWorkerStore(EndToEndKeyWorkerStore):
     def __init__(
         self,
         database: DatabasePool,

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -78,8 +78,8 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
     ):
         super().__init__(database, db_conn, hs)
 
-        # Type-ignore: _device_list_id_gen is mixed in from either DataStore, where it
-        # is a StreamIdGenerator or SlavedDataStore where it is a SlavedIdTracker.
+        # Type-ignore: _device_list_id_gen is mixed in from either DataStore (as a
+        # StreamIdGenerator) or SlavedDataStore (as a SlavedIdTracker).
         device_list_max = self._device_list_id_gen.get_current_token()  # type: ignore[attr-defined]
         device_list_prefill, min_device_list_id = self.db_pool.get_cache_dict(
             db_conn,
@@ -345,6 +345,7 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
         # following this stream later.
         last_processed_stream_id = from_stream_id
 
+        # A map of (user ID, device ID) to (stream ID, context).
         query_map: Dict[Tuple[str, str], Tuple[int, Optional[str]]] = {}
         cross_signing_keys_by_user: Dict[str, Dict[str, object]] = {}
         for user_id, device_id, update_stream_id, update_context in updates:
@@ -627,8 +628,6 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
             The new stream ID.
         """
 
-        # Type-ignore: _device_list_id_gen is mixed in from either DataStore, where it
-        # is a StreamIdGenerator or SlavedDataStore where it is a SlavedIdTracker.
         # TODO: this looks like it's _writing_. Should this be on DeviceStore rather
         #  than DeviceWorkerStore?
         async with self._device_list_id_gen.get_next() as stream_id:  # type: ignore[attr-defined]
@@ -1676,8 +1675,6 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
                 context,
             )
 
-        # Type-ignore: _device_list_id_gen is mixed in from either DataStore, where it
-        # is a StreamIdGenerator or SlavedDataStore where it is a SlavedIdTracker.
         async with self._device_list_id_gen.get_next_mult(  # type: ignore[attr-defined]
             len(device_ids)
         ) as stream_ids:
@@ -1902,7 +1899,6 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
                 [],
             )
 
-        # Type-ignore: _device_list_id_gen is mixed in from either DataStore where it
         # is a StreamIdGenerator, or SlavedDataStore where it is a SlavedIdTracker.
         async with self._device_list_id_gen.get_next_mult(len(hosts)) as stream_ids:  # type: ignore[attr-defined]
             return await self.db_pool.runInteraction(

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -729,7 +729,7 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
     def get_cached_device_list_changes(
         self,
         from_key: int,
-    ) -> Optional[Set[str]]:
+    ) -> Optional[List[str]]:
         """Get set of users whose devices have changed since `from_key`, or None
         if that information is not in our cache.
         """

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -1815,7 +1815,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
 
     async def get_uncoverted_outbound_room_pokes(
         self, limit: int = 10
-    ) -> List[Tuple[str, str, str, int, Dict[str, str]]]:
+    ) -> List[Tuple[str, str, str, int, Optional[Dict[str, str]]]]:
         """Get device list changes by room that have not yet been handled and
         written to `device_lists_outbound_pokes`.
 
@@ -1833,7 +1833,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
 
         def get_uncoverted_outbound_room_pokes_txn(
             txn: LoggingTransaction,
-        ) -> List[Tuple[str, str, str, int, Dict[str, str]]]:
+        ) -> List[Tuple[str, str, str, int, Optional[Dict[str, str]]]]:
             txn.execute(sql, (limit,))
 
             return [
@@ -1842,7 +1842,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
                     device_id,
                     room_id,
                     stream_id,
-                    db_to_json(opentracing_context) or {},
+                    db_to_json(opentracing_context),
                 )
                 for user_id, device_id, room_id, stream_id, opentracing_context in txn
             ]
@@ -1858,7 +1858,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
         room_id: str,
         stream_id: int,
         hosts: Collection[str],
-        context: Dict[str, str],
+        context: Optional[Dict[str, str]],
     ) -> None:
         """Queue the device update to be sent to the given set of hosts,
         calculated from the room ID.

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -22,6 +22,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Optional,
     Set,
     Tuple,
@@ -1354,9 +1355,9 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
 
         # Map of (user_id, device_id) -> bool. If there is an entry that implies
         # the device exists.
-        self.device_id_exists_cache = LruCache(
-            cache_name="device_id_exists", max_size=10000
-        )
+        self.device_id_exists_cache: LruCache[
+            Tuple[str, str], Literal[True]
+        ] = LruCache(cache_name="device_id_exists", max_size=10000)
 
     async def store_device(
         self,

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -1809,7 +1809,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
 
     async def get_uncoverted_outbound_room_pokes(
         self, limit: int = 10
-    ) -> List[Tuple[str, str, str, int, Optional[Dict[str, str]]]]:
+    ) -> List[Tuple[str, str, str, int, Dict[str, str]]]:
         """Get device list changes by room that have not yet been handled and
         written to `device_lists_outbound_pokes`.
 
@@ -1827,7 +1827,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
 
         def get_uncoverted_outbound_room_pokes_txn(
             txn: LoggingTransaction,
-        ) -> List[Tuple[str, str, str, int, Optional[Dict[str, str]]]]:
+        ) -> List[Tuple[str, str, str, int, Dict[str, str]]]:
             txn.execute(sql, (limit,))
 
             return [
@@ -1836,7 +1836,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
                     device_id,
                     room_id,
                     stream_id,
-                    db_to_json(opentracing_context),
+                    db_to_json(opentracing_context) or {},
                 )
                 for user_id, device_id, room_id, stream_id, opentracing_context in txn
             ]
@@ -1852,7 +1852,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
         room_id: str,
         stream_id: int,
         hosts: Collection[str],
-        context: Optional[Dict[str, str]],
+        context: Dict[str, str],
     ) -> None:
         """Queue the device update to be sent to the given set of hosts,
         calculated from the room ID.

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -598,7 +598,7 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
             txn=txn,
             table="device_lists_outbound_last_success",
             key_names=("destination", "user_id"),
-            key_values=((destination, user_id) for user_id, _ in rows),
+            key_values=tuple((destination, user_id) for user_id, _ in rows),
             value_names=("stream_id",),
             value_values=((stream_id,) for _, stream_id in rows),
         )

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -919,7 +919,7 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
             desc="get_device_list_last_stream_id_for_remotes",
         )
 
-        results = {user_id: None for user_id in user_ids}
+        results: Dict[str, Optional[str]] = {user_id: None for user_id in user_ids}
         results.update({row["user_id"]: row["stream_id"] for row in rows})
 
         return results

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -603,7 +603,7 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
             txn=txn,
             table="device_lists_outbound_last_success",
             key_names=("destination", "user_id"),
-            key_values=[destination, user_id) for user_id, _ in rows],
+            key_values=[(destination, user_id) for user_id, _ in rows],
             value_names=("stream_id",),
             value_values=((stream_id,) for _, stream_id in rows),
         )

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -77,7 +77,9 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
     ):
         super().__init__(database, db_conn, hs)
 
-        device_list_max = self._device_list_id_gen.get_current_token()
+        # Type-ignore: _device_list_id_gen is mixed in from either DataStore, where it
+        # is a StreamIdGenerator or SlavedDataStore where it is a SlavedIdTracker.
+        device_list_max = self._device_list_id_gen.get_current_token()  # type: ignore[attr-defined]
         device_list_prefill, min_device_list_id = self.db_pool.get_cache_dict(
             db_conn,
             "device_lists_stream",
@@ -624,7 +626,11 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
             The new stream ID.
         """
 
-        async with self._device_list_id_gen.get_next() as stream_id:
+        # Type-ignore: _device_list_id_gen is mixed in from either DataStore, where it
+        # is a StreamIdGenerator or SlavedDataStore where it is a SlavedIdTracker.
+        # TODO: this looks like it's _writing_. Should this be on DeviceStore rather
+        #  than DeviceWorkerStore?
+        async with self._device_list_id_gen.get_next() as stream_id:  # type: ignore[attr-defined]
             await self.db_pool.runInteraction(
                 "add_user_sig_change_to_streams",
                 self._add_user_signature_change_txn,
@@ -1669,7 +1675,9 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
                 context,
             )
 
-        async with self._device_list_id_gen.get_next_mult(
+        # Type-ignore: _device_list_id_gen is mixed in from either DataStore, where it
+        # is a StreamIdGenerator or SlavedDataStore where it is a SlavedIdTracker.
+        async with self._device_list_id_gen.get_next_mult(  # type: ignore[attr-defined]
             len(device_ids)
         ) as stream_ids:
             await self.db_pool.runInteraction(
@@ -1893,7 +1901,9 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
                 [],
             )
 
-        async with self._device_list_id_gen.get_next_mult(len(hosts)) as stream_ids:
+        # Type-ignore: _device_list_id_gen is mixed in from either DataStore where it
+        # is a StreamIdGenerator, or SlavedDataStore where it is a SlavedIdTracker.
+        async with self._device_list_id_gen.get_next_mult(len(hosts)) as stream_ids:  # type: ignore[attr-defined]
             return await self.db_pool.runInteraction(
                 "add_device_list_outbound_pokes",
                 add_device_list_outbound_pokes_txn,

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -1865,8 +1865,6 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
 
         Marks the associated row in `device_lists_changes_in_room` as handled.
         """
-        if context is None:
-            context = {}
 
         def add_device_list_outbound_pokes_txn(
             txn: LoggingTransaction, stream_ids: List[int]
@@ -1878,9 +1876,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
                     device_ids=[device_id],
                     hosts=hosts,
                     stream_ids=stream_ids,
-                    # mypy doesn't know that `context` is never None here, see
-                    # https://mypy.readthedocs.io/en/stable/common_issues.html#narrowing-and-inner-functions
-                    context=context,  # type: ignore[arg-type]
+                    context=context,
                 )
 
             self.db_pool.simple_update_txn(

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -1728,7 +1728,7 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
         device_ids: Iterable[str],
         hosts: Collection[str],
         stream_ids: List[int],
-        context: Dict[str, str],
+        context: Optional[Dict[str, str]],
     ) -> None:
         for host in hosts:
             txn.call_after(

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -341,8 +341,8 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
         # following this stream later.
         last_processed_stream_id = from_stream_id
 
-        query_map = {}
-        cross_signing_keys_by_user = {}
+        query_map: Dict[Tuple[str, str], Tuple[int, Optional[str]]] = {}
+        cross_signing_keys_by_user: Dict[str, Dict[str, object]] = {}
         for user_id, device_id, update_stream_id, update_context in updates:
             # Calculate the remaining length budget.
             # Note that, for now, each entry in `cross_signing_keys_by_user`
@@ -688,7 +688,7 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
         } - users_needing_resync
         user_ids_not_in_cache = user_ids - user_ids_in_cache
 
-        results = {}
+        results: Dict[str, Dict[str, JsonDict]] = {}
         for user_id, device_id in query_list:
             if user_id not in user_ids_in_cache:
                 continue
@@ -775,7 +775,7 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
             return set()
 
         def _get_users_whose_devices_changed_txn(txn: LoggingTransaction) -> Set[str]:
-            changes = set()
+            changes: Set[str] = set()
 
             stream_id_where_clause = "stream_id > ?"
             sql_args = [from_key]

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -22,12 +22,13 @@ from typing import (
     Dict,
     Iterable,
     List,
-    Literal,
     Optional,
     Set,
     Tuple,
     cast,
 )
+
+from typing_extensions import Literal
 
 from synapse.api.constants import EduTypes
 from synapse.api.errors import Codes, StoreError

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -739,7 +739,7 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
     async def get_users_whose_devices_changed(
         self,
         from_key: int,
-        user_ids: Optional[Iterable[str]] = None,
+        user_ids: Optional[Collection[str]] = None,
         to_key: Optional[int] = None,
     ) -> Set[str]:
         """Get set of users whose devices have changed since `from_key` that
@@ -759,6 +759,7 @@ class DeviceWorkerStore(EndToEndKeyWorkerStore):
         """
         # Get set of users who *may* have changed. Users not in the returned
         # list have definitely not changed.
+        user_ids_to_check: Optional[Collection[str]]
         if user_ids is None:
             # Get set of all users that have had device list changes since 'from_key'
             user_ids_to_check = self._device_list_stream_cache.get_all_entities_changed(

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -1865,6 +1865,8 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
 
         Marks the associated row in `device_lists_changes_in_room` as handled.
         """
+        if context is None:
+            context = {}
 
         def add_device_list_outbound_pokes_txn(
             txn: LoggingTransaction, stream_ids: List[int]
@@ -1876,7 +1878,9 @@ class DeviceStore(DeviceWorkerStore, DeviceBackgroundUpdateStore):
                     device_ids=[device_id],
                     hosts=hosts,
                     stream_ids=stream_ids,
-                    context=context,
+                    # mypy doesn't know that `context` is never None here, see
+                    # https://mypy.readthedocs.io/en/stable/common_issues.html#narrowing-and-inner-functions
+                    context=context,  # type: ignore[arg-type]
                 )
 
             self.db_pool.simple_update_txn(


### PR DESCRIPTION
This is one of the remaining files in the synapse source tree which isn't checked by mypy. This change starts checking that file.

Most of these fixes were relatively straightforward. The stream id generator/tracker was painful to deal with, though. I've type-ignored that and left a TODO.

Recommend commit-by-commit review.

```diff
                                                     Name    Anys    Exprs   Coverage
  ------------------------------------------------------------------------------------
--- out/any-exprs.txt	2022-06-10 19:23:16.151256162 +0100
+++ out2/any-exprs.txt	2022-06-10 19:22:47.460110866 +0100
@@ -358,0 +359 @@
+                   synapse.storage.databases.main.devices     133     1914     93.05%
@@ -625 +626 @@
-                                                    Total   24391   285258     91.45%
+                                                    Total   24524   287172     91.46%
```