### PR TITLE
Track a histogram of state res durations

### DIFF
--- a/changelog.d/13036.feature
+++ b/changelog.d/13036.feature
@@ -1,0 +1,1 @@
+Add metrics measuring the CPU and DB time spent in state resolution.

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -444,6 +444,21 @@ _biggest_room_by_db_counter = Counter(
     "expensive room for state resolution",
 )
 
+_cpu_times = Histogram(
+    "cpu",
+    "CPU time (utime+stime) spent computing a single state resolution",
+    namespace="synapse",
+    subsystem="state_res",
+    unit="seconds",
+)
+_db_times = Histogram(
+    "db",
+    "Database time spent computing a single state resolution",
+    namespace="synapse",
+    subsystem="state_res",
+    unit="seconds",
+)
+
 
 class StateResolutionHandler:
     """Responsible for doing state conflict resolution.
@@ -608,6 +623,9 @@ class StateResolutionHandler:
         room_metrics.cpu_time += rusage.ru_utime + rusage.ru_stime
         room_metrics.db_time += rusage.db_txn_duration_sec
         room_metrics.db_events += rusage.evt_db_fetch_count
+
+        _cpu_times.observe(rusage.ru_utime + rusage.ru_stime)
+        _db_times.observe(rusage.db_txn_duration_sec)
 
     def _report_metrics(self) -> None:
         if not self._state_res_metrics:

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -445,18 +445,12 @@ _biggest_room_by_db_counter = Counter(
 )
 
 _cpu_times = Histogram(
-    "cpu",
+    "synapse_state_res_cpu_for_all_rooms_seconds",
     "CPU time (utime+stime) spent computing a single state resolution",
-    namespace="synapse",
-    subsystem="state_res",
-    unit="seconds",
 )
 _db_times = Histogram(
-    "db",
+    "synapse_state_res_db_for_all_rooms_seconds",
     "Database time spent computing a single state resolution",
-    namespace="synapse",
-    subsystem="state_res",
-    unit="seconds",
 )
 
 


### PR DESCRIPTION
I want to try https://github.com/matrix-org/matrix-spec/issues/1118 to see if it makes Synapse quicker to compute state resolutions (particularly when there is little state in conflict). To evaluate if this has a noticeable effect, I would like to add finer metrics tracking the computation of state resolution.

At the moment, we track how much time we spend the state, totalled on a room-by-room basis. When Prometheus asks us for a report, we report the time spent in the largest N rooms, where N = 1 or 10 depending on the configured logging verbosity. This lets us see improvements to the worst-case performance of state-res, but not the average case. To address the latter, add a Histogram which tracks the duration of each individual state resolution.

Completely untested!