### PR TITLE
Attempt to speed up the computation of the `auth_difference`

### DIFF
--- a/changelog.d/13037.feature
+++ b/changelog.d/13037.feature
@@ -1,0 +1,1 @@
+Reduce the CPU time spent in state resolution.

--- a/synapse/state/v2.py
+++ b/synapse/state/v2.py
@@ -381,16 +381,18 @@ async def _get_auth_chain_difference(
 def _seperate(
     state_sets: Iterable[StateMap[str]],
 ) -> Tuple[StateMap[str], Set[str]]:
-    """Return the unconflicted and conflicted state. This is different than in
-    the original algorithm, as this defines a key to be conflicted if one of
-    the state sets doesn't have that key.
+    """Return the unconflicted state map and the conflicted state set. This differs
+    from the v1 algorithm: v2 additionally considers a key to be conflicted if one
+    of the state sets doesn't have that key.
 
     Args:
         state_sets
 
     Returns:
-        A tuple of unconflicted and conflicted state. The conflicted state dict
-        is a map from type/state_key to set of event IDs
+        A tuple containing the unconflicted state map and the conflicted state set.
+        The unconflicted state map is a dict from (type, state_key) to event IDs.
+        The conflicted state set is an unordered set of event IDs. It may contain
+        multiple events with the same (type, state_key) pair.
     """
     unconflicted_state: MutableStateMap[str] = {}
     conflicted_state: Set[str] = set()


### PR DESCRIPTION
In https://github.com/matrix-org/matrix-spec/issues/1118 I noted that one can ignore the events in the unconflicted state map when computing the auth difference, because their auth chains will never appear in the auth difference. This change changes Synapse to take advantage of this fact.

In highly unscientific testing, I reproduced the state resolution of an event with two parents whose conflicted state set contained 255 events (239 type/state-key pairs) and whose auth difference contains 250 events.

Before:

```
real	0m10.243s
user	0m2.117s
sys	0m0.106s
```

After:

```
real	0m7.869s
user	0m1.958s
sys	0m0.105s
```

I repeated these a handful of times and found those numbers (~10sec, ~8sec) to be fairly reproducible. But I'm afraid I don't have any rigorous statistics to justify this.

It's also worth nothing that I'm running this on my local machine connected remotely to a postgres database (circa 15 ms RTT) so that might be exaggerating time spent waiting for the DB.

I have no evidence to performance which shows what happens in a typical or average case. (Though see #13036.)

I checked my example that the outcome of state resolution was unchanged, but I'm relying on the unit test coverage to assert that is the case more broadly.