### PR TITLE
Uniformize spam-checker API, part 5: expand other spam-checker callba…

### DIFF
--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -297,8 +297,8 @@ class AuthError(SynapseError):
     other poorly-defined times.
     """
 
-    def __init__(self, code: int, msg: str, errcode: str = Codes.FORBIDDEN):
-        super().__init__(code, msg, errcode)
+    def __init__(self, code: int, msg: str, errcode: str = Codes.FORBIDDEN, additional_fields: Optional[dict] = None):
+        super().__init__(code, msg, errcode, additional_fields)
 
 
 class InvalidClientCredentialsError(SynapseError):

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -149,7 +149,8 @@ class DirectoryHandler:
                 raise AuthError(
                     403,
                     "This user is not permitted to create this alias",
-                    spam_check,
+                    errcode = spam_check[0],
+                    additional_fields = spam_check[1]
                 )
 
             if not self.config.roomdirectory.is_alias_creation_allowed(
@@ -441,7 +442,8 @@ class DirectoryHandler:
             raise AuthError(
                 403,
                 "This user is not permitted to publish rooms to the room list",
-                spam_check,
+                errcode = spam_check[0],
+                additional_fields = spam_check[1]
             )
 
         if requester.is_guest:

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -828,7 +828,8 @@ class FederationHandler:
             raise SynapseError(
                 403,
                 "This user is not permitted to send invites to this server/user",
-                spam_check,
+                errcode = spam_check[0],
+                additional_fields = spam_check[1]
             )
 
         membership = event.content.get("membership")

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -439,7 +439,7 @@ class RoomCreationHandler:
 
         spam_check = await self.spam_checker.user_may_create_room(user_id)
         if spam_check != NOT_SPAM:
-            raise SynapseError(403, "You are not permitted to create rooms", spam_check)
+            raise SynapseError(403, "You are not permitted to create rooms", errcode = spam_check[0], additional_fields = spam_check[1])
 
         creation_content: JsonDict = {
             "room_version": new_room_version.identifier,

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -702,18 +702,18 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                         "Blocking invite: user is not admin and non-admin "
                         "invites disabled"
                     )
-                    block_invite_code = Codes.FORBIDDEN
+                    block_invite_result = (Codes.FORBIDDEN, {})
 
                 spam_check = await self.spam_checker.user_may_invite(
                     requester.user.to_string(), target_id, room_id
                 )
                 if spam_check != NOT_SPAM:
                     logger.info("Blocking invite due to spam checker")
-                    block_invite_code = spam_check
+                    block_invite_result = spam_check
 
-            if block_invite_code is not None:
+            if block_invite_result is not None:
                 raise SynapseError(
-                    403, "Invites have been disabled on this server", block_invite_code
+                    403, "Invites have been disabled on this server", errcode = block_invite_result[0], additional_fields = block_invite_result[1]
                 )
 
         # An empty prev_events list is allowed as long as the auth_event_ids are present
@@ -827,7 +827,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                     target.to_string(), room_id, is_invited=inviter is not None
                 )
                 if spam_check != NOT_SPAM:
-                    raise SynapseError(403, "Not allowed to join this room", spam_check)
+                    raise SynapseError(403, "Not allowed to join this room", errcode = spam_check[0], additional_fields = spam_check[1])
 
             # Check if a remote join should be performed.
             remote_join, remote_room_hosts = await self._should_perform_remote_join(
@@ -1381,7 +1381,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 room_id=room_id,
             )
             if spam_check != NOT_SPAM:
-                raise SynapseError(403, "Cannot send threepid invite", spam_check)
+                raise SynapseError(403, "Cannot send threepid invite", errcode=spam_check[0], additional_fields=spam_check[1])
 
             stream_id = await self._make_and_store_3pid_invite(
                 requester,

--- a/synapse/rest/media/v1/media_storage.py
+++ b/synapse/rest/media/v1/media_storage.py
@@ -154,7 +154,9 @@ class MediaStorage:
                         # Note that we'll delete the stored media, due to the
                         # try/except below. The media also won't be stored in
                         # the DB.
-                        raise SpamMediaException(errcode=spam_check)
+                        # We currently ignore any additional field returned by
+                        # the spam-check API.
+                        raise SpamMediaException(errcode=spam_check[0])
 
                     for provider in self.storage_providers:
                         await provider.store_file(path, file_info)


### PR DESCRIPTION
…cks to return Tuple[Codes, dict]

The objective of this push is to progressively expand the spam-checker API into letting spam-checkers provide reasons for which an event/operation has been rejected. In particular, we wish to prototype account suspension (by opposition to account removal) through spam-checkers and let users know what they need to do to have the account unsuspended.

Specifically, letting a spam-checker return an additional `dict` gives us a way to point users towards an individual url on which they can read up all the details about their suspension.

This is a followup to:

- #12703, Uniformize spam-checker API, part 1: turning `Codes` into an `Enum`.
- #12808, Uniformize spam-checker API, part 2: converting `check_event_for_spam` to let callbacks return `Codes`.
- #12846, Uniformize spam-checker API, part 3: extend `check_event_for_spam` to let callbacks return additional fields.
- #12857, Uniformize spam-checker API, part 4: convert other spam-checker callbacks to return `Codes`.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
