### PR TITLE
Collapse Docker build commands in Complement CI runs to make the logs easier to read.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -371,7 +371,7 @@ jobs:
 
       - name: "Install Complement Dependencies"
         run: |
-          sudo apt-get -qq update && sudo apt-get -o=Dpkg::Use-Pty=0 install -qqy libolm3 libolm-dev
+          sudo apt-get -qq update && sudo apt-get install -qqy libolm3 libolm-dev
           go get -v github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
       - name: Run actions/checkout@v2 for synapse

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -371,7 +371,7 @@ jobs:
 
       - name: "Install Complement Dependencies"
         run: |
-          sudo apt-get update && sudo apt-get install -y libolm3 libolm-dev
+          sudo apt-get -qq update && sudo apt-get -o=Dpkg::Use-Pty=0 install -qqy libolm3 libolm-dev
           go get -v github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
       - name: Run actions/checkout@v2 for synapse

--- a/changelog.d/13058.misc
+++ b/changelog.d/13058.misc
@@ -1,0 +1,1 @@
+Make Complement CI logs easier to read.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ FROM docker.io/python:${PYTHON_VERSION}-slim as requirements
 RUN \
    --mount=type=cache,target=/var/cache/apt,sharing=locked \
    --mount=type=cache,target=/var/lib/apt,sharing=locked \
- apt-get update && apt-get install -y git \
+ apt-get update -qq && apt-get install -yqq git \
     && rm -rf /var/lib/apt/lists/*
 
 # We install poetry in its own build stage to avoid its dependencies conflicting with
@@ -73,7 +73,7 @@ FROM docker.io/python:${PYTHON_VERSION}-slim as builder
 RUN \
    --mount=type=cache,target=/var/cache/apt,sharing=locked \
    --mount=type=cache,target=/var/lib/apt,sharing=locked \
- apt-get update && apt-get install -y \
+ apt-get update -qq && apt-get install -yqq \
     build-essential \
     libffi-dev \
     libjpeg-dev \
@@ -118,7 +118,7 @@ LABEL org.opencontainers.image.licenses='Apache-2.0'
 RUN \
    --mount=type=cache,target=/var/cache/apt,sharing=locked \
    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt-get update && apt-get install -y \
+  apt-get update -qq && apt-get install -yqq \
     curl \
     gosu \
     libjpeg62-turbo \

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -6,8 +6,8 @@ FROM matrixdotorg/synapse:$SYNAPSE_VERSION
 RUN \
    --mount=type=cache,target=/var/cache/apt,sharing=locked \
    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  apt-get update -qq && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends \
      redis-server nginx-light
 
 # Install supervisord with pip instead of apt, to avoid installing a second

--- a/docker/complement/Dockerfile
+++ b/docker/complement/Dockerfile
@@ -9,7 +9,7 @@ FROM matrixdotorg/synapse-workers:$SYNAPSE_VERSION
 
 # Install postgresql
 RUN apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y postgresql-13
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -yqq postgresql-13
 
 # Configure a user and create a database for Synapse
 RUN pg_ctlcluster 13 main start &&  su postgres -c "echo \

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -24,6 +24,15 @@
 # Exit if a line returns a non-zero exit code
 set -e
 
+
+# Helper to emit annotations that collapse portions of the log in GitHub Actions
+echo_if_github() {
+  if [[ -n "$GITHUB_WORKFLOW" ]]; then
+    echo $*
+  fi
+}
+
+
 # enable buildkit for the docker builds
 export DOCKER_BUILDKIT=1
 
@@ -41,14 +50,20 @@ if [[ -z "$COMPLEMENT_DIR" ]]; then
 fi
 
 # Build the base Synapse image from the local checkout
+echo_if_github "::group::Build Docker image: matrixdotorg/synapse"
 docker build -t matrixdotorg/synapse -f "docker/Dockerfile" .
+echo_if_github "::endgroup::"
 
 # Build the workers docker image (from the base Synapse image we just built).
+echo_if_github "::group::Build Docker image: matrixdotorg/synapse-workers"
 docker build -t matrixdotorg/synapse-workers -f "docker/Dockerfile-workers" .
+echo_if_github "::endgroup::"
 
 # Build the unified Complement image (from the worker Synapse image we just built).
+echo_if_github "::group::Build Docker image: complement/Dockerfile"
 docker build -t complement-synapse \
   -f "docker/complement/Dockerfile" "docker/complement"
+echo_if_github "::endgroup::"
 
 export COMPLEMENT_BASE_IMAGE=complement-synapse
 


### PR DESCRIPTION
apt-get is frequently one of the spammiest things when scrolling down into Complement logs. Let's quieten it a bit.

Note that nobody seems to have found the ultimate cure for apt-get noise other than `/dev/null`, which I'm reluctant to do...

EDIT: The entire Docker building process is basically spam, so this PR now folds that away.