### PR TITLE
Don't use keyword arguments when initialising modules

### DIFF
--- a/changelog.d/13060.misc
+++ b/changelog.d/13060.misc
@@ -1,0 +1,1 @@
+Don't instantiate modules with keyword arguments.

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -450,7 +450,7 @@ async def start(hs: "HomeServer") -> None:
     # before we start the listeners.
     module_api = hs.get_module_api()
     for module, config in hs.config.modules.loaded_modules:
-        m = module(config=config, api=module_api)
+        m = module(config, module_api)
         logger.info("Loaded module %s", m)
 
     load_legacy_spam_checkers(hs)


### PR DESCRIPTION
Otherwise modules won't work if they name their `__init__` args differently than Synapse.