### PR TITLE
Complement: use SQLite by default

### DIFF
--- a/changelog.d/13075.misc
+++ b/changelog.d/13075.misc
@@ -1,0 +1,1 @@
+Merge the Complement testing Docker images into a single, multi-purpose image.

--- a/docker/complement/README.md
+++ b/docker/complement/README.md
@@ -7,7 +7,7 @@ so **please don't use this image for a production server**.
 This multi-purpose image is built on top of `Dockerfile-workers` in the parent directory
 and can be switched using environment variables between the following configurations:
 
-- Monolithic Synapse with SQLite (`SYNAPSE_COMPLEMENT_DATABASE=sqlite`)
+- Monolithic Synapse with SQLite (default, or `SYNAPSE_COMPLEMENT_DATABASE=sqlite`)
 - Monolithic Synapse with Postgres (`SYNAPSE_COMPLEMENT_DATABASE=postgres`)
 - Workerised Synapse with Postgres (`SYNAPSE_COMPLEMENT_DATABASE=postgres` and `SYNAPSE_COMPLEMENT_USE_WORKERS=true`)
 

--- a/docker/complement/conf/start_for_complement.sh
+++ b/docker/complement/conf/start_for_complement.sh
@@ -31,7 +31,7 @@ case "$SYNAPSE_COMPLEMENT_DATABASE" in
     export START_POSTGRES=true
     ;;
 
-  sqlite)
+  sqlite|)
     # Configure supervisord not to start Postgres, as we don't need it
     export START_POSTGRES=false
     ;;

--- a/docker/complement/conf/start_for_complement.sh
+++ b/docker/complement/conf/start_for_complement.sh
@@ -31,7 +31,7 @@ case "$SYNAPSE_COMPLEMENT_DATABASE" in
     export START_POSTGRES=true
     ;;
 
-  sqlite|)
+  sqlite|"")
     # Configure supervisord not to start Postgres, as we don't need it
     export START_POSTGRES=false
     ;;


### PR DESCRIPTION
If no database is configured explicitly, use sqlite.

This means that you don't have to pass any variables into the image.