### PR TITLE
Update opentracing docs to reference the configuration manual rather than the configuation file.

### DIFF
--- a/changelog.d/13076.doc
+++ b/changelog.d/13076.doc
@@ -1,0 +1,2 @@
+Update opentracing docs to reference the configuration manual rather than the configuation file.
+

--- a/changelog.d/13076.doc
+++ b/changelog.d/13076.doc
@@ -1,2 +1,1 @@
-Update opentracing docs to reference the configuration manual rather than the configuation file.
-
+Update OpenTracing docs to reference the configuration manual rather than the configuration file.

--- a/docs/opentracing.md
+++ b/docs/opentracing.md
@@ -57,8 +57,9 @@ https://www.jaegertracing.io/docs/latest/getting-started.
 ## Enable OpenTracing in Synapse
 
 OpenTracing is not enabled by default. It must be enabled in the
-homeserver config by uncommenting the config options under `opentracing`
-as shown in the [sample config](./sample_config.yaml). For example:
+homeserver config by adding the `opentracing` option to your config file. You can find 
+documentation about how to do this in the [config manual](usage/configuration/config_documentation.md) 
+under the header `opentracing`. See below for an example opentracing configuration: 
 
 ```yaml
 opentracing:

--- a/docs/opentracing.md
+++ b/docs/opentracing.md
@@ -58,8 +58,8 @@ https://www.jaegertracing.io/docs/latest/getting-started.
 
 OpenTracing is not enabled by default. It must be enabled in the
 homeserver config by adding the `opentracing` option to your config file. You can find 
-documentation about how to do this in the [config manual](usage/configuration/config_documentation.md) 
-under the header `opentracing`. See below for an example opentracing configuration: 
+documentation about how to do this in the [config manual under the header 'Opentracing'](usage/configuration/config_documentation.md#opentracing).
+See below for an example Opentracing configuration: 
 
 ```yaml
 opentracing:


### PR DESCRIPTION
Currently the opentracing docs in our manual reference un-commenting an option in the configuration file, which is no longer possible since the comments in the configuration file have been removed. This PR removes that reference and points the reader to the configuration manual instead. 