### PR TITLE
Add desc to `get_earliest_token_for_stats`

### DIFF
--- a/changelog.d/13085.misc
+++ b/changelog.d/13085.misc
@@ -1,0 +1,1 @@
+Correctly report prometheus DB stats for `get_earliest_token_for_stats`.

--- a/synapse/storage/databases/main/stats.py
+++ b/synapse/storage/databases/main/stats.py
@@ -295,6 +295,7 @@ class StatsStore(StateDeltasStore):
             keyvalues={id_col: id},
             retcol="completed_delta_stream_id",
             allow_none=True,
+            desc="get_earliest_token_for_stats",
         )
 
     async def bulk_update_stats_delta(


### PR DESCRIPTION
Otherwise it gets reported as `simple_select_one_onecol`