### PR TITLE
Fix logging context misuse when we fail to persist a federation event

### DIFF
--- a/changelog.d/13089.misc
+++ b/changelog.d/13089.misc
@@ -1,0 +1,1 @@
+Fix a long-standing bug where a finished logging context would be re-started when Synapse failed to persist an event from federation.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -57,7 +57,7 @@ from synapse.event_auth import (
 from synapse.events import EventBase
 from synapse.events.snapshot import EventContext
 from synapse.federation.federation_client import InvalidResponseError
-from synapse.logging.context import nested_logging_context, run_in_background
+from synapse.logging.context import nested_logging_context
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.replication.http.devices import ReplicationUserDevicesResyncRestServlet
 from synapse.replication.http.federation import (
@@ -1964,9 +1964,7 @@ class FederationEventHandler:
                 event.room_id, [(event, context)], backfilled=backfilled
             )
         except Exception:
-            run_in_background(
-                self._store.remove_push_actions_from_staging, event.event_id
-            )
+            await self._store.remove_push_actions_from_staging(event.event_id)
             raise
 
     async def persist_events_and_notify(


### PR DESCRIPTION
When we fail to persist a federation event, we kick off a task to remove
its push actions in the background, using the current logging context.
Since we don't `await` that task, we may finish our logging context
before the task finishes. There's no reason to not `await` the task, so
let's do that.

Fixes #12987.

Signed-off-by: Sean Quah <seanq@matrix.org>

----

As part of #12988, we'd like to raise a special exception from deep within the event persistence code.
That exception triggers the bug that we fix in this PR.
