### PR TITLE
Simplify the alias deletion logic as an application service.

### DIFF
--- a/changelog.d/13093.misc
+++ b/changelog.d/13093.misc
@@ -1,0 +1,1 @@
+Simplify the alias deletion logic as an application service.

--- a/tests/rest/client/test_directory.py
+++ b/tests/rest/client/test_directory.py
@@ -16,6 +16,7 @@ from http import HTTPStatus
 
 from twisted.test.proto_helpers import MemoryReactor
 
+from synapse.appservice import ApplicationService
 from synapse.rest import admin
 from synapse.rest.client import directory, login, room
 from synapse.server import HomeServer
@@ -126,6 +127,39 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
             "DELETE",
             f"/_matrix/client/r0/directory/room/{alias}",
             access_token=self.user_tok,
+        )
+        self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
+
+    def test_deleting_alias_via_directory_appservice(self) -> None:
+        user_id = "@as:test"
+        as_token = "i_am_an_app_service"
+
+        appservice = ApplicationService(
+            as_token,
+            id="1234",
+            namespaces={"aliases": [{"regex": "#asns-*", "exclusive": True}]},
+            sender=user_id,
+        )
+        self.hs.get_datastores().main.services_cache.append(appservice)
+
+        # Add an alias for the room, as the appservice
+        alias = RoomAlias(f"asns-{random_string(5)}", self.hs.hostname).to_string()
+        data = {"room_id": self.room_id}
+        request_data = json.dumps(data)
+
+        channel = self.make_request(
+            "PUT",
+            f"/_matrix/client/r0/directory/room/{alias}",
+            request_data,
+            access_token=as_token,
+        )
+        self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
+
+        # Then try to remove the alias, as the appservice
+        channel = self.make_request(
+            "DELETE",
+            f"/_matrix/client/r0/directory/room/{alias}",
+            access_token=as_token,
         )
         self.assertEqual(channel.code, HTTPStatus.OK, channel.result)
 


### PR DESCRIPTION
Part of #13019.

I'm trying to get rid of `Auth.get_appservice_by_req`, because it does things that `Auth.get_user_by_req` already does. Also, `get_user_by_req` sets up the tracing attributes span correctly, which `get_appservice_by_req` does not.

I also added a test for this specific endpoint, because I could not find one which was covering this branch (maybe in Sytest/Complement, but I have not looked that up)

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
