### PR TITLE
Move methods to extract the access token outside of the `Auth` class.

### DIFF
--- a/changelog.d/13097.misc
+++ b/changelog.d/13097.misc
@@ -1,0 +1,1 @@
+Move methods to extract the access token outside of the `Auth` class.

--- a/synapse/rest/client/account.py
+++ b/synapse/rest/client/account.py
@@ -30,6 +30,7 @@ from synapse.api.errors import (
 )
 from synapse.config.emailconfig import ThreepidBehaviour
 from synapse.handlers.ui_auth import UIAuthSessionDataConstants
+from synapse.http import request_has_access_token
 from synapse.http.server import HttpServer, finish_request, respond_with_html
 from synapse.http.servlet import (
     RestServlet,
@@ -195,7 +196,7 @@ class PasswordRestServlet(RestServlet):
         # In the second case, we require a password to confirm their identity.
 
         requester = None
-        if self.auth.has_access_token(request):
+        if request_has_access_token(request):
             requester = await self.auth.get_user_by_req(request)
             try:
                 params, session_id = await self.auth_handler.validate_user_via_ui_auth(

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Tuple
 
 from synapse.api import errors
 from synapse.api.errors import NotFoundError
+from synapse.http import get_request_access_token
 from synapse.http.server import HttpServer
 from synapse.http.servlet import (
     RestServlet,
@@ -293,7 +294,7 @@ class ClaimDehydratedDeviceServlet(RestServlet):
 
         result = await self.device_handler.rehydrate_device(
             requester.user.to_string(),
-            self.auth.get_access_token_from_request(request),
+            get_request_access_token(request),
             submission["device_id"],
         )
 

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -20,6 +20,7 @@ from twisted.web.server import Request
 
 import synapse
 import synapse.api.auth
+from synapse.http import get_request_access_token, request_has_access_token
 import synapse.types
 from synapse.api.constants import APP_SERVICE_REGISTRATION_TYPE, LoginType
 from synapse.api.errors import (
@@ -478,7 +479,7 @@ class RegisterRestServlet(RestServlet):
 
         # == Application Service Registration ==
         if body.get("type") == APP_SERVICE_REGISTRATION_TYPE:
-            if not self.auth.has_access_token(request):
+            if not request_has_access_token(request):
                 raise SynapseError(
                     400,
                     "Appservice token must be provided when using a type of m.login.application_service",
@@ -497,7 +498,7 @@ class RegisterRestServlet(RestServlet):
             # because the IRC bridges rely on being able to register stupid
             # IDs.
 
-            access_token = self.auth.get_access_token_from_request(request)
+            access_token = get_request_access_token(request)
 
             if not isinstance(desired_username, str):
                 raise SynapseError(400, "Desired Username is missing or not a string")
@@ -510,7 +511,7 @@ class RegisterRestServlet(RestServlet):
             )
 
             return 200, result
-        elif self.auth.has_access_token(request):
+        elif request_has_access_token(request):
             raise SynapseError(
                 400,
                 "An access token should not be provided on requests to /register (except if type is m.login.application_service)",

--- a/synapse/rest/client/transactions.py
+++ b/synapse/rest/client/transactions.py
@@ -21,6 +21,7 @@ from typing_extensions import ParamSpec
 
 from twisted.python.failure import Failure
 from twisted.web.server import Request
+from synapse.http import get_request_access_token
 
 from synapse.logging.context import make_deferred_yieldable, run_in_background
 from synapse.types import JsonDict
@@ -40,7 +41,6 @@ P = ParamSpec("P")
 class HttpTransactionCache:
     def __init__(self, hs: "HomeServer"):
         self.hs = hs
-        self.auth = self.hs.get_auth()
         self.clock = self.hs.get_clock()
         # $txn_key: (ObservableDeferred<(res_code, res_json_body)>, timestamp)
         self.transactions: Dict[
@@ -64,7 +64,7 @@ class HttpTransactionCache:
             A transaction key
         """
         assert request.path is not None
-        token = self.auth.get_access_token_from_request(request)
+        token = get_request_access_token(request)
         return request.path.decode("utf8") + "/" + token
 
     def fetch_or_execute_request(


### PR DESCRIPTION
Part of #13019 

It does not really make sense to have those methods attached to `synapse.api.auth.Auth` since they are static methods, so this moves them to standalone functions in `synapse.http`.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
