### PR TITLE
validate room alias before interacting with the room directory

### DIFF
--- a/changelog.d/13106.bugfix
+++ b/changelog.d/13106.bugfix
@@ -1,1 +1,1 @@
-Validates room alias before calling internal functions
+Fix a long-standing bug where room directory requests would cause an internal server error if given a malformed room alias.

--- a/changelog.d/13106.bugfix
+++ b/changelog.d/13106.bugfix
@@ -1,0 +1,1 @@
+Validates room alias before calling internal functions

--- a/synapse/rest/client/directory.py
+++ b/synapse/rest/client/directory.py
@@ -46,6 +46,8 @@ class ClientDirectoryServer(RestServlet):
         self.auth = hs.get_auth()
 
     async def on_GET(self, request: Request, room_alias: str) -> Tuple[int, JsonDict]:
+        if not RoomAlias.is_valid(room_alias):
+            raise SynapseError(400, 'Room alias invalid', errcode=Codes.BAD_JSON)
         room_alias_obj = RoomAlias.from_string(room_alias)
 
         res = await self.directory_handler.get_association(room_alias_obj)
@@ -55,6 +57,8 @@ class ClientDirectoryServer(RestServlet):
     async def on_PUT(
         self, request: SynapseRequest, room_alias: str
     ) -> Tuple[int, JsonDict]:
+        if not RoomAlias.is_valid(room_alias):
+            raise SynapseError(400, 'Room alias invalid', errcode=Codes.BAD_JSON)
         room_alias_obj = RoomAlias.from_string(room_alias)
 
         content = parse_json_object_from_request(request)
@@ -89,6 +93,8 @@ class ClientDirectoryServer(RestServlet):
     async def on_DELETE(
         self, request: SynapseRequest, room_alias: str
     ) -> Tuple[int, JsonDict]:
+        if not RoomAlias.is_valid(room_alias):
+            raise SynapseError(400, 'Room alias invalid', errcode=Codes.BAD_JSON)
         room_alias_obj = RoomAlias.from_string(room_alias)
         requester = await self.auth.get_user_by_req(request)
 

--- a/synapse/rest/client/directory.py
+++ b/synapse/rest/client/directory.py
@@ -47,7 +47,7 @@ class ClientDirectoryServer(RestServlet):
 
     async def on_GET(self, request: Request, room_alias: str) -> Tuple[int, JsonDict]:
         if not RoomAlias.is_valid(room_alias):
-            raise SynapseError(400, 'Room alias invalid', errcode=Codes.BAD_JSON)
+            raise SynapseError(400, "Room alias invalid", errcode=Codes.BAD_JSON)
         room_alias_obj = RoomAlias.from_string(room_alias)
 
         res = await self.directory_handler.get_association(room_alias_obj)
@@ -58,7 +58,7 @@ class ClientDirectoryServer(RestServlet):
         self, request: SynapseRequest, room_alias: str
     ) -> Tuple[int, JsonDict]:
         if not RoomAlias.is_valid(room_alias):
-            raise SynapseError(400, 'Room alias invalid', errcode=Codes.BAD_JSON)
+            raise SynapseError(400, "Room alias invalid", errcode=Codes.BAD_JSON)
         room_alias_obj = RoomAlias.from_string(room_alias)
 
         content = parse_json_object_from_request(request)
@@ -94,7 +94,7 @@ class ClientDirectoryServer(RestServlet):
         self, request: SynapseRequest, room_alias: str
     ) -> Tuple[int, JsonDict]:
         if not RoomAlias.is_valid(room_alias):
-            raise SynapseError(400, 'Room alias invalid', errcode=Codes.BAD_JSON)
+            raise SynapseError(400, "Room alias invalid", errcode=Codes.BAD_JSON)
         room_alias_obj = RoomAlias.from_string(room_alias)
         requester = await self.auth.get_user_by_req(request)
 

--- a/synapse/rest/client/directory.py
+++ b/synapse/rest/client/directory.py
@@ -47,7 +47,7 @@ class ClientDirectoryServer(RestServlet):
 
     async def on_GET(self, request: Request, room_alias: str) -> Tuple[int, JsonDict]:
         if not RoomAlias.is_valid(room_alias):
-            raise SynapseError(400, "Room alias invalid", errcode=Codes.BAD_JSON)
+            raise SynapseError(400, "Room alias invalid", errcode=Codes.INVALID_PARAM)
         room_alias_obj = RoomAlias.from_string(room_alias)
 
         res = await self.directory_handler.get_association(room_alias_obj)
@@ -58,7 +58,7 @@ class ClientDirectoryServer(RestServlet):
         self, request: SynapseRequest, room_alias: str
     ) -> Tuple[int, JsonDict]:
         if not RoomAlias.is_valid(room_alias):
-            raise SynapseError(400, "Room alias invalid", errcode=Codes.BAD_JSON)
+            raise SynapseError(400, "Room alias invalid", errcode=Codes.INVALID_PARAM)
         room_alias_obj = RoomAlias.from_string(room_alias)
 
         content = parse_json_object_from_request(request)
@@ -94,7 +94,7 @@ class ClientDirectoryServer(RestServlet):
         self, request: SynapseRequest, room_alias: str
     ) -> Tuple[int, JsonDict]:
         if not RoomAlias.is_valid(room_alias):
-            raise SynapseError(400, "Room alias invalid", errcode=Codes.BAD_JSON)
+            raise SynapseError(400, "Room alias invalid", errcode=Codes.INVALID_PARAM)
         room_alias_obj = RoomAlias.from_string(room_alias)
         requester = await self.auth.get_user_by_req(request)
 

--- a/tests/rest/client/test_directory.py
+++ b/tests/rest/client/test_directory.py
@@ -215,6 +215,19 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, expected_code, channel.result)
         return alias
 
+    def test_invalid_alias(self) -> None:
+        alias = "#potato"
+        channel = self.make_request(
+            "GET",
+            f"/_matrix/client/r0/directory/room/{alias}",
+            access_token=self.user_tok,
+        )
+        self.assertEqual(channel.code, HTTPStatus.BAD_REQUEST, channel.result)
+        self.assertIn("error", channel.json_body, channel.json_body)
+        self.assertEqual(
+            channel.json_body["errcode"], "M_INVALID_PARAM", channel.json_body
+        )
+
     def random_alias(self, length: int) -> str:
         return RoomAlias(random_string(length), self.hs.hostname).to_string()
 


### PR DESCRIPTION
Signed-off-by: santhoshivan23 <santhoshivan23@gmail.com>

Added validation checks for room aliases. This patch would prevent requests with invalid room aliases from causing internal server error. Fixes #13104 