### PR TITLE
Don't actually one-line the SQL statements we send to the DB

### DIFF
--- a/changelog.d/13129.misc
+++ b/changelog.d/13129.misc
@@ -1,0 +1,1 @@
+Only one-line SQL statements for logging and tracing.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -366,10 +366,11 @@ class LoggingTransaction:
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> R:
-        sql = self._make_sql_one_line(sql)
+        # Generate a one-line version of the SQL to better log it.
+        one_line_sql = self._make_sql_one_line(sql)
 
         # TODO(paul): Maybe use 'info' and 'debug' for values?
-        sql_logger.debug("[SQL] {%s} %s", self.name, sql)
+        sql_logger.debug("[SQL] {%s} %s", self.name, one_line_sql)
 
         sql = self.database_engine.convert_param_style(sql)
         if args:
@@ -389,7 +390,7 @@ class LoggingTransaction:
                 "db.query",
                 tags={
                     opentracing.tags.DATABASE_TYPE: "sql",
-                    opentracing.tags.DATABASE_STATEMENT: sql,
+                    opentracing.tags.DATABASE_STATEMENT: one_line_sql,
                 },
             ):
                 return func(sql, *args, **kwargs)


### PR DESCRIPTION
This came up while investigating why https://github.com/matrix-org/synapse-email-account-validity wasn't creating its database properly. It turns out the `CREATE TABLE` statement this module uses includes comments to explain what each column represents - see https://github.com/matrix-org/synapse-email-account-validity/blob/b05341f2cc56bc1b471138f095e8400438780567/email_account_validity/_store.py#L51-L74

However, this didn't work because by making the query one line we would make everything after the first comment part of that comment, meaning we would get errors about unfinished statement or syntax errors (depending on the engine).

According to the docstring of `_make_sql_one_line` we only need one-lined SQL for logging (which seems to match my understanding of the code), so let's use the original SQL everywhere else.

The only impact on logging/tracing I can see is that when using PostgreSQL the query's arguments will be represented by `?` instead of `%s` since we skip the call to `convert_param_style` (on SQLite this method returns the SQL as is).