### PR TITLE
Draft: Backfill remote event fetched by MSC3030 `/timestamp_to_event` so we can paginate `/messages` from it later

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1427,13 +1427,16 @@ class TimestampLookupHandler:
                         remote_response,
                     )
 
-                    # TODO: Do we want to persist this as an extremity?
                     # TODO: I think ideally, we would try to backfill from
                     # this event and run this whole
                     # `get_event_for_timestamp` function again to make sure
                     # they didn't give us an event from their gappy history.
                     remote_event_id = remote_response.event_id
                     origin_server_ts = remote_response.origin_server_ts
+
+                    # Persist this as an extremity so we can backfill from it
+                    # later when calling `/messages`
+                    self.store.insert_backward_extremeties([(room_id, remote_event_id)])
 
                     # Only return the remote event if it's closer than the local event
                     if not local_event or (


### PR DESCRIPTION
Backfill remote event fetched by MSC3030 `/timestamp_to_event` so we can paginate `/messages` from it later

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
