### PR TITLE
Don't process /send requests for users who have hit their ratelimit

### DIFF
--- a/changelog.d/13134.misc
+++ b/changelog.d/13134.misc
@@ -1,0 +1,1 @@
+Apply ratelimiting earlier in processing of /send request.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -903,6 +903,9 @@ class EventCreationHandler:
             await self.clock.sleep(random.randint(1, 10))
             raise ShadowBanError()
 
+        if ratelimit:
+            await self.request_ratelimiter.ratelimit(requester, update=False)
+
         # We limit the number of concurrent event sends in a room so that we
         # don't fork the DAG too much. If we don't limit then we can end up in
         # a situation where event persistence can't keep up, causing


### PR DESCRIPTION
Currently we check the ratelimit for a /send request after quite a bit of processing has already occurred. This PR adds a ratelimit check much earlier in the processing, reducing unnecessary processing and remediating performance delays caused by processing over-ratelimit requests. Fixes #13072. 