### PR TITLE
Actually typecheck `tests.test_server`

### DIFF
--- a/changelog.d/13135.misc
+++ b/changelog.d/13135.misc
@@ -1,0 +1,1 @@
+Enforce type annotations for `tests.test_server`.

--- a/mypy.ini
+++ b/mypy.ini
@@ -56,7 +56,6 @@ exclude = (?x)
    |tests/server.py
    |tests/server_notices/test_resource_limits_server_notices.py
    |tests/test_metrics.py
-   |tests/test_server.py
    |tests/test_state.py
    |tests/test_terms_auth.py
    |tests/util/caches/test_cached_call.py


### PR DESCRIPTION
Missed from #13124.