### PR TITLE
Add a link to the configuration manual from the homeserver sample config documentation page

### DIFF
--- a/changelog.d/13139.doc
+++ b/changelog.d/13139.doc
@@ -1,0 +1,1 @@
+Add a link to the configuration manual from the homeserver sample config documentation.

--- a/docs/usage/configuration/homeserver_sample_config.md
+++ b/docs/usage/configuration/homeserver_sample_config.md
@@ -9,6 +9,9 @@ a real homeserver.yaml. Instead, if you are starting from scratch, please genera
 a fresh config using Synapse by following the instructions in
 [Installation](../../setup/installation.md).
 
+Documentation for all configuration options can be found in the
+[Configuration Manual](./config_documentation.md).
+
 ```yaml
 {{#include ../../sample_config.yaml}}
 ```


### PR DESCRIPTION
After reducing the sample config to only a subset of options, this docs page became a bit of a dead end, especially if you were previously using it to search for option descriptions.

This PR simply adds a link to the configuration manual, which is the new place to find option documentation.