### PR TITLE
Add index to help delete old push actions

### DIFF
--- a/changelog.d/13141.bugfix
+++ b/changelog.d/13141.bugfix
@@ -1,0 +1,1 @@
+Fix DB performance when deleting old push notifications. Introduced in v1.62.0rc1.

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -58,9 +58,7 @@ from synapse.storage.databases.main.client_ips import ClientIpBackgroundUpdateSt
 from synapse.storage.databases.main.deviceinbox import DeviceInboxBackgroundUpdateStore
 from synapse.storage.databases.main.devices import DeviceBackgroundUpdateStore
 from synapse.storage.databases.main.end_to_end_keys import EndToEndKeyBackgroundStore
-from synapse.storage.databases.main.event_push_actions import (
-    EventPushActionsWorkerStore,
-)
+from synapse.storage.databases.main.event_push_actions import EventPushActionsStore
 from synapse.storage.databases.main.events_bg_updates import (
     EventsBackgroundUpdatesStore,
 )
@@ -202,7 +200,7 @@ R = TypeVar("R")
 
 
 class Store(
-    EventPushActionsWorkerStore,
+    EventPushActionsStore,
     ClientIpBackgroundUpdateStore,
     DeviceInboxBackgroundUpdateStore,
     DeviceBackgroundUpdateStore,

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -1189,6 +1189,16 @@ class EventPushActionsStore(EventPushActionsWorkerStore):
             where_clause="highlight=1",
         )
 
+        # Add index to make deleting old push actions faster.
+        self.db_pool.updates.register_background_index_update(
+            "event_push_actions_stream_highlight_index",
+            index_name="event_push_actions_stream_highlight_index",
+            table="event_push_actions",
+            columns=["highlight", "stream_ordering"],
+            where_clause="highlight=0",
+            psql_only=True,
+        )
+
     async def get_push_actions_for_user(
         self,
         user_id: str,

--- a/synapse/storage/schema/main/delta/72/02event_push_actions_index.sql
+++ b/synapse/storage/schema/main/delta/72/02event_push_actions_index.sql
@@ -16,4 +16,4 @@
 -- Add an index to `event_push_actions` to make deleting old non-highlight push
 -- actions faster.
 INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
-  (7002, 'event_push_actions_stream_highlight_index', '{}');
+  (7202, 'event_push_actions_stream_highlight_index', '{}');

--- a/synapse/storage/schema/main/delta/72/02event_push_actions_index.sql
+++ b/synapse/storage/schema/main/delta/72/02event_push_actions_index.sql
@@ -1,0 +1,19 @@
+/* Copyright 2022 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Add an index to `event_push_actions` to make deleting old non-highlight push
+-- actions faster.
+INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
+  (7002, 'event_push_actions_stream_highlight_index', '{}');


### PR DESCRIPTION
We need this index to efficiently delete old non-highlight push actions, without having to wade through all the old highlights.