### PR TITLE
complement.sh: Permit skipping docker build

### DIFF
--- a/changelog.d/13143.misc
+++ b/changelog.d/13143.misc
@@ -1,0 +1,1 @@
+Add support to `complement.sh` for skipping the docker build.

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -35,13 +35,26 @@ echo_if_github() {
   fi
 }
 
+# Helper to print out the usage instructions
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [-f] <go test arguments>...
+Run the complement test suite on Synapse.
+
+  -f    Skip rebuilding the docker images, and just use the most recent
+        'complement-synapse:latest' image
+
+For help on arguments to 'go test', run 'go help testflag'.
+EOF
+}
+
 # parse our arguments
 skip_docker_build=""
 while [ $# -ge 1 ]; do
     arg=$1
     case "$arg" in
         "-h")
-            echo >&2 "Usage: $0 [-f] <go test arguments>"
+            usage
             exit 1
             ;;
         "-f")

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -14,9 +14,12 @@
 # By default Synapse is run in monolith mode. This can be overridden by
 # setting the WORKERS environment variable.
 #
-# A regular expression of test method names can be supplied as the first
-# argument to the script. Complement will then only run those tests. If
-# no regex is supplied, all tests are run. For example;
+# You can optionally give a "-f" argument (for "fast") before any to skip
+# rebuilding the docker images, if you just want to rerun the tests.
+#
+# Remaining commandline arguments are passed through to `go test`. For example,
+# you can supply a regular expression of test method names via the "-run"
+# argument:
 #
 # ./complement.sh -run "TestOutboundFederation(Profile|Send)"
 #
@@ -32,6 +35,24 @@ echo_if_github() {
   fi
 }
 
+# parse our arguments
+skip_docker_build=""
+while [ $# -ge 1 ]; do
+    arg=$1
+    case "$arg" in
+        "-h")
+            echo >&2 "Usage: $0 [-f] <go test arguments>"
+            exit 1
+            ;;
+        "-f")
+            skip_docker_build=1
+            ;;
+        *)
+            # unknown arg: presumably an argument to gotest. break the loop.
+            break
+    esac
+    shift
+done
 
 # enable buildkit for the docker builds
 export DOCKER_BUILDKIT=1
@@ -49,21 +70,23 @@ if [[ -z "$COMPLEMENT_DIR" ]]; then
   echo "Checkout available at 'complement-${COMPLEMENT_REF}'"
 fi
 
-# Build the base Synapse image from the local checkout
-echo_if_github "::group::Build Docker image: matrixdotorg/synapse"
-docker build -t matrixdotorg/synapse -f "docker/Dockerfile" .
-echo_if_github "::endgroup::"
+if [ -z "$skip_docker_build" ]; then
+    # Build the base Synapse image from the local checkout
+    echo_if_github "::group::Build Docker image: matrixdotorg/synapse"
+    docker build -t matrixdotorg/synapse -f "docker/Dockerfile" .
+    echo_if_github "::endgroup::"
 
-# Build the workers docker image (from the base Synapse image we just built).
-echo_if_github "::group::Build Docker image: matrixdotorg/synapse-workers"
-docker build -t matrixdotorg/synapse-workers -f "docker/Dockerfile-workers" .
-echo_if_github "::endgroup::"
+    # Build the workers docker image (from the base Synapse image we just built).
+    echo_if_github "::group::Build Docker image: matrixdotorg/synapse-workers"
+    docker build -t matrixdotorg/synapse-workers -f "docker/Dockerfile-workers" .
+    echo_if_github "::endgroup::"
 
-# Build the unified Complement image (from the worker Synapse image we just built).
-echo_if_github "::group::Build Docker image: complement/Dockerfile"
-docker build -t complement-synapse \
-  -f "docker/complement/Dockerfile" "docker/complement"
-echo_if_github "::endgroup::"
+    # Build the unified Complement image (from the worker Synapse image we just built).
+    echo_if_github "::group::Build Docker image: complement/Dockerfile"
+    docker build -t complement-synapse \
+           -f "docker/complement/Dockerfile" "docker/complement"
+    echo_if_github "::endgroup::"
+fi
 
 export COMPLEMENT_BASE_IMAGE=complement-synapse
 


### PR DESCRIPTION
Add a `-f` argument to `complement.sh` to skip the docker build

The docker bits take 10 seconds or so even if everything is cached, so if you just want to rerun some complement tests, it's nice to be able to skip them.