### PR TITLE
Add --build-only option to complement.sh to prevent actually running Complement.

### DIFF
--- a/.ci/scripts/setup_complement_prerequisites.sh
+++ b/.ci/scripts/setup_complement_prerequisites.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Common commands to set up Complement's prerequisites in a GitHub Actions CI run.
+#
+# Must be called after Synapse has been checked out to `synapse/`.
+#
+set -eu
+
+alias block='{ set +x; } 2>/dev/null; func() { echo "::group::$*"; set -x; }; func'
+alias endblock='{ set +x; } 2>/dev/null; func() { echo "::endgroup::"; set -x; }; func'
+
+block Set Go Version
+  # The path is set via a file given by $GITHUB_PATH. We need both Go 1.17 and GOPATH on the path to run Complement.
+  # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+
+  # Add Go 1.17 to the PATH: see https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#environment-variables-2
+  echo "$GOROOT_1_17_X64/bin" >> $GITHUB_PATH
+  # Add the Go path to the PATH: We need this so we can call gotestfmt
+  echo "~/go/bin" >> $GITHUB_PATH
+endblock
+
+block Install Complement Dependencies
+  sudo apt-get -qq update && sudo apt-get install -qqy libolm3 libolm-dev
+  go get -v github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+endblock
+
+block Install custom gotestfmt template
+  mkdir .gotestfmt/github -p
+  cp synapse/.ci/complement_package.gotpl .gotestfmt/github/package.gotpl
+endblock
+

--- a/.ci/scripts/setup_complement_prerequisites.sh
+++ b/.ci/scripts/setup_complement_prerequisites.sh
@@ -29,3 +29,8 @@ block Install custom gotestfmt template
   cp synapse/.ci/complement_package.gotpl .gotestfmt/github/package.gotpl
 endblock
 
+block Check out Complement
+  # Attempt to check out the same branch of Complement as the PR. If it
+  # doesn't exist, fallback to HEAD.
+  synapse/.ci/scripts/checkout_complement.sh
+endblock

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -332,29 +332,13 @@ jobs:
             database: Postgres
 
     steps:
-      # The path is set via a file given by $GITHUB_PATH. We need both Go 1.17 and GOPATH on the path to run Complement.
-      # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
-      - name: "Set Go Version"
-        run: |
-          # Add Go 1.17 to the PATH: see https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#environment-variables-2
-          echo "$GOROOT_1_17_X64/bin" >> $GITHUB_PATH
-          # Add the Go path to the PATH: We need this so we can call gotestfmt
-          echo "~/go/bin" >> $GITHUB_PATH
-
-      - name: "Install Complement Dependencies"
-        run: |
-          sudo apt-get -qq update && sudo apt-get install -qqy libolm3 libolm-dev
-          go get -v github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
-
       - name: Run actions/checkout@v2 for synapse
         uses: actions/checkout@v2
         with:
           path: synapse
 
-      - name: "Install custom gotestfmt template"
-        run: |
-          mkdir .gotestfmt/github -p
-          cp synapse/.ci/complement_package.gotpl .gotestfmt/github/package.gotpl
+      - name: Prepare Complement's Prerequisites
+        run: synapse/.ci/scripts/setup_complement_prerequisites.sh
 
       # Attempt to check out the same branch of Complement as the PR. If it
       # doesn't exist, fallback to HEAD.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -340,11 +340,6 @@ jobs:
       - name: Prepare Complement's Prerequisites
         run: synapse/.ci/scripts/setup_complement_prerequisites.sh
 
-      # Attempt to check out the same branch of Complement as the PR. If it
-      # doesn't exist, fallback to HEAD.
-      - name: Checkout complement
-        run: synapse/.ci/scripts/checkout_complement.sh
-
       - run: |
           set -o pipefail
           POSTGRES=${{ (matrix.database == 'Postgres') && 1 || '' }} WORKERS=${{ (matrix.arrangement == 'workers') && 1 || '' }} COMPLEMENT_DIR=`pwd`/complement synapse/scripts-dev/complement.sh -json 2>&1 | gotestfmt

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -114,24 +114,13 @@ jobs:
             database: Postgres
 
     steps:
-      # The path is set via a file given by $GITHUB_PATH. We need both Go 1.17 and GOPATH on the path to run Complement.
-      # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
-      - name: "Set Go Version"
-        run: |
-          # Add Go 1.17 to the PATH: see https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#environment-variables-2
-          echo "$GOROOT_1_17_X64/bin" >> $GITHUB_PATH
-          # Add the Go path to the PATH: We need this so we can call gotestfmt
-          echo "~/go/bin" >> $GITHUB_PATH
-
-      - name: "Install Complement Dependencies"
-        run: |
-          sudo apt-get update && sudo apt-get install -y libolm3 libolm-dev
-          go get -v github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
-
       - name: Run actions/checkout@v2 for synapse
         uses: actions/checkout@v2
         with:
           path: synapse
+
+      - name: Prepare Complement's Prerequisites
+        run: synapse/.ci/scripts/setup_complement_prerequisites.sh
 
       # This step is specific to the 'Twisted trunk' test run:
       - name: Patch dependencies
@@ -145,11 +134,6 @@ jobs:
           poetry lock --no-update
           # NOT IN 1.1.12 poetry lock --check
         working-directory: synapse
-
-      - name: "Install custom gotestfmt template"
-        run: |
-          mkdir .gotestfmt/github -p
-          cp synapse/.ci/complement_package.gotpl .gotestfmt/github/package.gotpl
 
       # Attempt to check out the same branch of Complement as the PR. If it
       # doesn't exist, fallback to HEAD.

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -135,11 +135,6 @@ jobs:
           # NOT IN 1.1.12 poetry lock --check
         working-directory: synapse
 
-      # Attempt to check out the same branch of Complement as the PR. If it
-      # doesn't exist, fallback to HEAD.
-      - name: Checkout complement
-        run: synapse/.ci/scripts/checkout_complement.sh
-
       - run: |
           set -o pipefail
           TEST_ONLY_SKIP_DEP_HASH_VERIFICATION=1 POSTGRES=${{ (matrix.database == 'Postgres') && 1 || '' }} WORKERS=${{ (matrix.arrangement == 'workers') && 1 || '' }} COMPLEMENT_DIR=`pwd`/complement synapse/scripts-dev/complement.sh -json 2>&1 | gotestfmt

--- a/changelog.d/13157.misc
+++ b/changelog.d/13157.misc
@@ -1,0 +1,1 @@
+Enable Complement testing in the 'Twisted Trunk' CI runs.

--- a/changelog.d/13158.misc
+++ b/changelog.d/13158.misc
@@ -1,0 +1,1 @@
+Add support to `complement.sh` for skipping the docker build.

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -47,12 +47,16 @@ Run the complement test suite on Synapse.
   -f    Skip rebuilding the docker images, and just use the most recent
         'complement-synapse:latest' image
 
+  --build-only
+        Only build the Docker images. Don't actually run Complement.
+
 For help on arguments to 'go test', run 'go help testflag'.
 EOF
 }
 
 # parse our arguments
 skip_docker_build=""
+skip_complement_run=""
 while [ $# -ge 1 ]; do
     arg=$1
     case "$arg" in
@@ -62,6 +66,9 @@ while [ $# -ge 1 ]; do
             ;;
         "-f")
             skip_docker_build=1
+            ;;
+        "--build-only")
+            skip_complement_run=1
             ;;
         *)
             # unknown arg: presumably an argument to gotest. break the loop.
@@ -104,6 +111,11 @@ if [ -z "$skip_docker_build" ]; then
     docker build -t complement-synapse \
            -f "docker/complement/Dockerfile" "docker/complement"
     echo_if_github "::endgroup::"
+fi
+
+if [ -n "$skip_docker_build" ]; then
+    echo "Skipping Complement run as requested."
+    exit
 fi
 
 export COMPLEMENT_BASE_IMAGE=complement-synapse

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -44,7 +44,8 @@ usage() {
 Usage: $0 [-f] <go test arguments>...
 Run the complement test suite on Synapse.
 
-  -f    Skip rebuilding the docker images, and just use the most recent
+  -f, --fast
+        Skip rebuilding the docker images, and just use the most recent
         'complement-synapse:latest' image
 
   --build-only
@@ -64,7 +65,7 @@ while [ $# -ge 1 ]; do
             usage
             exit 1
             ;;
-        "-f")
+        "-f"|"--fast")
             skip_docker_build=1
             ;;
         "--build-only")


### PR DESCRIPTION
It's a dual to the `-f` option added in #13143.

A potential use of this flag would be to make CI only build the image once rather than once per matrix run.
That would save us some CPU cycles on the workers (seems prudent considering they sometimes are all busy).
