### PR TITLE
Remove tests/utils.py from mypy's exclude list

### DIFF
--- a/changelog.d/13159.misc
+++ b/changelog.d/13159.misc
@@ -1,0 +1,1 @@
+Improve and fix type hints.

--- a/mypy.ini
+++ b/mypy.ini
@@ -73,7 +73,6 @@ exclude = (?x)
    |tests/util/test_lrucache.py
    |tests/util/test_rwlock.py
    |tests/util/test_wheel_timer.py
-   |tests/utils.py
    )$
 
 [mypy-synapse.federation.transport.client]

--- a/tests/server.py
+++ b/tests/server.py
@@ -830,7 +830,6 @@ def setup_test_homeserver(
 
     # Mock TLS
     hs.tls_server_context_factory = Mock()
-    hs.tls_client_options_factory = Mock()
 
     hs.setup()
     if homeserver_to_use == TestHomeServer:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,7 +64,7 @@ def setupdb():
             password=POSTGRES_PASSWORD,
             dbname=POSTGRES_DBNAME_FOR_INITIAL_CREATE,
         )
-        db_conn.autocommit = True
+        db_engine.attempt_to_set_autocommit(db_conn, autocommit=True)
         cur = db_conn.cursor()
         cur.execute("DROP DATABASE IF EXISTS %s;" % (POSTGRES_BASE_DB,))
         cur.execute(
@@ -94,7 +94,7 @@ def setupdb():
                 password=POSTGRES_PASSWORD,
                 dbname=POSTGRES_DBNAME_FOR_INITIAL_CREATE,
             )
-            db_conn.autocommit = True
+            db_engine.attempt_to_set_autocommit(db_conn, autocommit=True)
             cur = db_conn.cursor()
             cur.execute("DROP DATABASE IF EXISTS %s;" % (POSTGRES_BASE_DB,))
             cur.close()


### PR DESCRIPTION
Replaces #11349.

Not many changes needed to do this these days compared to back then. Let's finish it off!