### PR TITLE
Make `_get_state_map_for_room` not break when room state events don't contain an event id.

### DIFF
--- a/changelog.d/13174.bugfix
+++ b/changelog.d/13174.bugfix
@@ -1,0 +1,1 @@
+Fix `_get_state_map_for_room` in third_party_rules to stop breaking when we have in our db an ill-formed event *and* at least one `on_new_event` callback.

--- a/changelog.d/13174.bugfix
+++ b/changelog.d/13174.bugfix
@@ -1,1 +1,1 @@
-Fix `_get_state_map_for_room` in third_party_rules to stop breaking when we have in our db an ill-formed event *and* at least one `on_new_event` callback.
+Make use of the more robust `get_current_state` in `_get_state_map_for_room` to avoid breakages.

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -397,9 +397,7 @@ class ThirdPartyEventRules:
             return
 
         event = await self.store.get_event(event_id)
-        state_events = await self._storage_controllers.state.get_current_state(
-            event.room_id
-        )
+        state_events = await self._get_state_map_for_room(event.room_id)
 
         for callback in self._on_new_event_callbacks:
             try:

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -469,7 +469,11 @@ class ThirdPartyEventRules:
 
         state_events = {}
         for key, event_id in state_ids.items():
-            state_events[key] = room_state_events[event_id]
+            try:
+                state_events[key] = room_state_events[event_id]
+            except KeyError:
+                # Ignore missing event id
+                pass
 
         return state_events
 

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -397,7 +397,9 @@ class ThirdPartyEventRules:
             return
 
         event = await self.store.get_event(event_id)
-        state_events = await self._get_state_map_for_room(event.room_id)
+        state_events = await self._storage_controllers.state.get_current_state(
+            event.room_id
+        )
 
         for callback in self._on_new_event_callbacks:
             try:
@@ -464,18 +466,7 @@ class ThirdPartyEventRules:
         Returns:
             A dict mapping (event type, state key) to state event.
         """
-        state_ids = await self._storage_controllers.state.get_current_state_ids(room_id)
-        room_state_events = await self.store.get_events(state_ids.values())
-
-        state_events = {}
-        for key, event_id in state_ids.items():
-            try:
-                state_events[key] = room_state_events[event_id]
-            except KeyError:
-                # Ignore missing event id
-                pass
-
-        return state_events
+        return await self._storage_controllers.state.get_current_state(room_id)
 
     async def on_profile_update(
         self, user_id: str, new_profile: ProfileInfo, by_admin: bool, deactivation: bool


### PR DESCRIPTION
When adding a `on_new_event` handler on a federated homeserver, I keep hitting:

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/synapse/replication/tcp/handler.py", line 285, in _unsafe_process_queue
    await self._process_command(cmd, conn, stream_name)
  File "/usr/local/lib/python3.9/site-packages/synapse/replication/tcp/handler.py", line 300, in _process_command
    await self._process_rdata(stream_name, conn, cmd)
  File "/usr/local/lib/python3.9/site-packages/synapse/replication/tcp/handler.py", line 516, in _process_rdata
    await self.on_rdata(stream_name, cmd.instance_name, cmd.token, rows)
  File "/usr/local/lib/python3.9/site-packages/synapse/replication/tcp/handler.py", line 531, in on_rdata
    await self._replication_data_handler.on_rdata(
  File "/usr/local/lib/python3.9/site-packages/synapse/replication/tcp/client.py", line 212, in on_rdata
    await self.notifier.on_new_room_event_args(
  File "/usr/local/lib/python3.9/site-packages/synapse/notifier.py", line 338, in on_new_room_event_args
    await self._third_party_rules.on_new_event(event_id)
  File "/usr/local/lib/python3.9/site-packages/synapse/events/third_party_rules.py", line 399, in on_new_event
    state_events = await self._get_state_map_for_room(event.room_id)
  File "/usr/local/lib/python3.9/site-packages/synapse/events/third_party_rules.py", line 471, in _get_state_map_for_room
    state_events[key] = room_state_events[event_id]
KeyError: (some event id)
```

Apparently, we have some invalid state in the database of this homeserver (the event was already in the logs last May) and any attempt to call `_get_state_map_for_room` will break. The fact that `_get_state_map_for_room` is solely due to the fact that there was no `on_new_event` callback on this homeserver until now.

This PR uses the more robust `get_current_state` to implement `_get_state_map_for_room`, to avoid such breakages.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
