### PR TITLE
Jump directly to failure in gotestfmt

### DIFF
--- a/.ci/complement_package.gotpl
+++ b/.ci/complement_package.gotpl
@@ -26,6 +26,19 @@ which is under the Unlicense licence.
     {{- with .Output -}}
         {{- . -}}{{- "\n" -}}
     {{- end -}}
+
+    {{- /* Output an error marker if there are any failing tests, so GitHub will skip straight to them */ -}}
+    {{- $anyFailures := false -}}
+	{{- range .TestCases -}}
+        {{- if and (ne .Result "PASS") (ne .Result "SKIP") -}}
+            {{- $anyFailures = true -}}
+        {{- end -}}
+	{{- end -}}
+    {{- if $anyFailures -}}
+        ::error title=Test Failures::At least one test failed
+        {{- printf "\n" -}}
+    {{- end -}}
+
     {{- with .TestCases -}}
         {{- /* Failing tests are first */ -}}
         {{- range . -}}

--- a/changelog.d/13180.misc
+++ b/changelog.d/13180.misc
@@ -1,0 +1,1 @@
+Jump directly to failure in `gotestfmt` output.


### PR DESCRIPTION
Now that we are seeing more complement failures (c.f. #13161) I'm more frequently encountering the following behaviour.

1. Click on a complement run to investigate the logs, e.g. [here](https://github.com/matrix-org/synapse/runs/7289951082?check_suite_focus=true).
2. GitHub automatically scrolls to the first "error message", where "error message" means an error annotation of [this form](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message).
3. Normally the only such error is " Error: Process completed with exit code 1." from calling `complement.sh ... | gotestfmt`. That error is automatically generated by github when we `run` a shell command and appears at the bottom of the output.
4. This is infuritating because the log you want to see is the first test failure! That means we have to scroll up a load which is also infuriating, and means that #13057 wasn't quite as useful as we'd hoped.

Fix this by tweaking go test fmt's outputter to output the special GHA error message.

To prove this works:
- https://github.com/matrix-org/synapse/runs/7303102301?check_suite_focus=true is a run against a complement branch with a small test suite that always includes one failure. This shows that we still generate sensible gotestfmt output. So this can't be any worse.
- TODO: I've deleted that branch and will try to generate a run with failures that demonstrates the scrolling behaviour.

The annotations could probably be made more precise/better/descriptive. But this is a quick drive by and I've already spent enough time on this.