### PR TITLE
Reduce event lookups during room creation by passing known event IDs

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1011,8 +1011,8 @@ class RoomCreationHandler:
 
         event_keys = {"room_id": room_id, "sender": creator_id, "state_key": ""}
 
-        sent_event_ids = []
-        state_event_ids = []
+        sent_event_ids: List[str] = []
+        state_event_ids: List[str] = []
 
         def create(etype: str, content: JsonDict, **kwargs: Any) -> JsonDict:
             e = {"type": etype, "content": content}
@@ -1028,7 +1028,7 @@ class RoomCreationHandler:
             # Allow these events to be sent even if the user is shadow-banned to
             # allow the room creation to complete.
             (
-                event,
+                sent_event,
                 last_stream_id,
             ) = await self.event_creation_handler.create_and_send_nonmember_event(
                 creator,
@@ -1039,9 +1039,9 @@ class RoomCreationHandler:
                 state_event_ids=state_event_ids.copy() if state_event_ids else None,
             )
 
-            sent_event_ids.append(event.event_id)
-            if event.is_state():
-                state_event_ids.append(event.event_id)
+            sent_event_ids.append(sent_event.event_id)
+            if sent_event.is_state():
+                state_event_ids.append(sent_event.event_id)
 
             return last_stream_id
 


### PR DESCRIPTION
Been looking into speeding up room creation recently, in particular reducing the number of queries required. Inspired by the room batch handler this uses previous event inserts to pre-populate state events during room creation, reducing the number of queries required to create a room.

Signed off by Nick @ Beeper (@fizzadar)

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
