### PR TITLE
Drop unused table `event_reference_hashes`

### DIFF
--- a/changelog.d/13218.misc
+++ b/changelog.d/13218.misc
@@ -1,0 +1,1 @@
+Remove unused database table `event_reference_hashes`.

--- a/synapse/storage/schema/main/delta/72/03drop_event_reference_hashes.sql
+++ b/synapse/storage/schema/main/delta/72/03drop_event_reference_hashes.sql
@@ -1,0 +1,17 @@
+/* Copyright 2022 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- event_reference_hashes is unused, so we can drop it
+DROP TABLE event_reference_hashes;


### PR DESCRIPTION
This is unused since Synapse 1.60.0 (#12679). It's time for it to go.

Fixes #6574.