### PR TITLE
Fix notification count after a highlighted message

### DIFF
--- a/changelog.d/13223.bugfix
+++ b/changelog.d/13223.bugfix
@@ -1,0 +1,1 @@
+Fix bug where notification counts would get stuck after a highlighted message. Broke in v1.62.0.

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -1016,9 +1016,14 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
                 upd.stream_ordering
             FROM (
                 SELECT user_id, room_id, count(*) as cnt,
-                    max(stream_ordering) as stream_ordering
-                FROM event_push_actions
-                WHERE ? < stream_ordering AND stream_ordering <= ?
+                    max(ea.stream_ordering) as stream_ordering
+                FROM event_push_actions AS ea
+                LEFT JOIN event_push_summary AS old USING (user_id, room_id)
+                WHERE ? < ea.stream_ordering AND ea.stream_ordering <= ?
+                    AND (
+                        old.last_receipt_stream_ordering IS NULL
+                        OR old.last_receipt_stream_ordering < ea.stream_ordering
+                    )
                     AND %s = 1
                 GROUP BY user_id, room_id
             ) AS upd

--- a/tests/storage/test_event_push_actions.py
+++ b/tests/storage/test_event_push_actions.py
@@ -196,6 +196,13 @@ class EventPushActionsStoreTestCase(HomeserverTestCase):
         _mark_read(10, 10)
         _assert_counts(0, 0)
 
+        _inject_actions(11, HIGHLIGHT)
+        _assert_counts(1, 1)
+        _mark_read(11, 11)
+        _assert_counts(0, 0)
+        _rotate(11)
+        _assert_counts(0, 0)
+
     def test_find_first_stream_ordering_after_ts(self) -> None:
         def add_event(so: int, ts: int) -> None:
             self.get_success(


### PR DESCRIPTION
The crux of the problem was that when we rotated the notifications we didn't filter out read-but-highlighted messages. This only affected highlights as we delete non-highlights after they're read.

Fixes #13196

Broke by #13005