### PR TITLE
Ensure portdb selects _all_ rows with negative rowids

### DIFF
--- a/changelog.d/13226.bugfix
+++ b/changelog.d/13226.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where the `synapse_port_db` script could fail to copy rows with negative row ids.

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -418,12 +418,15 @@ class Porter:
             self.progress.update(table, table_size)  # Mark table as done
             return
 
+        # We sweep over rowids in two directions: one forwards (rowids 1, 2, 3, ...)
+        # and another backwards (rowids 0, -1, -2, ...).
         forward_select = (
             "SELECT rowid, * FROM %s WHERE rowid >= ? ORDER BY rowid LIMIT ?" % (table,)
         )
 
         backward_select = (
-            "SELECT rowid, * FROM %s WHERE rowid <= ? ORDER BY rowid LIMIT ?" % (table,)
+            "SELECT rowid, * FROM %s WHERE rowid <= ? ORDER BY rowid DESC LIMIT ?"
+            % (table,)
         )
 
         do_forward = [True]


### PR DESCRIPTION
#982 tried to fix this problem (missing rows with negative row ids), but unfortunately it only selected at most one batch_size's worth of such rows (default: 1000).

The `backward_select` query uses the `backward_chunk` variable as an
inclusive upper bound on the rowids it selects. It is initially 0 (see
`setup_table`). It is then set to

```
backward_chunk = min(row[0] for row in brows) - 1
```

where `brows` is the result of running the `backwards_select` query.
For this to make sense, we need to ensure that `backwards_select` picks
rows in descending order. Otherwise we'll jump right to the bottom of
the rowids, pick out the lowest batch only and discard everything we
skipped over. This is a Bad Thing.

I've tested this locally with the reproduction case reported in #13191.
Without the patch, I could reproduce the reported failure; with the
patch, the portdb script completes successfully. I sanity checked that
 the postgres table had the right number of rows in events and 
events_edges too.
