### PR TITLE
Properly verify and error on power-level mismatch in `/batch_send` endpoint

### DIFF
--- a/changelog.d/13229.bugfix
+++ b/changelog.d/13229.bugfix
@@ -1,0 +1,1 @@
+Added better verification and tests for the `/batch_send` endpoint related to which users are allowed to send historical events. Specifically, when the room version does not support the `historical` power level, the `/batch_send` endpoint will now fail if the user performing the request is not the room creator. Contributed by @sumnerevans @ Beeper.

--- a/tests/rest/client/utils.py
+++ b/tests/rest/client/utils.py
@@ -60,6 +60,24 @@ class RestHelper:
     site: Site
     auth_user_id: Optional[str]
 
+    def _path_with_token_and_appservice_user_id(
+        self,
+        path: str,
+        tok: Optional[str] = None,
+        appservice_user_id: Optional[str] = None,
+    ) -> str:
+        url_params: Dict[str, str] = {}
+
+        if tok:
+            url_params["access_token"] = tok
+
+        if appservice_user_id:
+            url_params["user_id"] = appservice_user_id
+
+        if url_params:
+            path += "?" + urlencode(url_params)
+        return path
+
     @overload
     def create_room_as(
         self,
@@ -127,19 +145,14 @@ class RestHelper:
         """
         temp_id = self.auth_user_id
         self.auth_user_id = room_creator
-        path = "/_matrix/client/r0/createRoom"
+        path = self._path_with_token_and_appservice_user_id(
+            "/_matrix/client/r0/createRoom", tok, appservice_user_id
+        )
         content = extra_content or {}
         if is_public is not None:
             content["visibility"] = "public" if is_public else "private"
         if room_version:
             content["room_version"] = room_version
-        query_params = {}
-        if tok:
-            query_params["access_token"] = tok
-        if appservice_user_id:
-            query_params["user_id"] = appservice_user_id
-        if query_params:
-            path = f"{path}?{urlencode(query_params)}"
 
         channel = make_request(
             self.hs.get_reactor(),
@@ -209,9 +222,7 @@ class RestHelper:
     ) -> None:
         temp_id = self.auth_user_id
         self.auth_user_id = user
-        path = "/knock/%s" % room
-        if tok:
-            path = path + "?access_token=%s" % tok
+        path = self._path_with_token_and_appservice_user_id(f"/knock/{room}", tok)
 
         data = {}
         if reason:
@@ -301,17 +312,11 @@ class RestHelper:
         temp_id = self.auth_user_id
         self.auth_user_id = src
 
-        path = f"/_matrix/client/r0/rooms/{room}/state/m.room.member/{targ}"
-        url_params: Dict[str, str] = {}
-
-        if tok:
-            url_params["access_token"] = tok
-
-        if appservice_user_id:
-            url_params["user_id"] = appservice_user_id
-
-        if url_params:
-            path += "?" + urlencode(url_params)
+        path = self._path_with_token_and_appservice_user_id(
+            f"/_matrix/client/r0/rooms/{room}/state/m.room.member/{targ}",
+            tok,
+            appservice_user_id,
+        )
 
         data = {"membership": membership}
         data.update(extra_data or {})
@@ -396,14 +401,11 @@ class RestHelper:
         if txn_id is None:
             txn_id = "m%s" % (str(time.time()))
 
-        path = "/_matrix/client/r0/rooms/%s/send/%s/%s" % (room_id, type, txn_id)
-        query_params = {}
-        if tok:
-            query_params["access_token"] = tok
-        if appservice_user_id:
-            query_params["user_id"] = appservice_user_id
-        if query_params:
-            path = f"{path}?{urlencode(query_params)}"
+        path = self._path_with_token_and_appservice_user_id(
+            f"/_matrix/client/r0/rooms/{room_id}/send/{type}/{txn_id}",
+            tok,
+            appservice_user_id,
+        )
 
         channel = make_request(
             self.hs.get_reactor(),
@@ -430,6 +432,7 @@ class RestHelper:
         event_type: str,
         body: Optional[Dict[str, Any]],
         tok: Optional[str],
+        appservice_user_id: Optional[str] = None,
         expect_code: int = HTTPStatus.OK,
         state_key: str = "",
         method: str = "GET",
@@ -452,13 +455,11 @@ class RestHelper:
         Raises:
             AssertionError: if expect_code doesn't match the HTTP code we received
         """
-        path = "/_matrix/client/r0/rooms/%s/state/%s/%s" % (
-            room_id,
-            event_type,
-            state_key,
+        path = self._path_with_token_and_appservice_user_id(
+            f"/_matrix/client/r0/rooms/{room_id}/state/{event_type}/{state_key}",
+            tok,
+            appservice_user_id,
         )
-        if tok:
-            path = path + "?access_token=%s" % tok
 
         # Set request body if provided
         content = b""
@@ -482,6 +483,7 @@ class RestHelper:
         room_id: str,
         event_type: str,
         tok: str,
+        appservice_user_id: Optional[str] = None,
         expect_code: int = HTTPStatus.OK,
         state_key: str = "",
     ) -> JsonDict:
@@ -501,7 +503,14 @@ class RestHelper:
             AssertionError: if expect_code doesn't match the HTTP code we received
         """
         return self._read_write_state(
-            room_id, event_type, None, tok, expect_code, state_key, method="GET"
+            room_id,
+            event_type,
+            None,
+            tok,
+            appservice_user_id,
+            expect_code,
+            state_key,
+            method="GET",
         )
 
     def send_state(
@@ -510,6 +519,7 @@ class RestHelper:
         event_type: str,
         body: Dict[str, Any],
         tok: Optional[str],
+        appservice_user_id: Optional[str] = None,
         expect_code: int = HTTPStatus.OK,
         state_key: str = "",
     ) -> JsonDict:
@@ -530,7 +540,14 @@ class RestHelper:
             AssertionError: if expect_code doesn't match the HTTP code we received
         """
         return self._read_write_state(
-            room_id, event_type, body, tok, expect_code, state_key, method="PUT"
+            room_id,
+            event_type,
+            body,
+            tok,
+            appservice_user_id,
+            expect_code,
+            state_key,
+            method="PUT",
         )
 
     def upload_media(


### PR DESCRIPTION
Closes https://github.com/matrix-org/synapse/issues/13216

Signed-off-by: Sumner Evans <sumner@beeper.com>

### Outstanding Problem

In the `test_batch_send_with_permission_msc2716_room_version` test, I set the `historical` power level to 0 before calling the `/batch_send` endpoint: https://github.com/matrix-org/synapse/pull/13229/files#diff-7ec980d681db7426675aa46dfb312defa64ba0a6fa763f97eac107e9567c7e7fR438-R451

However, when the batch-send endpoint gets to the permission checks, it gets the power levels and `historical` is at 100, making the test fail.

Things I've done to debug include:

* Ran `self.helper.get_state` again after the `send_state` to ensure that the power level is correct. This returned the expected value for `historical` of 0.
* In `get_named_levels`, when the power levels event is retrieved, it has `historical` set to 100, which makes me think that maybe the `auth_events` being passed in are stale?

Clues I have:

* When the insertion event is created using `self.event_creation_handler.create_event`, it gets `initial_state_event_ids` passed in. This doesn't include the power levels event.

Asked for spec clarification here: https://github.com/matrix-org/matrix-spec-proposals/pull/2716/files#r924472086

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
