### PR TITLE
Document advising against publicly exposing the Admin API and provide a usage example

### DIFF
--- a/changelog.d/13231.doc
+++ b/changelog.d/13231.doc
@@ -1,0 +1,2 @@
+Pointed out, that the Admin API is not accessible by default from any remote computer, but only from the PC `matrix-synapse` is running on.
+Added a full, working example, making sure to include the cURL flag `-X`, which needs to be prepended to `GET`, `POST`, `PUT` etc. and listing the full query string including protocol, IP address and port.

--- a/changelog.d/13231.doc
+++ b/changelog.d/13231.doc
@@ -1,2 +1,1 @@
-Pointed out, that the Admin API is not accessible by default from any remote computer, but only from the PC `matrix-synapse` is running on.
-Added a full, working example, making sure to include the cURL flag `-X`, which needs to be prepended to `GET`, `POST`, `PUT` etc. and listing the full query string including protocol, IP address and port.
+Provide an example of using the Admin API. Contributed by @jejo86.

--- a/docs/usage/administration/admin_api/README.md
+++ b/docs/usage/administration/admin_api/README.md
@@ -18,8 +18,10 @@ already on your `$PATH` depending on how Synapse was installed.
 Finding your user's `access_token` is client-dependent, but will usually be shown in the client's settings.
 
 ## Making an Admin API request
-The Admin API (`/_synapse/admin/...`) is by default only accessible from within the host, so be sure to
-call the queries from a terminal on the PC `matrix-synapse` is running on.
+For security reasons, we [recommend](reverse_proxy.md#synapse-administration-endpoints)
+that the Admin API (`/_synapse/admin/...`) should be hidden from public view using a
+reverse proxy. This means you should typically query the Admin API from a terminal on
+the machine which runs Synapse.
 
 Once you have your `access_token`, you will need to authenticate each request to an Admin API endpoint by
 providing the token as either a query parameter or a request header. To add it as a request header in cURL:
@@ -28,8 +30,13 @@ providing the token as either a query parameter or a request header. To add it a
 curl --header "Authorization: Bearer <access_token>" <the_rest_of_your_API_request>
 ```
 
-For example, to query the information regarding the user '@foo:bar.com' call the following command in the terminal
-using the access token 'syt_AjfVef2_L33JNpafeif_0feKJfeaf0CQpoZk'.
+For example, suppose we want to
+[query the account](user_admin_api.md#query-user-account) of the user
+`@foo:bar.com`. We need an admin access token (e.g.
+`syt_AjfVef2_L33JNpafeif_0feKJfeaf0CQpoZk`), and we need to know which port
+Synapse's [`client` listener](config_documentation.md#listeners) is listening
+on (e.g. `8008`). Then we can use the following command to request the account
+information from the Admin API.
 
 ```sh
 curl --header "Authorization: Bearer syt_AjfVef2_L33JNpafeif_0feKJfeaf0CQpoZk" -X GET http://127.0.0.1:8008/_synapse/admin/v2/users/@foo:bar.com

--- a/docs/usage/administration/admin_api/README.md
+++ b/docs/usage/administration/admin_api/README.md
@@ -18,11 +18,21 @@ already on your `$PATH` depending on how Synapse was installed.
 Finding your user's `access_token` is client-dependent, but will usually be shown in the client's settings.
 
 ## Making an Admin API request
+The Admin API (`/_synapse/admin/...`) is by default only accessible from within the host, so be sure to
+call the queries from a terminal on the PC `matrix-synapse` is running on.
+
 Once you have your `access_token`, you will need to authenticate each request to an Admin API endpoint by
 providing the token as either a query parameter or a request header. To add it as a request header in cURL:
 
 ```sh
 curl --header "Authorization: Bearer <access_token>" <the_rest_of_your_API_request>
+```
+
+For example, to query the information regarding the user '@foo:bar.com' call the following command in the terminal
+using the access token 'syt_AjfVef2_L33JNpafeif_0feKJfeaf0CQpoZk'.
+
+```sh
+curl --header "Authorization: Bearer syt_AjfVef2_L33JNpafeif_0feKJfeaf0CQpoZk" -X GET http://127.0.0.1:8008/_synapse/admin/v2/users/@foo:bar.com
 ```
 
 For more details on access tokens in Matrix, please refer to the complete


### PR DESCRIPTION
Pointed out, that the Admin API is not accessible by default from any remote computer, but only from the PC `matrix-synapse` is running on.
Added a full, working example, making sure to include the cURL flag `-X`, which needs to be prepended to `GET`, `POST`, `PUT` etc. and listing the full query string including protocol, IP address and port.

Signed-off-by: jejo86 28619134+jejo86@users.noreply.github.com
