### PR TITLE
Fix appservice EDUs failing to send if the EDU doesn't have a room ID

### DIFF
--- a/changelog.d/13236.bugfix
+++ b/changelog.d/13236.bugfix
@@ -1,0 +1,1 @@
+Fix appservices not receiving room-less EDUs, like presence, if enabled.

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -319,7 +319,8 @@ class _ServiceQueuer:
         rooms_of_interesting_users.update(event.room_id for event in events)
         # EDUs
         rooms_of_interesting_users.update(
-            ephemeral["room_id"] for ephemeral in ephemerals if
+            ephemeral["room_id"]
+            for ephemeral in ephemerals if
             ephemeral.get("room_id") is not None
         )
 

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -320,8 +320,8 @@ class _ServiceQueuer:
         # EDUs
         rooms_of_interesting_users.update(
             ephemeral["room_id"]
-            for ephemeral in ephemerals if
-            ephemeral.get("room_id") is not None
+            for ephemeral in ephemerals
+            if ephemeral.get("room_id") is not None
         )
 
         # Look up the AS users in those rooms

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -319,7 +319,8 @@ class _ServiceQueuer:
         rooms_of_interesting_users.update(event.room_id for event in events)
         # EDUs
         rooms_of_interesting_users.update(
-            ephemeral["room_id"] for ephemeral in ephemerals
+            ephemeral["room_id"] for ephemeral in ephemerals if
+            ephemeral.get("room_id") is not None
         )
 
         # Look up the AS users in those rooms


### PR DESCRIPTION
As is in the case of presence.

Fixes this error:

```
element-dev-stack-eledev-synapse-1      | 2022-07-09 02:04:50,721 - synapse.metrics.background_process_metrics - 242 - ERROR - as-sender-encrypted_appservices-13 - Background process 'as-sender-encrypted_appservices' threw an exception
element-dev-stack-eledev-synapse-1      | Traceback (most recent call last):
element-dev-stack-eledev-synapse-1      |   File "/usr/local/lib/python3.9/site-packages/twisted/internet/defer.py", line 1660, in _inlineCallbacks
element-dev-stack-eledev-synapse-1      |     result = current_context.run(gen.send, result)
element-dev-stack-eledev-synapse-1      | StopIteration: 504208
element-dev-stack-eledev-synapse-1      | 
element-dev-stack-eledev-synapse-1      | During handling of the above exception, another exception occurred:
element-dev-stack-eledev-synapse-1      | 
element-dev-stack-eledev-synapse-1      | Traceback (most recent call last):
element-dev-stack-eledev-synapse-1      |   File "/usr/local/lib/python3.9/site-packages/synapse/metrics/background_process_metrics.py", line 240, in run
element-dev-stack-eledev-synapse-1      |     return await func(*args, **kwargs)
element-dev-stack-eledev-synapse-1      |   File "/usr/local/lib/python3.9/site-packages/synapse/appservice/scheduler.py", line 274, in _send_request
element-dev-stack-eledev-synapse-1      |     ) = await self._compute_msc3202_otk_counts_and_fallback_keys(
element-dev-stack-eledev-synapse-1      |   File "/usr/local/lib/python3.9/site-packages/synapse/appservice/scheduler.py", line 321, in _compute_msc3202_otk_counts_and_fallback_keys
element-dev-stack-eledev-synapse-1      |     rooms_of_interesting_users.update(
element-dev-stack-eledev-synapse-1      |   File "/usr/local/lib/python3.9/site-packages/synapse/appservice/scheduler.py", line 322, in <genexpr>
element-dev-stack-eledev-synapse-1      |     ephemeral["room_id"] for ephemeral in ephemerals
element-dev-stack-eledev-synapse-1      | KeyError: 'room_id'
```

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
