### PR TITLE
Async get event cache prep

### DIFF
--- a/changelog.d/13242.misc
+++ b/changelog.d/13242.misc
@@ -1,0 +1,1 @@
+Use an asynchronous cache wrapper for the get event cache. Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -823,7 +823,9 @@ class DatabasePool:
                 return cast(R, result)
             except Exception:
                 for exception_callback, after_args, after_kwargs in exception_callbacks:
-                    await maybe_awaitable(exception_callback(*after_args, **after_kwargs))
+                    await maybe_awaitable(
+                        exception_callback(*after_args, **after_kwargs)
+                    )
                 raise
 
         # To handle cancellation, we ensure that `after_callback`s and

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -823,7 +823,7 @@ class DatabasePool:
                 return cast(R, result)
             except Exception:
                 for after_callback, after_args, after_kwargs in exception_callbacks:
-                    after_callback(*after_args, **after_kwargs)
+                    await maybe_awaitable(after_callback(*after_args, **after_kwargs))
                 raise
 
         # To handle cancellation, we ensure that `after_callback`s and

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -57,7 +57,7 @@ from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.storage.background_updates import BackgroundUpdater
 from synapse.storage.engines import BaseDatabaseEngine, PostgresEngine, Sqlite3Engine
 from synapse.storage.types import Connection, Cursor
-from synapse.util.async_helpers import delay_cancellation
+from synapse.util.async_helpers import delay_cancellation, maybe_awaitable
 from synapse.util.iterutils import batch_iter
 
 if TYPE_CHECKING:
@@ -818,7 +818,7 @@ class DatabasePool:
                     )
 
                 for after_callback, after_args, after_kwargs in after_callbacks:
-                    after_callback(*after_args, **after_kwargs)
+                    await maybe_awaitable(after_callback(*after_args, **after_kwargs))
 
                 return cast(R, result)
             except Exception:

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -822,8 +822,8 @@ class DatabasePool:
 
                 return cast(R, result)
             except Exception:
-                for after_callback, after_args, after_kwargs in exception_callbacks:
-                    await maybe_awaitable(after_callback(*after_args, **after_kwargs))
+                for exception_callback, after_args, after_kwargs in exception_callbacks:
+                    await maybe_awaitable(exception_callback(*after_args, **after_kwargs))
                 raise
 
         # To handle cancellation, we ensure that `after_callback`s and

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -193,7 +193,7 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
         relates_to: Optional[str],
         backfilled: bool,
     ) -> None:
-        self._invalidate_get_event_cache(event_id)
+        self._invalidate_local_get_event_cache(event_id)
         self.have_seen_event.invalidate((room_id, event_id))
 
         self.get_latest_event_ids_in_room.invalidate((room_id,))
@@ -208,7 +208,7 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
             self._events_stream_cache.entity_has_changed(room_id, stream_ordering)
 
         if redacts:
-            self._invalidate_get_event_cache(redacts)
+            self._invalidate_local_get_event_cache(redacts)
             # Caches which might leak edits must be invalidated for the event being
             # redacted.
             self.get_relations_for_event.invalidate((redacts,))

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -193,6 +193,9 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
         relates_to: Optional[str],
         backfilled: bool,
     ) -> None:
+        # This invalidates any local in-memory cached event objects, the original
+        # process triggering the invalidation is responsible for clearing any external
+        # cached objects.
         self._invalidate_local_get_event_cache(event_id)
         self.have_seen_event.invalidate((room_id, event_id))
 

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1669,9 +1669,9 @@ class PersistEventsStore:
             if not row["rejects"] and not row["redacts"]:
                 to_prefill.append(EventCacheEntry(event=event, redacted_event=None))
 
-        def prefill() -> None:
+        async def prefill() -> None:
             for cache_entry in to_prefill:
-                self.store._get_event_cache.set(
+                await self.store._get_event_cache.set(
                     (cache_entry.event.event_id,), cache_entry
                 )
 

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -732,8 +732,8 @@ class EventsWorkerStore(SQLBaseStore):
         return event_entry_map
 
     async def _invalidate_get_event_cache(self, event_id: str) -> None:
-        # First we invalidate the asynchronous cache instance, this may include
-        # out of process caches such as Redis/memcache. Once complete we can
+        # First we invalidate the asynchronous cache instance. This may include
+        # out-of-process caches such as Redis/memcache. Once complete we can
         # invalidate any in memory cache. The ordering is important here to
         # ensure we don't pull in any remote invalid value after we invalidate
         # the in-memory cache.

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -732,6 +732,11 @@ class EventsWorkerStore(SQLBaseStore):
         return event_entry_map
 
     async def _invalidate_get_event_cache(self, event_id: str) -> None:
+        # First we invalidate the asynchronous cache instance, this may include
+        # out of process caches such as Redis/memcache. Once complete we can
+        # invalidate any in memory cache. The ordering is important here to
+        # ensure we don't pull in any remote invalid value after we invalidate
+        # the in-memory cache.
         await self._get_event_cache.invalidate((event_id,))
         self._event_ref.pop(event_id, None)
         self._current_event_fetches.pop(event_id, None)

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -736,7 +736,7 @@ class EventsWorkerStore(SQLBaseStore):
         self._invalidate_local_get_event_cache(event_id)
 
     def _invalidate_local_get_event_cache(self, event_id: str) -> None:
-        self._get_event_cache.lru_cache.invalidate((event_id,))
+        self._get_event_cache.invalidate_local((event_id,))
         self._event_ref.pop(event_id, None)
         self._current_event_fetches.pop(event_id, None)
 

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -733,7 +733,8 @@ class EventsWorkerStore(SQLBaseStore):
 
     async def _invalidate_get_event_cache(self, event_id: str) -> None:
         await self._get_event_cache.invalidate((event_id,))
-        self._invalidate_local_get_event_cache(event_id)
+        self._event_ref.pop(event_id, None)
+        self._current_event_fetches.pop(event_id, None)
 
     def _invalidate_local_get_event_cache(self, event_id: str) -> None:
         self._get_event_cache.invalidate_local((event_id,))

--- a/synapse/storage/databases/main/purge_events.py
+++ b/synapse/storage/databases/main/purge_events.py
@@ -302,7 +302,7 @@ class PurgeEventsStore(StateGroupWorkerStore, CacheInvalidationWorkerStore):
                 self._invalidate_cache_and_stream(
                     txn, self.have_seen_event, (room_id, event_id)
                 )
-                self._invalidate_get_event_cache(event_id)
+                txn.call_after(self._invalidate_get_event_cache, event_id)
 
         logger.info("[purge] done")
 

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -777,7 +777,9 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         # We don't update the event cache hit ratio as it completely throws off
         # the hit ratio counts. After all, we don't populate the cache if we
         # miss it here
-        event_map = self._get_events_from_cache(member_event_ids, update_metrics=False)
+        event_map = await self._get_events_from_cache(
+            member_event_ids, update_metrics=False
+        )
 
         missing_member_event_ids = []
         for event_id in member_event_ids:

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -736,7 +736,7 @@ class AsyncLruCache(Generic[KT, VT]):
     """
     An asynchronous wrapper around a subset of the LruCache API.
 
-    On it's own this doesn't change the behaviour but allows subclasses that
+    On its own this doesn't change the behaviour but allows subclasses that
     utilize external cache systems that require await behaviour to be created.
     """
 
@@ -756,6 +756,11 @@ class AsyncLruCache(Generic[KT, VT]):
         return self._lru_cache.invalidate(key)
 
     def invalidate_local(self, key: KT) -> None:
+        """Remove an entry from the local cache
+        
+        This variant of `invalidate` is useful if we know that the external
+        cache has already been invalidated.
+        """
         return self._lru_cache.invalidate(key)
 
     async def contains(self, key: KT) -> bool:

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -740,24 +740,24 @@ class AsyncLruCache(Generic[KT, VT]):
     """
 
     def __init__(self, *args, **kwargs):  # type: ignore
-        self.lru_cache: LruCache[KT, VT] = LruCache(*args, **kwargs)
+        self._lru_cache: LruCache[KT, VT] = LruCache(*args, **kwargs)
 
     async def get(
         self, key: KT, default: Optional[T] = None, update_metrics: bool = True
     ) -> Optional[VT]:
-        return self.lru_cache.get(key, update_metrics=update_metrics)
+        return self._lru_cache.get(key, update_metrics=update_metrics)
 
     async def set(self, key: KT, value: VT) -> None:
-        self.lru_cache.set(key, value)
+        self._lru_cache.set(key, value)
 
     async def invalidate(self, key: KT) -> None:
-        return self.lru_cache.invalidate(key)
+        return self._lru_cache.invalidate(key)
 
     def invalidate_local(self, key: KT) -> None:
-        return self.lru_cache.invalidate(key)
+        return self._lru_cache.invalidate(key)
 
     async def contains(self, key: KT) -> bool:
-        return self.lru_cache.contains(key)
+        return self._lru_cache.contains(key)
 
     def clear(self) -> None:
-        self.lru_cache.clear()
+        self._lru_cache.clear()

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -761,5 +761,5 @@ class AsyncLruCache(Generic[KT, VT]):
     async def contains(self, key: KT) -> bool:
         return self._lru_cache.contains(key)
 
-    def clear(self) -> None:
+    async def clear(self) -> None:
         self._lru_cache.clear()

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -751,6 +751,7 @@ class AsyncLruCache(Generic[KT, VT]):
         self._lru_cache.set(key, value)
 
     async def invalidate(self, key: KT) -> None:
+        # This method should invalidate any external cache and then invalidate the LruCache.
         return self._lru_cache.invalidate(key)
 
     def invalidate_local(self, key: KT) -> None:

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -734,9 +734,10 @@ class LruCache(Generic[KT, VT]):
 
 class AsyncLruCache(Generic[KT, VT]):
     """
-    An asynchronous wrapper around a subset of the LruCache API. On it's own
-    this doesn't change the behaviour but allows subclasses that utilize
-    external cache systems that require await behaviour to be created.
+    An asynchronous wrapper around a subset of the LruCache API.
+
+    On it's own this doesn't change the behaviour but allows subclasses that
+    utilize external cache systems that require await behaviour to be created.
     """
 
     def __init__(self, *args, **kwargs):  # type: ignore

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -730,3 +730,31 @@ class LruCache(Generic[KT, VT]):
         # This happens e.g. in the sync code where we have an expiring cache of
         # lru caches.
         self.clear()
+
+
+class AsyncLruCache(Generic[KT, VT]):
+    """
+    An asynchronous wrapper around a subset of the LruCache API. On it's own
+    this doesn't change the behaviour but allows subclasses that utilize
+    external cache systems that require await behaviour to be created.
+    """
+
+    def __init__(self, *args, **kwargs):  # type: ignore
+        self.lru_cache: LruCache[KT, VT] = LruCache(*args, **kwargs)
+
+    async def get(
+        self, key: KT, default: Optional[T] = None, update_metrics: bool = True
+    ) -> Optional[VT]:
+        return self.lru_cache.get(key, update_metrics=update_metrics)
+
+    async def set(self, key: KT, value: VT) -> None:
+        self.lru_cache.set(key, value)
+
+    async def invalidate(self, key: KT) -> None:
+        return self.lru_cache.invalidate(key)
+
+    async def contains(self, key: KT) -> bool:
+        return self.lru_cache.contains(key)
+
+    def clear(self) -> None:
+        self.lru_cache.clear()

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -753,6 +753,9 @@ class AsyncLruCache(Generic[KT, VT]):
     async def invalidate(self, key: KT) -> None:
         return self.lru_cache.invalidate(key)
 
+    def invalidate_local(self, key: KT) -> None:
+        return self.lru_cache.invalidate(key)
+
     async def contains(self, key: KT) -> bool:
         return self.lru_cache.contains(key)
 

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -757,7 +757,7 @@ class AsyncLruCache(Generic[KT, VT]):
 
     def invalidate_local(self, key: KT) -> None:
         """Remove an entry from the local cache
-        
+
         This variant of `invalidate` is useful if we know that the external
         cache has already been invalidated.
         """

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -159,7 +159,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
 
         # Blow away caches (supported room versions can only change due to a restart).
         self.store.get_rooms_for_user_with_stream_ordering.invalidate_all()
-        self.store._get_event_cache.clear()
+        self.get_success(self.store._get_event_cache.clear())
         self.store._event_ref.clear()
 
         # The rooms should be excluded from the sync response.

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -143,7 +143,7 @@ class EventCacheTestCase(unittest.HomeserverTestCase):
         self.event_id = res["event_id"]
 
         # Reset the event cache so the tests start with it empty
-        self.store._get_event_cache.clear()
+        self.get_success(self.store._get_event_cache.clear())
 
     def test_simple(self):
         """Test that we cache events that we pull from the DB."""
@@ -160,7 +160,7 @@ class EventCacheTestCase(unittest.HomeserverTestCase):
         """
 
         # Reset the event cache
-        self.store._get_event_cache.clear()
+        self.get_success(self.store._get_event_cache.clear())
 
         with LoggingContext("test") as ctx:
             # We keep hold of the event event though we never use it.
@@ -170,7 +170,7 @@ class EventCacheTestCase(unittest.HomeserverTestCase):
             self.assertEqual(ctx.get_resource_usage().evt_db_fetch_count, 1)
 
         # Reset the event cache
-        self.store._get_event_cache.clear()
+        self.get_success(self.store._get_event_cache.clear())
 
         with LoggingContext("test") as ctx:
             self.get_success(self.store.get_event(self.event_id))
@@ -345,7 +345,7 @@ class GetEventCancellationTestCase(unittest.HomeserverTestCase):
         self.event_id = res["event_id"]
 
         # Reset the event cache so the tests start with it empty
-        self.store._get_event_cache.clear()
+        self.get_success(self.store._get_event_cache.clear())
 
     @contextmanager
     def blocking_get_event_calls(

--- a/tests/storage/test_purge.py
+++ b/tests/storage/test_purge.py
@@ -115,6 +115,6 @@ class PurgeTests(HomeserverTestCase):
         )
 
         # The events aren't found.
-        self.store._invalidate_get_event_cache(create_event.event_id)
+        self.store._invalidate_local_get_event_cache(create_event.event_id)
         self.get_failure(self.store.get_event(create_event.event_id), NotFoundError)
         self.get_failure(self.store.get_event(first["event_id"]), NotFoundError)


### PR DESCRIPTION
Some experimental prep work to enable external event caching based on https://github.com/matrix-org/synapse/pull/9379 & https://github.com/matrix-org/synapse/pull/12955. Doesn't actually move the cache at all, just lays the groundwork for async implemented caches.

One change here is the invalidation is now divided into two types: async which the "primary" invalidator must call and local which is for replication based invalidation that happens after the async invalidation is completed. Any external cache is thus invalidated after database update and before local in memory process caches.

This should solve the original invalidation problem spotted in #9379 unblocking implementation of actual external cache classes. Passes tests & complement w/workers locally. This work is primarily for our own use, but I figured it may at this point be useful prep when that day comes; close if there's other plans!

Signed off by Nick @ Beeper (@fizzadar)

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
