### PR TITLE
Allow rate limiters to passively record actions they cannot limit

### DIFF
--- a/changelog.d/13253.misc
+++ b/changelog.d/13253.misc
@@ -1,0 +1,1 @@
+Preparatory work for a per-room rate limiter on joins.

--- a/synapse/api/ratelimiting.py
+++ b/synapse/api/ratelimiting.py
@@ -78,8 +78,7 @@ class Ratelimiter:
     def _get_key(
         self, requester: Optional[Requester], key: Optional[Hashable]
     ) -> Hashable:
-        """Use the requester's MXID as a fallback key if no key is provided.
-        """
+        """Use the requester's MXID as a fallback key if no key is provided."""
         if key is None:
             if not requester:
                 raise ValueError("Must supply at least one of `requester` or `key`")
@@ -90,8 +89,7 @@ class Ratelimiter:
     def _get_action_counts(
         self, key: Hashable, time_now_s: float
     ) -> Tuple[float, float, float]:
-        """Retrieve the action counts, with a fallback representing an empty bucket.
-        """
+        """Retrieve the action counts, with a fallback representing an empty bucket."""
         return self.actions.get(key, (0.0, time_now_s, 0.0))
 
     async def can_do_action(

--- a/synapse/api/ratelimiting.py
+++ b/synapse/api/ratelimiting.py
@@ -79,8 +79,6 @@ class Ratelimiter:
         self, requester: Optional[Requester], key: Optional[Hashable]
     ) -> Hashable:
         """Use the requester's MXID as a fallback key if no key is provided.
-
-        Pulled out so that `can_do_action` and `record_action` are consistent.
         """
         if key is None:
             if not requester:
@@ -93,8 +91,6 @@ class Ratelimiter:
         self, key: Hashable, time_now_s: float
     ) -> Tuple[float, float, float]:
         """Retrieve the action counts, with a fallback representing an empty bucket.
-
-        Pulled out so that `can_do_action` and `record_action` are consistent.
         """
         return self.actions.get(key, (0.0, time_now_s, 0.0))
 

--- a/synapse/api/ratelimiting.py
+++ b/synapse/api/ratelimiting.py
@@ -27,6 +27,33 @@ class Ratelimiter:
     """
     Ratelimit actions marked by arbitrary keys.
 
+    (Note that the source code speaks of "actions" and "burst_count" rather than
+    "tokens" and a "bucket_size".)
+
+    This is a "leaky bucket as a meter". For each key to be tracked there is a bucket
+    containing some number 0 <= T <= `burst_count` of tokens corresponding to previously
+    permitted requests for that key. Each bucket starts empty, and gradually leaks
+    tokens at a rate of `rate_hz`.
+
+    Upon an incoming request, we must determine:
+    - the key that this request falls under (which bucket to inspect), and
+    - the cost C of this request in tokens.
+    Then, if there is room in the bucket for C tokens (T + C <= `burst_count`),
+    the request is permitted and `cost` tokens are added to the bucket.
+    Otherwise the request is denied, and the bucket continues to hold T tokens.
+
+    This means that the limiter enforces an average request frequency of `rate_hz`,
+    while accumulating a buffer of up to `burst_count` requests which can be consumed
+    instantaneously.
+
+    The tricky bit is the leaking. We do not want to have a periodic process which
+    leaks every bucket! Instead, we track
+    - the time point when the bucket was last completely empty, and
+    - how many tokens have added to the bucket permitted since then.
+    Then for each incoming request, we can calculate how many tokens have leaked
+    since this time point, and use that to decide if we should accept or reject the
+    request.
+
     Args:
         clock: A homeserver clock, for retrieving the current time
         rate_hz: The long term number of actions that can be performed in a second.
@@ -41,12 +68,11 @@ class Ratelimiter:
         self.burst_count = burst_count
         self.store = store
 
-        # A ordered dictionary keeping track of actions, when they were last
-        # performed and how often. Each entry is a mapping from a key of arbitrary type
-        # to a tuple representing:
-        #   * How many times an action has occurred since a point in time
-        #   * The point in time
-        #   * The rate_hz of this particular entry. This can vary per request
+        # An ordered dictionary representing the token buckets tracked by this rate
+        # limiter. Each entry maps a key of arbitrary type to a tuple representing:
+        #   * The number of tokens currently in the bucket,
+        #   * The time point when the bucket was last completely empty, and
+        #   * The rate_hz (leak rate) of this particular bucket.
         self.actions: OrderedDict[Hashable, Tuple[float, float, float]] = OrderedDict()
 
     async def can_do_action(


### PR DESCRIPTION
This adds a new `record_action` method to Ratelimiters. It allows them to track occurrences of an action which they are not in a position to deny.

For motivation, the example I have in mind is a rate limiter which tracks the number of joins in a room (#12710). Any homeserver in the room can create and publish a join event via the `make_join`/`send_join` handshake. The rate limiter needs to track these joins so it can accurately reject future joins requested of it. But we cannot refuse those incoming joins: they have already taken place and are already part of the room.

Pulled out of #13169.
