### PR TITLE
Notifier: accept callbacks to fire on room joins

### DIFF
--- a/changelog.d/13254.misc
+++ b/changelog.d/13254.misc
@@ -1,0 +1,1 @@
+Preparatory work for a per-room rate limiter on joins.


### PR DESCRIPTION
Pulled out of #13169.

The per-room join rate planned for #12710 needs to be incremented by
- the event persistence logic, when persisting a join; and
- the replication logic, when one worker learns of a new event persisted by another worker.

The rate limiter itself will be kept on the RoomMemberHandler (i.e. the thing which services joins). We need a way for the incrementers to tell the room member handler that a join has happened. I first tried to make the relevant handlers directly call out to the RoomMemberHandler, but this introduced circular dependencies among the homeserver `cache_in_self` attributes. Break the dependency by using the notifier.