### PR TITLE
Faster room joins: Log the stack when waiting for a entire room to be un-partial stated

### DIFF
--- a/changelog.d/13257.misc
+++ b/changelog.d/13257.misc
@@ -1,0 +1,1 @@
+Log the stack when waiting for an entire room to be un-partial stated.

--- a/synapse/storage/util/partial_state_events_tracker.py
+++ b/synapse/storage/util/partial_state_events_tracker.py
@@ -166,6 +166,7 @@ class PartialCurrentStateTracker:
             logger.info(
                 "Awaiting un-partial-stating of room %s",
                 room_id,
+                stack_info=True,
             )
 
             await make_deferred_yieldable(d)


### PR DESCRIPTION
The stack is already logged when waiting for an event to be un-partial
stated. Log the stack for rooms as well.

---

When writing complement tests for faster room joins, debugging failing tests is easier when there's a nice big indicator in the logs when Synapse blocks itself waiting for full state.