### PR TITLE
Fix spurious warning when fetching state after a missing prev event

### DIFF
--- a/changelog.d/13258.misc
+++ b/changelog.d/13258.misc
@@ -1,0 +1,1 @@
+Fix spurious warning when fetching state after a missing prev event.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1036,7 +1036,7 @@ class FederationEventHandler:
         # XXX: this doesn't sound right? it means that we'll end up with incomplete
         #   state.
         failed_to_fetch = desired_events - event_metadata.keys()
-        # `event_id`'s missing from `event_metadata` because it's not necessarily a
+        # `event_id` could be missing from `event_metadata` because it's not necessarily a
         # state event. We've already checked that we've fetched it above.
         failed_to_fetch.discard(event_id)
         if failed_to_fetch:

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1036,6 +1036,9 @@ class FederationEventHandler:
         # XXX: this doesn't sound right? it means that we'll end up with incomplete
         #   state.
         failed_to_fetch = desired_events - event_metadata.keys()
+        # `event_id`'s missing from `event_metadata` because it's not necessarily a
+        # state event. We've already checked that we've fetched it above.
+        failed_to_fetch.discard(event_id)
         if failed_to_fetch:
             logger.warning(
                 "Failed to fetch missing state events for %s %s",

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1036,8 +1036,8 @@ class FederationEventHandler:
         # XXX: this doesn't sound right? it means that we'll end up with incomplete
         #   state.
         failed_to_fetch = desired_events - event_metadata.keys()
-        # `event_id` could be missing from `event_metadata` because it's not necessarily a
-        # state event. We've already checked that we've fetched it above.
+        # `event_id` could be missing from `event_metadata` because it's not necessarily
+        # a state event. We've already checked that we've fetched it above.
         failed_to_fetch.discard(event_id)
         if failed_to_fetch:
             logger.warning(


### PR DESCRIPTION
This warning showed up while I was testing faster room joins using Complement.
On closer inspection it turned out to be triggering incorrectly.