### PR TITLE
Use state before join to determine if we `_should_perform_remote_join`

### DIFF
--- a/changelog.d/13270.bugfix
+++ b/changelog.d/13270.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.40 where a user invited to a restricted room would be briefly unable to join.

--- a/synapse/events/builder.py
+++ b/synapse/events/builder.py
@@ -120,7 +120,7 @@ class EventBuilder:
             The signed and hashed event.
         """
         if auth_event_ids is None:
-            state_ids = await self._state.get_current_state_ids(
+            state_ids = await self._state.compute_state_after_events(
                 self.room_id, prev_event_ids
             )
             auth_event_ids = self._event_auth_handler.compute_auth_events(

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -153,8 +153,8 @@ class StateHandler:
             event_ids: the events whose state should be fetched and resolved.
 
         Returns:
-            the resolution of the states after the given event IDs. This is a mapping
-            (event_type, state_key) -> event_id.
+            the state dict (a mapping from (event_type, state_key) -> event_id) which
+            holds the resolution of the state dicts after the given event IDs.
         """
         logger.debug("calling resolve_state_groups from get_current_state_ids")
         ret = await self.resolve_state_groups_for_events(room_id, event_ids)

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -170,7 +170,7 @@ class StateHandler:
             the state dict (a mapping from (event_type, state_key) -> event_id) which
             holds the resolution of the states after the given event IDs.
         """
-        logger.debug("calling resolve_state_groups from get_current_state_ids")
+        logger.debug("calling resolve_state_groups from compute_state_after_events")
         ret = await self.resolve_state_groups_for_events(room_id, event_ids)
         return await ret.get_state(self._state_storage_controller, StateFilter.all())
 

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -168,7 +168,7 @@ class StateHandler:
 
         Returns:
             the state dict (a mapping from (event_type, state_key) -> event_id) which
-            holds the resolution of the state dicts after the given event IDs.
+            holds the resolution of the states after the given event IDs.
         """
         logger.debug("calling resolve_state_groups from get_current_state_ids")
         ret = await self.resolve_state_groups_for_events(room_id, event_ids)

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -137,22 +137,27 @@ class StateHandler:
             ReplicationUpdateCurrentStateRestServlet.make_client(hs)
         )
 
-    async def get_current_state_ids(
+    async def compute_state_after_events(
         self,
         room_id: str,
-        latest_event_ids: Collection[str],
+        event_ids: Collection[str],
     ) -> StateMap[str]:
-        """Get the current state, or the state at a set of events, for a room
+        """Fetch the state after each of the given event IDs. Resolve them and return.
+
+        This is typically used where `event_ids` is a collection of forward extremities
+        in a room, intended to become the `prev_events` of a new event E. If so, the
+        return value of this function represents the state before E.
 
         Args:
-            room_id:
-            latest_event_ids: The forward extremities to resolve.
+            room_id: the room_id containing the given events.
+            event_ids: the events whose state should be fetched and resolved.
 
         Returns:
-            the state dict, mapping from (event_type, state_key) -> event_id
+            the resolution of the states after the given event IDs. This is a mapping
+            (event_type, state_key) -> event_id.
         """
         logger.debug("calling resolve_state_groups from get_current_state_ids")
-        ret = await self.resolve_state_groups_for_events(room_id, latest_event_ids)
+        ret = await self.resolve_state_groups_for_events(room_id, event_ids)
         return ret.state
 
     async def get_current_users_in_room(


### PR DESCRIPTION
Before this change, we were using the current state of the room. (The two are usually but not always consistent.)

Fixes #13269, see there for context and motivation. Commitwise review recommended.

#10254 introduced some of the logic I'm changing here.