### PR TITLE
Refactor the code that sends state events into new rooms

### DIFF
--- a/changelog.d/13291.misc
+++ b/changelog.d/13291.misc
@@ -1,0 +1,1 @@
+Refactor the code that calculates the state events to send into new rooms.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1031,8 +1031,24 @@ class RoomCreationHandler:
     ) -> Tuple[int, str, int]:
         """Sends the initial events into a new room.
 
-        `power_level_content_override` doesn't apply when initial state has
-        power level state event content.
+        Args:
+            creator: The creator of the room.
+            room_id: The ID of the room to send events in.
+            invite_list: A list of Matrix user IDs to invite to the room. This is only
+                used by the method to set the power levels of the invitees to 100 if
+                the preset for the room specifies that initial invitees should have ops.
+            initial_state: A map of state key to an event definition or event ID.
+            creation_content: A json dict to use as the value of the "content" field
+                for the room's create event.
+            preset_config: The identifier of the room preset to use. This
+                determines the events that are sent into the room.
+            room_alias: A room alias to link to the room, if provided.
+            power_level_content_override: A json dictionary that specifies the initial
+                power levels of the room. If `initial_state` contains a 'm.room.power_levels'
+                event then this argument will be ignored.
+            creator_join_profile: The JSON dictionary value of the "content" field for the
+                'm.room.membership' join event that will be sent for the creator of the room.
+            ratelimit: Whether to ratelimit the join event of the room creator.
 
         Returns:
             A tuple containing the stream ID, event ID and depth of the last

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1070,7 +1070,7 @@ class RoomCreationHandler:
 
             return e
 
-        async def send(etype: str, content: JsonDict, **kwargs: Any) -> int:
+        async def send(etype: str, content: JsonDict, **kwargs: Any) -> None:
             nonlocal last_sent_event_id
             nonlocal depth
 
@@ -1080,7 +1080,7 @@ class RoomCreationHandler:
             # allow the room creation to complete.
             (
                 sent_event,
-                last_stream_id,
+                last_sent_stream_id,
             ) = await self.event_creation_handler.create_and_send_nonmember_event(
                 creator,
                 event,
@@ -1094,8 +1094,6 @@ class RoomCreationHandler:
 
             last_sent_event_id = sent_event.event_id
             depth += 1
-
-            return last_stream_id
 
         try:
             room_preset_config = self._presets_dict[room_preset_identifier]
@@ -1216,9 +1214,7 @@ class RoomCreationHandler:
 
         # Send each event in order of its insertion into the dictionary
         for (event_type, state_key), content in state_to_send.items():
-            last_sent_stream_id = await send(
-                etype=event_type, state_key=state_key, content=content
-            )
+            await send(etype=event_type, state_key=state_key, content=content)
 
         return last_sent_stream_id, last_sent_event_id, depth
 


### PR DESCRIPTION
A myriad of changes to the `_send_events_for_new_room` method, which calculates and sends the state events for a new room, given the room's preset and some other argument values.

This is split out from ongoing configurable room default/custom room presets work.

Recommended to review commit-by-commit, explanations for changes in commit descriptions.

**This is still a draft for now while I build on top of it locally.**