### PR TITLE
Improve performance of query ` _get_subset_users_in_room_with_profiles`

### DIFF
--- a/changelog.d/13299.misc
+++ b/changelog.d/13299.misc
@@ -1,0 +1,1 @@
+Improve performance of query  `_get_subset_users_in_room_with_profiles`.

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -243,7 +243,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             txn: LoggingTransaction,
         ) -> Dict[str, ProfileInfo]:
             clause, ids = make_in_list_sql_clause(
-                self.database_engine, "m.user_id", user_ids
+                self.database_engine, "c.state_key", user_ids
             )
 
             sql = """


### PR DESCRIPTION
While profiling local joins I noticed that this query (which was just added) appeared to be quite slow, which was confirmed by the query planner. This PR attempts to remedy that. 