### PR TITLE
Increase batch size of `bulk_get_push_rules` and `_get_joined_profiles_from_event_ids`.

### DIFF
--- a/changelog.d/13300.misc
+++ b/changelog.d/13300.misc
@@ -1,0 +1,1 @@
+Up batch size of `bulk_get_push_rules` and `_get_joined_profiles_from_event_ids`.

--- a/synapse/storage/databases/main/push_rule.py
+++ b/synapse/storage/databases/main/push_rule.py
@@ -228,6 +228,7 @@ class PushRulesWorkerStore(
             iterable=user_ids,
             retcols=("*",),
             desc="bulk_get_push_rules",
+            batch_size=1000,
         )
 
         rows.sort(key=lambda row: (-int(row["priority_class"]), -int(row["priority"])))

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -904,7 +904,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             iterable=event_ids,
             retcols=("user_id", "display_name", "avatar_url", "event_id"),
             keyvalues={"membership": Membership.JOIN},
-            batch_size=500,
+            batch_size=1000,
             desc="_get_joined_profiles_from_event_ids",
         )
 


### PR DESCRIPTION
This fell out of some investigation I was doing with Eric re: increasing local room join performance. Many small batches were being sent to the DB for processing by these calls (especially in larger rooms), and it seems that we could probably up the batch size some and hopefully improve overall transaction time. 