### PR TITLE
Update expected DB query count when creating a room

### DIFF
--- a/changelog.d/13307.misc
+++ b/changelog.d/13307.misc
@@ -1,0 +1,1 @@
+Don't pull out the full state when creating an event.

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -710,7 +710,7 @@ class RoomsCreateTestCase(RoomBase):
         self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
         self.assertTrue("room_id" in channel.json_body)
         assert channel.resource_usage is not None
-        self.assertEqual(36, channel.resource_usage.db_txn_count)
+        self.assertEqual(43, channel.resource_usage.db_txn_count)
 
     def test_post_room_initial_state(self) -> None:
         # POST with initial_state config key, expect new room id
@@ -723,7 +723,7 @@ class RoomsCreateTestCase(RoomBase):
         self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
         self.assertTrue("room_id" in channel.json_body)
         assert channel.resource_usage is not None
-        self.assertEqual(40, channel.resource_usage.db_txn_count)
+        self.assertEqual(49, channel.resource_usage.db_txn_count)
 
     def test_post_room_visibility_key(self) -> None:
         # POST with visibility config key, expect new room id


### PR DESCRIPTION
#13281 seems to have changed the number of expected database queries required when creating a room, thus breaking the following tests on develop:

- `tests.rest.client.test_rooms.RoomsCreateTestCase.test_post_room_no_keys`: 36 -> 43 queries
- `tests.rest.client.test_rooms.RoomsCreateTestCase.test_post_room_initial_state`: 40 -> 49 queries

It's currently not clear why the number of queries increased with the change. @DMRobertson proposed:

> I guess because we don't have a cache which takes the filter into account