### PR TITLE
Prevent #3679 from appearing in blame results

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
+# Run black (#3679).
+8b3d9b6b199abb87246f982d5db356f1966db925
+
 # Black reformatting (#5482).
 32e7c9e7f20b57dd081023ac42d6931a8da9b3a3
 


### PR DESCRIPTION
Ran into this commit a couple times when attempting to go back in blame history.

Adding the commit hash to this file will prevent it from showing in git blame.