### PR TITLE
Validate federation destinations and log an error if server name is invalid.

### DIFF
--- a/changelog.d/13318.misc
+++ b/changelog.d/13318.misc
@@ -1,1 +1,1 @@
-Validate federation destination and log an error if destination is invalid.
+Validate federation destinations and log an error if a destination is invalid.

--- a/changelog.d/13318.misc
+++ b/changelog.d/13318.misc
@@ -1,0 +1,1 @@
+Validate federation destination and log an error if destination is invalid.

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -484,7 +484,7 @@ class MatrixFederationHttpClient:
         try:
             parse_and_validate_server_name(request.destination)
         except ValueError:
-            logger.info(f"Invalid destination: {request.destination}")
+            logger.info(f"Invalid destination: {request.destination}.")
             raise FederationDeniedError(request.destination)
 
         if timeout:

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -98,6 +98,7 @@ MAX_LONG_RETRIES = 10
 MAX_SHORT_RETRIES = 3
 MAXINT = sys.maxsize
 
+
 _next_id = 1
 
 T = TypeVar("T")
@@ -565,6 +566,7 @@ class MatrixFederationHttpClient:
                         )
 
                     headers_dict[b"Authorization"] = auth_headers
+
                     logger.debug(
                         "{%s} [%s] Sending request: %s %s; timeout %fs",
                         request.txn_id,

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -485,7 +485,9 @@ class MatrixFederationHttpClient:
         try:
             parse_and_validate_server_name(request.destination)
         except ValueError:
-            logger.info(f"Invalid destination: {request.destination}.")
+            logger.error(
+                f"Invalid destination: {request.destination}.", stack_info=True
+            )
             raise FederationDeniedError(request.destination)
 
         if timeout:

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -485,9 +485,7 @@ class MatrixFederationHttpClient:
         try:
             parse_and_validate_server_name(request.destination)
         except ValueError:
-            logger.error(
-                f"Invalid destination: {request.destination}.", stack_info=True
-            )
+            logger.exception(f"Invalid destination: {request.destination}.")
             raise FederationDeniedError(request.destination)
 
         if timeout:

--- a/tests/federation/test_federation_client.py
+++ b/tests/federation/test_federation_client.py
@@ -102,7 +102,7 @@ class FederationClientTest(FederatingHomeserverTestCase):
         # now fire off the request
         state_resp, auth_resp = self.get_success(
             self.hs.get_federation_client().get_room_state(
-                "yet_another_server",
+                "yet.another.server",
                 test_room_id,
                 "event_id",
                 RoomVersions.V9,
@@ -112,7 +112,7 @@ class FederationClientTest(FederatingHomeserverTestCase):
         # check the right call got made to the agent
         self._mock_agent.request.assert_called_once_with(
             b"GET",
-            b"matrix://yet_another_server/_matrix/federation/v1/state/%21room_id?event_id=event_id",
+            b"matrix://yet.another.server/_matrix/federation/v1/state/%21room_id?event_id=event_id",
             headers=mock.ANY,
             bodyProducer=None,
         )


### PR DESCRIPTION
Fixes #13155. Currently we have some validation for destinations in place but apparently we are missing some code paths, part of the idea behind this PR to use the logging to pick out where validation is missing. 