### PR TITLE
Don't hold onto full state in state cache

### DIFF
--- a/changelog.d/13324.misc
+++ b/changelog.d/13324.misc
@@ -1,0 +1,1 @@
+Reduce the amount of state we store in the `state_cache`.

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -780,7 +780,7 @@ def _make_state_cache_entry(
         old_state_event_ids = set(state.values())
         if new_state_event_ids == old_state_event_ids:
             # got an exact match.
-            return _StateCacheEntry(state=new_state, state_group=sg)
+            return _StateCacheEntry(state=None, state_group=sg)
 
     # TODO: We want to create a state group for this set of events, to
     # increase cache hits, but we need to make sure that it doesn't

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -151,10 +151,18 @@ class _StateCacheEntry:
 
     def __len__(self) -> int:
         # The len should is used to estimate how large this cache entry is, for
-        # cache eviction purposes. This is why if `self.state` is None it's fine
-        # to return 1.
+        # cache eviction purposes. This is why it's fine to return 1 if we're
+        # not storing any state.
 
-        return len(self._state) if self._state else 1
+        length = 0
+
+        if self._state:
+            length += len(self._state)
+
+        if self.delta_ids:
+            length += len(self.delta_ids)
+
+        return length or 1  # Make sure its not 0.
 
 
 class StateHandler:

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -140,7 +140,9 @@ class _StateCacheEntry:
 
     def set_state_group(self, state_group: int) -> None:
         """Update the state group assigned to this state (e.g. after we've
-        persisted it)
+        persisted it).
+
+        Note: this will cause the cache entry to drop any stored state.
         """
 
         self.state_group = state_group

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -146,11 +146,11 @@ class _StateCacheEntry:
         self.state_group = state_group
 
         # We clear out the state as we know longer need to explicitly keep it in
-        # the `state_cache` (as the store state group cache will do that.)
+        # the `state_cache` (as the store state group cache will do that).
         self._state = None
 
     def __len__(self) -> int:
-        # The len should is used to estimate how large this cache entry is, for
+        # The len should be used to estimate how large this cache entry is, for
         # cache eviction purposes. This is why it's fine to return 1 if we're
         # not storing any state.
 


### PR DESCRIPTION
We have a `state_cache`  in `StateHandler` which stores the result of a state resolution. This is an `ExpiringCache`, rather than an `LruCache`, and so doesn't support the full set of cache expiry config options, which means we should try and keep this cache as small as possible. 

It's fairly safe to drop storing the `state` (whenever possible), as we have a separate cache for storing the state of each state group, so removing `state` from the `StateCacheEntry` is really only deduplicating the cached dicts. 

There's also a commit to make the `__len__` a bit more accurate.