### PR TITLE
Stop building Ubuntu 21.10 (Impish Indri) which is end of life.

### DIFF
--- a/changelog.d/13326.removal
+++ b/changelog.d/13326.removal
@@ -1,0 +1,1 @@
+Stop builindg `.deb` packages for Ubuntu 21.10 (Impish Indri), which has reached end of life.

--- a/scripts-dev/build_debian_packages.py
+++ b/scripts-dev/build_debian_packages.py
@@ -26,7 +26,6 @@ DISTS = (
     "debian:bookworm",
     "debian:sid",
     "ubuntu:focal",  # 20.04 LTS (our EOL forced by Py38 on 2024-10-14)
-    "ubuntu:impish",  # 21.10  (EOL 2022-07)
     "ubuntu:jammy",  # 22.04 LTS (EOL 2027-04)
 )
 


### PR DESCRIPTION
Fixes #13322