### PR TITLE
Don't include appservice users when calculating push rules

### DIFF
--- a/changelog.d/13332.bugfix
+++ b/changelog.d/13332.bugfix
@@ -1,0 +1,1 @@
+Fix bug where we incorrectly calculated push for appservice users, leading to performance issues on servers with large numbers of appservics. Introduced in v1.63.0.

--- a/changelog.d/13332.bugfix
+++ b/changelog.d/13332.bugfix
@@ -1,1 +1,1 @@
-Fix bug where we incorrectly calculated push for appservice users, leading to performance issues on servers with large numbers of appservics. Introduced in v1.63.0.
+Fix a bug introduced in Synapse 1.63.0 where push actions were incorrectly calculated for appservice users. This caused performance issues on servers with large numbers of appservices.

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -131,6 +131,13 @@ class BulkPushRuleEvaluator:
 
         local_users = await self.store.get_local_users_in_room(event.room_id)
 
+        # Filter out appservice users.
+        local_users = [
+            u
+            for u in local_users
+            if not self.store.get_if_app_services_interested_in_user(u)
+        ]
+
         # if this event is an invite event, we may need to run rules for the user
         # who's been invited, otherwise they won't get told they've been invited
         if event.type == EventTypes.Member and event.membership == Membership.INVITE:


### PR DESCRIPTION
This can cause a lot of extra load on servers with lots of appservice users. Introduced in https://github.com/matrix-org/synapse/pull/13078