### PR TITLE
Call out buildkit is required when building test docker images

### DIFF
--- a/docker/README-testing.md
+++ b/docker/README-testing.md
@@ -22,6 +22,10 @@ Consult the [contributing guide][guideComplementSh] for instructions on how to u
 Under some circumstances, you may wish to build the images manually.
 The instructions below will lead you to doing that.
 
+Note that this image can only be built using [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/),
+therefore BuildKit needs to be enabled when calling `docker build`. This can be done by
+setting `DOCKER_BUILDKIT=1` in your environment.
+
 Start by building the base Synapse docker image. If you wish to run tests with the latest
 release of Synapse, instead of your current checkout, you can skip this step. From the
 root of the repository:


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/13319

I first considered prepending every `docker build` line with `DOCKER_BUILDKIT=1` but then https://docs.docker.com/develop/develop-images/build_enhancements/ mentions other ways to enable buildkit.