### PR TITLE
Track DB txn times w/ two counters, not histogram

### DIFF
--- a/changelog.d/13342.misc
+++ b/changelog.d/13342.misc
@@ -1,0 +1,1 @@
+When reporting metrics is enabled, use ~8x less data to describe DB transaction metrics.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -39,7 +39,7 @@ from typing import (
 )
 
 import attr
-from prometheus_client import Histogram
+from prometheus_client import Counter, Histogram
 from typing_extensions import Concatenate, Literal, ParamSpec
 
 from twisted.enterprise import adbapi
@@ -76,7 +76,8 @@ perf_logger = logging.getLogger("synapse.storage.TIME")
 sql_scheduling_timer = Histogram("synapse_storage_schedule_time", "sec")
 
 sql_query_timer = Histogram("synapse_storage_query_time", "sec", ["verb"])
-sql_txn_timer = Histogram("synapse_storage_transaction_time", "sec", ["desc"])
+sql_txn_count = Counter("synapse_storage_transaction_time_count", "sec", ["desc"])
+sql_txn_duration = Counter("synapse_storage_transaction_time_sum", "sec", ["desc"])
 
 
 # Unique indexes which have been added in background updates. Maps from table name
@@ -795,7 +796,8 @@ class DatabasePool:
 
             self._current_txn_total_time += duration
             self._txn_perf_counters.update(desc, duration)
-            sql_txn_timer.labels(desc).observe(duration)
+            sql_txn_count.labels(desc).inc(1)
+            sql_txn_duration.labels(desc).inc(duration)
 
     async def runInteraction(
         self,


### PR DESCRIPTION
By my reckoning, this should mean that each txn `desc` produces 2 time
series, down from 17. If we don't like this, we could keep the histogram
but configure it with coarser buckets.

This saves on storage and CPU cycles. We don't use the full histogram distribution in our dashboards, so we think this is safe to drop.

Closes #11081.