### PR TITLE
Fix `get_pdu` asking every remote destination even after it finds an event

### DIFF
--- a/changelog.d/13346.misc
+++ b/changelog.d/13346.misc
@@ -1,1 +1,1 @@
-Fix long-standing bug where Synapse sometimes asked many different remote hosts for the same event.
+Fix long-standing bug in `get_pdu` asking every remote destination even after it finds an event.

--- a/changelog.d/13346.misc
+++ b/changelog.d/13346.misc
@@ -1,0 +1,1 @@
+Fix `get_pdu` asking every remote destination even after it finds an event.

--- a/changelog.d/13346.misc
+++ b/changelog.d/13346.misc
@@ -1,1 +1,1 @@
-Fix `get_pdu` asking every remote destination even after it finds an event.
+Fix long-standing bug where Synapse sometimes asked many different remote hosts for the same event.

--- a/changelog.d/13346.misc
+++ b/changelog.d/13346.misc
@@ -1,1 +1,1 @@
-Fix long-standing bug in `get_pdu` asking every remote destination even after it finds an event.
+Fix long-standing bugged logic which was never hit in `get_pdu` asking every remote destination even after it finds an event.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -403,9 +403,9 @@ class FederationClient(FederationBase):
                         # Prime the cache
                         self._get_pdu_cache[event.event_id] = event
 
-                        # FIXME: We should add a `break` here to avoid calling every
-                        # destination after we already found a PDU (will follow-up
-                        # in a separate PR)
+                        # Now that we have an event, we can break out of this
+                        # loop and stop asking other destinations.
+                        break
 
                 except SynapseError as e:
                     logger.info(


### PR DESCRIPTION
Fix `get_pdu` asking every remote destination even after it finds an event

As discovered by @richvdh, https://github.com/matrix-org/synapse/pull/13320#discussion_r924273830

> wait... does this loop *always* try all the destinations, even if the first one works? that would be a substantial bug, if it was ever called with more than one destination, which I don't think it is...

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
