### PR TITLE
Skip soft fail checks for rooms with partial state

### DIFF
--- a/changelog.d/13354.misc
+++ b/changelog.d/13354.misc
@@ -1,0 +1,1 @@
+Faster room joins: skip soft fail checks while Synapse only has partial room state, since the current membership of event senders may not be accurately known.


### PR DESCRIPTION
When a room has the partial state flag, we may not have an accurate
`m.room.member` event for event senders in the room's current state, and
so cannot perform soft fail checks correctly. Skip the soft fail check
entirely in this case.

As an alternative, we could block until we have full state, but that
would prevent us from receiving incoming events over federation, which
is undesirable.

Signed-off-by: Sean Quah <seanq@matrix.org>
