### PR TITLE
Faster room joins: avoid blocking when pulling events with missing prevs

### DIFF
--- a/changelog.d/13354.misc
+++ b/changelog.d/13354.misc
@@ -1,0 +1,1 @@
+Faster room joins: skip soft fail checks while Synapse only has partial room state, since the current membership of event senders may not be accurately known.

--- a/changelog.d/13355.misc
+++ b/changelog.d/13355.misc
@@ -1,0 +1,1 @@
+Faster room joins: avoid blocking when pulling events with partially missing prev events.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -540,6 +540,8 @@ class FederationEventHandler:
             context = await self._state_handler.compute_event_context(
                 event,
                 state_ids_before_event=state_ids,
+                # TODO(faster_joins): Calculate the partial_state flag correctly.
+                partial_state=None if state_ids is None else False,
             )
             if context.partial_state:
                 # this can happen if some or all of the event's prev_events still have
@@ -1132,6 +1134,7 @@ class FederationEventHandler:
         context = await self._state_handler.compute_event_context(
             event,
             state_ids_before_event=state_ids,
+            partial_state=None if state_ids is None else False,
         )
         try:
             await self._check_event_auth(origin, event, context)

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -833,8 +833,15 @@ class FederationEventHandler:
                 state_ids, partial_state = await self._resolve_state_at_missing_prevs(
                     origin, event
                 )
+
                 # We ought to have full state now, barring some unlikely race where we left and
                 # rejoned the room in the background.
+                if state_ids is not None and partial_state:
+                    raise AssertionError(
+                        f"Event {event.event_id} still has a partial resolved state "
+                        f"after room {event.room_id} was un-partial stated"
+                    )
+
                 await self._process_received_pdu(
                     origin,
                     event,

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -547,8 +547,8 @@ class FederationEventHandler:
             #     prev_events. The prev_events may or may not have partial state and
             #     we won't know until we compute the event context.
             #   * `state_ids` is not `None` and `partial_state` is `False` if we were
-            #     missing any prev_events. We calculated the full state after the
-            #     prev_events.
+            #     missing some prev_events (but we have full state for any we did
+            #     have). We calculated the full state after the prev_events.
             #   * `state_ids` is not `None` and `partial_state` is `True` if we were
             #     missing some, but not all, prev_events. At least one of the
             #     prev_events we did have had partial state, so we calculated a partial

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1135,6 +1135,10 @@ class EventCreationHandler:
             context = await self.state.compute_event_context(
                 event,
                 state_ids_before_event=state_map_for_event,
+                # TODO(faster_joins): check how MSC2716 works and whether we can have
+                #   partial state here
+                #   https://github.com/matrix-org/synapse/issues/13003
+                partial_state=False,
             )
         else:
             context = await self.state.compute_event_context(event)

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -82,13 +82,15 @@ class StateStorageController:
         return state_group_delta.prev_group, state_group_delta.delta_ids
 
     async def get_state_groups_ids(
-        self, _room_id: str, event_ids: Collection[str]
+        self, _room_id: str, event_ids: Collection[str], await_full_state: bool = True
     ) -> Dict[int, MutableStateMap[str]]:
         """Get the event IDs of all the state for the state groups for the given events
 
         Args:
             _room_id: id of the room for these events
             event_ids: ids of the events
+            await_full_state: if `True`, will block if we do not yet have complete
+               state at these events.
 
         Returns:
             dict of state_group_id -> (dict of (type, state_key) -> event id)
@@ -100,7 +102,9 @@ class StateStorageController:
         if not event_ids:
             return {}
 
-        event_to_groups = await self.get_state_group_for_events(event_ids)
+        event_to_groups = await self.get_state_group_for_events(
+            event_ids, await_full_state=await_full_state
+        )
 
         groups = set(event_to_groups.values())
         group_to_state = await self.stores.state._get_state_for_groups(groups)

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -287,6 +287,7 @@ class FederationTestCase(unittest.FederatingHomeserverTestCase):
                     state_ids={
                         (e.type, e.state_key): e.event_id for e in current_state
                     },
+                    partial_state=False,
                 )
             )
 

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -70,7 +70,11 @@ class ExtremPruneTestCase(HomeserverTestCase):
     def persist_event(self, event, state=None):
         """Persist the event, with optional state"""
         context = self.get_success(
-            self.state.compute_event_context(event, state_ids_before_event=state)
+            self.state.compute_event_context(
+                event,
+                state_ids_before_event=state,
+                partial_state=None if state is None else False,
+            )
         )
         self.get_success(self._persistence.persist_event(event, context))
 
@@ -148,6 +152,7 @@ class ExtremPruneTestCase(HomeserverTestCase):
             self.state.compute_event_context(
                 remote_event_2,
                 state_ids_before_event=state_before_gap,
+                partial_state=False,
             )
         )
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -462,6 +462,7 @@ class StateTestCase(unittest.TestCase):
                 state_ids_before_event={
                     (e.type, e.state_key): e.event_id for e in old_state
                 },
+                partial_state=False,
             )
         )
 
@@ -492,6 +493,7 @@ class StateTestCase(unittest.TestCase):
                 state_ids_before_event={
                     (e.type, e.state_key): e.event_id for e in old_state
                 },
+                partial_state=False,
             )
         )
 


### PR DESCRIPTION
Avoid blocking on full state in `_resolve_state_at_missing_prevs` and
return a new flag indicating whether the resolved state is partial.
Thread that flag around so that it makes it into the event context.

Resolves #13002.

---

Corresponding Complement tests: https://github.com/matrix-org/complement/pull/419
Best reviewed commit by commit.
The first commit is from #13354.