### PR TITLE
Additional fixes for opentracing type hints.

### DIFF
--- a/changelog.d/13362.misc
+++ b/changelog.d/13362.misc
@@ -1,0 +1,1 @@
+Add missing type hints to open tracing module.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -910,8 +910,8 @@ def tag_args(func: Callable[P, R]) -> Callable[P, R]:
     def _tag_args_inner(*args: P.args, **kwargs: P.kwargs) -> R:
         argspec = inspect.getfullargspec(func)
         for i, arg in enumerate(argspec.args[1:]):
-            set_tag("ARG_" + arg, args[i])  # type: ignore[index]
-        set_tag("args", args[len(argspec.args) :])  # type: ignore[index]
+            set_tag("ARG_" + arg, str(args[i]))  # type: ignore[index]
+        set_tag("args", str(args[len(argspec.args) :]))  # type: ignore[index]
         set_tag("kwargs", str(kwargs))
         return func(*args, **kwargs)
 


### PR DESCRIPTION
Should fix #13357.

I couldn't get poetry to properly update mypy / mypy-zope, but the changes are fine to do and pass with the current versions too.