### PR TITLE
Stop returning the room_id from the `/hierarchy` endpoint.

### DIFF
--- a/changelog.d/13365.bugfix
+++ b/changelog.d/13365.bugfix
@@ -1,1 +1,1 @@
-Fix a bug introduced in Synapse v1.41.0 where the `/hierarchy` API returned non-standard information (`room_id`).
+Fix a bug introduced in Synapse v1.41.0 where the `/hierarchy` API returned non-standard information (a `room_id` field under each entry in `children_state`).

--- a/changelog.d/13365.bugfix
+++ b/changelog.d/13365.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse v1.41.0 where the `/hierarchy` API returned non-standard information (`room_id`).

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -452,7 +452,6 @@ class RoomSummaryHandler:
                 "type": e.type,
                 "state_key": e.state_key,
                 "content": e.content,
-                "room_id": e.room_id,
                 "sender": e.sender,
                 "origin_server_ts": e.origin_server_ts,
             }


### PR DESCRIPTION
Fixes #10946

Needs the corresponding complement changes at matrix-org/complement#422.