### PR TITLE
Log when we get an invalid body on certain CS-API requests

### DIFF
--- a/changelog.d/13386.misc
+++ b/changelog.d/13386.misc
@@ -1,0 +1,1 @@
+Log when we get an invalid request body on room membership requests.

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -319,9 +319,10 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
 
         try:
             content = parse_json_object_from_request(request)
-        except Exception:
+        except Exception as e:
             # Turns out we used to ignore the body entirely, and some clients
             # cheekily send invalid bodies.
+            logger.warning("Ignoring invalid body on POST %s: %s", request.path, e)
             content = {}
 
         # twisted.web.server.Request.args is incorrectly defined as Optional[Any]
@@ -855,9 +856,10 @@ class RoomMembershipRestServlet(TransactionRestServlet):
 
         try:
             content = parse_json_object_from_request(request)
-        except Exception:
+        except Exception as e:
             # Turns out we used to ignore the body entirely, and some clients
             # cheekily send invalid bodies.
+            logger.warning("Ignoring invalid body on POST %s: %s", request.path, e)
             content = {}
 
         if membership_action == "invite" and self._has_3pid_invite_keys(content):


### PR DESCRIPTION
Some endpoints currently accept an invalid JSON object in the request body,
which we should stop. As a starting point, let's log when it happens so that we
can fix it.