### PR TITLE
Copy room serials before handling in `get_new_events_as`

### DIFF
--- a/changelog.d/13392.bugfix
+++ b/changelog.d/13392.bugfix
@@ -1,0 +1,1 @@
+Fix bug in handling of typing events for appservices. Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -490,8 +490,9 @@ class TypingNotificationEventSource(EventSource[int, JsonDict]):
 
             events = []
 
-            # Work on a copy of things here as these may change when this coroutine awaits the
-            # is_interested_in_room call. Shallow copy is safe as no nested data is present.
+            # Work on a copy of things here as these may change in the handler while
+            # waiting for the AS `is_interested_in_room` call to complete.
+            # Shallow copy is safe as no nested data is present.
             latest_room_serial = handler._latest_room_serial
             room_serials = handler._room_serials.copy()
 

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -489,8 +489,14 @@ class TypingNotificationEventSource(EventSource[int, JsonDict]):
             handler = self.get_typing_handler()
 
             events = []
-            for room_id in handler._room_serials.keys():
-                if handler._room_serials[room_id] <= from_key:
+
+            # Work on a copy of things here as these may change when this coroutine awaits the
+            # is_interested_in_room call. Shallow copy is safe as no nested data is present.
+            latest_room_serial = handler._latest_room_serial
+            room_serials = handler._room_serials.copy()
+
+            for room_id, serial in room_serials.items():
+                if serial <= from_key:
                     continue
 
                 if not await service.is_interested_in_room(room_id, self._main_store):
@@ -498,7 +504,7 @@ class TypingNotificationEventSource(EventSource[int, JsonDict]):
 
                 events.append(self._make_event_for(room_id))
 
-            return events, handler._latest_room_serial
+            return events, latest_room_serial
 
     async def get_new_events(
         self,


### PR DESCRIPTION
We encouter this from time to time:

```
RuntimeError  in synapse.handlers.typing in get_new_events_as: dictionary changed size during iteration
```

The await call to `service.is_interested_in_room` makes this possible and copying the data before generating events should work around it.

Signed off by Nick @ Beeper (@fizzadar).

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
