### PR TITLE
Add a `merge-back` command to the release script, which automates merging the correct branches after a release.

### DIFF
--- a/changelog.d/13393.misc
+++ b/changelog.d/13393.misc
@@ -1,0 +1,1 @@
+Add a `merge-back` command to the release script, which automates merging the correct branches after a release.

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -461,7 +461,7 @@ def _merge_into(repo: Repo, source: str, target: str) -> None:
 
     try:
         # TODO This seemed easier than using GitPython directly
-        click.echo(f"Merging {source}")
+        click.echo(f"Merging {source}...")
         repo.git.merge(source)
     except GitCommandError as exc:
         # If a merge conflict occurs, give some context and try to
@@ -475,7 +475,7 @@ def _merge_into(repo: Repo, source: str, target: str) -> None:
             return
 
     # Push result.
-    click.echo("Pushing")
+    click.echo("Pushing...")
     repo.remote().push()
 
 

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -502,11 +502,19 @@ def merge_back() -> None:
             _merge_into(synapse_repo, branch_name, "develop")
     else:
         # Full release
+        sytest_repo = get_repo_and_check_clean_checkout("../sytest", "sytest")
+
         if click.confirm(f"Merge {branch_name} → master?", default=True):
             _merge_into(synapse_repo, branch_name, "master")
 
         if click.confirm("Merge master → develop?", default=True):
             _merge_into(synapse_repo, "master", "develop")
+
+        if click.confirm(f"On SyTest, merge {branch_name} → master?", default=True):
+            _merge_into(sytest_repo, branch_name, "master")
+
+        if click.confirm("On SyTest, merge master → develop?", default=True):
+            _merge_into(sytest_repo, "master", "develop")
 
 
 @cli.command()

--- a/scripts-dev/release.py
+++ b/scripts-dev/release.py
@@ -485,28 +485,28 @@ def merge_back() -> None:
     All branches will be automatically pulled from the remote and the results
     will be pushed to the remote."""
 
-    repo = get_repo_and_check_clean_checkout()
-    branch_name = repo.active_branch.name
+    synapse_repo = get_repo_and_check_clean_checkout()
+    branch_name = synapse_repo.active_branch.name
 
     if not branch_name.startswith("release-v"):
         raise RuntimeError("Not on a release branch. This does not seem sensible.")
 
     # Pull so we're up to date
-    repo.remote().pull()
+    synapse_repo.remote().pull()
 
     current_version = get_package_version()
 
     if current_version.is_prerelease:
         # Release candidate
         if click.confirm(f"Merge {branch_name} → develop?", default=True):
-            _merge_into(repo, branch_name, "develop")
+            _merge_into(synapse_repo, branch_name, "develop")
     else:
         # Full release
         if click.confirm(f"Merge {branch_name} → master?", default=True):
-            _merge_into(repo, branch_name, "master")
+            _merge_into(synapse_repo, branch_name, "master")
 
         if click.confirm("Merge master → develop?", default=True):
-            _merge_into(repo, "master", "develop")
+            _merge_into(synapse_repo, "master", "develop")
 
 
 @cli.command()


### PR DESCRIPTION
I messed this up last time, so it's about time it was taken out of my hands and into the hands of the computer :-).

TODO: 

- [x] Do the same for SyTest
- [x] Test it on a full release


