### PR TITLE
Faster Room Joins: don't leave a stuck room partial state flag if the join fails.

### DIFF
--- a/changelog.d/13403.misc
+++ b/changelog.d/13403.misc
@@ -1,0 +1,1 @@
+Faster Room Joins: don't leave a stuck room partial state flag if the join fails.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -546,9 +546,9 @@ class FederationHandler:
             )
 
             if ret.partial_state:
-                # TODO(faster_joins): roll this back if we don't manage to start the
-                #   background resync (eg process_remote_join fails)
-                #   https://github.com/matrix-org/synapse/issues/12998
+                # Mark the room as having partial state.
+                # The background process is responsible for unmarking this flag,
+                # even if the join fails.
                 await self.store.store_partial_state_room(room_id, ret.servers_in_room)
 
             try:
@@ -574,17 +574,21 @@ class FederationHandler:
                     room_id,
                 )
                 raise LimitExceededError(msg=e.msg, errcode=e.errcode, retry_after_ms=0)
-
-            if ret.partial_state:
-                # Kick off the process of asynchronously fetching the state for this
-                # room.
-                run_as_background_process(
-                    desc="sync_partial_state_room",
-                    func=self._sync_partial_state_room,
-                    initial_destination=origin,
-                    other_destinations=ret.servers_in_room,
-                    room_id=room_id,
-                )
+            finally:
+                # Always kick off the background process that asynchronously fetches
+                # state for the room.
+                # If the join failed, the background process is responsible for
+                # cleaning up — including unmarking the room as a partial state room.
+                if ret.partial_state:
+                    # Kick off the process of asynchronously fetching the state for this
+                    # room.
+                    run_as_background_process(
+                        desc="sync_partial_state_room",
+                        func=self._sync_partial_state_room,
+                        initial_destination=origin,
+                        other_destinations=ret.servers_in_room,
+                        room_id=room_id,
+                    )
 
             # We wait here until this instance has seen the events come down
             # replication (if we're using replication) as the below uses caches.

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -554,6 +554,7 @@ class PartialJoinTestCase(unittest.FederatingHomeserverTestCase):
             fed_client, "make_membership_event", mock_make_membership_event
         ), patch.object(fed_client, "send_join", mock_send_join):
             # Join and check that our join event is rejected
+            # (The join event is rejected because it doesn't have any signatures)
             join_exc = self.get_failure(
                 fed_handler.do_invite_join(["example.com"], room_id, "@alice:test", {}),
                 SynapseError,

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -14,6 +14,7 @@
 import logging
 from typing import cast
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
 from twisted.test.proto_helpers import MemoryReactor
 
@@ -22,6 +23,7 @@ from synapse.api.errors import AuthError, Codes, LimitExceededError, SynapseErro
 from synapse.api.room_versions import RoomVersions
 from synapse.events import EventBase, make_event_from_dict
 from synapse.federation.federation_base import event_from_pdu_json
+from synapse.federation.federation_client import SendJoinResult
 from synapse.logging.context import LoggingContext, run_in_background
 from synapse.rest import admin
 from synapse.rest.client import login, room
@@ -30,7 +32,7 @@ from synapse.util import Clock
 from synapse.util.stringutils import random_string
 
 from tests import unittest
-from tests.test_utils import event_injection
+from tests.test_utils import event_injection, make_awaitable
 
 logger = logging.getLogger(__name__)
 
@@ -449,3 +451,117 @@ class EventFromPduTestCase(TestCase):
                 },
                 RoomVersions.V6,
             )
+
+
+class PartialJoinTestCase(unittest.FederatingHomeserverTestCase):
+    def test_failed_partial_join_is_clean(self) -> None:
+        """
+        Tests that, when failing to partial-join a room, we don't get stuck with
+        a partial-state flag on a room.
+        """
+
+        fed_handler = self.hs.get_federation_handler()
+        fed_client = fed_handler.federation_client
+
+        room_id = "!room:example.com"
+        membership_event = make_event_from_dict(
+            {
+                "room_id": room_id,
+                "type": "m.room.member",
+                "sender": "@alice:test",
+                "state_key": "@alice:test",
+                "content": {"membership": "join"},
+            },
+            RoomVersions.V10,
+        )
+
+        mock_make_membership_event = Mock(
+            return_value=make_awaitable(
+                (
+                    "example.com",
+                    membership_event,
+                    RoomVersions.V10,
+                )
+            )
+        )
+
+        EVENT_CREATE = make_event_from_dict(
+            {
+                "room_id": room_id,
+                "type": "m.room.create",
+                "sender": "@kristina:example.com",
+                "state_key": "",
+                "event_id": "$e",
+                "depth": 0,
+                "content": {"creator": "@kristina:example.com", "room_version": "10"},
+                "auth_events": [],
+                "origin_server_ts": 1,
+            }
+        )
+        EVENT_CREATOR_MEMBERSHIP = make_event_from_dict(
+            {
+                "room_id": room_id,
+                "type": "m.room.member",
+                "sender": "@kristina:example.com",
+                "state_key": "@kristina:example.com",
+                "content": {"membership": "join"},
+                "event_id": "$f",
+                "depth": 1,
+                "prev_events": ["$e"],
+                "auth_events": ["$e"],
+                "origin_server_ts": 1,
+            }
+        )
+        EVENT_INVITATION_MEMBERSHIP = make_event_from_dict(
+            {
+                "room_id": room_id,
+                "type": "m.room.member",
+                "sender": "@kristina:example.com",
+                "state_key": "@alice:test",
+                "content": {"membership": "invite"},
+                "event_id": "$g:test",
+                "depth": 2,
+                "prev_events": ["$f"],
+                "auth_events": ["$e", "$f"],
+                "origin_server_ts": 1,
+            }
+        )
+        mock_send_join = Mock(
+            return_value=make_awaitable(
+                SendJoinResult(
+                    membership_event,
+                    "example.com",
+                    state=[
+                        EVENT_CREATE,
+                        EVENT_CREATOR_MEMBERSHIP,
+                        EVENT_INVITATION_MEMBERSHIP,
+                    ],
+                    auth_chain=[
+                        EVENT_CREATE,
+                        EVENT_CREATOR_MEMBERSHIP,
+                        EVENT_INVITATION_MEMBERSHIP,
+                    ],
+                    partial_state=True,
+                    servers_in_room=["example.com"],
+                )
+            )
+        )
+
+        with patch.object(
+            fed_client, "make_membership_event", mock_make_membership_event
+        ), patch.object(fed_client, "send_join", mock_send_join):
+            # Join and check that our join event is rejected
+            join_exc = self.get_failure(
+                fed_handler.do_invite_join(["example.com"], room_id, "@alice:test", {}),
+                SynapseError,
+            )
+        self.assertIn("Join event was rejected", str(join_exc))
+
+        store = self.hs.get_datastores().main
+
+        # Check that we don't have a left-over partial_state entry.
+        self.assertFalse(
+            self.get_success(store.is_partial_state_room(room_id)),
+            f"Stale partial-stated room flag left over for {room_id} after a"
+            f" failed do_invite_join!",
+        )

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -491,12 +491,12 @@ class PartialJoinTestCase(unittest.FederatingHomeserverTestCase):
                 "type": "m.room.create",
                 "sender": "@kristina:example.com",
                 "state_key": "",
-                "event_id": "$e",
                 "depth": 0,
                 "content": {"creator": "@kristina:example.com", "room_version": "10"},
                 "auth_events": [],
                 "origin_server_ts": 1,
-            }
+            },
+            room_version=RoomVersions.V10,
         )
         EVENT_CREATOR_MEMBERSHIP = make_event_from_dict(
             {
@@ -505,12 +505,12 @@ class PartialJoinTestCase(unittest.FederatingHomeserverTestCase):
                 "sender": "@kristina:example.com",
                 "state_key": "@kristina:example.com",
                 "content": {"membership": "join"},
-                "event_id": "$f",
                 "depth": 1,
-                "prev_events": ["$e"],
-                "auth_events": ["$e"],
+                "prev_events": [EVENT_CREATE.event_id],
+                "auth_events": [EVENT_CREATE.event_id],
                 "origin_server_ts": 1,
-            }
+            },
+            room_version=RoomVersions.V10,
         )
         EVENT_INVITATION_MEMBERSHIP = make_event_from_dict(
             {
@@ -519,12 +519,15 @@ class PartialJoinTestCase(unittest.FederatingHomeserverTestCase):
                 "sender": "@kristina:example.com",
                 "state_key": "@alice:test",
                 "content": {"membership": "invite"},
-                "event_id": "$g:test",
                 "depth": 2,
-                "prev_events": ["$f"],
-                "auth_events": ["$e", "$f"],
+                "prev_events": [EVENT_CREATOR_MEMBERSHIP.event_id],
+                "auth_events": [
+                    EVENT_CREATE.event_id,
+                    EVENT_CREATOR_MEMBERSHIP.event_id,
+                ],
                 "origin_server_ts": 1,
-            }
+            },
+            room_version=RoomVersions.V10,
         )
         mock_send_join = Mock(
             return_value=make_awaitable(


### PR DESCRIPTION
Fixes #12998

