### PR TITLE
Add experimental `org.matrix.unstable.to_device_limit` to sync filter

### DIFF
--- a/changelog.d/13412.feature
+++ b/changelog.d/13412.feature
@@ -1,0 +1,1 @@
+Add do_not_use_to_device_limit to sync filter. This is an experiment to see if it improves client behavior.

--- a/changelog.d/13412.feature
+++ b/changelog.d/13412.feature
@@ -1,1 +1,1 @@
-Add `do_not_use_to_device_limit` field to sync filter. This is an experiment to see if it improves sync performance.
+Add `org.matrix.unstable.to_device_limit` field to sync filter. This is an experiment to see if it improves sync performance.

--- a/changelog.d/13412.feature
+++ b/changelog.d/13412.feature
@@ -1,1 +1,1 @@
-Add do_not_use_to_device_limit to sync filter. This is an experiment to see if it improves client behavior.
+Add `do_not_use_to_device_limit` field to sync filter. This is an experiment to see if it improves sync performance.

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -134,6 +134,9 @@ USER_FILTER_SCHEMA = {
                 "pattern": r"^((?!\\\\).)*$",
             },
         },
+        # This is an experiment, a MSC will follow if it happens to be useful
+        # for clients sync performance
+        "do_not_use_to_device_limit": {"type": "number"},
     },
     "additionalProperties": False,
 }
@@ -218,6 +221,13 @@ class FilterCollection:
         self.include_leave = filter_json.get("room", {}).get("include_leave", False)
         self.event_fields = filter_json.get("event_fields", [])
         self.event_format = filter_json.get("event_format", "client")
+
+        self.to_device_limit = 100
+        if hs.config.experimental.to_device_limit_enabled:
+            self.to_device_limit = filter_json.get("do_not_use_to_device_limit", 100)
+            # We don't want to overload the server so let's keep the limit under a thousand
+            if self.to_device_limit > 1000:
+                self.to_device_limit = 1000
 
     def __repr__(self) -> str:
         return "<FilterCollection %s>" % (json.dumps(self._filter_json),)

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -225,7 +225,7 @@ class FilterCollection:
         self.to_device_limit = 100
         if hs.config.experimental.to_device_limit_enabled:
             self.to_device_limit = filter_json.get("do_not_use_to_device_limit", 100)
-            # We don't want to overload the server so let's keep the limit under a thousand
+            # We don't want to overload the server so let's limit it to under a thousand
             if self.to_device_limit > 1000:
                 self.to_device_limit = 1000
 

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -136,7 +136,7 @@ USER_FILTER_SCHEMA = {
         },
         # This is an experiment, a MSC will follow if it happens to be useful
         # for clients sync performance
-        "do_not_use_to_device_limit": {"type": "number"},
+        "org.matrix.unstable.to_device_limit": {"type": "number"},
     },
     "additionalProperties": False,
 }
@@ -224,7 +224,9 @@ class FilterCollection:
 
         self.to_device_limit = 100
         if hs.config.experimental.to_device_limit_enabled:
-            self.to_device_limit = filter_json.get("do_not_use_to_device_limit", 100)
+            self.to_device_limit = filter_json.get(
+                "org.matrix.unstable.to_device_limit", 100
+            )
             # We don't want to overload the server so let's limit it to under a thousand
             if self.to_device_limit > 1000:
                 self.to_device_limit = 1000

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -90,3 +90,9 @@ class ExperimentalConfig(Config):
 
         # MSC3848: Introduce errcodes for specific event sending failures
         self.msc3848_enabled: bool = experimental.get("msc3848_enabled", False)
+
+        # Experimental feature to optimize client sync performance
+        # Will become a proper MSC if it appears to be useful
+        self.to_device_limit_enabled: bool = experimental.get(
+            "to_device_limit_enabled", False
+        )

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1329,7 +1329,11 @@ class SyncHandler:
 
         if device_id is not None and since_stream_id != int(now_token.to_device_key):
             messages, stream_id = await self.store.get_messages_for_device(
-                user_id, device_id, since_stream_id, now_token.to_device_key
+                user_id,
+                device_id,
+                since_stream_id,
+                now_token.to_device_key,
+                sync_result_builder.sync_config.filter_collection.to_device_limit,
             )
 
             for message in messages:

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -229,10 +229,6 @@ class DeviceInboxWorkerStore(SQLBaseStore):
             limit=limit,
         )
 
-        if not user_id_device_id_to_messages:
-            # There were no messages!
-            return [], to_stream_id
-
         # Extract the messages, no need to return the user and device ID again
         to_device_messages = user_id_device_id_to_messages.get((user_id, device_id), [])
 
@@ -296,6 +292,9 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                 "Programming error: _get_device_messages was passed 'limit' "
                 "without a specific user_id/device_id"
             )
+
+        if limit == 0:
+            return {}, from_stream_id
 
         user_ids_to_query: Set[str] = set()
         device_ids_to_query: Set[str] = set()

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -219,7 +219,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                   same device should pass this value as 'from_stream_id'.
         """
         if limit == 0:
-            return {}, from_stream_id
+            return [], from_stream_id
 
         (
             user_id_device_id_to_messages,

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -218,6 +218,9 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                 * The last-processed stream ID. Subsequent calls of this function with the
                   same device should pass this value as 'from_stream_id'.
         """
+        if limit == 0:
+            return {}, from_stream_id
+
         (
             user_id_device_id_to_messages,
             last_processed_stream_id,
@@ -228,6 +231,10 @@ class DeviceInboxWorkerStore(SQLBaseStore):
             to_stream_id=to_stream_id,
             limit=limit,
         )
+
+        if not user_id_device_id_to_messages:
+            # There were no messages!
+            return [], to_stream_id
 
         # Extract the messages, no need to return the user and device ID again
         to_device_messages = user_id_device_id_to_messages.get((user_id, device_id), [])
@@ -292,9 +299,6 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                 "Programming error: _get_device_messages was passed 'limit' "
                 "without a specific user_id/device_id"
             )
-
-        if limit == 0:
-            return {}, from_stream_id
 
         user_ids_to_query: Set[str] = set()
         device_ids_to_query: Set[str] = set()

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -219,6 +219,8 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                   same device should pass this value as 'from_stream_id'.
         """
         if limit == 0:
+            # We return the from token so that if a sync later on asks for
+            # non-zero number of to-device messages we won't have dropped any.
             return [], from_stream_id
 
         (

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -991,7 +991,7 @@ class ToDeviceLimitTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(chan.code, 200, chan.result)
 
-    # This does an incremental sync for user kermit with do_not_use_to_device_limit
+    # This does an incremental sync for user kermit with org.matrix.unstable.to_device_limit
     # setted and check the number of returned to_device msgs against
     # expected_to_device_msgs value
     def _limited_sync_and_check(
@@ -999,7 +999,7 @@ class ToDeviceLimitTestCase(unittest.HomeserverTestCase):
     ) -> None:
         channel = self.make_request(
             "GET",
-            f'/sync?since={self.next_batch}&filter={{"do_not_use_to_device_limit": {to_device_limit}}}',
+            f'/sync?since={self.next_batch}&filter={{"org.matrix.unstable.to_device_limit": {to_device_limit}}}',
             access_token=self.tok,
         )
         self.assertEqual(channel.code, 200)

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -1033,7 +1033,7 @@ class ToDeviceLimitTestCase(unittest.HomeserverTestCase):
         for _ in range(4):
             self._send_to_device()
 
-        # limit of 3 is setted but the experimental feature is not enabled,
+        # limit of 3 is used but the experimental feature is not enabled,
         # so we are still expecting 4 messages
         self._limited_sync_and_check(3, 4)
 


### PR DESCRIPTION
Currently the name of the filter parameter is `org.matrix.unstable.to_device_limit` since it is not in the spec, and a MSC has not been defined yet.

The goal is to do some testing with clients around the usefulness of it, and write a proper MSC if it ends up useful.