### PR TITLE
Faster Room Joins: prevent Synapse from answering federated join requests for a room which it has not fully joined yet.

### DIFF
--- a/changelog.d/13416.misc
+++ b/changelog.d/13416.misc
@@ -1,0 +1,1 @@
+Faster Room Joins: prevent Synapse from answering federated join requests for a room which it has not fully joined yet.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -843,7 +843,21 @@ class FederationServer(FederationBase):
                 Codes.BAD_JSON,
             )
 
+        # Note that get_room_version throws if the room does not exist here.
         room_version = await self.store.get_room_version(room_id)
+
+        if await self.store.is_partial_state_room(room_id):
+            # If our server is still only partially joined, we can't give a complete
+            # response to send_join, so return a 404 as we would if we weren't in the
+            # room at all.
+            logger.info(
+                "Rejecting send_join to %s because it's a partial state room", room_id
+            )
+            raise SynapseError(
+                404,
+                "Unable to handle send_join right now; this server is not fully joined.",
+                errcode=Codes.NOT_FOUND,
+            )
 
         if membership_type == Membership.KNOCK and not room_version.msc2403_knocking:
             raise SynapseError(

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -848,14 +848,17 @@ class FederationServer(FederationBase):
 
         if await self.store.is_partial_state_room(room_id):
             # If our server is still only partially joined, we can't give a complete
-            # response to send_join, so return a 404 as we would if we weren't in the
-            # room at all.
+            # response to /send_join, /send_knock or /send_leave.
+            # This is because we will not be able to provide the server list (for partial
+            # joins) or the full state (for full joins).
+            # Return a 404 as we would if we weren't in the room at all.
             logger.info(
-                "Rejecting send_join to %s because it's a partial state room", room_id
+                f"Rejecting /send_{membership_type} to %s because it's a partial state room",
+                room_id,
             )
             raise SynapseError(
                 404,
-                "Unable to handle send_join right now; this server is not fully joined.",
+                f"Unable to handle /send_{membership_type} right now; this server is not fully joined.",
                 errcode=Codes.NOT_FOUND,
             )
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -750,14 +750,14 @@ class FederationHandler:
 
         if await self.store.is_partial_state_room(room_id):
             # If our server is still only partially joined, we can't give a complete
-            # response to make_join, so return a 404 as we would if we weren't in the
+            # response to /make_join, so return a 404 as we would if we weren't in the
             # room at all.
             logger.info(
-                "Rejecting make_join to %s because it's a partial state room", room_id
+                "Rejecting /make_join to %s because it's a partial state room", room_id
             )
             raise SynapseError(
                 404,
-                "Unable to handle make_join right now; this server is not fully joined.",
+                "Unable to handle /make_join right now; this server is not fully joined.",
                 errcode=Codes.NOT_FOUND,
             )
 

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -748,6 +748,19 @@ class FederationHandler:
         # (and return a 404 otherwise)
         room_version = await self.store.get_room_version(room_id)
 
+        if await self.store.is_partial_state_room(room_id):
+            # If our server is still only partially joined, we can't give a complete
+            # response to make_join, so return a 404 as we would if we weren't in the
+            # room at all.
+            logger.info(
+                "Rejecting make_join to %s because it's a partial state room", room_id
+            )
+            raise SynapseError(
+                404,
+                "Unable to handle make_join right now; this server is not fully joined.",
+                errcode=Codes.NOT_FOUND,
+            )
+
         # now check that we are *still* in the room
         is_in_room = await self._event_auth_handler.check_host_in_room(
             room_id, self.server_name

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -752,6 +752,10 @@ class FederationHandler:
             # If our server is still only partially joined, we can't give a complete
             # response to /make_join, so return a 404 as we would if we weren't in the
             # room at all.
+            # The main reason we can't respond properly is that we need to know about
+            # the auth events for the join event that we would return.
+            # We also should not bother entertaining the /make_join since we cannot
+            # handle the /send_join.
             logger.info(
                 "Rejecting /make_join to %s because it's a partial state room", room_id
             )


### PR DESCRIPTION
Fixes #13290.

Complement test: https://github.com/matrix-org/complement/pull/432
