### PR TITLE
Re-enable running Complement tests against Synapse with workers.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -328,6 +328,9 @@ jobs:
           - arrangement: monolith
             database: Postgres
 
+          - arrangement: workers
+            database: Postgres
+
     steps:
       - name: Run actions/checkout@v2 for synapse
         uses: actions/checkout@v2
@@ -340,30 +343,6 @@ jobs:
       - run: |
           set -o pipefail
           POSTGRES=${{ (matrix.database == 'Postgres') && 1 || '' }} WORKERS=${{ (matrix.arrangement == 'workers') && 1 || '' }} COMPLEMENT_DIR=`pwd`/complement synapse/scripts-dev/complement.sh -json 2>&1 | gotestfmt
-        shell: bash
-        name: Run Complement Tests
-
-  # XXX When complement with workers is stable, move this back into the standard
-  #     "complement" matrix above.
-  #
-  # See https://github.com/matrix-org/synapse/issues/13161
-  complement-workers:
-    if: "${{ !failure() && !cancelled() }}"
-    needs: linting-done
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Run actions/checkout@v2 for synapse
-        uses: actions/checkout@v2
-        with:
-          path: synapse
-
-      - name: Prepare Complement's Prerequisites
-        run: synapse/.ci/scripts/setup_complement_prerequisites.sh
-
-      - run: |
-          set -o pipefail
-          POSTGRES=1 WORKERS=1 COMPLEMENT_DIR=`pwd`/complement synapse/scripts-dev/complement.sh -json 2>&1 | gotestfmt
         shell: bash
         name: Run Complement Tests
 

--- a/changelog.d/13420.misc
+++ b/changelog.d/13420.misc
@@ -1,0 +1,1 @@
+Re-enable running Complement tests against Synapse with workers.


### PR DESCRIPTION
Looking at #13161 and the status on recent PRs, the really big painful flakes have now been dealt with.

I don't think we've reached perfection, but that might take months! The remaining flakes of which I am aware are considerably rarer than the ones that kept biting us a few weeks ago.

