### PR TITLE
config: allow globs in federation_domain_whitelist

### DIFF
--- a/changelog.d/13424.feature
+++ b/changelog.d/13424.feature
@@ -1,0 +1,1 @@
+Allow to use wildcard patterns in `federation_domain_whitelist`, with the same behavior as `federation_certificate_verification_whitelist`.

--- a/synapse/config/_util.py
+++ b/synapse/config/_util.py
@@ -73,13 +73,10 @@ class DomainGlobSet:
                     glob_to_regex(entry.encode("ascii").decode("ascii"))
                 )
             except UnicodeEncodeError:
-                raise ConfigError(
-                    "IDNA domain names are not allowed in the "
-                    "federation_certificate_verification_whitelist: %s" % (entry,)
-                )
+                raise ConfigError("IDNA domain names are not allowed: %s " % (entry,))
 
     def __contains__(self, item: object) -> bool:
         for regex in self._entries:
-            if regex.match(item):
+            if regex.match(str(item)):
                 return True
         return False

--- a/synapse/config/federation.py
+++ b/synapse/config/federation.py
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from fnmatch import fnmatch
 from typing import Any, Optional
 
 from synapse.config._base import Config
 from synapse.config._util import validate_config
 from synapse.types import JsonDict
+
+from ._util import DomainGlobSet
 
 
 class FederationConfig(Config):
@@ -24,11 +25,10 @@ class FederationConfig(Config):
 
     def read_config(self, config: JsonDict, **kwargs: Any) -> None:
         # FIXME: federation_domain_whitelist needs sytests
-        self.federation_domain_whitelist: Optional[FederationDomainWhitelist] = None
+        self.federation_domain_whitelist: Optional[DomainGlobSet] = None
         federation_domain_whitelist = config.get("federation_domain_whitelist", None)
-
         if federation_domain_whitelist is not None:
-            self.federation_domain_whitelist = FederationDomainWhitelist(
+            self.federation_domain_whitelist = DomainGlobSet(
                 federation_domain_whitelist
             )
 
@@ -47,14 +47,6 @@ class FederationConfig(Config):
         self.allow_device_name_lookup_over_federation = config.get(
             "allow_device_name_lookup_over_federation", False
         )
-
-
-class FederationDomainWhitelist(list):
-    def __contains__(self, item: object) -> bool:
-        for x in self:
-            if fnmatch(str(item), x):
-                return True
-        return False
 
 
 _METRICS_FOR_DOMAINS_SCHEMA = {"type": "array", "items": {"type": "string"}}

--- a/synapse/crypto/context_factory.py
+++ b/synapse/crypto/context_factory.py
@@ -142,14 +142,9 @@ class FederationPolicyForHTTPS:
         ascii_host = host.decode("ascii")
 
         # Check if certificate verification has been enabled
-        should_verify = self._should_verify
-
-        # Check if we've disabled certificate verification for this host
-        if self._should_verify:
-            for regex in self._federation_certificate_verification_whitelist:
-                if regex.match(ascii_host):
-                    should_verify = False
-                    break
+        should_verify = self._should_verify and not (
+            ascii_host in self._federation_certificate_verification_whitelist
+        )
 
         ssl_context = (
             self._verify_ssl_context if should_verify else self._no_verify_ssl_context


### PR DESCRIPTION
Resolves #7346

Allows to use glob patterns in `federation_domain_whitelist`.

```
federation_domain_whitelist:
  - *.example.com
  # [...]
```

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
