### PR TITLE
Fix missing import in `federation_event` handler.

### DIFF
--- a/changelog.d/13431.misc
+++ b/changelog.d/13431.misc
@@ -1,0 +1,1 @@
+Refactor `_resolve_state_at_missing_prevs` to compute an `EventContext` instead.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -23,6 +23,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Optional,
     Sequence,
     Set,
     Tuple,


### PR DESCRIPTION
#13404 removed an import of `Optional` which was still needed (I think because #13413 added more usages).