### PR TITLE
Fix error when out of servers to sync partial state with

### DIFF
--- a/changelog.d/13432.bugfix
+++ b/changelog.d/13432.bugfix
@@ -1,0 +1,1 @@
+Faster room joins: Fix error when running out of servers to sync partial state with, so that Synapse raises the intended error instead.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1539,15 +1539,16 @@ class FederationHandler:
 
         # Make an infinite iterator of destinations to try. Once we find a working
         # destination, we'll stick with it until it flakes.
+        destinations: Collection[str]
         if initial_destination is not None:
             # Move `initial_destination` to the front of the list.
             destinations = list(other_destinations)
             if initial_destination in destinations:
                 destinations.remove(initial_destination)
             destinations = [initial_destination] + destinations
-            destination_iter = itertools.cycle(destinations)
         else:
-            destination_iter = itertools.cycle(other_destinations)
+            destinations = other_destinations
+        destination_iter = itertools.cycle(destinations)
 
         # `destination` is the current remote homeserver we're pulling from.
         destination = next(destination_iter)


### PR DESCRIPTION
so that we raise the intended error instead.

Signed-off-by: Sean Quah <seanq@matrix.org>

---

Fixes #13430:
```
Traceback (most recent call last):
  File "/home/synapse/src/synapse/synapse/metrics/background_process_metrics.py", line 240, in run
    return await func(*args, **kwargs)
  File "/home/synapse/src/synapse/synapse/handlers/federation.py", line 1597, in _sync_partial_state_room
    if attempt == len(destinations) - 1:
UnboundLocalError: local variable 'destinations' referenced before assignment
```