### PR TITLE
Optimise async get event lookups

### DIFF
--- a/changelog.d/13435.misc
+++ b/changelog.d/13435.misc
@@ -1,1 +1,1 @@
-Prevent unnecessary lookups to any external get event cache. Contributed by Nick @ Beeper (@fizzadar).
+Prevent unnecessary lookups to any external `get_event` cache. Contributed by Nick @ Beeper (@fizzadar).

--- a/changelog.d/13435.misc
+++ b/changelog.d/13435.misc
@@ -1,0 +1,1 @@
+Prevent unnecessary lookups to any external get event cache. Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -665,13 +665,12 @@ class EventsWorkerStore(SQLBaseStore):
                 missing_events = {}
                 try:
                     # First fetch from the cache - including any external caches
-                    cache_missing_events = await self._get_events_from_cache(
+                    missing_events = await self._get_events_from_cache(
                         missing_events_ids,
                     )
-                    missing_events.update(cache_missing_events)
                     # Now actually fetch any remaining events from the DB
                     db_missing_events = await self._get_events_from_db(
-                        missing_events_ids - set(cache_missing_events.keys()),
+                        missing_events_ids - missing_events.keys(),
                     )
                     missing_events.update(db_missing_events)
                 except Exception as e:

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -780,9 +780,12 @@ class EventsWorkerStore(SQLBaseStore):
         )
 
         missing_event_ids = {e for e in events if e not in event_map}
-        event_map.update(self._get_events_from_external_cache(
-            events=missing_event_ids, update_metrics=update_metrics,
-        ))
+        event_map.update(
+            await self._get_events_from_external_cache(
+                events=missing_event_ids,
+                update_metrics=update_metrics,
+            )
+        )
 
         return event_map
 

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -780,7 +780,7 @@ class EventsWorkerStore(SQLBaseStore):
             events, update_metrics=update_metrics
         )
 
-        missing_event_ids = {e for e in events if e not in event_map}
+        missing_event_ids = (e for e in events if e not in event_map)
         event_map.update(
             await self._get_events_from_external_cache(
                 events=missing_event_ids,

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -602,8 +602,8 @@ class EventsWorkerStore(SQLBaseStore):
         """
         # Shortcut: check if we have any events in the *in memory* cache - this function
         # may be called repeatedly for the same event so at this point we cannot reach
-        # out to any external cache for performance reasons, this is done later on in
-        # the `get_missing_events_from_cache_or_db` function below.
+        # out to any external cache for performance reasons. The external cache is
+        # checked later on in the `get_missing_events_from_cache_or_db` function below.
         event_entry_map = self._get_events_from_local_cache(
             event_ids,
         )
@@ -665,7 +665,8 @@ class EventsWorkerStore(SQLBaseStore):
                 #
                 missing_events = {}
                 try:
-                    # Try to fetch from any external cache, in-memory cache checked above
+                    # Try to fetch from any external cache. We already checked the
+                    # in-memory cache above.
                     missing_events = await self._get_events_from_external_cache(
                         missing_events_ids,
                     )

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -635,7 +635,9 @@ class EventsWorkerStore(SQLBaseStore):
 
         if missing_events_ids:
 
-            async def get_missing_events_from_cache_or_db() -> Dict[str, EventCacheEntry]:
+            async def get_missing_events_from_cache_or_db() -> Dict[
+                str, EventCacheEntry
+            ]:
                 """Fetches the events in `missing_event_ids` from the database.
 
                 Also creates entries in `self._current_event_fetches` to allow
@@ -773,7 +775,9 @@ class EventsWorkerStore(SQLBaseStore):
             events: list of event_ids to fetch
             update_metrics: Whether to update the cache hit ratio metrics
         """
-        event_map = self._get_events_from_local_cache(events, update_metrics=update_metrics)
+        event_map = self._get_events_from_local_cache(
+            events, update_metrics=update_metrics
+        )
 
         missing_event_ids = {e for e in events if e not in event_map}
 

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -896,7 +896,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         # We don't update the event cache hit ratio as it completely throws off
         # the hit ratio counts. After all, we don't populate the cache if we
         # miss it here
-        event_map = await self._get_events_from_cache(
+        event_map = self._get_events_from_local_cache(
             member_event_ids, update_metrics=False
         )
 

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -834,6 +834,12 @@ class AsyncLruCache(Generic[KT, VT]):
     ) -> Optional[VT]:
         return self._lru_cache.get(key, update_metrics=update_metrics)
 
+    async def get_external(
+        self, key: KT, default: Optional[T] = None, update_metrics: bool = True,
+    ) -> Optional[VT]:
+        # This method should fetch from any configured external cache, in this case noop.
+        return None
+
     def get_local(
         self, key: KT, default: Optional[T] = None, update_metrics: bool = True
     ) -> Optional[VT]:

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -835,7 +835,10 @@ class AsyncLruCache(Generic[KT, VT]):
         return self._lru_cache.get(key, update_metrics=update_metrics)
 
     async def get_external(
-        self, key: KT, default: Optional[T] = None, update_metrics: bool = True,
+        self,
+        key: KT,
+        default: Optional[T] = None,
+        update_metrics: bool = True,
     ) -> Optional[VT]:
         # This method should fetch from any configured external cache, in this case noop.
         return None

--- a/synapse/util/caches/lrucache.py
+++ b/synapse/util/caches/lrucache.py
@@ -834,7 +834,15 @@ class AsyncLruCache(Generic[KT, VT]):
     ) -> Optional[VT]:
         return self._lru_cache.get(key, update_metrics=update_metrics)
 
+    def get_local(
+        self, key: KT, default: Optional[T] = None, update_metrics: bool = True
+    ) -> Optional[VT]:
+        return self._lru_cache.get(key, update_metrics=update_metrics)
+
     async def set(self, key: KT, value: VT) -> None:
+        self._lru_cache.set(key, value)
+
+    def set_local(self, key: KT, value: VT) -> None:
         self._lru_cache.set(key, value)
 
     async def invalidate(self, key: KT) -> None:


### PR DESCRIPTION
We turned on Redis get event caching... and it hammered the CPU! The huge number of lookups came from the roomember optimisation lookup (changed in https://github.com/matrix-org/synapse/commit/030888bbfb7a8b86b06910a79be719ae2a0a9fed). I also changed the get events function to prevent double lookups from any external cache there too (unconfirmed whether that had any impact, but seems sensible).

Signed off by Nick @ Beeper (@fizzadar).

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
