### PR TITLE
Update module API "update room membership" method to allow for remote joins

### DIFF
--- a/changelog.d/13441.feature
+++ b/changelog.d/13441.feature
@@ -1,1 +1,1 @@
-Add remote join capability to the module API "update_room_membership" method (in a backwards compatible manner).
+Add remote join capability to the module API's `update_room_membership` method (in a backwards compatible manner).

--- a/changelog.d/13441.feature
+++ b/changelog.d/13441.feature
@@ -1,0 +1,1 @@
+Add remote join capability to the module API "update_room_membership" method (in a backwards compatible manner).

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -934,6 +934,7 @@ class ModuleApi:
         """Updates the membership of a user to the given value.
 
         Added in Synapse v1.46.0.
+        Changed in Synapse v1.65.0: Added the 'remote_room_hosts' parameter.
 
         Args:
             sender: The user performing the membership change. Must be a user local to

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -1013,10 +1013,6 @@ class ModuleApi:
         # Try to retrieve the resulting event.
         event = await self._hs.get_datastores().main.get_event(event_id)
 
-        # update_membership is supposed to always return after the event has been
-        # successfully persisted.
-        assert event is not None
-
         return event
 
     async def create_and_send_event_into_room(self, event_dict: JsonDict) -> EventBase:

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -117,7 +117,6 @@ from synapse.types import (
     JsonMapping,
     Requester,
     RoomAlias,
-    RoomID,
     StateMap,
     UserID,
     UserInfo,
@@ -930,7 +929,7 @@ class ModuleApi:
         room_id: str,
         new_membership: str,
         content: Optional[JsonDict] = None,
-        is_remote_join: bool = False,
+        remote_room_hosts: Optional[List[str]] = None,
     ) -> EventBase:
         """Updates the membership of a user to the given value.
 
@@ -948,9 +947,7 @@ class ModuleApi:
                 https://spec.matrix.org/unstable/client-server-api/#mroommember for the
                 list of allowed values.
             content: Additional values to include in the resulting event's content.
-            is_remote_join: Must be True if room_id refers to a remote room and
-                new_membership is "join" (i.e. a remote join is needed), otherwise must
-                be False.
+            remote_room_hosts: Remote servers to send the update to.
 
         Returns:
             The newly created membership event.
@@ -1004,17 +1001,13 @@ class ModuleApi:
             if "displayname" not in content:
                 content["displayname"] = profile["displayname"]
 
-        remote_room_hosts = None
-        if is_remote_join:
-            remote_room_hosts = [RoomID.from_string(room_id).domain]
-
         event_id, _ = await self._hs.get_room_member_handler().update_membership(
             requester=requester,
             target=target_user_id,
             room_id=room_id,
             action=new_membership,
-            remote_room_hosts=remote_room_hosts,
             content=content,
+            remote_room_hosts=remote_room_hosts,
         )
 
         # Try to retrieve the resulting event.

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -947,7 +947,7 @@ class ModuleApi:
                 https://spec.matrix.org/unstable/client-server-api/#mroommember for the
                 list of allowed values.
             content: Additional values to include in the resulting event's content.
-            remote_room_hosts: Remote servers to send the update to.
+            remote_room_hosts: Remote servers to use for remote joins/knocks/etc.
 
         Returns:
             The newly created membership event.

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -410,8 +410,7 @@ class ModuleApiTestCase(HomeserverTestCase):
 
         self.assertTrue(found_update)
 
-    @patch("synapse.handlers.room_member.RoomMemberMasterHandler._remote_join")
-    def test_update_membership(self, mocked_remote_join):
+    def test_update_membership(self):
         """Tests that the module API can update the membership of a user in a room."""
         peter = self.register_user("peter", "hackme")
         lesley = self.register_user("lesley", "hackme")
@@ -534,9 +533,8 @@ class ModuleApiTestCase(HomeserverTestCase):
         self.assertEqual(res["displayname"], "simone")
         self.assertIsNone(res["avatar_url"])
 
-        # Check that no remote join attempts have occurred thus far.
-        self.assertFalse(mocked_remote_join.called)
-
+    @patch("synapse.handlers.room_member.RoomMemberMasterHandler._remote_join")
+    def test_update_room_membership_remote_join(self, mocked_remote_join):
         # Necessary to fake a remote join.
         fake_stream_id = 1
         if isinstance(mocked_remote_join, MagicMock):
@@ -553,8 +551,8 @@ class ModuleApiTestCase(HomeserverTestCase):
         self.get_failure(
             defer.ensureDeferred(
                 self.module_api.update_room_membership(
-                    sender=peter,
-                    target=peter,
+                    sender=f"@user:{self.module_api.server_name}",
+                    target=f"@user:{self.module_api.server_name}",
                     room_id=f"!nonexistent:{fake_remote_host}",
                     new_membership="join",
                     remote_room_hosts=[fake_remote_host],


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

# Description

The current implementation is a manifestation of the discussion that ended [here](https://github.com/matrix-org/synapse/pull/11147#issuecomment-1202207819).

Following that discussion and prior to submitting this PR, I thought about the situation a bit more and came up with the following solutions:

1. Add some lines before [this line](https://github.com/matrix-org/synapse/blob/1c910e2216a2f7fa57971ffbdede509fd493ebb0/synapse/handlers/room_member.py#L929), which automatically adds in the hostname from `room_id` if `is_host_in_room` is `False`. Basically the equivalent of [these knocking lines](https://github.com/matrix-org/synapse/blob/1c910e2216a2f7fa57971ffbdede509fd493ebb0/synapse/handlers/room_member.py#L995-L997).
2. Similar to the previous solution, but do the `append`ing in the module API method (i.e. before [this line](https://github.com/matrix-org/synapse/blob/1c910e2216a2f7fa57971ffbdede509fd493ebb0/synapse/module_api/__init__.py#L1002)).
3. [Add a parameter to the module API method to control whether remote joining is done.](https://github.com/matrix-org/synapse/commit/6e2b45d78e3968de239db2283a82f0a4b996c389)

The solutions are ordered (in my opinion) from most invasive (i.e. least backwards compatible) to least invasive (most backwards compatible). They are also unfortunately reverse ordered (in my opinion) from most intuitive to least intuitive (from an API design/consumer perspective).

~I decided to go with the third option, for its desirable backwards compatibility trait.~ Took a different approach because of [this](https://github.com/matrix-org/synapse/pull/13441#discussion_r936397199).