### PR TITLE
Allow deleting all rows of a table using a new `simple_truncate` storage method

### DIFF
--- a/changelog.d/13446.misc
+++ b/changelog.d/13446.misc
@@ -1,1 +1,1 @@
-Allow dropping all rows from a database table via the `simple_delete` storage method.
+Allow dropping all rows from a database table via the `simple_truncate` storage method.

--- a/changelog.d/13446.misc
+++ b/changelog.d/13446.misc
@@ -1,0 +1,1 @@
+Allow dropping all rows from a database table via the `simple_delete` storage method.

--- a/changelog.d/13446.removal
+++ b/changelog.d/13446.removal
@@ -1,0 +1,1 @@
+Remove the unused `get_users` storage method.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -2195,8 +2195,7 @@ class DatabasePool:
             clauses.append("%s = ?" % (key,))
             values.append(value)
 
-        if clauses:
-            sql = "%s WHERE %s" % (sql, " AND ".join(clauses))
+        sql = "%s WHERE %s" % (sql, " AND ".join(clauses))
         txn.execute(sql, values)
 
         return txn.rowcount

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -2092,9 +2092,7 @@ class DatabasePool:
 
         Args:
             table: string giving the table name
-            keyvalues: dict of column names and values to select the row with. If an
-                empty dict is passed then no selection clauses are applied. Therefore,
-                ALL rows will be deleted.
+            keyvalues: dict of column names and values to select the row with
             desc: description of the transaction, for logging and metrics
 
         Returns:
@@ -2114,17 +2112,15 @@ class DatabasePool:
 
         Args:
             table: string giving the table name
-            keyvalues: dict of column names and values to select the row with. If an
-                empty dict is passed then no selection clauses are applied. Therefore,
-                ALL rows will be deleted.
+            keyvalues: dict of column names and values to select the row with
 
         Returns:
             The number of deleted rows.
         """
-        sql = "DELETE FROM %s" % (table,)
-
-        if keyvalues:
-            sql += " WHERE %s" % (" AND ".join("%s = ?" % (k,) for k in keyvalues),)
+        sql = "DELETE FROM %s WHERE %s" % (
+            table,
+            " AND ".join("%s = ?" % (k,) for k in keyvalues),
+        )
 
         txn.execute(sql, list(keyvalues.values()))
         return txn.rowcount
@@ -2139,19 +2135,18 @@ class DatabasePool:
     ) -> int:
         """Executes a DELETE query on the named table.
 
-        Filters rows if value of `column` is in `iterable`.
+        Filters rows by if value of `column` is in `iterable`.
 
         Args:
             table: string giving the table name
             column: column name to test for inclusion against `iterable`
             iterable: list of values to match against `column`. NB cannot be a generator
                 as it may be evaluated multiple times.
-            keyvalues: dict of column names and values to select the rows with. If an
-                emtpy dict is passed, this option will have no effect.
+            keyvalues: dict of column names and values to select the rows with
             desc: description of the transaction, for logging and metrics
 
         Returns:
-            The number of deleted rows.
+            Number rows deleted
         """
         return await self.runInteraction(
             desc,
@@ -2183,11 +2178,10 @@ class DatabasePool:
             column: column name to test for inclusion against `values`
             values: values of `column` which choose rows to delete
             keyvalues: dict of extra column names and values to select the rows
-                with. They will be ANDed together with the main predicate. If an
-                empty dict is passed, this option will have no effect.
+                with. They will be ANDed together with the main predicate.
 
         Returns:
-            The number of deleted rows.
+            Number rows deleted
         """
         if not values:
             return 0
@@ -2201,8 +2195,8 @@ class DatabasePool:
             clauses.append("%s = ?" % (key,))
             values.append(value)
 
-        sql = "%s WHERE %s" % (sql, " AND ".join(clauses))
-
+        if clauses:
+            sql = "%s WHERE %s" % (sql, " AND ".join(clauses))
         txn.execute(sql, values)
 
         return txn.rowcount

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -2112,11 +2112,15 @@ class DatabasePool:
 
         Args:
             table: string giving the table name
-            keyvalues: dict of column names and values to select the row with
+            keyvalues: dict of column names and values to select the row with. If empty,
+                no rows will be deleted.
 
         Returns:
             The number of deleted rows.
         """
+        if not keyvalues:
+            return 0
+
         sql = "DELETE FROM %s WHERE %s" % (
             table,
             " AND ".join("%s = ?" % (k,) for k in keyvalues),

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -2242,10 +2242,10 @@ class DatabasePool:
             table: The name of the table to delete all rows from.
         """
         if isinstance(txn.database_engine, PostgresEngine):
-            sql = "TRUNCATE %s" % table
+            sql = f"TRUNCATE {table}"
         else:
             # SQLite does not support the TRUNCATE command
-            sql = "DELETE FROM %s" % table
+            sql = f"DELETE FROM {table}"
 
         txn.execute(sql)
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -2108,18 +2108,25 @@ class DatabasePool:
     ) -> int:
         """Executes a DELETE query on the named table.
 
-        Filters rows by the key-value pairs.
+        Filter rows by the key-value pairs.
 
         Args:
             table: string giving the table name
-            keyvalues: dict of column names and values to select the row with. If empty,
-                no rows will be deleted.
+            keyvalues: dict of column names and values to select the row with. Must
+                not be empty.
 
         Returns:
             The number of deleted rows.
+
+        Raises:
+            ValueError: if keyvalues was a falsey value, such as an empty dict.
         """
         if not keyvalues:
-            return 0
+            raise ValueError(
+                "'keyvalues' arg to simple_delete_txn was falsey. If you were trying to "
+                "delete all rows from a database, perhaps try "
+                "DatabasePool.simple_truncate instead?"
+            )
 
         sql = "DELETE FROM %s WHERE %s" % (
             table,

--- a/synapse/storage/databases/main/__init__.py
+++ b/synapse/storage/databases/main/__init__.py
@@ -173,26 +173,6 @@ class DataStore(
         # TODO: shouldn't this be moved to `DeviceWorkerStore`?
         return self._device_list_id_gen.get_current_token()
 
-    async def get_users(self) -> List[JsonDict]:
-        """Function to retrieve a list of users in users table.
-
-        Returns:
-            A list of dictionaries representing users.
-        """
-        return await self.db_pool.simple_select_list(
-            table="users",
-            keyvalues={},
-            retcols=[
-                "name",
-                "password_hash",
-                "is_guest",
-                "admin",
-                "user_type",
-                "deactivated",
-            ],
-            desc="get_users",
-        )
-
     async def get_users_paginate(
         self,
         start: int,

--- a/tests/storage/test__base.py
+++ b/tests/storage/test__base.py
@@ -196,14 +196,12 @@ class SimpleTruncateTestCase(unittest.HomeserverTestCase):
         self.assertGreater(len(table_rows), 0)
 
         # Attempt to truncate the table
-        number_of_deleted_rows = self.get_success(
+        self.get_success(
             self.storage.db_pool.simple_truncate(
                 table=self.table_name,
                 desc="simple_truncate_test_truncate",
             )
         )
-        # Check that the number of deleted rows is as we expect.
-        self.assertEqual(number_of_deleted_rows, len(table_rows))
 
         # Perform another select and ensure there are no remaining rows.
         table_rows = self.get_success(


### PR DESCRIPTION
This PR adds a new storage method called `simple_truncate` that does what it says on the tin: truncates a given database table.

In addition, this PR modifies a couple storage methods:

* Passing an empty dictionary for the `keyvalues` argument to `simple_delete` would result in an invalid query error. It now simply returns 0, for 0 rows modified.
* The `get_users` storage method has been deleted (it would return a list of *all* users on the homeserver) which was not in use. My IDE picked up on it while I was in the area.

This change was motivated by needing to clear all rows from a table as part of custom room preset work. Note that due to `iterable` being a required argument for `simple_delete_many`, it was not possible to select all rows for deletion.