### PR TITLE
Fix `@tag_args` being off-by-one (ahead)

### DIFF
--- a/changelog.d/13452.misc
+++ b/changelog.d/13452.misc
@@ -1,0 +1,1 @@
+Fix `@tag_args` being off-by-one with the arguments when tagging a span (tracing).

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -901,6 +901,11 @@ def trace(func: Callable[P, R]) -> Callable[P, R]:
 def tag_args(func: Callable[P, R]) -> Callable[P, R]:
     """
     Tags all of the args to the active span.
+
+    Args:
+    func: `func` is assumed to be a method taking a `self` parameter, or a
+        `classmethod` taking a `cls` parameter. In either case, a tag is not created
+        for this parameter.
     """
 
     if not opentracing:

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -909,8 +909,9 @@ def tag_args(func: Callable[P, R]) -> Callable[P, R]:
     @wraps(func)
     def _tag_args_inner(*args: P.args, **kwargs: P.kwargs) -> R:
         argspec = inspect.getfullargspec(func)
+        # We use `[1:]` to skip the `self` object reference
         for i, arg in enumerate(argspec.args[1:]):
-            set_tag("ARG_" + arg, str(args[i]))  # type: ignore[index]
+            set_tag("ARG_" + arg, str(args[i + 1]))  # type: ignore[index]
         set_tag("args", str(args[len(argspec.args) :]))  # type: ignore[index]
         set_tag("kwargs", str(kwargs))
         return func(*args, **kwargs)

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -916,6 +916,10 @@ def tag_args(func: Callable[P, R]) -> Callable[P, R]:
         argspec = inspect.getfullargspec(func)
         # We use `[1:]` to skip the `self` object reference and `start=1` to
         # make the index line up with `argspec.args`.
+        #
+        # FIXME: We could update this handle any type of function by ignoring the
+        #   first argument only if it's named `self` or `cls`. This isn't fool-proof
+        #   but handles the idiomatic cases.
         for i, arg in enumerate(args[1:], start=1):  # type: ignore[index]
             set_tag("ARG_" + argspec.args[i], str(arg))
         set_tag("args", str(args[len(argspec.args) :]))  # type: ignore[index]

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -910,8 +910,8 @@ def tag_args(func: Callable[P, R]) -> Callable[P, R]:
     def _tag_args_inner(*args: P.args, **kwargs: P.kwargs) -> R:
         argspec = inspect.getfullargspec(func)
         # We use `[1:]` to skip the `self` object reference
-        for i, arg in enumerate(argspec.args[1:]):
-            set_tag("ARG_" + arg, str(args[i + 1]))  # type: ignore[index]
+        for i, arg in enumerate(args[1:]):
+            set_tag("ARG_" + argspec.args[i + 1], str(arg))  # type: ignore[index]
         set_tag("args", str(args[len(argspec.args) :]))  # type: ignore[index]
         set_tag("kwargs", str(kwargs))
         return func(*args, **kwargs)

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -903,9 +903,9 @@ def tag_args(func: Callable[P, R]) -> Callable[P, R]:
     Tags all of the args to the active span.
 
     Args:
-    func: `func` is assumed to be a method taking a `self` parameter, or a
-        `classmethod` taking a `cls` parameter. In either case, a tag is not created
-        for this parameter.
+        func: `func` is assumed to be a method taking a `self` parameter, or a
+            `classmethod` taking a `cls` parameter. In either case, a tag is not
+            created for this parameter.
     """
 
     if not opentracing:
@@ -916,8 +916,8 @@ def tag_args(func: Callable[P, R]) -> Callable[P, R]:
         argspec = inspect.getfullargspec(func)
         # We use `[1:]` to skip the `self` object reference and `start=1` to
         # make the index line up with `argspec.args`.
-        for i, arg in enumerate(args[1:], start=1):
-            set_tag("ARG_" + argspec.args[i], str(arg))  # type: ignore[index]
+        for i, arg in enumerate(args[1:], start=1):  # type: ignore[index]
+            set_tag("ARG_" + argspec.args[i], str(arg))
         set_tag("args", str(args[len(argspec.args) :]))  # type: ignore[index]
         set_tag("kwargs", str(kwargs))
         return func(*args, **kwargs)

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -909,9 +909,10 @@ def tag_args(func: Callable[P, R]) -> Callable[P, R]:
     @wraps(func)
     def _tag_args_inner(*args: P.args, **kwargs: P.kwargs) -> R:
         argspec = inspect.getfullargspec(func)
-        # We use `[1:]` to skip the `self` object reference
-        for i, arg in enumerate(args[1:]):
-            set_tag("ARG_" + argspec.args[i + 1], str(arg))  # type: ignore[index]
+        # We use `[1:]` to skip the `self` object reference and `start=1` to
+        # make the index line up with `argspec.args`.
+        for i, arg in enumerate(args[1:], start=1):
+            set_tag("ARG_" + argspec.args[i], str(arg))  # type: ignore[index]
         set_tag("args", str(args[len(argspec.args) :]))  # type: ignore[index]
         set_tag("kwargs", str(kwargs))
         return func(*args, **kwargs)


### PR DESCRIPTION
Fix `@tag_args` being off-by-one (ahead)

Before | After
--- | ---
<img width="667" alt="" src="https://user-images.githubusercontent.com/558581/182746546-d133b469-2f30-4e07-8b85-4cf3d363649d.png"> | <img width="473" alt="" src="https://user-images.githubusercontent.com/558581/182746316-30dc3bb7-a602-4aaf-85e2-4dd6eb825de0.png">


Example:

```
argspec.args=[
  'self',
  'room_id'
]

args=(
  <synapse.storage.databases.main.DataStore object at 0x10d0b8d00>,
  '!HBehERstyQBxyJDLfR:my.synapse.server'
)
```

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
