### PR TITLE
Allow the simple_upsert database unit test case to run

### DIFF
--- a/changelog.d/13458.misc
+++ b/changelog.d/13458.misc
@@ -1,0 +1,1 @@
+Make the unit tests responsible for testing the `simple_update` storage method run in CI.

--- a/tests/storage/test__base.py
+++ b/tests/storage/test__base.py
@@ -24,7 +24,7 @@ from synapse.util import Clock
 from tests import unittest
 
 
-class UpdateUpsertManyTests(unittest.HomeserverTestCase):
+class UpdateUpsertManyTestCase(unittest.HomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.storage = hs.get_datastores().main
 


### PR DESCRIPTION
Test cases won't be picked up by trial unless the class name ends in `TestCase`. Modify the name of this class so that it ends in `TestCase`.

Spotted while implementing #13446. Checked by looking at any existing test run. Ctrl-F'ing `UpdateUpsertManyTests` yielded no results.