### PR TITLE
Strengthen tests about deleted old push actions.

### DIFF
--- a/changelog.d/13471.misc
+++ b/changelog.d/13471.misc
@@ -1,0 +1,1 @@
+Clean-up tests for notifications.


### PR DESCRIPTION
This somewhat "regressed" in #13260.