### PR TITLE
Avoid blocking lazy-loading `/sync`s during partial joins

### DIFF
--- a/changelog.d/13477.misc
+++ b/changelog.d/13477.misc
@@ -1,0 +1,1 @@
+Faster room joins: Avoid blocking lazy-loading `/sync`s during partial joins due to remote memberships. Pull remote memberships from auth events instead of the room state.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -964,19 +964,26 @@ class SyncHandler:
                 if batch:
                     state_at_timeline_end = (
                         await self._state_storage_controller.get_state_ids_for_event(
-                            batch.events[-1].event_id, state_filter=state_filter
+                            batch.events[-1].event_id,
+                            state_filter=state_filter,
+                            await_full_state=not lazy_load_members,
                         )
                     )
 
                     state_at_timeline_start = (
                         await self._state_storage_controller.get_state_ids_for_event(
-                            batch.events[0].event_id, state_filter=state_filter
+                            batch.events[0].event_id,
+                            state_filter=state_filter,
+                            await_full_state=not lazy_load_members,
                         )
                     )
 
                 else:
                     state_at_timeline_end = await self.get_state_at(
-                        room_id, stream_position=now_token, state_filter=state_filter
+                        room_id,
+                        stream_position=now_token,
+                        state_filter=state_filter,
+                        await_full_state=not lazy_load_members,
                     )
 
                     state_at_timeline_start = state_at_timeline_end
@@ -992,14 +999,19 @@ class SyncHandler:
                 if batch:
                     state_at_timeline_start = (
                         await self._state_storage_controller.get_state_ids_for_event(
-                            batch.events[0].event_id, state_filter=state_filter
+                            batch.events[0].event_id,
+                            state_filter=state_filter,
+                            await_full_state=not lazy_load_members,
                         )
                     )
                 else:
                     # We can get here if the user has ignored the senders of all
                     # the recent events.
                     state_at_timeline_start = await self.get_state_at(
-                        room_id, stream_position=now_token, state_filter=state_filter
+                        room_id,
+                        stream_position=now_token,
+                        state_filter=state_filter,
+                        await_full_state=not lazy_load_members,
                     )
 
                 # for now, we disable LL for gappy syncs - see
@@ -1021,20 +1033,28 @@ class SyncHandler:
                 # is indeed the case.
                 assert since_token is not None
                 state_at_previous_sync = await self.get_state_at(
-                    room_id, stream_position=since_token, state_filter=state_filter
+                    room_id,
+                    stream_position=since_token,
+                    state_filter=state_filter,
+                    await_full_state=not lazy_load_members,
                 )
 
                 if batch:
                     state_at_timeline_end = (
                         await self._state_storage_controller.get_state_ids_for_event(
-                            batch.events[-1].event_id, state_filter=state_filter
+                            batch.events[-1].event_id,
+                            state_filter=state_filter,
+                            await_full_state=not lazy_load_members,
                         )
                     )
                 else:
                     # We can get here if the user has ignored the senders of all
                     # the recent events.
                     state_at_timeline_end = await self.get_state_at(
-                        room_id, stream_position=now_token, state_filter=state_filter
+                        room_id,
+                        stream_position=now_token,
+                        state_filter=state_filter,
+                        await_full_state=not lazy_load_members,
                     )
 
                 state_ids = _calculate_state(
@@ -1064,8 +1084,10 @@ class SyncHandler:
                                 (EventTypes.Member, member)
                                 for member in members_to_fetch
                             ),
+                            await_full_state=False,
                         )
 
+            # FIXME: `state_ids` may be missing memberships for partial state rooms.
             # At this point, if `lazy_load_members` is enabled, `state_ids` includes
             # the memberships of all event senders in the timeline. This is because we
             # may not have sent the memberships in a previous sync.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1758,7 +1758,11 @@ class SyncHandler:
                 continue
 
             if room_id in sync_result_builder.joined_room_ids or has_join:
-                old_state_ids = await self.get_state_at(room_id, since_token)
+                old_state_ids = await self.get_state_at(
+                    room_id,
+                    since_token,
+                    state_filter=StateFilter.from_types([(EventTypes.Member, user_id)]),
+                )
                 old_mem_ev_id = old_state_ids.get((EventTypes.Member, user_id), None)
                 old_mem_ev = None
                 if old_mem_ev_id:
@@ -1784,7 +1788,13 @@ class SyncHandler:
                     newly_left_rooms.append(room_id)
                 else:
                     if not old_state_ids:
-                        old_state_ids = await self.get_state_at(room_id, since_token)
+                        old_state_ids = await self.get_state_at(
+                            room_id,
+                            since_token,
+                            state_filter=StateFilter.from_types(
+                                [(EventTypes.Member, user_id)]
+                            ),
+                        )
                         old_mem_ev_id = old_state_ids.get(
                             (EventTypes.Member, user_id), None
                         )

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -653,7 +653,7 @@ class SyncHandler:
         self,
         event_id: str,
         state_filter: Optional[StateFilter] = None,
-        await_full_state: Optional[bool] = None,
+        await_full_state: bool = True,
     ) -> StateMap[str]:
         """
         Get the room state after the given event
@@ -662,8 +662,8 @@ class SyncHandler:
             event_id: event of interest
             state_filter: The state filter used to fetch state from the database.
             await_full_state: if `True`, will block if we do not yet have complete state
-                at the event. Defaults to `True` unless `state_filter` can be completely
-                satisfied with partial state.
+                at the event and `state_filter` is not satisfied by partial state.
+                Defaults to `True`.
         """
         state_ids = await self._state_storage_controller.get_state_ids_for_event(
             event_id,
@@ -691,7 +691,7 @@ class SyncHandler:
         room_id: str,
         stream_position: StreamToken,
         state_filter: Optional[StateFilter] = None,
-        await_full_state: Optional[bool] = None,
+        await_full_state: bool = True,
     ) -> StateMap[str]:
         """Get the room state at a particular stream position
 
@@ -700,9 +700,8 @@ class SyncHandler:
             stream_position: point at which to get state
             state_filter: The state filter used to fetch state from the database.
             await_full_state: if `True`, will block if we do not yet have complete state
-                at the last event in the room before `stream_position`. Defaults to
-                `True` unless `state_filter` can be completely satisfied with partial
-                state.
+                at the last event in the room before `stream_position` and
+                `state_filter` is not satisfied by partial state. Defaults to `True`.
         """
         # FIXME: This gets the state at the latest event before the stream ordering,
         # which might not be the same as the "current state" of the room at the time

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -232,6 +232,7 @@ class StateStorageController:
         self,
         event_ids: Collection[str],
         state_filter: Optional[StateFilter] = None,
+        await_full_state: Optional[bool] = None,
     ) -> Dict[str, StateMap[str]]:
         """
         Get the state dicts corresponding to a list of events, containing the event_ids
@@ -240,6 +241,9 @@ class StateStorageController:
         Args:
             event_ids: events whose state should be returned
             state_filter: The state filter used to fetch state from the database.
+            await_full_state: if `True`, will block if we do not yet have complete state
+                at these events. Defaults to `True` unless `state_filter` can be
+                completely satisfied with partial state.
 
         Returns:
             A dict from event_id -> (type, state_key) -> event_id
@@ -248,9 +252,13 @@ class StateStorageController:
             RuntimeError if we don't have a state group for one or more of the events
                 (ie they are outliers or unknown)
         """
-        await_full_state = True
-        if state_filter and not state_filter.must_await_full_state(self._is_mine_id):
-            await_full_state = False
+        if await_full_state is None:
+            if state_filter and not state_filter.must_await_full_state(
+                self._is_mine_id
+            ):
+                await_full_state = False
+            else:
+                await_full_state = True
 
         event_to_groups = await self.get_state_group_for_events(
             event_ids, await_full_state=await_full_state
@@ -292,7 +300,10 @@ class StateStorageController:
 
     @trace
     async def get_state_ids_for_event(
-        self, event_id: str, state_filter: Optional[StateFilter] = None
+        self,
+        event_id: str,
+        state_filter: Optional[StateFilter] = None,
+        await_full_state: Optional[bool] = None,
     ) -> StateMap[str]:
         """
         Get the state dict corresponding to a particular event
@@ -300,6 +311,9 @@ class StateStorageController:
         Args:
             event_id: event whose state should be returned
             state_filter: The state filter used to fetch state from the database.
+            await_full_state: if `True`, will block if we do not yet have complete state
+                at the event. Defaults to `True` unless `state_filter` can be completely
+                satisfied with partial state.
 
         Returns:
             A dict from (type, state_key) -> state_event_id
@@ -309,7 +323,9 @@ class StateStorageController:
                 outlier or is unknown)
         """
         state_map = await self.get_state_ids_for_events(
-            [event_id], state_filter or StateFilter.all()
+            [event_id],
+            state_filter or StateFilter.all(),
+            await_full_state=await_full_state,
         )
         return state_map[event_id]
 

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -232,7 +232,7 @@ class StateStorageController:
         self,
         event_ids: Collection[str],
         state_filter: Optional[StateFilter] = None,
-        await_full_state: Optional[bool] = None,
+        await_full_state: bool = True,
     ) -> Dict[str, StateMap[str]]:
         """
         Get the state dicts corresponding to a list of events, containing the event_ids
@@ -242,8 +242,8 @@ class StateStorageController:
             event_ids: events whose state should be returned
             state_filter: The state filter used to fetch state from the database.
             await_full_state: if `True`, will block if we do not yet have complete state
-                at these events. Defaults to `True` unless `state_filter` can be
-                completely satisfied with partial state.
+                at these events and `state_filter` is not satisfied by partial state.
+                Defaults to `True`.
 
         Returns:
             A dict from event_id -> (type, state_key) -> event_id
@@ -252,13 +252,13 @@ class StateStorageController:
             RuntimeError if we don't have a state group for one or more of the events
                 (ie they are outliers or unknown)
         """
-        if await_full_state is None:
-            if state_filter and not state_filter.must_await_full_state(
-                self._is_mine_id
-            ):
-                await_full_state = False
-            else:
-                await_full_state = True
+        if (
+            await_full_state
+            and state_filter
+            and not state_filter.must_await_full_state(self._is_mine_id)
+        ):
+            # Full state is not required if the state filter is restrictive enough.
+            await_full_state = False
 
         event_to_groups = await self.get_state_group_for_events(
             event_ids, await_full_state=await_full_state
@@ -303,7 +303,7 @@ class StateStorageController:
         self,
         event_id: str,
         state_filter: Optional[StateFilter] = None,
-        await_full_state: Optional[bool] = None,
+        await_full_state: bool = True,
     ) -> StateMap[str]:
         """
         Get the state dict corresponding to a particular event
@@ -312,8 +312,8 @@ class StateStorageController:
             event_id: event whose state should be returned
             state_filter: The state filter used to fetch state from the database.
             await_full_state: if `True`, will block if we do not yet have complete state
-                at the event. Defaults to `True` unless `state_filter` can be completely
-                satisfied with partial state.
+                at the event and `state_filter` is not satisfied by partial state.
+                Defaults to `True`.
 
         Returns:
             A dict from (type, state_key) -> state_event_id


### PR DESCRIPTION
Use a state filter or accept partial state in a few places where we
request state, to avoid blocking.

To make lazy-loading `/sync`s work, we need to provide the memberships
of event senders, which are not guaranteed to be in the room state.
Instead we dig through auth events for memberships to present to
clients. The auth events of an event are guaranteed to contain a
passable membership event, otherwise the event would have been rejected.

Note that this only covers the common code paths encountered during
testing. There has been no exhaustive checking of all sync code paths.

Fixes #13146.

Signed-off-by: Sean Quah <seanq@matrix.org>

---

May or may not be easier to review commit by commit.

Complement tests:
- https://github.com/matrix-org/complement/pull/440
- https://github.com/matrix-org/complement/pull/441
- https://github.com/matrix-org/complement/pull/442

