### PR TITLE
Prepatory work for batching events to send

### DIFF
--- a/changelog.d/13487.misc
+++ b/changelog.d/13487.misc
@@ -1,1 +1,1 @@
-Batch up events to be bulk persisted when creating a new room.
+Speed up creation of DM rooms.

--- a/changelog.d/13487.misc
+++ b/changelog.d/13487.misc
@@ -1,0 +1,1 @@
+Batch up events to be bulk persisted when creating a new room.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -716,7 +716,7 @@ class RoomCreationHandler:
 
         if (
             self._server_notices_mxid is not None
-            and requester.user.to_string() == self._server_notices_mxid
+            and user_id == self._server_notices_mxid
         ):
             # allow the server notices mxid to create rooms
             is_requester_admin = True
@@ -1059,7 +1059,7 @@ class RoomCreationHandler:
         depth = 1
         last_sent_event_id: Optional[str] = None
 
-        def create(etype: str, content: JsonDict, **kwargs: Any) -> JsonDict:
+        def create_event_dict(etype: str, content: JsonDict, **kwargs: Any) -> JsonDict:
             e = {"type": etype, "content": content}
 
             e.update(event_keys)
@@ -1067,32 +1067,48 @@ class RoomCreationHandler:
 
             return e
 
-        async def send(etype: str, content: JsonDict, **kwargs: Any) -> int:
+        async def create_event(
+            etype: str, content: JsonDict, **kwargs: Any
+        ) -> Tuple[EventBase, synapse.events.snapshot.EventContext]:
             nonlocal last_sent_event_id
             nonlocal depth
 
-            event = create(etype, content, **kwargs)
-            logger.debug("Sending %s in new room", etype)
-            # Allow these events to be sent even if the user is shadow-banned to
-            # allow the room creation to complete.
-            (
-                sent_event,
-                last_stream_id,
-            ) = await self.event_creation_handler.create_and_send_nonmember_event(
+            event_dict = create_event_dict(etype, content, **kwargs)
+
+            event, context = await self.event_creation_handler.create_event(
                 creator,
-                event,
-                ratelimit=False,
-                ignore_shadow_ban=True,
-                # Note: we don't pass state_event_ids here because this triggers
-                # an additional query per event to look them up from the events table.
+                event_dict,
                 prev_event_ids=[last_sent_event_id] if last_sent_event_id else [],
                 depth=depth,
             )
 
-            last_sent_event_id = sent_event.event_id
+            return event, context
+
+        async def send(
+            event: EventBase,
+            context: synapse.events.snapshot.EventContext,
+            creator: Requester,
+        ) -> int:
+            nonlocal last_sent_event_id
+            nonlocal depth
+            assert self.hs.is_mine_id(event.sender), "User must be our own: %s" % (
+                event.sender,
+            )
+
+            ev = await self.event_creation_handler.handle_new_client_event(
+                requester=creator,
+                event=event,
+                context=context,
+                ratelimit=False,
+                ignore_shadow_ban=True,
+            )
+
+            last_sent_event_id = ev.event_id
             depth += 1
 
-            return last_stream_id
+            # we know it was persisted, so must have a stream ordering
+            assert ev.internal_metadata.stream_ordering
+            return ev.internal_metadata.stream_ordering
 
         try:
             config = self._presets_dict[preset_config]
@@ -1102,9 +1118,13 @@ class RoomCreationHandler:
             )
 
         creation_content.update({"creator": creator_id})
-        await send(etype=EventTypes.Create, content=creation_content)
+        creation_event, creation_context = await create_event(
+            etype=EventTypes.Create, content=creation_content
+        )
 
         logger.debug("Sending %s in new room", EventTypes.Member)
+        await send(creation_event, creation_context, creator)
+
         # Room create event must exist at this point
         assert last_sent_event_id is not None
         member_event_id, _ = await self.room_member_handler.update_membership(
@@ -1124,9 +1144,10 @@ class RoomCreationHandler:
         # of the first events that get sent into a room.
         pl_content = initial_state.pop((EventTypes.PowerLevels, ""), None)
         if pl_content is not None:
-            last_sent_stream_id = await send(
+            power_event, power_context = await create_event(
                 etype=EventTypes.PowerLevels, content=pl_content
             )
+            last_sent_stream_id = await send(power_event, power_context, creator)
         else:
             power_level_content: JsonDict = {
                 "users": {creator_id: 100},
@@ -1170,44 +1191,64 @@ class RoomCreationHandler:
             if power_level_content_override:
                 power_level_content.update(power_level_content_override)
 
-            last_sent_stream_id = await send(
+            pl_event, pl_context = await create_event(
                 etype=EventTypes.PowerLevels, content=power_level_content
             )
+            last_sent_stream_id = await send(pl_event, pl_context, creator)
 
         if room_alias and (EventTypes.CanonicalAlias, "") not in initial_state:
-            last_sent_stream_id = await send(
+            room_alias_event, room_alias_context = await create_event(
                 etype=EventTypes.CanonicalAlias,
                 content={"alias": room_alias.to_string()},
             )
+            last_sent_stream_id = await send(
+                room_alias_event, room_alias_context, creator
+            )
 
         if (EventTypes.JoinRules, "") not in initial_state:
-            last_sent_stream_id = await send(
+            join_rules_event, join_rules_context = await create_event(
                 etype=EventTypes.JoinRules, content={"join_rule": config["join_rules"]}
+            )
+            last_sent_stream_id = await send(
+                join_rules_event, join_rules_context, creator
             )
 
         if (EventTypes.RoomHistoryVisibility, "") not in initial_state:
-            last_sent_stream_id = await send(
+            visibility_event, visibility_context = await create_event(
                 etype=EventTypes.RoomHistoryVisibility,
                 content={"history_visibility": config["history_visibility"]},
+            )
+            last_sent_stream_id = await send(
+                visibility_event, visibility_context, creator
             )
 
         if config["guest_can_join"]:
             if (EventTypes.GuestAccess, "") not in initial_state:
-                last_sent_stream_id = await send(
+                guest_access_event, guest_access_context = await create_event(
                     etype=EventTypes.GuestAccess,
                     content={EventContentFields.GUEST_ACCESS: GuestAccess.CAN_JOIN},
                 )
+                last_sent_stream_id = await send(
+                    guest_access_event, guest_access_context, creator
+                )
 
+        events = []
         for (etype, state_key), content in initial_state.items():
-            last_sent_stream_id = await send(
+            event, context = await create_event(
                 etype=etype, state_key=state_key, content=content
             )
+            events.append((event, context))
+        for event, context in events:
+            last_sent_stream_id = await send(event, context, creator)
 
         if config["encrypted"]:
-            last_sent_stream_id = await send(
+            encryption_event, encryption_context = await create_event(
                 etype=EventTypes.RoomEncryption,
                 state_key="",
                 content={"algorithm": RoomEncryptionAlgorithms.DEFAULT},
+            )
+            last_sent_stream_id = await send(
+                encryption_event, encryption_context, creator
             )
 
         return last_sent_stream_id, last_sent_event_id, depth

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1064,7 +1064,7 @@ class RoomCreationHandler:
         # a map of event types, state keys -> event_ids. We collect these mappings this as events are
         # created (but not persisted to the db) to determine state for future created events
         # (as this info can't be pulled from the db)
-        state_map: dict = {}
+        state_map: MutableStateMap[str] = {}
         # current_state_group of last event created. Used for computing event context of
         # events to be batched
         current_state_group = None

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -282,6 +282,7 @@ class StateHandler:
             RuntimeError if `state_ids_before_event` is not provided and one or more
                 prev events are missing or outliers.
         """
+
         assert not event.internal_metadata.is_outlier()
 
         #
@@ -332,7 +333,6 @@ class StateHandler:
             logger.debug("calling resolve_state_groups from compute_event_context")
             # we've already taken into account partial state, so no need to wait for
             # complete state here.
-
             entry = await self.resolve_state_groups_for_events(
                 event.room_id,
                 event.prev_event_ids(),

--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -282,7 +282,6 @@ class StateHandler:
             RuntimeError if `state_ids_before_event` is not provided and one or more
                 prev events are missing or outliers.
         """
-
         assert not event.internal_metadata.is_outlier()
 
         #
@@ -333,6 +332,7 @@ class StateHandler:
             logger.debug("calling resolve_state_groups from compute_event_context")
             # we've already taken into account partial state, so no need to wait for
             # complete state here.
+
             entry = await self.resolve_state_groups_for_events(
                 event.room_id,
                 event.prev_event_ids(),
@@ -418,6 +418,69 @@ class StateHandler:
             prev_group=state_group_before_event,
             delta_ids=delta_ids,
             partial_state=partial_state,
+        )
+
+    async def compute_event_context_for_batched(
+        self,
+        event: EventBase,
+        state_ids_before_event: StateMap[str],
+        current_state_group: int,
+    ) -> EventContext:
+        """
+        Generate an event context for an event that has not yet been persisted to the
+        database. Intended for use with events that are created to be persisted in a batch.
+        Args:
+            event: the event the context is being computed for
+            state_ids_before_event: a state map consisting of the state ids of the events
+            created prior to this event.
+            current_state_group: the current state group before the event.
+        """
+        state_group_before_event_prev_group = None
+        deltas_to_state_group_before_event = None
+
+        state_group_before_event = current_state_group
+
+        # if the event is not state, we are set
+        if not event.is_state():
+            return EventContext.with_state(
+                storage=self._storage_controllers,
+                state_group_before_event=state_group_before_event,
+                state_group=state_group_before_event,
+                state_delta_due_to_event={},
+                prev_group=state_group_before_event_prev_group,
+                delta_ids=deltas_to_state_group_before_event,
+                partial_state=False,
+            )
+
+        # otherwise, we'll need to create a new state group for after the event
+        key = (event.type, event.state_key)
+
+        if state_ids_before_event is not None:
+            replaces = state_ids_before_event.get(key)
+
+        if replaces and replaces != event.event_id:
+            event.unsigned["replaces_state"] = replaces
+
+        delta_ids = {key: event.event_id}
+
+        state_group_after_event = (
+            await self._state_storage_controller.store_state_group(
+                event.event_id,
+                event.room_id,
+                prev_group=state_group_before_event,
+                delta_ids=delta_ids,
+                current_state_ids=None,
+            )
+        )
+
+        return EventContext.with_state(
+            storage=self._storage_controllers,
+            state_group=state_group_after_event,
+            state_group_before_event=state_group_before_event,
+            state_delta_due_to_event=delta_ids,
+            prev_group=state_group_before_event,
+            delta_ids=delta_ids,
+            partial_state=False,
         )
 
     @measure_func()

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -710,7 +710,7 @@ class RoomsCreateTestCase(RoomBase):
         self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
         self.assertTrue("room_id" in channel.json_body)
         assert channel.resource_usage is not None
-        self.assertEqual(44, channel.resource_usage.db_txn_count)
+        self.assertEqual(35, channel.resource_usage.db_txn_count)
 
     def test_post_room_initial_state(self) -> None:
         # POST with initial_state config key, expect new room id
@@ -723,7 +723,7 @@ class RoomsCreateTestCase(RoomBase):
         self.assertEqual(HTTPStatus.OK, channel.code, channel.result)
         self.assertTrue("room_id" in channel.json_body)
         assert channel.resource_usage is not None
-        self.assertEqual(50, channel.resource_usage.db_txn_count)
+        self.assertEqual(38, channel.resource_usage.db_txn_count)
 
     def test_post_room_visibility_key(self) -> None:
         # POST with visibility config key, expect new room id


### PR DESCRIPTION
This PR begins work on batching up events during the creation of a room. The PR splits out the creation and sending/persisting of the events. The first three events in the creation of the room-creating the room, joining the creator to the room, and the power levels event are sent sequentially, while the subsequent events are created and collected to be sent at the end of the function. This is currently done by appending them to a list and then iterating over the list to send, the next step (after this PR) would be to send and persist the collected events as a batch. 
