### PR TITLE
Add note to `redaction_retention_period` documentation mentioning that event purging runs at most every 5m

### DIFF
--- a/changelog.d/13492.doc
+++ b/changelog.d/13492.doc
@@ -1,0 +1,1 @@
+Document that event purging related to the `redaction_retention_period` config option is executed only every 5 minutes.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -759,6 +759,10 @@ allowed_avatar_mimetypes: ["image/png", "image/jpeg", "image/gif"]
 How long to keep redacted events in unredacted form in the database. After
 this period redacted events get replaced with their redacted form in the DB.
 
+Synapse will check whether the rentention period has concluded for redacted
+events every 5 minutes. Thus, even if this option is set to `0`, Synapse may
+still take up to 5 minutes to purge redacted events from the database.
+
 Defaults to `7d`. Set to `null` to disable.
 
 Example configuration:


### PR DESCRIPTION
A small detail that may otherwise cause sysadmin confusion/run against policy in some enterprise environments.