### PR TITLE
Leave the room if the client calls `/forget`

### DIFF
--- a/changelog.d/13496.feature
+++ b/changelog.d/13496.feature
@@ -1,0 +1,1 @@
+Leave the room if a user is still in said room upon trying to forget it.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1812,7 +1812,7 @@ class RoomShutdownHandler:
                     stream_id,
                 )
 
-                await self.room_member_handler.forget(target_requester.user, room_id)
+                await self.room_member_handler.forget(target_requester, room_id)
 
                 # Join users to new room
                 if new_room_user_id:

--- a/synapse/handlers/room_member_worker.py
+++ b/synapse/handlers/room_member_worker.py
@@ -137,5 +137,5 @@ class RoomMemberWorkerHandler(RoomMemberHandler):
             user_id=target.to_string(), room_id=room_id, change="left"
         )
 
-    async def forget(self, target: UserID, room_id: str) -> None:
+    async def forget(self, target: Requester, room_id: str) -> None:
         raise RuntimeError("Cannot forget rooms on workers.")

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -799,6 +799,7 @@ class RoomForgetRestServlet(TransactionRestServlet):
         super().__init__(hs)
         self.room_member_handler = hs.get_room_member_handler()
         self.auth = hs.get_auth()
+        self.store = hs.get_datastores().main
 
     def register(self, http_server: HttpServer) -> None:
         PATTERNS = "/rooms/(?P<room_id>[^/]*)/forget"
@@ -809,7 +810,7 @@ class RoomForgetRestServlet(TransactionRestServlet):
     ) -> Tuple[int, JsonDict]:
         requester = await self.auth.get_user_by_req(request, allow_guest=False)
 
-        await self.room_member_handler.forget(user=requester.user, room_id=room_id)
+        await self.room_member_handler.forget(requester=requester, room_id=room_id)
 
         return 200, {}
 


### PR DESCRIPTION
Originally removed in https://github.com/matrix-org/synapse/pull/673.

Simplifies the "forget a room" flow for clients. If the user is in the room, calling `/forget` will now remove them from the room if they are currently in it (or reject a pending invite).

**This is not intended to be merged as-is.** It would require an MSC as the spec [currently forbids](PSB-148) clients from calling this endpoint without first leaving the room.