### PR TITLE
Add a warning to retention documentation regarding the possibility of database corruption

### DIFF
--- a/changelog.d/13497.doc
+++ b/changelog.d/13497.doc
@@ -1,0 +1,2 @@
+Add a warning to retention documentation reargding the possibility of databse corruption.
+

--- a/changelog.d/13497.doc
+++ b/changelog.d/13497.doc
@@ -1,2 +1,2 @@
-Add a warning to retention documentation regarding the possibility of databse corruption.
+Add a warning to retention documentation regarding the possibility of database corruption.
 

--- a/changelog.d/13497.doc
+++ b/changelog.d/13497.doc
@@ -1,2 +1,2 @@
-Add a warning to retention documentation reargding the possibility of databse corruption.
+Add a warning to retention documentation regarding the possibility of databse corruption.
 

--- a/docs/message_retention_policies.md
+++ b/docs/message_retention_policies.md
@@ -8,7 +8,8 @@ and allow server and room admins to configure how long messages should
 be kept in a homeserver's database before being purged from it.
 **Please note that, as this feature isn't part of the Matrix
 specification yet, this implementation is to be considered as
-experimental.** 
+experimental. There are known bugs which may cause database corruption.
+Proceed with caution.** 
 
 A message retention policy is mainly defined by its `max_lifetime`
 parameter, which defines how long a message can be kept around after

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -849,7 +849,7 @@ The message retention policies feature is disabled by default. Please be advised
 that enabling this feature carries some risk. There are known bugs with the implementation
 which can cause database corruption. Setting retention to delete older history
 is less risky than deleting newer history but in general caution is advised when enabling this
-experimental feature. YOu can read more about this feature [here](../../message_retention_policies.md).
+experimental feature. You can read more about this feature [here](../../message_retention_policies.md).
 
 This setting has the following sub-options:
 * `default_policy`: Default retention policy. If set, Synapse will apply it to rooms that lack the

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -845,7 +845,11 @@ which are older than the room's maximum retention period. Synapse will also
 filter events received over federation so that events that should have been
 purged are ignored and not stored again.
 
-The message retention policies feature is disabled by default.
+The message retention policies feature is disabled by default. Please be advised 
+that enabling this feature carries some risk, as it is possible to corrupt your database 
+due to insufficient cache invalidation. Setting retention to delete older history
+is less risky than deleting newer history (ie deleting 3-year-old history is safer than history from
+yesterday), but in general caution is advised when enabling this feature.
 
 This setting has the following sub-options:
 * `default_policy`: Default retention policy. If set, Synapse will apply it to rooms that lack the

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -846,10 +846,10 @@ filter events received over federation so that events that should have been
 purged are ignored and not stored again.
 
 The message retention policies feature is disabled by default. Please be advised 
-that enabling this feature carries some risk, as it is possible to corrupt your database 
-due to insufficient cache invalidation. Setting retention to delete older history
-is less risky than deleting newer history (ie deleting 3-year-old history is safer than history from
-yesterday), but in general caution is advised when enabling this feature.
+that enabling this feature carries some risk. There are known bugs with the implementation
+which can cause database corruption. Setting retention to delete older history
+is less risky than deleting newer history but in general caution is advised when enabling this
+experimental feature. YOu can read more about this feature [here](../../message_retention_policies.md).
 
 This setting has the following sub-options:
 * `default_policy`: Default retention policy. If set, Synapse will apply it to rooms that lack the


### PR DESCRIPTION
Retention is apparently well-known to cause database corruption, but we don't mention this in the docs. This PR changes that. Fixes  #13475.