### PR TITLE
Revert 'Remove the unspecced  field in the  response. (#13365)' to give more time for clients to update.

### DIFF
--- a/changelog.d/13501.misc
+++ b/changelog.d/13501.misc
@@ -1,0 +1,1 @@
+Revert 'Remove the unspecced `room_id` field in the `/hierarchy` response. (#13365)' to give more time for clients to update.

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -453,6 +453,7 @@ class RoomSummaryHandler:
                 "type": e.type,
                 "state_key": e.state_key,
                 "content": e.content,
+                "room_id": e.room_id,
                 "sender": e.sender,
                 "origin_server_ts": e.origin_server_ts,
             }


### PR DESCRIPTION
The only client we're aware of that needs updating to not use the unspecified field is Element iOS, but it will take some time for users to update even once a new version has been made available.

Reverts #13365.