### PR TITLE
Reject non-strict types in Pydantic models

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,8 +62,7 @@ jobs:
           fetch-depth: 0
       - uses: matrix-org/setup-python-poetry@v1
         with:
-          python-version: ${{ matrix.python-version }}
-          extras: ${{ matrix.extras }}
+          extras: "all"
       - run: poetry run scripts-dev/check_pydantic_models.py
 
   # Dummy step to gate other tests on without repeating the whole list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,10 +53,23 @@ jobs:
         env:
           PULL_REQUEST_NUMBER: ${{ github.event.number }}
 
+  lint-pydantic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: matrix-org/setup-python-poetry@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          extras: ${{ matrix.extras }}
+      - run: poetry run scripts-dev/check_pydantic_models.py
+
   # Dummy step to gate other tests on without repeating the whole list
   linting-done:
     if: ${{ !cancelled() }} # Run this even if prior jobs were skipped
-    needs: [lint, lint-crlf, lint-newsfile, check-sampleconfig, check-schema-delta]
+    needs: [lint, lint-crlf, lint-newsfile, lint-pydantic, check-sampleconfig, check-schema-delta]
     runs-on: ubuntu-latest
     steps:
       - run: "true"

--- a/changelog.d/13502.misc
+++ b/changelog.d/13502.misc
@@ -1,0 +1,1 @@
+Add a linter script which will reject non-strict types in Pydantic models.

--- a/scripts-dev/check_pydantic_models.py
+++ b/scripts-dev/check_pydantic_models.py
@@ -200,6 +200,7 @@ def do_lint() -> Set[str]:
     failures = set()
 
     with monkeypatch_pydantic():
+        logger.debug("Importing synapse")
         try:
             # TODO: make "synapse" an argument so we can target this script at
             # a subpackage
@@ -210,6 +211,7 @@ def do_lint() -> Set[str]:
             return failures
 
         try:
+            logger.debug("Fetching subpackages")
             module_infos = list(
                 pkgutil.walk_packages(module.__path__, f"{module.__name__}.")
             )
@@ -382,7 +384,7 @@ class TestFieldTypeInspection(unittest.TestCase):
             ("TypedDict('D', x=StrictInt)",),
         ]
     )
-    def test_field_holding_accepted_type_raises(self, annotation: str) -> None:
+    def test_field_holding_accepted_type_doesnt_raise(self, annotation: str) -> None:
         with monkeypatch_pydantic():
             run_test_snippet(
                 f"""
@@ -405,7 +407,7 @@ class TestFieldTypeInspection(unittest.TestCase):
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("mode", choices=["lint", "test"], default="lint")
+parser.add_argument("mode", choices=["lint", "test"], default="lint", nargs="?")
 parser.add_argument("-v", "--verbose", action="store_true")
 
 

--- a/scripts-dev/check_pydantic_models.py
+++ b/scripts-dev/check_pydantic_models.py
@@ -12,16 +12,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+A script which enforces that Synapse always uses strict types when defining a Pydantic
+model.
+
+Pydantic does not yet offer a strict mode (), but it is expected for V2. See
+    https://github.com/pydantic/pydantic/issues/1098
+    https://pydantic-docs.helpmanual.io/blog/pydantic-v2/#strict-mode
+
+until then, this script stops us from introducing type coersion bugs like stringy power
+levels.
+"""
 import argparse
 import contextlib
 import functools
+import importlib
+import logging
+import os
+import pkgutil
 import sys
 import textwrap
+import traceback
 import unittest.mock
 from contextlib import contextmanager
-from typing import Generator, Any
+from typing import Generator, TypeVar, Callable, Set
 
 from pydantic import confloat, conint, conbytes, constr
+from typing_extensions import ParamSpec
+
+logger = logging.getLogger(__name__)
 
 CONSTRAINED_TYPE_FACTORIES_WITH_STRICT_FLAG = [
     constr,
@@ -31,17 +50,31 @@ CONSTRAINED_TYPE_FACTORIES_WITH_STRICT_FLAG = [
 ]
 
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+class NonStrictTypeError(Exception):
+    ...
+
+
+def make_wrapper(factory: Callable[P, R]) -> Callable[P, R]:
+    @functools.wraps(factory)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        if "strict" not in kwargs:
+            raise NonStrictTypeError()
+        if not kwargs["strict"]:
+            raise NonStrictTypeError()
+        return factory(*args, **kwargs)
+
+    return wrapper
+
+
 @contextmanager
 def monkeypatch_pydantic() -> Generator[None, None, None]:
     with contextlib.ExitStack() as patches:
         for factory in CONSTRAINED_TYPE_FACTORIES_WITH_STRICT_FLAG:
-
-            @functools.wraps(factory)
-            def wrapper(**kwargs: object) -> Any:
-                assert "strict" in kwargs
-                assert kwargs["strict"]
-                return factory(**kwargs)
-
+            wrapper = make_wrapper(factory)
             patch1 = unittest.mock.patch(f"pydantic.{factory.__name__}", new=wrapper)
             patch2 = unittest.mock.patch(
                 f"pydantic.types.{factory.__name__}", new=wrapper
@@ -51,13 +84,63 @@ def monkeypatch_pydantic() -> Generator[None, None, None]:
         yield
 
 
+def format_error(e: Exception) -> str:
+    frame_summary = traceback.extract_tb(e.__traceback__)[-2]
+    return traceback.format_list([frame_summary])[0].lstrip()
+
+
+def lint() -> int:
+    failures = do_lint()
+    if failures:
+        print(f"Found {len(failures)} problem(s)")
+    for failure in sorted(failures):
+        print(failure)
+    return os.EX_DATAERR if failures else os.EX_OK
+
+
+def do_lint() -> Set[str]:
+    failures = set()
+
+    with monkeypatch_pydantic():
+        try:
+            synapse = importlib.import_module("synapse")
+        except NonStrictTypeError as e:
+            logger.warning(f"Bad annotation from importing synapse")
+            failures.add(format_error(e))
+            return failures
+
+        try:
+            modules = list(pkgutil.walk_packages(synapse.__path__, "synapse."))
+        except NonStrictTypeError as e:
+            logger.warning(f"Bad annotation when looking for modules to import")
+            failures.add(format_error(e))
+            return failures
+
+        for module in modules:
+            logger.debug("Importing %s", module.name)
+            try:
+                importlib.import_module(module.name)
+            except NonStrictTypeError as e:
+                logger.warning(f"Bad annotation from importing {module.name}")
+                failures.add(format_error(e))
+
+    return failures
+
+
 def run_test_snippet(source: str) -> None:
-    exec(textwrap.dedent(source), {}, {})
+    # To emulate `source` being called at the top level of the module,
+    # the globals and locals we provide have to be the same mapping.
+    #
+    # > Remember that at the module level, globals and locals are the same dictionary.
+    # > If exec gets two separate objects as globals and locals, the code will be
+    # > executed as if it were embedded in a class definition.
+    g = l = {}
+    exec(textwrap.dedent(source), g, l)
 
 
 class TestConstrainedTypesPatch(unittest.TestCase):
     def test_expression_without_strict_raises(self):
-        with monkeypatch_pydantic(), self.assertRaises(Exception):
+        with monkeypatch_pydantic(), self.assertRaises(NonStrictTypeError):
             run_test_snippet(
                 """
                 from pydantic import constr
@@ -66,7 +149,7 @@ class TestConstrainedTypesPatch(unittest.TestCase):
             )
 
     def test_called_as_module_attribute_raises(self):
-        with monkeypatch_pydantic(), self.assertRaises(Exception):
+        with monkeypatch_pydantic(), self.assertRaises(NonStrictTypeError):
             run_test_snippet(
                 """
                 import pydantic
@@ -75,7 +158,7 @@ class TestConstrainedTypesPatch(unittest.TestCase):
             )
 
     def test_alternative_import_raises(self):
-        with monkeypatch_pydantic(), self.assertRaises(Exception):
+        with monkeypatch_pydantic(), self.assertRaises(NonStrictTypeError):
             run_test_snippet(
                 """
                 from pydantic.types import constr
@@ -84,7 +167,7 @@ class TestConstrainedTypesPatch(unittest.TestCase):
             )
 
     def test_alternative_import_attribute_raises(self):
-        with monkeypatch_pydantic(), self.assertRaises(Exception):
+        with monkeypatch_pydantic(), self.assertRaises(NonStrictTypeError):
             run_test_snippet(
                 """
                 import pydantic.types
@@ -93,7 +176,7 @@ class TestConstrainedTypesPatch(unittest.TestCase):
             )
 
     def test_kwarg_but_no_strict_raises(self):
-        with monkeypatch_pydantic(), self.assertRaises(Exception):
+        with monkeypatch_pydantic(), self.assertRaises(NonStrictTypeError):
             run_test_snippet(
                 """
                 from pydantic import constr
@@ -102,7 +185,7 @@ class TestConstrainedTypesPatch(unittest.TestCase):
             )
 
     def test_kwarg_strict_False_raises(self):
-        with monkeypatch_pydantic(), self.assertRaises(Exception):
+        with monkeypatch_pydantic(), self.assertRaises(NonStrictTypeError):
             run_test_snippet(
                 """
                 from pydantic import constr
@@ -120,7 +203,7 @@ class TestConstrainedTypesPatch(unittest.TestCase):
             )
 
     def test_annotation_without_strict_raises(self):
-        with monkeypatch_pydantic(), self.assertRaises(Exception):
+        with monkeypatch_pydantic(), self.assertRaises(NonStrictTypeError):
             run_test_snippet(
                 """
                 from pydantic import constr
@@ -129,23 +212,30 @@ class TestConstrainedTypesPatch(unittest.TestCase):
             )
 
     def test_field_annotation_without_strict_raises(self):
-        with monkeypatch_pydantic(), self.assertRaises(Exception):
+        with monkeypatch_pydantic(), self.assertRaises(NonStrictTypeError):
             run_test_snippet(
                 """
-                from pydantic import BaseModel, constr
-                class C(BaseModel):
-                    f: constr()
+                from pydantic import BaseModel, conint
+                class C:
+                    x: conint()
                 """
             )
 
 
 parser = argparse.ArgumentParser()
 parser.add_argument("mode", choices=["lint", "test"])
+parser.add_argument("-v", "--verbose", action="store_true")
 
 
 if __name__ == "__main__":
     args = parser.parse_args(sys.argv[1:])
+    logging.basicConfig(
+        format="%(asctime)s %(name)s:%(lineno)d %(levelname)s %(message)s",
+        level=logging.DEBUG if args.verbose else logging.INFO,
+    )
+    # suppress logs we don't care about
+    logging.getLogger("xmlschema").setLevel(logging.WARNING)
     if args.mode == "lint":
-        ...
+        sys.exit(lint())
     elif args.mode == "test":
         unittest.main(argv=sys.argv[:1])

--- a/scripts-dev/check_pydantic_models.py
+++ b/scripts-dev/check_pydantic_models.py
@@ -1,0 +1,151 @@
+#! /usr/bin/env python
+# Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import contextlib
+import functools
+import sys
+import textwrap
+import unittest.mock
+from contextlib import contextmanager
+from typing import Generator, Any
+
+from pydantic import confloat, conint, conbytes, constr
+
+CONSTRAINED_TYPE_FACTORIES_WITH_STRICT_FLAG = [
+    constr,
+    conbytes,
+    conint,
+    confloat,
+]
+
+
+@contextmanager
+def monkeypatch_pydantic() -> Generator[None, None, None]:
+    with contextlib.ExitStack() as patches:
+        for factory in CONSTRAINED_TYPE_FACTORIES_WITH_STRICT_FLAG:
+
+            @functools.wraps(factory)
+            def wrapper(**kwargs: object) -> Any:
+                assert "strict" in kwargs
+                assert kwargs["strict"]
+                return factory(**kwargs)
+
+            patch1 = unittest.mock.patch(f"pydantic.{factory.__name__}", new=wrapper)
+            patch2 = unittest.mock.patch(
+                f"pydantic.types.{factory.__name__}", new=wrapper
+            )
+            patches.enter_context(patch1)
+            patches.enter_context(patch2)
+        yield
+
+
+def run_test_snippet(source: str) -> None:
+    exec(textwrap.dedent(source), {}, {})
+
+
+class TestConstrainedTypesPatch(unittest.TestCase):
+    def test_expression_without_strict_raises(self):
+        with monkeypatch_pydantic(), self.assertRaises(Exception):
+            run_test_snippet(
+                """
+                from pydantic import constr
+                constr()
+                """
+            )
+
+    def test_called_as_module_attribute_raises(self):
+        with monkeypatch_pydantic(), self.assertRaises(Exception):
+            run_test_snippet(
+                """
+                import pydantic
+                pydantic.constr()
+                """
+            )
+
+    def test_alternative_import_raises(self):
+        with monkeypatch_pydantic(), self.assertRaises(Exception):
+            run_test_snippet(
+                """
+                from pydantic.types import constr
+                constr()
+                """
+            )
+
+    def test_alternative_import_attribute_raises(self):
+        with monkeypatch_pydantic(), self.assertRaises(Exception):
+            run_test_snippet(
+                """
+                import pydantic.types
+                pydantic.types.constr()
+                """
+            )
+
+    def test_kwarg_but_no_strict_raises(self):
+        with monkeypatch_pydantic(), self.assertRaises(Exception):
+            run_test_snippet(
+                """
+                from pydantic import constr
+                constr(min_length=10)
+                """
+            )
+
+    def test_kwarg_strict_False_raises(self):
+        with monkeypatch_pydantic(), self.assertRaises(Exception):
+            run_test_snippet(
+                """
+                from pydantic import constr
+                constr(strict=False)
+                """
+            )
+
+    def test_kwarg_strict_True_doesnt_raise(self):
+        with monkeypatch_pydantic():
+            run_test_snippet(
+                """
+                from pydantic import constr
+                constr(strict=True)
+                """
+            )
+
+    def test_annotation_without_strict_raises(self):
+        with monkeypatch_pydantic(), self.assertRaises(Exception):
+            run_test_snippet(
+                """
+                from pydantic import constr
+                x: constr()
+                """
+            )
+
+    def test_field_annotation_without_strict_raises(self):
+        with monkeypatch_pydantic(), self.assertRaises(Exception):
+            run_test_snippet(
+                """
+                from pydantic import BaseModel, constr
+                class C(BaseModel):
+                    f: constr()
+                """
+            )
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("mode", choices=["lint", "test"])
+
+
+if __name__ == "__main__":
+    args = parser.parse_args(sys.argv[1:])
+    if args.mode == "lint":
+        ...
+    elif args.mode == "test":
+        unittest.main(argv=sys.argv[:1])

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -106,5 +106,5 @@ isort "${files[@]}"
 python3 -m black "${files[@]}"
 ./scripts-dev/config-lint.sh
 flake8 "${files[@]}"
-./scripts-dev/check-pydantic-models.py
+./scripts-dev/check_pydantic_models.py lint
 mypy

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -106,4 +106,5 @@ isort "${files[@]}"
 python3 -m black "${files[@]}"
 ./scripts-dev/config-lint.sh
 flake8 "${files[@]}"
+./scripts-dev/check-pydantic-models.py
 mypy


### PR DESCRIPTION
Closes #13336.

This script is a bodge. Until Pydantic 2 introduces a strict mode, this script does the following

1. monkey patches pydantic's machinery with versions that detect non-strict types at model definition time
2. imports all of synapse to detect non-strict types.

By "non-strict" type I mean types which will coerce when they are being ingested into a Pydantic model. For example, Pydantic is perfectly happy to receive the string `"123"` for the field `x: int`, and will interpret it as the integer `x = 123`.

Ideally review would suffice to catch this, but I found myself using non-strict types in #13188 even though I'd already spent some time thinking about how we want to use Pydantic.

I've tried to add comments to describe WTF this script does, but https://github.com/matrix-org/synapse/issues/13336#issuecomment-1210719322 might help give more context.