### PR TITLE
Document that the `DOCKER_BUILDKIT=1` flag is needed to build the docker image.

### DIFF
--- a/changelog.d/13515.doc
+++ b/changelog.d/13515.doc
@@ -1,0 +1,1 @@
+Document that the `DOCKER_BUILDKIT=1` flag is needed to build the docker image.

--- a/docker/README.md
+++ b/docker/README.md
@@ -191,7 +191,7 @@ If you need to build the image from a Synapse checkout, use the following `docke
  build` command from the repo's root:
 
 ```
-docker build -t matrixdotorg/synapse -f docker/Dockerfile .
+DOCKER_BUILDKIT=1 docker build -t matrixdotorg/synapse -f docker/Dockerfile .
 ```
 
 You can choose to build a different docker image by changing the value of the `-f` flag to


### PR DESCRIPTION
Small thing but it doesn't work without it :).

