### PR TITLE
Refuse to start when `faster_joins` is enabled on a worker deployment

### DIFF
--- a/changelog.d/13531.misc
+++ b/changelog.d/13531.misc
@@ -1,0 +1,1 @@
+Faster room joins: Refuse to start when faster joins is enabled on a deployment with workers, since worker configurations are not currently supported.

--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -441,6 +441,13 @@ def start(config_options: List[str]) -> None:
         "synapse.app.user_dir",
     )
 
+    if config.experimental.faster_joins_enabled:
+        raise ConfigError(
+            "You have enabled the experimental `faster_joins` config option, but it is "
+            "not compatible with worker deployments yet. Please disable `faster_joins` "
+            "or run Synapse as a single process deployment instead."
+        )
+
     synapse.events.USE_FROZEN_DICTS = config.server.use_frozen_dicts
     synapse.util.caches.TRACK_MEMORY_USAGE = config.caches.track_memory_usage
 

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -366,16 +366,6 @@ def setup(config_options: List[str]) -> SynapseHomeServer:
                 "`enable_registration_without_verification` config option to `true`."
             )
 
-    if (
-        config.experimental.faster_joins_enabled
-        and config.worker.worker_app is not None
-    ):
-        raise ConfigError(
-            "You have enabled the experimental `faster_joins` config option, but it is "
-            "not compatible with worker deployments yet. Please disable `faster_joins` "
-            "or run Synapse as a single process deployment instead."
-        )
-
     hs = SynapseHomeServer(
         config.server.server_name,
         config=config,

--- a/synapse/app/homeserver.py
+++ b/synapse/app/homeserver.py
@@ -366,6 +366,16 @@ def setup(config_options: List[str]) -> SynapseHomeServer:
                 "`enable_registration_without_verification` config option to `true`."
             )
 
+    if (
+        config.experimental.faster_joins_enabled
+        and config.worker.worker_app is not None
+    ):
+        raise ConfigError(
+            "You have enabled the experimental `faster_joins` config option, but it is "
+            "not compatible with worker deployments yet. Please disable `faster_joins` "
+            "or run Synapse as a single process deployment instead."
+        )
+
     hs = SynapseHomeServer(
         config.server.server_name,
         config=config,


### PR DESCRIPTION
Synapse does not currently support faster room joins on deployments with
workers.

Closes #13527.

Signed-off-by: Sean Quah <seanq@matrix.org>
