### PR TITLE
Fix that user cannot `/forget` rooms after the last member has left

### DIFF
--- a/changelog.d/13546.bugfix
+++ b/changelog.d/13546.bugfix
@@ -1,0 +1,1 @@
+Fix bug that user cannot `/forget` rooms after the last member has left the room.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -1923,8 +1923,11 @@ class RoomMemberMasterHandler(RoomMemberHandler):
         ]:
             raise SynapseError(400, "User %s in room %s" % (user_id, room_id))
 
-        if membership:
-            await self.store.forget(user_id, room_id)
+        # In normal case this call is only required if `membership` is not `None`.
+        # But: After the last member had left the room, the background update
+        # `_background_remove_left_rooms` is deleting rows related to this room from
+        # the table `current_state_events` and `get_current_state_events` is `None`.
+        await self.store.forget(user_id, room_id)
 
 
 def get_users_which_can_issue_invite(auth_events: StateMap[EventBase]) -> List[str]:

--- a/tests/handlers/test_room_member.py
+++ b/tests/handlers/test_room_member.py
@@ -328,10 +328,10 @@ class RoomMemberMasterHandlerTestCase(HomeserverTestCase):
             self.get_success(self.store.did_forget(self.alice, self.room_id))
         )
 
-        # TODO: server has not forgotten the room
-        # self.assertFalse(
-        #     self.get_success(self.store.is_locally_forgotten_room(self.room_id))
-        # )
+        # the server has not forgotten the room
+        self.assertFalse(
+            self.get_success(self.store.is_locally_forgotten_room(self.room_id))
+        )
 
     def test_leave_and_forget_last_user(self) -> None:
         """Tests that forget a room is successfully when the last user has left the room."""
@@ -343,10 +343,10 @@ class RoomMemberMasterHandlerTestCase(HomeserverTestCase):
             self.get_success(self.store.did_forget(self.alice, self.room_id))
         )
 
-        # TODO: server has forgotten the room
-        # self.assertTrue(
-        #     self.get_success(self.store.is_locally_forgotten_room(self.room_id))
-        # )
+        # the server has forgotten the room
+        self.assertTrue(
+            self.get_success(self.store.is_locally_forgotten_room(self.room_id))
+        )
 
     def test_forget_when_not_left(self) -> None:
         """Tests that a user cannot not forgets a room that has not left."""
@@ -356,6 +356,8 @@ class RoomMemberMasterHandlerTestCase(HomeserverTestCase):
         """Test that a user that has forgotten a room can do a re-join.
         The room was also forgotten from the local server and only
         remote users are in the room."""
+
+        # add remote user
         self.get_success(
             event_injection.inject_member_event(
                 self.hs, self.room_id, "@charlie:elsewhere", "join"
@@ -368,20 +370,20 @@ class RoomMemberMasterHandlerTestCase(HomeserverTestCase):
             self.get_success(self.store.did_forget(self.alice, self.room_id))
         )
 
-        # TODO: server has forgotten the room
-        # self.assertTrue(
-        #     self.get_success(self.store.is_locally_forgotten_room(self.room_id))
-        # )
+        # the server has forgotten the room
+        self.assertTrue(
+            self.get_success(self.store.is_locally_forgotten_room(self.room_id))
+        )
 
         self.helper.join(self.room_id, user=self.alice, tok=self.alice_token)
         self.assertFalse(
             self.get_success(self.store.did_forget(self.alice, self.room_id))
         )
 
-        # TODO: server has not forgotten the room
-        # self.assertFalse(
-        #     self.get_success(self.store.is_locally_forgotten_room(self.room_id))
-        # )
+        # the server has not forgotten the room anymore
+        self.assertFalse(
+            self.get_success(self.store.is_locally_forgotten_room(self.room_id))
+        )
 
     def test_rejoin_forgotten_by_user(self) -> None:
         """Test that a user that has forgotten a room can do a re-join.
@@ -395,10 +397,10 @@ class RoomMemberMasterHandlerTestCase(HomeserverTestCase):
             self.get_success(self.store.did_forget(self.alice, self.room_id))
         )
 
-        # TODO: server has forgotten the room
-        # self.assertFalse(
-        #     self.get_success(self.store.is_locally_forgotten_room(self.room_id))
-        # )
+        # the server has not forgotten the room
+        self.assertFalse(
+            self.get_success(self.store.is_locally_forgotten_room(self.room_id))
+        )
 
         self.helper.join(self.room_id, user=self.alice, tok=self.alice_token)
         # TODO: A join to a room does not invalidate the forgotten cache

--- a/tests/handlers/test_room_member.py
+++ b/tests/handlers/test_room_member.py
@@ -352,39 +352,6 @@ class RoomMemberMasterHandlerTestCase(HomeserverTestCase):
         """Tests that a user cannot not forgets a room that has not left."""
         self.get_failure(self.handler.forget(self.alice_ID, self.room_id), SynapseError)
 
-    def test_rejoin_forgotten_by_server(self) -> None:
-        """Test that a user that has forgotten a room can do a re-join.
-        The room was also forgotten from the local server and only
-        remote users are in the room."""
-
-        # add remote user
-        self.get_success(
-            event_injection.inject_member_event(
-                self.hs, self.room_id, "@charlie:elsewhere", "join"
-            )
-        )
-
-        self.helper.leave(self.room_id, user=self.alice, tok=self.alice_token)
-        self.get_success(self.handler.forget(self.alice_ID, self.room_id))
-        self.assertTrue(
-            self.get_success(self.store.did_forget(self.alice, self.room_id))
-        )
-
-        # the server has forgotten the room
-        self.assertTrue(
-            self.get_success(self.store.is_locally_forgotten_room(self.room_id))
-        )
-
-        self.helper.join(self.room_id, user=self.alice, tok=self.alice_token)
-        self.assertFalse(
-            self.get_success(self.store.did_forget(self.alice, self.room_id))
-        )
-
-        # the server has not forgotten the room anymore
-        self.assertFalse(
-            self.get_success(self.store.is_locally_forgotten_room(self.room_id))
-        )
-
     def test_rejoin_forgotten_by_user(self) -> None:
         """Test that a user that has forgotten a room can do a re-join.
         The room was not forgotten from the local server.

--- a/tests/handlers/test_room_member.py
+++ b/tests/handlers/test_room_member.py
@@ -16,7 +16,7 @@ from synapse.util import Clock
 
 from tests.replication._base import RedisMultiWorkerStreamTestCase
 from tests.server import make_request
-from tests.test_utils import event_injection, make_awaitable
+from tests.test_utils import make_awaitable
 from tests.unittest import (
     FederatingHomeserverTestCase,
     HomeserverTestCase,

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -158,7 +158,7 @@ class RoomMemberStoreTestCase(unittest.HomeserverTestCase):
         # Check that alice's display name is now None
         self.assertEqual(row[0]["display_name"], None)
 
-    def test_room_is_locally_forgotten(self):
+    def test_room_is_locally_forgotten(self) -> None:
         """Test that when the last local user has forgotten a room it is known as forgotten."""
         # join two local and one remote user
         self.room = self.helper.create_room_as(self.u_alice, tok=self.t_alice)
@@ -199,7 +199,7 @@ class RoomMemberStoreTestCase(unittest.HomeserverTestCase):
             self.get_success(self.store.is_locally_forgotten_room(self.room))
         )
 
-    def test_join_locally_forgotten_room(self):
+    def test_join_locally_forgotten_room(self) -> None:
         """Tests if a user joins a forgotten room the room is not forgotten anymore."""
         self.room = self.helper.create_room_as(self.u_alice, tok=self.t_alice)
         self.assertFalse(


### PR DESCRIPTION
https://github.com/matrix-org/synapse/issues/13517#issuecomment-1216133811:
> I suspect that after the last member leaves the room, the background update `_background_remove_left_rooms` is deleting rows related to this room from the table `current_state_events`.
> the return value for `get_current_state_events` is `None`

Fixes: #13517

~~Blocked by: #13503
for using ` is_locally_forgotten_room` in tests~~

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). 
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Dirk Klimpel dirk@klimpel.org