### PR TITLE
Fix breaking event sending due to bad push rule

### DIFF
--- a/changelog.d/13547.misc
+++ b/changelog.d/13547.misc
@@ -1,0 +1,1 @@
+Improve performance of sending messages in rooms with thousands of local users.

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -209,7 +209,9 @@ def compile_push_rules(rawrules: List[PushRule]) -> PushRules:
             )
             continue
         else:
-            raise Exception(f"Unknown priority class: {rule.priority_class}")
+            # We log and continue here so as not to break event sending
+            logger.error("Unknown priority class: %", rule.priority_class)
+            continue
 
         collection.append(rule)
 

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -49,12 +49,15 @@ kind, etc, etc.
 """
 
 import itertools
+import logging
 from typing import Dict, Iterator, List, Mapping, Sequence, Tuple, Union
 
 import attr
 
 from synapse.config.experimental import ExperimentalConfig
 from synapse.push.rulekinds import PRIORITY_CLASS_MAP
+
+logger = logging.getLogger(__name__)
 
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
@@ -199,6 +202,12 @@ def compile_push_rules(rawrules: List[PushRule]) -> PushRules:
             collection = rules.sender
         elif rule.priority_class == 1:
             collection = rules.underride
+        elif rule.priority_class <= 0:
+            logger.info(
+                "Got rule with priority class less than zero, but doesn't override a base rule: %s",
+                rule,
+            )
+            continue
         else:
             raise Exception(f"Unknown priority class: {rule.priority_class}")
 


### PR DESCRIPTION
Broke by https://github.com/matrix-org/synapse/pull/13522

It looks like we have some rules in the DB with a priority class less
than 0 that don't override the base rules. Before these were just
dropped, but https://github.com/matrix-org/synapse/pull/13522 made that a hard error.


I'm not sure if want the second commit, where we ignore push rules with bad priority classes entirely