### PR TITLE
Downgrade 'Closing scope' error to a warning to prevent hammering sentry

### DIFF
--- a/changelog.d/13552.misc
+++ b/changelog.d/13552.misc
@@ -1,0 +1,1 @@
+Downgrade an error that had the capacity to spam Sentry instances to a warning.

--- a/synapse/logging/scopecontextmanager.py
+++ b/synapse/logging/scopecontextmanager.py
@@ -156,7 +156,7 @@ class _LogContextScope(Scope):
     def close(self) -> None:
         active_scope = self.manager.active
         if active_scope is not self:
-            logger.error(
+            logger.warning(
                 "Closing scope %s which is not the currently-active one %s",
                 self,
                 active_scope,


### PR DESCRIPTION
We noticed an error repeatedly coming up in Sentry after deploying e91a9290494722d48ca42bb68e560f6bd5b6f212 to matrix.org yesterday: https://sentry.tools.element.io/organizations/element/issues/725/ (internal link for those with access).

In summary, we're seeing hundreds of thousands of the following on incoming `GET /_matrix/federation/v1/event/{eventId}` requests:

```
Closing scope %s which is not the currently-active one %s
<synapse.logging.scopecontextmanager._LogContextScope object at 0x7f181f60e4f0>
```

@squahtx proposed that this was due to changes in https://github.com/matrix-org/synapse/pull/13489.

> I imagine the messed up logging contexts have been there for a long time and it's only complaining extra hard now because of the new spans.

This PR reduces the error to a warning so that Sentry data is usable again. We should still separately fix the issue.