### PR TITLE
Optimize `have_seen_events`

### DIFF
--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1031,6 +1031,12 @@ class FederationEventHandler:
             InvalidResponseError: if the remote homeserver's response contains fields
                 of the wrong type.
         """
+
+        # It would be better if we could query the difference from our known
+        # state to the given `event_id` so the sending server doesn't have to
+        # send as much and we don't have to process so many events. For example
+        # in a room like #matrixhq, we get 200k events (77k state_events, 122k
+        # auth_events) from this and just the `have_seen_events` takes 20s.
         (
             state_event_ids,
             auth_event_ids,

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -1480,7 +1480,7 @@ class EventsWorkerStore(SQLBaseStore):
         # the batches as big as possible.
 
         remaining_event_ids: Set[str] = set()
-        for chunk in batch_iter(event_ids, 500):
+        for chunk in batch_iter(event_ids, 1000):
             remaining_event_ids_from_chunk = await self._have_seen_events_dict(chunk)
             remaining_event_ids.update(remaining_event_ids_from_chunk)
 
@@ -1495,8 +1495,8 @@ class EventsWorkerStore(SQLBaseStore):
         """
 
         # if the event cache contains the event, obviously we've seen it.
-        event_entry_map = self._get_events_from_local_cache(event_ids)
-        event_ids_in_cache = event_entry_map.keys()
+        event_cache_entry_map = self._get_events_from_local_cache(event_ids)
+        event_ids_in_cache = event_cache_entry_map.keys()
         remaining_event_ids = {
             event_id for event_id in event_ids if event_id not in event_ids_in_cache
         }

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -94,6 +94,7 @@ class HaveSeenEventsTestCase(unittest.HomeserverTestCase):
             )
             self.event_ids.append(event_id)
 
+    # TODO: Remove me before mergin
     def test_benchmark(self):
         import time
 
@@ -130,17 +131,30 @@ class HaveSeenEventsTestCase(unittest.HomeserverTestCase):
         )
 
         with LoggingContext(name="test") as ctx:
-            benchmark_start_time = time.time()
-            remaining_event_ids = self.get_success(
-                self.store.have_seen_events(room_id, event_ids)
-            )
-            benchmark_end_time = time.time()
-            logger.info("afewewf %s %s", benchmark_start_time, benchmark_end_time)
-            logger.info(
-                "Benchmark time: %s",
-                (benchmark_end_time - benchmark_start_time),
-            )
-            # self.assertEqual(remaining_event_ids, set())
+
+            def time_have_seen_events(test_index: int, event_ids):
+                benchmark_start_time = time.time()
+                remaining_event_ids = self.get_success(
+                    self.store.have_seen_events(room_id, event_ids)
+                )
+                benchmark_end_time = time.time()
+                logger.info(
+                    "Benchmark time%s: %s",
+                    test_index,
+                    (benchmark_end_time - benchmark_start_time),
+                )
+                self.assertIsNotNone(remaining_event_ids)
+
+            event_ids_odd = event_ids[::2]
+            event_ids_even = event_ids[1::2]
+
+            time_have_seen_events(1, event_ids)
+            time_have_seen_events(2, event_ids)
+            time_have_seen_events(3, event_ids)
+            time_have_seen_events(4, event_ids_odd)
+            time_have_seen_events(5, event_ids_odd)
+            time_have_seen_events(6, event_ids_even)
+            time_have_seen_events(7, event_ids_even)
 
             # that should result in a many db queries
             self.assertEqual(ctx.get_resource_usage().db_txn_count, 1)

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -91,6 +91,16 @@ class HaveSeenEventsTestCase(unittest.HomeserverTestCase):
             )
             self.event_ids.append(event_id)
 
+    # def test_benchmark(self):
+    #     with LoggingContext(name="test") as ctx:
+    #         res = self.get_success(
+    #             self.store.have_seen_events("room1", [self.event_ids[0], "event19"])
+    #         )
+    #         self.assertEqual(res, {self.event_ids[0]})
+
+    #         # that should result in a single db query
+    #         self.assertEqual(ctx.get_resource_usage().db_txn_count, 1)
+
     def test_simple(self):
         with LoggingContext(name="test") as ctx:
             res = self.get_success(

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -94,7 +94,7 @@ class HaveSeenEventsTestCase(unittest.HomeserverTestCase):
             )
             self.event_ids.append(event_id)
 
-    # TODO: Remove me before mergin
+    # TODO: Remove me before merging
     def test_benchmark(self):
         import time
 
@@ -132,15 +132,15 @@ class HaveSeenEventsTestCase(unittest.HomeserverTestCase):
 
         with LoggingContext(name="test") as ctx:
 
-            def time_have_seen_events(test_index: int, event_ids):
+            def time_have_seen_events(test_prefix: str, event_ids):
                 benchmark_start_time = time.time()
                 remaining_event_ids = self.get_success(
                     self.store.have_seen_events(room_id, event_ids)
                 )
                 benchmark_end_time = time.time()
                 logger.info(
-                    "Benchmark time%s: %s",
-                    test_index,
+                    "Benchmark time (%s): %s",
+                    "{test_prefix: <13}".format(test_prefix=test_prefix),
                     (benchmark_end_time - benchmark_start_time),
                 )
                 self.assertIsNotNone(remaining_event_ids)
@@ -148,13 +148,13 @@ class HaveSeenEventsTestCase(unittest.HomeserverTestCase):
             event_ids_odd = event_ids[::2]
             event_ids_even = event_ids[1::2]
 
-            time_have_seen_events(1, event_ids)
-            time_have_seen_events(2, event_ids)
-            time_have_seen_events(3, event_ids)
-            time_have_seen_events(4, event_ids_odd)
-            time_have_seen_events(5, event_ids_odd)
-            time_have_seen_events(6, event_ids_even)
-            time_have_seen_events(7, event_ids_even)
+            time_have_seen_events("1 cold cache", event_ids)
+            time_have_seen_events("2, warm cache", event_ids)
+            time_have_seen_events("3, warm cache", event_ids)
+            time_have_seen_events("4, odds", event_ids_odd)
+            time_have_seen_events("5, odds", event_ids_odd)
+            time_have_seen_events("6, evens", event_ids_even)
+            time_have_seen_events("7, evens", event_ids_even)
 
             # that should result in a many db queries
             self.assertEqual(ctx.get_resource_usage().db_txn_count, 1)


### PR DESCRIPTION
Fix https://github.com/matrix-org/synapse/issues/13625

Part of https://github.com/matrix-org/synapse/issues/13356

Mentioned in [internal doc](https://docs.google.com/document/d/1lvUoVfYUiy6UaHB6Rb4HicjaJAU40-APue9Q4vzuW3c/edit#bookmark=id.8eo3xt7lhv6b)

---

Optimize `have_seen_events` because when backfilling `#matrixhq`, 20s is just calling `have_seen_events` on the 200k state and auth events in the room. And in the future, hopefully a PR to avoid the `have_seen_events` altogether or do it in the background.

 - `have_seen_events` (157 `db.have_seen_events`) takes 6.62s to process 77k events
 - `have_seen_events` (246 `db.have_seen_events`) takes 13.19s to process 122k events

<img width="1674" alt="" src="https://user-images.githubusercontent.com/558581/185563852-f9d38e8f-15f5-4ca1-8878-ef01ec95fb60.png">

---

With 50k events, for a cold query, we're seeing a 3.7s -> 0.33s improvement. And the new version doesn't even have a cache yet and it still performs almost as good.

\# events | Before | Before with #1391 | Before (no cache) | After
--- | --- | --- | --- | ---
50k | . <pre>Benchmark time (1 cold cache ): 3.7170820236206055<br>Benchmark time (2, warm cache): 0.2985079288482666<br>Benchmark time (3, warm cache): 0.28847789764404297<br>Benchmark time (4, odds      ): 0.1537461280822754<br>Benchmark time (5, odds      ): 0.14780497550964355<br>Benchmark time (6, evens     ): 0.1475691795349121<br>Benchmark time (7, evens     ): 0.14868617057800293</pre>| . <pre>Benchmark time (1 cold cache ): 1.062384843826294<br>Benchmark time (2, warm cache): 0.18310809135437012<br>Benchmark time (3, warm cache): 0.17781400680541992<br>Benchmark time (4, odds      ): 0.09939789772033691<br>Benchmark time (5, odds      ): 0.09195113182067871<br>Benchmark time (6, evens     ): 0.08882665634155273<br>Benchmark time (7, evens     ): 0.08661413192749023</pre> | . <pre>Benchmark time (1 cold cache ): 0.3248419761657715<br>Benchmark time (2, warm cache): 0.32351016998291016<br>Benchmark time (3, warm cache): 0.3136260509490967<br>Benchmark time (4, odds      ): 0.15899014472961426<br>Benchmark time (5, odds      ): 0.15054106712341309<br>Benchmark time (6, evens     ): 0.15465688705444336<br>Benchmark time (7, evens     ): 0.1412408351898193</pre> | . <pre>Benchmark time (1 cold cache ): 0.31160497665405273<br>Benchmark time (2, warm cache): 0.3012270927429199<br>Benchmark time (3, warm cache): 0.2938399314880371<br>Benchmark time (4, odds      ): 0.15165090560913086<br>Benchmark time (5, odds      ): 0.14775395393371582<br>Benchmark time (6, evens     ): 0.14690089225769043<br>Benchmark time (7, evens     ): 0.14881110191345215</pre>
100k | . <pre>Benchmark time (1 cold cache ): 8.10055136680603<br>Benchmark time (2, warm cache): 0.6121761798858643<br>Benchmark time (3, warm cache): 0.6093218326568604<br>Benchmark time (4, odds      ): 0.29950785636901855<br>Benchmark time (5, odds      ): 0.3049640655517578<br>Benchmark time (6, evens     ): 0.3025388717651367<br>Benchmark time (7, evens     ): 0.29833483695983887</pre> | . <pre>Benchmark time (1 cold cache ): 2.264657735824585<br>Benchmark time (2, warm cache): 0.3539161682128906<br>Benchmark time (3, warm cache): 0.3556997776031494<br>Benchmark time (4, odds      ): 0.17580008506774902<br>Benchmark time (5, odds      ): 0.17888712882995605<br>Benchmark time (6, evens     ): 0.1756150722503662<br>Benchmark time (7, evens     ): 0.17418384552001953</pre> | . <pre>Benchmark time (1 cold cache ): 0.8466510772705078<br>Benchmark time (2, warm cache): 0.8022150993347168<br>Benchmark time (3, warm cache): 0.7888422012329102<br>Benchmark time (4, odds      ): 0.3941817283630371<br>Benchmark time (5, odds      ): 0.416118860244751<br>Benchmark time (6, evens     ): 0.42328405380249023<br>Benchmark time (7, evens     ): 0.3695280551910400</pre> | . <pre>Benchmark time (1 cold cache ): 0.6143028736114502<br>Benchmark time (2, warm cache): 0.5878009796142578<br>Benchmark time (3, warm cache): 0.5958888530731201<br>Benchmark time (4, odds      ): 0.3110220432281494<br>Benchmark time (5, odds      ): 0.3027939796447754<br>Benchmark time (6, evens     ): 0.2908449172973633<br>Benchmark time (7, evens     ): 0.3113112449645996</pre>
200k | . <pre>Benchmark time (1 cold cache ): 19.106724977493286<br>Benchmark time (2, warm cache): 22.98161005973816<br>Benchmark time (3, warm cache): 23.126408100128174<br>Benchmark time (4, odds      ): 11.401129007339478<br>Benchmark time (5, odds      ): 0.6159579753875732<br>Benchmark time (6, evens     ): 12.087002992630005<br>Benchmark time (7, evens     ): 0.6241748332977295</pre> | . <pre>Benchmark time (1 cold cache ): 4.827088117599487<br>Benchmark time (2, warm cache): 4.958348035812378<br>Benchmark time (3, warm cache): 4.923892974853516<br>Benchmark time (4, odds      ): 2.5139119625091553<br>Benchmark time (5, odds      ): 0.3530576229095459<br>Benchmark time (6, evens     ): 2.465486764907837<br>Benchmark time (7, evens     ): 0.3511021137237549</pre> | . <pre>Benchmark time (1 cold cache ): 1.328582763671875<br>Benchmark time (2, warm cache): 1.279066801071167<br>Benchmark time (3, warm cache): 1.2781598567962646<br>Benchmark time (4, odds      ): 0.6520607471466064<br>Benchmark time (5, odds      ): 0.647273063659668<br>Benchmark time (6, evens     ): 0.6393017768859863<br>Benchmark time (7, evens     ): 0.6427278518676758</pre> | . <pre>Benchmark time (1 cold cache ): 1.6177170276641846<br>Benchmark time (2, warm cache): 1.6484057903289795<br>Benchmark time (3, warm cache): 1.6546461582183838<br>Benchmark time (4, odds      ): 0.8459029197692871<br>Benchmark time (5, odds      ): 0.8401181697845459<br>Benchmark time (6, evens     ): 0.8196630477905273<br>Benchmark time (7, evens     ): 0.8566310405731201</pre>


### Dev notes

```
SYNAPSE_POSTGRES=1 SYNAPSE_TEST_LOG_LEVEL=INFO python -m twisted.trial tests.storage.databases.main.test_events_worker.HaveSeenEventsTestCase.test_benchmark
```

```
^.* (test|sentinel) - 
```


### Todo

 - [ ] Try with a cache
 - [ ] Refactor functions that use `have_seen_events` to use the returned remaining events we didn't see (previously, it returned the events we saw)


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
