### PR TITLE
Fix that sending server notices fail if avatar is `None`

### DIFF
--- a/changelog.d/13566.bugfix
+++ b/changelog.d/13566.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.52.0 where sending server notices fails if `max_avatar_size` or `allowed_avatar_mimetypes` is set and not `system_mxid_avatar_url`.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -689,7 +689,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 errcode=Codes.BAD_JSON,
             )
 
-        if "avatar_url" in content:
+        if "avatar_url" in content and content.get("avatar_url") is not None:
             if not await self.profile_handler.check_avatar_size_and_mime_type(
                 content["avatar_url"],
             ):

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -213,8 +213,7 @@ class ServerNoticeTestCase(unittest.HomeserverTestCase):
         self.assertEqual(200, channel.code, msg=channel.json_body)
 
         # user has one invite
-        invited_rooms = self._check_invite_and_join_status(self.other_user, 1, 0)
-        room_id = invited_rooms[0].room_id
+        self._check_invite_and_join_status(self.other_user, 1, 0)
 
     def test_server_notice_disabled(self) -> None:
         """Tests that server returns error if server notice is disabled"""

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -171,7 +171,7 @@ class ServerNoticeTestCase(unittest.HomeserverTestCase):
     def test_invalid_avatar_url(self) -> None:
         """If avatar url in homeserver.yaml is invalid and
         "check avatar size and mime type" is set, an error is returned.
-        TODO: validate when reading config"""
+        TODO: Should be checked when reading the configuration."""
         channel = self.make_request(
             "POST",
             self.url,
@@ -195,7 +195,7 @@ class ServerNoticeTestCase(unittest.HomeserverTestCase):
             "max_avatar_size": "10M",
         }
     )
-    def test_displayname_is_set_avatar_ist_none(self) -> None:
+    def test_displayname_is_set_avatar_is_none(self) -> None:
         """
         Tests that sending a server notices is successfully,
         if a display_name is set, avatar_url is `None` and

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -159,6 +159,63 @@ class ServerNoticeTestCase(unittest.HomeserverTestCase):
         self.assertEqual(Codes.UNKNOWN, channel.json_body["errcode"])
         self.assertEqual("'msgtype' not in content", channel.json_body["error"])
 
+    @override_config(
+        {
+            "server_notices": {
+                "system_mxid_localpart": "notices",
+                "system_mxid_avatar_url": "somthingwrong",
+            },
+            "max_avatar_size": "10M",
+        }
+    )
+    def test_invalid_avatar_url(self) -> None:
+        """If avatar url in homeserver.yaml is invalid and
+        "check avatar size and mime type" is set, an error is returned.
+        TODO: validate when reading config"""
+        channel = self.make_request(
+            "POST",
+            self.url,
+            access_token=self.admin_user_tok,
+            content={
+                "user_id": self.other_user,
+                "content": {"msgtype": "m.text", "body": "test msg"},
+            },
+        )
+
+        self.assertEqual(500, channel.code, msg=channel.json_body)
+        self.assertEqual(Codes.UNKNOWN, channel.json_body["errcode"])
+
+    @override_config(
+        {
+            "server_notices": {
+                "system_mxid_localpart": "notices",
+                "system_mxid_display_name": "test display name",
+                "system_mxid_avatar_url": None,
+            },
+            "max_avatar_size": "10M",
+        }
+    )
+    def test_displayname_is_set_avatar_ist_none(self) -> None:
+        """
+        Tests that sending a server notices is successfully,
+        if a display_name is set, avatar_url is `None` and
+        "check avatar size and mime type" is set.
+        """
+        channel = self.make_request(
+            "POST",
+            self.url,
+            access_token=self.admin_user_tok,
+            content={
+                "user_id": self.other_user,
+                "content": {"msgtype": "m.text", "body": "test msg"},
+            },
+        )
+        self.assertEqual(200, channel.code, msg=channel.json_body)
+
+        # user has one invite
+        invited_rooms = self._check_invite_and_join_status(self.other_user, 1, 0)
+        room_id = invited_rooms[0].room_id
+
     def test_server_notice_disabled(self) -> None:
         """Tests that server returns error if server notice is disabled"""
         channel = self.make_request(

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -11,16 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from unittest.mock import Mock
+
+from twisted.test.proto_helpers import MemoryReactor
 
 from synapse.api.constants import EventTypes, LimitBlockingTypes, ServerNoticeMsgType
 from synapse.api.errors import ResourceLimitError
 from synapse.rest import admin
 from synapse.rest.client import login, room, sync
+from synapse.server import HomeServer
 from synapse.server_notices.resource_limits_server_notices import (
     ResourceLimitsServerNotices,
 )
+from synapse.util import Clock
 
 from tests import unittest
 from tests.test_utils import make_awaitable
@@ -52,7 +55,7 @@ class TestResourceLimitsServerNotices(unittest.HomeserverTestCase):
 
         return config
 
-    def prepare(self, reactor, clock, hs):
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.server_notices_sender = self.hs.get_server_notices_sender()
 
         # relying on [1] is far from ideal, but the only case where
@@ -251,7 +254,7 @@ class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
         c["admin_contact"] = "mailto:user@test.com"
         return c
 
-    def prepare(self, reactor, clock, hs):
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = self.hs.get_datastores().main
         self.server_notices_sender = self.hs.get_server_notices_sender()
         self.server_notices_manager = self.hs.get_server_notices_manager()


### PR DESCRIPTION
Fixes an edge case, indroduced in #11846.

If `parse_and_validate_mxc_uri` is called in `check_avatar_size_and_mime_type` because `max_avatar_size` or `allowed_avatar_mimetypes` is set, you get an error if `system_mxid_avatar_url` is `None`.

Error
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/synapse/http/server.py", line 366, in _async_render_wrapper
    callback_return = await self._async_render(request)
  File "/usr/lib/python3.10/site-packages/synapse/http/server.py", line 572, in _async_render
    callback_return = await raw_callback_return
  File "/usr/lib/python3.10/site-packages/synapse/rest/admin/server_notice_servlet.py", line 99, in on_POST
    event = await self.server_notices_manager.send_notice(
  File "/usr/lib/python3.10/site-packages/synapse/server_notices/server_notices_manager.py", line 68, in send_notice
    room_id = await self.get_or_create_notice_room_for_user(user_id)
  File "/usr/lib/python3.10/site-packages/synapse/server_notices/server_notices_manager.py", line 175, in get_or_create_notice_room_for_user
    info, _ = await self._room_creation_handler.create_room(
  File "/usr/lib/python3.10/site-packages/synapse/handlers/room.py", line 896, in create_room
    ) = await self._send_events_for_new_room(
  File "/usr/lib/python3.10/site-packages/synapse/handlers/room.py", line 1097, in _send_events_for_new_room
    member_event_id, _ = await self.room_member_handler.update_membership(
  File "/usr/lib/python3.10/site-packages/synapse/handlers/room_member.py", line 567, in update_membership
    result = await self.update_membership_locked(
  File "/usr/lib/python3.10/site-packages/synapse/handlers/room_member.py", line 690, in update_membership_locked
    if not await self.profile_handler.check_avatar_size_and_mime_type(
  File "/usr/lib/python3.10/site-packages/twisted/internet/defer.py", line 1661, in _inlineCallbacks
    result = current_context.run(gen.send, result)
  File "/usr/lib/python3.10/site-packages/synapse/handlers/profile.py", line 310, in check_avatar_size_and_mime_type
    server_name, _, media_id = parse_and_validate_mxc_uri(mxc)
  File "/usr/lib/python3.10/site-packages/synapse/util/stringutils.py", line 186, in parse_and_validate_mxc_uri
    m = MXC_REGEX.match(mxc)
TypeError: expected string or bytes-like object
```

Set the `profile` for creating the room:
https://github.com/matrix-org/synapse/blob/2c42673a9b8c708a73f49575673c85a32ea32b82/synapse/server_notices/server_notices_manager.py#L166-L172

The profile is validated there:
https://github.com/matrix-org/synapse/blob/2c42673a9b8c708a73f49575673c85a32ea32b82/synapse/handlers/room_member.py#L692-L696

`if "avatar_url" in content:` is `True` because `content["avatar_url"]` is set and `None`

The function `check_avatar_size_and_mime_type` and `parse_and_validate_mxc_uri` require a string and not `None`.
https://github.com/matrix-org/synapse/blob/2b5ab8e3674b7d6003a5f17252c7933c2d6a381a/synapse/handlers/profile.py#L291


By the way: Should not the `avatar_url` always be checked with `parse_and_validate_mxc_uri` regardless of is set `max_avatar_size` or `allowed_avatar_mimetypes`.

https://github.com/matrix-org/synapse/blob/2b5ab8e3674b7d6003a5f17252c7933c2d6a381a/synapse/handlers/profile.py#L307-L310

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Dirk Klimpel dirk@klimpel.org
