### PR TITLE
Cache user IDs instead of profile objects

### DIFF
--- a/changelog.d/13573.misc
+++ b/changelog.d/13573.misc
@@ -1,1 +1,1 @@
-Cache user IDs instead of profiles to reduce cache memory usage (renames cache `_get_joined_profile_from_event_id` to `_get_user_id_from_membership_event_id`). Contributed by Nick @ Beeper (@fizzadar).
+Cache user IDs instead of profiles to reduce cache memory usage. Contributed by Nick @ Beeper (@fizzadar).

--- a/changelog.d/13573.misc
+++ b/changelog.d/13573.misc
@@ -1,0 +1,1 @@
+Cache user IDs instead of profiles to reduce cache memory usage (renames cache `_get_joined_profile_from_event_id` to `_get_user_id_from_membership_event_id`). Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -2421,10 +2421,10 @@ class SyncHandler:
                     joined_room.room_id, joined_room.event_pos.stream
                 )
             )
-            users_in_room = await self.state.get_current_users_in_room(
+            user_ids_in_room = await self.state.get_current_user_ids_in_room(
                 joined_room.room_id, extrems
             )
-            if user_id in users_in_room:
+            if user_id in user_ids_in_room:
                 joined_room_ids.add(joined_room.room_id)
 
         return frozenset(joined_room_ids)

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -952,7 +952,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             table="room_memberships",
             column="event_id",
             iterable=event_ids,
-            retcols=("user_id", "display_name", "avatar_url", "event_id"),
+            retcols=("user_id", "event_id"),
             keyvalues={"membership": Membership.JOIN},
             batch_size=1000,
             desc="_get_user_ids_from_membership_event_ids",

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -958,10 +958,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             desc="_get_user_ids_from_membership_event_ids",
         )
 
-        return {
-            row["event_id"]: row["user_id"]
-            for row in rows
-        }
+        return {row["event_id"]: row["user_id"] for row in rows}
 
     @cached(max_entries=10000)
     async def is_host_joined(self, room_id: str, host: str) -> bool:

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -925,7 +925,12 @@ class RoomMemberWorkerStore(EventsWorkerStore):
 
         return users_in_room
 
-    @cached(max_entries=10000)
+    @cached(
+        max_entries=10000,
+        # This name matches the old function that has been replaced - the cache name
+        # is kept here to maintain backwards compatibility.
+        name="_get_joined_profile_from_event_id",
+    )
     def _get_user_id_from_membership_event_id(
         self, event_id: str
     ) -> Optional[Tuple[str, ProfileInfo]]:


### PR DESCRIPTION
The profile objects are never used and increase cache size significantly.

Signed off by Nick @ Beeper (@fizzadar).

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
