### PR TITLE
Optimize how we calculate `likely_domains` during backfill

### DIFF
--- a/changelog.d/13575.misc
+++ b/changelog.d/13575.misc
@@ -1,0 +1,1 @@
+Optimize how Synapse calculates domains to fetch from during backfill.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -406,7 +406,7 @@ class FederationHandler:
             # TODO: Should we try multiple of these at a time?
             for dom in domains:
                 # We don't want to ask our own server for information we don't have
-                if dom != self.server_name:
+                if dom == self.server_name:
                     continue
 
                 try:

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -405,6 +405,10 @@ class FederationHandler:
         async def try_backfill(domains: Collection[str]) -> bool:
             # TODO: Should we try multiple of these at a time?
             for dom in domains:
+                # We don't want to ask our own server for information we don't have
+                if dom != self.server_name:
+                    continue
+
                 try:
                     await self._federation_event_handler.backfill(
                         dom, room_id, limit=100, extremities=extremities_to_request

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -70,7 +70,7 @@ from synapse.replication.http.federation import (
 from synapse.storage.databases.main.events import PartialStateConflictError
 from synapse.storage.databases.main.events_worker import EventRedactBehaviour
 from synapse.storage.state import StateFilter
-from synapse.types import JsonDict, StateMap, get_domain_from_id
+from synapse.types import JsonDict, get_domain_from_id
 from synapse.util.async_helpers import Linearizer
 from synapse.util.retryutils import NotRetryingDestination
 from synapse.visibility import filter_events_for_server
@@ -402,7 +402,7 @@ class FederationHandler:
             await self._storage_controllers.state.get_current_hosts_in_room(room_id)
         )
 
-        async def try_backfill(domains: List[str]) -> bool:
+        async def try_backfill(domains: Collection[str]) -> bool:
             # TODO: Should we try multiple of these at a time?
             for dom in domains:
                 try:

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1464,6 +1464,10 @@ class TimestampLookupHandler:
 
             # Loop through each homeserver candidate until we get a succesful response
             for domain in likely_domains:
+                # We don't want to ask our own server for information we don't have
+                if domain != self.server_name:
+                    continue
+
                 try:
                     remote_response = await self.federation_client.timestamp_to_event(
                         domain, room_id, timestamp, direction

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -60,7 +60,6 @@ from synapse.event_auth import validate_event_for_room_version
 from synapse.events import EventBase
 from synapse.events.utils import copy_and_fixup_power_levels_contents
 from synapse.federation.federation_client import InvalidResponseError
-from synapse.handlers.federation import get_domains_from_state
 from synapse.handlers.relations import BundledAggregations
 from synapse.module_api import NOT_SPAM
 from synapse.rest.admin._base import assert_user_is_admin
@@ -1459,14 +1458,9 @@ class TimestampLookupHandler:
                 timestamp,
             )
 
-            # Find other homeservers from the given state in the room
-            curr_state = await self._storage_controllers.state.get_current_state(
-                room_id
+            likely_domains = (
+                await self._storage_controllers.state.get_current_hosts_in_room(room_id)
             )
-            curr_domains = get_domains_from_state(curr_state)
-            likely_domains = [
-                domain for domain, depth in curr_domains if domain != self.server_name
-            ]
 
             # Loop through each homeserver candidate until we get a succesful response
             for domain in likely_domains:

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1465,7 +1465,7 @@ class TimestampLookupHandler:
             # Loop through each homeserver candidate until we get a succesful response
             for domain in likely_domains:
                 # We don't want to ask our own server for information we don't have
-                if domain != self.server_name:
+                if domain == self.server_name:
                     continue
 
                 try:

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -23,7 +23,6 @@ from typing import (
     List,
     Mapping,
     Optional,
-    Set,
     Tuple,
 )
 
@@ -520,7 +519,7 @@ class StateStorageController:
         )
         return state_map.get(key)
 
-    async def get_current_hosts_in_room(self, room_id: str) -> Set[str]:
+    async def get_current_hosts_in_room(self, room_id: str) -> List[str]:
         """Get current hosts in room based on current state."""
 
         await self._partial_state_room_tracker.await_full_state(room_id)

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1057,20 +1057,15 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         users = self.get_users_in_room.cache.get_immediate(
             (room_id,), None, update_metrics=False
         )
-        domains: List[str] = []
-        if users is not None:
-            # Because `users` is sorted from lowest -> highest depth, the list of
-            # domains will also be sorted that way.
-            for u in users:
-                domain = get_domain_from_id(u)
-                if domain not in domains:
-                    domains.append(domain)
-            return domains
-
-        if isinstance(self.database_engine, Sqlite3Engine):
+        if users is None and isinstance(self.database_engine, Sqlite3Engine):
             # If we're using SQLite then let's just always use
             # `get_users_in_room` rather than funky SQL.
             users = await self.get_users_in_room(room_id)
+
+        if users is not None:
+            # Because `users` is sorted from lowest -> highest depth, the list
+            # of domains will also be sorted that way.
+            domains: List[str] = []
             for u in users:
                 domain = get_domain_from_id(u)
                 if domain not in domains:

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1067,7 +1067,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             # of domains will also be sorted that way.
             domains: List[str] = []
             # We use a `Set` just for fast lookups
-            domain_set: Set[str] = {}
+            domain_set: Set[str] = set()
             for u in users:
                 domain = get_domain_from_id(u)
                 if domain not in domain_set:

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1066,9 +1066,12 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             # Because `users` is sorted from lowest -> highest depth, the list
             # of domains will also be sorted that way.
             domains: List[str] = []
+            # We use a `Set` just for fast lookups
+            domain_set: Set[str] = {}
             for u in users:
                 domain = get_domain_from_id(u)
-                if domain not in domains:
+                if domain not in domain_set:
+                    domain_set.add(domain)
                     domains.append(domain)
             return domains
 

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1038,6 +1038,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         # For PostgreSQL we can use a regex to pull out the domains from the
         # joined users in `current_state_events` via regex.
 
+        # TODO: Trying to remember what to do: group by host, order by depth
         def get_current_hosts_in_room_txn(txn: LoggingTransaction) -> Set[str]:
             sql = """
                 SELECT DISTINCT substring(state_key FROM '@[^:]*:(.*)$')

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -210,19 +210,20 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         # frequently this function gets called.
         if self._current_state_events_membership_up_to_date:
             sql = """
-                SELECT state_key FROM current_state_events as c
+                SELECT c.state_key FROM current_state_events as c
                 /* Get the depth of the event from the events table */
                 INNER JOIN events AS e USING (event_id)
-                WHERE type = 'm.room.member' AND room_id = ? AND membership = ?
+                WHERE c.type = 'm.room.member' AND c.room_id = ? AND membership = ?
                 /* Sorted by lowest depth first */
                 ORDER BY e.depth ASC;
             """
         else:
             sql = """
-                SELECT state_key FROM room_memberships as m
-                INNER JOIN current_state_events as c USING (event_id)
+                SELECT c.state_key FROM room_memberships as m
                 /* Get the depth of the event from the events table */
                 INNER JOIN events AS e USING (event_id)
+                INNER JOIN current_state_events as c
+                ON m.event_id = c.event_id
                 AND m.room_id = c.room_id
                 AND m.user_id = c.state_key
                 WHERE c.type = 'm.room.member' AND c.room_id = ? AND m.membership = ?

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1019,7 +1019,17 @@ class RoomMemberWorkerStore(EventsWorkerStore):
 
     @cached(iterable=True, max_entries=10000)
     async def get_current_hosts_in_room(self, room_id: str) -> Set[str]:
-        """Get current hosts in room based on current state."""
+        """
+        Get current hosts in room based on current state.
+
+        The heuristic of sorting by servers who have been in the room the
+        longest is good because they're most likely to have anything we ask
+        about.
+
+        Returns:
+            Returns a list of servers sorted by longest in the room first. (aka.
+            sorted by join with the lowest depth first).
+        """
 
         # First we check if we already have `get_users_in_room` in the cache, as
         # we can just calculate result from that
@@ -1040,7 +1050,10 @@ class RoomMemberWorkerStore(EventsWorkerStore):
 
         def get_current_hosts_in_room_txn(txn: LoggingTransaction) -> Set[str]:
             # Returns a list of servers currently joined in the room sorted by
-            # longest in the room first (aka. with the lowest depth).
+            # longest in the room first (aka. with the lowest depth). The
+            # heuristic of sorting by servers who have been in the room the
+            # longest is good because they're most likely to have anything we
+            # ask about.
             sql = """
                 SELECT
                     /* Match the domain part of the MXID */


### PR DESCRIPTION

Optimize how we calculate `likely_domains` during backfill because I've seen this take 17s in production just to `get_current_state` which is used to `get_domains_from_state` (see case [*2. Loading tons of events* in the `/messages` investigation issue](https://github.com/matrix-org/synapse/issues/13356)).


There are 3 ways we currently calculate hosts that are in the room:

 1. `get_current_state` -> `get_domains_from_state`
    - Used in `backfill` to calculate `likely_domains` and `/timestamp_to_event` because it was cargo-culted from `backfill`
    - This one is being eliminated in favor of `get_current_hosts_in_room` in this PR 🕳
 1. `get_current_hosts_in_room`
    - Used for other federation things like sending read receipts and typing indicators
 1. `get_hosts_in_room_at_events`
    - Used when pushing out events over federation to other servers in the `_process_event_queue_loop`

Fix https://github.com/matrix-org/synapse/issues/13626

Part of https://github.com/matrix-org/synapse/issues/13356

Mentioned in [internal doc](https://docs.google.com/document/d/1lvUoVfYUiy6UaHB6Rb4HicjaJAU40-APue9Q4vzuW3c/edit#bookmark=id.2tvwz3yhcafh)


### Query performance

#### Before

The query from `get_current_state` sucks just because we have to get all 80k events. And we see almost the exact same performance locally trying to get all of these events (16s vs 17s):
```
synapse=# SELECT type, state_key, event_id FROM current_state_events WHERE room_id = '!OGEhHVWSdvArJzumhm:matrix.org';
Time: 16035.612 ms (00:16.036)

synapse=# SELECT type, state_key, event_id FROM current_state_events WHERE room_id = '!OGEhHVWSdvArJzumhm:matrix.org';
Time: 4243.237 ms (00:04.243)
```

But what about `get_current_hosts_in_room`: When there is 8M rows in the `current_state_events` table, the previous query in `get_current_hosts_in_room` took 13s from complete freshness (when the events were first added). But takes 930ms after a Postgres restart or 390ms if running back to back to back.

```sh
$ psql synapse
synapse=# \timing on
synapse=# SELECT COUNT(DISTINCT substring(state_key FROM '@[^:]*:(.*)$'))
FROM current_state_events
WHERE
    type = 'm.room.member'
    AND membership = 'join'
    AND room_id = '!OGEhHVWSdvArJzumhm:matrix.org';
 count
-------
  4130
(1 row)

Time: 13181.598 ms (00:13.182)

synapse=# SELECT COUNT(*) from current_state_events where room_id = '!OGEhHVWSdvArJzumhm:matrix.org';
 count
-------
 80814

synapse=# SELECT COUNT(*) from current_state_events;
  count
---------
 8162847

synapse=# SELECT pg_size_pretty( pg_total_relation_size('current_state_events') );
 pg_size_pretty
----------------
 4702 MB
```

#### After

I'm not sure how long it takes from complete freshness as I only really get that opportunity once (maybe restarting computer but that's cumbersome) and it's not really relevant to normal operating times. Maybe you get closer to the fresh times the more access variability there is so that Postgres caches aren't as exact. Update: The longest I've seen this run for is 6.4s and 4.5s after a computer restart.

After a Postgres restart, it takes 330ms and running back to back takes 260ms.

```sh
$ psql synapse
synapse=# \timing on
Timing is on.
synapse=# SELECT
    substring(c.state_key FROM '@[^:]*:(.*)$') as host
FROM current_state_events c
/* Get the depth of the event from the events table */
INNER JOIN events AS e USING (event_id)
WHERE
    c.type = 'm.room.member'
    AND c.membership = 'join'
    AND c.room_id = '!OGEhHVWSdvArJzumhm:matrix.org'
GROUP BY host
ORDER BY min(e.depth) ASC;
Time: 333.800 ms
```

#### Going further

To improve things further we could add a `limit` parameter to `get_current_hosts_in_room`. Realistically, we don't need 4k domains to choose from because there is no way we're going to query that many before we a) probably get an answer or b) we give up. 

Another thing we can do is optimize the query to use a index skip scan:

 - https://wiki.postgresql.org/wiki/Loose_indexscan
 - Index Skip Scan, https://commitfest.postgresql.org/37/1741/
 - https://www.timescale.com/blog/how-we-made-distinct-queries-up-to-8000x-faster-on-postgresql/




### Dev notes

Created a utility script to dump the state events from a 
`GET https://matrix-client.matrix.org/_matrix/client/r0/rooms/!OGEhHVWSdvArJzumhm:matrix.org/state` response for testing in your local dev database, https://github.com/MadLittleMods/matrix-synapse-state-dumper

It can also add in filler events in between in the database so it isn't such an easy sequential read for Postgres.

It's rough and just barely does what I needed to get some testing for this PR. Not very general.

---

```
brew services restart postgresql@13

$ psql synapse
> \timing on
> ...
> \q
```

---



Get count of rows when using `group by`:
```
SELECT COUNT(*) OVER () AS TotalRecords
FROM current_state_events c
/* Get the depth of the event from the events table */
INNER JOIN events AS e USING (event_id)
WHERE
    c.type = 'm.room.member'
    AND c.membership = 'join'
    AND c.room_id = '!OGEhHVWSdvArJzumhm:matrix.org'
GROUP BY substring(c.state_key FROM '@[^:]*:(.*)$')
ORDER BY min(e.depth);
```

---


<details>
<summary><code>BackfillBenchmarkTestCase</code> <code>test_benchmark_likely_domains</code></summary>

```py
class BackfillBenchmarkTestCase(unittest.HomeserverTestCase):
    def prepare(self, reactor, clock, hs):
        self._storage_controllers = hs.get_storage_controllers()

    def test_benchmark_likely_domains(self):
        import time
        import logging

        logger = logging.getLogger(__name__)

        from synapse.handlers.federation import get_domains_from_state

        async def calculate_likely_domains():
            # Find other homeservers from the given state in the room
            curr_state = await self._storage_controllers.state.get_current_state(
                "!OGEhHVWSdvArJzumhm:matrix.org"
            )
            curr_domains = get_domains_from_state(curr_state)
            likely_domains = [
                domain for domain, depth in curr_domains if domain != self.server_name
            ]
            return likely_domains

        def time_calculate_likely_domains(test_prefix: str):
            benchmark_start_time = time.time()
            likely_domains = self.get_success(calculate_likely_domains())
            benchmark_end_time = time.time()
            logger.info(
                "Benchmark time (%s): %s",
                "{test_prefix: <13}".format(test_prefix=test_prefix),
                (benchmark_end_time - benchmark_start_time),
            )
            self.assertGreater(len(likely_domains), 4000)

        time_calculate_likely_domains("1")
        time_calculate_likely_domains("2")
        time_calculate_likely_domains("3")
```

</details>


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
