### PR TITLE
Faster Room Joins: fix `/make_knock` blocking indefinitely when the room in question is a partial-stated room.

### DIFF
--- a/changelog.d/13583.bugfix
+++ b/changelog.d/13583.bugfix
@@ -1,0 +1,1 @@
+Faster Room Joins: fix `/make_knock` blocking indefinitely when the room in question is a partial-stated room.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -763,6 +763,16 @@ class FederationServer(FederationBase):
             The partial knock event.
         """
         origin_host, _ = parse_server_name(origin)
+
+        if self.store.is_partial_state_room(room_id):
+            # Before we do anything: check if the room is partial-stated.
+            # Note that checking the ACL (below) requires full state, for example.
+            raise SynapseError(
+                404,
+                "Unable to handle /make_knock right now; this server is not fully joined.",
+                errcode=Codes.NOT_FOUND,
+            )
+
         await self.check_server_matches_acl(origin_host, room_id)
 
         room_version = await self.store.get_room_version(room_id)

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -764,7 +764,7 @@ class FederationServer(FederationBase):
         """
         origin_host, _ = parse_server_name(origin)
 
-        if self.store.is_partial_state_room(room_id):
+        if await self.store.is_partial_state_room(room_id):
             # Before we do anything: check if the room is partial-stated.
             # Note that at the time this check was added, `on_make_knock_request` would
             # block due to https://github.com/matrix-org/synapse/issues/12997.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -766,7 +766,8 @@ class FederationServer(FederationBase):
 
         if self.store.is_partial_state_room(room_id):
             # Before we do anything: check if the room is partial-stated.
-            # Note that checking the ACL (below) requires full state, for example.
+            # Note that at the time this check was added, `on_make_knock_request` would
+            # block due to https://github.com/matrix-org/synapse/issues/12997.
             raise SynapseError(
                 404,
                 "Unable to handle /make_knock right now; this server is not fully joined.",


### PR DESCRIPTION
Follow-up to #13416; caught by adding tests so that was a good idea :-).

