### PR TITLE
When loading current ids, sort by `stream_id` to avoid incorrect overwrite and avoid errors caused by sorting alphabetical instance name which can be `null`

### DIFF
--- a/changelog.d/13585.bugfix
+++ b/changelog.d/13585.bugfix
@@ -1,0 +1,1 @@
+Fix loading the current stream position behind the actual position.

--- a/synapse/storage/util/id_generators.py
+++ b/synapse/storage/util/id_generators.py
@@ -464,7 +464,13 @@ class MultiWriterIdGenerator(AbstractStreamIdGenerator):
             # rows in order for each instance because we don't want to overwrite
             # the current_position of an instance to a lower stream ID than
             # we're actually at.
-            rows.sort(key=lambda _, stream_id: stream_id)
+            def sort_by_stream_id_key_func(row: Tuple[str, int]) -> int:
+                (instance, stream_id) = row
+                # If `stream_id` is ever `None`, we will see a `TypeError: '<'
+                # not supported between instances of 'NoneType' and 'X'` error.
+                return stream_id
+
+            rows.sort(key=sort_by_stream_id_key_func)
 
             with self._lock:
                 for (


### PR DESCRIPTION
When loading current ids, sort by stream ID so that we don't want to overwrite the `current_position` of an instance to a lower stream ID than we're actually at ([discussion](https://github.com/matrix-org/synapse/pull/13585#discussion_r951795379)). Previously, it sorted alphabetically by instance name which can be `null` and throw errors but more importantly, accomplishes nothing.

Discovered because my local Synapse was throwing an error on startup:

```
$ poetry run synapse_homeserver --config-path homeserver.yaml
****************************************************************
 Error during initialisation:
    '<' not supported between instances of 'NoneType' and 'str'
 There may be more information in the logs.
****************************************************************
```

Somehow my database ended up looking like the following, notice the `instance_name` is `null` in the db, and we can't sort `NoneType` things. Another question is why do we see the `instance_name` as `null` sometimes instead of `master` in monolith mode?
```
$ psql synapse
synapse=# SELECT * FROM stream_positions;
   stream_name   | instance_name | stream_id
-----------------+---------------+-----------
 account_data    | master        |      1242
 events          | master        |      1787
 to_device       | master        |        58
 presence_stream | master        |    485638
 receipts        | master        |       341
 backfill        | master        |   -139106
(6 rows)
synapse=# SELECT instance_name, stream_id FROM receipts_linearized;
 instance_name | stream_id
---------------+-----------
               |       211
               |         3
               |         4
               |       212
               |       213
               |       224
               |       228
               |       164
               |       313
               |       253
               |        38
               |       321
               |       324
               |       189
               |       192
               |       193
               |       194
               |       195
               |       197
               |       198
               |       275
               |        79
               |       339
               |       340
               |        82
               |       341
               |        84
               |        85
               |        91
               |       119
```




<details>
<summary><code>homeserver.log</code> of the error:</summary>

```
2022-08-22 09:53:26,361 - synapse.app._base - 207 - ERROR - main - Exception during startup
Traceback (most recent call last):
  File "/Users/eric/Documents/github/element/synapse/synapse/app/homeserver.py", line 383, in setup
    hs.setup()
  File "/Users/eric/Documents/github/element/synapse/synapse/server.py", line 308, in setup
    self.datastores = Databases(self.DATASTORE_CLASS, self)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/__init__.py", line 93, in __init__
    main = main_store_class(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/__init__.py", line 152, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/events_bg_updates.py", line 98, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/roommember.py", line 1527, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/room.py", line 1704, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/room.py", line 1242, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/room.py", line 106, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/registration.py", line 1926, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/presence.py", line 67, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/presence.py", line 48, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/transactions.py", line 73, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/state.py", line 662, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/state.py", line 80, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/state.py", line 466, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/event_federation.py", line 1711, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/media_repository.py", line 148, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/media_repository.py", line 68, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/push_rule.py", line 322, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/event_push_actions.py", line 1340, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/metrics.py", line 68, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/event_push_actions.py", line 205, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/end_to_end_keys.py", line 1147, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/search.py", line 406, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/search.py", line 125, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/account_data.py", line 65, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/push_rule.py", line 112, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/appservice.py", line 97, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/pusher.py", line 54, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/roommember.py", line 88, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/receipts.py", line 99, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/stream.py", line 369, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/client_ips.py", line 409, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/client_ips.py", line 75, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/devices.py", line 1410, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/devices.py", line 79, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/end_to_end_keys.py", line 97, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/end_to_end_keys.py", line 79, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/deviceinbox.py", line 63, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/deviceinbox.py", line 845, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/user_directory.py", line 618, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/user_directory.py", line 70, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/monthly_active_users.py", line 45, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/stats.py", line 109, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/registration.py", line 1789, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/registration.py", line 125, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/censor_events.py", line 44, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/event_federation.py", line 96, in __init__
    super().__init__(database, db_conn, hs)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/databases/main/events_worker.py", line 187, in __init__
    self._stream_id_gen = MultiWriterIdGenerator(
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/util/id_generators.py", line 368, in __init__
    self._load_current_ids(db_conn, tables)
  File "/Users/eric/Documents/github/element/synapse/synapse/storage/util/id_generators.py", line 464, in _load_current_ids
    rows.sort()
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

</details>


### Potential cause

I might've got into this situation because of manually adding to the `current_state_events` and `events` table with https://github.com/MadLittleMods/matrix-synapse-state-dumper while looking at https://github.com/matrix-org/synapse/pull/13575. Not sure though, just something that could cause some db consistency issues.



### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
