### PR TITLE
Comment about a better future where we can get the state diff between two events

### DIFF
--- a/changelog.d/13586.misc
+++ b/changelog.d/13586.misc
@@ -1,0 +1,1 @@
+Comment about a better future where we can get the state diff between two events.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1031,6 +1031,12 @@ class FederationEventHandler:
             InvalidResponseError: if the remote homeserver's response contains fields
                 of the wrong type.
         """
+
+        # It would be better if we could query the difference from our known
+        # state to the given `event_id` so the sending server doesn't have to
+        # send as much and we don't have to process as many events. For example
+        # in a room like #matrixhq, we get 200k events (77k state_events, 122k
+        # auth_events) from this call.
         (
             state_event_ids,
             auth_event_ids,

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1035,7 +1035,7 @@ class FederationEventHandler:
         # It would be better if we could query the difference from our known
         # state to the given `event_id` so the sending server doesn't have to
         # send as much and we don't have to process as many events. For example
-        # in a room like #matrixhq, we get 200k events (77k state_events, 122k
+        # in a room like #matrix:matrix.org, we get 200k events (77k state_events, 122k
         # auth_events) from this call.
         #
         # Tracked by https://github.com/matrix-org/synapse/issues/13618

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -1037,6 +1037,8 @@ class FederationEventHandler:
         # send as much and we don't have to process as many events. For example
         # in a room like #matrixhq, we get 200k events (77k state_events, 122k
         # auth_events) from this call.
+        #
+        # Tracked by https://github.com/matrix-org/synapse/issues/13618
         (
             state_event_ids,
             auth_event_ids,


### PR DESCRIPTION
Comment about a better future where we can get the state diff between two events

Split off from https://github.com/matrix-org/synapse/pull/13561

Part of https://github.com/matrix-org/synapse/issues/13356

Mentioned in [internal doc](https://docs.google.com/document/d/1lvUoVfYUiy6UaHB6Rb4HicjaJAU40-APue9Q4vzuW3c/edit#bookmark=id.2tvwz3yhcafh)


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
