### PR TITLE
Hotfixes: revert room members hack

### DIFF
--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -339,9 +339,7 @@ class MessageHandler:
         # This can either be because the AS user is in the room or because there
         # is a user in the room that the AS is "interested in"
         if (
-            False  # See https://github.com/matrix-org/matrix-appservice-irc/issues/506
-                   # and https://github.com/matrix-org/synapse/issues/4826#issuecomment-1028105662
-            and requester.app_service
+            requester.app_service
             and requester.user.to_string() not in users_with_profile
         ):
             for uid in users_with_profile:


### PR DESCRIPTION
This reverts https://github.com/matrix-org/synapse/commit/fae708c0e8c35930f1172322b7c0e9f0b1b3f9a4.

We believe this to be unnecessary---other Synapse deployments do not
have this patch, and we are not aware of bridging problems as a result.

Related:

- https://github.com/matrix-org/matrix-appservice-irc/issues/506
- https://github.com/matrix-org/synapse/issues/4826