### PR TITLE
register_new_matrix_user: read server url from config

### DIFF
--- a/changelog.d/13616.bugfix
+++ b/changelog.d/13616.bugfix
@@ -1,0 +1,1 @@
+Fix a longstanding bug in `register_new_matrix_user` which meant it was always necessary to explicitly give a server URL.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/3672: `https://localhost:8448` is virtually never right.