### PR TITLE
Speed up inserting `event_push_actions_staging`

### DIFF
--- a/changelog.d/13634.feature
+++ b/changelog.d/13634.feature
@@ -1,0 +1,1 @@
+Improve performance of sending messages in rooms with thousands of local users.

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -707,15 +707,16 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
             sql = """
                 INSERT INTO event_push_actions_staging
                     (event_id, user_id, actions, notif, highlight, unread)
-                VALUES (?, ?, ?, ?, ?, ?)
+                VALUES ?
             """
 
-            txn.execute_batch(
+            txn.execute_values(
                 sql,
                 (
                     _gen_entry(user_id, actions)
                     for user_id, actions in user_id_actions.items()
                 ),
+                fetch=False,
             )
 
         return await self.db_pool.runInteraction(

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -700,27 +700,14 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
                 int(count_as_unread),  # unread column
             )
 
-        def _add_push_actions_to_staging_txn(txn: LoggingTransaction) -> None:
-            # We don't use simple_insert_many here to avoid the overhead
-            # of generating lists of dicts.
-
-            sql = """
-                INSERT INTO event_push_actions_staging
-                    (event_id, user_id, actions, notif, highlight, unread)
-                VALUES ?
-            """
-
-            txn.execute_values(
-                sql,
-                (
-                    _gen_entry(user_id, actions)
-                    for user_id, actions in user_id_actions.items()
-                ),
-                fetch=False,
-            )
-
-        return await self.db_pool.runInteraction(
-            "add_push_actions_to_staging", _add_push_actions_to_staging_txn
+        await self.db_pool.simple_insert_many(
+            "event_push_actions_staging",
+            keys=("event_id", "user_id", "actions", "notif", "highlight", "unread"),
+            values=[
+                _gen_entry(user_id, actions)
+                for user_id, actions in user_id_actions.items()
+            ],
+            desc="add_push_actions_to_staging",
         )
 
     async def remove_push_actions_from_staging(self, event_id: str) -> None:


### PR DESCRIPTION
This switches from using `execute_batch` to `execute_values`, from some testing against a large database with a room of 3870 local users this reduces the time to insert into the `event_push_actions_staging` from ~0.2s to <0.1s in most cases. (This wasn't super scientific, but it definitely seemed to help.)