### PR TITLE
Do not wait for background updates to complete do expire URL cache.

### DIFF
--- a/changelog.d/13657.bugfix
+++ b/changelog.d/13657.bugfix
@@ -1,2 +1,1 @@
-Fix a long-standing bug that downloaded media for URL previews was not deleted while database background updates were 
-running.
+Fix a long-standing bug that downloaded media for URL previews was not deleted while database background updates were running.

--- a/changelog.d/13657.bugfix
+++ b/changelog.d/13657.bugfix
@@ -1,0 +1,2 @@
+Fix a long-standing bug that downloaded media for URL previews was not deleted while database background updates were 
+running.

--- a/synapse/rest/media/v1/preview_url_resource.py
+++ b/synapse/rest/media/v1/preview_url_resource.py
@@ -732,10 +732,6 @@ class PreviewUrlResource(DirectServeJsonResource):
 
         logger.debug("Running url preview cache expiry")
 
-        if not (await self.store.db_pool.updates.has_completed_background_updates()):
-            logger.debug("Still running DB updates; skipping url preview cache expiry")
-            return
-
         def try_remove_parent_dirs(dirs: Iterable[str]) -> None:
             """Attempt to remove the given chain of parent directories
 


### PR DESCRIPTION
See the excellent write-up in #13637 of why this is safe.

Without this Synapse may not expire URL cache entries for a long time when there are large background updates (e.g. things that crawl `events`).

Fixes #13637.