### PR TITLE
Give the correct next event when the message timestamps are the same - MSC3030

### DIFF
--- a/changelog.d/13658.bugfix
+++ b/changelog.d/13658.bugfix
@@ -1,0 +1,1 @@
+Fix MSC3030 `/timestamp_to_event` endpoint returning the correct next event when the events have the same timestamp.

--- a/changelog.d/13658.bugfix
+++ b/changelog.d/13658.bugfix
@@ -1,1 +1,1 @@
-Fix MSC3030 `/timestamp_to_event` endpoint returning the correct next event when the events have the same timestamp.
+Fix MSC3030 `/timestamp_to_event` endpoint to return the correct next event when the events have the same timestamp.

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -2111,9 +2111,18 @@ class EventsWorkerStore(SQLBaseStore):
                 AND room_id = ?
                 /* Make sure event is not rejected */
                 AND rejections.event_id IS NULL
-            ORDER BY origin_server_ts %s
+            /**
+             * First sort by the message timestamp. If the message timestamps are the
+             * same, we want the message that logically comes "next" (before/after
+             * the given timestamp) based on the DAG and its topological order (`depth`).
+             * Finally, we can tie-break based on when it was received on the server
+             * (`stream_ordering`).
+             */
+            ORDER BY origin_server_ts %s, depth %s, stream_ordering %s
             LIMIT 1;
         """
+
+        #
 
         def get_event_id_for_timestamp_txn(txn: LoggingTransaction) -> Optional[str]:
             if direction == "b":
@@ -2130,7 +2139,8 @@ class EventsWorkerStore(SQLBaseStore):
                 order = "ASC"
 
             txn.execute(
-                sql_template % (comparison_operator, order), (timestamp, room_id)
+                sql_template % (comparison_operator, order, order, order),
+                (timestamp, room_id),
             )
             row = txn.fetchone()
             if row:

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -2122,8 +2122,6 @@ class EventsWorkerStore(SQLBaseStore):
             LIMIT 1;
         """
 
-        #
-
         def get_event_id_for_timestamp_txn(txn: LoggingTransaction) -> Optional[str]:
             if direction == "b":
                 # Find closest event *before* a given timestamp. We use descending


### PR DESCRIPTION
Give the correct next event when the message timestamps are the same.

Discovered while working on https://github.com/matrix-org/synapse/pull/13589 and I had all the messages at the same timestamp in the tests.

Part of https://github.com/matrix-org/matrix-spec-proposals/pull/3030

Complement tests: https://github.com/matrix-org/complement/pull/457

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
