### PR TITLE
Fix bug where we wedge media plugins if clients disconnect early

### DIFF
--- a/changelog.d/13660.bugfix
+++ b/changelog.d/13660.bugfix
@@ -1,0 +1,1 @@
+Fix bug where we wedge media plugins if clients disconnect early. Introduced in v1.22.0.


### PR DESCRIPTION
We incorrectly didn't use the returned `Responder` if the client had
disconnected, which meant that the resource used by the Responder
wasn't correctly released.

In particular, this exhausted the thread pools so that *all* requests
timed out.

The change is simply to move the `request._disconnected` into the context manager

Broke in #8465