### PR TITLE
Allow to pass directory for config files and data via environment files

### DIFF
--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -876,35 +876,34 @@ def find_config_files(search_paths: List[str]) -> List[str]:
         A list of file paths.
     """
 
-    config_files = []
-    if search_paths:
-        for config_path in search_paths:
-            if os.path.isdir(config_path):
-                # We accept specifying directories as config paths, we search
-                # inside that directory for all files matching *.yaml, and then
-                # we apply them in *sorted* order.
-                files = []
-                for entry in os.listdir(config_path):
-                    entry_path = os.path.join(config_path, entry)
-                    if not os.path.isfile(entry_path):
-                        err = "Found subdirectory in config directory: %r. IGNORING."
-                        print(err % (entry_path,))
-                        continue
+    config_files = {config_path: [] for config_path in search_paths}
+    for config_path, files in config_files.items():
+        if os.path.isdir(config_path):
+            # We accept specifying directories as config paths, we search
+            # inside that directory for all files matching *.yaml, and then
+            # we apply them in *sorted* order.
+            found_files = []
+            for entry in os.listdir(config_path):
+                entry_path = os.path.join(config_path, entry)
+                if not os.path.isfile(entry_path):
+                    err = "Found subdirectory in config directory: %r. IGNORING."
+                    print(err % (entry_path,))
+                    continue
 
-                    if not entry.endswith(".yaml"):
-                        err = (
-                            "Found file in config directory that does not end in "
-                            "'.yaml': %r. IGNORING."
-                        )
-                        print(err % (entry_path,))
-                        continue
+                if not entry.endswith(".yaml"):
+                    err = (
+                        "Found file in config directory that does not end in "
+                        "'.yaml': %r. IGNORING."
+                    )
+                    print(err % (entry_path,))
+                    continue
 
-                    files.append(entry_path)
+                found_files.append(entry_path)
 
-                config_files.extend(sorted(files))
-            else:
-                config_files.append(config_path)
-    return config_files
+            files.extend(sorted(found_files))
+        else:
+            files.append(config_path)
+    return list(itertools.chain(*config_files.values()))
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
### Pull Request Checklist

This PR adds the ability to pass the `--config-path` and `--data-dir` parameter via the `CONFIGURATION_DIRECTORY` and  `STATE_DIRECTORY` variables.

My intentions is to add a PR to add `ConfigurationDirectory=` and  `StateDirectory=` to the systemd service file, so that these directories are generated on first run of the service. systemd also sets the aforementioned environment variables, so that the running service knows where to look for everything.

The first commit (reworking `find_config_files`) is mostly to make sure, that this cannot be "held wrong" when people also pass in the same stuff via the environment and the CLI option.

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
