### PR TITLE
Remind people that direct TCP replication is deprecated.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+Synapse 1.66.0
+==============
+
+Deployments with multiple workers should note that the direct TCP replication
+configuration was deprecated in Synapse v1.18.0 and will be removed in Synapse
+v1.67.0. See [docs/workers.md](https://github.com/matrix-org/synapse/blob/release-v1.18.0/docs/workers.md)
+for more details.
+
 Synapse 1.66.0rc2 (2022-08-30)
 ==============================
 


### PR DESCRIPTION
Per the request at https://github.com/matrix-org/synapse/pull/13647#pullrequestreview-1090714217.