### PR TITLE
Return keys for unwhitelisted servers from `/_matrix/key/v2/query`

### DIFF
--- a/changelog.d/13683.bugfix
+++ b/changelog.d/13683.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug which meant that keys for unwhitelisted servers were not returned by `/_matrix/key/v2/query`.


### PR DESCRIPTION
I want to set up a test server which has lots of room data in it, but is part of a closed federation. It needs to return the signing keys to make that work.