### PR TITLE
Add a schema delta to drop unstable private read receipts.

### DIFF
--- a/changelog.d/13692.removal
+++ b/changelog.d/13692.removal
@@ -1,0 +1,1 @@
+Remove support for unstable [private read receipts](https://github.com/matrix-org/matrix-spec-proposals/pull/2285).

--- a/synapse/storage/schema/main/delta/72/05remove_unstable_private_read_receipts.sql
+++ b/synapse/storage/schema/main/delta/72/05remove_unstable_private_read_receipts.sql
@@ -1,0 +1,19 @@
+/* Copyright 2022 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Drop previously received private read receipts so they do not accidentally
+-- get leaked to other users.
+DELETE FROM receipts_linearized WHERE receipt_type = "org.matrix.msc2285.read.private";
+DELETE FROM receipts_graph WHERE receipt_type = "org.matrix.msc2285.read.private";

--- a/synapse/storage/schema/main/delta/72/05remove_unstable_private_read_receipts.sql
+++ b/synapse/storage/schema/main/delta/72/05remove_unstable_private_read_receipts.sql
@@ -15,5 +15,5 @@
 
 -- Drop previously received private read receipts so they do not accidentally
 -- get leaked to other users.
-DELETE FROM receipts_linearized WHERE receipt_type = "org.matrix.msc2285.read.private";
-DELETE FROM receipts_graph WHERE receipt_type = "org.matrix.msc2285.read.private";
+DELETE FROM receipts_linearized WHERE receipt_type = 'org.matrix.msc2285.read.private';
+DELETE FROM receipts_graph WHERE receipt_type = 'org.matrix.msc2285.read.private';


### PR DESCRIPTION
Follow-up to #13653, we need to somehow still handle unstable private read receipts that are in the database so that we don't leak them to other users.

As they're unstable it makes more sense to either:

1. Drop them completely.
2. Migrate them to the stable prefix.

I chose to just drop them since it is an unstable feature, but could be convinced to migrate them.