### PR TITLE
Only run trial CI on all python versions on non-PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,8 @@ jobs:
         extras: ["all"]
         is_pr:
           - ${{ startsWith(github.ref, 'refs/pull/') }}
+
+        # If we're a PR then we only test min and max python.
         exclude:
           - is_pr: true
             python-version: 3.8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:  ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         database: ["sqlite"]
         extras: ["all"]
         is_pr:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,13 +73,31 @@ jobs:
     steps:
       - run: "true"
 
+  trial-python-versions:
+    name: "Calculate list of python versions to run trial against"
+    needs: linting-done
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-pythons
+        run: |
+          # Only run oldest and latest support versions for PRs.
+          pythons='["3.7", "3.10"]'
+          if [[ $GITHUB_REF != refs/pull/* ]]; then
+              pythons='["3.7", "3.8", "3.9" "3.10"]'
+          fi
+          echo "::set-output name=pythons::$dists"
+    # map the step outputs to job outputs
+    outputs:
+      pythons: ${{ steps.set-pythons.outputs.pythons }}
+
   trial:
     if: ${{ !cancelled() && !failure() }} # Allow previous steps to be skipped, but not fail
-    needs: linting-done
+    needs: trial-python-versions
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version:  ${{ fromJson(trial-python-versions.pythons) }}
         database: ["sqlite"]
         extras: ["all"]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,33 +73,23 @@ jobs:
     steps:
       - run: "true"
 
-  trial-python-versions:
-    name: "Calculate list of python versions to run trial against"
-    needs: linting-done
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - id: set-pythons
-        run: |
-          # Only run oldest and latest support versions for PRs.
-          pythons='["3.7", "3.10"]'
-          if [[ $GITHUB_REF != refs/pull/* ]]; then
-              pythons='["3.7", "3.8", "3.9" "3.10"]'
-          fi
-          echo "::set-output name=pythons::$dists"
-    # map the step outputs to job outputs
-    outputs:
-      pythons: ${{ steps.set-pythons.outputs.pythons }}
-
   trial:
     if: ${{ !cancelled() && !failure() }} # Allow previous steps to be skipped, but not fail
-    needs: trial-python-versions
+    needs: linting-done
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:  ${{ fromJson(trial-python-versions.pythons) }}
+        python-version:  ["3.7", "3.8", "3.9", "3.10"]
         database: ["sqlite"]
         extras: ["all"]
+        is_pr:
+          - ${{ startsWith(github.ref, 'refs/pull/') }}
+        exclude:
+          - is_pr: true
+            python-version: 3.8
+          - is_pr: true
+            python-version: 3.9
+
         include:
           # Newest Python without optional deps
           - python-version: "3.10"

--- a/changelog.d/13698.misc
+++ b/changelog.d/13698.misc
@@ -1,0 +1,1 @@
+Only run trial CI on all python versions on non-PRs.


### PR DESCRIPTION
To reduce the number of CI jobs we have.