### PR TITLE
Add receipts event stream ordering

### DIFF
--- a/changelog.d/13703.misc
+++ b/changelog.d/13703.misc
@@ -1,0 +1,1 @@
+Add & populate `event_stream_ordering` column on receipts table for future optimisation of push action processing. Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -67,6 +67,7 @@ from synapse.storage.databases.main.media_repository import (
 )
 from synapse.storage.databases.main.presence import PresenceBackgroundUpdateStore
 from synapse.storage.databases.main.pusher import PusherWorkerStore
+from synapse.storage.databases.main.receipts import ReceiptsBackgroundUpdateStore
 from synapse.storage.databases.main.registration import (
     RegistrationBackgroundUpdateStore,
     find_max_generated_user_id_localpart,
@@ -203,6 +204,7 @@ class Store(
     PushRuleStore,
     PusherWorkerStore,
     PresenceBackgroundUpdateStore,
+    ReceiptsBackgroundUpdateStore,
 ):
     def execute(self, f: Callable[..., R], *args: Any, **kwargs: Any) -> Awaitable[R]:
         return self.db_pool.runInteraction(f.__name__, f, *args, **kwargs)

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -857,7 +857,9 @@ class ReceiptsBackgroundUpdateStore(SQLBaseStore):
     async def _populate_receipt_event_stream_ordering(
         self, progress: JsonDict, batch_size: int
     ) -> int:
-        def _populate_receipt_event_stream_ordering_txn(txn: LoggingTransaction) -> bool:
+        def _populate_receipt_event_stream_ordering_txn(
+            txn: LoggingTransaction,
+        ) -> bool:
 
             if "max_stream_id" in progress:
                 max_stream_id = progress["max_stream_id"]

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -838,5 +838,74 @@ class ReceiptsWorkerStore(SQLBaseStore):
         )
 
 
-class ReceiptsStore(ReceiptsWorkerStore):
+class ReceiptsBackgroundUpdateStore(SQLBaseStore):
+    POPULATE_RECEIPT_EVENT_STREAM_ORDERING = "populate_event_stream_ordering"
+
+    def __init__(
+        self,
+        database: DatabasePool,
+        db_conn: LoggingDatabaseConnection,
+        hs: "HomeServer",
+    ):
+        super().__init__(database, db_conn, hs)
+
+        self.db_pool.updates.register_background_update_handler(
+            self.POPULATE_RECEIPT_EVENT_STREAM_ORDERING,
+            self._populate_receipt_event_stream_ordering,
+        )
+
+    async def _populate_receipt_event_stream_ordering(
+        self, progress: JsonDict, batch_size: int
+    ) -> int:
+        def _populate_receipt_event_stream_ordering_txn(txn: LoggingTransaction) -> bool:
+
+            if "max_stream_id" in progress:
+                max_stream_id = progress["max_stream_id"]
+            else:
+                txn.execute("SELECT max(stream_id) FROM receipts_linearized")
+                res = txn.fetchone()
+                if res is None or res[0] is None:
+                    return True
+                else:
+                    max_stream_id = res[0]
+
+            start = progress.get("stream_id", 0)
+            stop = start + batch_size
+
+            sql = """
+                UPDATE receipts_linearized
+                SET event_stream_ordering = (
+                    SELECT stream_ordering
+                    FROM events
+                    WHERE event_id = receipts_linearized.event_id
+                )
+                WHERE stream_id >= ? AND stream_id < ?
+            """
+            txn.execute(sql, (start, stop))
+
+            self.db_pool.updates._background_update_progress_txn(
+                txn,
+                self.POPULATE_RECEIPT_EVENT_STREAM_ORDERING,
+                {
+                    "stream_id": stop,
+                    "max_stream_id": max_stream_id,
+                },
+            )
+
+            return stop > max_stream_id
+
+        finished = await self.db_pool.runInteraction(
+            "_remove_devices_from_device_inbox_txn",
+            _populate_receipt_event_stream_ordering_txn,
+        )
+
+        if finished:
+            await self.db_pool.updates._end_background_update(
+                self.POPULATE_RECEIPT_EVENT_STREAM_ORDERING
+            )
+
+        return batch_size
+
+
+class ReceiptsStore(ReceiptsWorkerStore, ReceiptsBackgroundUpdateStore):
     pass

--- a/synapse/storage/schema/main/delta/72/05receipts_event_stream_ordering.sql
+++ b/synapse/storage/schema/main/delta/72/05receipts_event_stream_ordering.sql
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-ALTER TABLE receipts_linearized ADD COLUMN event_stream_ordering integer;
+ALTER TABLE receipts_linearized ADD COLUMN event_stream_ordering BIGINT;
 
 INSERT INTO background_updates (update_name, progress_json) VALUES
   ('populate_event_stream_ordering', '{}');

--- a/synapse/storage/schema/main/delta/72/05receipts_event_stream_ordering.sql
+++ b/synapse/storage/schema/main/delta/72/05receipts_event_stream_ordering.sql
@@ -14,3 +14,6 @@
  */
 
 ALTER TABLE receipts_linearized ADD COLUMN event_stream_ordering integer;
+
+INSERT INTO background_updates (update_name, progress_json) VALUES
+  ('populate_event_stream_ordering', '{}');

--- a/synapse/storage/schema/main/delta/72/05receipts_event_stream_ordering.sql
+++ b/synapse/storage/schema/main/delta/72/05receipts_event_stream_ordering.sql
@@ -1,0 +1,16 @@
+/* Copyright 2022 Beeper
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE receipts_linearized ADD COLUMN event_stream_ordering integer;


### PR DESCRIPTION
More work on #13448. Adds a new column `event_stream_ordering` to the `receipts_linearized` table specifically to remove the relatively expensive join on events when processing push actions (https://github.com/beeper/synapse/commit/26fd50f2b030f1908a1259c6cd9bc264e42077ba).

One question here is when an event is `None` - as far as I can tell this should only ever happen if a client sends in a bad event ID with a receipt. In all other cases the event should exist - if the client knows about an event ID the server must have provided it.

Alternative approach to this problem: reject receipts with invalid event IDs (might need spec update?). Don't think that's within scope here, but probably worth considering unless I've missed something.

Signed off by Nick @ Beeper (@fizzadar).

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
