### PR TITLE
Fix event size checks

### DIFF
--- a/changelog.d/13710.bugfix
+++ b/changelog.d/13710.bugfix
@@ -1,0 +1,1 @@
+Fix a long standing bug, where Synapse would count codepoints instead of bytes when validating the size of some fields.

--- a/changelog.d/13710.bugfix
+++ b/changelog.d/13710.bugfix
@@ -1,1 +1,1 @@
-Fix a long standing bug, where Synapse would count codepoints instead of bytes when validating the size of some fields.
+Fix a long-standing bug where Synapse would count codepoints instead of bytes when validating the size of some fields.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -325,15 +325,15 @@ def check_state_dependent_auth_rules(
 
 
 def _check_size_limits(event: "EventBase") -> None:
-    if len(event.user_id) > 255:
+    if len(event.user_id.encode("utf-8")) > 255:
         raise EventSizeError("'user_id' too large")
-    if len(event.room_id) > 255:
+    if len(event.room_id.encode("utf-8")) > 255:
         raise EventSizeError("'room_id' too large")
-    if event.is_state() and len(event.state_key) > 255:
+    if event.is_state() and len(event.state_key.encode("utf-8")) > 255:
         raise EventSizeError("'state_key' too large")
-    if len(event.type) > 255:
+    if len(event.type.encode("utf-8")) > 255:
         raise EventSizeError("'type' too large")
-    if len(event.event_id) > 255:
+    if len(event.event_id.encode("utf-8")) > 255:
         raise EventSizeError("'event_id' too large")
     if len(encode_canonical_json(event.get_pdu_json())) > MAX_PDU_SIZE:
         raise EventSizeError("event too large")


### PR DESCRIPTION
This fixes Synapse possibly defederating some rooms with conduit and dendrite<=0.9.5 as well as breaking some clients relying on the guarantees of the client-server API.

Spec link: https://spec.matrix.org/v1.3/client-server-api/#size-limits

Spec issue: https://github.com/matrix-org/matrix-spec/issues/1001

This does break some rooms, if they have any events violating these constraints in their auth chain. This however should not affect that many rooms, considering how long it took to discover this. Most notably those rooms didn't federate with conduit or dendrite servers (although the latter has changed their auth code to match the current synapse implementation recently). More specifically:

- the event id and room id is not user controlled and all implementations so far use plain ASCII. There are some servers that patched in custom overrides for these IDs, but imo we can safely ignore those as any rooms I encountered so far that violate the tighter constraints were created to test this bug.
- similarly no event type in the specification currently violates this constraint and events outside of the spec are rarely an important part of the auth chain and can usually be safely dropped. Clients also generally use ascii and short event types when possible, but it might serve well to check the matrix.org database for any events falling into the now invalid area. Please ignore any rooms with room ids from maunium.net of course.
- The state key and user ids are trickier. Servers in general don't allow you to register non-ascii userids, many even properly restricting to lowercase characters only. So on unmodified servers such userids don't exist. However, you can somewhat trivially specify arbitrary state_keys using the devtools in Element. Though again, those events are usually not in the auth chain: https://spec.matrix.org/v1.3/server-server-api/#auth-events-selection. The only event with a non-empty state_key in the auth-chain is the m.room.member event, which uses the user_id as the state_key, which as previously discussed usually can't use non-ascii characters.

Considering all of the above, imo this should only break rooms intentionally abusing this issue to break rooms. It also makes Matrix a lot more predictable to handle and means you don't need to implement codepoint parsing in SDKs and other Matrix middleware.

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
