### PR TITLE
Actually fix typechecking with latest types-jsonschema

### DIFF
--- a/changelog.d/13724.misc
+++ b/changelog.d/13724.misc
@@ -1,0 +1,1 @@
+Fix typechecking with latest types-jsonschema.

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -140,13 +140,13 @@ USER_FILTER_SCHEMA = {
 
 
 @FormatChecker.cls_checks("matrix_room_id")
-def matrix_room_id_validator(room_id_str: str) -> bool:
-    return RoomID.is_valid(room_id_str)
+def matrix_room_id_validator(room_id: object) -> bool:
+    return isinstance(room_id, str) and RoomID.is_valid(room_id)
 
 
 @FormatChecker.cls_checks("matrix_user_id")
-def matrix_user_id_validator(user_id_str: str) -> bool:
-    return UserID.is_valid(user_id_str)
+def matrix_user_id_validator(user_id: object) -> bool:
+    return isinstance(user_id, str) and UserID.is_valid(user_id)
 
 
 class Filtering:


### PR DESCRIPTION
Closes #13721. In #13708 I forgot to actually check my changes against the latest stubs, whoops.

```
$ mypy
synapse/api/filtering.py:142: error: Value of type variable "_F" of function cannot be "Callable[[str], bool]"  [type-var]
synapse/api/filtering.py:147: error: Value of type variable "_F" of function cannot be "Callable[[str], bool]"  [type-var]
Found 2 errors in 1 file (checked 728 source files)

 $ pip install --upgrade types-jsonschema
Requirement already satisfied: types-jsonschema in /home/dmr/.cache/pypoetry/virtualenvs/matrix-synapse-RhMlrixz-py3.10/lib/python3.10/site-packages (4.4.6)
Collecting types-jsonschema
  Downloading types_jsonschema-4.15.1-py3-none-any.whl (8.7 kB)
Installing collected packages: types-jsonschema
  Attempting uninstall: types-jsonschema
    Found existing installation: types-jsonschema 4.4.6
    Uninstalling types-jsonschema-4.4.6:
      Successfully uninstalled types-jsonschema-4.4.6
Successfully installed types-jsonschema-4.15.1

$ mypy
Success: no issues found in 728 source files
```