### PR TITLE
Document easy room purge benefit of using `(room_id, event_id)`

### DIFF
--- a/changelog.d/13771.doc
+++ b/changelog.d/13771.doc
@@ -1,0 +1,1 @@
+Document easy room purge benefit of using `(room_id, event_id)` in our database schemas.

--- a/docs/development/database_schema.md
+++ b/docs/development/database_schema.md
@@ -208,10 +208,11 @@ But hash collisions are still possible, and by treating event IDs as room
 scoped, we can reduce the possibility of a hash collision. When scoping
 `event_id` in the database schema, it should be also accompanied by `room_id`
 (`PRIMARY KEY (room_id, event_id)`) and lookups should be done through the pair
-`(room_id, event_id)`.
+`(room_id, event_id)`. Another benefit of scoping `event_ids` to the room is
+that it makes it very easy to find and clean up everything in a room when it
+needs to be purged.
 
-There has been a lot of debate on this in places like
+`event_id` global uniqueness has had a lot debate in places like
 https://github.com/matrix-org/matrix-spec-proposals/issues/2779 and
 [MSC2848](https://github.com/matrix-org/matrix-spec-proposals/pull/2848) which
 has no resolution yet (as of 2022-09-01).
-

--- a/docs/development/database_schema.md
+++ b/docs/development/database_schema.md
@@ -210,7 +210,7 @@ scoped, we can reduce the possibility of a hash collision. When scoping
 (`PRIMARY KEY (room_id, event_id)`) and lookups should be done through the pair
 `(room_id, event_id)`. Another benefit of scoping `event_ids` to the room is
 that it makes it very easy to find and clean up everything in a room when it
-needs to be purged (no need to sub-`select` query or join from the `events`
+needs to be purged (no need to use sub-`select` query or join from the `events`
 table).
 
 `event_id` global uniqueness has had a lot debate in places like

--- a/docs/development/database_schema.md
+++ b/docs/development/database_schema.md
@@ -210,7 +210,8 @@ scoped, we can reduce the possibility of a hash collision. When scoping
 (`PRIMARY KEY (room_id, event_id)`) and lookups should be done through the pair
 `(room_id, event_id)`. Another benefit of scoping `event_ids` to the room is
 that it makes it very easy to find and clean up everything in a room when it
-needs to be purged.
+needs to be purged (no need to sub-`select` query or join from the `events`
+table).
 
 `event_id` global uniqueness has had a lot debate in places like
 https://github.com/matrix-org/matrix-spec-proposals/issues/2779 and


### PR DESCRIPTION
Document easy room purge benefit of using `(room_id, event_id)`

Discussed in the backend chapter sync as mentioned by @erikjohnston,
https://docs.google.com/document/d/1kmGRzPFfg_gRY6l0sxjYkSLW6UpMFn9ELQX5CtTLWlA/edit#bookmark=id.ciuq6xs2t47

Follow-up to https://github.com/matrix-org/synapse/pull/13701


### Dev notes

Database tables which don't have a `(room_id, event_id)` index, https://github.com/matrix-org/synapse/blob/fa2f3d8d0c915c6ebd84ef53526ac04c91fd4a19/synapse/storage/databases/main/purge_events.py#L388-L412


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
