### PR TITLE
Simplify CI tests DAG

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -468,10 +468,6 @@ jobs:
   tests-done:
     if: ${{ always() }}
     needs:
-      - check-sampleconfig
-      - lint
-      - lint-crlf
-      - lint-newsfile
       - trial
       - trial-olddeps
       - sytest

--- a/changelog.d/13784.misc
+++ b/changelog.d/13784.misc
@@ -1,0 +1,1 @@
+Simplify the dependency DAG in the tests workflow.


### PR DESCRIPTION
This removes edges from some lint jobs to `tests-done`.

Before: https://github.com/matrix-org/synapse/actions/runs/3039314342
After: https://github.com/matrix-org/synapse/actions/runs/3039998218

Should have no effect (it's removing an edge that's implied by transitivity). Makes me feel less neurotic though.