### PR TITLE
Be able to correlate timeouts in reverse-proxy layer in front of Synapse (tag specific request headers)

### DIFF
--- a/changelog.d/13786.feature
+++ b/changelog.d/13786.feature
@@ -1,0 +1,1 @@
+Add `opentracing.request_headers_to_tag` config to specify which request headers extract and tag traces with in order to correlate timeouts in reverse-proxy layers in front of Synapse with traces.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3612,6 +3612,11 @@ Sub-options include:
 * `jaeger_config`: Jaeger can be configured to sample traces at different rates.
    All configuration options provided by Jaeger can be set here. Jaeger's configuration is
    mostly related to trace sampling which is documented [here](https://www.jaegertracing.io/docs/latest/sampling/).
+* `request_headers_to_tag`: A list of headers to extract from the request and
+  add to to the top-level servlet tracing span as tags. Useful when you're using
+  a reverse proxy service like Cloudflare to protect your Synapse instance in
+  order to correlate and match up requests that timed out at the Cloudflare
+  layer to the Synapse traces.
 
 Example configuration:
 ```yaml
@@ -3629,6 +3634,9 @@ opentracing:
         param: 1
       logging:
         false
+
+    request_headers_to_tag:
+      - "cf-ray"
 ```
 ---
 ## Workers ##

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -184,7 +184,8 @@ class Auth:
                     headers = request.requestHeaders.getRawHeaders(header_name)
                     if headers is not None:
                         parent_span.set_tag(
-                            SynapseTags.REQUEST_HEADER_PREFIX + header_name, headers[0]
+                            SynapseTags.REQUEST_HEADER_PREFIX + header_name,
+                            str(headers[0]),
                         )
 
             return requester

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -180,11 +180,11 @@ class Auth:
                 # in that layer to a Synapse trace. ex. when Cloudflare times
                 # out it gives a `cf-ray` header which we can also tag here to
                 # find the trace.
-                for header_key in self.hs.config.tracing.request_headers_to_tag:
-                    headers = request.requestHeaders.getRawHeaders(header_key)
+                for header_name in self.hs.config.tracing.request_headers_to_tag:
+                    headers = request.requestHeaders.getRawHeaders(header_name)
                     if headers is not None:
                         parent_span.set_tag(
-                            SynapseTags.REQUEST_HEADER_PREFIX + header_key, headers[0]
+                            SynapseTags.REQUEST_HEADER_PREFIX + header_name, headers[0]
                         )
 
             return requester

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -182,7 +182,7 @@ class Auth:
                 # find the trace.
                 for header_key in self.hs.config.tracing.request_headers_to_tag:
                     headers = request.requestHeaders.getRawHeaders(header_key)
-                    if len(headers):
+                    if headers is not None:
                         parent_span.set_tag(
                             SynapseTags.REQUEST_HEADER_PREFIX + header_key, headers[0]
                         )

--- a/synapse/config/tracer.py
+++ b/synapse/config/tracer.py
@@ -42,10 +42,7 @@ class TracerConfig(Config):
         # reverse proxy service like Cloudflare to protect your Synapse instance
         # in order to correlate and match up requests that timed out at the
         # Cloudflare layer to the Synapse traces.
-        self.request_headers_to_tag = opentracing_config.get(
-            "request_headers_to_tag",
-            [],
-        )
+        self.request_headers_to_tag = []
 
         if not self.opentracer_enabled:
             return
@@ -72,3 +69,13 @@ class TracerConfig(Config):
                     ("opentracing", "force_tracing_for_users", f"index {i}"),
                 )
             self.force_tracing_for_users.add(u)
+
+        request_headers_to_tag = opentracing_config.get(
+            "request_headers_to_tag",
+            [],
+        )
+        if not isinstance(request_headers_to_tag, list):
+            raise ConfigError(
+                "Expected a list", ("opentracing", "request_headers_to_tag")
+            )
+        self.request_headers_to_tag = request_headers_to_tag

--- a/synapse/config/tracer.py
+++ b/synapse/config/tracer.py
@@ -37,6 +37,16 @@ class TracerConfig(Config):
 
         self.force_tracing_for_users: Set[str] = set()
 
+        # A list of headers to extract from the request and add to to the
+        # top-level servlet tracing span as tags. Useful when you're using a
+        # reverse proxy service like Cloudflare to protect your Synapse instance
+        # in order to correlate and match up requests that timed out at the
+        # Cloudflare layer to the Synapse traces.
+        self.request_headers_to_tag = opentracing_config.get(
+            "request_headers_to_tag",
+            [],
+        )
+
         if not self.opentracer_enabled:
             return
 

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -303,6 +303,10 @@ class SynapseTags:
     # incoming HTTP request ID  (as written in the logs)
     REQUEST_ID = "request_id"
 
+    # Tag a header from the incoming request. The name of the header should be
+    # appended to this prefix.
+    REQUEST_HEADER_PREFIX = "request_header."
+
     # HTTP request tag (used to distinguish full vs incremental syncs, etc)
     REQUEST_TAG = "request_tag"
 


### PR DESCRIPTION
Add `opentracing.request_headers_to_tag` config to specify which request headers extract and tag traces with in order to correlate timeouts in reverse-proxy layers in front of Synapse with traces.

Fix https://github.com/matrix-org/synapse/issues/13685

Alternative solution: https://github.com/matrix-org/synapse/pull/13801

---

<img width="764" alt="Jaeger span with a test request header tagged" src="https://user-images.githubusercontent.com/558581/189774162-f6bdd74c-bd3b-487c-bdc1-17b807ea4682.png">


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
