### PR TITLE
Optimise get_rooms_for_user (drop with_stream_ordering)

### DIFF
--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -271,11 +271,11 @@ class DeviceWorkerHandler:
             possibly_left = possibly_changed | possibly_left
 
             # Double check if we still share rooms with the given user.
-            users_rooms = await self.store.get_rooms_for_users_with_stream_ordering(
+            users_rooms = await self.store.get_rooms_for_users(
                 possibly_left
             )
             for changed_user_id, entries in users_rooms.items():
-                if any(e.room_id in room_ids for e in entries):
+                if any(room_id in room_ids for room_id in entries):
                     possibly_left.discard(changed_user_id)
                 else:
                     possibly_joined.discard(changed_user_id)

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -271,9 +271,7 @@ class DeviceWorkerHandler:
             possibly_left = possibly_changed | possibly_left
 
             # Double check if we still share rooms with the given user.
-            users_rooms = await self.store.get_rooms_for_users(
-                possibly_left
-            )
+            users_rooms = await self.store.get_rooms_for_users(possibly_left)
             for changed_user_id, entries in users_rooms.items():
                 if any(room_id in room_ids for room_id in entries):
                     possibly_left.discard(changed_user_id)

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1474,9 +1474,7 @@ class SyncHandler:
                 since_token.device_list_key
             )
             if changed_users is not None:
-                result = await self.store.get_rooms_for_users(
-                    changed_users
-                )
+                result = await self.store.get_rooms_for_users(changed_users)
 
                 for changed_user_id, entries in result.items():
                     # Check if the changed user shares any rooms with the user,
@@ -1517,11 +1515,7 @@ class SyncHandler:
                 newly_left_users.update(left_users)
 
             # Remove any users that we still share a room with.
-            left_users_rooms = (
-                await self.store.get_rooms_for_users(
-                    newly_left_users
-                )
-            )
+            left_users_rooms = await self.store.get_rooms_for_users(newly_left_users)
             for user_id, entries in left_users_rooms.items():
                 if any(rid in joined_rooms for rid in entries):
                     newly_left_users.discard(user_id)

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1474,7 +1474,7 @@ class SyncHandler:
                 since_token.device_list_key
             )
             if changed_users is not None:
-                result = await self.store.get_rooms_for_users_with_stream_ordering(
+                result = await self.store.get_rooms_for_users(
                     changed_users
                 )
 
@@ -1483,7 +1483,7 @@ class SyncHandler:
                     # or if the changed user is the syncing user (as we always
                     # want to include device list updates of their own devices).
                     if user_id == changed_user_id or any(
-                        e.room_id in joined_rooms for e in entries
+                        rid in joined_rooms for rid in entries
                     ):
                         users_that_have_changed.add(changed_user_id)
             else:
@@ -1518,12 +1518,12 @@ class SyncHandler:
 
             # Remove any users that we still share a room with.
             left_users_rooms = (
-                await self.store.get_rooms_for_users_with_stream_ordering(
+                await self.store.get_rooms_for_users(
                     newly_left_users
                 )
             )
             for user_id, entries in left_users_rooms.items():
-                if any(e.room_id in joined_rooms for e in entries):
+                if any(rid in joined_rooms for rid in entries):
                     newly_left_users.discard(user_id)
 
             return DeviceListUpdates(

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -205,6 +205,9 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
                 self.get_rooms_for_user_with_stream_ordering.invalidate(
                     (data.state_key,)
                 )
+                self.get_rooms_for_user.invalidate(
+                    (data.state_key,)
+                )
         else:
             raise Exception("Unknown events stream row type %s" % (row.type,))
 

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -205,9 +205,7 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
                 self.get_rooms_for_user_with_stream_ordering.invalidate(
                     (data.state_key,)
                 )
-                self.get_rooms_for_user.invalidate(
-                    (data.state_key,)
-                )
+                self.get_rooms_for_user.invalidate((data.state_key,))
         else:
             raise Exception("Unknown events stream row type %s" % (row.type,))
 

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1178,6 +1178,10 @@ class PersistEventsStore:
                     self.store.get_rooms_for_user_with_stream_ordering.invalidate,
                     (member,),
                 )
+                txn.call_after(
+                    self.store.get_rooms_for_user.invalidate,
+                    (member,),
+                )
 
             self.store._invalidate_state_caches_and_stream(
                 txn, room_id, members_changed

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -624,7 +624,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         participating in.
         """
         rooms = self.get_rooms_for_user_with_stream_ordering.cache.get_immediate(
-            user_id
+            (user_id,), None, update_metrics=False,
         )
         if rooms:
             return frozenset(r.room_id for r in rooms)

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -581,58 +581,6 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             for room_id, instance, stream_id in txn
         )
 
-    @cachedList(
-        cached_method_name="get_rooms_for_user_with_stream_ordering",
-        list_name="user_ids",
-    )
-    async def get_rooms_for_users_with_stream_ordering(
-        self, user_ids: Collection[str]
-    ) -> Dict[str, FrozenSet[GetRoomsForUserWithStreamOrdering]]:
-        """A batched version of `get_rooms_for_user_with_stream_ordering`.
-
-        Returns:
-            Map from user_id to set of rooms that is currently in.
-        """
-        return await self.db_pool.runInteraction(
-            "get_rooms_for_users_with_stream_ordering",
-            self._get_rooms_for_users_with_stream_ordering_txn,
-            user_ids,
-        )
-
-    def _get_rooms_for_users_with_stream_ordering_txn(
-        self, txn: LoggingTransaction, user_ids: Collection[str]
-    ) -> Dict[str, FrozenSet[GetRoomsForUserWithStreamOrdering]]:
-
-        clause, args = make_in_list_sql_clause(
-            self.database_engine,
-            "c.state_key",
-            user_ids,
-        )
-
-        sql = f"""
-            SELECT c.state_key, room_id, e.instance_name, e.stream_ordering
-            FROM current_state_events AS c
-            INNER JOIN events AS e USING (room_id, event_id)
-            WHERE
-                c.type = 'm.room.member'
-                AND c.membership = ?
-                AND {clause}
-        """
-
-        txn.execute(sql, [Membership.JOIN] + args)
-
-        result: Dict[str, Set[GetRoomsForUserWithStreamOrdering]] = {
-            user_id: set() for user_id in user_ids
-        }
-        for user_id, room_id, instance, stream_id in txn:
-            result[user_id].add(
-                GetRoomsForUserWithStreamOrdering(
-                    room_id, PersistedEventPosition(instance, stream_id)
-                )
-            )
-
-        return {user_id: frozenset(v) for user_id, v in result.items()}
-
     async def get_users_server_still_shares_room_with(
         self, user_ids: Collection[str]
     ) -> Set[str]:

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -15,7 +15,6 @@
 import logging
 from typing import (
     TYPE_CHECKING,
-    Callable,
     Collection,
     Dict,
     FrozenSet,
@@ -52,7 +51,6 @@ from synapse.types import JsonDict, PersistedEventPosition, StateMap, get_domain
 from synapse.util.async_helpers import Linearizer
 from synapse.util.caches import intern_string
 from synapse.util.caches.descriptors import _CacheContext, cached, cachedList
-from synapse.util.cancellation import cancellable
 from synapse.util.iterutils import batch_iter
 from synapse.util.metrics import Measure
 
@@ -670,19 +668,86 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             _get_users_server_still_shares_room_with_txn,
         )
 
-    @cancellable
+    @cached(max_entries=500000, iterable=True)
     async def get_rooms_for_user(
-        self, user_id: str, on_invalidate: Optional[Callable[[], None]] = None
+        self, user_id: str
     ) -> FrozenSet[str]:
         """Returns a set of room_ids the user is currently joined to.
 
         If a remote user only returns rooms this server is currently
         participating in.
         """
-        rooms = await self.get_rooms_for_user_with_stream_ordering(
-            user_id, on_invalidate=on_invalidate
+        rooms = self.get_rooms_for_user_with_stream_ordering.cache.get_immediate(user_id)
+        if rooms:
+            return frozenset(r.room_id for r in rooms)
+
+        return await self.db_pool.runInteraction(
+            "get_rooms_for_user",
+            self._get_rooms_for_user_txn,
+            user_id,
         )
-        return frozenset(r.room_id for r in rooms)
+
+    def _get_rooms_for_user_txn(
+        self, txn: LoggingTransaction, user_id: str
+    ) -> FrozenSet[str]:
+        sql = """
+            SELECT room_id
+            FROM current_state_events AS c
+            WHERE
+                c.type = 'm.room.member'
+                AND c.state_key = ?
+                AND c.membership = ?
+        """
+
+        txn.execute(sql, (user_id, Membership.JOIN))
+        return frozenset(txn)
+
+    @cachedList(
+        cached_method_name="get_rooms_for_user",
+        list_name="user_ids",
+    )
+    async def get_rooms_for_users(
+        self, user_ids: Collection[str]
+    ) -> Dict[str, FrozenSet[GetRoomsForUserWithStreamOrdering]]:
+        """A batched version of `get_rooms_for_user`.
+
+        Returns:
+            Map from user_id to set of rooms that is currently in.
+        """
+        return await self.db_pool.runInteraction(
+            "get_rooms_for_users",
+            self._get_rooms_for_users_txn,
+            user_ids,
+        )
+
+    def _get_rooms_for_users_txn(
+        self, txn: LoggingTransaction, user_ids: Collection[str]
+    ) -> Dict[str, FrozenSet[str]]:
+
+        clause, args = make_in_list_sql_clause(
+            self.database_engine,
+            "c.state_key",
+            user_ids,
+        )
+
+        sql = f"""
+            SELECT c.state_key, room_id
+            FROM current_state_events AS c
+            WHERE
+                c.type = 'm.room.member'
+                AND c.membership = ?
+                AND {clause}
+        """
+
+        txn.execute(sql, [Membership.JOIN] + args)
+
+        result: Dict[str, Set[str]] = {
+            user_id: set() for user_id in user_ids
+        }
+        for user_id, room_id in txn:
+            result[user_id].add(room_id)
+
+        return {user_id: frozenset(v) for user_id, v in result.items()}
 
     @cached(max_entries=10000)
     async def does_pair_of_users_share_a_room(

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -159,6 +159,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
 
         # Blow away caches (supported room versions can only change due to a restart).
         self.store.get_rooms_for_user_with_stream_ordering.invalidate_all()
+        self.store.get_rooms_for_user.invalidate_all()
         self.get_success(self.store._get_event_cache.clear())
         self.store._event_ref.clear()
 


### PR DESCRIPTION
More adventures on my quest to kill JOINs - bit more involved here: the `get_rooms_for_user_with_stream_ordering` function only has one use where the stream ordering is use - everywhere else this data is ignored. The only remaining call is in sync to cover the case where a join happens after the sync handler gets the current token (original change: https://github.com/matrix-org/synapse/commit/8cb44da4aa569188faa2a94aae6bc093aa8e22ec).

As it stands this PR should work as-is - sync processes will hit the original function and other paths will utilize the new methods. I suspect this would yield benefit in a workers setup but probably a small negative impact for monolith installs. What I'd really like to do is remove the method entirely, some thoughts:

The current call is within the [`get_rooms_for_user_at`](https://github.com/matrix-org/synapse/blob/cdbb6412327b542e0dead792717fe58253291131/synapse/handlers/sync.py#L2378-L2430) method in the sync handler. If I understand correctly the aim here is to get the users rooms ensuring they were joined at the current token, rather than "now" which will be slightly ahead. I think it could be solved by doing:

1. Call `get_rooms_for_user_at` before we get the current token
2. Get the current token
3. Call `get_membership_changes_for_user` to pull any joins between 1 & 2, we already need to pull the membership events anyway during other parts of sync (would need to change this to be passed between methods)

Signed off by Nick @ Beeper (@fizzadar).

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
