### PR TITLE
complement: move PG data outside of the container storage

### DIFF
--- a/changelog.d/13806.misc
+++ b/changelog.d/13806.misc
@@ -1,0 +1,1 @@
+complement tests: put postgres data folder on an host path on /tmp that we bindmount, outside of the container storage that can be quite slow.

--- a/docker/complement/Dockerfile
+++ b/docker/complement/Dockerfile
@@ -17,25 +17,16 @@ ARG SYNAPSE_VERSION=latest
 # the same debian version as Synapse's docker image (so the versions of the
 # shared libraries match).
 
-FROM postgres:13-bullseye AS postgres_base
-    # initialise the database cluster in /var/lib/postgresql
-    RUN gosu postgres initdb --locale=C --encoding=UTF-8 --auth-host password
-
-    # Configure a password and create a database for Synapse
-    RUN echo "ALTER USER postgres PASSWORD 'somesecret'" | gosu postgres postgres --single
-    RUN echo "CREATE DATABASE synapse" | gosu postgres postgres --single
-
 # now build the final image, based on the Synapse image.
 
 FROM matrixdotorg/synapse-workers:$SYNAPSE_VERSION
     # copy the postgres installation over from the image we built above
     RUN adduser --system --uid 999 postgres --home /var/lib/postgresql
-    COPY --from=postgres_base /var/lib/postgresql /var/lib/postgresql
-    COPY --from=postgres_base /usr/lib/postgresql /usr/lib/postgresql
-    COPY --from=postgres_base /usr/share/postgresql /usr/share/postgresql
+    COPY --from=postgres:13-bullseye /usr/lib/postgresql /usr/lib/postgresql
+    COPY --from=postgres:13-bullseye /usr/share/postgresql /usr/share/postgresql
     RUN mkdir /var/run/postgresql && chown postgres /var/run/postgresql
     ENV PATH="${PATH}:/usr/lib/postgresql/13/bin"
-    ENV PGDATA=/var/lib/postgresql/data
+    ENV PGDATA=/var/lib/postgresql/data/main
 
     # Extend the shared homeserver config to disable rate-limiting,
     # set Complement's static shared secret, enable registration, amongst other

--- a/docker/complement/conf/start_for_complement.sh
+++ b/docker/complement/conf/start_for_complement.sh
@@ -25,7 +25,15 @@ case "$SYNAPSE_COMPLEMENT_DATABASE" in
     # Set postgres authentication details which will be placed in the homeserver config file
     export POSTGRES_PASSWORD=somesecret
     export POSTGRES_USER=postgres
+
     export POSTGRES_HOST=localhost
+
+    if [ ! -f "$PGDATA/PG_VERSION" ]; then
+      gosu postgres initdb --locale=C --encoding=UTF-8 --auth-host password
+
+      echo "ALTER USER postgres PASSWORD 'somesecret'" | gosu postgres postgres --single
+      echo "CREATE DATABASE synapse" | gosu postgres postgres --single
+    fi
 
     # configure supervisord to start postgres
     export START_POSTGRES=true

--- a/scripts-dev/complement.sh
+++ b/scripts-dev/complement.sh
@@ -122,7 +122,14 @@ if [ -n "$skip_complement_run" ]; then
     exit
 fi
 
+PG_DATA_FOLDER=/tmp/postgres-data
+
+rm -rf $PG_DATA_FOLDER
+mkdir -p $PG_DATA_FOLDER
+chmod 777 $PG_DATA_FOLDER
+
 export COMPLEMENT_BASE_IMAGE=complement-synapse
+export COMPLEMENT_HOST_MOUNTS=$PG_DATA_FOLDER:/var/lib/postgresql/data
 
 extra_test_args=()
 
@@ -178,3 +185,5 @@ echo "Images built; running complement"
 cd "$COMPLEMENT_DIR"
 
 go test -v -tags $test_tags -count=1 "${extra_test_args[@]}" "$@" ./tests/...
+
+rm -rf $PG_DATA_FOLDER


### PR DESCRIPTION
This puts postgres data folder on an host path on `/tmp` that we bindmount.
Putting this inside a folder in the image is usually quite slow since it uses a specific Copy on Write filesystem that is reallly not optimized for that.

### Pull Request Checklist

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
