### PR TITLE
reverse-proxy docs: add missing .well-known paths

### DIFF
--- a/changelog.d/13820.doc
+++ b/changelog.d/13820.doc
@@ -1,0 +1,1 @@
+Add missing .well-known paths to Apache and nginx sample config. Contributed by Intevation GmbH.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -80,6 +80,11 @@ server {
         # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
         client_max_body_size 50M;
     }
+    location /.well-known/matrix/client {
+        return 200 '{"m.homeserver": {"base_url": "https://<matrix.example.com>"}}';
+        default_type application/json;
+        add_header Access-Control-Allow-Origin *;
+    }
 }
 ```
 
@@ -119,6 +124,13 @@ matrix.example.com {
     SSLEngine on
     ServerName matrix.example.com
 
+    # for .well-known/matrix/client
+    DocumentRoot /var/www/html/
+    <Location /.well-known/matrix/client>
+        ForceType application/json
+        Header set Access-Control-Allow-Origin "*"
+    </Location>
+
     RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
     AllowEncodedSlashes NoDecode
     ProxyPreserveHost on
@@ -137,6 +149,18 @@ matrix.example.com {
     ProxyPass /_matrix http://127.0.0.1:8008/_matrix nocanon
     ProxyPassReverse /_matrix http://127.0.0.1:8008/_matrix
 </VirtualHost>
+```
+
+Create the file `/var/www/html/.well-known/matrix/client` with the following content:
+```json
+{
+  "m.homeserver": {
+    "base_url": "https://<matrix.example.com>"
+  },
+  "m.identity_server": {
+    "base_url": "https://<identity.example.com>"
+  }
+}
 ```
 
 **NOTE**: ensure the  `nocanon` options are included.


### PR DESCRIPTION
Add missing .well-known paths to Apache, nginx and HAProxy

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
