### PR TITLE
Faster Remote Room Joins: tell remote homeservers that we are unable to authorise them if they query a room which has partial state on our server.

### DIFF
--- a/changelog.d/13823.misc
+++ b/changelog.d/13823.misc
@@ -1,0 +1,1 @@
+Faster Remote Room Joins: tell remote homeservers that we are unable to authorise them if they query a room which has partial state on our server.

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -100,6 +100,12 @@ class Codes(str, Enum):
 
     UNREDACTED_CONTENT_DELETED = "FI.MAU.MSC2815_UNREDACTED_CONTENT_DELETED"
 
+    # Returned for federation requests where we can't process a request as we
+    # can't ensure the sending server is in a room which is partial-stated on
+    # our side.
+    # Part of MSC3706-rei1.
+    UNABLE_DUE_TO_PARTIAL_STATE = "ORG.MATRIX.MSC3706_UNABLE_DUE_TO_PARTIAL_STATE"
+
 
 class CodeMessageException(RuntimeError):
     """An exception with integer code and message string attributes.

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -103,8 +103,8 @@ class Codes(str, Enum):
     # Returned for federation requests where we can't process a request as we
     # can't ensure the sending server is in a room which is partial-stated on
     # our side.
-    # Part of MSC3706-rei1.
-    UNABLE_DUE_TO_PARTIAL_STATE = "ORG.MATRIX.MSC3706_UNABLE_DUE_TO_PARTIAL_STATE"
+    # Part of MSC3895.
+    UNABLE_DUE_TO_PARTIAL_STATE = "ORG.MATRIX.MSC3895_UNABLE_DUE_TO_PARTIAL_STATE"
 
 
 class CodeMessageException(RuntimeError):

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -63,7 +63,8 @@ class ExperimentalConfig(Config):
         # MSC3706 (server-side support for partial state in /send_join responses)
         self.msc3706_enabled: bool = experimental.get("msc3706_enabled", False)
 
-        # experimental support for faster joins over federation (msc2775, msc3706)
+        # experimental support for faster joins over federation
+        # (MSC2775, MSC3706, MSC3895)
         # requires a target server with msc3706_enabled enabled.
         self.faster_joins_enabled: bool = experimental.get("faster_joins", False)
 

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -31,7 +31,6 @@ from synapse.events import EventBase
 from synapse.events.builder import EventBuilder
 from synapse.events.snapshot import EventContext
 from synapse.types import StateMap, get_domain_from_id
-from synapse.util.metrics import Measure
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
@@ -157,8 +156,7 @@ class EventAuthHandler:
         )
 
     async def is_host_in_room(self, room_id: str, host: str) -> bool:
-        with Measure(self._clock, "check_host_in_room"):
-            return await self._store.is_host_joined(room_id, host)
+        return await self._store.is_host_joined(room_id, host)
 
     async def assert_host_in_room(
         self, room_id: str, host: str, allow_partial_state_rooms: bool = False

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -167,7 +167,7 @@ class EventAuthHandler:
         Asserts that the host is in the room, or raises an AuthError.
 
         If the room is partial-stated, we raise an AuthError with the
-        UNABLE_DUE_TO_PARTIAL_STATE flag, unless `allow_partial_state_rooms` is true.
+        UNABLE_DUE_TO_PARTIAL_STATE error code, unless `allow_partial_state_rooms` is true.
         """
         if not allow_partial_state_rooms and await self._store.is_partial_state_room(
             room_id

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -156,7 +156,7 @@ class EventAuthHandler:
             Codes.UNABLE_TO_GRANT_JOIN,
         )
 
-    async def check_host_in_room(self, room_id: str, host: str) -> bool:
+    async def is_host_in_room(self, room_id: str, host: str) -> bool:
         with Measure(self._clock, "check_host_in_room"):
             return await self._store.is_host_joined(room_id, host)
 
@@ -178,7 +178,7 @@ class EventAuthHandler:
                 errcode=Codes.UNABLE_DUE_TO_PARTIAL_STATE,
             )
 
-        if not await self.check_host_in_room(room_id, host):
+        if not await self.is_host_in_room(room_id, host):
             raise AuthError(403, "Host not in room.")
 
     async def check_restricted_join_rules(

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -168,6 +168,10 @@ class EventAuthHandler:
 
         If the room is partial-stated, we raise an AuthError with the
         UNABLE_DUE_TO_PARTIAL_STATE error code, unless `allow_partial_state_rooms` is true.
+
+        If allow_partial_state_rooms is True and the room is partial-stated,
+        this function may return an incorrect result as we are not able to fully
+        track server membership in a room without full state.
         """
         if not allow_partial_state_rooms and await self._store.is_partial_state_room(
             room_id

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -804,7 +804,7 @@ class FederationHandler:
             )
 
         # now check that we are *still* in the room
-        is_in_room = await self._event_auth_handler.check_host_in_room(
+        is_in_room = await self._event_auth_handler.is_host_in_room(
             room_id, self.server_name
         )
         if not is_in_room:
@@ -1249,7 +1249,7 @@ class FederationHandler:
             "state_key": target_user_id,
         }
 
-        if await self._event_auth_handler.check_host_in_room(room_id, self.hs.hostname):
+        if await self._event_auth_handler.is_host_in_room(room_id, self.hs.hostname):
             room_version_obj = await self.store.get_room_version(room_id)
             builder = self.event_builder_factory.for_room_version(
                 room_version_obj, event_dict

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1150,9 +1150,7 @@ class FederationHandler:
     async def on_backfill_request(
         self, origin: str, room_id: str, pdu_list: List[str], limit: int
     ) -> List[EventBase]:
-        in_room = await self._event_auth_handler.check_host_in_room(room_id, origin)
-        if not in_room:
-            raise AuthError(403, "Host not in room.")
+        await self._event_auth_handler.assert_host_in_room(room_id, origin)
 
         # Synapse asks for 100 events per backfill request. Do not allow more.
         limit = min(limit, 100)
@@ -1199,11 +1197,7 @@ class FederationHandler:
         )
 
         if event:
-            in_room = await self._event_auth_handler.check_host_in_room(
-                event.room_id, origin
-            )
-            if not in_room:
-                raise AuthError(403, "Host not in room.")
+            await self._event_auth_handler.assert_host_in_room(event.room_id, origin)
 
             events = await filter_events_for_server(
                 self._storage_controllers, origin, [event]
@@ -1221,9 +1215,7 @@ class FederationHandler:
         latest_events: List[str],
         limit: int,
     ) -> List[EventBase]:
-        in_room = await self._event_auth_handler.check_host_in_room(room_id, origin)
-        if not in_room:
-            raise AuthError(403, "Host not in room.")
+        await self._event_auth_handler.assert_host_in_room(room_id, origin)
 
         # Only allow up to 20 events to be retrieved per request.
         limit = min(limit, 20)

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1196,16 +1196,16 @@ class FederationHandler:
             event_id, allow_none=True, allow_rejected=True
         )
 
-        if event:
-            await self._event_auth_handler.assert_host_in_room(event.room_id, origin)
-
-            events = await filter_events_for_server(
-                self._storage_controllers, origin, [event]
-            )
-            event = events[0]
-            return event
-        else:
+        if not event:
             return None
+
+        await self._event_auth_handler.assert_host_in_room(event.room_id, origin)
+
+        events = await filter_events_for_server(
+            self._storage_controllers, origin, [event]
+        )
+        event = events[0]
+        return event
 
     async def on_get_missing_events(
         self,

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -238,7 +238,7 @@ class FederationEventHandler:
         #
         # Note that if we were never in the room then we would have already
         # dropped the event, since we wouldn't know the room version.
-        is_in_room = await self._event_auth_handler.check_host_in_room(
+        is_in_room = await self._event_auth_handler.is_host_in_room(
             room_id, self._server_name
         )
         if not is_in_room:

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -70,7 +70,7 @@ class ReceiptsHandler:
             # If we're not in the room just ditch the event entirely. This is
             # probably an old server that has come back and thinks we're still in
             # the room (or we've been rejoined to the room by a state reset).
-            is_in_room = await self.event_auth_handler.check_host_in_room(
+            is_in_room = await self.event_auth_handler.is_host_in_room(
                 room_id, self.server_name
             )
             if not is_in_room:

--- a/synapse/handlers/room_summary.py
+++ b/synapse/handlers/room_summary.py
@@ -609,7 +609,7 @@ class RoomSummaryHandler:
         # If this is a request over federation, check if the host is in the room or
         # has a user who could join the room.
         elif origin:
-            if await self._event_auth_handler.check_host_in_room(
+            if await self._event_auth_handler.is_host_in_room(
                 room_id, origin
             ) or await self._store.is_host_invited(room_id, origin):
                 return True
@@ -624,9 +624,7 @@ class RoomSummaryHandler:
                     await self._event_auth_handler.get_rooms_that_allow_join(state_ids)
                 )
                 for space_id in allowed_rooms:
-                    if await self._event_auth_handler.check_host_in_room(
-                        space_id, origin
-                    ):
+                    if await self._event_auth_handler.is_host_in_room(space_id, origin):
                         return True
 
         logger.info(

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -340,7 +340,7 @@ class TypingWriterHandler(FollowerTypingHandler):
         # If we're not in the room just ditch the event entirely. This is
         # probably an old server that has come back and thinks we're still in
         # the room (or we've been rejoined to the room by a state reset).
-        is_in_room = await self.event_auth_handler.check_host_in_room(
+        is_in_room = await self.event_auth_handler.is_host_in_room(
             room_id, self.server_name
         )
         if not is_in_room:

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -129,7 +129,7 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
         async def check_host_in_room(room_id: str, server_name: str) -> bool:
             return room_id == ROOM_ID
 
-        hs.get_event_auth_handler().check_host_in_room = check_host_in_room
+        hs.get_event_auth_handler().is_host_in_room = check_host_in_room
 
         async def get_current_hosts_in_room(room_id: str):
             return {member.domain for member in self.room_members}


### PR DESCRIPTION
Fixes #13288.

Instead of trying to perform authorisation checks on the requesting server, we tell them that we're not able to authorise them right now. (This uses a small appendix to MSC3706 to define an error code.)

The requesting server should already have failover logic to query another resident server, so this shouldn't harm them.

The main concern comes about when sending an event (#12997), where we may need to answer some queries so that the server receiving our event can accept it. This PR leaves that as future work for #12997...


An alternative suggestion is to accept servers that are on the list given to us from the server we `/make_join`ed against (and possibly keep this up to date), but this seems error-prone and it's not as though we can't do that at a later date if we reason through it and decide that it's sound.
One notable reason that it's difficult to make it sound is that, during a partial join, we may accept (or reject) events that we later find out we should reject (or accept), so tracking the set of servers in the room doesn't seem trivial. See #13288 for info.

Leaking room contents to servers is a notable enough risk that it seems better to play it safe.
In any case, if we're partially joined to the room then it holds that there must be a fully-joined resident server online OR our join will ultimately fail anyway (at which point we're as good as not resident in the room).
The requesting homeserver should therefore be able to request from that server OR our view of the room is likely insufficient to answer queries anyway.


Commit-by-commit reviewable.

The error code is defined in MSC3895 (https://github.com/matrix-org/matrix-spec-proposals/pull/3895; draft).