### PR TITLE
Remove error spam when users query the keys of departed remote users

### DIFF
--- a/changelog.d/13826.bugfix
+++ b/changelog.d/13826.bugfix
@@ -1,0 +1,1 @@
+Fix a long standing bug where device lists would remain cached when remote users left and rejoined the last room shared with the local homeserver.


### PR DESCRIPTION
The error message introduced in #13749 has turned out to be very spammy.
Remove it for now.

At some point we'll want to create a background update to mark the appropriate device lists as unsubscribed (see https://github.com/matrix-org/synapse/issues/13651#issuecomment-1249234310).