### PR TITLE
typing: check origin server of typing event against room's servers

### DIFF
--- a/changelog.d/13830.bugfix
+++ b/changelog.d/13830.bugfix
@@ -1,1 +1,1 @@
-typing: check origin server of typing event against servers currently in the room. We also use a method that do not block on partial state so the transaction doesn't get stuck during a fast join.
+Fix a long-standing bug where typing events would be accepted from remote servers not present in a room. Also fix a bug where incoming typing events would cause other incoming events to get stuck during a fast join.

--- a/changelog.d/13830.bugfix
+++ b/changelog.d/13830.bugfix
@@ -1,0 +1,1 @@
+typing: check origin server of typing event against servers currently in the room. We also use a method that do not block on partial state so the transaction doesn't get stuck during a fast join.

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -362,11 +362,13 @@ class TypingWriterHandler(FollowerTypingHandler):
             )
             return
 
-        domains = await self._storage_controllers.state.get_current_hosts_in_room(
+        # Let's check that the origin server is in the room before accepting the typing event.
+        # We don't want to block waiting on a partial state so take the approximation if needed.
+        domains = await self._storage_controllers.state.get_current_hosts_in_room_or_partial_state_approximation(
             room_id
         )
 
-        if self.server_name in domains:
+        if user.domain in domains:
             logger.info("Got typing update from %s: %r", user_id, content)
             now = self.clock.time_msec()
             self._member_typing_until[member] = now + FEDERATION_TIMEOUT

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -362,7 +362,6 @@ class TypingWriterHandler(FollowerTypingHandler):
             )
             return
 
-        # Let's check that the origin server is in the room before accepting the typing event.
         # Let's check that the origin server is in the room before accepting the typing
         # event. We don't want to block waiting on a partial state so take an
         # approximation if needed.

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -363,7 +363,9 @@ class TypingWriterHandler(FollowerTypingHandler):
             return
 
         # Let's check that the origin server is in the room before accepting the typing event.
-        # We don't want to block waiting on a partial state so take the approximation if needed.
+        # Let's check that the origin server is in the room before accepting the typing
+        # event. We don't want to block waiting on a partial state so take an
+        # approximation if needed.
         domains = await self._storage_controllers.state.get_current_hosts_in_room_or_partial_state_approximation(
             room_id
         )

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -138,6 +138,10 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
             get_current_hosts_in_room
         )
 
+        hs.get_storage_controllers().state.get_current_hosts_in_room_or_partial_state_approximation = (
+            get_current_hosts_in_room
+        )
+
         async def get_users_in_room(room_id: str):
             return {str(u) for u in self.room_members}
 


### PR DESCRIPTION
This is also using the partial state approximation if needed so we do not block here during a fast join.

Fix at least partially #13684.

Also fix #13869.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
