### PR TITLE
Correct documentation for map_user_attributes of OpenID Mapping Providers

### DIFF
--- a/changelog.d/13836.doc
+++ b/changelog.d/13836.doc
@@ -1,0 +1,1 @@
+Fix a mistake in sso_mapping_providers.md: `map_user_attributes` is expected to return `display_name` not `displayname`.

--- a/docs/sso_mapping_providers.md
+++ b/docs/sso_mapping_providers.md
@@ -73,8 +73,8 @@ A custom mapping provider must specify the following methods:
 * `async def map_user_attributes(self, userinfo, token, failures)`
     - This method must be async.
     - Arguments:
-      - `userinfo` - A `authlib.oidc.core.claims.UserInfo` object to extract user
-                     information from.
+      - `userinfo` - An [`authlib.oidc.core.claims.UserInfo`](https://docs.authlib.org/en/latest/specs/oidc.html#authlib.oidc.core.UserInfo)
+                     object to extract user information from.
       - `token` - A dictionary which includes information necessary to make
                   further requests to the OpenID provider.
       - `failures` - An `int` that represents the amount of times the returned
@@ -91,7 +91,13 @@ A custom mapping provider must specify the following methods:
         `None`, the user is prompted to pick their own username. This is only used
         during a user's first login. Once a localpart has been associated with a
         remote user ID (see `get_remote_user_id`) it cannot be updated.
+      - `confirm_localpart`: A boolean. If a `localpart` string is returned from
+        this method and `confirm_localpart` is `True`, Synapse will ask users to 
+        confirm their Matrix ID. Otherwise Synapse will not ask for 
+        confirmation. If omitted, defaults to `False`.
       - `display_name`: An optional string, the display name for the user.
+      - `emails`: A list of strings, the email address(es) to associate with
+        this user. If omitted, defaults to an empty list.
 * `async def get_extra_attributes(self, userinfo, token)`
     - This method must be async.
     - Arguments:

--- a/docs/sso_mapping_providers.md
+++ b/docs/sso_mapping_providers.md
@@ -91,7 +91,7 @@ A custom mapping provider must specify the following methods:
         `None`, the user is prompted to pick their own username. This is only used
         during a user's first login. Once a localpart has been associated with a
         remote user ID (see `get_remote_user_id`) it cannot be updated.
-      - `displayname`: An optional string, the display name for the user.
+      - `display_name`: An optional string, the display name for the user.
 * `async def get_extra_attributes(self, userinfo, token)`
     - This method must be async.
     - Arguments:

--- a/docs/sso_mapping_providers.md
+++ b/docs/sso_mapping_providers.md
@@ -91,10 +91,10 @@ A custom mapping provider must specify the following methods:
         `None`, the user is prompted to pick their own username. This is only used
         during a user's first login. Once a localpart has been associated with a
         remote user ID (see `get_remote_user_id`) it cannot be updated.
-      - `confirm_localpart`: A boolean. If a `localpart` string is returned from
-        this method and `confirm_localpart` is `True`, Synapse will ask users to 
-        confirm their Matrix ID. Otherwise Synapse will not ask for 
-        confirmation. If omitted, defaults to `False`.
+      - `confirm_localpart`: A boolean. If set to `True`, when a `localpart`
+        string is returned from this method, Synapse will prompt the user to
+        either accept this localpart or pick their own username. Otherwise this
+        option has no effect. If omitted, defaults to `False`.
       - `display_name`: An optional string, the display name for the user.
       - `emails`: A list of strings, the email address(es) to associate with
         this user. If omitted, defaults to an empty list.

--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -128,6 +128,9 @@ class SsoIdentityProvider(Protocol):
 
 @attr.s(auto_attribs=True)
 class UserAttributes:
+    # NB: This struct is documented in docs/sso_mapping_providers.md so that users can
+    # populate it with data from their own mapping providers.
+
     # the localpart of the mxid that the mapper has assigned to the user.
     # if `None`, the mapper has not picked a userid, and the user should be prompted to
     # enter one.


### PR DESCRIPTION
Changed `displayname` to `display_name`.
See [/synapse/handlers/sso.py L130](https://github.com/matrix-org/synapse/blob/fe1daad67237c2154a3d8d8cdf6c603f0d33682e/synapse/handlers/sso.py#L130).
