### PR TITLE
Fix the release script not publishing binary wheels.

### DIFF
--- a/changelog.d/13850.misc
+++ b/changelog.d/13850.misc
@@ -1,0 +1,1 @@
+Fix the release script not publishing binary wheels.


### PR DESCRIPTION
Title a little bit misleading, but it failed altogether because we don't have a fully-portable wheel and the release script was hardcoded to download one.

Instead, we now consult GitHub as the source of truth and download all wheels and sdist-looking-things to publish to PyPI.


