### PR TITLE
Lower minimum rustc version to 1.58.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.61.0
+            toolchain: 1.58.1
             override: true
             components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -112,7 +112,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.61.0
+            toolchain: 1.58.1
             override: true
             components: rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -204,7 +204,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.61.0
+            toolchain: 1.58.1
             override: true
       - uses: Swatinem/rust-cache@v2
 
@@ -320,7 +320,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.61.0
+            toolchain: 1.58.1
             override: true
       - uses: Swatinem/rust-cache@v2
 
@@ -452,7 +452,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.61.0
+            toolchain: 1.58.1
             override: true
       - uses: Swatinem/rust-cache@v2
 
@@ -478,7 +478,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.61.0
+            toolchain: 1.58.1
             override: true
       - uses: Swatinem/rust-cache@v2
 

--- a/changelog.d/13857.misc
+++ b/changelog.d/13857.misc
@@ -1,0 +1,1 @@
+Lower minimum supported rustc version to 1.58.1.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ name = "synapse"
 version = "0.1.0"
 
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.58.1"
 
 [lib]
 name = "synapse"


### PR DESCRIPTION
To make life a bit easier for packagers. I don't think there are any particularly useful features for us between 1.58 and 1.61.