### PR TITLE
Add version flag for MSC3881

### DIFF
--- a/changelog.d/13860.feature
+++ b/changelog.d/13860.feature
@@ -1,0 +1,1 @@
+Add experimental support for [MSC3881: Remotely toggle push notifications for another client](https://github.com/matrix-org/matrix-spec-proposals/pull/3881).

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -107,6 +107,8 @@ class VersionsRestServlet(RestServlet):
                     "fi.mau.msc2815": self.config.experimental.msc2815_enabled,
                     # Adds support for login token requests as per MSC3882
                     "org.matrix.msc3882": self.config.experimental.msc3882_enabled,
+                    # Adds support for remotely enabling/disabling pushers, as per MSC3881
+                    "org.matrix.msc3881": self.config.experimental.msc3881_enabled,
                 },
             },
         )


### PR DESCRIPTION
Forgot this bit in #13799. Not yet part of the MSC (at the time of writing this) but should be added shortly.