### PR TITLE
Fix sdist to include rust build script

### DIFF
--- a/changelog.d/13866.bugfix
+++ b/changelog.d/13866.bugfix
@@ -1,0 +1,1 @@
+Fix building from packaged sdist. Broke in v1.68.0rc1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ include = [
     { path = "Cargo.toml", format = "sdist" },
     { path = "rust/Cargo.toml", format = "sdist" },
     { path = "rust/Cargo.lock", format = "sdist" },
+    { path = "rust/build.rs", format = "sdist" },
     { path = "rust/src/**", format = "sdist" },
 ]
 exclude = [


### PR DESCRIPTION
Fixes #13851

Broke in #13759  