### PR TITLE
Fix the cross-link from register admin API to config docs.

### DIFF
--- a/changelog.d/13870.doc
+++ b/changelog.d/13870.doc
@@ -1,0 +1,1 @@
+Fix a cross-link from the register admin API to the `registration_shared_secret` configuration documentation.

--- a/docs/admin_api/register_api.md
+++ b/docs/admin_api/register_api.md
@@ -5,7 +5,7 @@ non-interactive way. This is generally used for bootstrapping a Synapse
 instance with administrator accounts.
 
 To authenticate yourself to the server, you will need both the shared secret
-([`registration_shared_secret`](../configuration/config_documentation.md#registration_shared_secret)
+([`registration_shared_secret`](../usage/configuration/config_documentation.md#registration_shared_secret)
 in the homeserver configuration), and a one-time nonce. If the registration
 shared secret is not configured, this API is not enabled.
 


### PR DESCRIPTION
See https://matrix-org.github.io/synapse/latest/admin_api/register_api.html, the cross-link to `registration_shared_secret` is missing a `/usage` in it.