### PR TITLE
Faster room joins: Fix spurious error when joining a room

### DIFF
--- a/changelog.d/13872.bugfix
+++ b/changelog.d/13872.bugfix
@@ -1,0 +1,1 @@
+Faster room joins: Fix a bug introduced in 1.66.0 where an error would be logged when syncing after joining a room.


### PR DESCRIPTION
During a `lazy_load_members` `/sync`, we look through auth events in
rooms with partial state to find prior membership events. When such a
membership is not found, an error is logged.

Since the first join event for a user never has a prior membership event
to cite, the error would always be logged when one appeared in the room
timeline.

Avoid logging errors for such events.

Introduced in #13477.

Signed-off-by: Sean Quah <seanq@matrix.org>
