### PR TITLE
Add new columns tracking when we partial-joined

### DIFF
--- a/changelog.d/13892.feature
+++ b/changelog.d/13892.feature
@@ -1,0 +1,1 @@
+Faster remote room joins: record _when_ we first partial-join to a room.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -583,7 +583,12 @@ class FederationHandler:
                 # Mark the room as having partial state.
                 # The background process is responsible for unmarking this flag,
                 # even if the join fails.
-                await self.store.store_partial_state_room(room_id, ret.servers_in_room)
+                await self.store.store_partial_state_room(
+                    room_id,
+                    ret.servers_in_room,
+                    ret.event.event_id,
+                    self.store.get_device_stream_token(),
+                )
 
             try:
                 max_stream_id = (

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1839,12 +1839,12 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore):
         """
         await self.db_pool.runInteraction(
             "write_partial_state_rooms_join_event_id",
-            self._store_partial_state_room_txn,
+            self._write_partial_state_rooms_join_event_id,
             room_id,
             join_event_id,
         )
 
-    async def _write_partial_state_rooms_join_event_id(
+    def _write_partial_state_rooms_join_event_id(
         self,
         txn: LoggingTransaction,
         room_id: str,

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1777,7 +1777,6 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore):
         self,
         room_id: str,
         servers: Collection[str],
-        join_event_id: str,
         device_lists_stream_id: int,
     ) -> None:
         """Mark the given room as containing events with partial state.
@@ -1786,11 +1785,12 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore):
         room, which helps us to keep other homeservers in sync when we finally fully
         join this room.
 
+        We do not include a `join_event_id` here---we need to wait for the join event
+        to be persisted first.
+
         Args:
             room_id: the ID of the room
             servers: other servers known to be in the room
-            join_event_id: the event ID of the join membership event returned in the
-                (partial) /send_join response.
             device_lists_stream_id: the device_lists stream ID at the time when we first
                 joined the room.
         """
@@ -1799,7 +1799,6 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore):
             self._store_partial_state_room_txn,
             room_id,
             servers,
-            join_event_id,
             device_lists_stream_id,
         )
 
@@ -1808,7 +1807,6 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore):
         txn: LoggingTransaction,
         room_id: str,
         servers: Collection[str],
-        join_event_id: str,
         device_lists_stream_id: int,
     ) -> None:
         DatabasePool.simple_insert_txn(
@@ -1817,7 +1815,8 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore):
             values={
                 "room_id": room_id,
                 "device_lists_stream_id": device_lists_stream_id,
-                "join_event_id": join_event_id,
+                # To be updated later once the join event is persisted.
+                "join_event_id": None,
             },
         )
         DatabasePool.simple_insert_many_txn(
@@ -1827,6 +1826,36 @@ class RoomStore(RoomBackgroundUpdateStore, RoomWorkerStore):
             values=((room_id, s) for s in servers),
         )
         self._invalidate_cache_and_stream(txn, self.is_partial_state_room, (room_id,))
+
+    async def write_partial_state_rooms_join_event_id(
+        self,
+        room_id: str,
+        join_event_id: str,
+    ) -> None:
+        """Record the join event which resulted from a partial join.
+
+        We do this separately to `store_partial_state_room` because we need to wait for
+        the join event to be persisted. Otherwise we violate a foreign key constraint.
+        """
+        await self.db_pool.runInteraction(
+            "write_partial_state_rooms_join_event_id",
+            self._store_partial_state_room_txn,
+            room_id,
+            join_event_id,
+        )
+
+    async def _write_partial_state_rooms_join_event_id(
+        self,
+        txn: LoggingTransaction,
+        room_id: str,
+        join_event_id: str,
+    ) -> None:
+        DatabasePool.simple_update_txn(
+            txn,
+            table="partial_state_rooms",
+            keyvalues={"room_id": room_id},
+            updatevalues={"join_event_id": join_event_id},
+        )
 
     async def maybe_store_room_on_outlier_membership(
         self, room_id: str, room_version: RoomVersion

--- a/synapse/storage/schema/main/delta/73/04partial_join_details.sql
+++ b/synapse/storage/schema/main/delta/73/04partial_join_details.sql
@@ -18,6 +18,6 @@
 -- the partial join. For now it's sufficient to know the device_list stream_id at the
 -- time of the partial join, and the join event created for us during a partial join.
 --
--- Both columns are nullable without defaults, for backwards compatibility.
-ALTER TABLE partial_state_rooms ADD COLUMN device_lists_stream_id BIGINT;
+-- Both columns are backwards compatible.
+ALTER TABLE partial_state_rooms ADD COLUMN device_lists_stream_id BIGINT NOT NULL DEFAULT 0;
 ALTER TABLE partial_state_rooms ADD COLUMN join_event_id TEXT;

--- a/synapse/storage/schema/main/delta/73/04partial_join_details.sql
+++ b/synapse/storage/schema/main/delta/73/04partial_join_details.sql
@@ -1,0 +1,23 @@
+/* Copyright 2022 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- To ensure we correctly notify other homeservers about device list changes from our
+-- users after a partial join transitions to a full join, we need to know when we began
+-- the partial join. For now it's sufficient to know the device_list stream_id at the
+-- time of the partial join, and the join event created for us during a partial join.
+--
+-- Both columns are nullable without defaults, for backwards compatibility.
+ALTER TABLE partial_state_rooms ADD COLUMN device_lists_stream_id BIGINT;
+ALTER TABLE partial_state_rooms ADD COLUMN join_event_id TEXT REFERENCES events(event_id);

--- a/synapse/storage/schema/main/delta/73/04partial_join_details.sql
+++ b/synapse/storage/schema/main/delta/73/04partial_join_details.sql
@@ -20,4 +20,4 @@
 --
 -- Both columns are nullable without defaults, for backwards compatibility.
 ALTER TABLE partial_state_rooms ADD COLUMN device_lists_stream_id BIGINT;
-ALTER TABLE partial_state_rooms ADD COLUMN join_event_id TEXT REFERENCES events(event_id);
+ALTER TABLE partial_state_rooms ADD COLUMN join_event_id TEXT;

--- a/synapse/storage/schema/main/delta/73/04partial_join_details.sql
+++ b/synapse/storage/schema/main/delta/73/04partial_join_details.sql
@@ -20,4 +20,4 @@
 --
 -- Both columns are backwards compatible.
 ALTER TABLE partial_state_rooms ADD COLUMN device_lists_stream_id BIGINT NOT NULL DEFAULT 0;
-ALTER TABLE partial_state_rooms ADD COLUMN join_event_id TEXT;
+ALTER TABLE partial_state_rooms ADD COLUMN join_event_id TEXT REFERENCES events(event_id);


### PR DESCRIPTION
First half of #13891. A contribution to #12993.

This information will let us work out which servers to send device list updates to once we have fully joined the room. Doing so will ensure that we correctly fulfil our obligation to notify other HSes of our users' device list changes.