### PR TITLE
Enable WAL for SQLite

### DIFF
--- a/changelog.d/13897.feature
+++ b/changelog.d/13897.feature
@@ -1,1 +1,1 @@
-Enable WAL for SQLite installs. Contributed by [asymmetric](https://github.com/asymmetric).
+Enable Write-Ahead Logging for SQLite installs. Contributed by [asymmetric](https://github.com/asymmetric).

--- a/changelog.d/13897.feature
+++ b/changelog.d/13897.feature
@@ -1,0 +1,1 @@
+Enable WAL for SQLite installs. Contributed by [asymmetric](https://github.com/asymmetric).

--- a/synapse/storage/engines/sqlite.py
+++ b/synapse/storage/engines/sqlite.py
@@ -88,6 +88,10 @@ class Sqlite3Engine(BaseDatabaseEngine[sqlite3.Connection]):
 
         db_conn.create_function("rank", 1, _rank)
         db_conn.execute("PRAGMA foreign_keys = ON;")
+
+        # Enable WAL.
+        # see https://www.sqlite.org/wal.html
+        db_conn.execute("PRAGMA journal_mode = WAL;")
         db_conn.commit()
 
     def is_deadlock(self, error: Exception) -> bool:


### PR DESCRIPTION
As discussed in https://github.com/matrix-org/synapse/issues/2917#issuecomment-877146280, it makes sense to use the WAL for SQLite installs.

Further optimizations are possible (e.g. `synchronous = NORMAL`), but since they require tradeoffs (e.g. for the DB's durability), they have not been implemented in this PR, and could be implemented in a follow-up PR.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
