### PR TITLE
feat: support subdirs for appservice config files

### DIFF
--- a/changelog.d/13902.feature
+++ b/changelog.d/13902.feature
@@ -1,0 +1,1 @@
+Support subdirs for appservice config files in Docker start script. Contributed by @thefirstofthe300

--- a/docker/start.py
+++ b/docker/start.py
@@ -83,7 +83,7 @@ def generate_config_from_template(
                     handle.write(value)
             environ[secret] = value
 
-    environ["SYNAPSE_APPSERVICES"] = glob.glob("/data/appservices/*.yaml")
+    environ["SYNAPSE_APPSERVICES"] = glob.glob("/data/appservices/**/*.yaml", recurseive=True)
     if not os.path.exists(config_dir):
         os.mkdir(config_dir)
 


### PR DESCRIPTION
The current Docker container only supports when registration files are placed in the /data/appservices directory. Subdirectories are not currently supported. In the case of a user running Synapse on Kubernetes, the cleanest way to install appservice configuration files would be to use an individual configmap for each different bridge, resulting in multiple subdirectories for each appservice. Supporting placing registration files in subdirectories makes this deployment usecase easier.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
