### PR TITLE
Correctly add Cargo.lock to sdsit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,8 @@ include = [
     { path = "tests", format = "sdist" },
     { path = "UPGRADE.rst", format = "sdist" },
     { path = "Cargo.toml", format = "sdist" },
+    { path = "Cargo.lock", format = "sdist" },
     { path = "rust/Cargo.toml", format = "sdist" },
-    { path = "rust/Cargo.lock", format = "sdist" },
     { path = "rust/build.rs", format = "sdist" },
     { path = "rust/src/**", format = "sdist" },
 ]


### PR DESCRIPTION
This was incorrectly added in https://github.com/matrix-org/synapse/pull/12595