### PR TITLE
Update the manpage documentation for the hash_password script

### DIFF
--- a/changelog.d/13911.doc
+++ b/changelog.d/13911.doc
@@ -1,1 +1,1 @@
-Update the manpage for the `hash_password` script to correct the default number of bcrypt rounds performed.
+Update the man page for the `hash_password` script to correct the default number of bcrypt rounds performed.

--- a/changelog.d/13911.doc
+++ b/changelog.d/13911.doc
@@ -1,0 +1,1 @@
+Update the manpage for the `hash_password` script to correct the default number of bcrypt rounds performed.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+matrix-synapse-py3 (1.69.0~rc1+nmu1) UNRELEASED; urgency=medium
+
+  * The man page for the hash_password script has been updated to reflect
+    the correct default value of 'bcrypt_rounds'.
+
+ -- Synapse Packaging team <packages@matrix.org>  Mon, 26 Sep 2022 18:05:09 +0100
+
 matrix-synapse-py3 (1.68.0~rc2) stable; urgency=medium
 
   * New Synapse release 1.68.0rc2.

--- a/debian/hash_password.ronn
+++ b/debian/hash_password.ronn
@@ -14,7 +14,7 @@ or the `STDIN` if not supplied.
 
 It accepts an YAML file which can be used to specify parameters like the
 number of rounds for bcrypt and password_config section having the pepper
-value used for the hashing. By default `bcrypt_rounds` is set to **10**.
+value used for the hashing. By default `bcrypt_rounds` is set to **12**.
 
 The hashed password is written on the `STDOUT`.
 


### PR DESCRIPTION
The default number of bcrypt rounds were incorrect:

https://github.com/matrix-org/synapse/blob/f16ec055cc235eed1ae02f7cede99c366fedca5e/synapse/_scripts/hash_password.py#L26-L27

I don't claim that this PR prevents this mistake happening again in the future when we update the default for bcrypt rounds once more. Rather, it's just a quick drive-by fix.