### PR TITLE
Prioritize outbound to-device over device list updates

### DIFF
--- a/changelog.d/13922.bugfix
+++ b/changelog.d/13922.bugfix
@@ -1,0 +1,1 @@
+Fix long-standing bug where device updates could cause delays sending out to-device messages over federation.

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -649,11 +649,12 @@ class _TransactionQueueManager:
         limit = MAX_EDUS_PER_TRANSACTION - 2
 
         # We prioritize to-device messages so that existing encryption channels
-        # work.
+        # work. We also keep a few slots spare (by reducing the limit) so that
+        # we can still trickle out some device list updates.
         (
             to_device_edus,
             device_stream_id,
-        ) = await self.queue._get_to_device_message_edus(limit)
+        ) = await self.queue._get_to_device_message_edus(limit - 10)
 
         if to_device_edus:
             self._device_stream_id = device_stream_id

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -646,7 +646,7 @@ class _TransactionQueueManager:
 
         # We start by fetching device related EDUs, i.e device updates and to
         # device messages. We have to keep 2 free slots for presence and rr_edus.
-        limit = MAX_EDUS_PER_TRANSACTION - 2
+        device_edu_limit = MAX_EDUS_PER_TRANSACTION - 2
 
         # We prioritize to-device messages so that existing encryption channels
         # work. We also keep a few slots spare (by reducing the limit) so that
@@ -654,17 +654,17 @@ class _TransactionQueueManager:
         (
             to_device_edus,
             device_stream_id,
-        ) = await self.queue._get_to_device_message_edus(limit - 10)
+        ) = await self.queue._get_to_device_message_edus(device_edu_limit - 10)
 
         if to_device_edus:
             self._device_stream_id = device_stream_id
         else:
             self.queue._last_device_stream_id = device_stream_id
 
-        limit -= len(to_device_edus)
+        device_edu_limit -= len(to_device_edus)
 
         device_update_edus, dev_list_id = await self.queue._get_device_update_edus(
-            limit
+            device_edu_limit
         )
 
         if device_update_edus:


### PR DESCRIPTION
Otherwise device list changes for large accounts can temporarily delay to-device messages.