### PR TITLE
Add instruction for running unit tests in parallel

### DIFF
--- a/changelog.d/13928.doc
+++ b/changelog.d/13928.doc
@@ -1,0 +1,1 @@
+Added instruction to contributing guide for running unit tests in parallel. Contributed by @ashfame.

--- a/changelog.d/13928.doc
+++ b/changelog.d/13928.doc
@@ -1,1 +1,1 @@
-Added instruction to contributing guide for running unit tests in parallel. Contributed by @ashfame.
+Add instruction to contributing guide for running unit tests in parallel. Contributed by @ashfame.

--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -167,6 +167,12 @@ was broken. They are slower than the linters but will typically catch more error
 poetry run trial tests
 ```
 
+You can run unit tests in parallel by specifying `-jX` argument to `trial` where `X` is the number of parallel runners you want. To use 4 cpu cores, you would run them like:
+
+```sh
+poetry run trial -j4 tests
+```
+
 If you wish to only run *some* unit tests, you may specify
 another module instead of `tests` - or a test class or a method:
 


### PR DESCRIPTION
This PR updates the contributing guide with the instruction for running unit tests in parallel.