### PR TITLE
Correct default number of bcrypt hash rounds in .1 man page

### DIFF
--- a/changelog.d/13930.doc
+++ b/changelog.d/13930.doc
@@ -1,0 +1,1 @@
+Update the man page for the `hash_password` script to correct the default number of bcrypt rounds performed.

--- a/debian/hash_password.1
+++ b/debian/hash_password.1
@@ -10,7 +10,7 @@
 .P
 \fBhash_password\fR takes a password as an parameter either on the command line or the \fBSTDIN\fR if not supplied\.
 .P
-It accepts an YAML file which can be used to specify parameters like the number of rounds for bcrypt and password_config section having the pepper value used for the hashing\. By default \fBbcrypt_rounds\fR is set to \fB10\fR\.
+It accepts an YAML file which can be used to specify parameters like the number of rounds for bcrypt and password_config section having the pepper value used for the hashing\. By default \fBbcrypt_rounds\fR is set to \fB12\fR\.
 .P
 The hashed password is written on the \fBSTDOUT\fR\.
 .SH "FILES"


### PR DESCRIPTION
Missed in https://github.com/matrix-org/synapse/pull/13911, uses the same changelog entry.

Yes I'm still not happy about how manual this is, but doing a quick fix for now given we rarely update this value anyway.