### PR TITLE
Add upgrade notes for receipts replication.

### DIFF
--- a/changelog.d/13932.feature
+++ b/changelog.d/13932.feature
@@ -1,0 +1,1 @@
+Experimental support for thread-specific receipts ([MSC3771](https://github.com/matrix-org/matrix-spec-proposals/pull/3771)).

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -88,6 +88,18 @@ process, for example:
     dpkg -i matrix-synapse-py3_1.3.0+stretch1_amd64.deb
     ```
 
+# Upgrading to v1.69.0
+
+## Changes to the receipts replication streams
+
+Synapse now includes information indicating if a receipt applies to a thread when
+replicating it to other workers. This is a forwards- and backwards-incompatible
+change: v1.68 and workers cannot process receipts replicated by v1.69 workers, and
+vice versa.
+
+Once all workers are upgraded to v1.69 (or downgraded to v1.68), receipts
+replication will resume as normal.
+
 # Upgrading to v1.68.0
 
 Two changes announced in the upgrade notes for v1.67.0 have now landed in v1.68.0.


### PR DESCRIPTION
Missing from #13782, as discussed in #synapse-dev earlier today.

This is pretty much copied from the v1.64 notes:

https://matrix-org.github.io/synapse/latest/upgrade.html#changes-to-the-event-replication-streams
