### PR TITLE
Revert "Avoid returning an unused column."

### DIFF
--- a/changelog.d/13933.feature
+++ b/changelog.d/13933.feature
@@ -1,1 +1,0 @@
-Experimental support for thread-specific receipts ([MSC3771](https://github.com/matrix-org/matrix-spec-proposals/pull/3771)).

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -1053,7 +1053,7 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
         )
 
         sql = """
-            SELECT r.room_id, r.user_id, e.stream_ordering
+            SELECT r.stream_id, r.room_id, r.user_id, e.stream_ordering
             FROM receipts_linearized AS r
             INNER JOIN events AS e USING (event_id)
             WHERE ? < r.stream_id AND r.stream_id <= ? AND user_id LIKE ?
@@ -1078,7 +1078,7 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
 
         # For each new read receipt we delete push actions from before it and
         # recalculate the summary.
-        for room_id, user_id, stream_ordering in rows:
+        for _, room_id, user_id, stream_ordering in rows:
             # Only handle our own read receipts.
             if not self.hs.is_mine_id(user_id):
                 continue


### PR DESCRIPTION
Reverts matrix-org/synapse#13933.

Turns out this *is* used, but in a confusing spot further down in the code:

https://github.com/matrix-org/synapse/blob/7766bd5b354cd4ea1a33351ba320e54a14d3aeac/synapse/storage/databases/main/event_push_actions.py#L1124-L1127