### PR TITLE
Don't require `setuptools_rust` at runtime

### DIFF
--- a/changelog.d/13952.bugfix
+++ b/changelog.d/13952.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.68.0 where Synapse would require `setuptools_rust` at runtime, even though the package is only required at build time.

--- a/synapse/util/check_dependencies.py
+++ b/synapse/util/check_dependencies.py
@@ -70,8 +70,12 @@ def _should_ignore_runtime_requirement(req: Requirement) -> bool:
     # This is a build-time dependency. Irritatingly, `poetry build` ignores the
     # requirements listed in the [build-system] section of pyproject.toml, so in order
     # to support `poetry install --no-dev` we have to mark it as a runtime dependency.
-    # Workaround this by ignoring it here. (It might be slightly cleaner to put
-    # `setuptools_rust` in a `build` extra or similar, but . But for now I'
+    # See discussion on https://github.com/python-poetry/poetry/issues/6154 (it sounds
+    # like the poetry authors don't consider this a bug?)
+    #
+    # In any case, workaround this by ignoring setuptools_rust here. (It might be
+    # slightly cleaner to put `setuptools_rust` in a `build` extra or similar, but for
+    # now let's do something quick and dirty.
     if req.name == "setuptools_rust":
         return True
     return False


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/13926, see https://github.com/matrix-org/synapse/issues/13926#issuecomment-1260740889

I don't like special-casing it, but :shrug: