### PR TITLE
Discourage automatic replies to Synapse's emails

### DIFF
--- a/changelog.d/13957.feature
+++ b/changelog.d/13957.feature
@@ -1,0 +1,1 @@
+Ask mail servers receiving emails from Synapse to not send automatic reply (e.g. out-of-office responses).

--- a/synapse/handlers/send_email.py
+++ b/synapse/handlers/send_email.py
@@ -192,11 +192,10 @@ class SendEmailHandler:
         # header is present with any value other than "no". See
         #     https://www.rfc-editor.org/rfc/rfc3834.html#section-5.1
         multipart_msg["Auto-Submitted"] = "auto-generated"
-        # We also include a barely-documented Microsoft-Exchange specific header.
-        # The best reference I could find was
+        # Also include a Microsoft-Exchange specific header:
         #    https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcmail/ced68690-498a-4567-9d14-5c01f974d8b1
-        # which seems to suggest it can take the value "All" to mean "suppress all
-        # auto-replies", or a comma separated list of auto-reply classes to suppress.
+        # which suggests it can take the value "All" to "suppress all auto-replies",
+        # or a comma separated list of auto-reply classes to suppress.
         # The following stack overflow question has a little more context:
         #    https://stackoverflow.com/a/25324691/5252017
         #    https://stackoverflow.com/a/61646381/5252017

--- a/synapse/handlers/send_email.py
+++ b/synapse/handlers/send_email.py
@@ -187,13 +187,12 @@ class SendEmailHandler:
         multipart_msg["To"] = email_address
         multipart_msg["Date"] = email.utils.formatdate()
         multipart_msg["Message-ID"] = email.utils.make_msgid()
-        # A Microsoft Exchange user can configure an automatic reply (e.g. "I'm out of
-        # office until the 1st of January") to be sent to all incoming emails for a
-        # duration. But Exchange will NOT generate an automatic reply if the incoming
-        # message includes the following obscure, non-standard(?) and barely documented
-        # header with an appropriate value. The header does NOT mark the email as being
-        # auto-generated; it's more of a "don't reply to me" marker.
-        #
+        # Discourage automatic responses to Synapse's emails.
+        # Per RFC 3834, automatic responses should not be sent if the "Auto-Submitted"
+        # header is present with any value other than "no". See
+        #     https://www.rfc-editor.org/rfc/rfc3834.html#section-5.1
+        multipart_msg["Auto-Submitted"] = "auto-generated"
+        # We also include a barely-documented Microsoft-Exchange specific header.
         # The best reference I could find was
         #    https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcmail/ced68690-498a-4567-9d14-5c01f974d8b1
         # which seems to suggest it can take the value "All" to mean "suppress all

--- a/synapse/handlers/send_email.py
+++ b/synapse/handlers/send_email.py
@@ -187,6 +187,21 @@ class SendEmailHandler:
         multipart_msg["To"] = email_address
         multipart_msg["Date"] = email.utils.formatdate()
         multipart_msg["Message-ID"] = email.utils.make_msgid()
+        # A Microsoft Exchange user can configure an automatic reply (e.g. "I'm out of
+        # office until the 1st of January") to be sent to all incoming emails for a
+        # duration. But Exchange will NOT generate an automatic reply if the incoming
+        # message includes the following obscure, non-standard(?) and barely documented
+        # header with an appropriate value. The header does NOT mark the email as being
+        # auto-generated; it's more of a "don't reply to me" marker.
+        #
+        # The best reference I could find was
+        #    https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcmail/ced68690-498a-4567-9d14-5c01f974d8b1
+        # which seems to suggest it can take the value "All" to mean "suppress all
+        # auto-replies", or a comma separated list of auto-reply classes to suppress.
+        # The following stack overflow question has a little more context:
+        #    https://stackoverflow.com/a/25324691/5252017
+        #    https://stackoverflow.com/a/61646381/5252017
+        multipart_msg["X-Auto-Response-Suppress"] = "All"
         multipart_msg.attach(text_part)
         multipart_msg.attach(html_part)
 


### PR DESCRIPTION
Fixes #13951.

I don't have an email server (nor an Exchange account) to test this with, so it would be good if someone else could help on that front.

I'd like to sanity check that
- Synapse still sends out emails (and they don't now suddenly get marked as spam)
- Exchange auto-replies aren't sent in response to Synapse's emails
  - Perhaps @a-0-dev could confirm if this works once it has landed in a release?