### PR TITLE
Revert the general exception recording introduced in #13814

### DIFF
--- a/changelog.d/13969.misc
+++ b/changelog.d/13969.misc
@@ -1,0 +1,1 @@
+Revert catch-all exceptions being recorded as event pull attempt failures (only handle what we know about).

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -866,11 +866,6 @@ class FederationEventHandler:
                 event.room_id, event_id, str(err)
             )
             return
-        except Exception as exc:
-            await self._store.record_event_failed_pull_attempt(
-                event.room_id, event_id, str(exc)
-            )
-            raise exc
 
         try:
             try:
@@ -913,7 +908,7 @@ class FederationEventHandler:
                 logger.warning("Pulled event %s failed history check.", event_id)
             else:
                 raise
-        except Exception as exc:
+        except (FederationError, RuntimeError, InvalidResponseError) as exc:
             await self._store.record_event_failed_pull_attempt(
                 event.room_id, event_id, str(exc)
             )

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -908,11 +908,6 @@ class FederationEventHandler:
                 logger.warning("Pulled event %s failed history check.", event_id)
             else:
                 raise
-        except (FederationError, RuntimeError, InvalidResponseError) as exc:
-            await self._store.record_event_failed_pull_attempt(
-                event.room_id, event_id, str(exc)
-            )
-            raise exc
 
     @trace
     async def _compute_event_context_with_maybe_missing_prevs(


### PR DESCRIPTION
Revert the general exception recording introduced in https://github.com/matrix-org/synapse/pull/13814

As discussed with @reivilibre, https://github.com/matrix-org/synapse/pull/13815#discussion_r983384698

We should only be handling errors that we know how to handle. For example, we don't want to record the following errors or anything like them as failed pull attempts:

 - `CancelledError`: When a request is cancelled by the user. This one is probably not as applicable for `/backfill` but is a perfect example of why we shouldn't catch everything.
 - `NotRetryingDestination`: The per-destination HTTP request backoff error
 - `FederationDeniedError`: "If this destination  is not on our federation whitelist"
 - `RuntimeError`, `ValueError`, `AssertionError`, `KeyError`, etc because these represent programming errors rather than the remote not acting according to the way we expect.
 - Anything else with in the same vein

---

Follow-up to https://github.com/matrix-org/synapse/pull/13814 and https://github.com/matrix-org/synapse/pull/13589



### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
