### PR TITLE
Protoype automatic changelogs for dependabot PRs

### DIFF
--- a/.github/workflows/dependabot_changelog.yml
+++ b/.github/workflows/dependabot_changelog.yml
@@ -1,0 +1,23 @@
+name: Write changelog for dependabot PR
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-changelog:
+    runs-on: 'ubuntu-latest'
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Write, commit and push changelog
+        run: |
+          echo "${{ github.event.pull_request.title }}." > "changelog.d/${{ github.event.pull_request.number }}".docker
+          git add changelog.d
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "GitHub Actions"
+          git commit -m "Changelog"
+          git push
+        shell: bash

--- a/changelog.d/13998.misc
+++ b/changelog.d/13998.misc
@@ -1,0 +1,1 @@
+Prototype a workflow to automatically add changelogs to dependabot PRs.


### PR DESCRIPTION
I tried a version of this out on #13995 earlier and was able to automatically generate [a sensible-looking commit](https://github.com/matrix-org/synapse/pull/13995/commits/66a8cbb8107fc852d0fac3a110428a553c7de1f4).

Follow-up to #11828/#13976.