### PR TITLE
Linkify config documentation.

### DIFF
--- a/changelog.d/14003.doc
+++ b/changelog.d/14003.doc
@@ -1,0 +1,1 @@
+Linkify urls in config documentation.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -179,7 +179,7 @@ This will tell other servers to send traffic to port 443 instead.
 
 This option currently defaults to false.
 
-   See [Delegation of incoming federation traffic](https://matrix-org.github.io/synapse/latest/delegate.html) for more
+   See [Delegation of incoming federation traffic](../../delegate.md) for more
 information.
 
 Example configuration:
@@ -2977,7 +2977,7 @@ Options for each entry include:
 
      * `module`: The class name of a custom mapping module. Default is
        `synapse.handlers.oidc.JinjaOidcMappingProvider`.
-        See [OpenID Mapping Providers](https://matrix-org.github.io/synapse/latest/sso_mapping_providers.html#openid-mapping-providers)
+        See [OpenID Mapping Providers](../../../synapse/latest/sso_mapping_providers.html#openid-mapping-providers)
         for information on implementing a custom mapping provider.
 
      * `config`: Configuration for the mapping provider module. This section will
@@ -3422,8 +3422,8 @@ This option has the following sub-options:
     indexes were (re)built was before Synapse 1.44, you'll have to
     rebuild the indexes in order to search through all known users.
     These indexes are built the first time Synapse starts; admins can
-    manually trigger a rebuild via API following the instructions at
-         [https://matrix-org.github.io/synapse/latest/usage/administration/admin_api/background_updates.html#run](https://matrix-org.github.io/synapse/latest/usage/administration/admin_api/background_updates.html#run),
+    manually trigger a rebuild via the API following the instructions
+    [for running background updates](../administration/admin_api/background_updates.md#run),
     set to true to return search results containing all known users, even if that
     user does not share a room with the requester.
 * `prefer_local_users`: Defines whether to prefer local users in search query results.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -179,7 +179,7 @@ This will tell other servers to send traffic to port 443 instead.
 
 This option currently defaults to false.
 
-   See [Delegation of incoming federation traffic](../../delegate.md) for more
+See [Delegation of incoming federation traffic](../../delegate.md) for more
 information.
 
 Example configuration:

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3418,9 +3418,11 @@ This option has the following sub-options:
    the user directory. If false, search results will only contain users
     visible in public rooms and users sharing a room with the requester.
     Defaults to false.
+
     NB. If you set this to true, and the last time the user_directory search
     indexes were (re)built was before Synapse 1.44, you'll have to
     rebuild the indexes in order to search through all known users.
+    
     These indexes are built the first time Synapse starts; admins can
     manually trigger a rebuild via the API following the instructions
     [for running background updates](../administration/admin_api/background_updates.md#run),

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -2977,7 +2977,7 @@ Options for each entry include:
 
      * `module`: The class name of a custom mapping module. Default is
        `synapse.handlers.oidc.JinjaOidcMappingProvider`.
-        See [OpenID Mapping Providers](../../../synapse/latest/sso_mapping_providers.html#openid-mapping-providers)
+        See [OpenID Mapping Providers](../../sso_mapping_providers.md#openid-mapping-providers)
         for information on implementing a custom mapping provider.
 
      * `config`: Configuration for the mapping provider module. This section will

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -179,7 +179,7 @@ This will tell other servers to send traffic to port 443 instead.
 
 This option currently defaults to false.
 
-See https://matrix-org.github.io/synapse/latest/delegate.html for more
+   See [Delegation of incoming federation traffic](https://matrix-org.github.io/synapse/latest/delegate.html) for more
 information.
 
 Example configuration:
@@ -2952,7 +2952,7 @@ Options for each entry include:
 
      * `module`: The class name of a custom mapping module. Default is
        `synapse.handlers.oidc.JinjaOidcMappingProvider`.
-        See https://matrix-org.github.io/synapse/latest/sso_mapping_providers.html#openid-mapping-providers
+        See [OpenID Mapping Providers](https://matrix-org.github.io/synapse/latest/sso_mapping_providers.html#openid-mapping-providers)
         for information on implementing a custom mapping provider.
 
      * `config`: Configuration for the mapping provider module. This section will
@@ -3398,8 +3398,8 @@ This option has the following sub-options:
     rebuild the indexes in order to search through all known users.
     These indexes are built the first time Synapse starts; admins can
     manually trigger a rebuild via API following the instructions at
-         https://matrix-org.github.io/synapse/latest/usage/administration/admin_api/background_updates.html#run
-    Set to true to return search results containing all known users, even if that
+         [https://matrix-org.github.io/synapse/latest/usage/administration/admin_api/background_updates.html#run](https://matrix-org.github.io/synapse/latest/usage/administration/admin_api/background_updates.html#run),
+    set to true to return search results containing all known users, even if that
     user does not share a room with the requester.
 * `prefer_local_users`: Defines whether to prefer local users in search query results.
    If set to true, local users are more likely to appear above remote users when searching the


### PR DESCRIPTION
A lot of the links in the [documentation](https://matrix-org.github.io/synapse/v1.67/usage/configuration/config_documentation.html) have not been properly linkified, for [instance](https://matrix-org.github.io/synapse/v1.67/usage/configuration/config_documentation.html#user_directory), this PR fixes that!