### PR TITLE
Fix twisted trunk mypy errors

### DIFF
--- a/changelog.d/14012.misc
+++ b/changelog.d/14012.misc
@@ -1,0 +1,1 @@
+Fix type annotations to be compatible with new annotations in development versions of twisted.

--- a/synapse/handlers/cas.py
+++ b/synapse/handlers/cas.py
@@ -130,9 +130,10 @@ class CasHandler:
         except PartialDownloadError as pde:
             # Twisted raises this error if the connection is closed,
             # even if that's being used old-http style to signal end-of-data
-            # Cast safety: Error.response is Optional[bytes]. but a PartialDownloadError
-            # always has a non-None response.
-            body = cast(bytes, pde.response)
+            # Assertion is for mypy's benefit. Error.response is Optional[bytes],
+            # but a PartialDownloadError should always have a non-None response.
+            assert pde.response is not None
+            body = pde.response
         except HttpResponseException as e:
             description = (
                 'Authorization server responded with a "{status}" error '

--- a/synapse/handlers/cas.py
+++ b/synapse/handlers/cas.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 import urllib.parse
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, cast
 from xml.etree import ElementTree as ET
 
 import attr
@@ -130,7 +130,9 @@ class CasHandler:
         except PartialDownloadError as pde:
             # Twisted raises this error if the connection is closed,
             # even if that's being used old-http style to signal end-of-data
-            body = pde.response
+            # Cast safety: Error.response is Optional[bytes]. but a PartialDownloadError
+            # always has a non-None response.
+            body = cast(bytes, pde.response)
         except HttpResponseException as e:
             description = (
                 'Authorization server responded with a "{status}" error '

--- a/synapse/handlers/cas.py
+++ b/synapse/handlers/cas.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 import urllib.parse
-from typing import TYPE_CHECKING, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Dict, List, Optional
 from xml.etree import ElementTree as ET
 
 import attr

--- a/synapse/handlers/ui_auth/checkers.py
+++ b/synapse/handlers/ui_auth/checkers.py
@@ -119,6 +119,9 @@ class RecaptchaAuthChecker(UserInteractiveAuthChecker):
         except PartialDownloadError as pde:
             # Twisted is silly
             data = pde.response
+            # For mypy's benefit. A general Error.response is Optional[bytes], but
+            # a PartialDownloadError.response should be bytes AFAICS.
+            assert data is not None
             resp_body = json_decoder.decode(data.decode("utf-8"))
 
         if "success" in resp_body:


### PR DESCRIPTION
PartialDownloadError is now marked as `Optional[bytes]`, though I think it should never be None in practice. See
https://github.com/twisted/twisted/pull/11688/files#r985657476

Closes #14008.