### PR TITLE
Try again to automate dependabot changelogs

### DIFF
--- a/.github/workflows/dependabot_changelog.yml
+++ b/.github/workflows/dependabot_changelog.yml
@@ -4,6 +4,12 @@ on:
     types:
       - opened
 
+permissions:
+  # Needed to be able to push the commit. See 
+  #     https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+  # for a similar example
+  contents: write
+
 jobs:
   add-changelog:
     runs-on: 'ubuntu-latest'

--- a/changelog.d/14017.misc
+++ b/changelog.d/14017.misc
@@ -1,0 +1,1 @@
+Prototype a workflow to automatically add changelogs to dependabot PRs.


### PR DESCRIPTION
Follow-up to #11828, #13976, #13998, #14011.

We ran the workflow on a PR, but it failed to `git push` the changelog commit:

https://github.com/matrix-org/synapse/actions/runs/3174480896/jobs/5171326123