### PR TITLE
Do not return unspecced original_event field when using the stable /relations endpoint

### DIFF
--- a/synapse/rest/client/relations.py
+++ b/synapse/rest/client/relations.py
@@ -82,6 +82,11 @@ class RelationPaginationServlet(RestServlet):
         if to_token_str:
             to_token = await StreamToken.from_string(self.store, to_token_str)
 
+        # The unstable version of this API returns an extra field for client
+        # compatibility, see
+        assert request.path is not None
+        include_original_event = request.path.startswith(b"/_matrix/client/unstable/")
+
         result = await self._relations_handler.get_relations(
             requester=requester,
             event_id=parent_id,
@@ -92,6 +97,9 @@ class RelationPaginationServlet(RestServlet):
             direction=direction,
             from_token=from_token,
             to_token=to_token,
+            # The unstable version of this API returns an extra field for client
+            # compatibility, see
+            include_original_event=include_original_event,
         )
 
         return 200, result

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -654,6 +654,14 @@ class RelationsTestCase(BaseRelationsTestCase):
         )
 
         # We also expect to get the original event (the id of which is self.parent_id)
+        # when requesting the unstable endpoint.
+        self.assertNotIn("original_event", channel.json_body)
+        channel = self.make_request(
+            "GET",
+            f"/_matrix/client/unstable/rooms/{self.room}/relations/{self.parent_id}?limit=1",
+            access_token=self.user_token,
+        )
+        self.assertEqual(200, channel.code, channel.json_body)
         self.assertEqual(
             channel.json_body["original_event"]["event_id"], self.parent_id
         )
@@ -753,11 +761,6 @@ class RelationPaginationTestCase(BaseRelationsTestCase):
                 "type": "m.reaction",
             },
             channel.json_body["chunk"][0],
-        )
-
-        # We also expect to get the original event (the id of which is self.parent_id)
-        self.assertEqual(
-            channel.json_body["original_event"]["event_id"], self.parent_id
         )
 
         # Make sure next_batch has something in it that looks like it could be a


### PR DESCRIPTION
Related to #12930 (and #13953).

This updates the return value of `/relations` to *not* return the `original_event` field when using the `v1` version of the endpoint.

Note that the `v1` endpoint was added in #12403, as part of Synapse v1.57.0, but today's logs show not a single hit on this endpoint.