### PR TITLE
Dependabot changelogs: trigger CI explicitly

### DIFF
--- a/.github/workflows/dependabot_changelog.yml
+++ b/.github/workflows/dependabot_changelog.yml
@@ -3,16 +3,13 @@ on:
   pull_request:
     types:
       - opened
-      - reopened
+      - reopened  # For debugging!
 
 permissions:
   # Needed to be able to push the commit. See 
   #     https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
   # for a similar example
   contents: write
-  # The pull_requests "synchronize" event doesn't seem to fire with just `contents: write`, so
-  # CI doesn't run with the new changelog. Maybe `pull_requests: write` will fix this?
-  pull-requests: write
 
 jobs:
   add-changelog:
@@ -31,5 +28,20 @@ jobs:
           git commit -m "Changelog"
           git push
         shell: bash
+      # We have to explicitly start CI.
+      #
+      # By default, workflows can't trigger other workflows when they're just using the
+      # default `GITHUB_TOKEN` access token. (This is intended to stop you from writing
+      # recursive workflow loops by accident, because that'll get very expensive very
+      # quickly.) Instead, you have to manually call out to another workflow, or else
+      # make your changes (i.e. the `git push` above) using a personal access token.
+      # See
+      # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger CI
+        run: |
+          gh workflow run "tests.yml" --ref "${{ github.event.pull_request.head.ref }}"
+          gh workflow run "release-artifacts.yml" --ref "${{ github.event.pull_request.head.ref }}"
+        shell: bash
+
   # THIS WORKFLOW HAS VARIOUS WRITE PERMISSIONS---do not add other jobs here unless they
   # are sufficiently locked down to dependabot only as above.

--- a/.github/workflows/dependabot_changelog.yml
+++ b/.github/workflows/dependabot_changelog.yml
@@ -38,6 +38,9 @@ jobs:
       # See
       # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
       - name: Trigger CI
+        # Note: we use $GITHUB_REF here to run PR against the merge of this change with
+        # develop; use github.event.pull_request.head.ref above to commit to the PR
+        # branch.
         run: |
           gh workflow run "tests.yml" --ref "$GITHUB_REF"
           gh workflow run "release-artifacts.yml" --ref "$GITHUB_REF"

--- a/.github/workflows/dependabot_changelog.yml
+++ b/.github/workflows/dependabot_changelog.yml
@@ -39,8 +39,8 @@ jobs:
       # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
       - name: Trigger CI
         run: |
-          gh workflow run "tests.yml" --ref "${{ github.event.pull_request.head.ref }}"
-          gh workflow run "release-artifacts.yml" --ref "${{ github.event.pull_request.head.ref }}"
+          gh workflow run "tests.yml" --ref "$GITHUB_REF"
+          gh workflow run "release-artifacts.yml" --ref "$GITHUB_REF"
         shell: bash
 
   # THIS WORKFLOW HAS VARIOUS WRITE PERMISSIONS---do not add other jobs here unless they

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -11,6 +11,7 @@ on:
 
     # we do the full build on tags.
     tags: ["v*"]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["develop", "release-*"]
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/changelog.d/14027.misc
+++ b/changelog.d/14027.misc
@@ -1,0 +1,1 @@
+Prototype a workflow to automatically add changelogs to dependabot PRs.


### PR DESCRIPTION
History: #11828, #13976, #13998, #14011, #14017, #14021, ddcb52e455a275109d0d6f757e58118883b28fd8,  #this.

After some [digging](https://github.com/matrix-org/synapse/pull/14021#issuecomment-1265638135) it looks like workflows can't trigger other workflows by default. So let's be explicit and see if that lets us run CI on these `<EXPLETIVE>` changelogs.