### PR TITLE
Advertise supporting version 1.3 of the Matrix spec.

### DIFF
--- a/changelog.d/14032.feature
+++ b/changelog.d/14032.feature
@@ -1,0 +1,1 @@
+Advertise Matrix 1.3 support on `/_matrix/client/versions`.

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -75,6 +75,7 @@ class VersionsRestServlet(RestServlet):
                     "r0.6.1",
                     "v1.1",
                     "v1.2",
+                    "v1.3",
                 ],
                 # as per MSC1497:
                 "unstable_features": {


### PR DESCRIPTION
Fixes #13953.

It is likely worth a quick look over https://matrix.org/blog/2022/06/16/matrix-v-1-3-release#the-full-changelog by a reviewer to make sure that nothing is missed. #13953 also has some cross-links.