### PR TITLE
Fix backwards compatibility with upcoming threads schema changes

### DIFF
--- a/changelog.d/14045.misc
+++ b/changelog.d/14045.misc
@@ -1,0 +1,1 @@
+Ensure Synapse v1.69 works with upcoming database changes in v1.70.


### PR DESCRIPTION
I realized that the changes in #13776 (which are slated to go in v1.70.0, so the next release) cannot be properly rolled back, see below for a stack trace.

The changes in this PR essentially apply the on-going background update also to any new rows we're updating, so that the upsert will work correctly once the constraints are dropped (see #13776).

----

```
2022-10-04 08:30:22,309 - synapse.metrics.background_process_metrics - 242 - ERROR - rotate_notifs-4 - Background process 'rotate_notifs' threw an exception
Traceback (most recent call last):
  File "synapse/synapse/metrics/background_process_metrics.py", line 240, in run
    return await func(*args, **kwargs)
  File "synapse/synapse/storage/databases/main/event_push_actions.py", line 1006, in _rotate_notifs
    caught_up = await self.db_pool.runInteraction(
  File "synapse/synapse/storage/database.py", line 881, in runInteraction
    return await delay_cancellation(_runInteraction())
  File "venv/lib/python3.9/site-packages/twisted/internet/defer.py", line 1656, in _inlineCallbacks
    result = current_context.run(
  File "venv/lib/python3.9/site-packages/twisted/python/failure.py", line 514, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "synapse/synapse/storage/database.py", line 848, in _runInteraction
    result = await self.runWithConnection(
  File "synapse/synapse/storage/database.py", line 976, in runWithConnection
    return await make_deferred_yieldable(
  File "venv/lib/python3.9/site-packages/twisted/python/threadpool.py", line 244, in inContext
    result = inContext.theWork()  # type: ignore[attr-defined]
  File "venv/lib/python3.9/site-packages/twisted/python/threadpool.py", line 260, in <lambda>
    inContext.theWork = lambda: context.call(  # type: ignore[attr-defined]
  File "venv/lib/python3.9/site-packages/twisted/python/context.py", line 117, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "venv/lib/python3.9/site-packages/twisted/python/context.py", line 82, in callWithContext
    return func(*args, **kw)
  File "venv/lib/python3.9/site-packages/twisted/enterprise/adbapi.py", line 282, in _runWithConnection
    result = func(conn, *args, **kw)
  File "synapse/synapse/storage/database.py", line 969, in inner_func
    return func(db_conn, *args, **kwargs)
  File "synapse/synapse/storage/database.py", line 710, in new_transaction
    r = func(cursor, *args, **kwargs)
  File "synapse/synapse/storage/databases/main/event_push_actions.py", line 1109, in _handle_new_receipts_for_notifs_txn
    self.db_pool.simple_upsert_txn(
  File "synapse/synapse/storage/database.py", line 1257, in simple_upsert_txn
    return self.simple_upsert_txn_native_upsert(
  File "synapse/synapse/storage/database.py", line 1397, in simple_upsert_txn_native_upsert
    txn.execute(sql, list(allvalues.values()))
  File "synapse/synapse/storage/database.py", line 388, in execute
    self._do_execute(self.txn.execute, sql, *args)
  File "synapse/synapse/storage/database.py", line 436, in _do_execute
    return func(sql, *args, **kwargs)
sqlite3.OperationalError: ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint
```