### PR TITLE
Fix building wheels on OSX

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -108,6 +108,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
+        with:
+          # setup-python@v4 doesn't impose a default python version. Need to use 3.x
+          # here, because `python` on osx points to Python 2.7.
+          python-version: "3.x"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.9.0 poetry==1.2.0

--- a/changelog.d/14046.misc
+++ b/changelog.d/14046.misc
@@ -1,1 +1,1 @@
-Fix CI config for building wheels on OSX. Regressed in #13983.
+Bump actions/setup-python from 2 to 4.

--- a/changelog.d/14046.misc
+++ b/changelog.d/14046.misc
@@ -1,0 +1,1 @@
+Fix CI config for building wheels on OSX. Regressed in #13983.


### PR DESCRIPTION
Follow-up to #13983. I missed a breaking change in setup-python v4. Serves me right for rushing to cut through the dependabot spam.