### PR TITLE
Debug sync current token

### DIFF
--- a/changelog.d/14047.misc
+++ b/changelog.d/14047.misc
@@ -1,0 +1,1 @@
+Add debug parameter to sync API to override the current token. Contributed by Nick @ Beeper (@fizzadar).

--- a/changelog.d/14047.misc
+++ b/changelog.d/14047.misc
@@ -1,1 +1,1 @@
-Add debug parameter to sync API to override the current token. Contributed by Nick @ Beeper (@fizzadar).
+Add `?synapse_debug_current_token` query parameter to `/sync` API to override the current token. Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -361,7 +361,10 @@ class SyncHandler:
             # we are going to return immediately, so don't bother calling
             # notifier.wait_for_events.
             result: SyncResult = await self.current_sync_for_user(
-                sync_config, since_token, full_state=full_state
+                sync_config,
+                since_token,
+                full_state=full_state,
+                debug_current_token=debug_current_token,
             )
         else:
             # Otherwise, we wait for something to happen and report it to the user.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1330,7 +1330,15 @@ class SyncHandler:
         # this is due to some of the underlying streams not supporting the ability
         # to query up to a given point.
         # Always use the `now_token` in `SyncResultBuilder`
-        now_token = debug_current_token or self.event_sources.get_current_token()
+        now_token = self.event_sources.get_current_token()
+
+        if debug_current_token:
+            logger.info(
+                "Overriding sync current token for debugging to: %r",
+                debug_current_token,
+            )
+            now_token = debug_current_token
+
         log_kv({"now_token": now_token})
 
         logger.debug(

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -175,6 +175,11 @@ class SyncRestServlet(RestServlet):
         if since is not None:
             since_token = await StreamToken.from_string(self.store, since)
 
+        debug_token = parse_string(request, "synapse_debug_current_token")
+        debug_current_token = None
+        if debug_token is not None:
+            debug_current_token = await StreamToken.from_string(self.store, debug_token)
+
         # send any outstanding server notices to the user.
         await self._server_notices_sender.on_user_syncing(user.to_string())
 
@@ -192,6 +197,7 @@ class SyncRestServlet(RestServlet):
                 since_token=since_token,
                 timeout=timeout,
                 full_state=full_state,
+                debug_current_token=debug_current_token,
             )
 
         # the client may have disconnected by now; don't bother to serialize the


### PR DESCRIPTION
Something I threw together to aid debugging sync issues so we can pull a sync response between two points in time, rather than always since -> now. Thought I'd upstream if interested, feel free to close :)

Signed off by Nick @ Beeper (@fizzadar).

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
