### PR TITLE
Complement test image: capture logs from nginx

### DIFF
--- a/changelog.d/14063.misc
+++ b/changelog.d/14063.misc
@@ -1,0 +1,1 @@
+Complement test image: capture logs from nginx.

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -40,7 +40,11 @@ FROM matrixdotorg/synapse:$SYNAPSE_VERSION
     COPY --from=deps_base /etc/nginx /etc/nginx
     RUN rm /etc/nginx/sites-enabled/default
     RUN mkdir /var/log/nginx /var/lib/nginx
-    RUN chown www-data /var/log/nginx /var/lib/nginx
+    RUN chown www-data /var/lib/nginx
+
+    # have nginx log to stderr/out
+    RUN ln -sf /dev/stdout /var/log/nginx/access.log
+    RUN ln -sf /dev/stderr /var/log/nginx/error.log
 
     # Copy Synapse worker, nginx and supervisord configuration template files
     COPY ./docker/conf-workers/* /conf/

--- a/docker/conf-workers/nginx.conf.j2
+++ b/docker/conf-workers/nginx.conf.j2
@@ -2,6 +2,12 @@
 # configure_workers_and_start.py uses and amends to this file depending on the workers
 # that have been selected.
 
+error_log /dev/stderr info;
+
+http {
+  access_log /dev/stdout;
+}
+
 {{ upstream_directives }}
 
 server {

--- a/docker/conf-workers/nginx.conf.j2
+++ b/docker/conf-workers/nginx.conf.j2
@@ -2,12 +2,6 @@
 # configure_workers_and_start.py uses and amends to this file depending on the workers
 # that have been selected.
 
-error_log /dev/stderr info;
-
-http {
-  access_log /dev/stdout;
-}
-
 {{ upstream_directives }}
 
 server {


### PR DESCRIPTION
Have nginx send its logs to stderr/out, so that we can debug https://github.com/matrix-org/synapse/issues/13334.