### PR TITLE
Stop returning `unsigned.invite_room_state` in `PUT /_matrix/federation/v2/invite/{roomId}/{eventId}` responses

### DIFF
--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -499,6 +499,11 @@ class FederationV2InviteServlet(BaseFederationServerServlet):
         result = await self.handler.on_invite_request(
             origin, event, room_version_id=room_version
         )
+
+        # We only store invite_room_state for internal use, so remove it before
+        # returning the event to the remote homeserver.
+        result["event"].get("unsigned", {}).pop("invite_room_state", None)
+
         return 200, result
 
 


### PR DESCRIPTION
We were adding an 'invite_room_state' field in the 'unsigned' dict of invite events in response to a
[`PUT /_matrix/federation/v2/invite/{roomId}/{eventId}`](https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv2inviteroomideventid) request.

Internally, Synapse expects this to field to exist (as it did in the v1 version of this API), so we plonked it on before reusing the old code.

Unfortunately, we then forgot to remove it before sending the event out again.

Confirmed the problem and the fix using PyCharm's debugger. I thought about writing a unit/complement test but it's a bit specific...

[More information about stripped state events](https://spec.matrix.org/v1.4/client-server-api/#stripped-state).