### PR TITLE
Catch BrokenPipeError from metrics server, and log as a warning

### DIFF
--- a/changelog.d/14072.misc
+++ b/changelog.d/14072.misc
@@ -1,0 +1,1 @@
+Don't create noisy Sentry events when a requester drops connection to the metrics server mid-request.


### PR DESCRIPTION
Fixes #14066, I think?