### PR TITLE
Pin build-system requirements

### DIFF
--- a/changelog.d/14080.misc
+++ b/changelog.d/14080.misc
@@ -1,0 +1,1 @@
+Pin build-system requirements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,7 @@ twine = "*"
 towncrier = ">=18.6.0rc1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "setuptools_rust>=1.3"]
+requires = ["poetry-core==1.2.0", "setuptools_rust==1.5.2"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
Mitigates #14079 by using poetry-core 1.2.0, no exceptions.