### PR TITLE
Unpin build-system requirements, but impose an upper-bound

### DIFF
--- a/changelog.d/14085.misc
+++ b/changelog.d/14085.misc
@@ -1,0 +1,1 @@
+Rename the `url_preview` extra to `url-preview`, for compatability with poetry-core 1.3.0.

--- a/changelog.d/14085.misc
+++ b/changelog.d/14085.misc
@@ -1,1 +1,1 @@
-Rename the `url_preview` extra to `url-preview`, for compatability with poetry-core 1.3.0.
+Rename the `url_preview` extra to `url-preview`, for compatability with poetry-core 1.3.0 and [PEP 685](https://peps.python.org/pep-0685/). From-source installations using this extra will need to install using the new name.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -161,27 +161,6 @@ Synapse will log a warning when a module uses the deprecated method, to help
 administrators find modules using it.
 
 
-## Package extra `url_preview` now called `url-preview`
-
-This is compliant with [PEP 685](https://peps.python.org/pep-0685/#specification) and is necessary to use the URL preview option when Synapse is built with poetry-core 1.3.0 or greater. [#14079](https://github.com/matrix-org/synapse/issues/14079) has some more context.
-
-If you are installing Synapse from source with this extra specifically named, e.g. with
-
-```
-pip install /path/to/synapse[url_preview]
-```
-
-or
-
-```
-poetry install --extras url_preview
-```
-
-then you need to change the underscore `_` in `url_preview` to a hyphen `-` when upgrading to Synapse 1.69.0.
-No config changes are necessary.
-
-Installations using Debian packages and Docker images from Matrix.org are not affected. Installations from source that install the `all` extra are not affected.
-
 # Upgrading to v1.68.0
 
 Two changes announced in the upgrade notes for v1.67.0 have now landed in v1.68.0.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -161,6 +161,27 @@ Synapse will log a warning when a module uses the deprecated method, to help
 administrators find modules using it.
 
 
+## Package extra `url_preview` now called `url-preview`
+
+This is compliant with [PEP 685](https://peps.python.org/pep-0685/#specification) and is necessary to use the URL preview option when Synapse is built with poetry-core 1.3.0 or greater. [#14079](https://github.com/matrix-org/synapse/issues/14079) has some more context.
+
+If you are installing Synapse from source with this extra specifically named, e.g. with
+
+```
+pip install /path/to/synapse[url_preview]
+```
+
+or
+
+```
+poetry install --extras url_preview
+```
+
+then you need to change the underscore `_` in `url_preview` to a hyphen `-` when upgrading to Synapse 1.69.0.
+No config changes are necessary.
+
+Installations using Debian packages and Docker images from Matrix.org are not affected. Installations from source that install the `all` extra are not affected.
+
 # Upgrading to v1.68.0
 
 Two changes announced in the upgrade notes for v1.67.0 have now landed in v1.68.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,7 +309,8 @@ towncrier = ">=18.6.0rc1"
 [build-system]
 # The upper bounds here are defensive, intended to prevent situations like
 # #13849 and #14079 where we see buildtime or runtime errors caused by build
-# system changes. # We are happy to raise these upper bounds upon request,
+# system changes.
+# We are happy to raise these upper bounds upon request,
 # provided we check that it's safe to do so (i.e. that CI passes).
 requires = ["poetry-core>=1.0.0,<=1.3.1", "setuptools_rust>=1.3,<=1.5.2"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,7 @@ twine = "*"
 towncrier = ">=18.6.0rc1"
 
 [build-system]
-requires = ["poetry-core==1.2.0", "setuptools_rust==1.5.2"]
+requires = ["poetry-core>=1.0.0", "setuptools_rust>=1.3"]
 build-backend = "poetry.core.masonry.api"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,7 @@ oidc = ["authlib"]
 # `systemd.journal.JournalHandler`, as is documented in
 # `contrib/systemd/log_config.yaml`.
 systemd = ["systemd-python"]
-url_preview = ["lxml"]
+url-preview = ["lxml"]
 sentry = ["sentry-sdk"]
 opentracing = ["jaeger-client", "opentracing"]
 jwt = ["authlib"]
@@ -250,7 +250,7 @@ all = [
     "pysaml2",
     # oidc and jwt
     "authlib",
-    # url_preview
+    # url-preview
     "lxml",
     # sentry
     "sentry-sdk",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,11 @@ twine = "*"
 towncrier = ">=18.6.0rc1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "setuptools_rust>=1.3"]
+# The upper bounds here are defensive, intended to prevent situations like
+# #13849 and #14079 where we see buildtime or runtime errors caused by build
+# system changes. # We are happy to raise these upper bounds upon request,
+# provided we check that it's safe to do so (i.e. that CI passes).
+requires = ["poetry-core>=1.0.0,<=1.3.1", "setuptools_rust>=1.3,<=1.5.2"]
 build-backend = "poetry.core.masonry.api"
 
 

--- a/synapse/config/repository.py
+++ b/synapse/config/repository.py
@@ -205,7 +205,7 @@ class ContentRepositoryConfig(Config):
         )
         self.url_preview_enabled = config.get("url_preview_enabled", False)
         if self.url_preview_enabled:
-            check_requirements("url_preview")
+            check_requirements("url-preview")
 
             proxy_env = getproxies_environment()
             if "url_preview_ip_range_blacklist" not in config:


### PR DESCRIPTION
Fixes #14079, properly. Reverts #14080.

A summary of the problem:

1. Synapse defines an extra called `url_preview` with an underscore.
2. Synapse looks up its own packaging metadata at runtime to check if the dependencies needed for `url_preview` are installed.
3. Poetry-core 1.3.0 now [normalises extra names](https://github.com/python-poetry/poetry-core/pull/476) when writing metadata, per PEP 685. 
  - This means the extra will be written to metadata as `url-preview` _with a hyphen_. 
  - So the lookup in point 2 will fail if Synapse was built/installed by poetry-core 1.3.0.

Fix ourselves to be forward compatible by changing the spelling of `url_preview` to `url-preview`. Call this out in the upgrade notes.

_Remark._ I considered adding compatibility code to `check_dependencies.py` which could cope with denormalised extra names, both in source code and in the the on-disk metadata. But  hat would only be helpful for someone with stale metadata: for instance, someone who has `git pull`ed but not `poetry install --all-extras`ed. On reflection, I deemed this not important enough to work around for two reasons:

- In light of the rust changes, admins installing from source will have to `poetry install` (or similar) frequently anyway, or else Synapse will refuse to start because of an outdated Rust library.
- I doubt many people are installing the `url-preview` extra in isolation: I think most people just use `all`.