### PR TITLE
Faster joins: only choose locally-created events as `prev_events` when sending events into a partial-state room.

### DIFF
--- a/changelog.d/14105.misc
+++ b/changelog.d/14105.misc
@@ -1,0 +1,1 @@
+Faster joins: only choose locally-created events as `prev_events` when sending events into a partial-state room.

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -470,8 +470,14 @@ class PerDestinationQueue:
                 # servers, but the remote will correctly deduplicate them and
                 # handle it only once.
 
-                # Step 1, fetch the current extremities
-                extrems = await self._store.get_prev_events_for_room(pdu.room_id)
+                # Step 1, fetch some of the current extremities
+                # For partial state rooms, we intentionally restrict ourselves
+                # to only using our own events here, since we shouldn't divulge
+                # other servers' events to servers which we can't know,
+                # with certainty, whether they are in the room or not.
+                extrems = await self._store.get_prev_events_for_creating_event_in_room(
+                    pdu.room_id
+                )
 
                 if pdu.event_id in extrems:
                     # If the event is in the extremities, then great! We can just

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1121,7 +1121,11 @@ class EventCreationHandler:
                 len(prev_event_ids),
             )
         else:
-            prev_event_ids = await self.store.get_prev_events_for_room(builder.room_id)
+            prev_event_ids = (
+                await self.store.get_prev_events_for_creating_event_in_room(
+                    builder.room_id
+                )
+            )
 
         # Do a quick sanity check here, rather than waiting until we've created the
         # event and then try to auth it (which fails with a somewhat confusing "No
@@ -2061,7 +2065,9 @@ class EventCreationHandler:
 
         # modules can send new state events, so we re-calculate the auth events just in
         # case.
-        prev_event_ids = await self.store.get_prev_events_for_room(builder.room_id)
+        prev_event_ids = await self.store.get_prev_events_for_creating_event_in_room(
+            builder.room_id
+        )
 
         event = await builder.build(
             prev_event_ids=prev_event_ids,

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -799,7 +799,9 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                 origin_server_ts=origin_server_ts,
             )
 
-        latest_event_ids = await self.store.get_prev_events_for_room(room_id)
+        latest_event_ids = await self.store.get_prev_events_for_creating_event_in_room(
+            room_id
+        )
 
         state_before_join = await self.state_handler.compute_state_after_events(
             room_id, latest_event_ids

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1062,7 +1062,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
 
             return min_depth_event_id, current_min_depth
 
-    async def get_prev_events_for_room(self, room_id: str) -> List[str]:
+    async def get_prev_events_for_full_state_room(self, room_id: str) -> List[str]:
         """
         Gets a subset of the current forward extremities in the given room.
 
@@ -1073,7 +1073,8 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
             room_id: room_id
 
         Returns:
-            The event ids of the forward extremities.
+            The event ids of up to 10 of the forward extremities,
+            suitable for using as `prev_events` in a full-state room.
         """
 
         return await self.db_pool.runInteraction(

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1074,14 +1074,15 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
 
         Returns:
             The event ids of the forward extremities.
-
         """
 
         return await self.db_pool.runInteraction(
-            "get_prev_events_for_room", self._get_prev_events_for_room_txn, room_id
+            "get_prev_events_for_full_state_room",
+            self._get_prev_events_for_full_state_room_txn,
+            room_id,
         )
 
-    def _get_prev_events_for_room_txn(
+    def _get_prev_events_for_full_state_room_txn(
         self, txn: LoggingTransaction, room_id: str
     ) -> List[str]:
         # we just use the 10 newest events. Older events will become

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1062,7 +1062,9 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
 
             return min_depth_event_id, current_min_depth
 
-    async def get_prev_events_for_creating_event_in_room(self, room_id: str) -> List[str]:
+    async def get_prev_events_for_creating_event_in_room(
+        self, room_id: str
+    ) -> List[str]:
         """
         Gets up to 10 event IDs which are suitable for use as `prev_events`
         when creating an event in the given room.

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -249,7 +249,7 @@ class SyncTestCase(tests.unittest.HomeserverTestCase):
         # precede the join.
         mocked_get_prev_events = patch.object(
             self.hs.get_datastores().main,
-            "get_prev_events_for_room",
+            "get_prev_events_for_creating_event_in_room",
             new_callable=MagicMock,
             return_value=make_awaitable([last_room_creation_event_id]),
         )

--- a/tests/storage/test_event_chain.py
+++ b/tests/storage/test_event_chain.py
@@ -515,7 +515,7 @@ class EventChainBackgroundUpdateTestCase(HomeserverTestCase):
         # Create a fork in the DAG with different events.
         event_handler = self.hs.get_event_creation_handler()
         latest_event_ids = self.get_success(
-            self.store.get_prev_events_for_room(room_id)
+            self.store.get_prev_events_for_full_state_room(room_id)
         )
         event, context = self.get_success(
             event_handler.create_event(

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -77,7 +77,7 @@ class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
             )
 
         # this should get the last ten
-        r = self.get_success(self.store.get_prev_events_for_room(room_id))
+        r = self.get_success(self.store.get_prev_events_for_full_state_room(room_id))
         self.assertEqual(10, len(r))
         for i in range(0, 10):
             self.assertEqual("$event_%i:local" % (19 - i), r[i])

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -81,7 +81,7 @@ class ExtremPruneTestCase(HomeserverTestCase):
     def assert_extremities(self, expected_extremities):
         """Assert the current extremities for the room"""
         extremities = self.get_success(
-            self.store.get_prev_events_for_room(self.room_id)
+            self.store.get_prev_events_for_full_state_room(self.room_id)
         )
         self.assertCountEqual(extremities, expected_extremities)
 

--- a/tests/storage/test_room_search.py
+++ b/tests/storage/test_room_search.py
@@ -96,7 +96,9 @@ class EventSearchInsertionTest(HomeserverTestCase):
         # Construct a message with a numeric body to be received over federation
         # The message can't be sent using the client API, since Synapse's event
         # validation will reject it.
-        prev_event_ids = self.get_success(store.get_prev_events_for_room(room_id))
+        prev_event_ids = self.get_success(
+            store.get_prev_events_for_full_state_room(room_id)
+        )
         prev_event = self.get_success(store.get_event(prev_event_ids[0]))
         prev_state_map = self.get_success(
             self.hs.get_storage_controllers().state.get_state_ids_for_event(


### PR DESCRIPTION
Fixes #14057. Part of #12997.

The idea and rationale is given in #14057, but I'll re-iterate a bit:

Remote homeservers have 'the right' to ask us for the `prev_events` of any events that we create and send out to them.
As a partially-resident server, we can't track the set of servers in the room and so we don't know whether we're able to divulge any given event to another remote homeserver.

In the response to `/send_join` when we start our partial join, we receive a list of servers currently in the room at the point of our join event. This join event is therefore safe to divulge to the given list of homeservers, or if it isn't, that's equivalent to the resident homeserver being malicious or buggy and divulging events improperly itself.

We aren't violating any other servers' privacy by divulging our own events (and we know which servers are involved; though communicating that to the user is a separate problem).
If we persist our events in a 'chain' off from that join event, we never enter a situation where we need to divulge a `prev_event` which is another servers' event.

In practice, we may technically not have a chain but instead a DAG of events.


So, we:

- define a store method to calculate some `prev_events` for use in a partial-state room;
- use these when creating events; and
- decide upon whether we use the full forward extremities or this partial-state special case, in all instances where `get_prev_events` is used.

