### PR TITLE
Document encryption_enabled_by_default_for_room_type under the right name

### DIFF
--- a/changelog.d/14110.doc
+++ b/changelog.d/14110.doc
@@ -1,1 +1,1 @@
-Document encryption_enabled_by_default_for_room_type under the right name
+Correct the name of the config option [`encryption_enabled_by_default_for_room_type`](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#encryption_enabled_by_default_for_room_type).

--- a/changelog.d/14110.doc
+++ b/changelog.d/14110.doc
@@ -1,0 +1,1 @@
+Document encryption_enabled_by_default_for_room_type under the right name

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3385,7 +3385,7 @@ push:
 Config options relating to rooms.
 
 ---
-### `encryption_enabled_by_default`
+### `encryption_enabled_by_default_for_room_type`
 
 Controls whether locally-created rooms should be end-to-end encrypted by
 default.


### PR DESCRIPTION
(i really wish our doc was autogenerated from the code to avoid typos and desyncs like this.)