### PR TITLE
Fix name of "alias_creation_rules" option in config manual

### DIFF
--- a/changelog.d/14124.doc
+++ b/changelog.d/14124.doc
@@ -1,0 +1,1 @@
+Fix name of `alias_creation_rules` option in the config manual documentation.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3541,9 +3541,9 @@ Example configuration:
 enable_room_list_search: false
 ```
 ---
-### `alias_creation`
+### `alias_creation_rules`
 
-The `alias_creation` option controls who is allowed to create aliases
+The `alias_creation_rules` option controls who is allowed to create aliases
 on this server.
 
 The format of this option is a list of rules that contain globs that


### PR DESCRIPTION
The config manual had this listed as "alias_creation", whereas the option is named "alias_creation_rules".