### PR TITLE
Fix pinning Rust deps in docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !pyproject.toml
 !poetry.lock
 !Cargo.lock
+!Cargo.toml
 !build_rust.py
 
 rust/target

--- a/changelog.d/14129.bugfix
+++ b/changelog.d/14129.bugfix
@@ -1,0 +1,1 @@
+Fix pinning Rust dependencies in docker images.

--- a/changelog.d/14129.bugfix
+++ b/changelog.d/14129.bugfix
@@ -1,1 +1,1 @@
-Fix pinning Rust dependencies in docker images.
+Fix an issue with Docker images causing the Rust dependencies to not be pinned correctly.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -121,7 +121,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 COPY synapse /synapse/synapse/
 COPY rust /synapse/rust/
 # ... and what we need to `pip install`.
-COPY pyproject.toml README.rst build_rust.py /synapse/
+COPY pyproject.toml README.rst build_rust.py Cargo.toml Cargo.lock /synapse/
 
 # Repeat of earlier build argument declaration, as this is a new build stage.
 ARG TEST_ONLY_IGNORE_POETRY_LOCKFILE


### PR DESCRIPTION
We tried to do this in #13858, but failed.

The fix here is to copy over the `Cargo.lock` file in the dockerfile. While we're here we also copy over the `Cargo.toml`, which doesn't change anything right now but would if we included more metadata in it.

I'm not actually sure how to check this is picking up the lock file, beyond observing that the lockfile is in the directory when the Rust extension is built