### PR TITLE
Fallback if 'approved' isn't included in a registration replication request

### DIFF
--- a/changelog.d/14135.bugfix
+++ b/changelog.d/14135.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.69.0rc1 which would cause registration replication requests to fail if the worker sending the request is not running Synapse 1.69.

--- a/synapse/replication/http/register.py
+++ b/synapse/replication/http/register.py
@@ -102,6 +102,12 @@ class ReplicationRegisterServlet(ReplicationEndpoint):
 
         await self.registration_handler.check_registration_ratelimit(content["address"])
 
+        # Always default admin users to approved (since it means they were created by
+        # an admin).
+        approved_default = self._approval_default
+        if content["admin"]:
+            approved_default = True
+
         await self.registration_handler.register_with_store(
             user_id=user_id,
             password_hash=content["password_hash"],
@@ -113,7 +119,7 @@ class ReplicationRegisterServlet(ReplicationEndpoint):
             user_type=content["user_type"],
             address=content["address"],
             shadow_banned=content["shadow_banned"],
-            approved=content.get("approved", self._approval_default),
+            approved=content.get("approved", approved_default),
         )
 
         return 200, {}

--- a/synapse/replication/http/register.py
+++ b/synapse/replication/http/register.py
@@ -49,7 +49,6 @@ class ReplicationRegisterServlet(ReplicationEndpoint):
         else:
             self._approval_default = True
 
-
     @staticmethod
     async def _serialize_payload(  # type: ignore[override]
         user_id: str,

--- a/synapse/replication/http/register.py
+++ b/synapse/replication/http/register.py
@@ -39,6 +39,17 @@ class ReplicationRegisterServlet(ReplicationEndpoint):
         self.store = hs.get_datastores().main
         self.registration_handler = hs.get_registration_handler()
 
+        # Default value if the worker that sent the replication request did not include
+        # an 'approved' property.
+        if (
+            hs.config.experimental.msc3866.enabled
+            and hs.config.experimental.msc3866.require_approval_for_new_accounts
+        ):
+            self._approval_default = False
+        else:
+            self._approval_default = True
+
+
     @staticmethod
     async def _serialize_payload(  # type: ignore[override]
         user_id: str,
@@ -103,7 +114,7 @@ class ReplicationRegisterServlet(ReplicationEndpoint):
             user_type=content["user_type"],
             address=content["address"],
             shadow_banned=content["shadow_banned"],
-            approved=content["approved"],
+            approved=content.get("approved", self._approval_default),
         )
 
         return 200, {}


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/14131