### PR TITLE
Fix docstring in EventContext

### DIFF
--- a/changelog.d/14145.doc
+++ b/changelog.d/14145.doc
@@ -1,0 +1,2 @@
+Clarify comment on event contexts.
+

--- a/synapse/events/snapshot.py
+++ b/synapse/events/snapshot.py
@@ -65,7 +65,8 @@ class EventContext:
             None does not necessarily mean that ``state_group`` does not have
             a prev_group!
 
-            If the event is a state event, this is normally the same as ``prev_group``.
+            If the event is a state event, this is normally the same as
+            ``state_group_before_event``.
 
             If ``state_group`` is None (ie, the event is an outlier), ``prev_group``
             will always also be ``None``.


### PR DESCRIPTION
Based on the other comments I think this is what was meant? Otherwise it doesn't make sense.