### PR TITLE
Implement message forward pagination from start when no from is given, fixes #12383

### DIFF
--- a/changelog.d/14149.bugfix
+++ b/changelog.d/14149.bugfix
@@ -1,0 +1,1 @@
+Fix #12383: paginate room messages from the start if no from is given. Contributed by @gnunicorn .

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -448,6 +448,12 @@ class PaginationHandler:
 
         if pagin_config.from_token:
             from_token = pagin_config.from_token
+        elif pagin_config.direction == "f":
+            from_token = (
+                await self.hs.get_event_sources().get_start_token_for_pagination(
+                    room_id
+                )
+            )
         else:
             from_token = (
                 await self.hs.get_event_sources().get_current_token_for_pagination(

--- a/synapse/streams/events.py
+++ b/synapse/streams/events.py
@@ -74,6 +74,19 @@ class EventSources:
         return token
 
     @trace
+    async def get_start_token_for_pagination(self, room_id: str) -> StreamToken:
+        """Get the start token for a given room to be used to paginate
+        events.
+
+        The returned token does not have the current values for fields other
+        than `room`, since they are not used during pagination.
+
+        Returns:
+            The start token for pagination.
+        """
+        return StreamToken.START
+
+    @trace
     async def get_current_token_for_pagination(self, room_id: str) -> StreamToken:
         """Get the current token for a given room to be used to paginate
         events.


### PR DESCRIPTION
Include unit tests for forward and backward pagination of room messages.

Fixes #12383 .