### PR TITLE
Sync race cache invalidation fixes part 2

### DIFF
--- a/changelog.d/14156.misc
+++ b/changelog.d/14156.misc
@@ -1,0 +1,1 @@
+Fix race conditions with room membership in sync when using synapse workers. Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1375,6 +1375,9 @@ class SyncHandler:
                 # User joined a room - we have to then check the room state to ensure we
                 # respect any bans if there's a race between the join and ban events.
                 if event.membership == Membership.JOIN:
+                    # NB: we invalidate the cache here to avoid a race condition between
+                    # cache invalidation-over-replication and sync requests.
+                    self.store.get_users_in_room.invalidate((room_id,))
                     user_ids_in_room = await self.store.get_users_in_room(room_id)
                     if user_id in user_ids_in_room:
                         mutable_joined_room_ids.add(room_id)

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1323,6 +1323,11 @@ class SyncHandler:
             # See https://github.com/matrix-org/matrix-doc/issues/1144
             raise NotImplementedError()
 
+        # If we have no since token (init sync), ensure any cached rooms for the user
+        # is first invalidated to avoid race conditions with invalidation-over-replication.
+        if not since_token:
+            self.store.get_rooms_for_user.invalidate((user_id,))
+
         # Note: we get the users room list *before* we get the current token, this
         # avoids checking back in history if rooms are joined after the token is fetched.
         mutable_joined_room_ids = set(await self.store.get_rooms_for_user(user_id))

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1325,7 +1325,6 @@ class SyncHandler:
 
         # Note: we get the users room list *before* we get the current token, this
         # avoids checking back in history if rooms are joined after the token is fetched.
-        token_before_rooms = self.event_sources.get_current_token()
         mutable_joined_room_ids = set(await self.store.get_rooms_for_user(user_id))
 
         # NB: The now_token gets changed by some of the generate_sync_* methods,
@@ -1339,6 +1338,10 @@ class SyncHandler:
         # during which membership events may have been persisted, so we fetch these now
         # and modify the joined room list for any changes between the get_rooms_for_user
         # call and the get_current_token call.
+
+        # NB: due to race conditions in cache invalidation-over-replication we cannot
+        # assume that the get_rooms_for_user is up to date, looking at the membership
+        # events allows us to correct for this.
         membership_change_events = []
         if since_token:
             membership_change_events = await self.store.get_membership_changes_for_user(
@@ -1354,15 +1357,17 @@ class SyncHandler:
             # latest change is JOIN.
 
             for room_id, event in mem_last_change_by_room_id.items():
-                assert event.internal_metadata.stream_ordering
+                # Joined but we already know about it? Nothing to do here, this will bypass
+                # most membership events in any gappy syncs as get_rooms_for_user will already
+                # be up to date or close to it.
                 if (
-                    event.internal_metadata.stream_ordering
-                    < token_before_rooms.room_key.stream
+                    event.membership == Membership.JOIN
+                    and room_id in mutable_joined_room_ids
                 ):
                     continue
 
                 logger.info(
-                    "User membership change between getting rooms and current token: %s %s %s",
+                    "Checking membership change between since token and current token: %s %s %s",
                     user_id,
                     event.membership,
                     room_id,


### PR DESCRIPTION
See issue: https://github.com/matrix-org/synapse/issues/14154

More involved than the first fix, reviewable commit-by-commit. This essentially serves as a workaround for delayed cache invalidation by utilising the membership events we already pull as part of sync to identify any missing rooms.

Also has two always-invalidate cases for safety. I believe in both of these the frequency of them is so low that the extra invalidation won't be any performance impact.

Signed off by Nick @ Beeper (@fizzadar).

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
