### PR TITLE
Return the thread ID properly down sync.

### DIFF
--- a/changelog.d/14159.feature
+++ b/changelog.d/14159.feature
@@ -1,0 +1,1 @@
+Support for thread-specific notifications & receipts ([MSC3771](https://github.com/matrix-org/matrix-spec-proposals/pull/3771) and [MSC3773](https://github.com/matrix-org/matrix-spec-proposals/pull/3773)).

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -418,6 +418,8 @@ class ReceiptsWorkerStore(SQLBaseStore):
             receipt_type = event_entry.setdefault(row["receipt_type"], {})
 
             receipt_type[row["user_id"]] = db_to_json(row["data"])
+            if row["thread_id"]:
+                receipt_type[row["user_id"]]["thread_id"] = row["thread_id"]
 
         results = {
             room_id: [results[room_id]] if room_id in results else []


### PR DESCRIPTION
#13782 was missing a commit from #13202 (https://github.com/matrix-org/synapse/pull/13202/commits/d35ee33c050c4f7eca75022a2383c88e2e6c8e5c) causing the receipts returned down sync to be missing information.

Builds on #14140.

Tests at matrix-org/complement#500.