### PR TITLE
Avoid checking the event cache when backfilling events

### DIFF
--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -792,9 +792,41 @@ class FederationEventHandler:
             ],
         )
 
+        # Check if we already any of these have these events.
+        # Note: we currently make a lookup in the database directly here rather than
+        # checking the event cache, due to:
+        # https://github.com/matrix-org/synapse/issues/13476
+        existing_events_map = await self._store._get_events_from_db(
+            [event.event_id for event in events]
+        )
+
+        new_events = []
+        for event in events:
+            event_id = event.event_id
+
+            # If we've already seen this event ID...
+            if event_id in existing_events_map:
+                existing_event = existing_events_map[event_id]
+
+                # ...and the event itself was not previously stored as an outlier...
+                if not existing_event.event.internal_metadata.is_outlier():
+                    # ...then there's no need to persist it. We have it already.
+                    logger.info(
+                        "_process_pulled_event: Ignoring received event %s which we "
+                        "have already seen",
+                        event.event_id,
+                    )
+
+                # While we have seen this event before, it was stored as an outlier.
+                # We'll now persist it as a non-outlier.
+                logger.info("De-outliering event %s", event_id)
+
+            # Continue on with the events that are new to us.
+            new_events.append(event)
+
         # We want to sort these by depth so we process them and
         # tell clients about them in order.
-        sorted_events = sorted(events, key=lambda x: x.depth)
+        sorted_events = sorted(new_events, key=lambda x: x.depth)
         for ev in sorted_events:
             with nested_logging_context(ev.event_id):
                 await self._process_pulled_event(origin, ev, backfilled=backfilled)
@@ -845,18 +877,6 @@ class FederationEventHandler:
         )
 
         event_id = event.event_id
-
-        existing = await self._store.get_event(
-            event_id, allow_none=True, allow_rejected=True
-        )
-        if existing:
-            if not existing.internal_metadata.is_outlier():
-                logger.info(
-                    "_process_pulled_event: Ignoring received event %s which we have already seen",
-                    event_id,
-                )
-                return
-            logger.info("De-outliering event %s", event_id)
 
         try:
             self._sanity_check_event(event)


### PR DESCRIPTION
Most of the context is in #14161.

This PR augments another optimisation. In #14161, when we purged and rejoined a room, we found that while the state was now persisted correctly, non-state events were not. These events are not initially received when you rejoin a room, but must be [backfilled]() from the remote homeserver after you join the room.

Backfilling involves another area where we refuse to persist events if they already exist in the event cache:

https://github.com/matrix-org/synapse/blob/7b7478e8b65cceb9e7362c6c1cb932b569a6f383/synapse/handlers/federation_event.py#L849-L859

It has one more conditional over the `_have_seen_events_dict` case though. If we found an event in the cache, and it was an outlier, we'll still persist it. Of course, most events aren't outliers, including messages. Hence why we see messages get lost when rejoining a room after purging it in https://github.com/matrix-org/synapse/pull/14161#issuecomment-1276527040,

This PR changes this optimisation such that it skips the event cache entirely, and instead just checks the database directly. Again, as with #14161, there's a potential performance degradation here, but it prevents breakage until something like https://github.com/matrix-org/synapse/issues/13916 comes along and correctly invalidates the event cache.

---

The main change here is skipping the event cache during backfill when checking to see if we already have an event before persisting it.

Additionally, there's a potential speedup in this PR as well. Before, we were checking one event ID at a time against the cache (or DB in case of a cache miss) in `_process_pulled_event`.

This PR moves this checking code outside of `_process_pulled_event` and excludes events we've already seen before sorting them and passing them one-by-one to `_process_pulled_event`.

In the case of lots of cache misses, this code should theoretically be faster...