### PR TITLE
Fix sqlite syntax for upserts.

### DIFF
--- a/changelog.d/14171.feature
+++ b/changelog.d/14171.feature
@@ -1,0 +1,1 @@
+Experimental support for [MSC3856](https://github.com/matrix-org/matrix-spec-proposals/pull/3856): threads list API.

--- a/synapse/storage/databases/main/relations.py
+++ b/synapse/storage/databases/main/relations.py
@@ -138,7 +138,7 @@ class RelationsWorkerStore(SQLBaseStore):
             if isinstance(txn.database_engine, PostgresEngine):
                 txn.execute_values(sql % ("?",), rows, fetch=False)
             else:
-                txn.execute_batch(sql % ("?, ?, ?, ?, ?",), rows)
+                txn.execute_batch(sql % ("(?, ?, ?, ?, ?)",), rows)
 
             # Mark the progress.
             self.db_pool.updates._background_update_progress_txn(


### PR DESCRIPTION
Fixes the backfill script given in #13394. I missed parentheses for sqlite.