### PR TITLE
Optimise the event_push_backfill_thread_id bg job

### DIFF
--- a/changelog.d/14172.bugfix
+++ b/changelog.d/14172.bugfix
@@ -1,0 +1,1 @@
+Fix poor performance of the `event_push_backfill_thread_id` background update, which was introduced in Synapse 1.68.0rc1.

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -299,7 +299,13 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
             SET thread_id = 'main'
             WHERE ? < stream_ordering AND stream_ordering <= ? AND thread_id IS NULL
             """
-            txn.execute(sql, (start_stream_ordering, max_stream_ordering,))
+            txn.execute(
+                sql,
+                (
+                    start_stream_ordering,
+                    max_stream_ordering,
+                ),
+            )
 
             # Update progress.
             processed_rows = txn.rowcount

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -297,9 +297,9 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
             sql = f"""
             UPDATE {table_name}
             SET thread_id = 'main'
-            WHERE stream_ordering <= ? AND thread_id IS NULL
+            WHERE ? < stream_ordering AND stream_ordering <= ? AND thread_id IS NULL
             """
-            txn.execute(sql, (max_stream_ordering,))
+            txn.execute(sql, (start_stream_ordering, max_stream_ordering,))
 
             # Update progress.
             processed_rows = txn.rowcount


### PR DESCRIPTION
BG job added in #13753, see https://github.com/matrix-org/synapse/pull/13753/files#diff-f121377d76a7b35c60092da2c4bf8c849544459a2c676cf8e87057aff24ece54R244-R247