### PR TITLE
Set LD_PRELOAD to load jemalloc in Dockerfile-workers.

### DIFF
--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -39,6 +39,7 @@
 # continue to work if so.
 
 import os
+import platform
 import subprocess
 import sys
 from pathlib import Path
@@ -630,6 +631,14 @@ def main(args: List[str], environ: MutableMapping[str, str]) -> None:
         # Mark workers as being configured
         with open(mark_filepath, "w") as f:
             f.write("")
+
+    # Lifted right out of start.py
+    jemallocpath = "/usr/lib/%s-linux-gnu/libjemalloc.so.2" % (platform.machine(),)
+
+    if os.path.isfile(jemallocpath):
+        environ["LD_PRELOAD"] = jemallocpath
+    else:
+        log("Could not find %s, will not use" % (jemallocpath,))
 
     # Start supervisord, which will start Synapse, all of the configured worker
     # processes, redis, nginx etc. according to the config we created above.


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Using jemalloc instead of malloc is supposed to be more efficient at long running instances of Synapse. It's used in [start.py](https://github.com/matrix-org/synapse/blob/develop/docker/start.py) for simple single process homeservers started by the simple [Dockerfile](https://github.com/matrix-org/synapse/blob/develop/docker/Dockerfile). Stick it into [Dockerfile-workers](https://github.com/matrix-org/synapse/blob/develop/docker/Dockerfile-workers) too.

Signed-off-by: Jason Little <realtyem@gmail.com>