### PR TITLE
Fix dead link to admin registration API

### DIFF
--- a/changelog.d/14189.doc
+++ b/changelog.d/14189.doc
@@ -1,0 +1,1 @@
+Fix dead link to the [Admin Registration API](https://matrix-org.github.io/synapse/latest/admin_api/register_api.html).

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -2088,7 +2088,7 @@ set.
 
 This is primarily intended for use with the `register_new_matrix_user` script
 (see [Registering a user](../../setup/installation.md#registering-a-user));
-however, the interface is [documented](../admin_api/register_api.html).
+however, the interface is [documented](../../admin_api/register_api.html).
 
 See also [`registration_shared_secret_path`](#registration_shared_secret_path).
 


### PR DESCRIPTION
"Register a user" in https://matrix-org.github.io/synapse/v1.68/usage/configuration/config_documentation.html?highlight=shared%20secret#registration_shared_secret is broken. No longer.