### PR TITLE
`FederationDeniedError` is not a `SynapseError`

### DIFF
--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -248,7 +248,7 @@ class UserDeactivatedError(SynapseError):
         )
 
 
-class FederationDeniedError(SynapseError):
+class FederationDeniedError(RuntimeError):
     """An error raised when the server tries to federate with a server which
     is not on its federation whitelist.
 


### PR DESCRIPTION
`FederationDeniedError` is not a `SynapseError`

Spawning from https://github.com/matrix-org/synapse/pull/13816#discussion_r993262622

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
