### PR TITLE
Don't pin dev-deps in pyproject; use lower bounds

### DIFF
--- a/changelog.d/14227.misc
+++ b/changelog.d/14227.misc
@@ -1,1 +1,1 @@
-Specify dev-dependencies using lower bounds, to reduce the likelihood of a dependabot merge conflict. (The lockfile continues to pin to specific versions.)
+Specify dev-dependencies using lower bounds, to reduce the likelihood of a dependabot merge conflict. The lockfile continues to pin to specific versions.

--- a/changelog.d/14227.misc
+++ b/changelog.d/14227.misc
@@ -1,0 +1,1 @@
+Specify dev-dependencies using lower bounds, to reduce the likelihood of a dependabot merge conflict. (The lockfile continues to pin to specific versions.)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1632,7 +1632,7 @@ url-preview = ["lxml"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "327eb55e543f29feac9ca1a014f17c48fdf01a96bbed9ed9237dab787e9ac614"
+content-hash = "c566c0e9acace4c6c7026d0e0f52e3d2a5dff1ea927d223968356b3edcfc3d51"
 
 [metadata.files]
 attrs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,10 +267,10 @@ all = [
 
 [tool.poetry.dev-dependencies]
 ## We pin black so that our tests don't start failing on new releases.
-isort = "==5.10.1"
-black = "==22.3.0"
+isort = ">=5.10.1"
+black = ">=22.3.0"
 flake8-comprehensions = "*"
-flake8-bugbear = "==21.3.2"
+flake8-bugbear = ">=21.3.2"
 flake8 = "*"
 
 # Typechecking
@@ -296,11 +296,11 @@ parameterized = ">=0.7.4"
 idna = ">=2.5"
 
 # The following are used by the release script
-click = "==8.1.3"
+click = ">=8.1.3"
 # GitPython was == 3.1.14; bumped to 3.1.20, the first release with type hints.
 GitPython = ">=3.1.20"
-commonmark = "==0.9.1"
-pygithub = "==1.55"
+commonmark = ">=0.9.1"
+pygithub = ">=1.55"
 # The following are executed as commands by the release script.
 twine = "*"
 # Towncrier min version comes from #3425. Rationale unclear.


### PR DESCRIPTION
This makes it slightly less tedious to update these things via successive dependabot updates, by reducing the likelihood of a merge conflict.