### PR TITLE
Log stream cache behind current token

### DIFF
--- a/changelog.d/14239.misc
+++ b/changelog.d/14239.misc
@@ -1,0 +1,1 @@
+Add warning log when workers stream cache is not up to date with the current position. This will be used to identify race conditions to fix. Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/handlers/typing.py
+++ b/synapse/handlers/typing.py
@@ -422,7 +422,9 @@ class TypingWriterHandler(FollowerTypingHandler):
 
         changed_rooms: Optional[
             Iterable[str]
-        ] = self._typing_stream_change_cache.get_all_entities_changed(last_id)
+        ] = self._typing_stream_change_cache.get_all_entities_changed(
+            last_id, current_id
+        )
 
         if changed_rooms is None:
             changed_rooms = self._room_serials

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -309,7 +309,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
         # Determine which users have devices with pending messages
         for user_id in user_ids:
             if self._device_inbox_stream_cache.has_entity_changed(
-                user_id, from_stream_id
+                user_id, from_stream_id, to_stream_id
             ):
                 # This user has new messages sent to them. Query messages for them
                 user_ids_to_query.add(user_id)
@@ -440,7 +440,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
 
         if last_deleted_stream_id:
             has_changed = self._device_inbox_stream_cache.has_entity_changed(
-                user_id, last_deleted_stream_id
+                user_id, last_deleted_stream_id, up_to_stream_id
             )
             if not has_changed:
                 log_kv({"message": "No changes in cache since last check"})
@@ -491,7 +491,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
         set_tag("limit", limit)
 
         has_changed = self._device_federation_outbox_stream_cache.has_entity_changed(
-            destination, last_stream_id
+            destination, last_stream_id, current_stream_id
         )
         if not has_changed or last_stream_id == current_stream_id:
             log_kv({"message": "No new messages in stream"})

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -271,7 +271,7 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
         now_stream_id = self.get_device_stream_token()
 
         has_changed = self._device_list_federation_stream_cache.has_entity_changed(
-            destination, int(from_stream_id)
+            destination, int(from_stream_id), now_stream_id
         )
         if not has_changed:
             return now_stream_id, []
@@ -780,12 +780,12 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
         if user_ids is None:
             # Get set of all users that have had device list changes since 'from_key'
             user_ids_to_check = self._device_list_stream_cache.get_all_entities_changed(
-                from_key
+                from_key, to_key
             )
         else:
             # The same as above, but filter results to only those users in 'user_ids'
             user_ids_to_check = self._device_list_stream_cache.get_entities_changed(
-                user_ids, from_key
+                user_ids, from_key, to_key
             )
 
         if not user_ids_to_check:

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -793,7 +793,9 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
 
         # If there have been no events in the room since the stream ordering,
         # there can't be any push actions either.
-        if not self._events_stream_cache.has_entity_changed(room_id, stream_ordering):
+        if not self._events_stream_cache.has_entity_changed(
+            room_id, stream_ordering, max_stream_ordering
+        ):
             return []
 
         stream_ordering_clause = ""

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -293,7 +293,7 @@ class ReceiptsWorkerStore(SQLBaseStore):
             # Only ask the database about rooms where there have been new
             # receipts added since `from_key`
             room_ids = self._receipts_stream_cache.get_entities_changed(
-                room_ids, from_key
+                room_ids, from_key, to_key
             )
 
         results = await self._get_linearized_receipts_for_rooms(
@@ -319,7 +319,9 @@ class ReceiptsWorkerStore(SQLBaseStore):
         if from_key is not None:
             # Check the cache first to see if any new receipts have been added
             # since`from_key`. If not we can no-op.
-            if not self._receipts_stream_cache.has_entity_changed(room_id, from_key):
+            if not self._receipts_stream_cache.has_entity_changed(
+                room_id, from_key, to_key
+            ):
                 return []
 
         return await self._get_linearized_receipts_for_room(room_id, to_key, from_key)

--- a/synapse/storage/databases/main/state_deltas.py
+++ b/synapse/storage/databases/main/state_deltas.py
@@ -63,7 +63,7 @@ class StateDeltasStore(SQLBaseStore):
         ), f"New stream id {max_stream_id} is smaller than prev stream id {prev_stream_id}"
 
         if not self._curr_state_delta_stream_cache.has_any_entity_changed(
-            prev_stream_id
+            prev_stream_id, max_stream_id
         ):
             # if the CSDs haven't changed between prev_stream_id and now, we
             # know for certain that they haven't changed between prev_stream_id and

--- a/synapse/storage/databases/main/stream.py
+++ b/synapse/storage/databases/main/stream.py
@@ -487,7 +487,7 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
                 - stream ordering key for the start of the chunk of events returned.
         """
         room_ids = self._events_stream_cache.get_entities_changed(
-            room_ids, from_key.stream
+            room_ids, from_key.stream, to_key.stream
         )
 
         if not room_ids:
@@ -558,7 +558,7 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
             return [], from_key
 
         has_changed = self._events_stream_cache.has_entity_changed(
-            room_id, from_key.stream
+            room_id, from_key.stream, to_key.stream
         )
 
         if not has_changed:

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -50,6 +50,9 @@ class StreamChangeCache:
         # map from stream id to the a set of entities which changed at that stream id.
         self._cache: SortedDict[int, Set[EntityType]] = SortedDict()
 
+        # Maximum known stream position to wait on if behind the current persisted position.
+        self.max_stream_pos = current_stream_pos
+
         # the earliest stream_pos for which we can reliably answer
         # get_all_entities_changed. In other words, one less than the earliest
         # stream_pos for which we know _cache is valid.
@@ -194,6 +197,9 @@ class StreamChangeCache:
             self._earliest_known_stream_pos = max(k, self._earliest_known_stream_pos)
             for entity in r:
                 del self._entity_to_key[entity]
+
+        if stream_pos > self.max_stream_pos:
+            self.max_stream_pos = stream_pos
 
     def _evict(self) -> None:
         while len(self._cache) > self._max_size:


### PR DESCRIPTION
Specifically designed to track instances of https://github.com/matrix-org/synapse/issues/14158. Any time the warning is logged there is a risk of missed changes due to stream cache lagging behind the current token.

Signed off by Nick @ Beeper (@fizzadar).

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). 
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
