### PR TITLE
Fix presence bug introduced in 1.64 by #13313

### DIFF
--- a/changelog.d/14243.bugfix
+++ b/changelog.d/14243.bugfix
@@ -1,1 +1,1 @@
-Fix a bug introduced in Synapse 1.64.0 regarding presence updates in sync.
+Fix a bug introduced in Synapse 1.64.0 where presence updates could be missing from `/sync` responses.

--- a/changelog.d/14243.bugfix
+++ b/changelog.d/14243.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.64.0 regarding presence updates in sync.

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -751,7 +751,6 @@ class RoomMemberWorkerStore(EventsWorkerStore):
                     SELECT room_id, state_key FROM current_state_events
                     WHERE type = 'm.room.member' AND membership = 'join' AND {clause}
                 ) AS b using (room_id)
-                LIMIT 1
             """
 
             txn.execute(sql, (user_id, *args))

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -742,7 +742,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             # user and the set of other users, and then checking if there is any
             # overlap.
             sql = f"""
-                SELECT b.state_key
+                SELECT DISTINCT b.state_key
                 FROM (
                     SELECT room_id FROM current_state_events
                     WHERE type = 'm.room.member' AND membership = 'join' AND state_key = ?


### PR DESCRIPTION
Fix presence bug #13601 introduced by #13313.

This happens when presence coming from users that are in 2 or more different rooms is calculated for a sync.

Complement PR: https://github.com/matrix-org/complement/pull/525

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
