### PR TITLE
Properly update the threads table when thread events are redacted

### DIFF
--- a/changelog.d/14248.bugfix
+++ b/changelog.d/14248.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.70.0rc1 where the information returned from the `/threads` API could be stale when threaded events are redacted.

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -2081,7 +2081,9 @@ class PersistEventsStore:
             txn.execute(sql, (redacted_relates_to, RelationTypes.THREAD))
 
             row = txn.fetchone()
-            # If a new latest event is found, update the threads table.
+            # If a latest event is found, update the threads table, this might
+            # be the same current latest event (if an earlier event in the thread
+            # was redacted).
             if row:
                 self.db_pool.simple_upsert_txn(
                     txn,

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -2046,21 +2046,24 @@ class PersistEventsStore:
         self.store._invalidate_cache_and_stream(
             txn, self.store.get_relations_for_event, (redacted_relates_to,)
         )
-        self.store._invalidate_cache_and_stream(
-            txn, self.store.get_aggregation_groups_for_event, (redacted_relates_to,)
-        )
-        self.store._invalidate_cache_and_stream(
-            txn, self.store.get_applicable_edit, (redacted_relates_to,)
-        )
-        self.store._invalidate_cache_and_stream(
-            txn, self.store.get_thread_summary, (redacted_relates_to,)
-        )
-        self.store._invalidate_cache_and_stream(
-            txn, self.store.get_thread_participated, (redacted_relates_to,)
-        )
-        self.store._invalidate_cache_and_stream(
-            txn, self.store.get_threads, (room_id,)
-        )
+        if rel_type == RelationTypes.ANNOTATION:
+            self.store._invalidate_cache_and_stream(
+                txn, self.store.get_aggregation_groups_for_event, (redacted_relates_to,)
+            )
+        if rel_type == RelationTypes.REPLACE:
+            self.store._invalidate_cache_and_stream(
+                txn, self.store.get_applicable_edit, (redacted_relates_to,)
+            )
+        if rel_type == RelationTypes.THREAD:
+            self.store._invalidate_cache_and_stream(
+                txn, self.store.get_thread_summary, (redacted_relates_to,)
+            )
+            self.store._invalidate_cache_and_stream(
+                txn, self.store.get_thread_participated, (redacted_relates_to,)
+            )
+            self.store._invalidate_cache_and_stream(
+                txn, self.store.get_threads, (room_id,)
+            )
 
         self.db_pool.simple_delete_txn(
             txn, table="event_relations", keyvalues={"event_id": redacted_event_id}

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -2080,19 +2080,19 @@ class PersistEventsStore:
             """
             txn.execute(sql, (redacted_relates_to, RelationTypes.THREAD))
 
-            row = txn.fetchone()
             # If a latest event is found, update the threads table, this might
             # be the same current latest event (if an earlier event in the thread
             # was redacted).
-            if row:
+            latest_event_row = txn.fetchone()
+            if latest_event_row:
                 self.db_pool.simple_upsert_txn(
                     txn,
                     table="threads",
                     keyvalues={"room_id": room_id, "thread_id": redacted_relates_to},
                     values={
-                        "latest_event_id": row[0],
-                        "topological_ordering": row[1],
-                        "stream_ordering": row[2],
+                        "latest_event_id": latest_event_row[0],
+                        "topological_ordering": latest_event_row[1],
+                        "stream_ordering": latest_event_row[2],
                     },
                 )
 

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -1587,81 +1587,82 @@ class RelationRedactionTestCase(BaseRelationsTestCase):
         The redacted event should not be included in bundled aggregations or
         the response to relations.
         """
-        channel = self._send_relation(
-            RelationTypes.THREAD,
-            EventTypes.Message,
-            content={"body": "reply 1", "msgtype": "m.text"},
-        )
-        unredacted_event_id = channel.json_body["event_id"]
+        # Create a thread with a few events in it.
+        thread_replies = []
+        for i in range(3):
+            channel = self._send_relation(
+                RelationTypes.THREAD,
+                EventTypes.Message,
+                content={"body": f"reply {i}", "msgtype": "m.text"},
+            )
+            thread_replies.append(channel.json_body["event_id"])
 
-        # Note that the *last* event in the thread is redacted, as that gets
-        # included in the bundled aggregation.
-        channel = self._send_relation(
-            RelationTypes.THREAD,
-            EventTypes.Message,
-            content={"body": "reply 2", "msgtype": "m.text"},
-        )
-        to_redact_event_id = channel.json_body["event_id"]
-
-        # Both relations exist.
-        event_ids = self._get_related_events()
+        ##################################################
+        # Check the test data is configured as expected. #
+        ##################################################
+        self.assertEquals(self._get_related_events(), list(reversed(thread_replies)))
         relations = self._get_bundled_aggregations()
-        self.assertEquals(event_ids, [to_redact_event_id, unredacted_event_id])
         self.assertDictContainsSubset(
-            {
-                "count": 2,
-                "current_user_participated": True,
-            },
+            {"count": 3, "current_user_participated": True},
             relations[RelationTypes.THREAD],
         )
-        # And the latest event returned is the event that will be redacted.
+        # The latest event is the last sent event.
         self.assertEqual(
             relations[RelationTypes.THREAD]["latest_event"]["event_id"],
-            to_redact_event_id,
+            thread_replies[-1],
         )
 
-        # Request the threads in the room.
-        threads = self._get_threads()
         # There should be one thread, the latest event is the event that will be redacted.
-        self.assertEqual(threads, [(self.parent_id, to_redact_event_id)])
+        self.assertEqual(self._get_threads(), [(self.parent_id, thread_replies[-1])])
 
-        # Redact one of the reactions.
-        self._redact(to_redact_event_id)
+        ##########################
+        # Redact the last event. #
+        ##########################
+        self._redact(thread_replies.pop())
 
-        # The unredacted relation should still exist.
-        event_ids = self._get_related_events()
+        # The thread should still exist, but the latest event should be updated.
+        self.assertEquals(self._get_related_events(), list(reversed(thread_replies)))
         relations = self._get_bundled_aggregations()
-        self.assertEquals(event_ids, [unredacted_event_id])
         self.assertDictContainsSubset(
-            {
-                "count": 1,
-                "current_user_participated": True,
-            },
+            {"count": 2, "current_user_participated": True},
             relations[RelationTypes.THREAD],
         )
-        # And the latest event is now the unredacted event.
+        # And the latest event is the last unredacted event.
         self.assertEqual(
             relations[RelationTypes.THREAD]["latest_event"]["event_id"],
-            unredacted_event_id,
+            thread_replies[-1],
         )
+        self.assertEqual(self._get_threads(), [(self.parent_id, thread_replies[-1])])
 
-        # Request the threads in the room again.
-        threads = self._get_threads()
-        # There should still be one thread, but the latest event is the unredacted event.
-        self.assertEqual(threads, [(self.parent_id, unredacted_event_id)])
+        ###########################################
+        # Redact the *first* event in the thread. #
+        ###########################################
+        self._redact(thread_replies.pop(0))
 
-        # Redact the remaining event in the thread.
-        self._redact(unredacted_event_id)
+        # Nothing should have changed (except the thread count).
+        self.assertEquals(self._get_related_events(), thread_replies)
+        relations = self._get_bundled_aggregations()
+        self.assertDictContainsSubset(
+            {"count": 1, "current_user_participated": True},
+            relations[RelationTypes.THREAD],
+        )
+        # And the latest event is the last unredacted event.
+        self.assertEqual(
+            relations[RelationTypes.THREAD]["latest_event"]["event_id"],
+            thread_replies[-1],
+        )
+        self.assertEqual(self._get_threads(), [(self.parent_id, thread_replies[-1])])
+
+        ####################################
+        # Redact the last remaining event. #
+        ####################################
+        self._redact(thread_replies.pop(0))
+        self.assertEquals(thread_replies, [])
 
         # The event should no longer be considered a thread.
-        event_ids = self._get_related_events()
-        relations = self._get_bundled_aggregations()
-        self.assertEquals(event_ids, [])
-        self.assertEquals(relations, {})
-
-        threads = self._get_threads()
-        # There should be no threads.
-        self.assertEqual(threads, [])
+        self.assertEquals(self._get_related_events(), [])
+        self.assertEquals(self._get_bundled_aggregations(), {})
+        self.assertEqual(self._get_threads(), [])
 
     def test_redact_parent_edit(self) -> None:
         """Test that edits of an event are redacted when the original event


### PR DESCRIPTION
When the last event in a thread was redacted we were not properly updating the `threads` table to either:

* Find the *new* latest event in the thread and store it into the table; or
* Removing the thread from the table if it is no longer a thread (i.e. all events in the thread were redacted).

Fixes #14241 