### PR TITLE
Build wheels on macos 11, not 10.15

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -107,9 +107,9 @@ jobs:
           - ${{ startsWith(github.ref, 'refs/pull/') }}
 
         exclude:
-          # Don't build macos wheels on PR CI.
-          - is_pr: true
-            os: "macos-11"
+#          # Don't build macos wheels on PR CI.
+#          - is_pr: true
+#            os: "macos-11"
           # Don't build aarch64 wheels on mac.
           - os: "macos-11"
             arch: aarch64
@@ -139,9 +139,9 @@ jobs:
         if: matrix.arch == 'aarch64'
         run: echo 'CIBW_ARCHS_LINUX=aarch64' >> $GITHUB_ENV
 
-      - name: Only build a single wheel on PR
-        if: startsWith(github.ref, 'refs/pull/')
-        run: echo "CIBW_BUILD="cp37-manylinux_${{ matrix.arch }}"" >> $GITHUB_ENV
+#      - name: Only build a single wheel on PR
+#        if: startsWith(github.ref, 'refs/pull/')
+#        run: echo "CIBW_BUILD="cp37-manylinux_${{ matrix.arch }}"" >> $GITHUB_ENV
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
         arch: [x86_64, aarch64]
         # is_pr is a flag used to exclude certain jobs from the matrix on PRs.
         # It is not read by the rest of the workflow.
@@ -109,9 +109,9 @@ jobs:
         exclude:
           # Don't build macos wheels on PR CI.
           - is_pr: true
-            os: "macos-10.15"
+            os: "macos-11"
           # Don't build aarch64 wheels on mac.
-          - os: "macos-10.15"
+          - os: "macos-11"
             arch: aarch64
           # Don't build aarch64 wheels on PR CI.
           - is_pr: true

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -107,9 +107,9 @@ jobs:
           - ${{ startsWith(github.ref, 'refs/pull/') }}
 
         exclude:
-#          # Don't build macos wheels on PR CI.
-#          - is_pr: true
-#            os: "macos-11"
+          # Don't build macos wheels on PR CI.
+          - is_pr: true
+            os: "macos-11"
           # Don't build aarch64 wheels on mac.
           - os: "macos-11"
             arch: aarch64
@@ -139,9 +139,9 @@ jobs:
         if: matrix.arch == 'aarch64'
         run: echo 'CIBW_ARCHS_LINUX=aarch64' >> $GITHUB_ENV
 
-#      - name: Only build a single wheel on PR
-#        if: startsWith(github.ref, 'refs/pull/')
-#        run: echo "CIBW_BUILD="cp37-manylinux_${{ matrix.arch }}"" >> $GITHUB_ENV
+      - name: Only build a single wheel on PR
+        if: startsWith(github.ref, 'refs/pull/')
+        run: echo "CIBW_BUILD="cp37-manylinux_${{ matrix.arch }}"" >> $GITHUB_ENV
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/changelog.d/14249.misc
+++ b/changelog.d/14249.misc
@@ -1,0 +1,1 @@
+Build wheels on macos 11, not 10.15.


### PR DESCRIPTION
Part of of https://github.com/matrix-org/synapse/issues/14203

10.15 is end-of-life as of ~5 weeks ago, see https://endoflife.date/macos and also https://github.com/actions/runner-images/issues/5583

