### PR TITLE
Only build aarch64 wheels for cpython manylinux

### DIFF
--- a/changelog.d/14259.misc
+++ b/changelog.d/14259.misc
@@ -1,0 +1,1 @@
+Only build aarch64 wheels for cpython manylinux.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,7 +318,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.cibuildwheel]
 # Skip unsupported platforms (by us or by Rust).
-skip = "cp36* *-musllinux_i686"
+skip = "cp36* *-musllinux_i686 pp*aarch64 musllinux_aarch64"
 
 # We need a rust compiler
 before-all =  "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y --profile minimal"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,7 +318,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.cibuildwheel]
 # Skip unsupported platforms (by us or by Rust).
-skip = "cp36* *-musllinux_i686 pp*aarch64 musllinux_aarch64"
+skip = "cp36* *-musllinux_i686 pp*aarch64 *-musllinux_aarch64"
 
 # We need a rust compiler
 before-all =  "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y --profile minimal"


### PR DESCRIPTION
As they are too slow to build for everything else