### PR TITLE
Wait for room stream change cache position

### DIFF
--- a/changelog.d/14269.misc
+++ b/changelog.d/14269.misc
@@ -1,0 +1,1 @@
+Fix race conditions with stream change cache invalidation when using synapse workers. Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -487,14 +487,6 @@ class PersistEventsStore:
         # NB: This function invalidates all state related caches
         self._update_current_state_txn(txn, state_delta_for_room, min_stream_order)
 
-        # Flag the stream change cache for this room if we added non-backfilled events
-        if max_stream_order > 0:
-            for event, _ in events_and_contexts:
-                assert event.internal_metadata.stream_ordering is not None
-                self.store._events_stream_cache.entity_has_changed(
-                    event.room_id, event.internal_metadata.stream_ordering
-                )
-
     def _persist_event_auth_chain_txn(
         self,
         txn: LoggingTransaction,

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -487,6 +487,14 @@ class PersistEventsStore:
         # NB: This function invalidates all state related caches
         self._update_current_state_txn(txn, state_delta_for_room, min_stream_order)
 
+        # Flag the stream change cache for this room if we added non-backfilled events
+        if max_stream_order > 0:
+            for event, _ in events_and_contexts:
+                assert event.internal_metadata.stream_ordering is not None
+                self.store._events_stream_cache.entity_has_changed(
+                    event.room_id, event.internal_metadata.stream_ordering
+                )
+
     def _persist_event_auth_chain_txn(
         self,
         txn: LoggingTransaction,
@@ -1045,6 +1053,9 @@ class PersistEventsStore:
                 state_delta_by_room={room_id: state_delta},
                 stream_id=stream_ordering,
             )
+
+            # Flag the stream change cache for this room
+            self.store._events_stream_cache.entity_has_changed(room_id, stream_ordering)
 
     def _update_current_state_txn(
         self,

--- a/synapse/storage/databases/main/stream.py
+++ b/synapse/storage/databases/main/stream.py
@@ -486,6 +486,7 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
                 - list of recent events in the room
                 - stream ordering key for the start of the chunk of events returned.
         """
+        await self._events_stream_cache.wait_for_position(to_key.stream)
         room_ids = self._events_stream_cache.get_entities_changed(
             room_ids, from_key.stream
         )


### PR DESCRIPTION
Proposed fix for race conditions between room stream change caches and invalidation over replication (see: #14158).

NOTE: this PR originally applied the wait for on device lists/device inbox stream change caches, but ran into a bunch of issues with those so leaving for a separate PR, this just focusses on rooms/events.

Signed off by Nick @ Beeper (@fizzadar).

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
