### PR TITLE
Revert behavior change for bundling edits of non-message events

### DIFF
--- a/changelog.d/14283.bugfix
+++ b/changelog.d/14283.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.70.0rc1 where edits to non-message events were aggregated by the homeserver.

--- a/synapse/storage/databases/main/relations.py
+++ b/synapse/storage/databases/main/relations.py
@@ -484,11 +484,12 @@ class RelationsWorkerStore(SQLBaseStore):
             the event will map to None.
         """
 
-        # We only allow edits for events that have the same sender and event type.
-        # We can't assert these things during regular event auth so we have to do
-        # the checks post hoc.
+        # We only allow edits for `m.room.message` events that have the same sender
+        # and event type. We can't assert these things during regular event auth so
+        # we have to do the checks post hoc.
 
-        # Fetches latest edit that has the same type and sender as the original.
+        # Fetches latest edit that has the same type and sender as the
+        # original, and is an `m.room.message`.
         if isinstance(self.database_engine, PostgresEngine):
             # The `DISTINCT ON` clause will pick the *first* row it encounters,
             # so ordering by origin server ts + event ID desc will ensure we get
@@ -504,6 +505,7 @@ class RelationsWorkerStore(SQLBaseStore):
                 WHERE
                     %s
                     AND relation_type = ?
+                    AND edit.type = 'm.room.message'
                 ORDER by original.event_id DESC, edit.origin_server_ts DESC, edit.event_id DESC
             """
         else:
@@ -522,6 +524,7 @@ class RelationsWorkerStore(SQLBaseStore):
                 WHERE
                     %s
                     AND relation_type = ?
+                    AND edit.type = 'm.room.message'
                 ORDER by edit.origin_server_ts, edit.event_id
             """
 


### PR DESCRIPTION
This reverts commit ab8047b4bf581d0c343c1e900e8740745668d941 (#14034) due to #14252.

Fixes #14252.
Reopens #12793, #12503.

Any subsequent fix requires behavior corrections to the spec, see matrix-org/matrix-spec#1299.