### PR TITLE
Cache rust build deps in trial CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,6 +167,14 @@ jobs:
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
             postgres:${{ matrix.job.postgres-version }}
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: 1.58.1
+            override: true
+      - uses: Swatinem/rust-cache@v2
+
       - uses: matrix-org/setup-python-poetry@v1
         with:
           python-version: ${{ matrix.job.python-version }}

--- a/changelog.d/14287.misc
+++ b/changelog.d/14287.misc
@@ -1,0 +1,1 @@
+Add Rust cache to CI for `trial` runs.


### PR DESCRIPTION
This was missed in #12595 I think, as the docker images already had a rust compiler in it?

Anyway, I'm hoping this will speed up starting `trial` runs a bit due to the rust cache. 