### PR TITLE
Prevent federation user keys query from returning device names if disallowed

### DIFF
--- a/changelog.d/14304.bugfix
+++ b/changelog.d/14304.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where device names would be returned via a federation user key query request when `allow_device_name_lookup_over_federation` was set to `false`.

--- a/changelog.d/14304.bugfix
+++ b/changelog.d/14304.bugfix
@@ -1,1 +1,1 @@
-Fix a long-standing bug where device names would be returned via a federation user key query request when `allow_device_name_lookup_over_federation` was set to `false`.
+Fix a bug introduced in 1.34.0 where device names would be returned via a federation user key query request when `allow_device_name_lookup_over_federation` was set to `false`.

--- a/synapse/handlers/e2e_keys.py
+++ b/synapse/handlers/e2e_keys.py
@@ -493,7 +493,7 @@ class E2eKeysHandler:
     ) -> JsonDict:
         """Handle a device key query from a federated server:
 
-        Handles the path: /_matrix/federation/v1/users/keys/query
+        Handles the path: GET /_matrix/federation/v1/users/keys/query
 
         Args:
             query_body: The body of the query request. Should contain a key

--- a/synapse/handlers/e2e_keys.py
+++ b/synapse/handlers/e2e_keys.py
@@ -49,6 +49,7 @@ logger = logging.getLogger(__name__)
 
 class E2eKeysHandler:
     def __init__(self, hs: "HomeServer"):
+        self.config = hs.config
         self.store = hs.get_datastores().main
         self.federation = hs.get_federation_client()
         self.device_handler = hs.get_device_handler()
@@ -59,9 +60,6 @@ class E2eKeysHandler:
 
         federation_registry = hs.get_federation_registry()
 
-        self._allow_device_name_lookup_over_federation = (
-            hs.config.federation.allow_device_name_lookup_over_federation
-        )
         self._is_master = hs.config.worker.worker_app is None
         if not self._is_master:
             self._user_device_resync_client = (
@@ -514,7 +512,9 @@ class E2eKeysHandler:
         )
         res = await self.query_local_devices(
             device_keys_query,
-            include_displaynames=self._allow_device_name_lookup_over_federation,
+            include_displaynames=(
+                self.config.federation.allow_device_name_lookup_over_federation
+            ),
         )
         ret = {"device_keys": res}
 

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -139,11 +139,15 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
     @trace
     @cancellable
     async def get_e2e_device_keys_for_cs_api(
-        self, query_list: List[Tuple[str, Optional[str]]]
+        self,
+        query_list: List[Tuple[str, Optional[str]]],
+        include_displaynames: bool = True,
     ) -> Dict[str, Dict[str, JsonDict]]:
         """Fetch a list of device keys, formatted suitably for the C/S API.
         Args:
-            query_list(list): List of pairs of user_ids and device_ids.
+            query_list: List of pairs of user_ids and device_ids.
+            include_displaynames: Whether to include the displayname of returned devices
+                (if one exists).
         Returns:
             Dict mapping from user-id to dict mapping from device_id to
             key data.  The key data will be a dict in the same format as the
@@ -166,9 +170,12 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
                     continue
 
                 r["unsigned"] = {}
-                display_name = device_info.display_name
-                if display_name is not None:
-                    r["unsigned"]["device_display_name"] = display_name
+                if include_displaynames:
+                    # Include the device's display name in the "unsigned" dictionary
+                    display_name = device_info.display_name
+                    if display_name is not None:
+                        r["unsigned"]["device_display_name"] = display_name
+
                 rv[user_id][device_id] = r
 
         return rv


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/13114 using the solution described in https://github.com/matrix-org/synapse/issues/13114#issuecomment-1171312030. May also fix https://github.com/matrix-org/synapse/issues/12750.

This commit prevents the [`POST /_matrix/federation/v1/user/keys/query`](https://spec.matrix.org/v1.4/server-server-api/#post_matrixfederationv1userkeysquery) endpoint from returning device names for users when the [`allow_device_name_lookup_over_federation` config option](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#allow_device_name_lookup_over_federation) was set to `false`.

I opted for a `include_displaynames` option for `query_local_devices` as I assume we'll eventually add in a similar option to `allow_device_name_lookup_over_federation`, but between users on the same homeserver (in which case setting this to `False` in some other places will also be useful).

---

Once again I'm not really sure how to test this other than manually (which doing so - looks good). Because it's homeserver-specific whether these display names will be returned, Complement isn't really the right place. But testing federation between servers is unit tests is tricky. I could try to mangle something together for this specific federation endpoint, if that seems useful.)

---

Failing sytests are fixed by https://github.com/matrix-org/sytest/pull/1311, **please review in tandem with this PR.**