### PR TITLE
Fix tests for change in PostgreSQL 14 behavior change.

### DIFF
--- a/changelog.d/14310.feature
+++ b/changelog.d/14310.feature
@@ -1,0 +1,1 @@
+Allow use of postgres and sqllite full-text search operators in search queries.

--- a/synapse/storage/databases/main/search.py
+++ b/synapse/storage/databases/main/search.py
@@ -824,9 +824,8 @@ def _tokenize_query(query: str) -> TokenList:
     in_phrase = False
     parts = deque(query.split('"'))
     for i, part in enumerate(parts):
-        # The contents inside double quotes is treated as a phrase, a trailing
-        # double quote is not implied.
-        in_phrase = bool(i % 2) and i != (len(parts) - 1)
+        # The contents inside double quotes is treated as a phrase.
+        in_phrase = bool(i % 2)
 
         # Pull out the individual words, discarding any non-word characters.
         words = deque(re.findall(r"([\w\-]+)", part, re.UNICODE))

--- a/tests/storage/test_room_search.py
+++ b/tests/storage/test_room_search.py
@@ -273,6 +273,7 @@ class MessageSearchTest(HomeserverTestCase):
         main_store = homeserver.get_datastores().main
         found = False
         if isinstance(main_store.database_engine, PostgresEngine):
+            assert main_store.database_engine._version is not None
             found = main_store.database_engine._version < 140000
         self.COMMON_CASES.append(('"fox quick', (found, True)))
 

--- a/tests/storage/test_room_search.py
+++ b/tests/storage/test_room_search.py
@@ -239,7 +239,6 @@ class MessageSearchTest(HomeserverTestCase):
         ("fox -nope", (True, False)),
         ("fox -brown", (False, True)),
         ('"fox" quick', True),
-        ('"fox quick', True),
         ('"quick brown', True),
         ('" quick "', True),
         ('" nope"', False),
@@ -269,6 +268,14 @@ class MessageSearchTest(HomeserverTestCase):
         response = self.helper.send(self.room_id, self.PHRASE, tok=self.access_token)
         self.assertIn("event_id", response)
 
+        # The behaviour of a missing trailing double quote changed in PostgreSQL 14
+        # from ignoring the initial double quote to treating it as a phrase.
+        main_store = homeserver.get_datastores().main
+        found = False
+        if isinstance(main_store.database_engine, PostgresEngine):
+            found = main_store.database_engine._version < 140000
+        self.COMMON_CASES.append(('"fox quick', (found, True)))
+
     def test_tokenize_query(self) -> None:
         """Test the custom logic to tokenize a user's query."""
         cases = (
@@ -280,9 +287,9 @@ class MessageSearchTest(HomeserverTestCase):
             ("fox -brown", ["fox", SearchToken.Not, "brown"]),
             ("- fox", [SearchToken.Not, "fox"]),
             ('"fox" quick', [Phrase(["fox"]), SearchToken.And, "quick"]),
-            # No trailing double quoe.
-            ('"fox quick', ["fox", SearchToken.And, "quick"]),
-            ('"-fox quick', [SearchToken.Not, "fox", SearchToken.And, "quick"]),
+            # No trailing double quote.
+            ('"fox quick', [Phrase(["fox", "quick"])]),
+            ('"-fox quick', [Phrase(["-fox", "quick"])]),
             ('" quick "', [Phrase(["quick"])]),
             (
                 'q"uick brow"n',


### PR DESCRIPTION
See #14298 for details, but postgresql 14 changed the behavior of `websearch_to_tsquery` to fix some bugs. The tests were hitting those edge-cases though.

This is a bit ugly, but I couldn't come up with a better way to do it...

Fixes #14298.

This was broken in #11635.