### PR TITLE
Fix room creation being rate limited too aggressively since Synapse v1.69.0.

### DIFF
--- a/changelog.d/14314.bugfix
+++ b/changelog.d/14314.bugfix
@@ -1,0 +1,1 @@
+Fix room creation being rate limited too aggressively since Synapse v1.69.0.

--- a/synapse/api/ratelimiting.py
+++ b/synapse/api/ratelimiting.py
@@ -343,6 +343,7 @@ class RequestRatelimiter:
         requester: Requester,
         update: bool = True,
         is_admin_redaction: bool = False,
+        n_actions: int = 1,
     ) -> None:
         """Ratelimits requests.
 
@@ -355,6 +356,8 @@ class RequestRatelimiter:
             is_admin_redaction: Whether this is a room admin/moderator
                 redacting an event. If so then we may apply different
                 ratelimits depending on config.
+            n_actions: Multiplier for the number of actions to apply to the
+                rate limiter at once.
 
         Raises:
             LimitExceededError if the request should be ratelimited
@@ -383,7 +386,9 @@ class RequestRatelimiter:
         if is_admin_redaction and self.admin_redaction_ratelimiter:
             # If we have separate config for admin redactions, use a separate
             # ratelimiter as to not have user_ids clash
-            await self.admin_redaction_ratelimiter.ratelimit(requester, update=update)
+            await self.admin_redaction_ratelimiter.ratelimit(
+                requester, update=update, n_actions=n_actions
+            )
         else:
             # Override rate and burst count per-user
             await self.request_ratelimiter.ratelimit(
@@ -391,4 +396,5 @@ class RequestRatelimiter:
                 rate_hz=messages_per_second,
                 burst_count=burst_count,
                 update=update,
+                n_actions=n_actions,
             )

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -559,7 +559,6 @@ class RoomCreationHandler:
             invite_list=[],
             initial_state=initial_state,
             creation_content=creation_content,
-            ratelimit=False,
         )
 
         # Transfer membership events
@@ -753,7 +752,13 @@ class RoomCreationHandler:
                 )
 
         if ratelimit:
-            await self.request_ratelimiter.ratelimit(requester)
+            # We rate limit by 2 actions because historical Synapse versions,
+            # up to and including v1.68.0 did so: they applied one count for the
+            # room creation and one count for setting the membership of the room
+            # creator.
+            # This makes room creations more 'expensive' from a ratelimiting
+            # point of view, so it's sensible as well.
+            await self.request_ratelimiter.ratelimit(requester, n_actions=2)
 
         room_version_id = config.get(
             "room_version", self.config.server.default_room_version.identifier
@@ -913,7 +918,6 @@ class RoomCreationHandler:
             room_alias=room_alias,
             power_level_content_override=power_level_content_override,
             creator_join_profile=creator_join_profile,
-            ratelimit=ratelimit,
         )
 
         if "name" in config:
@@ -1037,7 +1041,6 @@ class RoomCreationHandler:
         room_alias: Optional[RoomAlias] = None,
         power_level_content_override: Optional[JsonDict] = None,
         creator_join_profile: Optional[JsonDict] = None,
-        ratelimit: bool = True,
     ) -> Tuple[int, str, int]:
         """Sends the initial events into a new room. Sends the room creation, membership,
         and power level events into the room sequentially, then creates and batches up the
@@ -1045,6 +1048,8 @@ class RoomCreationHandler:
 
         `power_level_content_override` doesn't apply when initial state has
         power level state event content.
+
+        Rate limiting should already have been applied by this point.
 
         Returns:
             A tuple containing the stream ID, event ID and depth of the last
@@ -1144,7 +1149,7 @@ class RoomCreationHandler:
             creator.user,
             room_id,
             "join",
-            ratelimit=ratelimit,
+            ratelimit=False,
             content=creator_join_profile,
             new_room=True,
             prev_event_ids=[last_sent_event_id],
@@ -1269,7 +1274,10 @@ class RoomCreationHandler:
             events_to_send.append((encryption_event, encryption_context))
 
         last_event = await self.event_creation_handler.handle_new_client_event(
-            creator, events_to_send, ignore_shadow_ban=True
+            creator,
+            events_to_send,
+            ignore_shadow_ban=True,
+            ratelimit=False,
         )
         assert last_event.internal_metadata.stream_ordering is not None
         return last_event.internal_metadata.stream_ordering, last_event.event_id, depth

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -752,13 +752,11 @@ class RoomCreationHandler:
                 )
 
         if ratelimit:
-            # We rate limit by 2 actions because historical Synapse versions,
-            # up to and including v1.68.0 did so: they applied one count for the
-            # room creation and one count for setting the membership of the room
-            # creator.
-            # This makes room creations more 'expensive' from a ratelimiting
-            # point of view, so it's sensible as well.
-            await self.request_ratelimiter.ratelimit(requester, n_actions=2)
+            # Rate limit once in advance, but don't rate limit the individual
+            # events in the room — room creation isn't atomic and it's very
+            # janky if half the events in the initial state don't make it because
+            # of rate limiting.
+            await self.request_ratelimiter.ratelimit(requester)
 
         room_version_id = config.get(
             "room_version", self.config.server.default_room_version.identifier


### PR DESCRIPTION
Fixes #14312.

~~I make special effort to match the old limits, though I've tried to do it in a saner way: we apply the 2 units of ratelimiting upfront atomically rather than perhaps doing some work only to fail persisting the creator's membership event.
It doesn't seem to make sense to ratelimit half-way through creating a room — it's much better to avoid the wasted work and avoid half-creating a room (possibly leading to a janky state).~~

I *did* match the old limits, but now decided to be twice as lenient — Element Web's space creation screen always did fall over even with the old limits if you were fast enough. Given that we're making room creation more performant, it seems reasonable to apply the same cost as one event send — you're not really hurting anyone by creating empty rooms.

Test included for good measure.
