### PR TITLE
Add a note that #14300 did not get a fix for 1.70.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 Synapse 1.70.1 (2022-10-28)
 ===========================
 
+This release fixes some regressions that were discovered in 1.70.0.
+
+[#14300](https://github.com/matrix-org/synapse/issues/14300)
+was previously reported to be a regression in 1.70.0 as well. However, we have
+since concluded that it was limited to the reporter and thus have not needed
+to include any fix for it in 1.70.1.
+
+
 Bugfixes
 --------
 


### PR DESCRIPTION
We noted in a [previous announcement](https://matrix.to/#/!iyIlInqJyxXrRmRHFx:matrix.org/$JCTRKh_85cuEUuM0HB1a8w9WtRaypmqDUR-GqOLqw2Q?via=matrix.org&via=tchncs.de&via=privacytools.io) that https://github.com/matrix-org/synapse/issues/14300 was a regression in 1.70.0.

Since then, we've concluded that the problem was limited to the reporter, and thus have not needed to include a fix for it in 1.70.1.

---

This PR does not require a changelog entry.