### PR TITLE
Fix dehydrated device REST checks

### DIFF
--- a/changelog.d/14336.bugfix
+++ b/changelog.d/14336.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.70 where clients were unable to PUT new [dehydrated devices](https://github.com/matrix-org/matrix-spec-proposals/pull/2697).

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -231,7 +231,7 @@ class DehydratedDeviceServlet(RestServlet):
       }
     }
 
-    PUT /org.matrix.msc2697/dehydrated_device
+    PUT /org.matrix.msc2697.v2/dehydrated_device
     Content-Type: application/json
 
     {

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -271,7 +271,6 @@ class DehydratedDeviceServlet(RestServlet):
             raise errors.NotFoundError("No dehydrated device available")
 
     class PutBody(RequestBodyModel):
-        device_id: StrictStr
         device_data: DehydratedDeviceDataModel
         initial_device_display_name: Optional[StrictStr]
 
@@ -281,7 +280,7 @@ class DehydratedDeviceServlet(RestServlet):
 
         device_id = await self.device_handler.store_dehydrated_device(
             requester.user.to_string(),
-            submission.device_data,
+            submission.device_data.dict(),
             submission.initial_device_display_name,
         )
         return 200, {"device_id": device_id}


### PR DESCRIPTION
Fixes #14334, an oversight in #14054.

Unspotted because no test hits that rest endpoint. I've written a very rudimentary one.

Also fixes a bug in #14054 which mypy missed. https://github.com/matrix-org/synapse/pull/14055 would have helped.