### PR TITLE
Fix typo in #13320 which could cause log spam

### DIFF
--- a/changelog.d/14347.bugfix
+++ b/changelog.d/14347.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.64.0rc1 which could cause log spam when fetching events from other homeservers.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -465,7 +465,7 @@ class FederationClient(FederationBase):
                     pdu_attempts[destination] = now
 
                     logger.info(
-                        "get_pdu(event_id=): Failed to get PDU from %s because %s",
+                        "get_pdu(event_id=%s): Failed to get PDU from %s because %s",
                         event_id,
                         destination,
                         e,


### PR DESCRIPTION
The typo causes `logger.info(...)` to fail. Stdlib(?) logging describes the failure on stderr, which ends up getting reported as multiple events in Sentry.