### PR TITLE
Fix background update table-scanning `events`

### DIFF
--- a/changelog.d/14374.bugfix
+++ b/changelog.d/14374.bugfix
@@ -1,1 +1,1 @@
-Fix a background database update which could cause poor database performance.
+Fix a background database update, introduced in Synapse 1.64.0, which could cause poor database performance.

--- a/changelog.d/14374.bugfix
+++ b/changelog.d/14374.bugfix
@@ -1,0 +1,1 @@
+Fix a background database update which could cause poor database performance.


### PR DESCRIPTION
When this background update did its last batch, it would try to update all the
events that had been inserted since the bgupdate started, which could cause a
table-scan. Make sure we limit the update correctly