### PR TITLE
Fix an invalid comparison of `UserPresenceState` to `str`

### DIFF
--- a/changelog.d/14393.bugfix
+++ b/changelog.d/14393.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in 1.58.0 where a user with presence state 'org.matrix.msc3026.busy' would mistakenly be set to 'online' when calling `/sync` or `/events` on a worker process.

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -478,7 +478,7 @@ class WorkerPresenceHandler(BasePresenceHandler):
             return _NullContextManager()
 
         prev_state = await self.current_state_for_user(user_id)
-        if prev_state != PresenceState.BUSY:
+        if prev_state.state != PresenceState.BUSY:
             # We set state here but pass ignore_status_msg = True as we don't want to
             # cause the status message to be cleared.
             # Note that this causes last_active_ts to be incremented which is not

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -740,7 +740,7 @@ class PresenceHandlerTestCase(BaseMultiWorkerStreamTestCase):
 
         self._set_presencestate_with_status_msg(user_id, PresenceState.BUSY, status_msg)
 
-        if test_with_workers and worker_hs is not None:
+        if worker_hs is not None:
             # Sync against a worker instead of the main process. Busy state should still
             # be preserved in this instance.
             self.get_success(

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -716,11 +716,15 @@ class PresenceHandlerTestCase(unittest.HomeserverTestCase):
         # our status message should be the same as it was before
         self.assertEqual(state.status_msg, status_msg)
 
+    @unittest.override_config(
+        {
+            "experimental_features": {
+                "msc3026_enabled": True,
+            },
+        }
+    )
     def test_set_presence_from_syncing_keeps_busy(self):
         """Test that presence set by syncing doesn't affect busy status"""
-        # while this isn't the default
-        self.presence_handler._busy_presence_enabled = True
-
         user_id = "@test:server"
         status_msg = "I'm busy!"
 

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -762,7 +762,7 @@ class ModuleApiWorkerTestCase(BaseMultiWorkerStreamTestCase):
 
 
 def _test_sending_local_online_presence_to_local_user(
-    test_case: BaseMultiWorkerStreamTestCase, test_with_workers: bool = False
+    test_case: HomeserverTestCase, test_with_workers: bool = False
 ):
     """Tests that send_local_presence_to_users sends local online presence to local users.
 
@@ -778,8 +778,11 @@ def _test_sending_local_online_presence_to_local_user(
             worker process. The test users will still sync with the main process. The purpose of testing
             with a worker is to check whether a Synapse module running on a worker can inform other workers/
             the main process that they should include additional presence when a user next syncs.
+            If this argument is True, `test_case` MUST be an instance of BaseMultiWorkerStreamTestCase.
     """
     if test_with_workers:
+        assert isinstance(test_case, BaseMultiWorkerStreamTestCase)
+
         # Create a worker process to make module_api calls against
         worker_hs = test_case.make_worker_hs(
             "synapse.app.generic_worker", {"worker_name": "presence_writer"}

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -762,7 +762,7 @@ class ModuleApiWorkerTestCase(BaseMultiWorkerStreamTestCase):
 
 
 def _test_sending_local_online_presence_to_local_user(
-    test_case: HomeserverTestCase, test_with_workers: bool = False
+    test_case: BaseMultiWorkerStreamTestCase, test_with_workers: bool = False
 ):
     """Tests that send_local_presence_to_users sends local online presence to local users.
 

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -542,8 +542,13 @@ class FakeRedisPubSubProtocol(Protocol):
             self.send("OK")
         elif command == b"GET":
             self.send(None)
+
+        # Connection keep-alives.
+        elif command == b"PING":
+            self.send("PONG")
+
         else:
-            raise Exception("Unknown command")
+            raise Exception(f"Unknown command: {command}")
 
     def send(self, msg):
         """Send a message back to the client."""


### PR DESCRIPTION
This PR fixes an invalid comparison of types. The comparison was included in https://github.com/matrix-org/synapse/pull/12213 and effectively meant that the fix did not apply when calling `/sync` or `/events` on a worker process. Presumably the included unit tests didn't catch the bug as they don't run in worker mode.

How come mypy didn't catch this?