### PR TITLE
Update sample Nginx configuration to HTTP 1.1

### DIFF
--- a/changelog.d/14414.doc
+++ b/changelog.d/14414.doc
@@ -1,0 +1,1 @@
+Edited sample Nginx reverse proxy configuration to use HTTP/1.1. Contributed by Brad Jones.

--- a/changelog.d/14414.doc
+++ b/changelog.d/14414.doc
@@ -1,1 +1,1 @@
-Edited sample Nginx reverse proxy configuration to use HTTP/1.1. Contributed by Brad Jones.
+Edit sample Nginx reverse proxy configuration to use HTTP/1.1. Contributed by Brad Jones.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -79,6 +79,10 @@ server {
         # Nginx by default only allows file uploads up to 1M in size
         # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
         client_max_body_size 50M;
+	
+	# Synapse responses may be chunked, which is an HTTP/1.1 feature.
+	proxy_http_version 1.1;
+        proxy_buffering off;
     }
 }
 ```

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -82,7 +82,6 @@ server {
 	
 	# Synapse responses may be chunked, which is an HTTP/1.1 feature.
 	proxy_http_version 1.1;
-        proxy_buffering off;
     }
 }
 ```


### PR DESCRIPTION
I chased my tail for a few hours tonight debugging an issue where my client seemed to time out on production requests that seemed to go off without a hitch in my local environment.

After a good amount of debugging, it appeared to me that the chunked responses from upstream (likely thanks to https://github.com/matrix-org/synapse/pull/8013) were not being properly handled by one of the proxies in use. (I'm running an Openresty/Nginx proxy on Cloud Run.)

Turns out that Nginx [defaults to using HTTP/1.0 for upstream proxy requests](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version), which is crazy to me but that's the way it is. `transfer-encoding: chunked` was introduced in HTTP 1.1.

It also seems to me that Nginx response buffering isn't helpful to us in this context, so we should recommend disabling it in the sample config.

Had this been documented in the Synapse docs, I feel like I would have caught on to this a lot earlier.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
