### PR TITLE
Update docstring to clarify that `get_partial_state_events_batch` does not just give you completely arbitrary partial-state events.

### DIFF
--- a/changelog.d/14417.misc
+++ b/changelog.d/14417.misc
@@ -1,0 +1,1 @@
+Update docstring to clarify that `get_partial_state_events_batch` does not just give you completely arbitrary partial-state events.

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -2235,7 +2235,15 @@ class EventsWorkerStore(SQLBaseStore):
         return result is not None
 
     async def get_partial_state_events_batch(self, room_id: str) -> List[str]:
-        """Get a list of events in the given room that have partial state"""
+        """
+        Get a list of events in the given room that:
+        - have partial state; and
+        - are ready to be resynced (because they have no prev_events that are
+          partial-stated)
+
+        See the docstring on `_get_partial_state_events_batch_txn` for more
+        information.
+        """
         return await self.db_pool.runInteraction(
             "get_partial_state_events_batch",
             self._get_partial_state_events_batch_txn,


### PR DESCRIPTION
Sometimes a docstring that omits detail is more harmful than not having one — it wasn't clear to me that this had extra conditions on what events it returned.

