### PR TITLE
Make Dependabot only bump Rust deps in the lock file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,6 @@ updates:
 
   - package-ecosystem: "cargo"
     directory: "/"
+    versioning-strategy: "lockfile-only"
     schedule:
       interval: "weekly"

--- a/changelog.d/14434.misc
+++ b/changelog.d/14434.misc
@@ -1,0 +1,1 @@
+Make Dependabot only bump Rust deps in the lock file.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,16 +20,16 @@ crate-type = ["lib", "cdylib"]
 name = "synapse.synapse_rust"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.63"
 lazy_static = "1.4.0"
 log = "0.4.17"
-pyo3 = { version = "0.17.3", features = ["extension-module", "macros", "anyhow", "abi3", "abi3-py37"] }
+pyo3 = { version = "0.17.1", features = ["extension-module", "macros", "anyhow", "abi3", "abi3-py37"] }
 pyo3-log = "0.7.0"
 pythonize = "0.17.0"
-regex = "1.7.0"
-serde = { version = "1.0.147", features = ["derive"] }
-serde_json = "1.0.87"
+regex = "1.6.0"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 
 [build-dependencies]
-blake2 = "0.10.5"
+blake2 = "0.10.4"
 hex = "0.4.3"


### PR DESCRIPTION
This is to help downstream packagers.

c.f. https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy