### PR TITLE
Fix check to ignore blank lines in incoming TCP replication

### DIFF
--- a/synapse/replication/tcp/protocol.py
+++ b/synapse/replication/tcp/protocol.py
@@ -245,7 +245,7 @@ class BaseReplicationStreamProtocol(LineOnlyReceiver):
             self._parse_and_dispatch_line(line)
 
     def _parse_and_dispatch_line(self, line: bytes) -> None:
-        if line.strip() == "":
+        if line.strip() == b"":
             # Ignore blank lines
             return
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -569,15 +569,15 @@ class DatabasePool:
             retcols=["update_name"],
             desc="check_background_updates",
         )
-        updates = [x["update_name"] for x in updates]
+        background_update_names = [x["update_name"] for x in updates]
 
         for table, update_name in UNIQUE_INDEX_BACKGROUND_UPDATES.items():
-            if update_name not in updates:
+            if update_name not in background_update_names:
                 logger.debug("Now safe to upsert in %s", table)
                 self._unsafe_to_upsert_tables.discard(table)
 
         # If there's any updates still running, reschedule to run.
-        if updates:
+        if background_update_names:
             self._clock.call_later(
                 15.0,
                 run_as_background_process,


### PR DESCRIPTION
This PR does two things:

* Fixes a comparison between two incompatible types, leading to the blank line check not working.
* Fixes a reassignment of a variable's type in the background updates code.

I've bundled in the second change as it's small also helps fix type warnings.

Both of these issues were discovered after enabling mypy's `strict_equality` feature. See https://github.com/matrix-org/synapse/pull/14393#issuecomment-1307457282 for the discussion that lead to this PR.