### PR TITLE
Enable 'strict_equality' checking for mypy

### DIFF
--- a/changelog.d/14452.misc
+++ b/changelog.d/14452.misc
@@ -1,0 +1,1 @@
+Enable mypy's [`strict_equality` check](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict-equality) by default.

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,7 @@ warn_unused_ignores = True
 local_partial_types = True
 no_implicit_optional = True
 disallow_untyped_defs = True
+strict_equality = True
 
 files =
   docker/,


### PR DESCRIPTION
This change enables the [`strict_equality`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict-equality) option for mypy. This catches equality comparisons between variables with "non-overlapping" types.

This check would have prevented the bug in:
- https://github.com/matrix-org/synapse/pull/14393
- https://github.com/matrix-org/synapse/pull/14449

so seems worthwhile to switch on by default!

The following PRs must first be merged (to fix existing errors) before this PR can be merged:
- https://github.com/matrix-org/synapse/pull/14393
- https://github.com/matrix-org/synapse/pull/14449
- https://github.com/matrix-org/synapse/pull/14451

Thanks to @babolivier for originally pointing out this option in https://github.com/matrix-org/synapse/pull/14393#issuecomment-1307161843.