### PR TITLE
Fix background updates failing to add unique indexes on receipts

### DIFF
--- a/changelog.d/14453.bugfix
+++ b/changelog.d/14453.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.70.0 where the background updates to add non-thread unique indexes on receipts could fail when upgrading from 1.67.0 or earlier.

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -702,9 +702,6 @@ class ReceiptsWorkerStore(SQLBaseStore):
                 "data": json_encoder.encode(data),
             },
             where_clause=where_clause,
-            # receipts_linearized has a unique constraint on
-            # (user_id, room_id, receipt_type), so no need to lock
-            lock=False,
         )
 
         return rx_ts
@@ -862,9 +859,6 @@ class ReceiptsWorkerStore(SQLBaseStore):
                 "data": json_encoder.encode(data),
             },
             where_clause=where_clause,
-            # receipts_graph has a unique constraint on
-            # (user_id, room_id, receipt_type), so no need to lock
-            lock=False,
         )
 
 

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -924,20 +924,106 @@ class ReceiptsBackgroundUpdateStore(SQLBaseStore):
 
         return batch_size
 
-    async def _background_receipts_unique_index(
-        self, update_name: str, index_name: str, table: str
-    ) -> int:
+    async def _create_receipts_index(self, index_name: str, table: str) -> None:
         """Adds a unique index on `(room_id, receipt_type, user_id)` to the given
-        receipts table, for non-thread receipts.
-        """
+        receipts table, for non-thread receipts."""
 
-        def _receipts_unique_index_txn(txn: LoggingTransaction) -> None:
+        def _create_index(conn: LoggingDatabaseConnection) -> None:
+            conn.rollback()
+
+            # we have to set autocommit, because postgres refuses to
+            # CREATE INDEX CONCURRENTLY without it.
+            if isinstance(self.database_engine, PostgresEngine):
+                conn.set_session(autocommit=True)
+
+            try:
+                c = conn.cursor()
+
+                # Now that the duplicates are gone, we can create the index.
+                concurrently = (
+                    "CONCURRENTLY"
+                    if isinstance(self.database_engine, PostgresEngine)
+                    else ""
+                )
+                sql = f"""
+                    CREATE UNIQUE INDEX {concurrently} {index_name}
+                    ON {table}(room_id, receipt_type, user_id)
+                    WHERE thread_id IS NULL
+                """
+                c.execute(sql)
+            finally:
+                if isinstance(self.database_engine, PostgresEngine):
+                    conn.set_session(autocommit=False)
+
+        await self.db_pool.runWithConnection(_create_index)
+
+    async def _background_receipts_linearized_unique_index(
+        self, progress: dict, batch_size: int
+    ) -> int:
+        """Removes duplicate receipts and adds a unique index on
+        `(room_id, receipt_type, user_id)` to `receipts_linearized`, for non-thread
+        receipts."""
+
+        def _remote_duplicate_receipts_txn(txn: LoggingTransaction) -> None:
             # Identify any duplicate receipts arising from
             # https://github.com/matrix-org/synapse/issues/14406.
             # We expect the following query to use the per-thread receipt index and take
             # less than a minute.
-            sql = f"""
-                SELECT room_id, receipt_type, user_id FROM {table}
+            sql = """
+                SELECT MAX(stream_id), room_id, receipt_type, user_id
+                FROM receipts_linearized
+                WHERE thread_id IS NULL
+                GROUP BY room_id, receipt_type, user_id
+                HAVING COUNT(*) > 1
+            """
+            txn.execute(sql)
+            duplicate_keys = cast(List[Tuple[int, str, str, str]], list(txn))
+
+            # Then remove duplicate receipts, keeping the one with the highest
+            # `stream_id`. There should only be a single receipt with any given
+            # `stream_id`.
+            for max_stream_id, room_id, receipt_type, user_id in duplicate_keys:
+                sql = """
+                    DELETE FROM receipts_linearized
+                    WHERE
+                        room_id = ? AND
+                        receipt_type = ? AND
+                        user_id = ? AND
+                        thread_id IS NULL AND
+                        stream_id < ?
+                """
+                txn.execute(sql, (room_id, receipt_type, user_id, max_stream_id))
+
+        await self.db_pool.runInteraction(
+            self.RECEIPTS_LINEARIZED_UNIQUE_INDEX_UPDATE_NAME,
+            _remote_duplicate_receipts_txn,
+        )
+
+        await self._create_receipts_index(
+            "receipts_linearized_unique_index",
+            "receipts_linearized",
+        )
+
+        await self.db_pool.updates._end_background_update(
+            self.RECEIPTS_LINEARIZED_UNIQUE_INDEX_UPDATE_NAME
+        )
+
+        return 1
+
+    async def _background_receipts_graph_unique_index(
+        self, progress: dict, batch_size: int
+    ) -> int:
+        """Removes duplicate receipts and adds a unique index on
+        `(room_id, receipt_type, user_id)` to `receipts_graph`, for non-thread
+        receipts."""
+
+        def _remote_duplicate_receipts_txn(txn: LoggingTransaction) -> None:
+            # Identify any duplicate receipts arising from
+            # https://github.com/matrix-org/synapse/issues/14406.
+            # We expect the following query to use the per-thread receipt index and take
+            # less than a minute.
+            sql = """
+                SELECT room_id, receipt_type, user_id FROM receipts_graph
                 WHERE thread_id IS NULL
                 GROUP BY room_id, receipt_type, user_id
                 HAVING COUNT(*) > 1
@@ -949,8 +1035,8 @@ class ReceiptsBackgroundUpdateStore(SQLBaseStore):
             # We could be clever and try to keep the latest receipt out of every set of
             # duplicates, but it's far simpler to remove them all.
             for room_id, receipt_type, user_id in duplicate_keys:
-                sql = f"""
-                    DELETE FROM {table}
+                sql = """
+                    DELETE FROM receipts_graph
                     WHERE
                         room_id = ? AND
                         receipt_type = ? AND
@@ -959,51 +1045,21 @@ class ReceiptsBackgroundUpdateStore(SQLBaseStore):
                 """
                 txn.execute(sql, (room_id, receipt_type, user_id))
 
-            # Now that the duplicates are gone, we can create the index.
-            concurrently = (
-                "CONCURRENTLY"
-                if isinstance(self.database_engine, PostgresEngine)
-                else ""
-            )
-            sql = f"""
-                CREATE UNIQUE INDEX {concurrently} {index_name}
-                ON {table}(room_id, receipt_type, user_id)
-                WHERE thread_id IS NULL
-            """
-            txn.execute(sql)
-
         await self.db_pool.runInteraction(
-            update_name,
-            _receipts_unique_index_txn,
-        )
-
-        await self.db_pool.updates._end_background_update(update_name)
-
-        return 1
-
-    async def _background_receipts_linearized_unique_index(
-        self, progress: dict, batch_size: int
-    ) -> int:
-        """Adds a unique index on `(room_id, receipt_type, user_id)` to
-        `receipts_linearized`, for non-thread receipts.
-        """
-        return await self._background_receipts_unique_index(
-            self.RECEIPTS_LINEARIZED_UNIQUE_INDEX_UPDATE_NAME,
-            "receipts_linearized_unique_index",
-            "receipts_linearized",
-        )
-
-    async def _background_receipts_graph_unique_index(
-        self, progress: dict, batch_size: int
-    ) -> int:
-        """Adds a unique index on `(room_id, receipt_type, user_id)` to
-        `receipts_graph`, for non-thread receipts.
-        """
-        return await self._background_receipts_unique_index(
             self.RECEIPTS_GRAPH_UNIQUE_INDEX_UPDATE_NAME,
+            _remote_duplicate_receipts_txn,
+        )
+
+        await self._create_receipts_index(
             "receipts_graph_unique_index",
             "receipts_graph",
         )
+
+        await self.db_pool.updates._end_background_update(
+            self.RECEIPTS_GRAPH_UNIQUE_INDEX_UPDATE_NAME
+        )
+
+        return 1
 
 
 class ReceiptsStore(ReceiptsWorkerStore, ReceiptsBackgroundUpdateStore):

--- a/tests/storage/databases/main/test_receipts.py
+++ b/tests/storage/databases/main/test_receipts.py
@@ -1,0 +1,169 @@
+# Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict
+
+from twisted.test.proto_helpers import MemoryReactor
+
+from synapse.rest import admin
+from synapse.rest.client import login, room
+from synapse.server import HomeServer
+from synapse.storage.database import LoggingTransaction
+from synapse.util import Clock
+
+from tests.unittest import HomeserverTestCase
+
+
+class ReceiptsBackgroundUpdateStoreTestCase(HomeserverTestCase):
+
+    servlets = [
+        admin.register_servlets,
+        room.register_servlets,
+        login.register_servlets,
+    ]
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer):
+        self.store = hs.get_datastores().main
+        self.user_id = self.register_user("foo", "pass")
+        self.token = self.login("foo", "pass")
+        self.room_id = self.helper.create_room_as(self.user_id, tok=self.token)
+        self.other_room_id = self.helper.create_room_as(self.user_id, tok=self.token)
+
+    def _test_background_receipts_unique_index(
+        self,
+        update_name: str,
+        index_name: str,
+        table: str,
+        values: Dict[str, Any],
+    ):
+        """Test that the background update to uniqueify non-thread receipts in
+        the given receipts table works properly.
+        """
+        # First, undo the background update.
+        def drop_receipts_unique_index(txn: LoggingTransaction) -> None:
+            txn.execute(f"DROP INDEX IF EXISTS {index_name}")
+
+        self.get_success(
+            self.store.db_pool.runInteraction(
+                "drop_receipts_unique_index",
+                drop_receipts_unique_index,
+            )
+        )
+
+        # Add duplicate receipts for `room_id`.
+        for _ in range(2):
+            self.get_success(
+                self.store.db_pool.simple_insert(
+                    table,
+                    {
+                        "room_id": self.room_id,
+                        "receipt_type": "m.read",
+                        "user_id": self.user_id,
+                        "thread_id": None,
+                        "data": "{}",
+                        **values,
+                    },
+                )
+            )
+
+        # Add a unique receipt for `other_room_id`.
+        self.get_success(
+            self.store.db_pool.simple_insert(
+                table,
+                {
+                    "room_id": self.other_room_id,
+                    "receipt_type": "m.read",
+                    "user_id": self.user_id,
+                    "thread_id": None,
+                    "data": "{}",
+                    **values,
+                },
+            )
+        )
+
+        # Insert and run the background update.
+        self.get_success(
+            self.store.db_pool.simple_insert(
+                "background_updates",
+                {
+                    "update_name": update_name,
+                    "progress_json": "{}",
+                },
+            )
+        )
+
+        self.store.db_pool.updates._all_done = False
+
+        self.wait_for_background_updates()
+
+        # Check that the background task deleted the duplicate receipts.
+        res = self.get_success(
+            self.store.db_pool.simple_select_onecol(
+                table=table,
+                keyvalues={
+                    "room_id": self.room_id,
+                    "receipt_type": "m.read",
+                    "user_id": self.user_id,
+                    # `simple_select_onecol` does not support NULL filters,
+                    # so skip the filter on `thread_id`.
+                },
+                retcol="room_id",
+                desc="get_receipt",
+            )
+        )
+        self.assertEqual(0, len(res))
+
+        # Check that the background task did not delete the unique receipts.
+        res = self.get_success(
+            self.store.db_pool.simple_select_onecol(
+                table=table,
+                keyvalues={
+                    "room_id": self.other_room_id,
+                    "receipt_type": "m.read",
+                    "user_id": self.user_id,
+                    # `simple_select_onecol` does not support NULL filters,
+                    # so skip the filter on `thread_id`.
+                },
+                retcol="room_id",
+                desc="get_receipt",
+            )
+        )
+        self.assertEqual(1, len(res))
+
+    def test_background_receipts_linearized_unique_index(self):
+        """Test that the background update to uniqueify non-thread receipts in
+        `receipts_linearized` works properly.
+        """
+        self._test_background_receipts_unique_index(
+            "receipts_linearized_unique_index",
+            "receipts_linearized_unique_index",
+            "receipts_linearized",
+            {
+                "stream_id": 5,
+                "event_id": "$some_event",
+            },
+        )
+
+    def test_background_receipts_graph_unique_index(self):
+        """Test that the background update to uniqueify non-thread receipts in
+        `receipts_graph` works properly.
+        """
+        self._test_background_receipts_unique_index(
+            "receipts_graph_unique_index",
+            "receipts_graph_unique_index",
+            "receipts_graph",
+            {
+                "event_ids": '["$some_event"]',
+            },
+        )


### PR DESCRIPTION
As part of the database migration to support threaded receipts, there is
a possible window in between
`73/08thread_receipts_non_null.sql.postgres` removing the original
unique constraints on `receipts_linearized` and `receipts_graph` and the
`reeipts_linearized_unique_index` and `receipts_graph_unique_index`
background updates from `72/08thread_receipts.sql` completing where
the unique constraints on `receipts_linearized` and `receipts_graph` are
missing. Any emulated upserts on these tables must therefore be
performed with a lock held, otherwise duplicate rows can end up in the
tables when there are concurrent emulated upserts. Fix the missing lock.

Note that emulated upserts no longer happen by default on sqlite, since
the minimum supported version of sqlite supports native upserts by
default now.

Finally, clean up any duplicate receipts that may have crept in before
trying to create the `receipts_graph_unique_index` and
`receipts_linearized_unique_index` unique indexes.

Signed-off-by: Sean Quah <seanq@matrix.org>

---

Resolves #14406, but not the follow on to remove `lock=False`.

The first commit fixes the race that creates the duplicates.
The second commit changes the background update to clean up the duplicates.