### PR TITLE
Set account data ID gen extra tables when using SQLite

### DIFF
--- a/changelog.d/14458.misc
+++ b/changelog.d/14458.misc
@@ -1,0 +1,1 @@
+Fix account data stream ID tracking. Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -97,7 +97,10 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
                 db_conn,
                 "room_account_data",
                 "stream_id",
-                extra_tables=[("room_tags_revisions", "stream_id")],
+                extra_tables=[
+                    ("room_tags_revisions", "stream_id"),
+                    ("account_data", "instance_name", "stream_id"),
+                ],
                 is_writer=self._instance_name in hs.config.worker.writers.account_data,
             )
 

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -99,7 +99,7 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
                 "stream_id",
                 extra_tables=[
                     ("room_tags_revisions", "stream_id"),
-                    ("account_data", "instance_name", "stream_id"),
+                    ("account_data", "stream_id"),
                 ],
                 is_writer=self._instance_name in hs.config.worker.writers.account_data,
             )


### PR DESCRIPTION
This matches the Postgres multi writer generator code.

Testing potential fix to https://github.com/matrix-org/synapse/issues/14456, although this didn't change in the other PR (#14376) so is possibly not the cause.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
