### PR TITLE
Don't filter state in /context response

### DIFF
--- a/changelog.d/14461.misc
+++ b/changelog.d/14461.misc
@@ -1,0 +1,1 @@
+Improve performance of `/context` in large rooms.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1451,7 +1451,7 @@ class RoomContextHandler:
             events_before=events_before,
             event=event,
             events_after=events_after,
-            state=await filter_evts(state_events),
+            state=state_events,
             aggregations=aggregations,
             start=await token.copy_and_replace(
                 StreamKeyType.ROOM, results.start


### PR DESCRIPTION
We don't filter state usually, so doing so here is a waste of time. This is not much of an issue for clients that enable lazy loading of members, since there will be fewer state events.

c.f. implementation of `/state` where we don't do the same filitering: https://github.com/matrix-org/synapse/blob/1eed795fc56d95df3968e37f3a4db92f24513e15/synapse/handlers/message.py#L165