### PR TITLE
Include thread information when sending receipts over federation.

### DIFF
--- a/changelog.d/14466.bugfix
+++ b/changelog.d/14466.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.70.0 where a receipt's thread ID was not sent over federation.

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -244,12 +244,13 @@ class PerDestinationQueue:
             )
 
     def flush_read_receipts_for_room(self, room_id: str) -> None:
-        # if we don't have any receipts for this room, it may be that we've already
-        # sent them out, so we don't need to flush.
+        # If there are any pending receipts for this room then force-flush them
+        # in a new transaction.
         for edu in self._pending_receipt_edus:
             if room_id in edu:
                 self._rrs_pending_flush = True
                 self.attempt_new_transaction()
+                # No use in checking remaining EDUs if the room was found.
                 break
 
     def send_keyed_edu(self, edu: Edu, key: Hashable) -> None:

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -250,6 +250,7 @@ class PerDestinationQueue:
             if room_id in edu:
                 self._rrs_pending_flush = True
                 self.attempt_new_transaction()
+                break
 
     def send_keyed_edu(self, edu: Edu, key: Hashable) -> None:
         self._pending_edus_keyed[(edu.edu_type, key)] = edu

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -562,8 +562,8 @@ class PerDestinationQueue:
         # need additional ones for different threads. The result is that we will
         # send N EDUs where N is the number of unique threads across rooms.
         #
-        # This could be more efficient by bundling users who have sent receipts
-        # for different threads.
+        # TODO This could be more efficient by bundling users who have sent
+        #      receipts for different threads.
         generated_edus = 0
         while self._pending_rrs and generated_edus < limit:
             # The next EDU's content.
@@ -577,17 +577,18 @@ class PerDestinationQueue:
             for room_id in list(self._pending_rrs.keys()):
                 for receipt_type in list(self._pending_rrs[room_id].keys()):
                     thread_ids = self._pending_rrs[room_id][receipt_type]
-                    # The thread ID itself doesn't matter at this point.
+                    # The thread ID itself doesn't matter at this point -- it is
+                    # included in the receipt data already.
                     content.setdefault(room_id, {})[
                         receipt_type
                     ] = thread_ids.popitem()[1]
 
-                    # If there are no threads left in this room / receipt type.
-                    # Clear it out.
+                    # If there are no threads left in the receipt type for this
+                    # room, then delete the entire receipt type.
                     if not thread_ids:
                         del self._pending_rrs[room_id][receipt_type]
 
-                # Again, clear out any blank rooms.
+                # If there are no receipt types left in this room, delete the room.
                 if not self._pending_rrs[room_id]:
                     del self._pending_rrs[room_id]
 

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -560,10 +560,10 @@ class PerDestinationQueue:
         # Build the EDUs needed to send these receipts. This is a bit complicated
         # since we can share one for each unique (room, receipt type, user), but
         # need additional ones for different threads. The result is that we will
-        # send N EDUs where N is the maximum number of threads in a room.
+        # send N EDUs where N is the number of unique threads across rooms.
         #
-        # This could be slightly more efficient by bundling users who have only
-        # send receipts for different threads.
+        # This could be more efficient by bundling users who have sent receipts
+        # for different threads.
         while self._pending_rrs:
             # The next EDU's content.
             content: JsonDict = {}

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -600,7 +600,10 @@ class PerDestinationQueue:
             )
             generated_edus += 1
 
-        self._rrs_pending_flush = False
+        # If there are still pending read-receipts, don't reset the pending flush
+        # flag.
+        if not self._pending_rrs:
+            self._rrs_pending_flush = False
 
     def _pop_pending_edus(self, limit: int) -> List[Edu]:
         pending_edus = self._pending_edus

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -687,7 +687,7 @@ class _TransactionQueueManager:
         # First we calculate the EDUs we want to send, if any.
 
         # There's a maximum number of EDUs that can be sent with a transaction,
-        # generally device udates and to-device messages get priority, but we
+        # generally device updates and to-device messages get priority, but we
         # want to ensure that there's room for some other EDUs as well.
         #
         # This is done by:

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -570,6 +570,10 @@ class PerDestinationQueue:
             content: JsonDict = {}
 
             # Iterate each room's receipt types and threads, adding it to the content.
+            #
+            # _pending_rrs is mutated inside of this loop so take care to iterate
+            # a copy of the keys. Similarly, the dictionary values of _pending_rrs
+            # are mutated during iteration.
             for room_id in list(self._pending_rrs.keys()):
                 for receipt_type in list(self._pending_rrs[room_id].keys()):
                     thread_ids = self._pending_rrs[room_id][receipt_type]

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -595,7 +595,6 @@ class PerDestinationQueue:
             )
             generated_edus += 1
 
-        self._pending_rrs = {}
         self._rrs_pending_flush = False
 
     def _pop_pending_edus(self, limit: int) -> List[Edu]:

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -752,11 +752,10 @@ class _TransactionQueueManager:
         edu_limit -= len(device_update_edus)
 
         # Finally add any other types of EDUs if there is room.
-        pending_edus.extend(self.queue._pop_pending_edus(edu_limit))
-        while (
-            len(pending_edus) < MAX_EDUS_PER_TRANSACTION
-            and self.queue._pending_edus_keyed
-        ):
+        other_edus = self.queue._pop_pending_edus(edu_limit)
+        pending_edus.extend(other_edus)
+        edu_limit -= len(other_edus)
+        while edu_limit > 0 and self.queue._pending_edus_keyed:
             _, val = self.queue._pending_edus_keyed.popitem()
             pending_edus.append(val)
             edu_limit -= 1

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -92,7 +92,6 @@ class ReceiptsHandler:
                         continue
 
                     # Check if these receipts apply to a thread.
-                    thread_id = None
                     data = user_values.get("data", {})
                     thread_id = data.get("thread_id")
                     # If the thread ID is invalid, consider it missing.

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -95,7 +95,12 @@ class FederationSenderReceiptsTestCases(HomeserverTestCase):
         # * The same room / user on multiple threads.
         # * A different user in the same room.
         sender = self.hs.get_federation_sender()
-        for user, thread in (("alice", None), ("alice", "thread"), ("bob", None)):
+        for user, thread in (
+            ("alice", None),
+            ("alice", "thread"),
+            ("bob", None),
+            ("bob", "diff-thread"),
+        ):
             receipt = ReadReceipt(
                 "room_id",
                 "m.read",
@@ -126,7 +131,11 @@ class FederationSenderReceiptsTestCases(HomeserverTestCase):
                                 "alice": {
                                     "event_ids": ["event_id"],
                                     "data": {"ts": 1234, "thread_id": "thread"},
-                                }
+                                },
+                                "bob": {
+                                    "event_ids": ["event_id"],
+                                    "data": {"ts": 1234, "thread_id": "diff-thread"},
+                                },
                             }
                         }
                     },


### PR DESCRIPTION
Send the thread ID as part of the receipt meta data over federation.

This gets a bit complicated since the same room / receipt type / user could appear multiple times with different thread IDs and we don't want to stomp over each other. To avoid this we send them as separate EDUs.

Fixes #14459

This was missed as part of #12550 somehow.