### PR TITLE
Faster remote room joins: unblock tasks waiting for full room state when the un-partial-stating of that room is received over the replication stream. [rei:frrj/streams/unpsr]

### DIFF
--- a/changelog.d/14474.misc
+++ b/changelog.d/14474.misc
@@ -1,0 +1,1 @@
+Faster remote room joins: stream the un-partial-stating of rooms over replication.

--- a/tests/replication/tcp/streams/test_partial_state.py
+++ b/tests/replication/tcp/streams/test_partial_state.py
@@ -1,0 +1,67 @@
+# Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from twisted.internet.defer import ensureDeferred
+
+from synapse.rest.client import room
+
+from tests.replication._base import BaseMultiWorkerStreamTestCase
+
+
+class PartialStateStreamsTestCase(BaseMultiWorkerStreamTestCase):
+    servlets = [room.register_servlets]
+    hijack_auth = True
+    user_id = "@bob:test"
+
+    def setUp(self):
+        super().setUp()
+        self.store = self.hs.get_datastores().main
+
+    def test_un_partial_stated_room_unblocks_over_replication(self) -> None:
+        """
+        Tests that, when a room is un-partial-stated on another worker,
+        pending calls to `await_full_state` get unblocked.
+        """
+
+        # user_id = self.register_user("bob", "verysecret")
+        # token = self.login("bob", "verysecret")
+        # Make a room.
+        room_id = self.helper.create_room_as("@bob:test")
+        # Mark the room as partial-stated.
+        self.get_success(
+            self.store.store_partial_state_room(room_id, ["serv1", "serv2"], 0, "serv1")
+        )
+
+        worker = self.make_worker_hs("synapse.app.generic_worker")
+
+        # On the worker, attempt to get the current hosts in the room
+        d = ensureDeferred(
+            worker.get_storage_controllers().state.get_current_hosts_in_room(room_id)
+        )
+
+        self.reactor.advance(0.1)
+
+        # This should block
+        self.assertFalse(
+            d.called, "get_current_hosts_in_room/await_full_state did not block"
+        )
+
+        # On the master, clear the partial state flag.
+        self.get_success(self.store.clear_partial_state_room(room_id))
+
+        self.reactor.advance(0.1)
+
+        # The worker should have unblocked
+        self.assertTrue(
+            d.called, "get_current_hosts_in_room/await_full_state did not unblock"
+        )

--- a/tests/replication/tcp/streams/test_partial_state.py
+++ b/tests/replication/tcp/streams/test_partial_state.py
@@ -33,8 +33,6 @@ class PartialStateStreamsTestCase(BaseMultiWorkerStreamTestCase):
         pending calls to `await_full_state` get unblocked.
         """
 
-        # user_id = self.register_user("bob", "verysecret")
-        # token = self.login("bob", "verysecret")
         # Make a room.
         room_id = self.helper.create_room_as("@bob:test")
         # Mark the room as partial-stated.


### PR DESCRIPTION
Fixes: requests blocking forever on workers if another worker un-partial-stated a room (no open issue for this) <!-- -->
<!--
Supersedes: # <!-- -->
Follows: #14473 <!-- -->
Part of: #12994 <!-- -->
Base: `rei/frrj_stream_unps_rooms` <!-- git-stack-base-branch:rei/frrj_stream_unps_rooms -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->



<!---GHSTACKOPEN-->
### Stacked PR Chain: rei:frrj/streams/unpsr
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#14473|Faster remote room joins: stream the un-partial-stating of rooms over replication.|![](https://img.shields.io/github/pulls/detail/state/matrix-org/synapse/14473?label=Pending)|-|
|#14474|👉 Faster remote room joins: unblock tasks waiting for full room state when the un-partial-stating of that room is received over the replication stream.|![](https://img.shields.io/github/pulls/detail/state/matrix-org/synapse/14474?label=Pending)|#14473|
|#14545|*(Draft) Faster remote room joins: stream the un-partial-stating of events over replication.*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/synapse/14545?label=Pending)|#14474|
|#14546|*(Draft) Faster remote room joins: invalidate caches and unblock requests when receiving un-partial-stated event notifications over replication.*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/synapse/14546?label=Pending)|#14545|
<!---GHSTACKCLOSE-->


