### PR TITLE
Fix version that `worker_main_http_uri` is redundant from

### DIFF
--- a/changelog.d/14476.misc
+++ b/changelog.d/14476.misc
@@ -1,0 +1,1 @@
+Remove the `worker_main_http_uri` configuration setting. This is now handled via internal replication.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -135,8 +135,8 @@ In the config file for each worker, you must specify:
    [`worker_replication_http_port`](usage/configuration/config_documentation.md#worker_replication_http_port)).
  * If handling HTTP requests, a [`worker_listeners`](usage/configuration/config_documentation.md#worker_listeners) option
    with an `http` listener.
- * **Synapse 1.71 and older:** if handling the `^/_matrix/client/v3/keys/upload` endpoint, the HTTP URI for
-   the main process (`worker_main_http_uri`). This config option is no longer required and is ignored when running Synapse 1.72 and newer.
+ * **Synapse 1.72 and older:** if handling the `^/_matrix/client/v3/keys/upload` endpoint, the HTTP URI for
+   the main process (`worker_main_http_uri`). This config option is no longer required and is ignored when running Synapse 1.73 and newer.
 
 For example:
 

--- a/synapse/config/workers.py
+++ b/synapse/config/workers.py
@@ -166,7 +166,7 @@ class WorkerConfig(Config):
         self.worker_main_http_uri = config.get("worker_main_http_uri", None)
         if self.worker_main_http_uri is not None:
             logger.warning(
-                "The config option worker_main_http_uri is unused since Synapse 1.72. "
+                "The config option worker_main_http_uri is unused since Synapse 1.73. "
                 "It can be safely removed from your configuration."
             )
 


### PR DESCRIPTION
#14400 just missed the 1.72 merge window. Thanks @dklimpel for [pointing that out](https://github.com/matrix-org/synapse/pull/14400#discussion_r1025303088).