### PR TITLE
Fixes to `federation_client` dev script

### DIFF
--- a/changelog.d/14479.misc
+++ b/changelog.d/14479.misc
@@ -1,0 +1,1 @@
+`scripts-dev/federation_client`: Fix routing on servers with `.well-known` files.

--- a/scripts-dev/federation_client.py
+++ b/scripts-dev/federation_client.py
@@ -286,7 +286,8 @@ class MatrixConnectionAdapter(HTTPAdapter):
         )
 
         # at this point we also add the host header (otherwise urllib will add one
-        # based on the host we connect to, which may be wrong).
+        # based on the `host` from the connection returned by `get_connection`,
+        # which will be wrong if there is an SRV record).
         request.headers["Host"] = server_name
 
         return super().send(request, *args, **kwargs)

--- a/scripts-dev/federation_client.py
+++ b/scripts-dev/federation_client.py
@@ -265,13 +265,14 @@ class MatrixConnectionAdapter(HTTPAdapter):
     def send(
         self,
         request: PreparedRequest,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> Response:
         # overrides the send() method in the base class.
 
         # We need to look for .well-known redirects before passing the request up to
         # HTTPAdapter.send().
+        assert isinstance(request.url, str)
         parsed = urlparse.urlsplit(request.url)
         server_name = parsed.netloc
         well_known = self._get_well_known(parsed.netloc)


### PR DESCRIPTION
Turns out that the `federation_client` script had a bug for servers with `.well-known` files: suppose the server `example.com` had a well-known file which redirected to `matrix.example.net`. The client would then set the `Host` header to `example.com`, where it should have been `matrix.example.net`.

While I'm messing about with it, I've fixed TLS verification.