### PR TITLE
Reduce default third party invite rate limit to 216 invites per day

### DIFF
--- a/changelog.d/14487.misc
+++ b/changelog.d/14487.misc
@@ -1,0 +1,1 @@
+Reduce default third party invite rate limit to 216 invites per day.

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -150,8 +150,5 @@ class RatelimitConfig(Config):
 
         self.rc_third_party_invite = RatelimitSettings(
             config.get("rc_third_party_invite", {}),
-            defaults={
-                "per_second": self.rc_message.per_second,
-                "burst_count": self.rc_message.burst_count,
-            },
+            defaults={"per_second": 0.0025, "burst_count": 5},
         )


### PR DESCRIPTION
The previous default was the same as the `rc_message` rate limit, which
defaults to 17,280 per day.

Signed-off-by: Sean Quah <seanq@matrix.org>

---

As suggested by @clokep.