### PR TITLE
Fix /key/v2/server calls with URL-unsafe key IDs

### DIFF
--- a/changelog.d/14490.misc
+++ b/changelog.d/14490.misc
@@ -1,1 +1,1 @@
-Fix a bug introduced in Synapse 0.9 we would fail to fetch server keys whose IDs contain a forward slash.
+Fix a bug introduced in Synapse 0.9 where it would fail to fetch server keys whose IDs contain a forward slash.

--- a/changelog.d/14490.misc
+++ b/changelog.d/14490.misc
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 0.9 we would fail to fetch server keys whose IDs contain a forward slash.

--- a/synapse/crypto/keyring.py
+++ b/synapse/crypto/keyring.py
@@ -857,7 +857,7 @@ class ServerKeyFetcher(BaseV2KeyFetcher):
                 response = await self.client.get_json(
                     destination=server_name,
                     path="/_matrix/key/v2/server/"
-                    + urllib.parse.quote(requested_key_id),
+                    + urllib.parse.quote(requested_key_id, safe=""),
                     ignore_backoff=True,
                     # we only give the remote server 10s to respond. It should be an
                     # easy request to handle, so if it doesn't reply within 10s, it's


### PR DESCRIPTION
Fixes #14488.

I haven't yet done an audit of everywhere else we call urllib.parse.quote---suggest making that a separate task.