### PR TITLE
Optimize `filter_events_for_client` for faster `/messages` - v1

### DIFF
--- a/changelog.d/14494.misc
+++ b/changelog.d/14494.misc
@@ -1,0 +1,1 @@
+Speed-up `/messages` with  `filter_events_for_client` optimizations.

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -184,10 +184,21 @@ class StateStorageController:
 
     @trace
     @tag_args
-    async def _get_state_for_client_filtering_for_events(
+    async def _get_state_for_events_when_filtering_for_client(
         self, event_ids: Collection[str], user_id_viewing_events: str
     ) -> Dict[str, StateMap[EventBase]]:
-        """TODO"""
+        """Get the state at each event that is necessary to filter
+        them before being displayed to clients from the perspective of the
+        `user_id_viewing_events`. Will fetch `m.room.history_visibility` and
+        `m.room.member` event of `user_id_viewing_events`.
+
+        Args:
+            event_ids: List of event ID's that will be displayed to the client
+            user_id_viewing_events: User ID that will be viewing these events
+
+        Returns:
+            Dict of event_id to state map.
+        """
         set_tag(
             SynapseTags.FUNC_ARG_PREFIX + "event_ids.length",
             str(len(event_ids)),
@@ -204,10 +215,6 @@ class StateStorageController:
         group_to_state = await self.stores.state._get_state_for_client_filtering(
             groups, user_id_viewing_events
         )
-        # logger.info(
-        #     "_get_state_for_client_filtering_for_events: group_to_state=%s",
-        #     group_to_state,
-        # )
 
         state_event_map = await self.stores.main.get_events(
             [ev_id for sd in group_to_state.values() for ev_id in sd.values()],
@@ -255,7 +262,6 @@ class StateStorageController:
         group_to_state = await self.stores.state._get_state_for_groups(
             groups, state_filter or StateFilter.all()
         )
-        # logger.info("get_state_for_events: group_to_state=%s", group_to_state)
 
         state_event_map = await self.stores.main.get_events(
             [ev_id for sd in group_to_state.values() for ev_id in sd.values()],

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -201,17 +201,13 @@ class StateStorageController:
         )
 
         groups = set(event_to_groups.values())
-        logger.info(
-            "_get_state_for_client_filtering_for_events: groups=%s",
-            groups,
-        )
         group_to_state = await self.stores.state._get_state_for_client_filtering(
             groups, user_id_viewing_events
         )
-        logger.info(
-            "_get_state_for_client_filtering_for_events: group_to_state=%s",
-            group_to_state,
-        )
+        # logger.info(
+        #     "_get_state_for_client_filtering_for_events: group_to_state=%s",
+        #     group_to_state,
+        # )
 
         state_event_map = await self.stores.main.get_events(
             [ev_id for sd in group_to_state.values() for ev_id in sd.values()],
@@ -256,11 +252,10 @@ class StateStorageController:
         )
 
         groups = set(event_to_groups.values())
-        logger.info("get_state_for_events: groups=%s", groups)
         group_to_state = await self.stores.state._get_state_for_groups(
             groups, state_filter or StateFilter.all()
         )
-        logger.info("get_state_for_events: group_to_state=%s", group_to_state)
+        # logger.info("get_state_for_events: group_to_state=%s", group_to_state)
 
         state_event_map = await self.stores.main.get_events(
             [ev_id for sd in group_to_state.values() for ev_id in sd.values()],

--- a/synapse/storage/databases/state/bg_updates.py
+++ b/synapse/storage/databases/state/bg_updates.py
@@ -101,9 +101,11 @@ class StateGroupBackgroundUpdateStore(SQLBaseStore):
             where_clause = " AND (%s)" % (where_clause,)
 
         if isinstance(self.database_engine, PostgresEngine):
+            # Suspicion start
             # Temporarily disable sequential scans in this transaction. This is
             # a temporary hack until we can add the right indices in
             txn.execute("SET LOCAL enable_seqscan=off")
+            # Suspicion end
 
             # The below query walks the state_group tree so that the "state"
             # table includes all state_groups in the tree. It then joins

--- a/synapse/storage/databases/state/bg_updates.py
+++ b/synapse/storage/databases/state/bg_updates.py
@@ -101,11 +101,9 @@ class StateGroupBackgroundUpdateStore(SQLBaseStore):
             where_clause = " AND (%s)" % (where_clause,)
 
         if isinstance(self.database_engine, PostgresEngine):
-            # Suspicion start
             # Temporarily disable sequential scans in this transaction. This is
             # a temporary hack until we can add the right indices in
             txn.execute("SET LOCAL enable_seqscan=off")
-            # Suspicion end
 
             # The below query walks the state_group tree so that the "state"
             # table includes all state_groups in the tree. It then joins

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -318,9 +318,10 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
         def _get_state_for_client_filtering_txn(
             txn: LoggingTransaction, groups: Iterable[int]
         ) -> Mapping[int, MutableStateMap[str]]:
+
             sql = """
                 WITH RECURSIVE sgs(state_group) AS (
-                    VALUES(?::bigint)
+                    VALUES(CAST(? AS bigint))
                     UNION ALL
                     SELECT prev_state_group FROM state_group_edges e, sgs s
                     WHERE s.state_group = e.state_group

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Collection, Dict, Iterable, List, Optional, Se
 import attr
 
 from synapse.api.constants import EventTypes
+from synapse.logging.tracing import SynapseTags, set_tag, tag_args, trace
 from synapse.storage._base import SQLBaseStore
 from synapse.storage.database import (
     DatabasePool,
@@ -158,6 +159,8 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
         )
 
     @cancellable
+    @trace
+    @tag_args
     async def _get_state_groups_from_groups(
         self, groups: List[int], state_filter: StateFilter
     ) -> Dict[int, StateMap[str]]:
@@ -171,6 +174,11 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
         Returns:
             Dict of state group to state map.
         """
+        set_tag(
+            SynapseTags.FUNC_ARG_PREFIX + "groups.length",
+            str(len(groups)),
+        )
+
         results: Dict[int, StateMap[str]] = {}
 
         chunks = [groups[i : i + 100] for i in range(0, len(groups), 100)]

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -246,6 +246,8 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
         return state_filter.filter_state(state_dict_ids), not missing_types
 
     @cancellable
+    @trace
+    @tag_args
     async def _get_state_for_groups(
         self, groups: Iterable[int], state_filter: Optional[StateFilter] = None
     ) -> Dict[int, MutableStateMap[str]]:

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -374,7 +374,6 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
                 _get_state_for_client_filtering_txn,
                 batch,
             )
-            logger.info("group_to_state_mapping=%s", group_to_state_mapping)
 
             # Now lets update the caches
             # Help the cache hit ratio by expanding the filter a bit

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -119,9 +119,6 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
             "*stateGroupMembersCache*",
             500000,
         )
-        # TODO: Remove cache invalidation
-        self._state_group_cache.invalidate_all()
-        self._state_group_members_cache.invalidate_all()
 
         def get_max_state_group_txn(txn: Cursor) -> int:
             txn.execute("SELECT COALESCE(max(id), 0) FROM state_groups")

--- a/synapse/storage/databases/state/store.py
+++ b/synapse/storage/databases/state/store.py
@@ -335,8 +335,6 @@ class StateGroupDataStore(StateBackgroundUpdateStore, SQLBaseStore):
                     )
                     AND (type = ? AND state_key = ?)
                 ORDER BY
-                    type,
-                    state_key,
                     -- Use the lastest state in the chain (highest numbered state_group in the chain)
                     state_group DESC
                 LIMIT 1

--- a/synapse/storage/state.py
+++ b/synapse/storage/state.py
@@ -100,16 +100,16 @@ class StateFilter:
             The new state filter.
         """
         type_dict: Dict[str, Optional[Set[str]]] = {}
-        for typ, s in types:
+        for typ, state_key in types:
             if typ in type_dict:
                 if type_dict[typ] is None:
                     continue
 
-            if s is None:
+            if state_key is None:
                 type_dict[typ] = None
                 continue
 
-            type_dict.setdefault(typ, set()).add(s)  # type: ignore
+            type_dict.setdefault(typ, set()).add(state_key)  # type: ignore
 
         return StateFilter(
             types=frozendict(

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -117,8 +117,8 @@ async def filter_events_for_client(
     )
 
     # TODO: Remove comparison
-    logger.info("----------------------------------------------------")
-    logger.info("----------------------------------------------------")
+    # logger.info("----------------------------------------------------")
+    # logger.info("----------------------------------------------------")
     types = (_HISTORY_VIS_KEY, (EventTypes.Member, user_id))
     event_id_to_state_orig = await storage.state.get_state_for_events(
         frozenset(e.event_id for e in events if not e.internal_metadata.outlier),

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -106,33 +106,16 @@ async def filter_events_for_client(
                 [event.event_id for event in events],
             )
 
-    non_outlier_event_ids = event_ids = frozenset(
+    non_outlier_event_ids = frozenset(
         e.event_id for e in events if not e.internal_metadata.outlier
-    )
-
-    # TODO: Remove: We do this just to remove await_full_state from the comparison
-    await storage.state.get_state_group_for_events(
-        non_outlier_event_ids, await_full_state=True
     )
 
     # Grab the history visibility and membership for each of the events. That's all we
     # need to know in order to filter them.
-    event_id_to_state = await storage.state._get_state_for_client_filtering_for_events(
+    event_id_to_state = await storage.state._get_state_for_events_when_filtering_for_client(
         # we exclude outliers at this point, and then handle them separately later
         event_ids=non_outlier_event_ids,
         user_id_viewing_events=user_id,
-    )
-
-    # TODO: Remove comparison
-    # TODO: Remove cache invalidation
-    storage.state.stores.state._state_group_cache.invalidate_all()
-    storage.state.stores.state._state_group_members_cache.invalidate_all()
-    # logger.info("----------------------------------------------------")
-    # logger.info("----------------------------------------------------")
-    types = (_HISTORY_VIS_KEY, (EventTypes.Member, user_id))
-    event_id_to_state_orig = await storage.state.get_state_for_events(
-        non_outlier_event_ids,
-        state_filter=StateFilter.from_types(types),
     )
 
     # Get the users who are ignored by the requesting user.

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -106,12 +106,13 @@ async def filter_events_for_client(
                 [event.event_id for event in events],
             )
 
-    types = (_HISTORY_VIS_KEY, (EventTypes.Member, user_id))
-
-    # we exclude outliers at this point, and then handle them separately later
+    # Grab the history visibility and membership for each of the events. That's all we
+    # need to know in order to filter them.
+    filter_types = (_HISTORY_VIS_KEY, (EventTypes.Member, user_id))
     event_id_to_state = await storage.state.get_state_for_events(
+        # we exclude outliers at this point, and then handle them separately later
         frozenset(e.event_id for e in events if not e.internal_metadata.outlier),
-        state_filter=StateFilter.from_types(types),
+        state_filter=StateFilter.from_types(filter_types),
     )
 
     # Get the users who are ignored by the requesting user.


### PR DESCRIPTION
Optimize `filter_events_for_client`. See https://github.com/matrix-org/synapse/pull/14494#discussion_r1028806102 for SQL query optimization talk. Seems like it will make it a magnitude faster.

Fix https://github.com/matrix-org/synapse/issues/14108

Part of https://github.com/matrix-org/synapse/issues/13356#issuecomment-1272149596


### Dev notes

Previous optimizations:

 - https://github.com/matrix-org/synapse/pull/7567


---

Grabbing all of the state via `get_state_for_events` is the longest part of `filter_events_for_client`

 - `filter_events_for_client`
    - `get_state_for_events`
        - `get_state_group_for_events`
           -  `_get_state_group_for_events`
        - `_get_state_for_groups`
            - `_get_state_for_groups_using_cache`
            - `_get_state_groups_from_groups` 🐢
                - `_get_state_groups_from_groups_txn` (`db._get_state_groups_from_groups`)
        - `get_events`
            - ...

Of all the state we grab in `filter_events_for_client`, we only ever use `EventTypes.RoomHistoryVisibility` and `EventTypes.Member` from it

 - `filter_events_for_client`
 - `_check_client_allowed_to_see_event`
    - `_check_filter_send_to_client`
        - ->Uses no `state`
    - `get_effective_room_visibility_from_state`
        - -> `EventTypes.RoomHistoryVisibility` 🎈
    - `_check_history_visibility`
        - -> Uses `visibility` result from above
    - `_check_membership`
        - -> Uses `visibility` result from above
        - -> `EventTypes.Member` 🎈


---

Relevant database tables:

 - `state_groups`
 - `state_groups_state`
 - `state_group_edges`
 - `event_to_state_groups`

Docs:

 - [`docs/development/room-dag-concepts.md`](https://github.com/matrix-org/synapse/blob/e1b15f25f3ad4b45b381544ca6b3cd2caf43d25d/docs/development/room-dag-concepts.md)
 - [`docs/usage/administration/state_groups.md`](https://github.com/matrix-org/synapse/blob/e1b15f25f3ad4b45b381544ca6b3cd2caf43d25d/docs/usage/administration/state_groups.md)

---

This thing that is part of `_get_state_groups_from_groups_txn` seems suspicious:

https://github.com/matrix-org/synapse/blob/e1b15f25f3ad4b45b381544ca6b3cd2caf43d25d/synapse/storage/databases/state/bg_updates.py#L104-L106


---

```
WITH RECURSIVE state(state_group) AS (
    VALUES(1088::bigint)
    UNION ALL
    SELECT prev_state_group FROM state_group_edges e, state s
    WHERE s.state_group = e.state_group
)
SELECT DISTINCT ON (type, state_key)
    type, state_key, event_id
FROM state_groups_state
WHERE
    state_group IN (
        SELECT state_group FROM state
    )
    AND ((type = 'm.room.history_visibility' AND state_key = '') OR (type = 'm.room.member' AND state_key = '@erictroupetester:my.synapse.server'))
ORDER BY type, state_key, state_group DESC;
```

```
WITH RECURSIVE sgs(state_group) AS (
    VALUES(1088::bigint)
    UNION ALL
    SELECT prev_state_group FROM state_group_edges e, sgs s
    WHERE s.state_group = e.state_group
)
SELECT
    state_group, type, state_key, event_id
FROM state_groups_state
WHERE
    state_group IN (
        SELECT state_group FROM sgs
    )
    AND ((type = 'm.room.history_visibility' AND state_key = '') OR (type = 'm.room.member' AND state_key = '@erictroupetester:my.synapse.server'))
ORDER BY type, state_key, state_group DESC;

 state_group |           type            |              state_key              |                   event_id
-------------+---------------------------+-------------------------------------+----------------------------------------------
           7 | m.room.history_visibility |                                     | $e2uT1YAwZQvMvXG0Ee5mqGyQ1KqVLH7JNhE88QqAnXY
        1088 | m.room.member             | @erictroupetester:my.synapse.server | $fO0oJZQ4rL2UiE7vDYo_uKuNrAmnRESrFhsRNIGFAh8
        1062 | m.room.member             | @erictroupetester:my.synapse.server | $QzoIckuimPX4Y8QZaMgxC5XB45ChAC1RZ43N3Y2FXOQ
        1036 | m.room.member             | @erictroupetester:my.synapse.server | $7-qHsVnP-5zKgeKujvKz1LHfVVEVln3y_GTDwS9f228
        1010 | m.room.member             | @erictroupetester:my.synapse.server | $9RsIrIeoBA-X4loFFOKNHOnqaDm8bNKGzXRhcp6kNuA
         984 | m.room.member             | @erictroupetester:my.synapse.server | $vHsSOWAdn9E6pOLLrO6vnB6TJXCdfyQd0uWl6gMftsE
         957 | m.room.member             | @erictroupetester:my.synapse.server | $V3A1GXrisvM0vY8tRR68e_cayLVbV-9zzkTCQpmXs84
           3 | m.room.member             | @erictroupetester:my.synapse.server | $uTRdQa2r7LgK17YRs-m5DWfkmcsoXgkBAo8If4pcVuA
```



### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
