### PR TITLE
Parallelize calls to fetch bundled aggregations.

### DIFF
--- a/changelog.d/14510.feature
+++ b/changelog.d/14510.feature
@@ -1,0 +1,1 @@
+Reduce database load of [Client-Server endpoints](https://spec.matrix.org/v1.4/client-server-api/#aggregations) which return bundled aggregations.

--- a/synapse/handlers/relations.py
+++ b/synapse/handlers/relations.py
@@ -566,7 +566,7 @@ class RelationsHandler:
             for event_id, edit in edits.items():
                 results.setdefault(event_id, BundledAggregations()).replace = edit
 
-        # Parallelize the calls for annotations, references, ane edits since they
+        # Parallelize the calls for annotations, references, and edits since they
         # are unrelated.
         await make_deferred_yieldable(
             gather_results(


### PR DESCRIPTION
This parallelizes the calls to fetch annotations, references, and edits since they can't affect one another.

Related to #13624.

Based on #14508.