### PR TITLE
Faster joins: use servers list approximation in `assert_host_in_room`

### DIFF
--- a/changelog.d/14515.misc
+++ b/changelog.d/14515.misc
@@ -1,0 +1,1 @@
+Faster joins: use servers list approximation received during `send_join` (potentially updated with received membership events) in `assert_host_in_room`.

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -193,9 +193,9 @@ class EventAuthHandler:
                     "Unable to authorise you right now; room is partial-stated here.",
                     errcode=Codes.UNABLE_DUE_TO_PARTIAL_STATE,
                 )
-
-        if not await self.is_host_in_room(room_id, host):
-            raise AuthError(403, "Host not in room.")
+        else:
+            if not await self.is_host_in_room(room_id, host):
+                raise AuthError(403, "Host not in room.")
 
     async def check_restricted_join_rules(
         self,

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -45,6 +45,7 @@ class EventAuthHandler:
     def __init__(self, hs: "HomeServer"):
         self._clock = hs.get_clock()
         self._store = hs.get_datastores().main
+        self._state_storage_controller = hs.get_storage_controllers().state
         self._server_name = hs.hostname
 
     async def check_auth_rules_from_context(
@@ -179,14 +180,19 @@ class EventAuthHandler:
         this function may return an incorrect result as we are not able to fully
         track server membership in a room without full state.
         """
-        if not allow_partial_state_rooms and await self._store.is_partial_state_room(
-            room_id
-        ):
-            raise AuthError(
-                403,
-                "Unable to authorise you right now; room is partial-stated here.",
-                errcode=Codes.UNABLE_DUE_TO_PARTIAL_STATE,
-            )
+        if self._store.is_partial_state_room(room_id):
+            if allow_partial_state_rooms:
+                current_hosts = await self._state_storage_controller.get_current_hosts_in_room_or_partial_state_approximation(
+                    room_id
+                )
+                if host not in current_hosts:
+                    raise AuthError(403, "Host not in room (partial-state approx).")
+            else:
+                raise AuthError(
+                    403,
+                    "Unable to authorise you right now; room is partial-stated here.",
+                    errcode=Codes.UNABLE_DUE_TO_PARTIAL_STATE,
+                )
 
         if not await self.is_host_in_room(room_id, host):
             raise AuthError(403, "Host not in room.")

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -180,7 +180,7 @@ class EventAuthHandler:
         this function may return an incorrect result as we are not able to fully
         track server membership in a room without full state.
         """
-        if self._store.is_partial_state_room(room_id):
+        if await self._store.is_partial_state_room(room_id):
             if allow_partial_state_rooms:
                 current_hosts = await self._state_storage_controller.get_current_hosts_in_room_or_partial_state_approximation(
                     room_id


### PR DESCRIPTION
Follow up to #14404.

If `allow_partial_state_rooms` is specified we use the servers list received on `send_join` (potentially updated with received membership events) instead of using the membership events only to check that we can send events to a server.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
