### PR TITLE
Apply correct editorconfig to .pyi files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@
 root = true
 
 # 4 space indentation
-[*.py]
+[*.{py,pyi}]
 indent_style = space
 indent_size = 4
 max_line_length = 88

--- a/changelog.d/14526.misc
+++ b/changelog.d/14526.misc
@@ -1,0 +1,1 @@
+Extend editorconfig rules on indent and line length to `.pyi` files.


### PR DESCRIPTION
The current configuration might cause some editors to misbehave when editing stub files.