### PR TITLE
Optimize `filter_events_for_client` for faster `/messages` - v2

### DIFF
--- a/changelog.d/14527.misc
+++ b/changelog.d/14527.misc
@@ -1,0 +1,1 @@
+Speed-up `/messages` with `filter_events_for_client` optimizations.

--- a/synapse/storage/databases/state/bg_updates.py
+++ b/synapse/storage/databases/state/bg_updates.py
@@ -139,13 +139,13 @@ class StateGroupBackgroundUpdateStore(SQLBaseStore):
             # with no testing behind it)
             if use_condition_optimization and len(state_filter_condition_combos) < 10:
                 select_clause_list: List[str] = []
-                for etype, state_key in state_filter_condition_combos:
-                    if state_key is None:
+                for etype, skey in state_filter_condition_combos:
+                    if skey is None:
                         where_clause = "(type = ?)"
                         overall_select_query_args.extend([etype])
                     else:
                         where_clause = "(type = ? AND state_key = ?)"
-                        overall_select_query_args.extend([etype, state_key])
+                        overall_select_query_args.extend([etype, skey])
 
                     select_clause_list.append(
                         f"""

--- a/synapse/storage/databases/state/bg_updates.py
+++ b/synapse/storage/databases/state/bg_updates.py
@@ -193,6 +193,8 @@ class StateGroupBackgroundUpdateStore(SQLBaseStore):
         else:
             max_entries_returned = state_filter.max_entries_returned()
 
+            where_clause, where_args = state_filter.make_sql_filter_clause()
+
             # We don't use WITH RECURSIVE on sqlite3 as there are distributions
             # that ship with an sqlite3 version that doesn't support it (e.g. wheezy)
             for group in groups:

--- a/synapse/storage/databases/state/bg_updates.py
+++ b/synapse/storage/databases/state/bg_updates.py
@@ -160,9 +160,6 @@ class StateGroupBackgroundUpdateStore(SQLBaseStore):
                     ORDER BY type, state_key, state_group DESC
                 """
 
-            logger.info("overall_select_clause=%s", overall_select_clause)
-            logger.info("overall_select_query_args=%s", overall_select_query_args)
-
             for group in groups:
                 args: List[Union[int, str]] = [group]
                 args.extend(overall_select_query_args)

--- a/synapse/storage/databases/state/bg_updates.py
+++ b/synapse/storage/databases/state/bg_updates.py
@@ -152,18 +152,18 @@ class StateGroupBackgroundUpdateStore(SQLBaseStore):
 
                     select_clause_list.append(
                         f"""
-                        SELECT DISTINCT ON (type, state_key)
-                            type, state_key, event_id
-                        FROM state_groups_state
-                        INNER JOIN sgs USING (state_group)
-                        WHERE {where_clause}
-                        ORDER BY type, state_key, state_group DESC
+                        (
+                            SELECT DISTINCT ON (type, state_key)
+                                type, state_key, event_id
+                            FROM state_groups_state
+                            INNER JOIN sgs USING (state_group)
+                            WHERE {where_clause}
+                            ORDER BY type, state_key, state_group DESC
+                        )
                         """
                     )
 
-                overall_select_clause = (
-                    "(" + (") UNION (".join(select_clause_list)) + ")"
-                )
+                overall_select_clause = " UNION ".join(select_clause_list)
             else:
                 where_clause, where_args = state_filter.make_sql_filter_clause()
                 # Unless the filter clause is empty, we're going to append it after an


### PR DESCRIPTION
Optimize `filter_events_for_client` for faster `/messages`. Seems like it will make it a magnitude faster. As discussed at https://github.com/matrix-org/synapse/pull/14494#discussion_r1028806102 (which was a v1 of this PR)

Fix https://github.com/matrix-org/synapse/issues/14108

Part of https://github.com/matrix-org/synapse/issues/13356#issuecomment-1272149596




### Dev notes

Previous optimizations:

 - https://github.com/matrix-org/synapse/pull/7567
 - A v1 attempt of this PR: https://github.com/matrix-org/synapse/pull/14494

---

Grabbing all of the state via `get_state_for_events` is the longest part of `filter_events_for_client`

 - `filter_events_for_client`
    - `get_state_for_events`
        - `get_state_group_for_events`
           -  `_get_state_group_for_events`
        - `_get_state_for_groups`
            - `_get_state_for_groups_using_cache`
            - `_get_state_groups_from_groups` 🐢
                - `_get_state_groups_from_groups_txn` (`db._get_state_groups_from_groups`)
        - `get_events`
            - ...

Of all the state we grab in `filter_events_for_client`, we only ever use `EventTypes.RoomHistoryVisibility` and `EventTypes.Member` from it

 - `filter_events_for_client`
 - `_check_client_allowed_to_see_event`
    - `_check_filter_send_to_client`
        - ->Uses no `state`
    - `get_effective_room_visibility_from_state`
        - -> `EventTypes.RoomHistoryVisibility` 🎈
    - `_check_history_visibility`
        - -> Uses `visibility` result from above
    - `_check_membership`
        - -> Uses `visibility` result from above
        - -> `EventTypes.Member` 🎈


---

Relevant database tables:

 - `state_groups`
 - `state_groups_state`
 - `state_group_edges`
 - `event_to_state_groups`

Docs:

 - [`docs/development/room-dag-concepts.md`](https://github.com/matrix-org/synapse/blob/e1b15f25f3ad4b45b381544ca6b3cd2caf43d25d/docs/development/room-dag-concepts.md)
 - [`docs/usage/administration/state_groups.md`](https://github.com/matrix-org/synapse/blob/e1b15f25f3ad4b45b381544ca6b3cd2caf43d25d/docs/usage/administration/state_groups.md)




### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
