### PR TITLE
Faster remote room joins: invalidate caches and unblock requests when receiving un-partial-stated event notifications over replication. [rei:frrj/streams/unpsr]

### DIFF
--- a/changelog.d/14546.misc
+++ b/changelog.d/14546.misc
@@ -1,0 +1,1 @@
+Faster remote room joins: stream the un-partial-stating of events over replication.

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -36,6 +36,7 @@ from synapse.replication.tcp.streams import (
     TagAccountDataStream,
     ToDeviceStream,
     TypingStream,
+    UnPartialStatedEventStream,
     UnPartialStatedRoomStream,
 )
 from synapse.replication.tcp.streams.events import (
@@ -43,7 +44,10 @@ from synapse.replication.tcp.streams.events import (
     EventsStreamEventRow,
     EventsStreamRow,
 )
-from synapse.replication.tcp.streams.partial_state import UnPartialStatedRoomStreamRow
+from synapse.replication.tcp.streams.partial_state import (
+    UnPartialStatedEventStreamRow,
+    UnPartialStatedRoomStreamRow,
+)
 from synapse.types import PersistedEventPosition, ReadReceipt, StreamKeyType, UserID
 from synapse.util.async_helpers import Linearizer, timeout_deferred
 from synapse.util.metrics import Measure
@@ -246,6 +250,14 @@ class ReplicationDataHandler:
                 # Wake up any tasks waiting for the room to be un-partial-stated.
                 self._state_storage_controller.notify_room_un_partial_stated(
                     row.room_id
+                )
+        elif stream_name == UnPartialStatedEventStream.NAME:
+            for row in rows:
+                assert isinstance(row, UnPartialStatedEventStreamRow)
+
+                # Wake up any tasks waiting for the event to be un-partial-stated.
+                self._state_storage_controller.notify_event_un_partial_stated(
+                    row.event_id
                 )
 
         await self._presence_handler.process_replication_rows(

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -2391,6 +2391,9 @@ class EventsWorkerStore(SQLBaseStore):
 
         This can happen, for example, when resyncing state during a faster join.
 
+        It is the caller's responsibility to ensure that other workers are
+        sent a notification so that they call `_invalidate_local_get_event_cache()`.
+
         Args:
             txn:
             event_id: ID of event to update
@@ -2429,14 +2432,3 @@ class EventsWorkerStore(SQLBaseStore):
         )
 
         self.invalidate_get_event_cache_after_txn(txn, event_id)
-
-        # TODO(faster_joins): invalidate the cache on workers. Ideally we'd just
-        #   call '_send_invalidation_to_replication', but we actually need the other
-        #   end to call _invalidate_local_get_event_cache() rather than (just)
-        #   _get_event_cache.invalidate().
-        #
-        #   One solution might be to (somehow) get the workers to call
-        #   _invalidate_caches_for_event() (though that will invalidate more than
-        #   strictly necessary).
-        #
-        #   https://github.com/matrix-org/synapse/issues/12994

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -396,7 +396,7 @@ class EventsWorkerStore(SQLBaseStore):
             for row in rows:
                 assert isinstance(row, UnPartialStatedEventStreamRow)
 
-                self.is_partial_state_event.invalidate(row.event_id)
+                self.is_partial_state_event.invalidate((row.event_id,))
 
                 if row.rejection_status_changed:
                     # If the partial-stated event became rejected or unrejected


### PR DESCRIPTION
Fixes: caches not being invalidated, requests not being unblocked — no issue as such — though #14418 heavily hints at it. <!-- -->
<!--
Supersedes: # <!-- -->
Follows: #14545 <!-- -->
Part of: #12994 <!-- -->
Base: `rei/frrj_streams_unps_events`

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Process received rows by invalidating caches and notifying 

</li>
<li>

Update comment about notifying cache changes on workers when changing rejection status 

</li>
</ol>

<!---GHSTACKOPEN-->
### Stacked PR Chain: rei:frrj/streams/unpsr
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#14473|Faster remote room joins: stream the un-partial-stating of rooms over replication.|![](https://img.shields.io/github/pulls/detail/state/matrix-org/synapse/14473?label=Pending)|-|
|#14474|Faster remote room joins: unblock tasks waiting for full room state when the un-partial-stating of that room is received over the replication stream.|![](https://img.shields.io/github/pulls/detail/state/matrix-org/synapse/14474?label=Pending)|#14473|
|#14545|Faster remote room joins: stream the un-partial-stating of events over replication.|![](https://img.shields.io/github/pulls/detail/state/matrix-org/synapse/14545?label=Pending)|#14474|
|#14546|👉 Faster remote room joins: invalidate caches and unblock requests when receiving un-partial-stated event notifications over replication.|![](https://img.shields.io/github/pulls/detail/state/matrix-org/synapse/14546?label=Pending)|#14545|
<!---GHSTACKCLOSE-->
