### PR TITLE
Fix unit test configuration settings for pusher workers.

### DIFF
--- a/changelog.d/14553.misc
+++ b/changelog.d/14553.misc
@@ -1,0 +1,1 @@
+Update unit test configuration for pusher workers.

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -66,7 +66,6 @@ class EmailPusherTests(HomeserverTestCase):
             "riot_base_url": None,
         }
         config["public_baseurl"] = "http://aaa"
-        config["start_pushers"] = True
 
         hs = self.setup_test_homeserver(config=config)
 

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -43,7 +43,6 @@ class HTTPPusherTests(HomeserverTestCase):
 
     def default_config(self) -> Dict[str, Any]:
         config = super().default_config()
-        config["start_pushers"] = True
         return config
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -20,6 +20,7 @@ from synapse.rest import admin
 from synapse.rest.client import login, room
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase
+from tests.unittest import override_config
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,10 @@ class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
 
         return event_id
 
+    # Pusher functionality is active on the main process by default. Disable that by
+    # explicitly overriding what 'pusher_instances' will be available so
+    # ShardedWorkerHandlingConfig will be filled out correctly.
+    @override_config({"pusher_instances": ["pusher1"]})
     def test_send_push_single_worker(self):
         """Test that registration works when using a pusher worker."""
         http_client_mock = Mock(spec_set=["post_json_get_json"])
@@ -116,6 +121,10 @@ class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
             ],
         )
 
+    # Pusher functionality is active on the main process by default. Disable that by
+    # explicitly overriding what 'pusher_instances' will be available so
+    # ShardedWorkerHandlingConfig will be filled out correctly.
+    @override_config({"pusher_instances": ["pusher1", "pusher2"]})
     def test_send_push_multiple_workers(self):
         """Test that registration works when using sharded pusher workers."""
         http_client_mock1 = Mock(spec_set=["post_json_get_json"])

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -40,7 +40,6 @@ class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
 
     def default_config(self):
         conf = super().default_config()
-        conf["start_pushers"] = False
         return conf
 
     def _create_pusher_and_send_msg(self, localpart):
@@ -92,8 +91,11 @@ class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
         )
 
         self.make_worker_hs(
-            "synapse.app.pusher",
-            {"start_pushers": False},
+            "synapse.app.generic_worker",
+            {
+                "worker_name": "pusher1",
+                "pusher_instances": ["pusher1"],
+            },
             proxied_blacklisted_http_client=http_client_mock,
         )
 
@@ -122,9 +124,8 @@ class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
         )
 
         self.make_worker_hs(
-            "synapse.app.pusher",
+            "synapse.app.generic_worker",
             {
-                "start_pushers": True,
                 "worker_name": "pusher1",
                 "pusher_instances": ["pusher1", "pusher2"],
             },
@@ -137,9 +138,8 @@ class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
         )
 
         self.make_worker_hs(
-            "synapse.app.pusher",
+            "synapse.app.generic_worker",
             {
-                "start_pushers": True,
                 "worker_name": "pusher2",
                 "pusher_instances": ["pusher1", "pusher2"],
             },


### PR DESCRIPTION
### Update settings for unit tests

Just what it says it on the tin. The setting `start_pushers` is no longer necessary when using `pusher_instances`.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>