### PR TITLE
Fix unit test configuration settings for federation sender workers

### DIFF
--- a/changelog.d/14554.misc
+++ b/changelog.d/14554.misc
@@ -1,0 +1,1 @@
+Update unit test configuration for federation sending workers.

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -162,7 +162,9 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
                     },
                 }
             },
-            "send_federation": True,
+            # default test case disables federation sending. Setting this to None turns
+            # it back on for the main process.
+            "federation_sender_instances": None,
         }
     )
     def test_receiving_all_presence_legacy(self):
@@ -180,7 +182,9 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
                     },
                 },
             ],
-            "send_federation": True,
+            # default test case disables federation sending. Setting this to None turns
+            # it back on for the main process.
+            "federation_sender_instances": None,
         }
     )
     def test_receiving_all_presence(self):
@@ -290,7 +294,9 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
                     },
                 }
             },
-            "send_federation": True,
+            # default test case disables federation sending. Setting this to None turns
+            # it back on for the main process.
+            "federation_sender_instances": None,
         }
     )
     def test_send_local_online_presence_to_with_module_legacy(self):
@@ -310,7 +316,9 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
                     },
                 },
             ],
-            "send_federation": True,
+            # default test case disables federation sending. Setting this to None turns
+            # it back on for the main process.
+            "federation_sender_instances": None,
         }
     )
     def test_send_local_online_presence_to_with_module(self):

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -79,7 +79,9 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
         )[0]
         return {"event_id": event_id, "stream_ordering": stream_ordering}
 
-    @override_config({"send_federation": True})
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})
     def test_catch_up_destination_rooms_tracking(self):
         """
         Tests that we populate the `destination_rooms` table as needed.
@@ -105,7 +107,9 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
         self.assertEqual(row_2["event_id"], event_id_2)
         self.assertEqual(row_1["stream_ordering"], row_2["stream_ordering"] - 1)
 
-    @override_config({"send_federation": True})
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})
     def test_catch_up_last_successful_stream_ordering_tracking(self):
         """
         Tests that we populate the `destination_rooms` table as needed.
@@ -163,7 +167,9 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
             "Send succeeded but not marked as last_successful_stream_ordering",
         )
 
-    @override_config({"send_federation": True})  # critical to federate
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})  # critical to federate
     def test_catch_up_from_blank_state(self):
         """
         Runs an overall test of federation catch-up from scratch.
@@ -260,7 +266,9 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
 
         return per_dest_queue, results_list
 
-    @override_config({"send_federation": True})
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})
     def test_catch_up_loop(self):
         """
         Tests the behaviour of _catch_up_transmission_loop.
@@ -325,7 +333,9 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
             event_5.internal_metadata.stream_ordering,
         )
 
-    @override_config({"send_federation": True})
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})
     def test_catch_up_on_synapse_startup(self):
         """
         Tests the behaviour of get_catch_up_outstanding_destinations and
@@ -424,7 +434,9 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
         # - all destinations are woken exactly once; they appear once in woken.
         self.assertCountEqual(woken, server_names[:-1])
 
-    @override_config({"send_federation": True})
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})
     def test_not_latest_event(self):
         """Test that we send the latest event in the room even if its not ours."""
 

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -40,7 +40,9 @@ class FederationSenderReceiptsTestCases(HomeserverTestCase):
 
         return hs
 
-    @override_config({"send_federation": True})
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})
     def test_send_receipts(self):
         mock_send_transaction = (
             self.hs.get_federation_transport_client().send_transaction
@@ -83,7 +85,9 @@ class FederationSenderReceiptsTestCases(HomeserverTestCase):
             ],
         )
 
-    @override_config({"send_federation": True})
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})
     def test_send_receipts_with_backoff(self):
         """Send two receipts in quick succession; the second should be flushed, but
         only after 20ms"""
@@ -184,7 +188,9 @@ class FederationSenderDevicesTestCases(HomeserverTestCase):
 
     def default_config(self):
         c = super().default_config()
-        c["send_federation"] = True
+        # default test case disables federation sending. Setting this to None turns it
+        # back on for the main process.
+        c["federation_sender_instances"] = None
         return c
 
     def prepare(self, reactor, clock, hs):

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -992,7 +992,9 @@ class PresenceJoinTestCase(unittest.HomeserverTestCase):
 
     def default_config(self):
         config = super().default_config()
-        config["send_federation"] = True
+        # default test case disables federation sending. Setting this to None turns it
+        # back on for the main process.
+        config["federation_sender_instances"] = None
         return config
 
     def prepare(self, reactor, clock, hs):

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -200,7 +200,9 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
             ],
         )
 
-    @override_config({"send_federation": True})
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})
     def test_started_typing_remote_send(self) -> None:
         self.room_members = [U_APPLE, U_ONION]
 
@@ -305,7 +307,9 @@ class TypingNotificationsTestCase(unittest.HomeserverTestCase):
         self.assertEqual(events[0], [])
         self.assertEqual(events[1], 0)
 
-    @override_config({"send_federation": True})
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})
     def test_stopped_typing(self) -> None:
         self.room_members = [U_APPLE, U_BANANA, U_ONION]
 

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -336,7 +336,9 @@ class ModuleApiTestCase(HomeserverTestCase):
         # Test sending local online presence to users from the main process
         _test_sending_local_online_presence_to_local_user(self, test_with_workers=False)
 
-    @override_config({"send_federation": True})
+    # default test case disables federation sending. Setting this to None turns it back
+    # on for the main process.
+    @override_config({"federation_sender_instances": None})
     def test_send_local_online_presence_to_federation(self):
         """Tests that send_local_presence_to_users sends local online presence to remote users."""
         # Create a user who will send presence updates

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -307,7 +307,7 @@ class BaseMultiWorkerStreamTestCase(unittest.HomeserverTestCase):
         stream to the master HS.
 
         Args:
-            worker_app: Type of worker, e.g. `synapse.app.federation_sender`.
+            worker_app: Type of worker, e.g. `synapse.app.generic_worker`.
             extra_config: Any extra config to use for this instances.
             **kwargs: Options that get passed to `self.setup_test_homeserver`,
                 useful to e.g. pass some mocks for things like `federation_http_client`

--- a/tests/replication/tcp/streams/test_federation.py
+++ b/tests/replication/tcp/streams/test_federation.py
@@ -22,9 +22,9 @@ class FederationStreamTestCase(BaseStreamTestCase):
     def _get_worker_hs_config(self) -> dict:
         # enable federation sending on the worker
         config = super()._get_worker_hs_config()
-        # TODO: make it so we don't need both of these
-        config["send_federation"] = False
-        config["worker_app"] = "synapse.app.federation_sender"
+        # 'synapse.app.generic_worker' is declared in 'super()'
+        # workers with no name default to whatever is in 'worker_app'
+        config["federation_sender_instances"] = ["synapse.app.generic_worker"]
         return config
 
     def test_catchup(self):

--- a/tests/replication/test_federation_ack.py
+++ b/tests/replication/test_federation_ack.py
@@ -25,8 +25,9 @@ from tests.unittest import HomeserverTestCase
 class FederationAckTestCase(HomeserverTestCase):
     def default_config(self) -> dict:
         config = super().default_config()
-        config["worker_app"] = "synapse.app.federation_sender"
-        config["send_federation"] = False
+        config["worker_app"] = "synapse.app.generic_worker"
+        # workers with no name default to whatever is in 'worker_app'
+        config["federation_sender_instances"] = ["synapse.app.generic_worker"]
         return config
 
     def make_homeserver(self, reactor, clock):

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -35,7 +35,10 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
 
     def default_config(self):
         conf = super().default_config()
-        conf["send_federation"] = False
+        # default test case disables federation sending. This is duplicated here to
+        # assert that it is disabled and will be enabled explicitly below for each test
+        # case.
+        conf["federation_sender_instances"] = {}
         return conf
 
     def test_send_event_single_sender(self):

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -46,8 +46,11 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
         mock_client.put_json.return_value = make_awaitable({})
 
         self.make_worker_hs(
-            "synapse.app.federation_sender",
-            {"send_federation": False},
+            "synapse.app.generic_worker",
+            {
+                "worker_name": "sender1",
+                "federation_sender_instances": ["sender1"],
+            },
             federation_http_client=mock_client,
         )
 
@@ -73,9 +76,8 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
         mock_client1 = Mock(spec=["put_json"])
         mock_client1.put_json.return_value = make_awaitable({})
         self.make_worker_hs(
-            "synapse.app.federation_sender",
+            "synapse.app.generic_worker",
             {
-                "send_federation": True,
                 "worker_name": "sender1",
                 "federation_sender_instances": ["sender1", "sender2"],
             },
@@ -85,9 +87,8 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
         mock_client2 = Mock(spec=["put_json"])
         mock_client2.put_json.return_value = make_awaitable({})
         self.make_worker_hs(
-            "synapse.app.federation_sender",
+            "synapse.app.generic_worker",
             {
-                "send_federation": True,
                 "worker_name": "sender2",
                 "federation_sender_instances": ["sender1", "sender2"],
             },
@@ -136,9 +137,8 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
         mock_client1 = Mock(spec=["put_json"])
         mock_client1.put_json.return_value = make_awaitable({})
         self.make_worker_hs(
-            "synapse.app.federation_sender",
+            "synapse.app.generic_worker",
             {
-                "send_federation": True,
                 "worker_name": "sender1",
                 "federation_sender_instances": ["sender1", "sender2"],
             },
@@ -148,9 +148,8 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
         mock_client2 = Mock(spec=["put_json"])
         mock_client2.put_json.return_value = make_awaitable({})
         self.make_worker_hs(
-            "synapse.app.federation_sender",
+            "synapse.app.generic_worker",
             {
-                "send_federation": True,
                 "worker_name": "sender2",
                 "federation_sender_instances": ["sender1", "sender2"],
             },

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -38,7 +38,7 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
         # default test case disables federation sending. This is duplicated here to
         # assert that it is disabled and will be enabled explicitly below for each test
         # case.
-        conf["federation_sender_instances"] = {}
+        conf["federation_sender_instances"] = []
         return conf
 
     def test_send_event_single_sender(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -125,7 +125,7 @@ def default_config(
     """
     config_dict = {
         "server_name": name,
-        "send_federation": False,
+        "federation_sender_instances": [],
         "media_store_path": "media",
         # the test signing key is just an arbitrary ed25519 key to keep the config
         # parser happy


### PR DESCRIPTION
### Update settings for unit tests

Does what it says on the tin. `send_federation` isn't necessary if using `federation_sender_instances`.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>