### PR TITLE
[POC Do-not-merge] Show concept

### DIFF
--- a/changelog.d/14570.misc
+++ b/changelog.d/14570.misc
@@ -1,0 +1,1 @@
+Something boring, doesn't matter this is getting closed.

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -52,6 +52,7 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
     def default_config(self):
         conf = super().default_config()
         conf["federation_custom_ca_list"] = [get_test_ca_cert_file()]
+        conf["enable_media_repo"] = False
         return conf
 
     def _get_media_req(
@@ -124,7 +125,7 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
 
     def test_basic(self):
         """Test basic fetching of remote media from a single worker."""
-        hs1 = self.make_worker_hs("synapse.app.generic_worker")
+        hs1 = self.make_worker_hs("synapse.app.media_repository")
 
         channel, request = self._get_media_req(hs1, "example.com:443", "ABC123")
 
@@ -142,8 +143,8 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
         """Test that fetching remote media from two different processes at the
         same time works.
         """
-        hs1 = self.make_worker_hs("synapse.app.generic_worker")
-        hs2 = self.make_worker_hs("synapse.app.generic_worker")
+        hs1 = self.make_worker_hs("synapse.app.media_repository")
+        hs2 = self.make_worker_hs("synapse.app.media_repository")
 
         start_count = self._count_remote_media()
 
@@ -183,8 +184,8 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
 
         This checks that races generating thumbnails are handled correctly.
         """
-        hs1 = self.make_worker_hs("synapse.app.generic_worker")
-        hs2 = self.make_worker_hs("synapse.app.generic_worker")
+        hs1 = self.make_worker_hs("synapse.app.media_repository")
+        hs2 = self.make_worker_hs("synapse.app.media_repository")
 
         start_count = self._count_remote_thumbnails()
 


### PR DESCRIPTION
### This is what I mean

If these tests are changed to reflect what both the docs and the source say to do for a media repository worker

Relevant source code points:
1. (Mostly for the comment)
https://github.com/matrix-org/synapse/blob/09de2aecb05cb46e0513396e2675b24c8beedb68/synapse/config/server.py#L350-L354
2. https://github.com/matrix-org/synapse/blob/09de2aecb05cb46e0513396e2675b24c8beedb68/synapse/config/repository.py#L120-L130

### Pull Request Checklist
<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
