### PR TITLE
Fix logging context warnings due to common usage metrics setup

### DIFF
--- a/changelog.d/14574.bugfix
+++ b/changelog.d/14574.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.67.0 where two logging context warnings would be logged on startup.

--- a/synapse/metrics/common_usage_metrics.py
+++ b/synapse/metrics/common_usage_metrics.py
@@ -54,7 +54,9 @@ class CommonUsageMetricsManager:
 
     async def setup(self) -> None:
         """Keep the gauges for common usage metrics up to date."""
-        await self._update_gauges()
+        run_as_background_process(
+            desc="common_usage_metrics_update_gauges", func=self._update_gauges
+        )
         self._clock.looping_call(
             run_as_background_process,
             5 * 60 * 1000,


### PR DESCRIPTION
`setup()` is run under the sentinel context manager, so we wrap the
initial update in a background process. Before this change, Synapse
would log two warnings on startup:
    Starting db txn 'count_daily_users' from sentinel context
    Starting db connection from sentinel context: metrics will be lost

Signed-off-by: Sean Quah <seanq@matrix.org>

---

Noticed while debugging complement flakes.