### PR TITLE
Fix possible variable shadow in `create_new_client_event`

### DIFF
--- a/changelog.d/14575.misc
+++ b/changelog.d/14575.misc
@@ -1,0 +1,1 @@
+Fix a possible variable shadow in `create_new_client_event`.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1135,7 +1135,9 @@ class EventCreationHandler:
             )
             state_events = await self.store.get_events_as_list(state_event_ids)
             # Create a StateMap[str]
-            current_state_ids = {(e.type, e.state_key): e.event_id for e in state_events}
+            current_state_ids = {
+                (e.type, e.state_key): e.event_id for e in state_events
+            }
             # Actually strip down and only use the necessary auth events
             auth_event_ids = self._event_auth_handler.compute_auth_events(
                 event=temp_event,

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1135,11 +1135,11 @@ class EventCreationHandler:
             )
             state_events = await self.store.get_events_as_list(state_event_ids)
             # Create a StateMap[str]
-            state_map = {(e.type, e.state_key): e.event_id for e in state_events}
+            current_state_ids = {(e.type, e.state_key): e.event_id for e in state_events}
             # Actually strip down and only use the necessary auth events
             auth_event_ids = self._event_auth_handler.compute_auth_events(
                 event=temp_event,
-                current_state_ids=state_map,
+                current_state_ids=current_state_ids,
                 for_verification=False,
             )
 


### PR DESCRIPTION
This PR renames a variable in `create_new_client_event` which potentially clashes with a same-named parameter of the function. It seems unlikely that they would clash but I figured it should be fixed just in case as the fix is easy. 