### PR TITLE
Advertise support for Matrix v1.5.

### DIFF
--- a/changelog.d/14576.feature
+++ b/changelog.d/14576.feature
@@ -1,0 +1,1 @@
+Advertise support for Matrix 1.5 on `/_matrix/client/versions`.

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -77,6 +77,7 @@ class VersionsRestServlet(RestServlet):
                     "v1.2",
                     "v1.3",
                     "v1.4",
+                    "v1.5",
                 ],
                 # as per MSC1497:
                 "unstable_features": {


### PR DESCRIPTION
Fixes #14486, see https://matrix.org/blog/2022/11/17/matrix-v-1-5-release. I think everything is supported here so this isn't much to do.