### PR TITLE
Improve logging and opentracing for to-device message handling

### DIFF
--- a/changelog.d/14598.feature
+++ b/changelog.d/14598.feature
@@ -1,0 +1,1 @@
+Improve opentracing and logging for to-device message handling.

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -230,6 +230,9 @@ class EventContentFields:
     # The authorising user for joining a restricted room.
     AUTHORISING_USER: Final = "join_authorised_via_users_server"
 
+    # an unspecced field added to to-device messages to identify them uniquely-ish
+    TO_DEVICE_MSGID: Final = "org.matrix.msgid"
+
 
 class RoomTypes:
     """Understood values of the room_type field of m.room.create events."""

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -641,7 +641,7 @@ class PerDestinationQueue:
             if not message_id:
                 continue
 
-            set_tag(SynapseTags.TO_DEVICE_MESSAGE_ID, message_id)
+            set_tag(SynapseTags.TO_DEVICE_EDU_ID, message_id)
 
         edus = [
             Edu(

--- a/synapse/handlers/appservice.py
+++ b/synapse/handlers/appservice.py
@@ -578,9 +578,6 @@ class ApplicationServicesHandler:
             device_id,
         ), messages in recipient_device_to_messages.items():
             for message_json in messages:
-                # Remove 'message_id' from the to-device message, as it's an internal ID
-                message_json.pop("message_id", None)
-
                 message_payload.append(
                     {
                         "to_user_id": user_id,

--- a/synapse/handlers/devicemessage.py
+++ b/synapse/handlers/devicemessage.py
@@ -216,9 +216,6 @@ class DeviceMessageHandler:
         """
         sender_user_id = requester.user.to_string()
 
-        message_id = random_string(16)
-        set_tag(SynapseTags.TO_DEVICE_MESSAGE_ID, message_id)
-
         log_kv({"number_of_to_device_messages": len(messages)})
         set_tag("sender", sender_user_id)
         local_messages = {}
@@ -247,7 +244,6 @@ class DeviceMessageHandler:
                         "content": message_content,
                         "type": message_type,
                         "sender": sender_user_id,
-                        "message_id": message_id,
                     }
                     for device_id, message_content in by_device.items()
                 }
@@ -267,7 +263,11 @@ class DeviceMessageHandler:
 
         remote_edu_contents = {}
         for destination, messages in remote_messages.items():
-            log_kv({"destination": destination})
+            # The EDU contains a "message_id" property which is used for
+            # idempotence. Make up a random one.
+            message_id = random_string(16)
+            log_kv({"destination": destination, "message_id": message_id})
+
             remote_edu_contents[destination] = {
                 "messages": messages,
                 "sender": sender_user_id,

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1602,13 +1602,6 @@ class SyncHandler:
                 user_id, device_id, since_stream_id, now_token.to_device_key
             )
 
-            for message in messages:
-                # We pop here as we shouldn't be sending the message ID down
-                # `/sync`
-                message_id = message.pop("message_id", None)
-                if message_id:
-                    set_tag(SynapseTags.TO_DEVICE_MESSAGE_ID, message_id)
-
             logger.debug(
                 "Returning %d to-device messages between %d and %d (current token: %d)",
                 len(messages),

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -292,8 +292,8 @@ logger = logging.getLogger(__name__)
 
 
 class SynapseTags:
-    # The message ID of any to_device message processed
-    TO_DEVICE_MESSAGE_ID = "to_device.message_id"
+    # The message ID of any to_device EDU processed
+    TO_DEVICE_EDU_ID = "to_device.edu_id"
 
     # Whether the sync response has new data to be returned to the client.
     SYNC_RESULT = "sync.new_data"

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -295,6 +295,13 @@ class SynapseTags:
     # The message ID of any to_device EDU processed
     TO_DEVICE_EDU_ID = "to_device.edu_id"
 
+    # Details about to-device messages
+    TO_DEVICE_TYPE = "to_device.type"
+    TO_DEVICE_SENDER = "to_device.sender"
+    TO_DEVICE_RECIPIENT = "to_device.recipient"
+    TO_DEVICE_RECIPIENT_DEVICE = "to_device.recipient_device"
+    TO_DEVICE_MSGID = "to_device.msgid"  # client-generated ID
+
     # Whether the sync response has new data to be returned to the client.
     SYNC_RESULT = "sync.new_data"
 

--- a/synapse/rest/client/sendtodevice.py
+++ b/synapse/rest/client/sendtodevice.py
@@ -46,7 +46,6 @@ class SendToDeviceRestServlet(servlet.RestServlet):
     def on_PUT(
         self, request: SynapseRequest, message_type: str, txn_id: str
     ) -> Awaitable[Tuple[int, JsonDict]]:
-        set_tag("message_type", message_type)
         set_tag("txn_id", txn_id)
         return self.txns.fetch_or_execute_request(
             request, self._put, request, message_type, txn_id

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -26,8 +26,15 @@ from typing import (
     cast,
 )
 
+from synapse.api.constants import EventContentFields
 from synapse.logging import issue9533_logger
-from synapse.logging.opentracing import log_kv, set_tag, trace
+from synapse.logging.opentracing import (
+    SynapseTags,
+    log_kv,
+    set_tag,
+    start_active_span,
+    trace,
+)
 from synapse.replication.tcp.streams import ToDeviceStream
 from synapse.storage._base import SQLBaseStore, db_to_json
 from synapse.storage.database import (
@@ -678,12 +685,35 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                 ],
             )
 
-            if remote_messages_by_destination:
-                issue9533_logger.debug(
-                    "Queued outgoing to-device messages with stream_id %i for %s",
-                    stream_id,
-                    list(remote_messages_by_destination.keys()),
-                )
+            for destination, edu in remote_messages_by_destination.items():
+                if issue9533_logger.isEnabledFor(logging.DEBUG):
+                    issue9533_logger.debug(
+                        "Queued outgoing to-device messages with "
+                        "stream_id %i, EDU message_id %s, type %s for %s: %s",
+                        stream_id,
+                        edu["message_id"],
+                        edu["type"],
+                        destination,
+                        [
+                            f"{user_id}/{device_id} (msgid "
+                            f"{msg.get(EventContentFields.TO_DEVICE_MSGID)})"
+                            for (user_id, messages_by_device) in edu["messages"].items()
+                            for (device_id, msg) in messages_by_device.items()
+                        ],
+                    )
+
+                for (user_id, messages_by_device) in edu["messages"].items():
+                    for (device_id, msg) in messages_by_device.items():
+                        with start_active_span("store_outgoing_to_device_message"):
+                            set_tag(SynapseTags.TO_DEVICE_EDU_ID, edu["sender"])
+                            set_tag(SynapseTags.TO_DEVICE_EDU_ID, edu["message_id"])
+                            set_tag(SynapseTags.TO_DEVICE_TYPE, edu["type"])
+                            set_tag(SynapseTags.TO_DEVICE_RECIPIENT, user_id)
+                            set_tag(SynapseTags.TO_DEVICE_RECIPIENT_DEVICE, device_id)
+                            set_tag(
+                                SynapseTags.TO_DEVICE_MSGID,
+                                msg.get(EventContentFields.TO_DEVICE_MSGID),
+                            )
 
         async with self._device_inbox_id_gen.get_next() as stream_id:
             now_ms = self._clock.time_msec()

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -404,6 +404,17 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                     (recipient_user_id, recipient_device_id), []
                 ).append(message_dict)
 
+                # start a new span for each message, so that we can tag each separately
+                with start_active_span("get_to_device_message"):
+                    set_tag(SynapseTags.TO_DEVICE_TYPE, message_dict["type"])
+                    set_tag(SynapseTags.TO_DEVICE_SENDER, message_dict["sender"])
+                    set_tag(SynapseTags.TO_DEVICE_RECIPIENT, recipient_user_id)
+                    set_tag(SynapseTags.TO_DEVICE_RECIPIENT_DEVICE, recipient_device_id)
+                    set_tag(
+                        SynapseTags.TO_DEVICE_MSGID,
+                        message_dict["content"].get(EventContentFields.TO_DEVICE_MSGID),
+                    )
+
             if limit is not None and rowcount == limit:
                 # We ended up bumping up against the message limit. There may be more messages
                 # to retrieve. Return what we have, as well as the last stream position that

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -765,7 +765,12 @@ class ApplicationServicesHandlerSendEventsTestCase(unittest.HomeserverTestCase):
         fake_device_ids = [f"device_{num}" for num in range(number_of_messages - 1)]
         messages = {
             self.exclusive_as_user: {
-                device_id: to_device_message_content for device_id in fake_device_ids
+                device_id: {
+                    "type": "test_to_device_message",
+                    "sender": "@some:sender",
+                    "content": to_device_message_content,
+                }
+                for device_id in fake_device_ids
             }
         }
 


### PR DESCRIPTION
A batch of changes intended to make it easier to trace to-device messages through the system.

The intention here is that a client can set a property `org.matrix.msgid` in any to-device message it sends. That ID is then included in any tracing or logging related to the message.  (Suggestions as to where this field should be documented welcome. I'm not enthusiastic about speccing it - it's very much an optional extra to help with debugging.)

I've also generally improved the data we send to opentracing for these messages.

Suggest reviewing commit-by-commit.

Part of https://github.com/vector-im/element-meta/issues/558.

## Example logs and traces

If you know the message id (eg, from a client rageshake), the Jaeger spans can be found by searching for a tag such as `to_device.msgid=8ea835d3-0470-4f74-aa75-9ccd2521f194`. To find interesting `/sync` spans, search for the `get_to_device_message` operation.

### Sending a to-device message to a remote user

```
2022-12-02 14:51:48,115 - synapse.9533_debug - 701 - DEBUG - PUT-20---- - Queued outgoing to-device messages with stream_id 2, EDU message_id PQklhsydWZbQFrDI, type m.room.encrypted for localhost:8482: ['@testuser82:localhost:8482/QSEDQLTFJA (msgid 8ea835d3-0470-4f74-aa75-9ccd2521f194)']
2022-12-02 14:51:48,118 - synapse.9533_debug - 466 - DEBUG - PUT-20 - to-device messages stream id 2, awaking streams for []
2022-12-02 14:51:48,121 - synapse.access.http.8081 - 460 - INFO - PUT-20 - 127.0.0.1 - 8081 - {@testuser81:localhost:8481} Processed request: 0.009sec/0.002sec (0.001sec, 0.000sec) (0.001sec/0.005sec/1) 2B 200 "PUT /_matrix/client/r0/sendToDevice/m.room.encrypted/m1669992708036.3 HTTP/1.1" "Mozilla/5.0 (X11; Linux x86_64; rv:106.0) Gecko/20100101 Firefox/106.0" [0 dbevts]
```

![image](https://user-images.githubusercontent.com/1389908/205320602-e833c99d-a801-48af-916e-130d357fd0d1.png)

### Receiving a to-device message over federation

```
2022-12-02 14:51:48,281 - synapse.federation.transport.server.federation - 103 - INFO - PUT-13- - Received txn 1669992689396 from localhost:8481. (PDUs: 0, EDUs: 1)
2022-12-02 14:51:48,290 - synapse.9533_debug - 878 - DEBUG - PUT-13------ - Stored to-device messages with stream_id 7: ['@testuser82:localhost:8482/QSEDQLTFJA (msgid 8ea835d3-0470-4f74-aa75-9ccd2521f194)']
2022-12-02 14:51:48,292 - synapse.9533_debug - 466 - DEBUG - PUT-13--- - to-device messages stream id 7, awaking streams for dict_keys(['@testuser82:localhost:8482'])
2022-12-02 14:51:48,304 - synapse.access.https.8482 - 460 - INFO - PUT-13 - ::ffff:127.0.0.1 - 8482 - {localhost:8481} Processed request: 0.129sec/0.001sec (0.008sec, 0.000sec) (0.002sec/0.012sec/3) 11B 200 "PUT /_matrix/federation/v1/send/1669992689396 HTTP/1.1" "Synapse/1.73.0rc2" [0 dbevts]
```

![image](https://user-images.githubusercontent.com/1389908/205320941-5918ea4c-121b-407b-bf70-a4f5e064cc25.png)

### Sending a to-device message to a user over /sync

![image](https://user-images.githubusercontent.com/1389908/205321121-7c398e45-dbb4-424e-b16a-8dc0e5c1d636.png)

