### PR TITLE
Unit tests CI speedup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,7 +224,7 @@ jobs:
         if: ${{ matrix.job.postgres-version }}
         timeout-minutes: 2
         run: until pg_isready -h localhost; do sleep 1; done
-      - run: poetry run trial --jobs=2 tests
+      - run: poetry run trial --jobs=6 tests
         env:
           SYNAPSE_POSTGRES: ${{ matrix.job.database == 'postgres' || '' }}
           SYNAPSE_POSTGRES_HOST: /var/run/postgresql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,8 +197,10 @@ jobs:
       - run: sudo apt-get -qq install xmlsec1
       - name: Set up PostgreSQL ${{ matrix.job.postgres-version }}
         if: ${{ matrix.job.postgres-version }}
+        # 1. Mount postgres data files onto a tmpfs in-memory filesystem to reduce overhead of docker's overlayfs layer.
         run: |
           docker run -d -p 5432:5432 \
+            --tmpfs /var/lib/postgres:rw,size=6144m \
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
             postgres:${{ matrix.job.postgres-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -296,7 +296,7 @@ jobs:
           python-version: '3.7'
           extras: "all test"
 
-      - run: poetry run trial -j2 tests
+      - run: poetry run trial -j6 tests
       - name: Dump logs
         # Logs are most useful when the command fails, always include them.
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -198,9 +198,11 @@ jobs:
       - name: Set up PostgreSQL ${{ matrix.job.postgres-version }}
         if: ${{ matrix.job.postgres-version }}
         # 1. Mount postgres data files onto a tmpfs in-memory filesystem to reduce overhead of docker's overlayfs layer.
+        # 2. Expose the unix socket for postgres. This removes latency of using docker-proxy for connections.
         run: |
           docker run -d -p 5432:5432 \
             --tmpfs /var/lib/postgres:rw,size=6144m \
+            --mount 'type=bind,src=/var/run/postgresql,dst=/var/run/postgresql' \
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
             postgres:${{ matrix.job.postgres-version }}
@@ -225,7 +227,7 @@ jobs:
       - run: poetry run trial --jobs=2 tests
         env:
           SYNAPSE_POSTGRES: ${{ matrix.job.database == 'postgres' || '' }}
-          SYNAPSE_POSTGRES_HOST: localhost
+          SYNAPSE_POSTGRES_HOST: /var/run/postgresql
           SYNAPSE_POSTGRES_USER: postgres
           SYNAPSE_POSTGRES_PASSWORD: postgres
       - name: Dump logs

--- a/changelog.d/14610.misc
+++ b/changelog.d/14610.misc
@@ -1,0 +1,1 @@
+Alter some unit test environment parameters to decrease time spent running tests.


### PR DESCRIPTION
A few small changes that allow the unit tests to exercise more of the full power of the hardware they are running on.
1. Postgres data files by default are written inside the docker container as a layer on top of the container file system. This can add up in latency if the underlaying filesystem on Github doesn't support Copy-on-write(but it probably does). Remove this abstraction layer by mounting those files on a [tmpfs](https://docs.docker.com/engine/reference/commandline/run/#mount-tmpfs---tmpfs) filesystem inside the docker instead. Bonus: tmpfs has less complex data structures and a much simpler filesystem layout, and doesn't have to deal with the added latency of a fsync operation on a(potentially) external device like a hard drive.
2. Postgres exposes a unix socket for communication by default, but it's hidden inside the docker container used by these tests on Github. Bring that out by a bind mount, then hook it up to be used by Synapse inside these tests. This will reduce latency of database requests by not using the (relatively) slower TCP stack(Interesting side fact: Linux TCP ACK's are delayed by 40ms by default). As an added complication, docker routes these TCP connections through it's 'docker-proxy' service. As an example, on a 48 core machine running the tests with -j20 and watching a htop instance running, docker-proxy sometimes reached as high as 150% of cpu time. This change makes all that extra processing time go away.
3. Increase number of test jobs running at a time. With the above changes relaxing some of the artifical software constraints, you can now do more at a time with the magic of context switching. Github actions runners use a (effectively) 2 core [Xeon Platinum 8171M CPU](https://ark.intel.com/content/www/us/en/ark/products/120506/intel-xeon-platinum-8170-processor-35-75m-cache-2-10-ghz.html). Mine are older, but a -j48 test run and watching htop showed on average about 30% of each cpu being used at any given time. Run 6 jobs at a time instead of the 2 assigned now. This actually benefits Sqlite tests in a minor way as well, since they have periods while they are essentially 'doing nothing'.

**TL;DR**: Test runs in my repo with these additions show on average 2 - 8 minute reduction time for the trial tests.

Some notes:
* [What Github says about it's runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)
* [Better details about hardware the Github runners use](https://github.com/marketplace/actions/docker-on-tmpfs#more-information) (This Github action has no use here, but contains relevant data)


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>