### PR TITLE
Handle 'go get' deprecation

### DIFF
--- a/.ci/scripts/setup_complement_prerequisites.sh
+++ b/.ci/scripts/setup_complement_prerequisites.sh
@@ -21,7 +21,7 @@ endblock
 
 block Install Complement Dependencies
   sudo apt-get -qq update && sudo apt-get install -qqy libolm3 libolm-dev
-  go get -v github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+  go install -v github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
 endblock
 
 block Install custom gotestfmt template

--- a/changelog.d/14611.misc
+++ b/changelog.d/14611.misc
@@ -1,0 +1,1 @@
+Switch to Go recommended installation method for `gotestfmt` template in CI.


### PR DESCRIPTION
```
go get: installing executables with 'go get' in module mode is deprecated.
  Use 'go install pkg@version' instead.
  For more information, see https://golang.org/doc/go-get-install-deprecation
  or run 'go help get' or 'go help install'.
```
So, this is coming. And it's been in the logs for a long time now. Simple change from `go get` to `go install`. [Quick link](https://golang.org/doc/go-get-install-deprecation) to the address given in the log message.


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>