### PR TITLE
Failover on proper error responses.

### DIFF
--- a/changelog.d/14620.bugfix
+++ b/changelog.d/14620.bugfix
@@ -1,0 +1,1 @@
+Return spec-compliant JSON errors when unknown endpoints are requested.


### PR DESCRIPTION
Implement the client side of MSC3743 over federation APIs: treat a spec-compliant homeserver which returns a `404`/`405` with an errcode of `M_UNRECOGNIZED` as not implementing an endpoint.

Split out of #14605

Part of #14599.