### PR TITLE
Change `turn_allow_guests` example value to lowercase `true`

### DIFF
--- a/changelog.d/14634.doc
+++ b/changelog.d/14634.doc
@@ -1,0 +1,1 @@
+Change `turn_allow_guests` example value to lowercase `true`.

--- a/docs/turn-howto.md
+++ b/docs/turn-howto.md
@@ -38,7 +38,7 @@ As an example, here is the relevant section of the config file for `matrix.org`.
     turn_uris: [ "turn:turn.matrix.org?transport=udp", "turn:turn.matrix.org?transport=tcp" ]
     turn_shared_secret: "n0t4ctuAllymatr1Xd0TorgSshar3d5ecret4obvIousreAsons"
     turn_user_lifetime: 86400000
-    turn_allow_guests: True
+    turn_allow_guests: true
 
 After updating the homeserver configuration, you must restart synapse:
 


### PR DESCRIPTION
### Pull Request Checklist

When running yamllint on homeserver.yaml, I got an error because `turn_allow_guests` was `True` instead of its lowercase value. Changed the value based on [truthy](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy) instructions. 

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Ville Petteri Huh.