### PR TITLE
Check the stream position before checking if the cache is empty.

### DIFF
--- a/changelog.d/14639.bugfix
+++ b/changelog.d/14639.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where a device list update might not be sent to clients in certain circumstances.

--- a/changelog.d/14639.bugfix
+++ b/changelog.d/14639.bugfix
@@ -1,1 +1,1 @@
-Fix a long-standing bug where a device list update might not be sent to clients in certain circumstances.
+Fix a long-standing bug where the user directory and room/user stats might be out of sync.

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -221,7 +221,7 @@ class StreamChangeCache:
 
         # If the cache is empty, nothing can have changed.
         if not self._cache:
-            # TODO Metrics?
+            self.metrics.inc_misses()
             return False
 
         self.metrics.inc_hits()

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -213,15 +213,16 @@ class StreamChangeCache:
         """
         assert isinstance(stream_pos, int)
 
-        if not self._cache:
-            # If the cache is empty, nothing can have changed.
-            return False
-
         # _cache is not valid at or before the earliest known stream position, so
         # return that an entity has changed.
         if stream_pos <= self._earliest_known_stream_pos:
             self.metrics.inc_misses()
             return True
+
+        # If the cache is empty, nothing can have changed.
+        if not self._cache:
+            # TODO Metrics?
+            return False
 
         self.metrics.inc_hits()
         return stream_pos < self._cache.peekitem()[0]

--- a/tests/util/test_stream_change_cache.py
+++ b/tests/util/test_stream_change_cache.py
@@ -144,9 +144,10 @@ class StreamChangeCacheTests(unittest.HomeserverTestCase):
         """
         cache = StreamChangeCache("#test", 1)
 
-        # With no entities, it returns False for the past, present, and future.
-        self.assertFalse(cache.has_any_entity_changed(0))
-        self.assertFalse(cache.has_any_entity_changed(1))
+        # With no entities, it returns True for the past, present, and False for
+        # the future.
+        self.assertTrue(cache.has_any_entity_changed(0))
+        self.assertTrue(cache.has_any_entity_changed(1))
         self.assertFalse(cache.has_any_entity_changed(2))
 
         # We add an entity


### PR DESCRIPTION
If the stream position is at/earlier than the earliest known stream position, but the cache is empty we should still consider entities to have changed.