### PR TITLE
Rebuild the user directory and stats tables.

### DIFF
--- a/changelog.d/14643.bugfix
+++ b/changelog.d/14643.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where a device list update might not be sent to clients in certain circumstances.

--- a/changelog.d/14643.bugfix
+++ b/changelog.d/14643.bugfix
@@ -1,1 +1,1 @@
-Fix a long-standing bug where a device list update might not be sent to clients in certain circumstances.
+Fix a long-standing bug where the user directory and room/user stats might be out of sync.

--- a/synapse/storage/schema/main/delta/73/22_rebuild_user_dir_stats.sql
+++ b/synapse/storage/schema/main/delta/73/22_rebuild_user_dir_stats.sql
@@ -1,0 +1,29 @@
+/* Copyright 2022 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+INSERT INTO background_updates (ordering, update_name, progress_json, depends_on) VALUES
+  -- Set up user directory staging tables.
+  (7322, 'populate_user_directory_createtables', '{}', NULL),
+  -- Run through each room and update the user directory according to who is in it.
+  (7322, 'populate_user_directory_process_rooms', '{}', 'populate_user_directory_createtables'),
+  -- Insert all users into the user directory, if search_all_users is on.
+  (7322, 'populate_user_directory_process_users', '{}', 'populate_user_directory_process_rooms'),
+  -- Clean up user directory staging tables.
+  (7322, 'populate_user_directory_cleanup', '{}', 'populate_user_directory_process_users'),
+  -- Rebuild the room_stats_current and room_stats_state tables.
+  (7322, 'populate_stats_process_rooms', '{}', NULL),
+  -- Update the user_stats_current table.
+  (7322, 'populate_stats_process_users', '{}', NULL)
+ON CONFLICT (update_name) DO NOTHING;


### PR DESCRIPTION
Due to #14435, #14592, and #14639 I was curious if these tables were actually of date.

I ran the following on matrix.org to see if any room names in `room_stats_state` were different from `current_state_events`:

```sql
SELECT room_id, event_id, name AS stats_name, json::json->'content'->>'name' AS json_name
FROM current_state_events
INNER JOIN event_json USING (event_id, room_id)
INNER JOIN room_stats_state USING (room_id)
WHERE
    type = 'm.room.name' AND state_key = ''
    AND name != json::json->'content'->>'name';
```

(This returned results, I limited it to 3 since I didn't see any reason to get a full list.)

Thus, we should likely rebuild the tables which are affected by the state delta processing. To my knowledge this is just the user directory and user / room stats.