### PR TITLE
Fix the *MAU Limits* section of the Grafana dashboard relying on a specific `job` name for the workers of a Synapse deployment.

### DIFF
--- a/changelog.d/14644.bugfix
+++ b/changelog.d/14644.bugfix
@@ -1,0 +1,1 @@
+Fix the *MAU Limits* section of the Grafana dashboard relying on a specific `job` name for the workers of a Synapse deployment.

--- a/contrib/grafana/synapse.json
+++ b/contrib/grafana/synapse.json
@@ -1008,8 +1008,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1681,8 +1680,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2533,8 +2531,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -11296,7 +11293,7 @@
                 "uid": "$datasource"
               },
               "editorMode": "code",
-              "expr": "synapse_admin_mau_max{instance=\"$instance\", job=~\"(hhs_)?synapse\"}",
+              "expr": "max(synapse_admin_mau_max{instance=\"$instance\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -11310,7 +11307,7 @@
                 "uid": "$datasource"
               },
               "editorMode": "code",
-              "expr": "synapse_admin_mau_current{instance=\"$instance\", job=~\"(hhs_)?synapse\"}",
+              "expr": "max(synapse_admin_mau_current{instance=\"$instance\"})",
               "hide": false,
               "legendFormat": "Current",
               "range": true,
@@ -12760,6 +12757,6 @@
   "timezone": "",
   "title": "Synapse",
   "uid": "000000012",
-  "version": 149,
+  "version": 150,
   "weekStart": ""
 }


### PR DESCRIPTION
Fixes: #14622 <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Introduced in #14477; copied over from our Grafana where someone must have made this well-intentioned change without knowing that this isn't portable (and perhaps not even knowing that we export our Grafana dashboard into the Synapse repository).

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Remove job~= condition and aggregate with max() \
The job~= condition is not portable: it depends on how we do things on EMS and matrix.org

Other people don't set up their job names the same way we do.

Therefore we can't rely on job~= and cut it out.

But doing that means that you end up with one trace per worker.

To avoid this being a problem, I propose we aggregate them with max() so we take the number from the

correct worker that is reporting MAU.


</li>
</ol>
