### PR TITLE
Update events stream cache before ID generator

### DIFF
--- a/changelog.d/14648.misc
+++ b/changelog.d/14648.misc
@@ -1,0 +1,1 @@
+Fix events stream change cache and stream ID update order. Contributed by Nick @ Beeper (@fizzadar).

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -235,9 +235,6 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
         # case where we look up an event *before* persisting it.
         self._attempt_to_invalidate_cache("_get_membership_from_event_id", (event_id,))
 
-        if not backfilled:
-            self._events_stream_cache.entity_has_changed(room_id, stream_ordering)
-
         if redacts:
             self._invalidate_local_get_event_cache(redacts)
             # Caches which might leak edits must be invalidated for the event being
@@ -248,7 +245,6 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
             self._attempt_to_invalidate_cache("get_thread_id_for_receipts", (redacts,))
 
         if etype == EventTypes.Member:
-            self._membership_stream_cache.entity_has_changed(state_key, stream_ordering)
             self._attempt_to_invalidate_cache(
                 "get_invited_rooms_for_local_user", (state_key,)
             )

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -235,6 +235,9 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
         # case where we look up an event *before* persisting it.
         self._attempt_to_invalidate_cache("_get_membership_from_event_id", (event_id,))
 
+        if not backfilled:
+            self._events_stream_cache.entity_has_changed(room_id, stream_ordering)
+
         if redacts:
             self._invalidate_local_get_event_cache(redacts)
             # Caches which might leak edits must be invalidated for the event being
@@ -245,6 +248,7 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
             self._attempt_to_invalidate_cache("get_thread_id_for_receipts", (redacts,))
 
         if etype == EventTypes.Member:
+            self._membership_stream_cache.entity_has_changed(state_key, stream_ordering)
             self._attempt_to_invalidate_cache(
                 "get_invited_rooms_for_local_user", (state_key,)
             )

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1187,7 +1187,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
         """
         # We want to make the cache more effective, so we clamp to the last
         # change before the given ordering.
-        last_change = self._events_stream_cache.get_max_pos_of_last_change(room_id)  # type: ignore[attr-defined]
+        last_change = self._events_stream_cache.get_max_pos_of_last_change(room_id)
 
         # We don't always have a full stream_to_exterm_id table, e.g. after
         # the upgrade that introduced it, so we make sure we never ask for a

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -242,6 +242,22 @@ class EventsWorkerStore(SQLBaseStore):
             prefilled_cache=curr_state_delta_prefill,
         )
 
+        event_cache_prefill, min_event_val = self.db_pool.get_cache_dict(
+            db_conn,
+            "events",
+            entity_column="room_id",
+            stream_column="stream_ordering",
+            max_value=events_max,
+        )
+        self._events_stream_cache = StreamChangeCache(
+            "EventsRoomStreamChangeCache",
+            min_event_val,
+            prefilled_cache=event_cache_prefill,
+        )
+        self._membership_stream_cache = StreamChangeCache(
+            "MembershipStreamChangeCache", events_max
+        )
+
         if hs.config.worker.run_background_tasks:
             # We periodically clean out old transaction ID mappings
             self._clock.looping_call(

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -250,9 +250,12 @@ class EventsWorkerStore(SQLBaseStore):
             "EventsRoomStreamChangeCache",
             min_event_val,
             prefilled_cache=event_cache_prefill,
+            stream_id_gen=self._stream_id_gen,
         )
         self._membership_stream_cache = StreamChangeCache(
-            "MembershipStreamChangeCache", events_max
+            "MembershipStreamChangeCache",
+            events_max,
+            stream_id_gen=self._stream_id_gen,
         )
 
         if hs.config.worker.run_background_tasks:

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -208,10 +208,7 @@ class EventsWorkerStore(SQLBaseStore):
             # We shouldn't be running in worker mode with SQLite, but its useful
             # to support it for unit tests.
             #
-            # If this process is the writer than we need to use
-            # `StreamIdGenerator`, otherwise we use `SlavedIdTracker` which gets
-            # updated over replication. (Multiple writers are not supported for
-            # SQLite).
+            # SQLite/StreamIdGenerator only support a single writer instance (is_writer)
             self._stream_id_gen = StreamIdGenerator(
                 db_conn,
                 "events",
@@ -327,6 +324,7 @@ class EventsWorkerStore(SQLBaseStore):
             # NOTE: this must be updated *after* the stream change cache, so other threads don't
             # see a token ahead of the cache.
             self._stream_id_gen.advance(instance_name, token)
+
         elif stream_name == BackfillStream.NAME:
             self._backfill_id_gen.advance(instance_name, -token)
 

--- a/synapse/storage/databases/main/stream.py
+++ b/synapse/storage/databases/main/stream.py
@@ -71,7 +71,6 @@ from synapse.storage.engines import BaseDatabaseEngine, PostgresEngine
 from synapse.storage.util.id_generators import MultiWriterIdGenerator
 from synapse.types import PersistedEventPosition, RoomStreamToken
 from synapse.util.caches.descriptors import cached
-from synapse.util.caches.stream_change_cache import StreamChangeCache
 from synapse.util.cancellation import cancellable
 
 if TYPE_CHECKING:
@@ -396,23 +395,6 @@ class StreamWorkerStore(EventsWorkerStore, SQLBaseStore):
         # config. We don't do this now as otherwise two processes could conflict
         # during startup which would cause one to die.
         self._need_to_reset_federation_stream_positions = self._send_federation
-
-        events_max = self.get_room_max_stream_ordering()
-        event_cache_prefill, min_event_val = self.db_pool.get_cache_dict(
-            db_conn,
-            "events",
-            entity_column="room_id",
-            stream_column="stream_ordering",
-            max_value=events_max,
-        )
-        self._events_stream_cache = StreamChangeCache(
-            "EventsRoomStreamChangeCache",
-            min_event_val,
-            prefilled_cache=event_cache_prefill,
-        )
-        self._membership_stream_cache = StreamChangeCache(
-            "MembershipStreamChangeCache", events_max
-        )
 
         self._stream_order_on_start = self.get_room_max_stream_ordering()
         self._min_stream_order_on_start = self.get_room_min_stream_ordering()

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -277,8 +277,10 @@ class StreamChangeCache:
 
         # Any change being flagged must be ahead of any current token, otherwise
         # we have a race condition between token position and stream change cache.
+        # NOTE: this checks for equal to allow for a process persisting an event to
+        # immediately flag the cache, as it cannot know the ID before generating it.
         if self.stream_id_gen:
-            assert stream_pos > self.stream_id_gen.get_current_token()
+            assert stream_pos >= self.stream_id_gen.get_current_token()
 
         old_pos = self._entity_to_key.get(entity, None)
         if old_pos is not None:

--- a/synapse/util/caches/stream_change_cache.py
+++ b/synapse/util/caches/stream_change_cache.py
@@ -98,7 +98,7 @@ class StreamChangeCache:
 
         if prefilled_cache:
             for entity, stream_pos in prefilled_cache.items():
-                self.entity_has_changed(entity, stream_pos)
+                self.entity_has_changed(entity, stream_pos, check_pos=False)
 
     def set_cache_factor(self, factor: float) -> bool:
         """
@@ -260,7 +260,9 @@ class StreamChangeCache:
             changed_entities.extend(self._cache[k])
         return AllEntitiesChangedResult(changed_entities)
 
-    def entity_has_changed(self, entity: EntityType, stream_pos: int) -> None:
+    def entity_has_changed(
+        self, entity: EntityType, stream_pos: int, check_pos: bool = True
+    ) -> None:
         """
         Informs the cache that the entity has been changed at the given position.
 
@@ -279,7 +281,7 @@ class StreamChangeCache:
         # we have a race condition between token position and stream change cache.
         # NOTE: this checks for equal to allow for a process persisting an event to
         # immediately flag the cache, as it cannot know the ID before generating it.
-        if self.stream_id_gen:
+        if check_pos and self.stream_id_gen:
             assert stream_pos >= self.stream_id_gen.get_current_token()
 
         old_pos = self._entity_to_key.get(entity, None)


### PR DESCRIPTION
Part of #14158

Essentially this just moves all the handling logic for the events stream change cache and ID generator under the `EventsWorkerStore` and ensures that the cache is updated before the token position. This prevents other threads seeing tokens ahead of the cache (full description at https://github.com/matrix-org/synapse/issues/14158#issuecomment-1344048703).

This now also includes an assertion in flagging changes in the stream change cache, as described in this comment: https://github.com/matrix-org/synapse/issues/14158#issuecomment-1344094805.

Signed off by Nick @ Beeper (@fizzadar).

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
