### PR TITLE
Add a `cached` helper to the module API

### DIFF
--- a/changelog.d/14663.feature
+++ b/changelog.d/14663.feature
@@ -1,0 +1,1 @@
+Add a `cached` function to `synapse.module_api` that returns a decorator to cache return values of functions.

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -18,6 +18,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     Dict,
     Generator,
     Iterable,
@@ -25,7 +26,7 @@ from typing import (
     Optional,
     Tuple,
     TypeVar,
-    Union, Collection,
+    Union,
 )
 
 import attr
@@ -136,6 +137,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 P = ParamSpec("P")
+F = TypeVar("F", bound=Callable[..., Any])
 
 """
 This package defines the 'stable' API which can be used by extension modules which
@@ -190,7 +192,7 @@ def cached(
     max_entries: int = 1000,
     num_args: Optional[int] = None,
     uncached_args: Optional[Collection[str]] = None,
-):
+) -> Callable[[F], CachedFunction[F]]:
     """Returns a decorator that applies a memoizing cache around the function. This
     decorator behaves similarly to functools.lru_cache.
 

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -200,6 +200,8 @@ def cached(
         def foo('a', 'b'):
             ...
 
+    Added in Synapse v1.74.0.
+
     Args:
         max_entries: The maximum number of entries in the cache. If the cache is full
             and a new entry is added, the least recently accessed entry will be evicted

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -191,8 +191,8 @@ def cached(
     num_args: Optional[int] = None,
     uncached_args: Optional[Collection[str]] = None,
 ):
-    """Returns a decorator that caches the value of the decorated function for a given
-    set of arguments. This decorator behaves similarly to functools.lru_cache.
+    """Returns a decorator that applies a memoizing cache around the function. This
+    decorator behaves similarly to functools.lru_cache.
 
     Example:
 
@@ -211,6 +211,8 @@ def cached(
         uncached_args: A list of argument names to not use as the cache key. (`self` is
             always ignored.) Cannot be used with num_args.
 
+    Returns:
+        A decorator that applies a memoizing cache around the function.
     """
     return _cached(
         max_entries=max_entries,

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -25,7 +25,7 @@ from typing import (
     Optional,
     Tuple,
     TypeVar,
-    Union,
+    Union, Collection,
 )
 
 import attr
@@ -126,7 +126,7 @@ from synapse.types import (
 )
 from synapse.util import Clock
 from synapse.util.async_helpers import maybe_awaitable
-from synapse.util.caches.descriptors import CachedFunction, cached
+from synapse.util.caches.descriptors import CachedFunction, cached as _cached
 from synapse.util.frozenutils import freeze
 
 if TYPE_CHECKING:
@@ -183,6 +183,38 @@ class UserIpAndAgent:
     user_agent: str
     # The time at which this user agent/ip was last seen.
     last_seen: int
+
+
+def cached(
+    *,
+    max_entries: int = 1000,
+    num_args: Optional[int] = None,
+    uncached_args: Optional[Collection[str]] = None,
+):
+    """Returns a decorator that caches the value of the decorated function for a given
+    set of arguments. This decorator behaves similarly to functools.lru_cache.
+
+    Example:
+
+        @cached()
+        def foo('a', 'b'):
+            ...
+
+    Args:
+        max_entries: The maximum number of entries in the cache. If the cache is full
+            and a new entry is added, the least recently accessed entry will be evicted
+            from the cache.
+        num_args: The number of positional arguments (excluding `self`) to use as cache
+            keys. Defaults to all named args of the function.
+        uncached_args: A list of argument names to not use as the cache key. (`self` is
+            always ignored.) Cannot be used with num_args.
+
+    """
+    return _cached(
+        max_entries=max_entries,
+        num_args=num_args,
+        uncached_args=uncached_args,
+    )
 
 
 class ModuleApi:


### PR DESCRIPTION
As suggested in https://github.com/matrix-org/synapse/pull/14026#discussion_r1003324598

I've had a look at the parameters the internal `cached` method has, and concluded that the three that didn't sound too Synapse internals-ey and sounded helpful for modules to have are `max_entries`, `num_args` and `uncached_args`. I'm happy to revisit this list if folks think modules would benefit from having access to more controls (it's also worth nothing that it's easy to add support to more arguments of `synapse.util.caches.descriptors.cached` later on).