### PR TITLE
Proof of concept for better typed datastores

### DIFF
--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -25,6 +25,7 @@ from synapse.util.caches.descriptors import CachedFunction
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
+    from synapse.storage.databases import DataStore
 
 logger = logging.getLogger(__name__)
 
@@ -42,11 +43,14 @@ class SQLBaseStore(metaclass=ABCMeta):
         database: DatabasePool,
         db_conn: LoggingDatabaseConnection,
         hs: "HomeServer",
+        datastore: Optional["DataStore"] = None,
     ):
         self.hs = hs
         self._clock = hs.get_clock()
         self.database_engine = database.engine
         self.db_pool = database
+        # A reference back to the root datastore.
+        self.datastore = datastore
 
         self.external_cached_functions: Dict[str, CachedFunction] = {}
 

--- a/synapse/storage/databases/main/__init__.py
+++ b/synapse/storage/databases/main/__init__.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, List, Optional, Tuple, cast
+import re
+from typing import TYPE_CHECKING, Any, List, Match, Optional, Tuple, Type, cast
 
 from synapse.config.homeserver import HomeServerConfig
 from synapse.storage.database import (
@@ -23,6 +24,7 @@ from synapse.storage.database import (
     LoggingDatabaseConnection,
     LoggingTransaction,
 )
+from synapse.storage._base import SQLBaseStore
 from synapse.storage.databases.main.stats import UserSortOrder
 from synapse.storage.engines import BaseDatabaseEngine
 from synapse.storage.types import Cursor
@@ -79,8 +81,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class DataStore(
-    EventsBackgroundUpdatesStore,
+class DataStore(EventsBackgroundUpdatesStore,
     DeviceStore,
     RoomMemberStore,
     RoomStore,
@@ -118,7 +119,6 @@ class DataStore(
     UserErasureStore,
     MonthlyActiveUsersWorkerStore,
     StatsStore,
-    RelationsStore,
     CensorEventsStore,
     UIAuthStore,
     EventForwardExtremitiesStore,
@@ -126,6 +126,13 @@ class DataStore(
     LockStore,
     SessionStore,
 ):
+    DATASTORE_CLASSES: List[Type[SQLBaseStore]] = [
+        RelationsStore,
+    ]
+
+    # XXX So mypy knows about dynamic properties.
+    relations: RelationsStore
+
     def __init__(
         self,
         database: DatabasePool,
@@ -137,6 +144,19 @@ class DataStore(
         self.database_engine = database.engine
 
         super().__init__(database, db_conn, hs)
+
+        def repl(match: Match[str]) -> str:
+            return "_" + match.group(0).lower()
+
+        for datastore_class in self.DATASTORE_CLASSES:
+            name = datastore_class.__name__
+            if name.endswith("Store"):
+                name = name[: -len("Store")]
+
+            name = re.sub(r"[A-Z]", repl, name)[1:]
+
+            store = datastore_class(database, db_conn, hs, self)
+            setattr(self, name, store)
 
     async def get_users(self) -> List[JsonDict]:
         """Function to retrieve a list of users in users table.

--- a/synapse/storage/databases/main/relations.py
+++ b/synapse/storage/databases/main/relations.py
@@ -47,6 +47,7 @@ from synapse.util.caches.descriptors import cached, cachedList
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
+    from synapse.storage.databases.main import DataStore
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +91,9 @@ class RelationsWorkerStore(SQLBaseStore):
         database: DatabasePool,
         db_conn: LoggingDatabaseConnection,
         hs: "HomeServer",
+        datastore: "DataStore",
     ):
-        super().__init__(database, db_conn, hs)
+        super().__init__(database, db_conn, hs, datastore)
 
         self.db_pool.updates.register_background_update_handler(
             "threads_backfill", self._backfill_threads

--- a/tests/storage/test_relations.py
+++ b/tests/storage/test_relations.py
@@ -58,28 +58,28 @@ class RelationsStoreTestCase(unittest.HomeserverTestCase):
         Ensure that get_thread_id only searches up the tree for threads.
         """
         # The thread itself and children of it return the thread.
-        thread_id = self.get_success(self._main_store.get_thread_id("B"))
+        thread_id = self.get_success(self._main_store.relations.get_thread_id("B"))
         self.assertEqual("A", thread_id)
 
-        thread_id = self.get_success(self._main_store.get_thread_id("C"))
+        thread_id = self.get_success(self._main_store.relations.get_thread_id("C"))
         self.assertEqual("A", thread_id)
 
         # But the root and events related to the root do not.
-        thread_id = self.get_success(self._main_store.get_thread_id("A"))
+        thread_id = self.get_success(self._main_store.relations.get_thread_id("A"))
         self.assertEqual(MAIN_TIMELINE, thread_id)
 
-        thread_id = self.get_success(self._main_store.get_thread_id("D"))
+        thread_id = self.get_success(self._main_store.relations.get_thread_id("D"))
         self.assertEqual(MAIN_TIMELINE, thread_id)
 
-        thread_id = self.get_success(self._main_store.get_thread_id("E"))
+        thread_id = self.get_success(self._main_store.relations.get_thread_id("E"))
         self.assertEqual(MAIN_TIMELINE, thread_id)
 
         # Events which are not related to a thread at all should return the
         # main timeline.
-        thread_id = self.get_success(self._main_store.get_thread_id("F"))
+        thread_id = self.get_success(self._main_store.relations.get_thread_id("F"))
         self.assertEqual(MAIN_TIMELINE, thread_id)
 
-        thread_id = self.get_success(self._main_store.get_thread_id("G"))
+        thread_id = self.get_success(self._main_store.relations.get_thread_id("G"))
         self.assertEqual(MAIN_TIMELINE, thread_id)
 
     def test_get_thread_id_for_receipts(self) -> None:
@@ -87,25 +87,35 @@ class RelationsStoreTestCase(unittest.HomeserverTestCase):
         Ensure that get_thread_id_for_receipts searches up and down the tree for a thread.
         """
         # All of the events are considered related to this thread.
-        thread_id = self.get_success(self._main_store.get_thread_id_for_receipts("A"))
+        thread_id = self.get_success(
+            self._main_store.relations.get_thread_id_for_receipts("A")
+        )
         self.assertEqual("A", thread_id)
 
-        thread_id = self.get_success(self._main_store.get_thread_id_for_receipts("B"))
+        thread_id = self.get_success(
+            self._main_store.relations.get_thread_id_for_receipts("B")
+        )
         self.assertEqual("A", thread_id)
 
-        thread_id = self.get_success(self._main_store.get_thread_id_for_receipts("C"))
+        thread_id = self.get_success(
+            self._main_store.relations.get_thread_id_for_receipts("C")
+        )
         self.assertEqual("A", thread_id)
 
-        thread_id = self.get_success(self._main_store.get_thread_id_for_receipts("D"))
+        thread_id = self.get_success(
+            self._main_store.relations.get_thread_id_for_receipts("D")
+        )
         self.assertEqual("A", thread_id)
 
-        thread_id = self.get_success(self._main_store.get_thread_id_for_receipts("E"))
+        thread_id = self.get_success(
+            self._main_store.relations.get_thread_id_for_receipts("E")
+        )
         self.assertEqual("A", thread_id)
 
         # Events which are not related to a thread at all should return the
         # main timeline.
-        thread_id = self.get_success(self._main_store.get_thread_id("F"))
+        thread_id = self.get_success(self._main_store.relations.get_thread_id("F"))
         self.assertEqual(MAIN_TIMELINE, thread_id)
 
-        thread_id = self.get_success(self._main_store.get_thread_id("G"))
+        thread_id = self.get_success(self._main_store.relations.get_thread_id("G"))
         self.assertEqual(MAIN_TIMELINE, thread_id)


### PR DESCRIPTION
By being explicit about methods we *should* be able to get better type checking (although this isn't entirely proven in this PR). The idea is to mostly treat datastores the way we handle config classes, each as an individual unit that has to reach back to a "root" object to query other datastores.

This means that the main `DataStore` object would become a bundle of `SQLBaseStore` objects instead of a single entity which has super-classes of `SQLBaseStore`.

As a proof-of-concept I convert the `RelationsStore` (it is simple and I know it fairly well).

Related to #11165

Downsides of this approach is it might make #11733 worse as you now have a `DataStore` which includes a `RelationsStore`? It adds another layer to the puzzle.