### PR TITLE
Improve type annotations for the helper methods on a `CachedFunction`.

### DIFF
--- a/changelog.d/14685.misc
+++ b/changelog.d/14685.misc
@@ -1,0 +1,1 @@
+Improve type annotations for the helper methods on a `CachedFunction`.

--- a/synapse/util/caches/descriptors.py
+++ b/synapse/util/caches/descriptors.py
@@ -53,9 +53,9 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 class CachedFunction(Generic[F]):
-    invalidate: Any = None
-    invalidate_all: Any = None
-    prefill: Any = None
+    invalidate: Callable[[Tuple[Any, ...]], None]
+    invalidate_all: Callable[[], None]
+    prefill: Callable[[Tuple[Any, ...], Any], None]
     cache: Any = None
     num_args: Any = None
 


### PR DESCRIPTION
`invalidate` bit me — I forgot to wrap my single arg in a tuple.

I noticed we can do slightly better on these type annotations. But notably I couldn't figure out how to convert it to `ParamSpec` to ensure the tuples passed are all correct — I'm not even sure it's possible. (I think ParamSpec can only be used within `Concatenate` (which can only prepend args) and you don't seem to be able to convert ParamSpec to a Tuple(?) -- or at least just using `FP.args` doesn't cause any type errors when called with the wrong things).

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop`

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Add type annotations for invalidate, invalidate_all, prefill 

</li>
</ol>
