### PR TITLE
Bump minimum pyyaml to 3.13.

### DIFF
--- a/changelog.d/14720.misc
+++ b/changelog.d/14720.misc
@@ -1,0 +1,1 @@
+Bump minimum PyYAML to 3.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ Twisted = {extras = ["tls"], version = ">=18.9.0"}
 treq = ">=15.1"
 # Twisted has required pyopenssl 16.0 since about Twisted 16.6.
 pyOpenSSL = ">=16.0.0"
-PyYAML = ">=3.11"
+PyYAML = ">=3.13"
 pyasn1 = ">=0.1.9"
 pyasn1-modules = ">=0.0.7"
 bcrypt = ">=3.1.7"


### PR DESCRIPTION
Develop's trial-olddeps is [currently failing](https://github.com/matrix-org/synapse/actions/runs/3749275354/jobs/6367704839) with:

```
  Failed to build PyYAML
  ERROR: Could not build wheels for PyYAML, which is required to install pyproject.toml-based projects
```

The actual error seems to be:

```
         ext/_yaml.c:20800:21: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘exc_type’; did you mean ‘curexc_type’?
        20800 |     *type = tstate->exc_type;
              |                     ^~~~~~~~
              |                     curexc_type
```

This matches the error of yaml/pyyaml#152 which says [they released PyYAML 3.13 to fix this](https://github.com/yaml/pyyaml/issues/152#issuecomment-402791014). (See [diff from 3.12](https://github.com/yaml/pyyaml/compare/3.12...3.13)).

Unfortunately I haven't been able to track down anything that would have changed to start causing this. Maybe something updated in the GitHub runners? The version of libyaml?