### PR TITLE
Log to-device msgids when we return them over /sync

### DIFF
--- a/changelog.d/14724.misc
+++ b/changelog.d/14724.misc
@@ -1,0 +1,1 @@
+If debug logging is enabled, log the `msgid`s of any to-device messages that are returned over `/sync`.


### PR DESCRIPTION
An extension to https://github.com/matrix-org/synapse/pull/14598, and related to https://github.com/vector-im/element-meta/issues/558.