### PR TITLE
Draft: Ignore sending events to appservice when they come from our own homeserver

### DIFF
--- a/changelog.d/14729.misc
+++ b/changelog.d/14729.misc
@@ -1,0 +1,1 @@
+Don't merge this.

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -149,14 +149,16 @@ class ApplicationServiceScheduler:
         ):
             return
 
-        # XXX: Special patch just for Gitter which we should remove after the import,
-        # https://github.com/matrix-org/synapse/pull/14729
-        #
-        # Ignore events that come from our own users. We probably already know about
-        # them and sent them ourself.
-        events = [event for event in events if not self._hs.is_mine_id(event.sender)]
-
         if events:
+            # XXX: Special patch just for Gitter which we should remove after the import,
+            # https://github.com/matrix-org/synapse/pull/14729
+            #
+            # Ignore events that come from our own users. We probably already know about
+            # them and sent them ourself.
+            events = [
+                event for event in events if not self._hs.is_mine_id(event.sender)
+            ]
+
             self.queuer.queued_events.setdefault(appservice.id, []).extend(events)
         if ephemeral:
             self.queuer.queued_ephemeral.setdefault(appservice.id, []).extend(ephemeral)

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -98,6 +98,7 @@ class ApplicationServiceScheduler:
     """
 
     def __init__(self, hs: "HomeServer"):
+        self._hs = hs
         self.clock = hs.get_clock()
         self.store = hs.get_datastores().main
         self.as_api = hs.get_application_service_api()
@@ -138,6 +139,11 @@ class ApplicationServiceScheduler:
                 to refresh the device lists of, or those that the application service need no
                 longer track the device lists of.
         """
+
+        # Ignore events that come from our own users. We probably already know about
+        # them and sent them ourself.
+        events = [event for event in events if self._hs.is_mine_id(event.sender)]
+
         # We purposefully allow this method to run with empty events/ephemeral
         # collections, so that callers do not need to check iterable size themselves.
         if (

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -139,14 +139,6 @@ class ApplicationServiceScheduler:
                 to refresh the device lists of, or those that the application service need no
                 longer track the device lists of.
         """
-
-        # XXX: Special patch just for Gitter which we should remove after the import,
-        # https://github.com/matrix-org/synapse/pull/14729
-        #
-        # Ignore events that come from our own users. We probably already know about
-        # them and sent them ourself.
-        events = [event for event in events if not self._hs.is_mine_id(event.sender)]
-
         # We purposefully allow this method to run with empty events/ephemeral
         # collections, so that callers do not need to check iterable size themselves.
         if (
@@ -156,6 +148,13 @@ class ApplicationServiceScheduler:
             and not device_list_summary
         ):
             return
+
+        # XXX: Special patch just for Gitter which we should remove after the import,
+        # https://github.com/matrix-org/synapse/pull/14729
+        #
+        # Ignore events that come from our own users. We probably already know about
+        # them and sent them ourself.
+        events = [event for event in events if not self._hs.is_mine_id(event.sender)]
 
         if events:
             self.queuer.queued_events.setdefault(appservice.id, []).extend(events)

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -142,7 +142,7 @@ class ApplicationServiceScheduler:
 
         # Ignore events that come from our own users. We probably already know about
         # them and sent them ourself.
-        events = [event for event in events if self._hs.is_mine_id(event.sender)]
+        events = [event for event in events if not self._hs.is_mine_id(event.sender)]
 
         # We purposefully allow this method to run with empty events/ephemeral
         # collections, so that callers do not need to check iterable size themselves.

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -159,6 +159,7 @@ class ApplicationServiceScheduler:
                 event for event in events if not self._hs.is_mine_id(event.sender)
             ]
 
+        if events:
             self.queuer.queued_events.setdefault(appservice.id, []).extend(events)
         if ephemeral:
             self.queuer.queued_ephemeral.setdefault(appservice.id, []).extend(ephemeral)

--- a/synapse/appservice/scheduler.py
+++ b/synapse/appservice/scheduler.py
@@ -140,6 +140,9 @@ class ApplicationServiceScheduler:
                 longer track the device lists of.
         """
 
+        # XXX: Special patch just for Gitter which we should remove after the import,
+        # https://github.com/matrix-org/synapse/pull/14729
+        #
         # Ignore events that come from our own users. We probably already know about
         # them and sent them ourself.
         events = [event for event in events if not self._hs.is_mine_id(event.sender)]


### PR DESCRIPTION
Ignore sending events to appservice when they come from our own homeserver

This is a rough patch for the Gitter homeserver so we can better cope with the massive import load. Since we're the ones who imported the messages and the only ones who send messages on the homeserver, we can safely ignore any events that come from us since we already know about the events on the Gitter side.

Currently, we import a bunch of messages Gitter -> Synapse and Synapse sends them back to us via the appservice where they are ignored on the Gitter bridge side via the [`suppressEcho` option in `matrix-appservice-bridge`](https://github.com/matrix-org/matrix-appservice-bridge/blob/a6be350a706379c92344e248e29338bb7c1b9041/src/bridge.ts#L510). But just the overhead of ignoring all of the transactions isn't fast enough to keep up. Instead of having the round-trip just to ignore, we can ignore directly in Synapse to not send to us via the appservice.

This logic only really applies to the Gitter situation but if we can write a more general patch in the future, it would be good to ignore events that come in through the appservice to not go back out the appservice that sent it. This probably requires a MSC to define the behavior in the AS registration config.

An alternative, is to something like https://github.com/matrix-org/synapse/issues/3237 which ignores any old events which for the Gitter import would be perfectly fine since we're only importing old messages. And on the Gitter side of the bridge, we already ignore any events older than 30 minutes anyway so a solution to that separate issue makes sense in any case.


---

Context:

 - [Gitter sunset plan](https://github.com/vector-im/roadmap/issues/26)
 - https://github.com/matrix-org/matrix-hosted/issues/6793

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
