### PR TITLE
Update reverse_proxy.md

### DIFF
--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -67,7 +67,7 @@ server {
 
     server_name matrix.example.com;
 
-    location ~ ^(/_matrix|/_synapse/client) {
+    location ~ ^(/_matrix|/_synapse/client|/$) {
         # note: do not add a path (even a single /) after the port in `proxy_pass`,
         # otherwise nginx will canonicalise the URI and cause signature verification
         # errors.


### PR DESCRIPTION
In issue #11895, the redirect from /_matrix/client to the URL configured in web_client_location was moved to the root URL (/). This change requires local administrators to update their proxy setups to include the root URL, as the current recommendations only include proxies for /_matrix/ and /_synapse/client/. This is necessary for the new location of the redirect to be effective.

This issue was raised in #14722 by @sumpfralle

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
