### PR TITLE
Suppress the update check in the ruff linter.

### DIFF
--- a/changelog.d/14741.misc
+++ b/changelog.d/14741.misc
@@ -1,0 +1,1 @@
+Use [ruff](https://github.com/charliermarsh/ruff/) instead of flake8.

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -104,6 +104,7 @@ set -x
 isort "${files[@]}"
 python3 -m black "${files[@]}"
 ./scripts-dev/config-lint.sh
-ruff "${files[@]}"
+# --quiet suppresses the update check.
+ruff --quiet "${files[@]}"
 ./scripts-dev/check_pydantic_models.py lint
 mypy


### PR DESCRIPTION
I find it distracting and I don't particularly like software checking for updates automatically, so I propose we quieten this.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->

Follows: #14633 <!-- -->
<!--
Part of: # <!-- -->
Base: `develop`

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Suppress update check in ruff 

</li>
</ol>
