### PR TITLE
Faster remote room joins (worker mode): do not populate external hosts-in-room cache when sending events as this requires blocking for full state.

### DIFF
--- a/changelog.d/14749.misc
+++ b/changelog.d/14749.misc
@@ -1,0 +1,1 @@
+Faster remote room joins (worker mode): do not populate external hosts-in-room cache when sending events as this requires blocking for full state.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1539,9 +1539,14 @@ class EventCreationHandler:
 
         for event, event_context in events_and_context:
             if event_context.partial_state:
-                # We can't precalculate joined hosts for a partial-state event,
-                # (at least not without blocking until full state).
-                # So skip this calculation entirely.
+                # To populate the cache for a partial-state event, we either have to
+                # block until full state, which the code below does, or change the
+                # meaning of cache values to be the list of hosts to which we plan to
+                # send events and calculate that instead.
+                #
+                # The federation senders don't use the external cache when sending
+                # events in partial-state rooms anyway, so let's not bother populating
+                # the cache.
                 continue
 
             # We actually store two mappings, event ID -> prev state group,

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1531,12 +1531,18 @@ class EventCreationHandler:
         external federation senders don't have to recalculate it themselves.
         """
 
-        for event, _ in events_and_context:
+        for event, event_context in events_and_context:
             if not self._external_cache.is_enabled():
                 return
 
             # If external cache is enabled we should always have this.
             assert self._external_cache_joined_hosts_updates is not None
+
+            if event_context.partial_state:
+                # We can't precalculate joined hosts for a partial-state event,
+                # (at least not without blocking until full state).
+                # So skip this calculation entirely.
+                continue
 
             # We actually store two mappings, event ID -> prev state group,
             # state group -> joined hosts, which is much more space efficient

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1531,13 +1531,13 @@ class EventCreationHandler:
         external federation senders don't have to recalculate it themselves.
         """
 
+        if not self._external_cache.is_enabled():
+            return
+
+        # If external cache is enabled we should always have this.
+        assert self._external_cache_joined_hosts_updates is not None
+
         for event, event_context in events_and_context:
-            if not self._external_cache.is_enabled():
-                return
-
-            # If external cache is enabled we should always have this.
-            assert self._external_cache_joined_hosts_updates is not None
-
             if event_context.partial_state:
                 # We can't precalculate joined hosts for a partial-state event,
                 # (at least not without blocking until full state).


### PR DESCRIPTION
Fixes: Complement `TestPartialStateJoin/CanSendEventsDuringPartialStateJoin` under `WORKERS=1` <!-- -->
<!--
Supersedes: # <!-- -->
Follows: #14403 <!-- -->
Part of: #12994 <!-- -->
Base: `develop`

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Don't block for full state to cache hosts in room when sending events 

</li>
</ol>
