### PR TITLE
Actually use the picture_claim as configured in OIDC config.

### DIFF
--- a/changelog.d/14751.bugfix
+++ b/changelog.d/14751.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.73.0 where the `picture_claim` configured under `oidc_providers` was unused (the default value of `"picture"` was used instead).

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -1615,7 +1615,7 @@ class JinjaOidcMappingProvider(OidcMappingProvider[JinjaOidcMappingConfig]):
         if email:
             emails.append(email)
 
-        picture = userinfo.get("picture")
+        picture = userinfo.get(self._config.picture_claim)
 
         return UserAttributeDict(
             localpart=localpart,


### PR DESCRIPTION
This seems like a bug in #13917, related to #9357.

The default mapping provider allowed a `picture_claim` to be configured, but it was not used.