### PR TITLE
Improve /sync performance of when passing filters with empty arrays

### DIFF
--- a/changelog.d/14786.feature
+++ b/changelog.d/14786.feature
@@ -1,0 +1,1 @@
+Improve performance of `/sync` when filtering all rooms, message types, or senders.

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -283,6 +283,9 @@ class FilterCollection:
             await self._room_filter.filter(events)
         )
 
+    def blocks_all_rooms(self) -> bool:
+        return self._room_filter.filters_all_rooms()
+
     def blocks_all_presence(self) -> bool:
         return (
             self._presence_filter.filters_all_types()

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -351,13 +351,13 @@ class Filter:
             self.not_rel_types = filter_json.get("org.matrix.msc3874.not_rel_types", [])
 
     def filters_all_types(self) -> bool:
-        return "*" in self.not_types
+        return self.types == [] or "*" in self.not_types
 
     def filters_all_senders(self) -> bool:
-        return "*" in self.not_senders
+        return self.senders == [] or "*" in self.not_senders
 
     def filters_all_rooms(self) -> bool:
-        return "*" in self.not_rooms
+        return self.rooms == [] or "*" in self.not_rooms
 
     def _check(self, event: FilterEvent) -> bool:
         """Checks whether the filter matches the given event.
@@ -450,8 +450,8 @@ class Filter:
             if any(map(match_func, disallowed_values)):
                 return False
 
-            # Other the event does not match at least one of the allowed values,
-            # reject it.
+            # Otherwise if the event does not match at least one of the allowed
+            # values, reject it.
             allowed_values = getattr(self, name)
             if allowed_values is not None:
                 if not any(map(match_func, allowed_values)):

--- a/synapse/handlers/search.py
+++ b/synapse/handlers/search.py
@@ -275,7 +275,7 @@ class SearchHandler:
         )
         room_ids = {r.room_id for r in rooms}
 
-        # If doing a subset of all rooms seearch, check if any of the rooms
+        # If doing a subset of all rooms search, check if any of the rooms
         # are from an upgraded room, and search their contents as well
         if search_filter.rooms:
             historical_room_ids: List[str] = []

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1403,11 +1403,14 @@ class SyncHandler:
 
         logger.debug("Fetching room data")
 
-        res = await self._generate_sync_entry_for_rooms(
+        (
+            newly_joined_rooms,
+            newly_joined_or_invited_or_knocked_users,
+            newly_left_rooms,
+            newly_left_users,
+        ) = await self._generate_sync_entry_for_rooms(
             sync_result_builder, account_data_by_room
         )
-        newly_joined_rooms, newly_joined_or_invited_or_knocked_users, _, _ = res
-        _, _, newly_left_rooms, newly_left_users = res
 
         block_all_presence_data = (
             since_token is None and sync_config.filter_collection.blocks_all_presence()

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1792,6 +1792,11 @@ class SyncHandler:
             - newly_left_rooms
             - newly_left_users
         """
+
+        # If the request doesn't care about rooms then nothing to do!
+        if sync_result_builder.sync_config.filter_collection.blocks_all_rooms():
+            return set(), set(), set(), set()
+
         since_token = sync_result_builder.since_token
 
         # 1. Start by fetching all ephemeral events in rooms we've joined (if required).


### PR DESCRIPTION
This has two related fixes:

* It enables fast-path processing for an empty filter (`[]`) which was previously only used for wildcard not-filters (`"*"`), e.g. it treats a filter like `{"types": []}` equivalent to `{"not_types": ["*"]}`. The spec isn't really clear if this is meant to be the same (see matrix-org/matrix-spec#1312), but empirically they do the same thing in Synapse today, except that in the empty filter case we would pull all data from the database to disregard it.
* It special cases a `/sync` filter with no-rooms to skip all room processing, previously we would partially skip processing, but would generally still calculate state for each room.

Things it does *not* do:

* We still generate per-room account data (to throw away).
* It does not try to make improvements to other endpoints which have filters.