### PR TITLE
Add index to improve performance of the `/timestamp_to_event` endpoint used for jumping to a specific date in the timeline of a room.

### DIFF
--- a/changelog.d/14799.bugfix
+++ b/changelog.d/14799.bugfix
@@ -1,0 +1,1 @@
+Add index to improve performance of the `/timestamp_to_event` endpoint used for jumping to a specific date in the timeline of a room.

--- a/synapse/storage/databases/main/events_bg_updates.py
+++ b/synapse/storage/databases/main/events_bg_updates.py
@@ -69,6 +69,8 @@ class _BackgroundUpdates:
 
     EVENTS_POPULATE_STATE_KEY_REJECTIONS = "events_populate_state_key_rejections"
 
+    EVENTS_JUMP_TO_DATE_INDEX = "events_jump_to_date_index"
+
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
 class _CalculateChainCover:
@@ -258,6 +260,16 @@ class EventsBackgroundUpdatesStore(SQLBaseStore):
         self.db_pool.updates.register_background_update_handler(
             _BackgroundUpdates.EVENTS_POPULATE_STATE_KEY_REJECTIONS,
             self._background_events_populate_state_key_rejections,
+        )
+
+        # Add an index that would be useful for jumping to date using
+        # get_event_id_for_timestamp.
+        self.db_pool.updates.register_background_index_update(
+            _BackgroundUpdates.EVENTS_JUMP_TO_DATE_INDEX,
+            index_name="events_jump_to_date_idx",
+            table="events",
+            columns=["room_id", "origin_server_ts"],
+            where_clause="NOT outlier",
         )
 
     async def _background_reindex_fields_sender(

--- a/synapse/storage/schema/main/delta/73/24_events_jump_to_date_index.sql
+++ b/synapse/storage/schema/main/delta/73/24_events_jump_to_date_index.sql
@@ -1,0 +1,17 @@
+/* Copyright 2023 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
+  (7324, 'events_jump_to_date_index', '{}');


### PR DESCRIPTION
<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
Follows: #9445, #14215 <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Add index to `events` table to help with 'jump to date' \
Before

```sql
synapse=> explain             SELECT event_id FROM events
            LEFT JOIN rejections USING (event_id)
            WHERE
                room_id = '!...:matrix.org'
                AND origin_server_ts <= 1620172800000
                /**
                 * Make sure the event isn't an `outlier` because we have no way
                 * to later check whether it's next to a gap. `outliers` do not
                 * have entries in the `event_edges`, `event_forward_extremeties`,
                 * and `event_backward_extremities` tables to check against
                 * (used by `is_event_next_to_backward_gap` and `is_event_next_to_forward_gap`).
                 */
                AND NOT outlier
                /* Make sure event is not rejected */
                AND rejections.event_id IS NULL
            /**
             * First sort by the message timestamp. If the message timestamps are the
             * same, we want the message that logically comes "next" (before/after
             * the given timestamp) based on the DAG and its topological order (`depth`).
             * Finally, we can tie-break based on when it was received on the server
             * (`stream_ordering`).
             */
            ORDER BY origin_server_ts DESC, depth DESC, stream_ordering DESC
            LIMIT 1;
                                                    QUERY PLAN
------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1075.38..2148.31 rows=1 width=66)
   ->  Incremental Sort  (cost=1075.38..650197.88 rows=605 width=66)
         Sort Key: events.origin_server_ts DESC, events.depth DESC, events.stream_ordering DESC
         Presorted Key: events.origin_server_ts
         ->  Nested Loop Anti Join  (cost=0.71..650170.66 rows=605 width=66)
               ->  Index Scan Backward using events_ts on events  (cost=0.43..649835.91 rows=605 width=66)
                     Index Cond: (origin_server_ts <= '1620172800000'::bigint)
                     Filter: ((NOT outlier) AND (room_id = '!...:matrix.org'::text))
               ->  Index Only Scan using rejections_event_id_key on rejections  (cost=0.28..0.55 rows=1 width=41)
                     Index Cond: (event_id = events.event_id)
```

Index

```sql
synapse=> create index rei_jtd_idx ON events(room_id, origin_server_ts) WHERE not outlier;
CREATE INDEX
synapse=> explain             SELECT event_id FROM events
            LEFT JOIN rejections USING (event_id)
            WHERE
                room_id = '!...:matrix.org'
                AND origin_server_ts <= 1620172800000
                /**
                 * Make sure the event isn't an `outlier` because we have no way
                 * to later check whether it's next to a gap. `outliers` do not
                 * have entries in the `event_edges`, `event_forward_extremeties`,
                 * and `event_backward_extremities` tables to check against
                 * (used by `is_event_next_to_backward_gap` and `is_event_next_to_forward_gap`).
                 */
                AND NOT outlier
                /* Make sure event is not rejected */
                AND rejections.event_id IS NULL
            /**
             * First sort by the message timestamp. If the message timestamps are the
             * same, we want the message that logically comes "next" (before/after
             * the given timestamp) based on the DAG and its topological order (`depth`).
             * Finally, we can tie-break based on when it was received on the server
             * (`stream_ordering`).
             */
            ORDER BY origin_server_ts DESC, depth DESC, stream_ordering DESC
            LIMIT 1;
                                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=5.44..10.08 rows=1 width=66)
   ->  Incremental Sort  (cost=5.44..2819.10 rows=607 width=66)
         Sort Key: events.origin_server_ts DESC, events.depth DESC, events.stream_ordering DESC
         Presorted Key: events.origin_server_ts
         ->  Nested Loop Anti Join  (cost=0.83..2791.78 rows=607 width=66)
               ->  Index Scan Backward using rei_jtd_idx on events  (cost=0.56..2456.44 rows=607 width=66)
                     Index Cond: ((room_id = '!...:matrix.org'::text) AND (origin_server_ts <= '1620172800000'::bigint))
               ->  Index Only Scan using rejections_event_id_key on rejections  (cost=0.28..0.55 rows=1 width=41)
                     Index Cond: (event_id = events.event_id)
```


</li>
</ol>
