### PR TITLE
Skip testing pypy-3.7-linux wheels as we don't have openssl 3.x on manylinux2014

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -139,6 +139,10 @@ jobs:
         if: matrix.arch == 'aarch64'
         run: echo 'CIBW_ARCHS_LINUX=aarch64' >> $GITHUB_ENV
 
+      - name: Only build a single wheel on PR
+        if: startsWith(github.ref, 'refs/pull/')
+        run: echo "CIBW_BUILD="cp37-manylinux_${{ matrix.arch }}"" >> $GITHUB_ENV
+
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -139,10 +139,6 @@ jobs:
         if: matrix.arch == 'aarch64'
         run: echo 'CIBW_ARCHS_LINUX=aarch64' >> $GITHUB_ENV
 
-      - name: Only build a single wheel on PR
-        if: startsWith(github.ref, 'refs/pull/')
-        run: echo "CIBW_BUILD="cp37-manylinux_${{ matrix.arch }}"" >> $GITHUB_ENV
-
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -148,7 +148,7 @@ jobs:
         env:
           # Skip testing for platforms which various libraries don't have wheels
           # for, and so need extra build deps.
-          CIBW_TEST_SKIP: pp39-* *i686* *musl* pp37-macosx*
+          CIBW_TEST_SKIP: pp3{7,9}-* *i686* *musl*
           # Fix Rust OOM errors on emulated aarch64: https://github.com/rust-lang/cargo/issues/10583
           CARGO_NET_GIT_FETCH_WITH_CLI: true
           CIBW_ENVIRONMENT_PASS_LINUX: CARGO_NET_GIT_FETCH_WITH_CLI

--- a/changelog.d/14802.misc
+++ b/changelog.d/14802.misc
@@ -1,0 +1,1 @@
+Skip testing built wheels for PyPy 3.7 on Linux x86_64 as we lack new required dependencies in the build environment.


### PR DESCRIPTION
The `build_wheel` CI job broke on develop when running tests against the built `pypy37-manylinux-x86_64` wheel. This was due to the `cryptography` package dropping support for OpenSSL 1.x.y [as of v39.0.0](https://cryptography.io/en/latest/changelog/#v39-0-0).

The container that `cibuildwheel` pulls and spins up ([`manylinux2014`](https://github.com/pypa/manylinux#manylinux) aka CentOS 7) does not come with OpenSSL 3.x.y, which causes the tests to fail. The wheel is still built successfully however, so downstream users will not be affected as long as they have OpenSSL 3.x.y and other dependencies available on their system.

A proper solution here is to run tests for our wheels on a more modern distribution - we're currently skipping testing a few different configurations (as shown in the changed files), however it's not as easy as upgrading our `manylinux*` image as those images are meant to remain old. For now, let's just unbreak CI on develop.

Supersedes https://github.com/matrix-org/synapse/pull/14798.