### PR TITLE
Add poetry.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ book/
 
 # Poetry will create a setup.py, which we don't want to include.
 /setup.py
+
+# Don't include users' poetry configs
+/poetry.toml

--- a/changelog.d/14807.misc
+++ b/changelog.d/14807.misc
@@ -1,0 +1,1 @@
+Add local poetry config files (`poetry.toml`) to `.gitignore`.


### PR DESCRIPTION
Did you know that `poetry` has [lots of configuration options](https://python-poetry.org/docs/configuration/)? You can use `poetry config ...` to set them, and if you add the `--local` flag then changes are written to a `poetry.toml` file in the local checkout.

The poetry config docs (above link) explicitly recommend not checking these into source control, as they will then apply to all users, which is typically undesirable.

This commits add `/poetry.toml` to `.gitignore`, such that any local poetry config files are automatically ignored by git.