### PR TITLE
Calculate rooms changed for device lists to work.

### DIFF
--- a/changelog.d/14810.bugfix
+++ b/changelog.d/14810.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.75.0rc1 where device lists could be miscalculated with some sync filters.

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -283,9 +283,6 @@ class FilterCollection:
             await self._room_filter.filter(events)
         )
 
-    def blocks_all_rooms(self) -> bool:
-        return self._room_filter.filters_all_rooms()
-
     def blocks_all_presence(self) -> bool:
         return (
             self._presence_filter.filters_all_types()

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1793,10 +1793,6 @@ class SyncHandler:
             - newly_left_users
         """
 
-        # If the request doesn't care about rooms then nothing to do!
-        if sync_result_builder.sync_config.filter_collection.blocks_all_rooms():
-            return set(), set(), set(), set()
-
         since_token = sync_result_builder.since_token
 
         # 1. Start by fetching all ephemeral events in rooms we've joined (if required).


### PR DESCRIPTION
#14786 was overly ambitious -- the results of `_generate_sync_entry_for_rooms` is used to calculate device lists as an input to `_generate_sync_entry_for_device_list` (by looking through the events of joined / left rooms to see who has joined / left).