### PR TITLE
Add rust linting commands to `scripts-dev/lint.sh`

### DIFF
--- a/changelog.d/14822.misc
+++ b/changelog.d/14822.misc
@@ -1,0 +1,1 @@
+Add `cargo fmt` and `cargo clippy` to the lint script.

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -114,6 +114,27 @@ python3 -m black "${files[@]}"
 # --quiet suppresses the update check.
 ruff --quiet "${files[@]}"
 
+# Catch any common programming mistakes in Rust code.
+#
+# --bins, --examples, --lib, --tests combined explicitly disable checking
+# the benchmarks, which can fail on the stable rust toolchain.
+#
+# --allow-staged and --allow-dirty suppress clippy raising errors
+# for uncommitted files. Only needed when using --fix.
+#
+# -D warnings disables the "warnings" lint.
+#
+# Using --fix has a tendency to cause subsequent runs of clippy to recompile
+# rust code, which can slow down this script. Thus we run clippy without --fix
+# first which is quick, and then re-run it with --fix if an error was found.
+if ! cargo-clippy --bins --examples --lib --tests -- -D warnings > /dev/null 2>&1; then
+  cargo-clippy \
+    --bins --examples --lib --tests --allow-staged --allow-dirty --fix -- -D warnings
+fi
+
+# Ensure the formatting of Rust code.
+cargo-fmt
+
 # Ensure all Pydantic models use strict types.
 ./scripts-dev/check_pydantic_models.py lint
 

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -117,7 +117,8 @@ ruff --quiet "${files[@]}"
 # Catch any common programming mistakes in Rust code.
 #
 # --bins, --examples, --lib, --tests combined explicitly disable checking
-# the benchmarks, which can fail on the stable rust toolchain.
+# the benchmarks, which can fail due to `#![feature]` macros not being
+# allowed on the stable rust toolchain (rustc error E0554).
 #
 # --allow-staged and --allow-dirty suppress clippy raising errors
 # for uncommitted files. Only needed when using --fix.

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -101,10 +101,21 @@ echo
 # Print out the commands being run
 set -x
 
+# Ensure the sort order of imports.
 isort "${files[@]}"
+
+# Ensure Python code conforms to an opinionated style.
 python3 -m black "${files[@]}"
+
+# Ensure the sample configuration file conforms to style checks.
 ./scripts-dev/config-lint.sh
+
+# Catch any common programming mistakes in Python code.
 # --quiet suppresses the update check.
 ruff --quiet "${files[@]}"
+
+# Ensure all Pydantic models use strict types.
 ./scripts-dev/check_pydantic_models.py lint
+
+# Ensure type hints are correct.
 mypy


### PR DESCRIPTION
This PR:

* Adds the `cargo clippy` and `cargo fmt` commands to the linting script.
* Adds comments with a brief description for the existing commands.

These should roughly match what's run in CI ([clippy](https://github.com/matrix-org/synapse/blob/f4d2a734f977c0a88f3a5fcdea38b7f9490481dc/.github/workflows/tests.yml#L112), [fmt](https://github.com/matrix-org/synapse/blob/f4d2a734f977c0a88f3a5fcdea38b7f9490481dc/.github/workflows/tests.yml#L154)).

The `clippy` command required some finesse for two reasons:
1. `clippy` may be configured to check benchmark code by default on some distributions (nixpkgs). Doing so on a stable Rust channel will yield an `#![feature]` may not be used on the stable release channel` on the files in `rust/benches/`. We can explicitly specify `--bins, --examples, --lib, --tests` and not `--benches` to avoid this edge case. It's verbose, but it works and being more explicit is never a bad thing.
2. Running with `--fix` seems to change the files each time or do something else that causes a rebuild of synapse's Rust code every time it's invoked, even if you didn't change any Rust code. Only using `--fix` if an invocation without `--fix` failed seems to be the way to go here.