### PR TITLE
Stabilise serving partial join responses

### DIFF
--- a/changelog.d/14839.feature
+++ b/changelog.d/14839.feature
@@ -1,0 +1,1 @@
+Faster joins: always serve a partial join response to servers that request it.

--- a/changelog.d/14839.feature
+++ b/changelog.d/14839.feature
@@ -1,1 +1,1 @@
-Faster joins: always serve a partial join response to servers that request it.
+Faster joins: always serve a partial join response to servers that request it with the stable query param.

--- a/docker/complement/conf/workers-shared-extra.yaml.j2
+++ b/docker/complement/conf/workers-shared-extra.yaml.j2
@@ -94,8 +94,6 @@ allow_device_name_lookup_over_federation: true
 experimental_features:
   # Enable history backfilling support
   msc2716_enabled: true
-  # server-side support for partial state in /send_join responses
-  msc3706_enabled: true
   {% if not workers_in_use %}
   # client-side support for partial state in /send_join responses
   faster_joins: true

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -73,6 +73,13 @@ class ExperimentalConfig(Config):
             "msc3202_transaction_extensions", False
         )
 
+        # MSC3706 (server-side support for partial state in /send_join responses)
+        # Synapse will always serve partial state responses to requests using the stable
+        # query parameter `omit_members`. If this flag is set, Synapse will also serve
+        # partial state responses to requests using the unstable query parameter
+        # `org.matrix.msc3706.partial_state`.
+        self.msc3706_enabled: bool = experimental.get("msc3706_enabled", False)
+
         # experimental support for faster joins over federation
         # (MSC2775, MSC3706, MSC3895)
         # requires a target server that can provide a partial join response (MSC3706)

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -73,12 +73,9 @@ class ExperimentalConfig(Config):
             "msc3202_transaction_extensions", False
         )
 
-        # MSC3706 (server-side support for partial state in /send_join responses)
-        self.msc3706_enabled: bool = experimental.get("msc3706_enabled", False)
-
         # experimental support for faster joins over federation
         # (MSC2775, MSC3706, MSC3895)
-        # requires a target server with msc3706_enabled enabled.
+        # requires a target server that can provide a partial join response (MSC3706)
         self.faster_joins_enabled: bool = experimental.get("faster_joins", False)
 
         # MSC3720 (Account status endpoint)

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -422,7 +422,6 @@ class FederationV2SendJoinServlet(BaseFederationServerServlet):
         server_name: str,
     ):
         super().__init__(hs, authenticator, ratelimiter, server_name)
-        self._msc3706_enabled = hs.config.experimental.msc3706_enabled
 
     async def on_PUT(
         self,
@@ -435,17 +434,15 @@ class FederationV2SendJoinServlet(BaseFederationServerServlet):
         # TODO(paul): assert that event_id parsed from path actually
         #   match those given in content
 
-        partial_state = False
-        if self._msc3706_enabled:
-            # The stable query parameter wins, if it disagrees with the unstable
-            # parameter for some reason.
-            stable_param = parse_boolean_from_args(query, "omit_members", default=None)
-            if stable_param is not None:
-                partial_state = stable_param
-            else:
-                partial_state = parse_boolean_from_args(
-                    query, "org.matrix.msc3706.partial_state", default=False
-                )
+        # The stable query parameter wins, if it disagrees with the unstable
+        # parameter for some reason.
+        stable_param = parse_boolean_from_args(query, "omit_members", default=None)
+        if stable_param is not None:
+            partial_state = stable_param
+        else:
+            partial_state = parse_boolean_from_args(
+                query, "org.matrix.msc3706.partial_state", default=False
+            )
 
         result = await self.handler.on_send_join_request(
             origin, content, room_id, caller_supports_partial_state=partial_state

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -422,6 +422,7 @@ class FederationV2SendJoinServlet(BaseFederationServerServlet):
         server_name: str,
     ):
         super().__init__(hs, authenticator, ratelimiter, server_name)
+        self._read_msc3706_query_param = hs.config.experimental.msc3706_enabled
 
     async def on_PUT(
         self,
@@ -434,12 +435,13 @@ class FederationV2SendJoinServlet(BaseFederationServerServlet):
         # TODO(paul): assert that event_id parsed from path actually
         #   match those given in content
 
+        partial_state = False
         # The stable query parameter wins, if it disagrees with the unstable
         # parameter for some reason.
         stable_param = parse_boolean_from_args(query, "omit_members", default=None)
         if stable_param is not None:
             partial_state = stable_param
-        else:
+        elif self._read_msc3706_query_param:
             partial_state = parse_boolean_from_args(
                 query, "org.matrix.msc3706.partial_state", default=False
             )

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -211,9 +211,8 @@ class SendJoinFederationTests(unittest.FederatingHomeserverTestCase):
         )
         self.assertEqual(r[("m.room.member", joining_user)].membership, "join")
 
-    @override_config({"experimental_features": {"msc3706_enabled": True}})
     def test_send_join_partial_state(self) -> None:
-        """When MSC3706 support is enabled, /send_join should return partial state"""
+        """/send_join should return partial state, if requested"""
         joining_user = "@misspiggy:" + self.OTHER_SERVER_NAME
         join_result = self._make_join(joining_user)
 


### PR DESCRIPTION
Fixes #14829.

Serving partial join responses is no longer experimental. They will only be served under the stable identifier if the the undocumented config flag `experimental.msc3706_enabled` is set to true.

Synapse continues to _request_ a partial join only if the undocumented config flag `experimental.faster_joins` is set to `true`; this setting remains present and unaffected.