### PR TITLE
Do not always start a db txn on Postgres

### DIFF
--- a/changelog.d/14840.misc
+++ b/changelog.d/14840.misc
@@ -1,0 +1,1 @@
+Prevent "WARNING:  there is already a transaction in progress" lines appearing in PostgreSQL's logs on some occasions.

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -108,11 +108,14 @@ def prepare_database(
         # so we start one before running anything. This ensures that any upgrades
         # are either applied completely, or not at all.
         #
-        # psycopg2 does automatically start transactions, and while this is technically
-        # harmless to do there as well, doing so results in nested transactions. Those
-        # will generate warnings in Postgres' logs per query, and we'd rather like to
+        # psycopg2 does not automatically start transactions when in autocommit mode.
+        # While it is technically harmless nest transactions in postgres, doing so
+        # results in warnings in Postgres' logs per query. And we'd rather like to
         # avoid doing that.
-        if isinstance(database_engine, Sqlite3Engine):
+        if isinstance(database_engine, Sqlite3Engine) or (
+            isinstance(database_engine, PostgresEngine)
+            and db_conn.autocommit
+        ):
             cur.execute("BEGIN TRANSACTION")
 
         logger.info("%r: Checking existing schema version", databases)

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -113,8 +113,7 @@ def prepare_database(
         # results in a warning in Postgres' logs per query. And we'd rather like to
         # avoid doing that.
         if isinstance(database_engine, Sqlite3Engine) or (
-            isinstance(database_engine, PostgresEngine)
-            and db_conn.autocommit
+            isinstance(database_engine, PostgresEngine) and db_conn.autocommit
         ):
             cur.execute("BEGIN TRANSACTION")
 

--- a/synapse/storage/prepare_database.py
+++ b/synapse/storage/prepare_database.py
@@ -109,8 +109,8 @@ def prepare_database(
         # are either applied completely, or not at all.
         #
         # psycopg2 does not automatically start transactions when in autocommit mode.
-        # While it is technically harmless nest transactions in postgres, doing so
-        # results in warnings in Postgres' logs per query. And we'd rather like to
+        # While it is technically harmless to nest transactions in postgres, doing so
+        # results in a warning in Postgres' logs per query. And we'd rather like to
         # avoid doing that.
         if isinstance(database_engine, Sqlite3Engine) or (
             isinstance(database_engine, PostgresEngine)


### PR DESCRIPTION
While running the unit tests locally and watching my postgres logs, I saw the following log line start to be emitted for every DB query that was being run:

```
2023-01-13 18:05:15.379 GMT [493791] WARNING:  there is already a transaction in progress
```

Which resulted in quite a lot of log lines, generating noise...

This warning is harmless, and is merely telling us that we've started a transaction (with `BEGIN`) and then started another one (with another `BEGIN`). Now this warning will only appear when we actually prepare a database for the first time (which we do all the time when running the unit tests, as each tests uses a separate database) or apply database migrations. 

So while on your actual homeserver you may see this warning pop up a couple times when you update Synapse, it won't be very frequent.

In any case, it should be a harmless change and reduces some noise, mostly for devs :)