### PR TITLE
Also use stable name in SendJoinResponse struct

### DIFF
--- a/changelog.d/14841.misc
+++ b/changelog.d/14841.misc
@@ -1,0 +1,1 @@
+Faster joins: use stable identifiers from [MSC3706](https://github.com/matrix-org/matrix-spec-proposals/pull/3706).

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -1152,7 +1152,7 @@ class FederationClient(FederationBase):
                 state=signed_state,
                 auth_chain=signed_auth,
                 origin=destination,
-                partial_state=response.partial_state,
+                partial_state=response.members_omitted,
                 servers_in_room=response.servers_in_room or [],
             )
 

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -1144,7 +1144,7 @@ class FederationClient(FederationBase):
 
             if response.members_omitted and not response.servers_in_room:
                 raise InvalidResponseError(
-                    "partial_state was set, but no servers were listed in the room"
+                    "members_omitted was set, but no servers were listed in the room"
                 )
 
             return SendJoinResult(

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -1142,7 +1142,7 @@ class FederationClient(FederationBase):
                     % (auth_chain_create_events,)
                 )
 
-            if response.partial_state and not response.servers_in_room:
+            if response.members_omitted and not response.servers_in_room:
                 raise InvalidResponseError(
                     "partial_state was set, but no servers were listed in the room"
                 )

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -1502,7 +1502,7 @@ def _get_event_ids_for_partial_state_join(
     prev_state_ids: StateMap[str],
     summary: Dict[str, MemberSummary],
 ) -> Collection[str]:
-    """Calculate state to be retuned in a partial_state send_join
+    """Calculate state to be returned in a partial_state send_join
 
     Args:
         join_event: the join event being send_joined

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -843,7 +843,9 @@ def _members_omitted_parser(response: SendJoinResponse) -> Generator[None, Any, 
     while True:
         val = yield
         if not isinstance(val, bool):
-            raise TypeError("members_omitted (formerly org.matrix.msc370c.partial_state) must be a boolean")
+            raise TypeError(
+                "members_omitted (formerly org.matrix.msc370c.partial_state) must be a boolean"
+            )
         response.members_omitted = val
 
 

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -795,7 +795,7 @@ class SendJoinResponse:
     event: Optional[EventBase] = None
 
     # The room state is incomplete
-    partial_state: bool = False
+    members_omitted: bool = False
 
     # List of servers in the room
     servers_in_room: Optional[List[str]] = None
@@ -835,16 +835,16 @@ def _event_list_parser(
 
 
 @ijson.coroutine
-def _partial_state_parser(response: SendJoinResponse) -> Generator[None, Any, None]:
+def _members_omitted_parser(response: SendJoinResponse) -> Generator[None, Any, None]:
     """Helper function for use with `ijson.items_coro`
 
-    Parses the partial_state field in send_join responses
+    Parses the members_omitted field in send_join responses
     """
     while True:
         val = yield
         if not isinstance(val, bool):
-            raise TypeError("partial_state must be a boolean")
-        response.partial_state = val
+            raise TypeError("members_omitted (formerly org.matrix.msc370c.partial_state) must be a boolean")
+        response.members_omitted = val
 
 
 @ijson.coroutine
@@ -905,7 +905,7 @@ class SendJoinParser(ByteParser[SendJoinResponse]):
         if not v1_api:
             self._coros.append(
                 ijson.items_coro(
-                    _partial_state_parser(self._response),
+                    _members_omitted_parser(self._response),
                     "org.matrix.msc3706.partial_state",
                     use_float="True",
                 )
@@ -913,7 +913,7 @@ class SendJoinParser(ByteParser[SendJoinResponse]):
             # The stable field name comes last, so it "wins" if the fields disagree
             self._coros.append(
                 ijson.items_coro(
-                    _partial_state_parser(self._response),
+                    _members_omitted_parser(self._response),
                     "members_omitted",
                     use_float="True",
                 )

--- a/tests/federation/transport/test_client.py
+++ b/tests/federation/transport/test_client.py
@@ -68,11 +68,11 @@ class SendJoinParserTestCase(TestCase):
         self.assertEqual(len(parsed_response.state), 1, parsed_response)
         self.assertEqual(parsed_response.event_dict, {}, parsed_response)
         self.assertIsNone(parsed_response.event, parsed_response)
-        self.assertFalse(parsed_response.partial_state, parsed_response)
+        self.assertFalse(parsed_response.members_omitted, parsed_response)
         self.assertEqual(parsed_response.servers_in_room, None, parsed_response)
 
     def test_partial_state(self) -> None:
-        """Check that the partial_state flag is correctly parsed"""
+        """Check that the members_omitted flag is correctly parsed"""
 
         def parse(response: JsonDict) -> bool:
             parser = SendJoinParser(RoomVersions.V1, False)
@@ -83,7 +83,7 @@ class SendJoinParserTestCase(TestCase):
 
             # Retrieve and check the parsed SendJoinResponse
             parsed_response = parser.finish()
-            return parsed_response.partial_state
+            return parsed_response.members_omitted
 
         self.assertTrue(parse({"members_omitted": True}))
         self.assertTrue(parse({"org.matrix.msc3706.partial_state": True}))


### PR DESCRIPTION
follow-up to #14832

Sean [pointed out](https://matrix.to/#/!vcyiEtMVHIhWXcJAfl:sw1v.org/$SdA3tdegQxt8tOFAKwNPZGKLgHrNzbko-D0KpmTSrVc?via=matrix.org&via=element.io&via=beeper.com) that the response struct should mirror the spec, which I agree with. I haven't chased this through the rest of the source tree though---I don't think it'd be worth it.