### PR TITLE
Add parameter to control whether we do a faster join

### DIFF
--- a/changelog.d/14843.misc
+++ b/changelog.d/14843.misc
@@ -1,0 +1,1 @@
+Add a parameter to control whether the federation client performs a partial state join.

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -351,13 +351,16 @@ class TransportLayerClient:
         room_id: str,
         event_id: str,
         content: JsonDict,
+        omit_members: bool,
     ) -> "SendJoinResponse":
         path = _create_v2_path("/send_join/%s/%s", room_id, event_id)
         query_params: Dict[str, str] = {}
         if self._faster_joins_enabled:
             # lazy-load state on join
-            query_params["org.matrix.msc3706.partial_state"] = "true"
-            query_params["omit_members"] = "true"
+            query_params["org.matrix.msc3706.partial_state"] = (
+                "true" if omit_members else "false"
+            )
+            query_params["omit_members"] = "true" if omit_members else "false"
 
         return await self.client.put_json(
             destination=destination,


### PR DESCRIPTION
When the local homeserver is already joined to a room and wants to
perform a remote join, we may find it useful to do a non-partial state
join if we already have the full state for the room.

Signed-off-by: Sean Quah <seanq@matrix.org>