### PR TITLE
Add an early return when handling no-op presence updates.

### DIFF
--- a/changelog.d/14855.misc
+++ b/changelog.d/14855.misc
@@ -1,0 +1,1 @@
+Add an early return when handling no-op presence updates.

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -2155,6 +2155,11 @@ class PresenceFederationQueue:
         # This should only be called on a presence writer.
         assert self._presence_writer
 
+        if not states or not destinations:
+            # Ignore calls which either don't have any new states or don't need
+            # to be sent anywhere.
+            return
+
         if self._federation:
             self._federation.send_presence_to_destinations(
                 states=states,


### PR DESCRIPTION
This stops us from incrementing the presence stream position for no-op updates.