### PR TITLE
Properly check for frozendicts.

### DIFF
--- a/changelog.d/14864.bugfix
+++ b/changelog.d/14864.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.64.0 when using room version 10 with frozen events enabled.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections.abc
 import logging
 import typing
 from typing import (
@@ -877,7 +878,7 @@ def _check_power_levels(
                 if not isinstance(v, int):
                     raise SynapseError(400, f"{v!r} must be an integer.")
             if k in {"events", "notifications", "users"}:
-                if not isinstance(v, dict) or not all(
+                if not isinstance(v, collections.abc.Mapping) or not all(
                     isinstance(v, int) for v in v.values()
                 ):
                     raise SynapseError(


### PR DESCRIPTION
Fixes a bug in #13220 when using frozen events.

Tested @ matrix-org/sytest#1328.