### PR TITLE
Fix paginating /relations with a live token

### DIFF
--- a/changelog.d/14866.bugfix
+++ b/changelog.d/14866.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.53.0 where `next_batch` tokens from `/sync` could not be used with the `/relations` endpoint.

--- a/synapse/storage/databases/main/stream.py
+++ b/synapse/storage/databases/main/stream.py
@@ -171,14 +171,18 @@ def generate_pagination_where_clause(
 
 
 def generate_pagination_bounds(
-    direction: str, from_token: RoomStreamToken, to_token: Optional[RoomStreamToken]
-) -> Tuple[str, Tuple[Optional[int], int], Optional[Tuple[Optional[int], int]]]:
+    direction: str,
+    from_token: Optional[RoomStreamToken],
+    to_token: Optional[RoomStreamToken],
+) -> Tuple[
+    str, Optional[Tuple[Optional[int], int]], Optional[Tuple[Optional[int], int]]
+]:
     """
     Generate a start and end point for this page of events.
 
     Args:
         direction: Whether pagination is going forwards or backwards. One of "f" or "b".
-        from_token: The token to start pagination at.
+        from_token: The token to start pagination at, or None to start at the first value.
         to_token: The token to end pagination at, or None to not limit the end point.
 
     Returns:
@@ -187,8 +191,8 @@ def generate_pagination_bounds(
             ASC or DESC for sorting of the query.
 
             The starting position as a tuple of ints representing
-            (topological position, stream position). The topological position
-            may be None for live tokens.
+            (topological position, stream position) or None if no from_token was
+            provided. The topological position may be None for live tokens.
 
             The end position in the same format as the starting position, or None
             if no to_token was provided.
@@ -207,18 +211,20 @@ def generate_pagination_bounds(
     # by fetching all events between the min stream token and the maximum
     # stream token (as returned by `RoomStreamToken.get_max_stream_pos`) and
     # then filtering the results.
-    if from_token.topological is not None:
-        from_bound: Tuple[Optional[int], int] = from_token.as_historical_tuple()
-    elif direction == "b":
-        from_bound = (
-            None,
-            from_token.get_max_stream_pos(),
-        )
-    else:
-        from_bound = (
-            None,
-            from_token.stream,
-        )
+    from_bound: Optional[Tuple[Optional[int], int]] = None
+    if from_token:
+        if from_token.topological is not None:
+            from_bound = from_token.as_historical_tuple()
+        elif direction == "b":
+            from_bound = (
+                None,
+                from_token.get_max_stream_pos(),
+            )
+        else:
+            from_bound = (
+                None,
+                from_token.stream,
+            )
 
     to_bound: Optional[Tuple[Optional[int], int]] = None
     if to_token:


### PR DESCRIPTION
The `/relations` endpoint was not properly handle "live tokens" (i.e sync tokens), to do this properly we abstract the code that `/messages` has and re-use it.

Tests at matrix-org/complement#586.

Reviewable commit-by-commit.

Fixes #14830

Related to #13862