### PR TITLE
Experimental MSC3890 Implementation: Fix deleting account data when using an account data writer worker

### DIFF
--- a/changelog.d/14869.bugfix
+++ b/changelog.d/14869.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in v1.75.0rc1 that caused experimental support for deleting account data to raise an internal server error while using an account data writer worker.

--- a/synapse/handlers/account_data.py
+++ b/synapse/handlers/account_data.py
@@ -248,7 +248,6 @@ class AccountDataHandler:
                 instance_name=random.choice(self._account_data_writers),
                 user_id=user_id,
                 account_data_type=account_data_type,
-                content={},
             )
             return response["max_stream_id"]
 

--- a/synapse/handlers/account_data.py
+++ b/synapse/handlers/account_data.py
@@ -155,9 +155,6 @@ class AccountDataHandler:
             max_stream_id = await self._store.remove_account_data_for_room(
                 user_id, room_id, account_data_type
             )
-            if max_stream_id is None:
-                # The referenced account data did not exist, so no delete occurred.
-                return None
 
             self._notifier.on_new_event(
                 StreamKeyType.ACCOUNT_DATA, max_stream_id, users=[user_id]
@@ -230,9 +227,6 @@ class AccountDataHandler:
             max_stream_id = await self._store.remove_account_data_for_user(
                 user_id, account_data_type
             )
-            if max_stream_id is None:
-                # The referenced account data did not exist, so no delete occurred.
-                return None
 
             self._notifier.on_new_event(
                 StreamKeyType.ACCOUNT_DATA, max_stream_id, users=[user_id]

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -585,7 +585,7 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
 
     async def remove_account_data_for_room(
         self, user_id: str, room_id: str, account_data_type: str
-    ) -> Optional[int]:
+    ) -> int:
         """Delete the room account data for the user of a given type.
 
         Args:
@@ -637,15 +637,13 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
                 next_id,
             )
 
-            if not row_updated:
-                return None
-
-            self._account_data_stream_cache.entity_has_changed(user_id, next_id)
-            self.get_room_account_data_for_user.invalidate((user_id,))
-            self.get_account_data_for_room.invalidate((user_id, room_id))
-            self.get_account_data_for_room_and_type.prefill(
-                (user_id, room_id, account_data_type), {}
-            )
+            if row_updated:
+                self._account_data_stream_cache.entity_has_changed(user_id, next_id)
+                self.get_room_account_data_for_user.invalidate((user_id,))
+                self.get_account_data_for_room.invalidate((user_id, room_id))
+                self.get_account_data_for_room_and_type.prefill(
+                    (user_id, room_id, account_data_type), {}
+                )
 
         return self._account_data_id_gen.get_current_token()
 
@@ -753,7 +751,7 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
         self,
         user_id: str,
         account_data_type: str,
-    ) -> Optional[int]:
+    ) -> int:
         """
         Delete a single piece of user account data by type.
 
@@ -840,14 +838,12 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
                 next_id,
             )
 
-            if not row_updated:
-                return None
-
-            self._account_data_stream_cache.entity_has_changed(user_id, next_id)
-            self.get_global_account_data_for_user.invalidate((user_id,))
-            self.get_global_account_data_by_type_for_user.prefill(
-                (user_id, account_data_type), {}
-            )
+            if row_updated:
+                self._account_data_stream_cache.entity_has_changed(user_id, next_id)
+                self.get_global_account_data_for_user.invalidate((user_id,))
+                self.get_global_account_data_by_type_for_user.prefill(
+                    (user_id, account_data_type), {}
+                )
 
         return self._account_data_id_gen.get_current_token()
 


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/matrix-org/synapse/pull/14714 with ~~two~~ one major change:

* Stop providing a `content` kwarg to `ReplicationRemoveUserAccountDataRestServlet`, which didn't take that argument. This was causing a `TypeError` when trying to remove user account when experimental MSC3890 support was enabled and an account data writer worker was in use.
* ~~Set `WAIT_FOR_STREAMS` to `False` for `ReplicationRemoveUserAccountDataRestServlet`. Don't update the account_data stream when a delete comes in for data that doesn't exist. This stops the master process waiting for the `account_data` stream to increment after issuing a replication command. In the case of attempting to delete an account data entry which doesn't exist, we don't update the account data stream. This saves up from needing to wake up any listeners when a change in state hasn't actually occurred.~~

---

The only other change is to return the maximum stream ID (one that has not been incremented) instead of `None` in the response to the replication command. This means that in the case of a replication call to remove account data that didn't exist, the replication response body is now `{"max_stream_id": current_stream_id}` instead of `{"max_stream_id": None}`.

Nothing actually read this response body other than the replication stream code, but it feels better to respond with the actual maximum stream ID in this case, rather than `None`.

Thanks to @realtyem for [pointing out the bug in #synapse-dev](https://matrix.to/#/!vcyiEtMVHIhWXcJAfl:sw1v.org/$xWLiPEniucGZ7ac2x2pHSII9xNTs3uqIWD_LQRem2lY?via=matrix.org&via=element.io&via=envs.net).