### PR TITLE
Faster joins: Update room stats and the user directory on workers when finishing join

### DIFF
--- a/changelog.d/14874.bugfix
+++ b/changelog.d/14874.bugfix
@@ -1,0 +1,1 @@
+Faster joins: Fix a bug in worker deployments where the room stats and user directory would not get updated when finishing a fast join until another event is sent or received.

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1735,10 +1735,6 @@ class FederationHandler:
                     # Poke the notifier so that other workers see the write to
                     # the un-partial-stated rooms stream.
                     self._notifier.notify_replication()
-
-                    # TODO(faster_joins) update room stats and user directory?
-                    #   https://github.com/matrix-org/synapse/issues/12814
-                    #   https://github.com/matrix-org/synapse/issues/12815
                     return
 
                 # we raced against more events arriving with partial state. Go round

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -208,9 +208,10 @@ class ReplicationDataHandler:
             for row in rows:
                 if row.type != EventsStreamEventRow.TypeId:
                     # The row's data is an `EventsStreamCurrentStateRow`.
-                    # When finishing up a partial state join, the current state of a
-                    # room will change without any new events being persisted, so we
-                    # must poke the replication callbacks ourselves.
+                    # When we recompute the current state of a room based on forward
+                    # extremities (see `update_current_state`), no new events are
+                    # persisted, so we must poke the replication callbacks ourselves.
+                    # This functionality is used when finishing up a partial state join.
                     self.notifier.notify_replication()
                     continue
                 assert isinstance(row, EventsStreamRow)

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -207,6 +207,11 @@ class ReplicationDataHandler:
             # we don't need to optimise this for multiple rows.
             for row in rows:
                 if row.type != EventsStreamEventRow.TypeId:
+                    # The row's data is an `EventsStreamCurrentStateRow`.
+                    # When finishing up a partial state join, the current state of a
+                    # room will change without any new events being persisted, so we
+                    # must poke the replication callbacks ourselves.
+                    self.notifier.notify_replication()
                     continue
                 assert isinstance(row, EventsStreamRow)
                 assert isinstance(row.data, EventsStreamEventRow)

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -493,8 +493,6 @@ class StateStorageController:
                  up to date.
         """
         # FIXME(faster_joins): what do we do here?
-        #   https://github.com/matrix-org/synapse/issues/12814
-        #   https://github.com/matrix-org/synapse/issues/12815
         #   https://github.com/matrix-org/synapse/issues/13008
 
         return await self.stores.main.get_partial_current_state_deltas(


### PR DESCRIPTION
When finishing a partial state join to a room, we update the current
state of the room without persisting additional events. Workers receive
notice of the current state update over replication, but neglect to wake
the room stats and user directory updaters, which then get incidentally
triggered the next time an event is persisted or an unrelated event
persister sends out a stream position update.

We wake the room stats and user directory updaters at the appropriate
time in this commit.

Part of #12814 and #12815.

Signed-off-by: Sean Quah <seanq@matrix.org>
