### PR TITLE
Fix type hints in knocking tests

### DIFF
--- a/changelog.d/14887.misc
+++ b/changelog.d/14887.misc
@@ -1,0 +1,1 @@
+Add missing type hints.

--- a/mypy.ini
+++ b/mypy.ini
@@ -40,7 +40,6 @@ exclude = (?x)
    |tests/events/test_utils.py
    |tests/federation/test_federation_catch_up.py
    |tests/federation/test_federation_sender.py
-   |tests/federation/transport/test_knocking.py
    |tests/handlers/test_typing.py
    |tests/http/federation/test_matrix_federation_agent.py
    |tests/http/federation/test_srv_resolver.py

--- a/tests/federation/transport/test_knocking.py
+++ b/tests/federation/transport/test_knocking.py
@@ -23,14 +23,10 @@ from synapse.server import HomeServer
 from synapse.types import RoomAlias
 
 from tests.test_utils import event_injection
-from tests.unittest import (
-    FederatingHomeserverTestCase,
-    HomeserverTestCaseProtocol,
-    TestCase,
-)
+from tests.unittest import FederatingHomeserverTestCase, HomeserverTestCase
 
 
-class KnockingStrippedStateEventHelperMixin(TestCase, HomeserverTestCaseProtocol):
+class KnockingStrippedStateEventHelperMixin(HomeserverTestCase):
     def send_example_state_events_to_room(
         self,
         hs: "HomeServer",

--- a/tests/federation/transport/test_knocking.py
+++ b/tests/federation/transport/test_knocking.py
@@ -23,10 +23,14 @@ from synapse.server import HomeServer
 from synapse.types import RoomAlias
 
 from tests.test_utils import event_injection
-from tests.unittest import FederatingHomeserverTestCase, TestCase
+from tests.unittest import (
+    FederatingHomeserverTestCase,
+    HomeserverTestCaseProtocol,
+    TestCase,
+)
 
 
-class KnockingStrippedStateEventHelperMixin(TestCase):
+class KnockingStrippedStateEventHelperMixin(TestCase, HomeserverTestCaseProtocol):
     def send_example_state_events_to_room(
         self,
         hs: "HomeServer",
@@ -49,7 +53,7 @@ class KnockingStrippedStateEventHelperMixin(TestCase):
         # To set a canonical alias, we'll need to point an alias at the room first.
         canonical_alias = "#fancy_alias:test"
         self.get_success(
-            self.store.create_room_alias_association(
+            self.hs.get_datastores().main.create_room_alias_association(
                 RoomAlias.from_string(canonical_alias), room_id, ["test"]
             )
         )

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -294,9 +294,7 @@ class SyncTypingTests(unittest.HomeserverTestCase):
             self.make_request("GET", sync_url % (access_token, next_batch))
 
 
-class SyncKnockTestCase(
-    KnockingStrippedStateEventHelperMixin, unittest.HomeserverTestCase
-):
+class SyncKnockTestCase(KnockingStrippedStateEventHelperMixin):
     servlets = [
         synapse.rest.admin.register_servlets,
         login.register_servlets,

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -295,7 +295,7 @@ class SyncTypingTests(unittest.HomeserverTestCase):
 
 
 class SyncKnockTestCase(
-    unittest.HomeserverTestCase, KnockingStrippedStateEventHelperMixin
+    KnockingStrippedStateEventHelperMixin, unittest.HomeserverTestCase
 ):
     servlets = [
         synapse.rest.admin.register_servlets,

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -223,6 +223,27 @@ def logcontext_clean(target: TV) -> TV:
     return patcher(target)  # type: ignore[call-overload]
 
 
+class HomeserverTestCaseProtocol(Protocol):
+    """
+    A protocol type specifying that a class has access to various common
+    unit test helper methods defined by unittest.TestCase and the classes
+    that inherit from it. Add more methods or properties below as necessary.
+
+    Used for typing mixin classes. See this link for more info:
+    https://mypy.readthedocs.io/en/stable/protocols.html
+
+    TODO: HomeserverTestCase should inherit from this protocol, so that
+    mypy checks that HomeserverTestCase implements these properties/methods.
+    Unfortunately this causes mypy to find many type errors in our test
+    classes, which need to first be fixed.
+    """
+
+    hs: HomeServer
+
+    def get_success(self, d: Awaitable[TV], by: float = 0.0) -> TV:
+        ...
+
+
 class HomeserverTestCase(TestCase):
     """
     A base TestCase that reduces boilerplate for HomeServer-using test cases.

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -223,27 +223,6 @@ def logcontext_clean(target: TV) -> TV:
     return patcher(target)  # type: ignore[call-overload]
 
 
-class HomeserverTestCaseProtocol(Protocol):
-    """
-    A protocol type specifying that a class has access to various common
-    unit test helper methods defined by unittest.TestCase and the classes
-    that inherit from it. Add more methods or properties below as necessary.
-
-    Used for typing mixin classes. See this link for more info:
-    https://mypy.readthedocs.io/en/stable/protocols.html
-
-    TODO: HomeserverTestCase should inherit from this protocol, so that
-    mypy checks that HomeserverTestCase implements these properties/methods.
-    Unfortunately this causes mypy to find many type errors in our test
-    classes, which need to first be fixed.
-    """
-
-    hs: HomeServer
-
-    def get_success(self, d: Awaitable[TV], by: float = 0.0) -> TV:
-        ...
-
-
 class HomeserverTestCase(TestCase):
     """
     A base TestCase that reduces boilerplate for HomeServer-using test cases.


### PR DESCRIPTION
This is my first type declaring a `Protocol` for type hinting, so hopefully I've done it right!

Reviewable commit-by-commit.