### PR TITLE
Request partial joins by default

### DIFF
--- a/changelog.d/14905.feature
+++ b/changelog.d/14905.feature
@@ -1,0 +1,1 @@
+Faster joins: request partial joins by default. Admins can opt-out of this for the time being---see the upgrade notes.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -90,6 +90,19 @@ process, for example:
 
 # Upgrading to v1.76.0
 
+## Faster joins are enabled by default
+
+When joining a room for the first time, Synapse 1.76.0rc1 will request a partial join from the other server by default. Previously, server admins had to opt-in to this using an experimental config flag.
+
+Server admins can opt out of this feature for the time being by setting
+
+```yaml
+experimental:
+    faster_joins: false
+```
+
+in their server config.
+
 ## Changes to the account data replication streams
 
 Synapse has changed the format of the account data and devices replication

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -84,7 +84,7 @@ class ExperimentalConfig(Config):
         # experimental support for faster joins over federation
         # (MSC2775, MSC3706, MSC3895)
         # requires a target server that can provide a partial join response (MSC3706)
-        self.faster_joins_enabled: bool = experimental.get("faster_joins", False)
+        self.faster_joins_enabled: bool = experimental.get("faster_joins", True)
 
         # MSC3720 (Account status endpoint)
         self.msc3720_enabled: bool = experimental.get("msc3720_enabled", False)


### PR DESCRIPTION
This is a little sloppy, but we are trying to gain confidence in faster joins in the upcoming RC.

Admins can still opt out by adding the following to their Synapse config:

```yaml
experimental:
    faster_joins: false
```

We may revert this change before the release proper, depending on how testing in the wild goes.