### PR TITLE
Bump the client-side timeout for /state

### DIFF
--- a/changelog.d/14912.misc
+++ b/changelog.d/14912.misc
@@ -1,0 +1,1 @@
+Faster joins: allow the resync process more time to fetch `/state` ids.

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -102,6 +102,10 @@ class TransportLayerClient:
             destination,
             path=path,
             args={"event_id": event_id},
+            # This can take a looooooong time for large rooms. Give this a generous
+            # timeout, to avoid the partial state resync timing out early and trying
+            # a bunch of servers who haven't see our join yet.
+            timeout=600,
             parser=_StateParser(room_version),
         )
 

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -103,9 +103,9 @@ class TransportLayerClient:
             path=path,
             args={"event_id": event_id},
             # This can take a looooooong time for large rooms. Give this a generous
-            # timeout, to avoid the partial state resync timing out early and trying
-            # a bunch of servers who haven't see our join yet.
-            timeout=600,
+            # timeout of 10 minutes to avoid the partial state resync timing out early
+            # and trying a bunch of servers who haven't seen our join yet.
+            timeout=600_000,
             parser=_StateParser(room_version),
         )
 


### PR DESCRIPTION
to allow faster joins resyncs the chance to complete for large rooms. We have seen this fair poorly (~90s for Matrix HQ's /state) in testing, causing the resync to advance to another HS who hasn't seen our join yet.

I'd like to see something cleverer "e.g. extend timeout as you receive data" but this is good enough for now.