### PR TITLE
Fix initialization of `_device_list_id_gen`

### DIFF
--- a/changelog.d/14914.bugfix
+++ b/changelog.d/14914.bugfix
@@ -1,1 +1,1 @@
-Faster joins: Fix a bug where device list EDUs could fail to be handled after a restart when a faster join sync is in progress.
+Faster joins: Fix a bug introduced in Synapse 1.69 where device list EDUs could fail to be handled after a restart when a faster join sync is in progress.

--- a/changelog.d/14914.bugfix
+++ b/changelog.d/14914.bugfix
@@ -1,0 +1,1 @@
+Faster joins: Fix a bug where device list EDUs could fail to be handled after a restart when a faster join sync is in progress.

--- a/synapse/storage/databases/main/devices.py
+++ b/synapse/storage/databases/main/devices.py
@@ -99,6 +99,7 @@ class DeviceWorkerStore(RoomMemberWorkerStore, EndToEndKeyWorkerStore):
                 ("user_signature_stream", "stream_id"),
                 ("device_lists_outbound_pokes", "stream_id"),
                 ("device_lists_changes_in_room", "stream_id"),
+                ("device_lists_remote_pending", "stream_id"),
             ],
             is_writer=hs.config.worker.worker_app is None,
         )


### PR DESCRIPTION
On startup, the `_device_list_id_gen` stream id generator is initialized
using the maximum stream id seen in a list of tables. When we started
populating the `device_list_remote_pending` table in #13913, we forgot
to add it to the aforementioned list of tables, so the stream id
generator can hand out old stream ids after a restart. The end result is
that Synapse can fail to handle device list update EDUs after a restart
when a partial state join is in progress.

Add the `device_list_remote_pending` table to the list of tables to
consider when initializing the `_device_list_id_gen` stream id generator.

Signed-off-by: Sean Quah <seanq@matrix.org>
