### PR TITLE
Batch look-ups to see if rooms are partial stated.

### DIFF
--- a/changelog.d/14917.misc
+++ b/changelog.d/14917.misc
@@ -1,0 +1,1 @@
+Improve performance of looking up partial-state status.

--- a/changelog.d/14917.misc
+++ b/changelog.d/14917.misc
@@ -1,1 +1,1 @@
-Improve performance of looking up partial-state status.
+Faster joins: Improve performance of looking up partial-state status of rooms.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1408,7 +1408,7 @@ class SyncHandler:
             forced_newly_joined_room_ids.update(
                 room_id
                 for room_id, is_partial_state in results.items()
-                if is_partial_state
+                if not is_partial_state
             )
 
         # Now we have our list of joined room IDs, exclude as configured and freeze

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1383,7 +1383,7 @@ class SyncHandler:
         if not sync_config.filter_collection.lazy_load_members():
             # Non-lazy syncs should never include partially stated rooms.
             # Exclude all partially stated rooms from this sync.
-            results = await self.store.is_partial_state_rooms(mutable_joined_room_ids)
+            results = await self.store.is_partial_state_room_batched(mutable_joined_room_ids)
             mutable_rooms_to_exclude.update(
                 room_id
                 for room_id, is_partial_state in results.items()
@@ -1404,7 +1404,7 @@ class SyncHandler:
                     mutable_joined_room_ids,
                 )
             )
-            results = await self.store.is_partial_state_rooms(un_partial_stated_rooms)
+            results = await self.store.is_partial_state_room_batched(un_partial_stated_rooms)
             forced_newly_joined_room_ids.update(
                 room_id
                 for room_id, is_partial_state in results.items()

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1383,9 +1383,9 @@ class SyncHandler:
         if not sync_config.filter_collection.lazy_load_members():
             # Non-lazy syncs should never include partially stated rooms.
             # Exclude all partially stated rooms from this sync.
-            for room_id in mutable_joined_room_ids:
-                if await self.store.is_partial_state_room(room_id):
-                    mutable_rooms_to_exclude.add(room_id)
+            results = await self.store.is_partial_state_rooms(mutable_joined_room_ids)
+            for room_id, result in results.items():
+                mutable_rooms_to_exclude.add(room_id)
 
         # Incremental eager syncs should additionally include rooms that
         # - we are joined to
@@ -1401,9 +1401,9 @@ class SyncHandler:
                     mutable_joined_room_ids,
                 )
             )
-            for room_id in un_partial_stated_rooms:
-                if not await self.store.is_partial_state_room(room_id):
-                    forced_newly_joined_room_ids.add(room_id)
+            results = await self.store.is_partial_state_rooms(un_partial_stated_rooms)
+            for room_id, result in results.items():
+                forced_newly_joined_room_ids.add(room_id)
 
         # Now we have our list of joined room IDs, exclude as configured and freeze
         joined_room_ids = frozenset(

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1383,7 +1383,9 @@ class SyncHandler:
         if not sync_config.filter_collection.lazy_load_members():
             # Non-lazy syncs should never include partially stated rooms.
             # Exclude all partially stated rooms from this sync.
-            results = await self.store.is_partial_state_room_batched(mutable_joined_room_ids)
+            results = await self.store.is_partial_state_room_batched(
+                mutable_joined_room_ids
+            )
             mutable_rooms_to_exclude.update(
                 room_id
                 for room_id, is_partial_state in results.items()
@@ -1404,7 +1406,9 @@ class SyncHandler:
                     mutable_joined_room_ids,
                 )
             )
-            results = await self.store.is_partial_state_room_batched(un_partial_stated_rooms)
+            results = await self.store.is_partial_state_room_batched(
+                un_partial_stated_rooms
+            )
             forced_newly_joined_room_ids.update(
                 room_id
                 for room_id, is_partial_state in results.items()

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1819,7 +1819,7 @@ class DatabasePool:
         keyvalues: Optional[Dict[str, Any]] = None,
         desc: str = "simple_select_many_batch",
         batch_size: int = 100,
-    ) -> List[Any]:
+    ) -> List[Dict[str, Any]]:
         """Executes a SELECT query on the named table, which may return zero or
         more rows, returning the result as a list of dicts.
 

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1275,7 +1275,9 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
         return entry is not None
 
     @cachedList(cached_method_name="is_partial_State_room", list_name="room_ids")
-    async def is_partial_state_rooms(self, room_ids: StrCollection) -> Mapping[str, bool]:
+    async def is_partial_state_rooms(
+        self, room_ids: StrCollection
+    ) -> Mapping[str, bool]:
         """Checks if this room has partial state.
 
         Returns true if this is a "partial-state" room, which means that the state
@@ -1283,13 +1285,15 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
         complete.
         """
 
-        entries = set(await self.db_pool.simple_select_many_batch(
-            table="partial_state_rooms",
-            column="room_id",
-            iterable=room_ids,
-            retcols=("room_id",),
-            desc="is_partial_state_room",
-        ))
+        entries = set(
+            await self.db_pool.simple_select_many_batch(
+                table="partial_state_rooms",
+                column="room_id",
+                iterable=room_ids,
+                retcols=("room_id",),
+                desc="is_partial_state_room",
+            )
+        )
 
         return {room_id: room_id in entries for room_id in room_ids}
 

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1275,7 +1275,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
         return entry is not None
 
     @cachedList(cached_method_name="is_partial_state_room", list_name="room_ids")
-    async def is_partial_state_rooms(
+    async def is_partial_state_room_batched(
         self, room_ids: StrCollection
     ) -> Mapping[str, bool]:
         """Checks if the given rooms have partial state.

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1274,7 +1274,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
 
         return entry is not None
 
-    @cachedList(cached_method_name="is_partial_State_room", list_name="room_ids")
+    @cachedList(cached_method_name="is_partial_state_room", list_name="room_ids")
     async def is_partial_state_rooms(
         self, room_ids: StrCollection
     ) -> Mapping[str, bool]:

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1255,7 +1255,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
 
         return room_servers
 
-    @cached()
+    @cached(max_entries=10000)
     async def is_partial_state_room(self, room_id: str) -> bool:
         """Checks if this room has partial state.
 

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -23,7 +23,6 @@ from typing import (
     Collection,
     Dict,
     List,
-    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -1286,14 +1285,16 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
         complete.
         """
 
-        rows: List[Dict[str, Literal[1]]] = await self.db_pool.simple_select_many_batch(
+        rows: List[Dict[str, str]] = await self.db_pool.simple_select_many_batch(
             table="partial_state_rooms",
-            column="1",
+            column="room_id",
             iterable=room_ids,
             retcols=("room_id",),
             desc="is_partial_state_room",
         )
-        partial_state_rooms = {room_id for row_dict in rows for room_id in row_dict}
+        partial_state_rooms = {
+            room_id for row_dict in rows for room_id in row_dict.values()
+        }
         return {room_id: room_id in partial_state_rooms for room_id in room_ids}
 
     async def get_join_event_id_and_device_lists_stream_id_for_partial_state(

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1292,9 +1292,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
             retcols=("room_id",),
             desc="is_partial_state_room_batched",
         )
-        partial_state_rooms = {
-            row_dict["room_id"] for row_dict in rows
-        }
+        partial_state_rooms = {row_dict["room_id"] for row_dict in rows}
         return {room_id: room_id in partial_state_rooms for room_id in room_ids}
 
     async def get_join_event_id_and_device_lists_stream_id_for_partial_state(

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1290,7 +1290,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
             column="room_id",
             iterable=room_ids,
             retcols=("room_id",),
-            desc="is_partial_state_room",
+            desc="is_partial_state_room_batched",
         )
         partial_state_rooms = {
             room_id for row_dict in rows for room_id in row_dict.values()

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1278,9 +1278,9 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
     async def is_partial_state_rooms(
         self, room_ids: StrCollection
     ) -> Mapping[str, bool]:
-        """Checks if this room has partial state.
+        """Checks if the given rooms have partial state.
 
-        Returns true if this is a "partial-state" room, which means that the state
+        Returns true for "partial-state" rooms, which means that the state
         at events in the room, and `current_state_events`, may not yet be
         complete.
         """

--- a/synapse/storage/databases/main/room.py
+++ b/synapse/storage/databases/main/room.py
@@ -1293,7 +1293,7 @@ class RoomWorkerStore(CacheInvalidationWorkerStore):
             desc="is_partial_state_room_batched",
         )
         partial_state_rooms = {
-            room_id for row_dict in rows for room_id in row_dict.values()
+            row_dict["room_id"] for row_dict in rows
         }
         return {room_id: room_id in partial_state_rooms for room_id in room_ids}
 


### PR DESCRIPTION
This should save some CPU time.

We might also want to increase the cache size on `is_partial_state_room`?