### PR TITLE
Handle malformed values of `notification.room` in power level events

### DIFF
--- a/changelog.d/14942.bugfix
+++ b/changelog.d/14942.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.68.0 where we were unable to service remote joins in rooms with `@room` notification levels set to `null` in their (malformed) power levels.

--- a/tests/test_event_auth.py
+++ b/tests/test_event_auth.py
@@ -733,6 +733,7 @@ class EventAuthTestCase(unittest.TestCase):
 
         test_room_v10_rejects_string_power_levels above handles the string case.
         """
+
         def create_event(pl_event_content: Dict[str, Any]) -> EventBase:
             return make_event_from_dict(
                 {

--- a/tests/test_event_auth.py
+++ b/tests/test_event_auth.py
@@ -729,6 +729,10 @@ class EventAuthTestCase(unittest.TestCase):
             )
 
     def test_room_v10_rejects_other_non_integer_power_levels(self) -> None:
+        """We should reject PLs that are non-integer, non-string JSON values.
+
+        test_room_v10_rejects_string_power_levels above handles the string case.
+        """
         def create_event(pl_event_content: Dict[str, Any]) -> EventBase:
             return make_event_from_dict(
                 {

--- a/tests/test_event_auth.py
+++ b/tests/test_event_auth.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from typing import Collection, Dict, Iterable, List, Optional
+from typing import Any, Collection, Dict, Iterable, List, Optional
 
 from parameterized import parameterized
 
@@ -727,6 +727,31 @@ class EventAuthTestCase(unittest.TestCase):
             event_auth._check_power_levels(
                 pl_event.room_version, pl_event2, {("fake_type", "fake_key"): pl_event}
             )
+
+    def test_room_v10_rejects_other_non_integer_power_levels(self) -> None:
+        def create_event(pl_event_content: Dict[str, Any]) -> EventBase:
+            return make_event_from_dict(
+                {
+                    "room_id": TEST_ROOM_ID,
+                    **_maybe_get_event_id_dict_for_room_version(RoomVersions.V10),
+                    "type": "m.room.power_levels",
+                    "sender": "@test:test.com",
+                    "state_key": "",
+                    "content": pl_event_content,
+                    "signatures": {"test.com": {"ed25519:0": "some9signature"}},
+                },
+                room_version=RoomVersions.V10,
+            )
+
+        contents: Iterable[Dict[str, Any]] = [
+            {"notifications": {"room": None}},
+            {"users": {"@alice:wonderland": []}},
+            {"users_default": {}},
+        ]
+        for content in contents:
+            event = create_event(content)
+            with self.assertRaises(SynapseError):
+                event_auth._check_power_levels(event.room_version, event, {})
 
 
 # helpers for making events


### PR DESCRIPTION
Commitwise-reviewable.

Should fix https://github.com/matrix-org/synapse/issues/14933. The problem is that a pre-v10 room has `{"notifications": {"room": null}}` in its power levels event content. The `null` becomes a `None` inside the Python interpreter. Then the logic which tries to handle stringy power levels falls over when computing `int(None)`.

I have implemented this assuming that the spec considers `{"notifications": {"room": null}}` to be acceptable and equivalent to `{"notifications": {}}`. I don't know if this is actually true; the OpenAPI definition is https://github.com/matrix-org/matrix-spec/blob/5f2fac89afdd02830099b5010e46724d905057d5/data/event-schemas/schema/m.room.power_levels.yaml#L88-L97. (`room` is not marked as `required`, but nor is it marked as `nullable`.)

But being pragmatic for a moment: we have this event in our DB for some reason, and we may as well try to unbreak the room for new joiners.