### PR TITLE
Ensure cargo bench still functions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -566,6 +566,28 @@ jobs:
 
       - run: cargo test
 
+  # We want to ensure that the cargo benchmarks still compile appropriately.
+  cargo-bench:
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    needs:
+      - linting-done
+      - changes
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        # There don't seem to be versioned releases of this action per se: for each rust
+        # version there is a branch which gets constantly rebased on top of master.
+        # We pin to a specific commit for paranoia's sake.
+        uses: dtolnay/rust-toolchain@e645b0cf01249a964ec099494d38d2da0f0b349f
+        with:
+            toolchain: 1.58.1
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo bench --no-run
+
   # a job which marks all the other jobs as complete, thus allowing PRs to be merged.
   tests-done:
     if: ${{ always() }}
@@ -577,6 +599,7 @@ jobs:
       - portdb
       - complement
       - cargo-test
+      - cargo-bench
     runs-on: ubuntu-latest
     steps:
       - uses: matrix-org/done-action@v2
@@ -588,3 +611,4 @@ jobs:
           skippable: |
             lint-newsfile
             cargo-test
+            cargo-bench

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -566,7 +566,8 @@ jobs:
 
       - run: cargo test
 
-  # We want to ensure that the cargo benchmarks still compile appropriately.
+  # We want to ensure that the cargo benchmarks still compile, which requires a
+  # nightly compiler.
   cargo-bench:
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
@@ -583,7 +584,7 @@ jobs:
         # We pin to a specific commit for paranoia's sake.
         uses: dtolnay/rust-toolchain@e645b0cf01249a964ec099494d38d2da0f0b349f
         with:
-            toolchain: 1.58.1
+            toolchain: nightly-2022-12-01
       - uses: Swatinem/rust-cache@v2
 
       - run: cargo bench --no-run

--- a/changelog.d/14943.feature
+++ b/changelog.d/14943.feature
@@ -1,0 +1,1 @@
+Experimental support for [MSC3952](https://github.com/matrix-org/matrix-spec-proposals/pull/3952): intentional mentions.

--- a/rust/benches/evaluator.rs
+++ b/rust/benches/evaluator.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![feature(test)]
+use std::collections::BTreeSet;
 use synapse::push::{
     evaluator::PushRuleEvaluator, Condition, EventMatchCondition, FilteredPushRules, PushRules,
 };
@@ -33,6 +34,7 @@ fn bench_match_exact(b: &mut Bencher) {
     let eval = PushRuleEvaluator::py_new(
         flattened_keys,
         BTreeSet::new(),
+        false,
         10,
         Some(0),
         Default::default(),
@@ -69,6 +71,8 @@ fn bench_match_word(b: &mut Bencher) {
 
     let eval = PushRuleEvaluator::py_new(
         flattened_keys,
+        BTreeSet::new(),
+        false,
         10,
         Some(0),
         Default::default(),
@@ -105,6 +109,8 @@ fn bench_match_word_miss(b: &mut Bencher) {
 
     let eval = PushRuleEvaluator::py_new(
         flattened_keys,
+        BTreeSet::new(),
+        false,
         10,
         Some(0),
         Default::default(),
@@ -141,6 +147,8 @@ fn bench_eval_message(b: &mut Bencher) {
 
     let eval = PushRuleEvaluator::py_new(
         flattened_keys,
+        BTreeSet::new(),
+        false,
         10,
         Some(0),
         Default::default(),
@@ -154,6 +162,7 @@ fn bench_eval_message(b: &mut Bencher) {
     let rules = FilteredPushRules::py_new(
         PushRules::new(Vec::new()),
         Default::default(),
+        false,
         false,
         false,
         false,

--- a/rust/benches/evaluator.rs
+++ b/rust/benches/evaluator.rs
@@ -32,6 +32,7 @@ fn bench_match_exact(b: &mut Bencher) {
 
     let eval = PushRuleEvaluator::py_new(
         flattened_keys,
+        BTreeSet::new(),
         10,
         Some(0),
         Default::default(),


### PR DESCRIPTION
As #14823 broke it where I didn't update all the callers of `PushRuleEvaluator::py_new(...)`.

See https://github.com/matrix-org/synapse/actions/runs/4047992030/jobs/6962741368 for example output.