### PR TITLE
Allow poetry-core 1.5.0

### DIFF
--- a/changelog.d/14949.misc
+++ b/changelog.d/14949.misc
@@ -1,0 +1,1 @@
+Update build system requirements to allow building with poetry-core==1.5.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,9 @@ exclude = [
     { path = "synapse/*.so", format = "sdist"}
 ]
 
-build = "build_rust.py"
+[tool.poetry.build]
+script = "build_rust.py"
+generate-setup-file = true
 
 [tool.poetry.scripts]
 synapse_homeserver = "synapse.app.homeserver:main"
@@ -350,7 +352,7 @@ towncrier = ">=18.6.0rc1"
 # system changes.
 # We are happy to raise these upper bounds upon request,
 # provided we check that it's safe to do so (i.e. that CI passes).
-requires = ["poetry-core>=1.0.0,<=1.3.2", "setuptools_rust>=1.3,<=1.5.2"]
+requires = ["poetry-core>=1.0.0,<=1.5.0", "setuptools_rust>=1.3,<=1.5.2"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
Following up from https://github.com/matrix-org/synapse/issues/14931

To force building with poetry-core-1.5.0, I ran the following on a fresh synapse checkout with the pr patch
```
#!/bin/bash

set -euxo pipefail

poetry install --no-root --extras "saml2 oidc url-preview redis test"
poetry add build installer poetry-core==1.5.0
poetry run python -m build --no-isolation --wheel
poetry run python -m installer --dest=$(poetry env info --path) --prefix=/ dist/matrix_synapse-*.whl
poetry run python -m twisted.trial --jobs=$(nproc) tests
poetry remove build installer poetry-core
```

Test summary `PASSED (skips=60, successes=2574)` with the following skipped categories
```
[SKIPPED]
`BaseFederationServlet` does not support cancellation yet.

[SKIPPED]
Requires Postgres

[SKIPPED]
Requires jaeger_client

[SKIPPED]
Test only applies when postgres is used as the database

[SKIPPED]
Requires PyICU
```

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off) (requested via email)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))