### PR TITLE
Tag /send_join responses to detect faster joins

### DIFF
--- a/changelog.d/14950.misc
+++ b/changelog.d/14950.misc
@@ -1,0 +1,1 @@
+Faster joins: tag `v2/send_join/` requests to indicate if they served a partial join response.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -67,6 +67,7 @@ from synapse.logging.opentracing import (
     start_active_span_from_edu,
     tag_args,
     trace,
+    SynapseTags,
 )
 from synapse.metrics.background_process_metrics import wrap_as_background_process
 from synapse.replication.http.federation import (
@@ -679,7 +680,10 @@ class FederationServer(FederationBase):
         room_id: str,
         caller_supports_partial_state: bool = False,
     ) -> Dict[str, Any]:
-        set_tag("partial_state", caller_supports_partial_state)
+        set_tag(
+            SynapseTags.SEND_JOIN_RESPONSE_IS_PARTIAL_STATE,
+            caller_supports_partial_state,
+        )
         await self._room_member_handler._join_rate_per_room_limiter.ratelimit(  # type: ignore[has-type]
             requester=None,
             key=room_id,

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -63,6 +63,7 @@ from synapse.logging.context import (
 )
 from synapse.logging.opentracing import (
     log_kv,
+    set_tag,
     start_active_span_from_edu,
     tag_args,
     trace,
@@ -678,6 +679,7 @@ class FederationServer(FederationBase):
         room_id: str,
         caller_supports_partial_state: bool = False,
     ) -> Dict[str, Any]:
+        set_tag("partial_state", caller_supports_partial_state)
         await self._room_member_handler._join_rate_per_room_limiter.ratelimit(  # type: ignore[has-type]
             requester=None,
             key=room_id,

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -62,12 +62,12 @@ from synapse.logging.context import (
     run_in_background,
 )
 from synapse.logging.opentracing import (
+    SynapseTags,
     log_kv,
     set_tag,
     start_active_span_from_edu,
     tag_args,
     trace,
-    SynapseTags,
 )
 from synapse.metrics.background_process_metrics import wrap_as_background_process
 from synapse.replication.http.federation import (

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -322,6 +322,11 @@ class SynapseTags:
     # The name of the external cache
     CACHE_NAME = "cache.name"
 
+    # Boolean. Present on /v2/send_join requests, omitted from all others.
+    # True iff partial state was requested and we provided (or intended to provide)
+    # partial state in the response.
+    SEND_JOIN_RESPONSE_IS_PARTIAL_STATE = "send_join.partial_state_response"
+
     # Used to tag function arguments
     #
     # Tag a named arg. The name of the argument should be appended to this prefix.


### PR DESCRIPTION
Useful when using jaeger to retroactively profile.

Propose that we don't put this in the RC.