### PR TITLE
Clarify limitations of SRV delegation in documentation

### DIFF
--- a/changelog.d/14959.doc
+++ b/changelog.d/14959.doc
@@ -1,2 +1,2 @@
 Update delegation documentation to clarify that SRV DNS delegation does not eliminate all needs to serve files from
-.well-known locations. @williamkray
+.well-known locations. Contributed by @williamkray.

--- a/changelog.d/14959.doc
+++ b/changelog.d/14959.doc
@@ -1,2 +1,1 @@
-Update delegation documentation to clarify that SRV DNS delegation does not eliminate all needs to serve files from
-.well-known locations. Contributed by @williamkray.
+Update delegation documentation to clarify that SRV DNS delegation does not eliminate all needs to serve files from .well-known locations. Contributed by @williamkray.

--- a/changelog.d/14959.doc
+++ b/changelog.d/14959.doc
@@ -1,2 +1,2 @@
 Update delegation documentation to clarify that SRV DNS delegation does not eliminate all needs to serve files from
-.well-known locations.
+.well-known locations. @williamkray

--- a/changelog.d/14959.doc
+++ b/changelog.d/14959.doc
@@ -1,0 +1,2 @@
+Update delegation documentation to clarify that SRV DNS delegation does not eliminate all needs to serve files from
+.well-known locations.

--- a/docs/delegate.md
+++ b/docs/delegate.md
@@ -73,6 +73,15 @@ It is also possible to do delegation using a SRV DNS record. However, that is ge
 not recommended, as it can be difficult to configure the TLS certificates correctly in
 this case, and it offers little advantage over `.well-known` delegation.
 
+Please keep in mind that server delegation is a function of server-server communication,
+and as such using SRV DNS records will not cover use cases involving client-server comms.
+This means setting global client settings (such as a Jitsi endpoint, or disabling
+creating new rooms as encrypted by default, etc) will still require that you serve a file
+from the `https://<server_name>/.well-known/` endpoints defined in the spec! If you are
+considering using SRV DNS delegation to avoid serving files from this endpoint, consider
+the impact that you will not be able to change those client-based default values globally,
+and will be relegated to the featureset of the configuration of each individual client.
+
 However, if you really need it, you can find some documentation on what such a
 record should look like and how Synapse will use it in [the Matrix
 specification](https://matrix.org/docs/spec/server_server/latest#resolving-server-names).


### PR DESCRIPTION
This PR just clarifies in the SRV DNS delegation document that there are still cases a user may have to serve files from `.well-known`  endpoints, and this may not be a valid case for using SRV delegation. This has caused some confusion in a few cases.

Signed-off-by: William Kray <github@williamkray.com>


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
