### PR TITLE
Fetch fewer events when getting hosts in room

### DIFF
--- a/changelog.d/14962.feature
+++ b/changelog.d/14962.feature
@@ -1,0 +1,1 @@
+Improve performance when joining or sending an event large rooms.

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1169,7 +1169,6 @@ class RoomMemberWorkerStore(EventsWorkerStore):
 
         return frozenset(cache.hosts_to_joined_users)
 
-    # TODO: this _might_ turn out to need caching, let's see
     async def _get_approximate_current_memberships_in_room(
         self, room_id: str
     ) -> Mapping[str, Optional[str]]:


### PR DESCRIPTION
This should hopefully improve the response time to serve a faster join, to persist an outgoing event, and probably other things too.