### PR TITLE
Make extension-module optional, but default.

### DIFF
--- a/changelog.d/14965.misc
+++ b/changelog.d/14965.misc
@@ -1,0 +1,1 @@
+Allow running `cargo` without the `extension-module` option.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,12 +23,16 @@ name = "synapse.synapse_rust"
 anyhow = "1.0.63"
 lazy_static = "1.4.0"
 log = "0.4.17"
-pyo3 = { version = "0.17.1", features = ["extension-module", "macros", "anyhow", "abi3", "abi3-py37"] }
+pyo3 = { version = "0.17.1", features = ["macros", "anyhow", "abi3", "abi3-py37"] }
 pyo3-log = "0.7.0"
 pythonize = "0.17.0"
 regex = "1.6.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
+
+[features]
+extension-module = ["pyo3/extension-module"]
+default = ["extension-module"]
 
 [build-dependencies]
 blake2 = "0.10.4"


### PR DESCRIPTION
I have linking errors when using `cargo test` or `cargo bench` locally. From the [pyo3 FAQs this is the suggested fix](https://pyo3.rs/v0.17.1/faq#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror).

Everything now works if I run with the `--no-default-features` flag, e.g.:

```
cargo test --no-default-features
```

Spun out of #14964.