### PR TITLE
Add a filter flag for disabling calculation of device list changes.

### DIFF
--- a/changelog.d/14972.misc
+++ b/changelog.d/14972.misc
@@ -1,0 +1,1 @@
+Improve performance of `/sync` in a few situations.

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -142,6 +142,7 @@ USER_FILTER_SCHEMA = {
                 "pattern": r"^((?!\\\\).)*$",
             },
         },
+        "org.matrix.include_device_list_updates": {"type": "boolean"},
     },
     "additionalProperties": True,  # Allow new fields for forward compatibility
 }
@@ -226,6 +227,9 @@ class FilterCollection:
         self.include_leave = filter_json.get("room", {}).get("include_leave", False)
         self.event_fields = filter_json.get("event_fields", [])
         self.event_format = filter_json.get("event_format", "client")
+        self.include_device_list_updates = filter_json.get(
+            "org.matrix.include_device_list_updates", True
+        )
 
     def __repr__(self) -> str:
         return "<FilterCollection %s>" % (json.dumps(self._filter_json),)

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1462,8 +1462,12 @@ class SyncHandler:
             self.hs_config.server.use_presence
             and not sync_config.filter_collection.blocks_all_presence()
         )
-        # Device list updates are sent if a since token is provided.
-        include_device_list_updates = bool(since_token and since_token.device_list_key)
+        # Device list updates are sent if a since token is provided and are requested.
+        include_device_list_updates = bool(
+            since_token
+            and since_token.device_list_key
+            and sync_config.filter_collection.include_device_list_updates
+        )
 
         # Work out which users have joined or left rooms we're in. We use this
         # to build the presence and device_list parts of the sync response in


### PR DESCRIPTION
This allows disabling fetching of device list updates for processes which may not care about them, while still doing incremental syncs.