### PR TITLE
Avoid fetching unused account data in sync

### DIFF
--- a/changelog.d/14973.misc
+++ b/changelog.d/14973.misc
@@ -1,0 +1,1 @@
+Improve performance of `/sync` in a few situations.

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -219,7 +219,9 @@ class FilterCollection:
         self._room_timeline_filter = Filter(hs, room_filter_json.get("timeline", {}))
         self._room_state_filter = Filter(hs, room_filter_json.get("state", {}))
         self._room_ephemeral_filter = Filter(hs, room_filter_json.get("ephemeral", {}))
-        self._room_account_data = Filter(hs, room_filter_json.get("account_data", {}))
+        self._room_account_data_filter = Filter(
+            hs, room_filter_json.get("account_data", {})
+        )
         self._presence_filter = Filter(hs, filter_json.get("presence", {}))
         self._account_data = Filter(hs, filter_json.get("account_data", {}))
 
@@ -279,7 +281,7 @@ class FilterCollection:
     async def filter_room_account_data(
         self, events: Iterable[JsonDict]
     ) -> List[JsonDict]:
-        return await self._room_account_data.filter(
+        return await self._room_account_data_filter.filter(
             await self._room_filter.filter(events)
         )
 
@@ -297,6 +299,13 @@ class FilterCollection:
             self._room_ephemeral_filter.filters_all_types()
             or self._room_ephemeral_filter.filters_all_senders()
             or self._room_ephemeral_filter.filters_all_rooms()
+        )
+
+    def blocks_all_room_account_data(self) -> bool:
+        return (
+            self._room_account_data_filter.filters_all_types()
+            or self._room_account_data_filter.filters_all_senders()
+            or self._room_account_data_filter.filters_all_rooms()
         )
 
     def blocks_all_room_timeline(self) -> bool:

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -223,7 +223,7 @@ class FilterCollection:
             hs, room_filter_json.get("account_data", {})
         )
         self._presence_filter = Filter(hs, filter_json.get("presence", {}))
-        self._account_data = Filter(hs, filter_json.get("account_data", {}))
+        self._account_data_filter = Filter(hs, filter_json.get("account_data", {}))
 
         self.include_leave = filter_json.get("room", {}).get("include_leave", False)
         self.event_fields = filter_json.get("event_fields", [])
@@ -259,7 +259,7 @@ class FilterCollection:
         return await self._presence_filter.filter(presence_states)
 
     async def filter_account_data(self, events: Iterable[JsonDict]) -> List[JsonDict]:
-        return await self._account_data.filter(events)
+        return await self._account_data_filter.filter(events)
 
     async def filter_room_state(self, events: Iterable[EventBase]) -> List[EventBase]:
         return await self._room_state_filter.filter(
@@ -292,6 +292,13 @@ class FilterCollection:
         return (
             self._presence_filter.filters_all_types()
             or self._presence_filter.filters_all_senders()
+        )
+
+    def blocks_all_account_data(self) -> bool:
+        """True if all global acount data will be filtered out."""
+        return (
+            self._account_data_filter.filters_all_types()
+            or self._account_data_filter.filters_all_senders()
         )
 
     def blocks_all_room_ephemeral(self) -> bool:

--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -223,7 +223,9 @@ class FilterCollection:
             hs, room_filter_json.get("account_data", {})
         )
         self._presence_filter = Filter(hs, filter_json.get("presence", {}))
-        self._account_data_filter = Filter(hs, filter_json.get("account_data", {}))
+        self._global_account_data_filter = Filter(
+            hs, filter_json.get("account_data", {})
+        )
 
         self.include_leave = filter_json.get("room", {}).get("include_leave", False)
         self.event_fields = filter_json.get("event_fields", [])
@@ -258,8 +260,10 @@ class FilterCollection:
     ) -> List[UserPresenceState]:
         return await self._presence_filter.filter(presence_states)
 
-    async def filter_account_data(self, events: Iterable[JsonDict]) -> List[JsonDict]:
-        return await self._account_data_filter.filter(events)
+    async def filter_global_account_data(
+        self, events: Iterable[JsonDict]
+    ) -> List[JsonDict]:
+        return await self._global_account_data_filter.filter(events)
 
     async def filter_room_state(self, events: Iterable[EventBase]) -> List[EventBase]:
         return await self._room_state_filter.filter(
@@ -294,11 +298,11 @@ class FilterCollection:
             or self._presence_filter.filters_all_senders()
         )
 
-    def blocks_all_account_data(self) -> bool:
+    def blocks_all_global_account_data(self) -> bool:
         """True if all global acount data will be filtered out."""
         return (
-            self._account_data_filter.filters_all_types()
-            or self._account_data_filter.filters_all_senders()
+            self._global_account_data_filter.filters_all_types()
+            or self._global_account_data_filter.filters_all_senders()
         )
 
     def blocks_all_room_ephemeral(self) -> bool:

--- a/synapse/handlers/account_data.py
+++ b/synapse/handlers/account_data.py
@@ -343,10 +343,12 @@ class AccountDataEventSource(EventSource[int, JsonDict]):
                 }
             )
 
-        (
-            account_data,
-            room_account_data,
-        ) = await self.store.get_updated_account_data_for_user(user_id, last_stream_id)
+        account_data = await self.store.get_updated_global_account_data_for_user(
+            user_id, last_stream_id
+        )
+        room_account_data = await self.store.get_updated_room_account_data_for_user(
+            user_id, last_stream_id
+        )
 
         for account_data_type, content in account_data.items():
             results.append({"type": account_data_type, "content": content})

--- a/synapse/handlers/initial_sync.py
+++ b/synapse/handlers/initial_sync.py
@@ -154,9 +154,8 @@ class InitialSyncHandler:
 
         tags_by_room = await self.store.get_tags_for_user(user_id)
 
-        account_data, account_data_by_room = await self.store.get_account_data_for_user(
-            user_id
-        )
+        account_data = await self.store.get_global_account_data_for_user(user_id)
+        account_data_by_room = await self.store.get_room_account_data_for_user(user_id)
 
         public_room_ids = await self.store.get_public_room_ids()
 

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -484,7 +484,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             user_id: The user's ID.
         """
         # Retrieve user account data for predecessor room
-        user_account_data, _ = await self.store.get_account_data_for_user(user_id)
+        user_account_data = await self.store.get_global_account_data_for_user(user_id)
 
         # Copy direct message state if applicable
         direct_rooms = user_account_data.get(AccountDataTypes.DIRECT, {})

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1444,7 +1444,9 @@ class SyncHandler:
 
         logger.debug("Fetching account data")
 
-        await self._generate_sync_entry_for_account_data(sync_result_builder)
+        # Account data is included if it is not filtered out.
+        if not sync_config.filter_collection.blocks_all_account_data():
+            await self._generate_sync_entry_for_account_data(sync_result_builder)
 
         # Presence data is included if the server has it enabled and not filtered out.
         include_presence_data = bool(

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1741,11 +1741,15 @@ class SyncHandler:
 
         if since_token and not sync_result_builder.full_state:
             # TODO Do not fetch room account data if it will be unused.
-            (
-                global_account_data,
-                account_data_by_room,
-            ) = await self.store.get_updated_account_data_for_user(
-                user_id, since_token.account_data_key
+            global_account_data = (
+                await self.store.get_updated_global_account_data_for_user(
+                    user_id, since_token.account_data_key
+                )
+            )
+            account_data_by_room = (
+                await self.store.get_updated_room_account_data_for_user(
+                    user_id, since_token.account_data_key
+                )
             )
 
             push_rules_changed = await self.store.have_push_rules_changed_for_user(

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1445,7 +1445,7 @@ class SyncHandler:
         logger.debug("Fetching account data")
 
         # Account data is included if it is not filtered out.
-        if not sync_config.filter_collection.blocks_all_account_data():
+        if not sync_config.filter_collection.blocks_all_global_account_data():
             await self._generate_sync_entry_for_account_data(sync_result_builder)
 
         # Presence data is included if the server has it enabled and not filtered out.
@@ -1763,11 +1763,13 @@ class SyncHandler:
                 sync_config.user
             )
 
-        account_data_for_user = await sync_config.filter_collection.filter_account_data(
-            [
-                {"type": account_data_type, "content": content}
-                for account_data_type, content in global_account_data.items()
-            ]
+        account_data_for_user = (
+            await sync_config.filter_collection.filter_global_account_data(
+                [
+                    {"type": account_data_type, "content": content}
+                    for account_data_type, content in global_account_data.items()
+                ]
+            )
         )
 
         sync_result_builder.account_data = account_data_for_user

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1762,10 +1762,12 @@ class SyncHandler:
                 )
         else:
             # TODO Do not fetch room account data if it will be unused.
-            (
-                global_account_data,
-                account_data_by_room,
-            ) = await self.store.get_account_data_for_user(sync_config.user.to_string())
+            global_account_data = await self.store.get_global_account_data_for_user(
+                sync_config.user.to_string()
+            )
+            account_data_by_room = await self.store.get_room_account_data_for_user(
+                sync_config.user.to_string()
+            )
 
             global_account_data["m.push_rules"] = await self.push_rules_for_user(
                 sync_config.user

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -1192,7 +1192,8 @@ class AccountDataRestServlet(RestServlet):
         if not await self._store.get_user_by_id(user_id):
             raise NotFoundError("User not found")
 
-        global_data, by_room_data = await self._store.get_account_data_for_user(user_id)
+        global_data = await self._store.get_global_account_data_for_user(user_id)
+        by_room_data = await self._store.get_room_account_data_for_user(user_id)
         return HTTPStatus.OK, {
             "account_data": {
                 "global": global_data,

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -21,6 +21,7 @@ from typing import (
     FrozenSet,
     Iterable,
     List,
+    Mapping,
     Optional,
     Tuple,
     cast,
@@ -124,9 +125,9 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
     @cached()
     async def get_global_account_data_for_user(
         self, user_id: str
-    ) -> Dict[str, JsonDict]:
+    ) -> Mapping[str, JsonDict]:
         """
-        Get all the client account_data for a user.
+        Get all the global client account_data for a user.
 
         If experimental MSC3391 support is enabled, any entries with an empty
         content body are excluded; as this means they have been deleted.
@@ -169,9 +170,9 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
     @cached()
     async def get_room_account_data_for_user(
         self, user_id: str
-    ) -> Dict[str, Dict[str, JsonDict]]:
+    ) -> Mapping[str, Mapping[str, JsonDict]]:
         """
-        Get all the client account_data for a user.
+        Get all of the per-room client account_data for a user.
 
         If experimental MSC3391 support is enabled, any entries with an empty
         content body are excluded; as this means they have been deleted.
@@ -180,7 +181,7 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
             user_id: The user to get the account_data for.
 
         Returns:
-            A  dict mapping from room_id string to per room account_data dicts.
+            A dict mapping from room_id string to per-room account_data dicts.
         """
 
         def get_room_account_data_for_user_txn(


### PR DESCRIPTION
Currently we fetch global & room specific account data at once, but if we don't care about the room account data than we discard that data.

Regardless, it is confusing that we fetch those in a single place and then pass them around.

Follow-on to #14908.