### PR TITLE
Add Synapse-Trace-Id to access-control-allow-headers header

### DIFF
--- a/changelog.d/14973.misc
+++ b/changelog.d/14973.misc
@@ -1,0 +1,1 @@
+Add `Synapse-Trace-Id` to `access-control-allow-headers` header.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -900,7 +900,7 @@ def set_cors_headers(request: SynapseRequest) -> None:
     else:
         request.setHeader(
             b"Access-Control-Allow-Headers",
-            b"X-Requested-With, Content-Type, Authorization, Date",
+            b"X-Requested-With, Content-Type, Authorization, Date, Synapse-Trace-Id",
         )
 
 


### PR DESCRIPTION
No idea if this is correct but I thought I'd give it a shot. This PR adds the newly-created `Synapse-Trace-Id` response header to `access-control-allow-headers` header to facilitate Jaeger tracing across the client/server boundary. Fixes #14951.