### PR TITLE
Skip calculating unread push actions in `/sync` when `enable_push` is false.

### DIFF
--- a/changelog.d/14980.misc
+++ b/changelog.d/14980.misc
@@ -1,0 +1,1 @@
+Skip calculating unread push actions in /sync when enable_push is false.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -269,6 +269,8 @@ class SyncHandler:
         self._state_storage_controller = self._storage_controllers.state
         self._device_handler = hs.get_device_handler()
 
+        self.should_calculate_push_rules = hs.config.push.enable_push
+
         # TODO: flush cache entries on subsequent sync request.
         #    Once we get the next /sync request (ie, one with the same access token
         #    that sets 'since' to 'next_batch'), we know that device won't need a
@@ -1288,6 +1290,9 @@ class SyncHandler:
     async def unread_notifs_for_room_id(
         self, room_id: str, sync_config: SyncConfig
     ) -> RoomNotifCounts:
+        if not self.should_calculate_push_rules:
+            return RoomNotifCounts.empty()
+
         with Measure(self.clock, "unread_notifs_for_room_id"):
 
             return await self.store.get_unread_event_push_actions_by_room_for_user(

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1291,6 +1291,9 @@ class SyncHandler:
         self, room_id: str, sync_config: SyncConfig
     ) -> RoomNotifCounts:
         if not self.should_calculate_push_rules:
+            # If push rules have been universally disabled then we know we won't
+            # have any unread counts in the DB, so we may as well skip asking
+            # the DB.
             return RoomNotifCounts.empty()
 
         with Measure(self.clock, "unread_notifs_for_room_id"):

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -203,6 +203,10 @@ class RoomNotifCounts:
     # Map of thread ID to the notification counts.
     threads: Dict[str, NotifCounts]
 
+    @staticmethod
+    def empty() -> "RoomNotifCounts":
+        return RoomNotifCounts(NotifCounts(), {})
+
     def __len__(self) -> int:
         # To properly account for the amount of space in any caches.
         return len(self.threads) + 1

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -205,11 +205,14 @@ class RoomNotifCounts:
 
     @staticmethod
     def empty() -> "RoomNotifCounts":
-        return RoomNotifCounts(NotifCounts(), {})
+        return _EMPTY_ROOM_NOTIF_COUNTS
 
     def __len__(self) -> int:
         # To properly account for the amount of space in any caches.
         return len(self.threads) + 1
+
+
+_EMPTY_ROOM_NOTIF_COUNTS = RoomNotifCounts(NotifCounts(), {})
 
 
 def _serialize_action(


### PR DESCRIPTION
This is strictly a perf improvement, since we don't calculate push actions if `enable_push` config is false.