### PR TITLE
Expect type stubs from canonicaljson

### DIFF
--- a/changelog.d/14992.misc
+++ b/changelog.d/14992.misc
@@ -1,0 +1,1 @@
+Improve type hints.

--- a/mypy.ini
+++ b/mypy.ini
@@ -140,9 +140,6 @@ disallow_untyped_defs = True
 [mypy-authlib.*]
 ignore_missing_imports = True
 
-[mypy-canonicaljson]
-ignore_missing_imports = True
-
 [mypy-ijson.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Canonicaljson has included (properly-distributed) type hints since https://github.com/matrix-org/python-canonicaljson/pull/52, which is included in the canonicaljson present in the lockfile.