### PR TITLE
Add tests for using _flatten_dict with an event.

### DIFF
--- a/changelog.d/15002.misc
+++ b/changelog.d/15002.misc
@@ -1,0 +1,1 @@
+Add tests for `_flatten_dict`.

--- a/tests/push/test_push_rule_evaluator.py
+++ b/tests/push/test_push_rule_evaluator.py
@@ -110,7 +110,7 @@ class FlattenDictTestCase(unittest.TestCase):
         }
         self.assertEqual(expected, _flatten_dict(event))
 
-        # For a room version with extensible events, they arse out the text/plain
+        # For a room version with extensible events, they parse out the text/plain
         # to a content.body property.
         event = make_event_from_dict(event_dict, room_version=RoomVersions.MSC1767v10)
         expected = {


### PR DESCRIPTION
As was asked for in https://github.com/matrix-org/synapse/pull/14981#discussion_r1095990509

They were easier than expected, should have just done it in that PR. Sorry for the churn!