### PR TITLE
Include no actions instead of dont_notify for suppressing edits.

### DIFF
--- a/changelog.d/15016.feature
+++ b/changelog.d/15016.feature
@@ -1,0 +1,1 @@
+Experimental support to suppress notifications from message edits ([MSC3958](https://github.com/matrix-org/matrix-spec-proposals/pull/3958)).

--- a/rust/src/push/base_rules.rs
+++ b/rust/src/push/base_rules.rs
@@ -76,7 +76,7 @@ pub const BASE_APPEND_OVERRIDE_RULES: &[PushRule] = &[
                 pattern_type: None,
             },
         ))]),
-        actions: Cow::Borrowed(&[Action::DontNotify]),
+        actions: Cow::Borrowed(&[]),
         default: true,
         default_enabled: true,
     },


### PR DESCRIPTION
Per @richvdh's comment: https://github.com/matrix-org/synapse/pull/14960#discussion_r1099037197

And to match what MSC3958 says.