### PR TITLE
Hacky fix to make mac wheels 

### DIFF
--- a/.ci/scripts/auditwheel_wrapper.py
+++ b/.ci/scripts/auditwheel_wrapper.py
@@ -56,8 +56,8 @@ def cpython(wheel_file: str, name: str, version: Version, tag: Tag) -> str:
     #     https://github.com/pantsbuild/pants/pull/12857
     #     https://github.com/pypa/pip/issues/9138
     #     https://github.com/pypa/packaging/pull/319
-    # Empirically this seems to work.
-    # I hate Python packaging, and you should too. Guido, why have you forsaken me?
+    # Empirically this seems to work, note that macOS 11 and 10.16 are the same,
+    # both versions are valid for backwards compatibility.
     platform = tag.platform.replace("macosx_11_0", "macosx_10_16")
     abi3_tag = Tag(tag.interpreter, "abi3", platform)
 

--- a/.ci/scripts/auditwheel_wrapper.py
+++ b/.ci/scripts/auditwheel_wrapper.py
@@ -50,7 +50,16 @@ def cpython(wheel_file: str, name: str, version: Version, tag: Tag) -> str:
 
     check_is_abi3_compatible(wheel_file)
 
-    abi3_tag = Tag(tag.interpreter, "abi3", tag.platform)
+    # HACK: it seems that some older versions of pip will consider a wheel marked
+    # as macosx_11_0 as incompatible with Big Sur. I haven't done the full archaeology
+    # here; there are some clues in
+    #     https://github.com/pantsbuild/pants/pull/12857
+    #     https://github.com/pypa/pip/issues/9138
+    #     https://github.com/pypa/packaging/pull/319
+    # Empirically this seems to work.
+    # I hate Python packaging, and you should too. Guido, why have you forsaken me?
+    platform = tag.platform.replace("macosx_11_0", "macosx_10_16")
+    abi3_tag = Tag(tag.interpreter, "abi3", platform)
 
     dirname = os.path.dirname(wheel_file)
     new_wheel_file = os.path.join(

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -148,7 +148,7 @@ jobs:
         env:
           # Skip testing for platforms which various libraries don't have wheels
           # for, and so need extra build deps.
-          CIBW_TEST_SKIP: pp3{7,9}-* *i686* *musl*
+          CIBW_TEST_SKIP: pp3*-* *i686* *musl*
           # Fix Rust OOM errors on emulated aarch64: https://github.com/rust-lang/cargo/issues/10583
           CARGO_NET_GIT_FETCH_WITH_CLI: true
           CIBW_ENVIRONMENT_PASS_LINUX: CARGO_NET_GIT_FETCH_WITH_CLI

--- a/changelog.d/15019.misc
+++ b/changelog.d/15019.misc
@@ -1,1 +1,1 @@
-Workaround packaging pain when making OSX wheels.
+Fix creation of wheels on macOS.

--- a/changelog.d/15019.misc
+++ b/changelog.d/15019.misc
@@ -1,0 +1,1 @@
+Workaround packaging pain when making OSX wheels.


### PR DESCRIPTION
A desperate attempt to make CI work again after #14949.

Tested in #15015.

My hypothesis is:

- poetry-core 1.3.2 builds a wheel that says it's for `macosx_10_16` under the CI env
- poetry-core 1.5.0 (maybe 1.4.0?) builds a wheel that says it's for `macosx_11_0` under the CI
- the version of pip in the CI env considers that not installable