### PR TITLE
Fix bug in replication where response is cached

### DIFF
--- a/changelog.d/15024.bugfix
+++ b/changelog.d/15024.bugfix
@@ -1,0 +1,1 @@
+Fix bug where retried replication requests would return a failure. Introduced in v1.76.0.

--- a/synapse/replication/http/_base.py
+++ b/synapse/replication/http/_base.py
@@ -426,6 +426,8 @@ class ReplicationEndpoint(metaclass=abc.ABCMeta):
             code, response = await self.response_cache.wrap(
                 txn_id, self._handle_request, request, content, **kwargs
             )
+            # Take a copy so we don't mutate things in the cache.
+            response = dict(response)
         else:
             # The `@cancellable` decorator may be applied to `_handle_request`. But we
             # told `HttpServer.register_paths` that our handler is `_check_auth_and_handle`,


### PR DESCRIPTION
Fixes exception:

```
Exception: ('data to send contains %r key', '_INT_STREAM_POS')
  File "synapse/http/server.py", line 307, in _async_render_wrapper
    callback_return = await self._async_render(request)
  File "synapse/http/server.py", line 513, in _async_render
    callback_return = await raw_callback_return
  File "synapse/replication/http/_base.py", line 442, in _check_auth_and_handle
    raise Exception("data to send contains %r key", _STREAM_POSITION_KEY)
```

Introduced in #14820