### PR TITLE
Explicit disabling of disallowed_untyped_defs.

### DIFF
--- a/changelog.d/15026.misc
+++ b/changelog.d/15026.misc
@@ -1,0 +1,1 @@
+Improve type hints.

--- a/mypy.ini
+++ b/mypy.ini
@@ -60,80 +60,47 @@ disallow_untyped_defs = False
 [mypy-synapse.storage.database]
 disallow_untyped_defs = False
 
-[mypy-tests.*]
+[mypy-tests.scripts.test_new_matrix_user]
 disallow_untyped_defs = False
 
-[mypy-tests.api.*]
-disallow_untyped_defs = True
+[mypy-tests.server_notices.test_consent]
+disallow_untyped_defs = False
 
-[mypy-tests.app.*]
-disallow_untyped_defs = True
+[mypy-tests.server_notices.test_resource_limits_server_notices]
+disallow_untyped_defs = False
 
-[mypy-tests.appservice.*]
-disallow_untyped_defs = True
+[mypy-tests.test_distributor]
+disallow_untyped_defs = False
 
-[mypy-tests.config.*]
-disallow_untyped_defs = True
+[mypy-tests.test_event_auth]
+disallow_untyped_defs = False
 
-[mypy-tests.crypto.*]
-disallow_untyped_defs = True
+[mypy-tests.test_federation]
+disallow_untyped_defs = False
 
-[mypy-tests.events.*]
-disallow_untyped_defs = True
+[mypy-tests.test_mau]
+disallow_untyped_defs = False
 
-[mypy-tests.federation.*]
-disallow_untyped_defs = True
+[mypy-tests.test_rust]
+disallow_untyped_defs = False
 
-[mypy-tests.handlers.*]
-disallow_untyped_defs = True
+[mypy-tests.test_test_utils]
+disallow_untyped_defs = False
 
-[mypy-tests.http.*]
-disallow_untyped_defs = True
+[mypy-tests.test_types]
+disallow_untyped_defs = False
 
-[mypy-tests.logging.*]
-disallow_untyped_defs = True
+[mypy-tests.test_utils.*]
+disallow_untyped_defs = False
 
-[mypy-tests.metrics.*]
-disallow_untyped_defs = True
+[mypy-tests.test_visibility]
+disallow_untyped_defs = False
 
-[mypy-tests.push.*]
-disallow_untyped_defs = True
-
-[mypy-tests.replication.*]
-disallow_untyped_defs = True
-
-[mypy-tests.rest.*]
-disallow_untyped_defs = True
-
-[mypy-tests.state.test_profile]
-disallow_untyped_defs = True
-
-[mypy-tests.storage.*]
-disallow_untyped_defs = True
-
-[mypy-tests.test_server]
-disallow_untyped_defs = True
-
-[mypy-tests.test_state]
-disallow_untyped_defs = True
-
-[mypy-tests.test_terms_auth]
-disallow_untyped_defs = True
-
-[mypy-tests.types.*]
-disallow_untyped_defs = True
-
-[mypy-tests.util.caches.*]
-disallow_untyped_defs = True
+[mypy-tests.unittest]
+disallow_untyped_defs = False
 
 [mypy-tests.util.caches.test_descriptors]
 disallow_untyped_defs = False
-
-[mypy-tests.util.*]
-disallow_untyped_defs = True
-
-[mypy-tests.utils]
-disallow_untyped_defs = True
 
 ;; Dependencies without annotations
 ;; Before ignoring a module, check to see if type stubs are available.


### PR DESCRIPTION
If mypy passes we can merge this.

My thought is that we now have an explicit list of things to "fix" and any newly added files will be opted in automatically to requiring type hints.