### PR TITLE
Avoid mutating cached room aliases.

### DIFF
--- a/changelog.d/15038.bugfix
+++ b/changelog.d/15038.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where the room aliases returned could be corrupted.

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -485,7 +485,8 @@ class DirectoryHandler:
                 )
             )
             if canonical_alias:
-                room_aliases.append(canonical_alias)
+                # Ensure we do not mutate room_aliases.
+                room_aliases = room_aliases + [canonical_alias]
 
             if not self.config.roomdirectory.is_publishing_room_allowed(
                 user_id, room_id, room_aliases


### PR DESCRIPTION
Split out of #13755.