### PR TITLE
Tag federation request spans with the worker name

### DIFF
--- a/changelog.d/15042.feature
+++ b/changelog.d/15042.feature
@@ -1,0 +1,1 @@
+Tag opentracing spans for federation requests with the name of the worker serving the request.

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -32,7 +32,6 @@ from synapse.appservice import ApplicationService
 from synapse.http import get_request_user_agent
 from synapse.http.site import SynapseRequest
 from synapse.logging.opentracing import (
-    SynapseTags,
     active_span,
     force_tracing,
     start_active_span,
@@ -161,12 +160,6 @@ class Auth:
                     force_tracing(parent_span)
                 parent_span.set_tag(
                     "authenticated_entity", requester.authenticated_entity
-                )
-                # We tag the Synapse instance name so that it's an easy jumping
-                # off point into the logs. Can also be used to filter for an
-                # instance that is under load.
-                parent_span.set_tag(
-                    SynapseTags.INSTANCE_NAME, self.hs.get_instance_name()
                 )
                 parent_span.set_tag("user_id", requester.user.to_string())
                 if requester.device_id is not None:

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -466,8 +466,16 @@ def init_tracer(hs: "HomeServer") -> None:
         STRIP_INSTANCE_NUMBER_SUFFIX_REGEX, "", hs.get_instance_name()
     )
 
+    jaeger_config = hs.config.tracing.jaeger_config
+    tags = jaeger_config.setdefault("tags", {})
+
+    # tag the Synapse instance name so that it's an easy jumping
+    # off point into the logs. Can also be used to filter for an
+    # instance that is under load.
+    tags.setdefault(SynapseTags.INSTANCE_NAME, hs.get_instance_name())
+
     config = JaegerConfig(
-        config=hs.config.tracing.jaeger_config,
+        config=jaeger_config,
         service_name=f"{hs.config.server.server_name} {instance_name_by_type}",
         scope_manager=LogContextScopeManager(),
         metrics_factory=PrometheusMetricsFactory(),

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -472,7 +472,7 @@ def init_tracer(hs: "HomeServer") -> None:
     # tag the Synapse instance name so that it's an easy jumping
     # off point into the logs. Can also be used to filter for an
     # instance that is under load.
-    tags.setdefault(SynapseTags.INSTANCE_NAME, hs.get_instance_name())
+    tags[SynapseTags.INSTANCE_NAME] = hs.get_instance_name()
 
     config = JaegerConfig(
         config=jaeger_config,


### PR DESCRIPTION
Rich commented that we should do this, when we were looking at /send_join traces last week.

We already include such a tag for CSAPI requests in `get_user_by_req`; this includes a worker name tag in all traces by making it part of the tracer's configuration.

After:

![image](https://user-images.githubusercontent.com/8614563/217914062-481ecd3b-efb9-484c-8564-a77555a783c2.png)

