### PR TITLE
Avoid mutating cached values in `_generate_sync_entry_for_account_data`

### DIFF
--- a/changelog.d/15047.misc
+++ b/changelog.d/15047.misc
@@ -1,0 +1,1 @@
+Avoid mutating cached values in `_generate_sync_entry_for_account_data`.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1753,6 +1753,7 @@ class SyncHandler:
             )
 
             if push_rules_changed:
+                global_account_data = dict(global_account_data)
                 global_account_data["m.push_rules"] = await self.push_rules_for_user(
                     sync_config.user
                 )
@@ -1763,6 +1764,7 @@ class SyncHandler:
                 account_data_by_room,
             ) = await self.store.get_account_data_for_user(sync_config.user.to_string())
 
+            global_account_data = dict(global_account_data)
             global_account_data["m.push_rules"] = await self.push_rules_for_user(
                 sync_config.user
             )


### PR DESCRIPTION
Signed-off-by: Sean Quah <seanq@matrix.org>

---

Split out from https://github.com/matrix-org/synapse/pull/13755.