### PR TITLE
Faster joins: Omit device list updates from partial state rooms in /sync

### DIFF
--- a/changelog.d/15069.misc
+++ b/changelog.d/15069.misc
@@ -1,0 +1,1 @@
+Faster joins: omit device list updates originating from partial state rooms in /sync responses without lazy loading of members enabled.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1391,6 +1391,11 @@ class SyncHandler:
                 for room_id, is_partial_state in results.items()
                 if is_partial_state
             )
+            membership_change_events = [
+                event
+                for event in membership_change_events
+                if not results.get(event.room_id, False)
+            ]
 
         # Incremental eager syncs should additionally include rooms that
         # - we are joined to


### PR DESCRIPTION
...when lazy loading of members is not enabled. It's weird to notify
a client that another user's device list has changed when the client
doesn't think that they share a room.

Note that when a room is un-partial stated, device list updates are
emitted for every member in that room over /sync.

Signed-off-by: Sean Quah <seanq@matrix.org>
