### PR TITLE
Clarify the workers that the ThirdPartyRules' `on_new_event` callback will run on

### DIFF
--- a/changelog.d/15071.doc
+++ b/changelog.d/15071.doc
@@ -1,0 +1,1 @@
+Clarify which worker processes the ThirdPartyRules' [`on_new_event`](https://matrix-org.github.io/synapse/v1.78/modules/third_party_rules_callbacks.html#on_new_event) module API callback runs on.

--- a/docs/modules/third_party_rules_callbacks.md
+++ b/docs/modules/third_party_rules_callbacks.md
@@ -146,6 +146,9 @@ Note that this callback is called when the event has already been processed and 
 into the room, which means this callback cannot be used to deny persisting the event. To
 deny an incoming event, see [`check_event_for_spam`](spam_checker_callbacks.md#check_event_for_spam) instead.
 
+For any given event, this callback will be called on every worker process, even if that worker will not end up
+acting on that event. This callback will not be called for events that are marked as rejected.
+
 If multiple modules implement this callback, Synapse runs them all in order.
 
 ### `check_can_shutdown_room`


### PR DESCRIPTION
Just a bit of clarification for the `on_new_event` module API callback as a result of a question someone asked internally.

This callback is called on the worker that persists the new event, as well as every worker that's listening on the events stream (which is every worker afaik).