### PR TITLE
Remove spurious `dont_notify` action from `.m.rule.reaction`

### DIFF
--- a/changelog.d/15073.feature
+++ b/changelog.d/15073.feature
@@ -1,0 +1,1 @@
+Remove spurious `dont_notify` action from the defaults for the `.m.rule.reaction` pushrule.

--- a/rust/src/push/base_rules.rs
+++ b/rust/src/push/base_rules.rs
@@ -223,7 +223,7 @@ pub const BASE_APPEND_OVERRIDE_RULES: &[PushRule] = &[
                 pattern_type: None,
             },
         ))]),
-        actions: Cow::Borrowed(&[Action::DontNotify]),
+        actions: Cow::Borrowed(&[]),
         default: true,
         default_enabled: true,
     },


### PR DESCRIPTION
This does nothing and I want to remove it from the MSC.