### PR TITLE
Fix federated joins when the first server in the list is not in the room

### DIFF
--- a/changelog.d/15074.bugfix
+++ b/changelog.d/15074.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where federated joins would fail if the first server in the list of servers to try is not in the room.


### PR DESCRIPTION
Previously we would give up upon receiving a 404 from the first server,
instead of trying the rest of the servers in the list.

Signed-off-by: Sean Quah <seanq@matrix.org>

---

Tested by https://github.com/matrix-org/complement/pull/612.