### PR TITLE
Update the error code for duplicate annotation

### DIFF
--- a/changelog.d/15075.feature
+++ b/changelog.d/15075.feature
@@ -1,0 +1,2 @@
+Update the error code returned when user sends a duplicate annotation.
+

--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -108,6 +108,10 @@ class Codes(str, Enum):
 
     USER_AWAITING_APPROVAL = "ORG.MATRIX.MSC3866_USER_AWAITING_APPROVAL"
 
+    # Attempt to send a second annotation with the same event type & annotation key
+    # MSC2677
+    DUPLICATE_ANNOTATION = "M_DUPLICATE_ANNOTATION"
+
 
 class CodeMessageException(RuntimeError):
     """An exception with integer code and message string attributes.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1337,7 +1337,11 @@ class EventCreationHandler:
                 relation.parent_id, event.type, aggregation_key, event.sender
             )
             if already_exists:
-                raise SynapseError(400, "Can't send same reaction twice")
+                raise SynapseError(
+                    400,
+                    "Can't send same reaction twice",
+                    errcode=Codes.DUPLICATE_ANNOTATION,
+                )
 
         # Don't attempt to start a thread if the parent event is a relation.
         elif relation.rel_type == RelationTypes.THREAD:


### PR DESCRIPTION
MSC2677 now specifies `M_DUPLICATE_ANNOTATION`.