### PR TITLE
Fix a bug introduced in Synapse v1.74.0 where searching with colons when using ICU for search term tokenisation would fail with an error.

### DIFF
--- a/changelog.d/15079.bugfix
+++ b/changelog.d/15079.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse v1.74.0 where searching with colons when using ICU for search term tokenisation would fail with an error.

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -918,11 +918,11 @@ def _parse_query_postgres(search_term: str) -> Tuple[str, str, str]:
     We use this so that we can add prefix matching, which isn't something
     that is supported by default.
     """
-    results = _parse_words(search_term)
+    words = _parse_words(search_term)
 
-    both = " & ".join("(%s:* | %s)" % (result, result) for result in results)
-    exact = " & ".join("%s" % (result,) for result in results)
-    prefix = " & ".join("%s:*" % (result,) for result in results)
+    both = " & ".join("(%s:* | %s)" % (word, word) for word in words)
+    exact = " & ".join("%s" % (word,) for word in words)
+    prefix = " & ".join("%s:*" % (word,) for word in words)
 
     return both, exact, prefix
 

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -944,6 +944,14 @@ def _parse_words(search_term: str) -> List[str]:
     if USE_ICU:
         return _parse_words_with_icu(search_term)
 
+    return _parse_words_with_regex(search_term)
+
+
+def _parse_words_with_regex(search_term: str) -> List[str]:
+    """
+    Break down search term into words, when we don't have ICU available.
+    See: `_parse_words`
+    """
     return re.findall(r"([\w\-]+)", search_term, re.UNICODE)
 
 

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -192,7 +192,7 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         self.helper.join(room, self.appservice.sender, tok=self.appservice.token)
         self._check_only_one_user_in_directory(user, room)
 
-    def test_search_term_with_colon_in_it(self) -> None:
+    def test_search_term_with_colon_in_it_does_not_raise(self) -> None:
         """
         Regression test: Test that search terms with colons in them are acceptable.
         """

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -192,6 +192,13 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
         self.helper.join(room, self.appservice.sender, tok=self.appservice.token)
         self._check_only_one_user_in_directory(user, room)
 
+    def test_search_term_with_colon_in_it(self) -> None:
+        """
+        Regression test: Test that search terms with colons in them are acceptable.
+        """
+        u1 = self.register_user("user1", "pass")
+        self.get_success(self.handler.search_users(u1, "haha:paamayim-nekudotayim", 10))
+
     def test_user_not_in_users_table(self) -> None:
         """Unclear how it happens, but on matrix.org we've seen join events
         for users who aren't in the users table. Test that we don't fall over

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -25,6 +25,10 @@ from synapse.rest.client import login, register, room
 from synapse.server import HomeServer
 from synapse.storage import DataStore
 from synapse.storage.background_updates import _BackgroundUpdateHandler
+from synapse.storage.databases.main.user_directory import (
+    _parse_words_with_icu,
+    _parse_words_with_regex,
+)
 from synapse.storage.roommember import ProfileInfo
 from synapse.util import Clock
 
@@ -512,4 +516,22 @@ class UserDirectoryICUTestCase(HomeserverTestCase):
         self.assertDictEqual(
             r["results"][0],
             {"user_id": ALICE, "display_name": display_name, "avatar_url": None},
+        )
+
+    def test_icu_word_boundary_punctuation(self) -> None:
+        """
+        Tests the behaviour of punctuation with the ICU tokeniser
+        """
+        self.assertEqual(
+            _parse_words_with_icu("lazy'fox jumped:over the.dog"),
+            ["lazy'fox", "jumped:over", "the.dog"],
+        )
+
+    def test_regex_word_boundary_punctuation(self) -> None:
+        """
+        Tests the behaviour of punctuation with the non-ICU tokeniser
+        """
+        self.assertEqual(
+            _parse_words_with_regex("lazy'fox jumped:over the.dog"),
+            ["lazy", "fox", "jumped", "over", "the", "dog"],
         )

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -46,7 +46,7 @@ ALICE = "@alice:a"
 BOB = "@bob:b"
 BOBBY = "@bobby:a"
 # The localpart isn't 'Bela' on purpose so we can test looking up display names.
-BELA = "@somenickname:a"
+BELA = "@somenickname:example.org"
 
 
 class GetUserDirectoryTables:
@@ -475,6 +475,19 @@ class UserDirectoryStoreTestCase(HomeserverTestCase):
         usually be ignored in full text searches.
         """
         r = self.get_success(self.store.search_user_dir(ALICE, "be", 10))
+        self.assertFalse(r["limited"])
+        self.assertEqual(1, len(r["results"]))
+        self.assertDictEqual(
+            r["results"][0],
+            {"user_id": BELA, "display_name": "Bela", "avatar_url": None},
+        )
+
+    @override_config({"user_directory": {"search_all_users": True}})
+    def test_search_user_dir_start_of_user_id(self) -> None:
+        """Tests that a user can look up another user by searching for the start
+        of their user ID.
+        """
+        r = self.get_success(self.store.search_user_dir(ALICE, "somenickname:exa", 10))
         self.assertFalse(r["limited"])
         self.assertEqual(1, len(r["results"]))
         self.assertDictEqual(

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -533,11 +533,21 @@ class UserDirectoryICUTestCase(HomeserverTestCase):
 
     def test_icu_word_boundary_punctuation(self) -> None:
         """
-        Tests the behaviour of punctuation with the ICU tokeniser
+        Tests the behaviour of punctuation with the ICU tokeniser.
+
+        Seems to depend on underlying version of ICU.
         """
-        self.assertEqual(
+
+        # Note: either tokenisation is fine, because Postgres actually splits
+        # words itself afterwards.
+        self.assertIn(
             _parse_words_with_icu("lazy'fox jumped:over the.dog"),
-            ["lazy'fox", "jumped:over", "the.dog"],
+            (
+                # ICU 66 on Ubuntu 20.04
+                ["lazy'fox", "jumped", "over", "the", "dog"],
+                # ICU 70 on Ubuntu 22.04
+                ["lazy'fox", "jumped:over", "the.dog"],
+            ),
         )
 
     def test_regex_word_boundary_punctuation(self) -> None:


### PR DESCRIPTION
Fixes: #14815 <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->

Introduced by: #14464 (as far as I can tell: it changed the tokenisation rules to leave `:`s in when you have ICU installed.)

Base: `develop` <!-- git-stack-base-branch:develop -->

This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Add failing test 

</li>
<li>

Small rename of variables 

</li>
<li>

Add minitests to characterise how we do tokenisation today 

</li>
<li>

Add escaping to our tsquery builder 

</li>
<li>

Test that we can find a user by prefix of MXID \
(I wasn't super confident that the ICU tokeniser wouldn't break this, but a bit of poking later,

I think I'm happy. But thought it should be tested anyway!)


</li>
</ol>
