### PR TITLE
Mitigate a race where /make_join could 403 for restricted rooms

### DIFF
--- a/changelog.d/15080.bugfix
+++ b/changelog.d/15080.bugfix
@@ -1,0 +1,1 @@
+Reduce the likelihood of a rare race condition where rejoining a restricted room over federation would fail.


### PR DESCRIPTION
Previously, when creating a join event in /make_join, we would decide
whether to include additional fields to satisfy restricted room checks
based on the current state of the room. Then, when building the event,
we would capture the forward extremities of the room to use as prev
events.

This is subject to race conditions. For example, when leaving and
rejoining a room, the following sequence of events leads to a misleading
403 response:
1. /make_join reads the current state of the room and sees that the user
   is still in the room. It decides to omit the field required for
   restricted room joins.
2. The leave event is persisted and the room's forward extremities are
   updated.
3. /make_join builds the event, using the post-leave forward extremities.
   The event then fails the restricted room checks.

To mitigate the race, we move the read of the forward extremities closer
to the read of the current state. Ideally, we would compute the state
based off the chosen prev events, but that can involve state resolution,
which is expensive.

Signed-off-by: Sean Quah <seanq@matrix.org>

---

This race occurs in the flakes seen in https://github.com/matrix-org/synapse/issues/14986.
https://github.com/matrix-org/complement/pull/614 fixes the flakes by waiting for the remote homeserver to process the leave event before rejoining.