### PR TITLE
When populating the user directory, query remote servers for user profiles instead of leaking the profiles in private rooms. [rei:userdirpriv]

### DIFF
--- a/changelog.d/15091.bugfix
+++ b/changelog.d/15091.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug in which the user directory would assume any remote membership state events represent a profile change.

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -422,6 +422,21 @@ class RemoteServerUpCommand(_SimpleCommand):
     NAME = "REMOTE_SERVER_UP"
 
 
+class ReadyToRefreshStaleUserDirectoryProfilesCommand(_SimpleCommand):
+    """
+    Sent when a worker needs to tell the user directory worker that there are
+    stale remote user profiles that require refreshing.
+
+    Triggered when the user directory background update has been completed.
+
+    Format::
+
+        USER_DIRECTORY_READY_TO_REFRESH_STALE_REMOTE_PROFILES ''
+    """
+
+    NAME = "USER_DIRECTORY_READY_TO_REFRESH_STALE_REMOTE_PROFILES"
+
+
 _COMMANDS: Tuple[Type[Command], ...] = (
     ServerCommand,
     RdataCommand,
@@ -435,6 +450,7 @@ _COMMANDS: Tuple[Type[Command], ...] = (
     UserIpCommand,
     RemoteServerUpCommand,
     ClearUserSyncsCommand,
+    ReadyToRefreshStaleUserDirectoryProfilesCommand,
 )
 
 # Map of command name to command type.
@@ -448,6 +464,7 @@ VALID_SERVER_COMMANDS = (
     ErrorCommand.NAME,
     PingCommand.NAME,
     RemoteServerUpCommand.NAME,
+    ReadyToRefreshStaleUserDirectoryProfilesCommand.NAME,
 )
 
 # The commands the client is allowed to send
@@ -461,6 +478,7 @@ VALID_CLIENT_COMMANDS = (
     UserIpCommand.NAME,
     ErrorCommand.NAME,
     RemoteServerUpCommand.NAME,
+    ReadyToRefreshStaleUserDirectoryProfilesCommand.NAME,
 )
 
 

--- a/synapse/rest/admin/background_updates.py
+++ b/synapse/rest/admin/background_updates.py
@@ -138,6 +138,11 @@ class BackgroundUpdateStartJobRestServlet(RestServlet):
                     "populate_user_directory_process_rooms",
                 ),
                 (
+                    "populate_user_directory_process_remote_users",
+                    "{}",
+                    "populate_user_directory_process_users",
+                ),
+                (
                     "populate_user_directory_cleanup",
                     "{}",
                     "populate_user_directory_process_users",

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -26,6 +26,10 @@ from typing import (
     cast,
 )
 
+from synapse.replication.tcp.commands import (
+    ReadyToRefreshStaleUserDirectoryProfilesCommand,
+)
+
 try:
     # Figure out if ICU support is available for searching users.
     import icu
@@ -525,6 +529,16 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
             await self.db_pool.updates._end_background_update(
                 "populate_user_directory_process_users"
             )
+
+            # Now kick off querying remote homeservers for profile information.
+            if self.hs.config.worker.should_update_user_directory:
+                self.hs.get_user_directory_handler().kick_off_remote_profile_refresh_process()
+            else:
+                command_handler = self.hs.get_replication_command_handler()
+                command_handler.send_command(
+                    ReadyToRefreshStaleUserDirectoryProfilesCommand("")
+                )
+
             return 1
 
         await self.db_pool.runInteraction(

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -93,6 +93,10 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
             self._populate_user_directory_process_local_users,
         )
         self.db_pool.updates.register_background_update_handler(
+            "populate_user_directory_process_remote_users",
+            self._populate_user_directory_process_remote_users,
+        )
+        self.db_pool.updates.register_background_update_handler(
             "populate_user_directory_cleanup", self._populate_user_directory_cleanup
         )
 
@@ -440,6 +444,94 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
             )
 
         return len(users_to_work_on)
+
+    async def _populate_user_directory_process_remote_users(
+        self, progress: JsonDict, batch_size: int
+    ) -> int:
+        """
+        Sorts through the `_remote_users_needing_lookup` table and adds the
+        users within to the list of stale remote profiles,
+        unless we already populated a user directory entry for them (i.e. they were
+        also in a public room).
+        """
+
+        def _get_next_batch_txn(
+            txn: LoggingTransaction, done_up_to_user_id: str
+        ) -> Optional[str]:
+            """
+            Given the last user ID we've processed,
+            Returns
+                - a user ID to process up to and including; or
+                - `None` if there is no limit left (i.e. we should just process all
+                  remaining rows).
+            """
+            # Should be a B-Tree index only scan: so reasonably efficient despite the
+            # OFFSET
+            # If we're lucky, will also warm up the disk cache for the subsequent query
+            # that actually does some work.
+            txn.execute(
+                f"""
+                SELECT user_id
+                FROM {TEMP_TABLE}_remote_users_needing_lookup
+                WHERE user_id > ?
+                ORDER BY user_id
+                OFFSET ? LIMIT 1
+            """,
+                (done_up_to_user_id, batch_size),
+            )
+            row = txn.fetchone()
+            if row:
+                return row[0]
+            else:
+                return None
+
+        def _add_private_only_users_to_stale_profile_refresh_queue_txn(
+            txn: LoggingTransaction, from_exc: str, until_inc: Optional[str]
+        ) -> None:
+            end_condition = "AND user_id <= ?" if until_inc is not None else ""
+            end_args = (until_inc,) if until_inc is not None else ()
+
+            txn.execute(
+                f"""
+                INSERT INTO user_directory_stale_remote_users
+                    (user_id, next_try_at_ts, retry_counter, user_server_name)
+                SELECT
+                    user_id, 0, 0, SUBSTRING(user_id FROM POSITION(':' IN user_id) + 1)
+                FROM {TEMP_TABLE}_remote_users_needing_lookup AS runl
+                LEFT JOIN user_directory AS ud USING (user_id)
+                WHERE ud.user_id IS NULL
+                AND ? < user_id {end_condition}
+            """,
+                (from_exc,) + end_args,
+            )
+
+        def _do_txn(txn: LoggingTransaction) -> None:
+            """
+            Does a step of background update.
+            """
+            last_user_id = progress.get("last_user_id", "@")
+            next_end_limit_inc = _get_next_batch_txn(txn, last_user_id)
+            _add_private_only_users_to_stale_profile_refresh_queue_txn(
+                txn, last_user_id, next_end_limit_inc
+            )
+
+            # Update the progress
+            progress["last_user_id"] = next_end_limit_inc
+            self.db_pool.updates._background_update_progress_txn(
+                txn, "populate_user_directory_process_remote_users", progress
+            )
+
+        if progress.get("last_user_id", "@") is None:
+            await self.db_pool.updates._end_background_update(
+                "populate_user_directory_process_users"
+            )
+            return 1
+
+        await self.db_pool.runInteraction(
+            "populate_user_directory_process_remote_users",
+            _do_txn,
+        )
+        return batch_size
 
     async def should_include_local_user_in_dir(self, user: str) -> bool:
         """Certain classes of local user are omitted from the user directory.

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -104,12 +104,22 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
             "populate_user_directory_cleanup", self._populate_user_directory_cleanup
         )
 
+    @staticmethod
+    def _delete_staging_area(txn: LoggingTransaction) -> None:
+        txn.execute("DROP TABLE IF EXISTS " + TEMP_TABLE + "_rooms")
+        txn.execute("DROP TABLE IF EXISTS " + TEMP_TABLE + "_users")
+        txn.execute(
+            "DROP TABLE IF EXISTS " + TEMP_TABLE + "_remote_users_needing_lookup"
+        )
+        txn.execute("DROP TABLE IF EXISTS " + TEMP_TABLE + "_position")
+
     async def _populate_user_directory_createtables(
         self, progress: JsonDict, batch_size: int
     ) -> int:
-
-        # Get all the rooms that we want to process.
         def _make_staging_area(txn: LoggingTransaction) -> None:
+            # Clear out any tables if they already exist beforehand.
+            UserDirectoryBackgroundUpdateStore._delete_staging_area(txn)
+
             sql = (
                 "CREATE TABLE IF NOT EXISTS "
                 + TEMP_TABLE
@@ -188,16 +198,9 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         )
         await self.update_user_directory_stream_pos(position)
 
-        def _delete_staging_area(txn: LoggingTransaction) -> None:
-            txn.execute("DROP TABLE IF EXISTS " + TEMP_TABLE + "_rooms")
-            txn.execute("DROP TABLE IF EXISTS " + TEMP_TABLE + "_users")
-            txn.execute(
-                "DROP TABLE IF EXISTS " + TEMP_TABLE + "_remote_users_needing_lookup"
-            )
-            txn.execute("DROP TABLE IF EXISTS " + TEMP_TABLE + "_position")
-
         await self.db_pool.runInteraction(
-            "populate_user_directory_cleanup", _delete_staging_area
+            "populate_user_directory_cleanup",
+            UserDirectoryBackgroundUpdateStore._delete_staging_area,
         )
 
         await self.db_pool.updates._end_background_update(

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -90,7 +90,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         )
         self.db_pool.updates.register_background_update_handler(
             "populate_user_directory_process_users",
-            self._populate_user_directory_process_users,
+            self._populate_user_directory_process_local_users,
         )
         self.db_pool.updates.register_background_update_handler(
             "populate_user_directory_cleanup", self._populate_user_directory_cleanup
@@ -265,7 +265,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
                 # Upsert a user_directory record for each remote user we see.
                 for user_id, profile in users_with_profile.items():
                     # Local users are processed separately in
-                    # `_populate_user_directory_users`; there we can read from
+                    # `_populate_user_directory_local_users`; there we can read from
                     # the `profiles` table to ensure we don't leak their per-room
                     # profiles. It also means we write local users to this table
                     # exactly once, rather than once for every room they're in.
@@ -336,7 +336,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
 
         return processed_event_count
 
-    async def _populate_user_directory_process_users(
+    async def _populate_user_directory_process_local_users(
         self, progress: JsonDict, batch_size: int
     ) -> int:
         """

--- a/synapse/storage/schema/main/delta/74/02_user_directory_rebuild.sql
+++ b/synapse/storage/schema/main/delta/74/02_user_directory_rebuild.sql
@@ -1,0 +1,40 @@
+/* Copyright 2023 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Rebuild the user directory in light of the fix for leaking the per-room
+-- profiles of remote users to the user directory.
+
+-- First cancel any existing rebuilds if already pending; we'll run from fresh.
+DELETE FROM background_updates WHERE update_name IN (
+    'populate_user_directory_createtables',
+    'populate_user_directory_process_rooms',
+    'populate_user_directory_process_users',
+    'populate_user_directory_process_remote_users',
+    'populate_user_directory_cleanup'
+);
+
+-- Then schedule the steps.
+INSERT INTO background_updates (ordering, update_name, progress_json, depends_on) VALUES
+  -- Set up user directory staging tables.
+  (7402, 'populate_user_directory_createtables', '{}', NULL),
+  -- Run through each room and update the user directory according to who is in it.
+  (7402, 'populate_user_directory_process_rooms', '{}', 'populate_user_directory_createtables'),
+  -- Insert all users into the user directory, if search_all_users is on.
+  (7402, 'populate_user_directory_process_users', '{}', 'populate_user_directory_process_rooms'),
+  -- Insert remote users into the queue for fetching.
+  (7402, 'populate_user_directory_process_remote_users', '{}', 'populate_user_directory_process_users'),
+  -- Clean up user directory staging tables.
+  (7402, 'populate_user_directory_cleanup', '{}', 'populate_user_directory_process_users'),
+ON CONFLICT (update_name) DO NOTHING;


### PR DESCRIPTION
Fixes: #5677 <!-- -->
<!--
Supersedes: # <!-- -->
Follows: #14756 <!-- -->
<!--
Part of: # <!-- -->
Base: `rei/userdirpriv2_refresh_remotes` <!-- git-stack-base-branch:rei/userdirpriv2_refresh_remotes -->

This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Rename method to make obvious it only applies to local users 

</li>
<li>

Add another temporary table to the user directory background update for storing remote users needing lookup 

</li>
<li>

Don't add private remote users straight to the user directory \
Instead, queue them up to be added to the stale profile queue.


</li>
<li>

Add a background update stage to sort the remote users into the stale profile queue as appropriate 

</li>
<li>

(ugly?) Kick off the fetching of remote profiles once ready 

</li>
<li>

When we start populating the user directory, clear out the old tables first if they're there 

</li>
<li>

When rebuilding user dir, schedule the new task 

</li>
<li>

Schedule a user directory rebuild 

</li>
</ol>
