### PR TITLE
Do not fail completely if oEmbed autodiscovery fails.

### DIFF
--- a/changelog.d/15092.bugfix
+++ b/changelog.d/15092.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where a URL preview would break if the discovered oEmbed failed to download.

--- a/tests/rest/media/v1/test_url_preview.py
+++ b/tests/rest/media/v1/test_url_preview.py
@@ -660,7 +660,7 @@ class URLPreviewTests(unittest.HomeserverTestCase):
         """If the preview image doesn't exist, ensure some data is returned."""
         self.lookups["matrix.org"] = [(IPv4Address, "10.1.2.3")]
 
-        end_content = (
+        result = (
             b"""<html><body><img src="http://cdn.matrix.org/foo.jpg"></body></html>"""
         )
 
@@ -681,8 +681,8 @@ class URLPreviewTests(unittest.HomeserverTestCase):
                 b"HTTP/1.0 200 OK\r\nContent-Length: %d\r\n"
                 b'Content-Type: text/html; charset="utf8"\r\n\r\n'
             )
-            % (len(end_content),)
-            + end_content
+            % (len(result),)
+            + result
         )
 
         self.pump()
@@ -690,6 +690,44 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
         # The image should not be in the result.
         self.assertNotIn("og:image", channel.json_body)
+
+    def test_oembed_failure(self) -> None:
+        """If the autodiscovered oEmbed URL fails, ensure some data is returned."""
+        self.lookups["matrix.org"] = [(IPv4Address, "10.1.2.3")]
+
+        result = b"""
+        <title>oEmbed Autodiscovery Fail</title>
+        <link rel="alternate" type="application/json+oembed"
+            href="http://example.com/oembed?url=http%3A%2F%2Fmatrix.org&format=json"
+            title="matrixdotorg" />
+        """
+
+        channel = self.make_request(
+            "GET",
+            "preview_url?url=http://matrix.org",
+            shorthand=False,
+            await_result=False,
+        )
+        self.pump()
+
+        client = self.reactor.tcpClients[0][2].buildProtocol(None)
+        server = AccumulatingProtocol()
+        server.makeConnection(FakeTransport(client, self.reactor))
+        client.makeConnection(FakeTransport(server, self.reactor))
+        client.dataReceived(
+            (
+                b"HTTP/1.0 200 OK\r\nContent-Length: %d\r\n"
+                b'Content-Type: text/html; charset="utf8"\r\n\r\n'
+            )
+            % (len(result),)
+            + result
+        )
+
+        self.pump()
+        self.assertEqual(channel.code, 200)
+
+        # The image should not be in the result.
+        self.assertEqual(channel.json_body["og:title"], "oEmbed Autodiscovery Fail")
 
     def test_data_url(self) -> None:
         """


### PR DESCRIPTION
This fixes previews of https://blog.jetbrains.com/idea/2022/05/take-part-in-the-new-ui-preview-for-your-jetbrains-ide/, that page has oEmbed autodiscovery in it:

```html
<link
	rel="alternate"
	type="application/json+oembed"
	href="https://blog.jetbrains.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fblog.jetbrains.com%2Fidea%2F2022%2F05%2Ftake-part-in-the-new-ui-preview-for-your-jetbrains-ide%2F" />
```

But if you go to that URL you get a 403 forbidden error. This shouldn't break URL previews completely, we already parsed the HTML page, let's just return that.

This is similar to #12950 where I made this change for image previews.