### PR TITLE
Allow health listener resource to load

### DIFF
--- a/changelog.d/15096.bugfix
+++ b/changelog.d/15096.bugfix
@@ -1,0 +1,1 @@
+Allow `health` listener to load.

--- a/changelog.d/15096.bugfix
+++ b/changelog.d/15096.bugfix
@@ -1,1 +1,1 @@
-Allow `health` listener to load.
+Fix a bug introduced in Synapse 1.76 where workers would fail to start if the `health` listener was configured.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -177,6 +177,7 @@ KNOWN_RESOURCES = {
     "client",
     "consent",
     "federation",
+    "health",
     "keys",
     "media",
     "metrics",


### PR DESCRIPTION
I was testing the new(ish) `health` listener resource that was added in #14747 and....it didn't work. All I got as an error was:
```log
Unknown listener resource
```
Very cryptic. The worker I attached it to would not start up.

This should fix it to work now.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog)
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>