### PR TITLE
Add `matrix-org-archive-keyring` package as `Recommends`

### DIFF
--- a/changelog.d/15110.misc
+++ b/changelog.d/15110.misc
@@ -1,0 +1,1 @@
+Add `matrix-org-archive-keyring` package as recommended in the debian package.

--- a/changelog.d/15110.misc
+++ b/changelog.d/15110.misc
@@ -1,1 +1,0 @@
-Add `matrix-org-archive-keyring` package as recommended in the debian package.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+matrix-synapse-py3 (1.77.0ubuntu1) UNRELEASED; urgency=medium
+
+  * Add `matrix-org-archive-keyring` package as recommended.
+
+ -- Synapse Packaging team <packages@matrix.org>  Mon, 20 Feb 2023 15:41:41 +0000
+
 matrix-synapse-py3 (1.77.0) stable; urgency=medium
 
   * New Synapse release 1.77.0.

--- a/debian/control
+++ b/debian/control
@@ -37,6 +37,7 @@ Depends:
 # so we put perl:Depends in Suggests rather than Depends.
 Recommends:
  ${shlibs1:Recommends},
+ matrix-org-archive-keyring,
 Suggests:
  sqlite3,
  ${perl:Depends},


### PR DESCRIPTION
This is so installations will pull in the keyring package, allowing us to update the expiry time of the `packages.matrix.org` repository.

c.f. https://github.com/matrix-org/synapse/issues/10389