### PR TITLE
Stop parsing the unspecced type parameter on thumbnail requests.

### DIFF
--- a/changelog.d/15137.removal
+++ b/changelog.d/15137.removal
@@ -1,0 +1,1 @@
+Remove the undocumented and unspecced `type` parameter to the `/thumbnail` endpoint.

--- a/synapse/rest/media/v1/thumbnail_resource.py
+++ b/synapse/rest/media/v1/thumbnail_resource.py
@@ -69,7 +69,8 @@ class ThumbnailResource(DirectServeJsonResource):
         width = parse_integer(request, "width", required=True)
         height = parse_integer(request, "height", required=True)
         method = parse_string(request, "method", "scale")
-        m_type = parse_string(request, "type", "image/png")
+        # TODO Parse the Accept header to get an prioritised list of thumbnail types.
+        m_type = "image/png"
 
         if server_name == self.server_name:
             if self.dynamic_thumbnails:


### PR DESCRIPTION
Fixes #14913, this is the minimum change necessary to be spec compliant. I didn't want to rip out all of the functions which then use this as I think we'll want to do something similar with the `Accept` header. @Half-Shot and I are planning an MSC there.

Note that if a client *is* sending this then it will just be ignored, which is the behavior the client would see on e.g. Conduit or Dendrite.