### PR TITLE
Fix a long-standing bug where an initial sync would not respond to changes to the list of ignored users if there was an initial sync cached.

### DIFF
--- a/changelog.d/15163.bugfix
+++ b/changelog.d/15163.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where an initial sync would not respond to changes to the list of ignored users if there was an initial sync cached.

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -139,7 +139,7 @@ class SyncRestServlet(RestServlet):
             device_id,
         )
 
-        # ID of the last ignored users account data event for this user,
+        # Stream position of the last ignored users account data event for this user,
         # if we're initial syncing.
         # We include this in the request key to invalidate an initial sync
         # in the response cache once the set of ignored users has changed.


### PR DESCRIPTION

Partially addresses: #15162

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Invalidate initial sync if ignored user set changes 

</li>
</ol>
