### PR TITLE
Add missing type hints to InsecureInterceptableContextFactory.

### DIFF
--- a/changelog.d/15164.misc
+++ b/changelog.d/15164.misc
@@ -1,0 +1,1 @@
+Improve type hints.

--- a/mypy.ini
+++ b/mypy.ini
@@ -36,9 +36,6 @@ exclude = (?x)
 [mypy-synapse.federation.transport.client]
 disallow_untyped_defs = False
 
-[mypy-synapse.http.client]
-disallow_untyped_defs = False
-
 [mypy-synapse.http.matrixfederationclient]
 disallow_untyped_defs = False
 

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -44,7 +44,6 @@ from twisted.internet.interfaces import (
     IAddress,
     IDelayedCall,
     IHostResolution,
-    IOpenSSLClientConnectionCreator,
     IOpenSSLContextFactory,
     IReactorCore,
     IReactorPluggableNameResolver,

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -44,6 +44,8 @@ from twisted.internet.interfaces import (
     IAddress,
     IDelayedCall,
     IHostResolution,
+    IOpenSSLClientConnectionCreator,
+    IOpenSSLContextFactory,
     IReactorCore,
     IReactorPluggableNameResolver,
     IReactorTime,
@@ -958,8 +960,8 @@ class InsecureInterceptableContextFactory(ssl.ContextFactory):
         self._context = SSL.Context(SSL.SSLv23_METHOD)
         self._context.set_verify(VERIFY_NONE, lambda *_: False)
 
-    def getContext(self, hostname=None, port=None):
+    def getContext(self) -> SSL.Context:
         return self._context
 
-    def creatorForNetloc(self, hostname: bytes, port: int):
+    def creatorForNetloc(self, hostname: bytes, port: int) -> IOpenSSLContextFactory:
         return self


### PR DESCRIPTION
Bitty PR to finish type hints in `synapse.http.client`.