### PR TITLE
Update spam checker documentation for moved media modules.

### DIFF
--- a/changelog.d/15175.misc
+++ b/changelog.d/15175.misc
@@ -1,0 +1,1 @@
+Refactor the media modules.

--- a/docs/modules/spam_checker_callbacks.md
+++ b/docs/modules/spam_checker_callbacks.md
@@ -307,8 +307,8 @@ _Changed in Synapse v1.62.0: `synapse.module_api.NOT_SPAM` and `synapse.module_a
 
 ```python
 async def check_media_file_for_spam(
-    file_wrapper: "synapse.rest.media.v1.media_storage.ReadableFileWrapper",
-    file_info: "synapse.rest.media.v1._base.FileInfo",
+    file_wrapper: "synapse.media.media_storage.ReadableFileWrapper",
+    file_info: "synapse.media._base.FileInfo",
 ) -> Union["synapse.module_api.NOT_SPAM", "synapse.module_api.errors.Codes", bool]
 ```
 


### PR DESCRIPTION
This was missed in #15146. Note that the `FileStorageProvider` is not referenced in the config manual (we use `file_system` as a special constant instead).