### PR TITLE
Fix conflicting URLs for dehydrated devices.

### DIFF
--- a/changelog.d/15180.bugfix
+++ b/changelog.d/15180.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.78.0 where requests to claim dehydrated devices would fail with a `405` error.

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -255,7 +255,7 @@ class DehydratedDeviceServlet(RestServlet):
 
     """
 
-    PATTERNS = client_patterns("/org.matrix.msc2697.v2/dehydrated_device", releases=())
+    PATTERNS = client_patterns("/org.matrix.msc2697.v2/dehydrated_device$", releases=())
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()


### PR DESCRIPTION
A regression from #14605.

Fixes #15178

I tested with: `curl -v -X POST http://localhost:8080/_matrix/client/unstable/org.matrix.msc2697.v2/dehydrated_device/claim` which was returning unrecognised request and is now returning a missing access token error. 👍 

I also checked that `curl -v http://localhost:8080/_matrix/client/unstable/org.matrix.msc2697.v2/dehydrated_device` (and with `-X PUT`) still works as expected.