### PR TITLE
Allow ruff to automatically fix issues.

### DIFF
--- a/changelog.d/15194.misc
+++ b/changelog.d/15194.misc
@@ -1,0 +1,1 @@
+Automatically fix errors with `ruff`.

--- a/scripts-dev/lint.sh
+++ b/scripts-dev/lint.sh
@@ -112,7 +112,7 @@ python3 -m black "${files[@]}"
 
 # Catch any common programming mistakes in Python code.
 # --quiet suppresses the update check.
-ruff --quiet "${files[@]}"
+ruff --quiet --fix "${files[@]}"
 
 # Catch any common programming mistakes in Rust code.
 #


### PR DESCRIPTION
This adds the `--fix` option to `ruff`, similar to what we allow our other linting bits to do.