### PR TITLE
More speedups/fixes to creating batched events

### DIFF
--- a/changelog.d/15195.misc
+++ b/changelog.d/15195.misc
@@ -1,0 +1,1 @@
+Misc speedups to creating and authing events.

--- a/changelog.d/15195.misc
+++ b/changelog.d/15195.misc
@@ -1,1 +1,1 @@
-Misc speedups to creating and authing events.
+Improve performance of creating and authenticating events.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -168,13 +168,23 @@ async def check_state_independent_auth_rules(
         return
 
     # 2. Reject if event has auth_events that: ...
-    auth_events = await store.get_events(
-        event.auth_event_ids(),
-        redact_behaviour=EventRedactBehaviour.as_is,
-        allow_rejected=True,
-    )
     if batched_auth_events:
-        auth_events.update(batched_auth_events)
+        auth_event_ids = event.auth_event_ids()
+        auth_events = dict(batched_auth_events)
+        if set(auth_event_ids) - batched_auth_events.keys():
+            auth_events.update(
+                await store.get_events(
+                    set(auth_event_ids) - batched_auth_events.keys(),
+                    redact_behaviour=EventRedactBehaviour.as_is,
+                    allow_rejected=True,
+                )
+            )
+    else:
+        auth_events = await store.get_events(
+            event.auth_event_ids(),
+            redact_behaviour=EventRedactBehaviour.as_is,
+            allow_rejected=True,
+        )
 
     room_id = event.room_id
     auth_dict: MutableStateMap[str] = {}

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -169,6 +169,7 @@ async def check_state_independent_auth_rules(
 
     # 2. Reject if event has auth_events that: ...
     if batched_auth_events:
+        # Copy the batched auth events to avoid mutating them.
         auth_events = dict(batched_auth_events)
         needed_auth_event_ids = set(event.auth_event_ids()) - batched_auth_events.keys()
         if needed_auth_event_ids:

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -169,12 +169,12 @@ async def check_state_independent_auth_rules(
 
     # 2. Reject if event has auth_events that: ...
     if batched_auth_events:
-        auth_event_ids = event.auth_event_ids()
         auth_events = dict(batched_auth_events)
-        if set(auth_event_ids) - batched_auth_events.keys():
+        needed_auth_event_ids = set(event.auth_event_ids()) - batched_auth_events.keys()
+        if needed_auth_event_ids:
             auth_events.update(
                 await store.get_events(
-                    set(auth_event_ids) - batched_auth_events.keys(),
+                    needed_auth_event_ids,
                     redact_behaviour=EventRedactBehaviour.as_is,
                     allow_rejected=True,
                 )

--- a/synapse/events/snapshot.py
+++ b/synapse/events/snapshot.py
@@ -135,6 +135,8 @@ class EventContext(UnpersistedEventContextBase):
     delta_ids: Optional[StateMap[str]] = None
     app_service: Optional[ApplicationService] = None
 
+    _state_map_before_event: Optional[StateMap[str]] = None
+
     partial_state: bool = False
 
     @staticmethod
@@ -293,6 +295,11 @@ class EventContext(UnpersistedEventContextBase):
             Maps a (type, state_key) to the event ID of the state event matching
             this tuple.
         """
+        if self._state_map_before_event is not None:
+            if state_filter is not None:
+                return state_filter.filter_state(self._state_map_before_event)
+            return self._state_map_before_event
+
         assert self.state_group_before_event is not None
         return await self._storage.state.get_state_ids_for_group(
             self.state_group_before_event, state_filter

--- a/synapse/events/snapshot.py
+++ b/synapse/events/snapshot.py
@@ -135,8 +135,6 @@ class EventContext(UnpersistedEventContextBase):
     delta_ids: Optional[StateMap[str]] = None
     app_service: Optional[ApplicationService] = None
 
-    _state_map_before_event: Optional[StateMap[str]] = None
-
     partial_state: bool = False
 
     @staticmethod
@@ -295,10 +293,6 @@ class EventContext(UnpersistedEventContextBase):
             Maps a (type, state_key) to the event ID of the state event matching
             this tuple.
         """
-        if self._state_map_before_event is not None:
-            if state_filter is not None:
-                return state_filter.filter_state(self._state_map_before_event)
-            return self._state_map_before_event
 
         assert self.state_group_before_event is not None
         return await self._storage.state.get_state_ids_for_group(

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -63,19 +63,13 @@ class EventAuthHandler:
             self._store, event, batched_auth_events
         )
         auth_event_ids = event.auth_event_ids()
-        logger.info("auth events %s", auth_event_ids)
 
         if batched_auth_events:
-            logger.info("Batched auth events %s", list(batched_auth_events.keys()))
             auth_events_by_id = dict(batched_auth_events)
-            if set(auth_event_ids) - set(batched_auth_events):
-                logger.info(
-                    "fetching %s", set(auth_event_ids) - set(batched_auth_events)
-                )
+            needed_auth_event_ids = set(auth_event_ids) - set(batched_auth_events)
+            if needed_auth_event_ids:
                 auth_events_by_id.update(
-                    await self._store.get_events(
-                        set(auth_event_ids) - set(batched_auth_events)
-                    )
+                    await self._store.get_events(needed_auth_event_ids)
                 )
         else:
             auth_events_by_id = await self._store.get_events(auth_event_ids)

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -65,6 +65,7 @@ class EventAuthHandler:
         auth_event_ids = event.auth_event_ids()
 
         if batched_auth_events:
+            # Copy the batched auth events to avoid mutating them.
             auth_events_by_id = dict(batched_auth_events)
             needed_auth_event_ids = set(auth_event_ids) - set(batched_auth_events)
             if needed_auth_event_ids:

--- a/synapse/handlers/event_auth.py
+++ b/synapse/handlers/event_auth.py
@@ -63,9 +63,23 @@ class EventAuthHandler:
             self._store, event, batched_auth_events
         )
         auth_event_ids = event.auth_event_ids()
-        auth_events_by_id = await self._store.get_events(auth_event_ids)
+        logger.info("auth events %s", auth_event_ids)
+
         if batched_auth_events:
-            auth_events_by_id.update(batched_auth_events)
+            logger.info("Batched auth events %s", list(batched_auth_events.keys()))
+            auth_events_by_id = dict(batched_auth_events)
+            if set(auth_event_ids) - set(batched_auth_events):
+                logger.info(
+                    "fetching %s", set(auth_event_ids) - set(batched_auth_events)
+                )
+                auth_events_by_id.update(
+                    await self._store.get_events(
+                        set(auth_event_ids) - set(batched_auth_events)
+                    )
+                )
+        else:
+            auth_events_by_id = await self._store.get_events(auth_event_ids)
+
         check_state_dependent_auth_rules(event, auth_events_by_id.values())
 
     def compute_auth_events(

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1123,7 +1123,7 @@ class RoomCreationHandler:
                 event_dict,
                 prev_event_ids=prev_event,
                 depth=depth,
-                state_map=state_map,
+                state_map=dict(state_map),
                 for_batch=for_batch,
             )
 

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1123,6 +1123,8 @@ class RoomCreationHandler:
                 event_dict,
                 prev_event_ids=prev_event,
                 depth=depth,
+                # Take a copy to ensure each event gets a unique copy of
+                # state_map since it is modified below.
                 state_map=dict(state_map),
                 for_batch=for_batch,
             )


### PR DESCRIPTION
These changes come from a discussion with Erik and are follow-ups to the batching persisting event work, speeding it up/making it more efficient. Best reviewable commit-by-commit, and I can split these out into separate PRs if others think it necessary.