### PR TITLE
ModuleAPI SSO auth callbacks

### DIFF
--- a/changelog.d/15192.feature
+++ b/changelog.d/15192.feature
@@ -1,0 +1,1 @@
+Adds on_sso_login ModuleAPI callback allowing to execute custom code on SSO Auth

--- a/docs/modules/account_validity_callbacks.md
+++ b/docs/modules/account_validity_callbacks.md
@@ -42,3 +42,16 @@ operations to keep track of them. (e.g. add them to a database table). The user 
 represented by their Matrix user ID.
 
 If multiple modules implement this callback, Synapse runs them all in order.
+
+### `on_sso_login`
+
+_First introduced in Synapse < TODO >
+
+```python
+async def on_sso_login(user: str) -> None
+```
+
+Called after successfully login or registration of a user using SSO for cases when module needs to perform extra operations after SSO auth.
+represented by their Matrix user ID.
+
+If multiple modules implement this callback, Synapse runs them all in order.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -213,6 +213,7 @@ class AuthHandler:
         self._password_enabled_for_reauth = hs.config.auth.password_enabled_for_reauth
         self._password_localdb_enabled = hs.config.auth.password_localdb_enabled
         self._third_party_rules = hs.get_third_party_event_rules()
+        self._account_validity_handler = hs.get_account_validity_handler()
 
         # Ratelimiter for failed auth during UIA. Uses same ratelimit config
         # as per `rc_login.failed_attempts`.
@@ -1778,6 +1779,9 @@ class AuthHandler:
         redirect_url = self.add_query_param_to_url(
             client_redirect_url, "loginToken", login_token
         )
+
+        # Run post-login module callback handlers
+        await self._account_validity_handler.on_sso_login(registered_user_id)
 
         # if the client is whitelisted, we can redirect straight to it
         if client_redirect_url.startswith(self._whitelisted_sso_clients):

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -79,6 +79,7 @@ from synapse.handlers.account_validity import (
     ON_LEGACY_RENEW_CALLBACK,
     ON_LEGACY_SEND_MAIL_CALLBACK,
     ON_USER_REGISTRATION_CALLBACK,
+    ON_SSO_LOGIN_CALLBACK,
 )
 from synapse.handlers.auth import (
     CHECK_3PID_AUTH_CALLBACK,
@@ -324,6 +325,7 @@ class ModuleApi:
         *,
         is_user_expired: Optional[IS_USER_EXPIRED_CALLBACK] = None,
         on_user_registration: Optional[ON_USER_REGISTRATION_CALLBACK] = None,
+        on_sso_login: Optional[ON_SSO_LOGIN_CALLBACK] = None,
         on_legacy_send_mail: Optional[ON_LEGACY_SEND_MAIL_CALLBACK] = None,
         on_legacy_renew: Optional[ON_LEGACY_RENEW_CALLBACK] = None,
         on_legacy_admin_request: Optional[ON_LEGACY_ADMIN_REQUEST] = None,
@@ -335,6 +337,7 @@ class ModuleApi:
         return self._account_validity_handler.register_account_validity_callbacks(
             is_user_expired=is_user_expired,
             on_user_registration=on_user_registration,
+            on_sso_login=on_sso_login,
             on_legacy_send_mail=on_legacy_send_mail,
             on_legacy_renew=on_legacy_renew,
             on_legacy_admin_request=on_legacy_admin_request,


### PR DESCRIPTION
This PR implements a callaback that is executed on any SSO auth (registration and logins). This introduces an ability to add custom callbacks using ModuleAPI.

Reasoning:
- [Password auth provider callbacks](https://matrix-org.github.io/synapse/latest/modules/password_auth_provider_callbacks.html#password-auth-provider-callbacks) - will not work with SSO type logins;
- [account_validity_callbacks.on_user_registration](https://matrix-org.github.io/synapse/latest/modules/account_validity_callbacks.html#on_user_registration) runs only on registration and is called before external_ids are set removing the ability to get the remote_user_id inside the ModuleAPI callback'
- There is not general on_login callback (which can be another interesting solution);

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Andrii Yasynyshyn <yasinishyn.a.n@gmail.com>
