### PR TITLE
Add a missing endpoint to the workers documentation.

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -231,6 +231,7 @@ information.
     ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/event/
     ^/_matrix/client/(api/v1|r0|v3|unstable)/joined_rooms$
     ^/_matrix/client/v1/rooms/.*/timestamp_to_event$
+    ^/_matrix/client/(api/v1|r0|v3|unstable/.*)/rooms/.*/aliases
     ^/_matrix/client/(api/v1|r0|v3|unstable)/search$
     ^/_matrix/client/(r0|v3|unstable)/user/.*/filter(/|$)
 


### PR DESCRIPTION
This is already at [sytest](https://github.com/matrix-org/sytest/blob/160dde018ee6a7f5b6388026aaa066e38f133830/lib/SyTest/Homeserver/Synapse.pm#L1304) and [complement](https://github.com/matrix-org/synapse/blob/ecbe0ddbe7c47e05bc27b39dc10a9c30eafd2960/docker/configure_workers_and_start.py#L142).