### PR TITLE
Fix missing conditional for registering `on_remove_user_third_party_identifier` module api callbacks (#15227

### DIFF
--- a/changelog.d/15227.bugfix
+++ b/changelog.d/15227.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.79.0rc1 where attempting to register a `on_remove_user_third_party_identifier` module API callback would be a no-op.

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -247,6 +247,11 @@ class ThirdPartyEventRules:
                 on_add_user_third_party_identifier
             )
 
+        if on_remove_user_third_party_identifier is not None:
+            self._on_remove_user_third_party_identifier_callbacks.append(
+                on_remove_user_third_party_identifier
+            )
+
     async def check_event_allowed(
         self,
         event: EventBase,

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -941,18 +941,16 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
         just before associating and removing a 3PID to/from an account.
         """
         # Pretend to be a Synapse module and register both callbacks as mocks.
-        third_party_rules = self.hs.get_third_party_event_rules()
         on_add_user_third_party_identifier_callback_mock = Mock(
             return_value=make_awaitable(None)
         )
         on_remove_user_third_party_identifier_callback_mock = Mock(
             return_value=make_awaitable(None)
         )
-        third_party_rules._on_threepid_bind_callbacks.append(
-            on_add_user_third_party_identifier_callback_mock
-        )
-        third_party_rules._on_threepid_bind_callbacks.append(
-            on_remove_user_third_party_identifier_callback_mock
+        third_party_rules = self.hs.get_third_party_event_rules()
+        third_party_rules.register_third_party_rules_callbacks(
+            on_add_user_third_party_identifier=on_add_user_third_party_identifier_callback_mock,
+            on_remove_user_third_party_identifier=on_remove_user_third_party_identifier_callback_mock,
         )
 
         # Register an admin user.
@@ -1008,12 +1006,12 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
         when a user is deactivated and their third-party ID associations are deleted.
         """
         # Pretend to be a Synapse module and register both callbacks as mocks.
-        third_party_rules = self.hs.get_third_party_event_rules()
         on_remove_user_third_party_identifier_callback_mock = Mock(
             return_value=make_awaitable(None)
         )
-        third_party_rules._on_threepid_bind_callbacks.append(
-            on_remove_user_third_party_identifier_callback_mock
+        third_party_rules = self.hs.get_third_party_event_rules()
+        third_party_rules.register_third_party_rules_callbacks(
+            on_threepid_bind=on_remove_user_third_party_identifier_callback_mock,
         )
 
         # Register an admin user.
@@ -1038,6 +1036,9 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
             access_token=admin_tok,
         )
         self.assertEqual(channel.code, 200, channel.json_body)
+
+        # Check that the mock was not called on the act of adding a third-party ID.
+        on_remove_user_third_party_identifier_callback_mock.assert_not_called()
 
         # Now deactivate the user.
         channel = self.make_request(

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -1011,7 +1011,7 @@ class ThirdPartyRulesTestCase(unittest.FederatingHomeserverTestCase):
         )
         third_party_rules = self.hs.get_third_party_event_rules()
         third_party_rules.register_third_party_rules_callbacks(
-            on_threepid_bind=on_remove_user_third_party_identifier_callback_mock,
+            on_remove_user_third_party_identifier=on_remove_user_third_party_identifier_callback_mock,
         )
 
         # Register an admin user.


### PR DESCRIPTION
https://github.com/matrix-org/synapse/pull/15044 added two new Module API callbacks: `on_add_user_third_party_identifier` and `on_remove_user_third_party_identifier` for informing Synapse modules that a user had added/removed a third party ID (email, phone number) to/from their account.

However, the bit of code which actually did the registering of `on_remove_user_third_party_identifier` callbacks was missing.

Additionally, the tests included with that PR were also wrong: they registered mocked callbacks under `on_threepid_bind`, instead of the correct callback names. The tests still passed, as `test_on_remove_user_third_party_identifier_is_called_on_deactivate` only checked that the removal variant of the callbacks was called once after both an add and remove action. It has been modified to double-check that the mock *wasn't* called after only the _add_ occurs.