### PR TITLE
Add missing type hints to `synapse.storage.database`.

### DIFF
--- a/changelog.d/15230.misc
+++ b/changelog.d/15230.misc
@@ -1,0 +1,1 @@
+Improve type hints.

--- a/mypy.ini
+++ b/mypy.ini
@@ -48,9 +48,6 @@ warn_unused_ignores = False
 [mypy-synapse.util.caches.treecache]
 disallow_untyped_defs = False
 
-[mypy-synapse.storage.database]
-disallow_untyped_defs = False
-
 [mypy-tests.util.caches.test_descriptors]
 disallow_untyped_defs = False
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -105,6 +105,7 @@ class _PoolConnection(Connection):
     """
     A Connection from twisted.enterprise.adbapi.Connection.
     """
+
     def reconnect(self) -> None:
         ...
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -865,7 +865,8 @@ class DatabasePool:
             try:
                 with opentracing.start_active_span(f"db.{desc}"):
                     result = await self.runWithConnection(
-                        self.new_transaction,
+                        # mypy seems to have an issue with this, maybe a bug?
+                        self.new_transaction,  # type: ignore[arg-type]
                         desc,
                         after_callbacks,
                         async_after_callbacks,


### PR DESCRIPTION
Finishes up this module so we can require type hints in it.