### PR TITLE
Fix error when sending message into deleted room.

### DIFF
--- a/changelog.d/15235.bugfix
+++ b/changelog.d/15235.bugfix
@@ -1,1 +1,1 @@
-Fix error when sending message into deleted room.
+Fix long-standing error when sending message into deleted room.

--- a/changelog.d/15235.bugfix
+++ b/changelog.d/15235.bugfix
@@ -1,0 +1,1 @@
+Fix error when sending message into deleted room.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1169,6 +1169,17 @@ class EventCreationHandler:
                 len(prev_event_ids),
             )
         else:
+            # If we don't have any prev event IDs specified then we need to
+            # check that the host is in the room (as otherwise populating the
+            # prev events will fail), at which point we may as well check the
+            # local user is in the room.
+            user_id = requester.user.to_string()
+            is_user_in_room = await self.store.check_local_user_in_room(
+                requester.user.to_string(), builder.room_id
+            )
+            if not is_user_in_room:
+                raise AuthError(403, f"User {user_id} not in room {builder.room_id}")
+
             prev_event_ids = await self.store.get_prev_events_for_room(builder.room_id)
 
         # Do a quick sanity check here, rather than waiting until we've created the

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1173,12 +1173,13 @@ class EventCreationHandler:
             # check that the host is in the room (as otherwise populating the
             # prev events will fail), at which point we may as well check the
             # local user is in the room.
-            user_id = requester.user.to_string()
             is_user_in_room = await self.store.check_local_user_in_room(
-                requester.user.to_string(), builder.room_id
+                builder.sender, builder.room_id
             )
             if not is_user_in_room:
-                raise AuthError(403, f"User {user_id} not in room {builder.room_id}")
+                raise AuthError(
+                    403, f"User {builder.sender} not in room {builder.room_id}"
+                )
 
             prev_event_ids = await self.store.get_prev_events_for_room(builder.room_id)
 

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1000,14 +1000,18 @@ class EventCreationHandler:
                         event,
                         event.internal_metadata.stream_ordering,
                     )
+
         # If we don't have any prev event IDs specified then we need to
         # check that the host is in the room (as otherwise populating the
         # prev events will fail), at which point we may as well check the
         # local user is in the room.
-        user_id = requester.user.to_string()
-        is_user_in_room = await self.store.check_local_user_in_room(user_id, room_id)
-        if not is_user_in_room:
-            raise AuthError(403, f"User {user_id} not in room {room_id}")
+        if not prev_event_ids:
+            user_id = requester.user.to_string()
+            is_user_in_room = await self.store.check_local_user_in_room(
+                user_id, room_id
+            )
+            if not is_user_in_room:
+                raise AuthError(403, f"User {user_id} not in room {room_id}")
 
         # Try several times, it could fail with PartialStateConflictError
         # in handle_new_client_event, cf comment in except block.

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -402,6 +402,21 @@ class DeleteRoomTestCase(unittest.HomeserverTestCase):
         # Assert we can no longer peek into the room
         self._assert_peek(self.room_id, expect_code=403)
 
+    def test_room_delete_send(self) -> None:
+        """Test that sending into a deleted room returns a 403"""
+        channel = self.make_request(
+            "DELETE",
+            self.url,
+            content={},
+            access_token=self.admin_user_tok,
+        )
+
+        self.assertEqual(200, channel.code, msg=channel.json_body)
+
+        self.helper.send(
+            self.room_id, "test message", expect_code=403, tok=self.other_user_tok
+        )
+
     def _is_blocked(self, room_id: str, expect: bool = True) -> None:
         """Assert that the room is blocked or not"""
         d = self.store.is_room_blocked(room_id)


### PR DESCRIPTION
When a room is deleted in Synapse we remove the event forward extremities in the room, so if (say a bot) tries to send a message into the room we error out due to not being able to calculate prev events for the new event *before* we check if the sender is in the room.

Fixes #8094