### PR TITLE
Refactor `filter_events_for_server`

### DIFF
--- a/changelog.d/15240.misc
+++ b/changelog.d/15240.misc
@@ -1,0 +1,1 @@
+Refactor `filter_events_for_server`.

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -548,7 +548,7 @@ class PerDestinationQueue:
                         new_pdus,
                         redact=False,
                         filter_out_erased_senders=True,
-                        filter_out_partial_state_rooms=True,
+                        filter_out_remote_partial_state_events=True,
                     )
 
                     # If we've filtered out all the extremities, fall back to

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -547,6 +547,7 @@ class PerDestinationQueue:
                         self._server_name,
                         new_pdus,
                         redact=False,
+                        filter_out_erased_senders=True,
                     )
 
                     # If we've filtered out all the extremities, fall back to

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -548,6 +548,7 @@ class PerDestinationQueue:
                         new_pdus,
                         redact=False,
                         filter_out_erased_senders=True,
+                        filter_out_partial_state_rooms=True,
                     )
 
                     # If we've filtered out all the extremities, fall back to

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -401,6 +401,7 @@ class FederationHandler:
                 events_to_check,
                 redact=False,
                 filter_out_erased_senders=False,
+                filter_out_partial_state_rooms=False,
             )
             if filtered_extremities:
                 extremities_to_request.append(bp.event_id)
@@ -1337,6 +1338,7 @@ class FederationHandler:
             events,
             redact=True,
             filter_out_erased_senders=True,
+            filter_out_partial_state_rooms=True,
         )
 
         return events
@@ -1373,6 +1375,7 @@ class FederationHandler:
             [event],
             redact=True,
             filter_out_erased_senders=True,
+            filter_out_partial_state_rooms=True,
         )
         event = events[0]
         return event
@@ -1406,6 +1409,7 @@ class FederationHandler:
             missing_events,
             redact=True,
             filter_out_erased_senders=True,
+            filter_out_partial_state_rooms=True,
         )
 
         return missing_events

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1331,7 +1331,12 @@ class FederationHandler:
         )
 
         events = await filter_events_for_server(
-            self._storage_controllers, origin, self.server_name, events
+            self._storage_controllers,
+            origin,
+            self.server_name,
+            events,
+            redact=True,
+            filter_out_erased_senders=True,
         )
 
         return events
@@ -1362,7 +1367,12 @@ class FederationHandler:
         await self._event_auth_handler.assert_host_in_room(event.room_id, origin)
 
         events = await filter_events_for_server(
-            self._storage_controllers, origin, self.server_name, [event]
+            self._storage_controllers,
+            origin,
+            self.server_name,
+            [event],
+            redact=True,
+            filter_out_erased_senders=True,
         )
         event = events[0]
         return event
@@ -1390,7 +1400,12 @@ class FederationHandler:
         )
 
         missing_events = await filter_events_for_server(
-            self._storage_controllers, origin, self.server_name, missing_events
+            self._storage_controllers,
+            origin,
+            self.server_name,
+            missing_events,
+            redact=True,
+            filter_out_erased_senders=True,
         )
 
         return missing_events

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -401,7 +401,7 @@ class FederationHandler:
                 events_to_check,
                 redact=False,
                 filter_out_erased_senders=False,
-                filter_out_partial_state_rooms=False,
+                filter_out_remote_partial_state_events=False,
             )
             if filtered_extremities:
                 extremities_to_request.append(bp.event_id)
@@ -1338,7 +1338,7 @@ class FederationHandler:
             events,
             redact=True,
             filter_out_erased_senders=True,
-            filter_out_partial_state_rooms=True,
+            filter_out_remote_partial_state_events=True,
         )
 
         return events
@@ -1375,7 +1375,7 @@ class FederationHandler:
             [event],
             redact=True,
             filter_out_erased_senders=True,
-            filter_out_partial_state_rooms=True,
+            filter_out_remote_partial_state_events=True,
         )
         event = events[0]
         return event
@@ -1409,7 +1409,7 @@ class FederationHandler:
             missing_events,
             redact=True,
             filter_out_erased_senders=True,
-            filter_out_partial_state_rooms=True,
+            filter_out_remote_partial_state_events=True,
         )
 
         return missing_events

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -392,7 +392,7 @@ class FederationHandler:
                 get_prev_content=False,
             )
 
-            # We set `check_history_visibility_only` as we might otherwise get false
+            # We unset `filter_out_erased_senders` as we might otherwise get false
             # positives from users having been erased.
             filtered_extremities = await filter_events_for_server(
                 self._storage_controllers,
@@ -400,7 +400,7 @@ class FederationHandler:
                 self.server_name,
                 events_to_check,
                 redact=False,
-                check_history_visibility_only=True,
+                filter_out_erased_senders=False,
             )
             if filtered_extremities:
                 extremities_to_request.append(bp.event_id)

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -669,8 +669,7 @@ async def filter_events_for_server(
         target_server_name,
     )
 
-    to_return = []
-    for e in events:
+    def include_event_in_output(e: EventBase) -> bool:
         erased = is_sender_erased(e, erased_senders)
         visible = check_event_is_visible(
             event_to_history_vis[e.event_id], event_to_memberships.get(e.event_id, {})
@@ -679,7 +678,11 @@ async def filter_events_for_server(
         if e in partial_state_invisible_events:
             visible = False
 
-        if visible and not erased:
+        return visible and not erased
+
+    to_return = []
+    for e in events:
+        if include_event_in_output(e):
             to_return.append(e)
         elif redact:
             to_return.append(prune_event(e))

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -579,7 +579,7 @@ async def filter_events_for_server(
     *,
     redact: bool,
     filter_out_erased_senders: bool,
-    filter_out_partial_state_rooms: bool,
+    filter_out_remote_partial_state_events: bool,
 ) -> List[EventBase]:
     """Filter a list of events based on whether the target server is allowed to
     see them.
@@ -605,8 +605,8 @@ async def filter_events_for_server(
         filter_out_erased_senders: If true, also filter out events whose sender has been
             erased. This is used e.g. during pagination to decide whether to
             backfill or not.
-        filter_out_partial_state_rooms: If True, also filter out events in partial state
-            rooms.
+        filter_out_remote_partial_state_events: If True, also filter out events in
+            partial state rooms created by other homeservers.
     Returns
         The filtered events.
     """
@@ -656,7 +656,7 @@ async def filter_events_for_server(
     # this check but would base the filtering on an outdated view of the membership events.
 
     partial_state_invisible_event_ids: Set[str] = set()
-    if filter_out_partial_state_rooms:
+    if filter_out_remote_partial_state_events:
         for e in events:
             sender_domain = get_domain_from_id(e.sender)
             if (

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -576,8 +576,9 @@ async def filter_events_for_server(
     target_server_name: str,
     local_server_name: str,
     events: Sequence[EventBase],
-    redact: bool = True,
-    filter_out_erased_senders: bool = True,
+    *,
+    redact: bool,
+    filter_out_erased_senders: bool,
 ) -> List[EventBase]:
     """Filter a list of events based on whether the target server is allowed to
     see them.

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -14,7 +14,17 @@
 # limitations under the License.
 import logging
 from enum import Enum, auto
-from typing import Collection, Dict, FrozenSet, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Collection,
+    Dict,
+    FrozenSet,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 import attr
 from typing_extensions import Final
@@ -642,7 +652,7 @@ async def filter_events_for_server(
     # otherwise a room could be fully joined after we retrieve those, which would then bypass
     # this check but would base the filtering on an outdated view of the membership events.
 
-    partial_state_invisible_events = set()
+    partial_state_invisible_event_ids: Set[str] = set()
     if filter_out_erased_senders:
         for e in events:
             sender_domain = get_domain_from_id(e.sender)
@@ -650,7 +660,7 @@ async def filter_events_for_server(
                 sender_domain != local_server_name
                 and await storage.main.is_partial_state_room(e.room_id)
             ):
-                partial_state_invisible_events.add(e)
+                partial_state_invisible_event_ids.add(e.event_id)
 
     # Let's check to see if all the events have a history visibility
     # of "shared" or "world_readable". If that's the case then we don't
@@ -675,7 +685,7 @@ async def filter_events_for_server(
             event_to_history_vis[e.event_id], event_to_memberships.get(e.event_id, {})
         )
 
-        if e in partial_state_invisible_events:
+        if e.event_id in partial_state_invisible_event_ids:
             visible = False
 
         return visible and not erased

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -579,6 +579,7 @@ async def filter_events_for_server(
     *,
     redact: bool,
     filter_out_erased_senders: bool,
+    filter_out_partial_state_rooms: bool,
 ) -> List[EventBase]:
     """Filter a list of events based on whether the target server is allowed to
     see them.
@@ -604,7 +605,8 @@ async def filter_events_for_server(
         filter_out_erased_senders: If true, also filter out events whose sender has been
             erased. This is used e.g. during pagination to decide whether to
             backfill or not.
-
+        filter_out_partial_state_rooms: If True, also filter out events in partial state
+            rooms.
     Returns
         The filtered events.
     """
@@ -654,7 +656,7 @@ async def filter_events_for_server(
     # this check but would base the filtering on an outdated view of the membership events.
 
     partial_state_invisible_event_ids: Set[str] = set()
-    if filter_out_erased_senders:
+    if filter_out_partial_state_rooms:
         for e in events:
             sender_domain = get_domain_from_id(e.sender)
             if (

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -69,6 +69,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 events_to_filter,
                 redact=True,
                 filter_out_erased_senders=True,
+                filter_out_partial_state_rooms=True,
             )
         )
 
@@ -96,6 +97,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                     [outlier],
                     redact=True,
                     filter_out_erased_senders=True,
+                    filter_out_partial_state_rooms=True,
                 )
             ),
             [outlier],
@@ -112,6 +114,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 [outlier, evt],
                 redact=True,
                 filter_out_erased_senders=True,
+                filter_out_partial_state_rooms=True,
             )
         )
         self.assertEqual(len(filtered), 2, f"expected 2 results, got: {filtered}")
@@ -129,6 +132,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 [outlier, evt],
                 redact=True,
                 filter_out_erased_senders=True,
+                filter_out_partial_state_rooms=True,
             )
         )
         self.assertEqual(filtered[0], outlier)
@@ -169,6 +173,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 events_to_filter,
                 redact=True,
                 filter_out_erased_senders=True,
+                filter_out_partial_state_rooms=True,
             )
         )
 

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -69,7 +69,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 events_to_filter,
                 redact=True,
                 filter_out_erased_senders=True,
-                filter_out_partial_state_rooms=True,
+                filter_out_remote_partial_state_events=True,
             )
         )
 
@@ -97,7 +97,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                     [outlier],
                     redact=True,
                     filter_out_erased_senders=True,
-                    filter_out_partial_state_rooms=True,
+                    filter_out_remote_partial_state_events=True,
                 )
             ),
             [outlier],
@@ -114,7 +114,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 [outlier, evt],
                 redact=True,
                 filter_out_erased_senders=True,
-                filter_out_partial_state_rooms=True,
+                filter_out_remote_partial_state_events=True,
             )
         )
         self.assertEqual(len(filtered), 2, f"expected 2 results, got: {filtered}")
@@ -132,7 +132,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 [outlier, evt],
                 redact=True,
                 filter_out_erased_senders=True,
-                filter_out_partial_state_rooms=True,
+                filter_out_remote_partial_state_events=True,
             )
         )
         self.assertEqual(filtered[0], outlier)
@@ -173,7 +173,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 events_to_filter,
                 redact=True,
                 filter_out_erased_senders=True,
-                filter_out_partial_state_rooms=True,
+                filter_out_remote_partial_state_events=True,
             )
         )
 

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -63,7 +63,12 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
 
         filtered = self.get_success(
             filter_events_for_server(
-                self._storage_controllers, "test_server", "hs", events_to_filter
+                self._storage_controllers,
+                "test_server",
+                "hs",
+                events_to_filter,
+                redact=True,
+                filter_out_erased_senders=True,
             )
         )
 
@@ -85,7 +90,12 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
         self.assertEqual(
             self.get_success(
                 filter_events_for_server(
-                    self._storage_controllers, "remote_hs", "hs", [outlier]
+                    self._storage_controllers,
+                    "remote_hs",
+                    "hs",
+                    [outlier],
+                    redact=True,
+                    filter_out_erased_senders=True,
                 )
             ),
             [outlier],
@@ -96,7 +106,12 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
 
         filtered = self.get_success(
             filter_events_for_server(
-                self._storage_controllers, "remote_hs", "local_hs", [outlier, evt]
+                self._storage_controllers,
+                "remote_hs",
+                "local_hs",
+                [outlier, evt],
+                redact=True,
+                filter_out_erased_senders=True,
             )
         )
         self.assertEqual(len(filtered), 2, f"expected 2 results, got: {filtered}")
@@ -108,7 +123,12 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
         # be redacted)
         filtered = self.get_success(
             filter_events_for_server(
-                self._storage_controllers, "other_server", "local_hs", [outlier, evt]
+                self._storage_controllers,
+                "other_server",
+                "local_hs",
+                [outlier, evt],
+                redact=True,
+                filter_out_erased_senders=True,
             )
         )
         self.assertEqual(filtered[0], outlier)
@@ -143,7 +163,12 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
         # ... and the filtering happens.
         filtered = self.get_success(
             filter_events_for_server(
-                self._storage_controllers, "test_server", "local_hs", events_to_filter
+                self._storage_controllers,
+                "test_server",
+                "local_hs",
+                events_to_filter,
+                redact=True,
+                filter_out_erased_senders=True,
             )
         )
 


### PR DESCRIPTION
I found it hard to reason about; this is my attempt to remedy that.

Spun out of https://github.com/matrix-org/synapse/pull/15228.
Commitwise reviewable.
Intended to have no behavioural changes.