### PR TITLE
WIP: Avoid blocking on full state during fed sender catchup

### DIFF
--- a/changelog.d/15240.misc
+++ b/changelog.d/15240.misc
@@ -1,0 +1,1 @@
+Refactor `filter_events_for_server`.

--- a/changelog.d/15241.bugfix
+++ b/changelog.d/15241.bugfix
@@ -1,0 +1,1 @@
+Fix a rare bug introduced in Synapse 1.73 where events could remain unsent to other homeservers after a faster-join to a room.

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -548,7 +548,7 @@ class PerDestinationQueue:
                         new_pdus,
                         redact=False,
                         filter_out_erased_senders=True,
-                        filter_out_partial_state_rooms=True,
+                        filter_out_remote_partial_state_events=True,
                     )
 
                     # If we've filtered out all the extremities, fall back to

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -547,6 +547,7 @@ class PerDestinationQueue:
                         self._server_name,
                         new_pdus,
                         redact=False,
+                        filter_out_erased_senders=True,
                     )
 
                     # If we've filtered out all the extremities, fall back to

--- a/synapse/federation/sender/per_destination_queue.py
+++ b/synapse/federation/sender/per_destination_queue.py
@@ -548,6 +548,7 @@ class PerDestinationQueue:
                         new_pdus,
                         redact=False,
                         filter_out_erased_senders=True,
+                        filter_out_partial_state_rooms=True,
                     )
 
                     # If we've filtered out all the extremities, fall back to

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -401,6 +401,7 @@ class FederationHandler:
                 events_to_check,
                 redact=False,
                 filter_out_erased_senders=False,
+                filter_out_partial_state_rooms=False,
             )
             if filtered_extremities:
                 extremities_to_request.append(bp.event_id)
@@ -1337,6 +1338,7 @@ class FederationHandler:
             events,
             redact=True,
             filter_out_erased_senders=True,
+            filter_out_partial_state_rooms=True,
         )
 
         return events
@@ -1373,6 +1375,7 @@ class FederationHandler:
             [event],
             redact=True,
             filter_out_erased_senders=True,
+            filter_out_partial_state_rooms=True,
         )
         event = events[0]
         return event
@@ -1406,6 +1409,7 @@ class FederationHandler:
             missing_events,
             redact=True,
             filter_out_erased_senders=True,
+            filter_out_partial_state_rooms=True,
         )
 
         return missing_events

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1331,7 +1331,12 @@ class FederationHandler:
         )
 
         events = await filter_events_for_server(
-            self._storage_controllers, origin, self.server_name, events
+            self._storage_controllers,
+            origin,
+            self.server_name,
+            events,
+            redact=True,
+            filter_out_erased_senders=True,
         )
 
         return events
@@ -1362,7 +1367,12 @@ class FederationHandler:
         await self._event_auth_handler.assert_host_in_room(event.room_id, origin)
 
         events = await filter_events_for_server(
-            self._storage_controllers, origin, self.server_name, [event]
+            self._storage_controllers,
+            origin,
+            self.server_name,
+            [event],
+            redact=True,
+            filter_out_erased_senders=True,
         )
         event = events[0]
         return event
@@ -1390,7 +1400,12 @@ class FederationHandler:
         )
 
         missing_events = await filter_events_for_server(
-            self._storage_controllers, origin, self.server_name, missing_events
+            self._storage_controllers,
+            origin,
+            self.server_name,
+            missing_events,
+            redact=True,
+            filter_out_erased_senders=True,
         )
 
         return missing_events

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -401,7 +401,7 @@ class FederationHandler:
                 events_to_check,
                 redact=False,
                 filter_out_erased_senders=False,
-                filter_out_partial_state_rooms=False,
+                filter_out_remote_partial_state_events=False,
             )
             if filtered_extremities:
                 extremities_to_request.append(bp.event_id)
@@ -1338,7 +1338,7 @@ class FederationHandler:
             events,
             redact=True,
             filter_out_erased_senders=True,
-            filter_out_partial_state_rooms=True,
+            filter_out_remote_partial_state_events=True,
         )
 
         return events
@@ -1375,7 +1375,7 @@ class FederationHandler:
             [event],
             redact=True,
             filter_out_erased_senders=True,
-            filter_out_partial_state_rooms=True,
+            filter_out_remote_partial_state_events=True,
         )
         event = events[0]
         return event
@@ -1409,7 +1409,7 @@ class FederationHandler:
             missing_events,
             redact=True,
             filter_out_erased_senders=True,
-            filter_out_partial_state_rooms=True,
+            filter_out_remote_partial_state_events=True,
         )
 
         return missing_events

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -392,7 +392,7 @@ class FederationHandler:
                 get_prev_content=False,
             )
 
-            # We set `check_history_visibility_only` as we might otherwise get false
+            # We unset `filter_out_erased_senders` as we might otherwise get false
             # positives from users having been erased.
             filtered_extremities = await filter_events_for_server(
                 self._storage_controllers,
@@ -400,7 +400,7 @@ class FederationHandler:
                 self.server_name,
                 events_to_check,
                 redact=False,
-                check_history_visibility_only=True,
+                filter_out_erased_senders=False,
             )
             if filtered_extremities:
                 extremities_to_request.append(bp.event_id)

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -669,8 +669,7 @@ async def filter_events_for_server(
         target_server_name,
     )
 
-    to_return = []
-    for e in events:
+    def include_event_in_output(e: EventBase) -> bool:
         erased = is_sender_erased(e, erased_senders)
         visible = check_event_is_visible(
             event_to_history_vis[e.event_id], event_to_memberships.get(e.event_id, {})
@@ -679,7 +678,11 @@ async def filter_events_for_server(
         if e in partial_state_invisible_events:
             visible = False
 
-        if visible and not erased:
+        return visible and not erased
+
+    to_return = []
+    for e in events:
+        if include_event_in_output(e):
             to_return.append(e)
         elif redact:
             to_return.append(prune_event(e))

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -579,7 +579,7 @@ async def filter_events_for_server(
     *,
     redact: bool,
     filter_out_erased_senders: bool,
-    filter_out_partial_state_rooms: bool,
+    filter_out_remote_partial_state_events: bool,
 ) -> List[EventBase]:
     """Filter a list of events based on whether the target server is allowed to
     see them.
@@ -605,8 +605,8 @@ async def filter_events_for_server(
         filter_out_erased_senders: If true, also filter out events whose sender has been
             erased. This is used e.g. during pagination to decide whether to
             backfill or not.
-        filter_out_partial_state_rooms: If True, also filter out events in partial state
-            rooms.
+        filter_out_remote_partial_state_events: If True, also filter out events in
+            partial state rooms created by other homeservers.
     Returns
         The filtered events.
     """
@@ -656,7 +656,7 @@ async def filter_events_for_server(
     # this check but would base the filtering on an outdated view of the membership events.
 
     partial_state_invisible_event_ids: Set[str] = set()
-    if filter_out_partial_state_rooms:
+    if filter_out_remote_partial_state_events:
         for e in events:
             sender_domain = get_domain_from_id(e.sender)
             if (

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -576,8 +576,9 @@ async def filter_events_for_server(
     target_server_name: str,
     local_server_name: str,
     events: Sequence[EventBase],
-    redact: bool = True,
-    filter_out_erased_senders: bool = True,
+    *,
+    redact: bool,
+    filter_out_erased_senders: bool,
 ) -> List[EventBase]:
     """Filter a list of events based on whether the target server is allowed to
     see them.

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -14,7 +14,17 @@
 # limitations under the License.
 import logging
 from enum import Enum, auto
-from typing import Collection, Dict, FrozenSet, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Collection,
+    Dict,
+    FrozenSet,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 import attr
 from typing_extensions import Final
@@ -642,7 +652,7 @@ async def filter_events_for_server(
     # otherwise a room could be fully joined after we retrieve those, which would then bypass
     # this check but would base the filtering on an outdated view of the membership events.
 
-    partial_state_invisible_events = set()
+    partial_state_invisible_event_ids: Set[str] = set()
     if filter_out_erased_senders:
         for e in events:
             sender_domain = get_domain_from_id(e.sender)
@@ -650,7 +660,7 @@ async def filter_events_for_server(
                 sender_domain != local_server_name
                 and await storage.main.is_partial_state_room(e.room_id)
             ):
-                partial_state_invisible_events.add(e)
+                partial_state_invisible_event_ids.add(e.event_id)
 
     # Let's check to see if all the events have a history visibility
     # of "shared" or "world_readable". If that's the case then we don't
@@ -675,7 +685,7 @@ async def filter_events_for_server(
             event_to_history_vis[e.event_id], event_to_memberships.get(e.event_id, {})
         )
 
-        if e in partial_state_invisible_events:
+        if e.event_id in partial_state_invisible_event_ids:
             visible = False
 
         return visible and not erased

--- a/synapse/visibility.py
+++ b/synapse/visibility.py
@@ -579,6 +579,7 @@ async def filter_events_for_server(
     *,
     redact: bool,
     filter_out_erased_senders: bool,
+    filter_out_partial_state_rooms: bool,
 ) -> List[EventBase]:
     """Filter a list of events based on whether the target server is allowed to
     see them.
@@ -604,7 +605,8 @@ async def filter_events_for_server(
         filter_out_erased_senders: If true, also filter out events whose sender has been
             erased. This is used e.g. during pagination to decide whether to
             backfill or not.
-
+        filter_out_partial_state_rooms: If True, also filter out events in partial state
+            rooms.
     Returns
         The filtered events.
     """
@@ -654,7 +656,7 @@ async def filter_events_for_server(
     # this check but would base the filtering on an outdated view of the membership events.
 
     partial_state_invisible_event_ids: Set[str] = set()
-    if filter_out_erased_senders:
+    if filter_out_partial_state_rooms:
         for e in events:
             sender_domain = get_domain_from_id(e.sender)
             if (

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -1,4 +1,5 @@
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, Collection, List, Optional, Tuple
+from unittest import mock
 from unittest.mock import Mock
 
 from twisted.test.proto_helpers import MemoryReactor
@@ -500,3 +501,87 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
         self.assertEqual(len(sent_pdus), 1)
         self.assertEqual(sent_pdus[0].event_id, event_2.event_id)
         self.assertFalse(per_dest_queue._catching_up)
+
+    def test_catch_up_is_not_blocked_by_remote_event_in_partial_state_room(
+        self,
+    ) -> None:
+        """Detects (part of?) https://github.com/matrix-org/synapse/issues/15220."""
+        # ARRANGE:
+        # - a local user (u1)
+        # - a room which contains u1 and two remote users, @u2:host2 and @u3:other
+        # - events in that room such that
+        #   - history visibility is restricted
+        #   - u1 sent message events e1 and e2
+        #   - afterwards, u3 sent a remote event e3
+        # - catchup to begin for host2; last successfully sent event was e1
+        per_dest_queue, sent_pdus = self.make_fake_destination_queue()
+
+        self.register_user("u1", "you the one")
+        u1_token = self.login("u1", "you the one")
+        room = self.helper.create_room_as("u1", tok=u1_token)
+        self.helper.send_state(
+            room_id=room,
+            event_type="m.room.history_visibility",
+            body={"history_visibility": "joined"},
+            tok=u1_token,
+        )
+        self.get_success(
+            event_injection.inject_member_event(self.hs, room, "@u2:host2", "join")
+        )
+        self.get_success(
+            event_injection.inject_member_event(self.hs, room, "@u3:other", "join")
+        )
+
+        # create some events
+        event_id_1 = self.helper.send(room, "hello", tok=u1_token)["event_id"]
+        event_id_2 = self.helper.send(room, "world", tok=u1_token)["event_id"]
+        # pretend that u3 changes their displayname
+        event_id_3 = self.get_success(
+            event_injection.inject_member_event(self.hs, room, "@u3:other", "join")
+        ).event_id
+
+        # destination_rooms should already be populated, but let us pretend that we already
+        # sent (successfully) up to and including event id 1
+        event_1 = self.get_success(self.hs.get_datastores().main.get_event(event_id_1))
+        assert event_1.internal_metadata.stream_ordering is not None
+        self.get_success(
+            self.hs.get_datastores().main.set_destination_last_successful_stream_ordering(
+                "host2", event_1.internal_metadata.stream_ordering
+            )
+        )
+
+        # also fetch event 2 so we can compare its stream ordering to the sender's
+        # last_successful_stream_ordering later
+        event_2 = self.get_success(self.hs.get_datastores().main.get_event(event_id_2))
+
+        # Mock event 3 as having partial state
+        self.get_success(
+            event_injection.mark_event_as_partial_state(self.hs, event_id_3, room)
+        )
+
+        # Fail the test if we block on full state for event 3.
+        async def mock_await_full_state(event_ids: Collection[str]) -> None:
+            if event_id_3 in event_ids:
+                raise AssertionError("Tried to await full state for event_id_3")
+
+        # ACT
+        with mock.patch.object(
+            self.hs.get_storage_controllers().state._partial_state_events_tracker,
+            "await_full_state",
+            mock_await_full_state,
+        ):
+            self.get_success(per_dest_queue._catch_up_transmission_loop())
+
+        # ASSERT
+        # We should have:
+        # - not sent event 3: it's not ours, and the room is partial stated
+        # - fallen back to sending event 2: it's the most recent event in the room
+        #   we tried to send to host2
+        # - completed catch-up
+        self.assertEqual(len(sent_pdus), 1)
+        self.assertEqual(sent_pdus[0].event_id, event_id_2)
+        self.assertFalse(per_dest_queue._catching_up)
+        self.assertEqual(
+            per_dest_queue._last_successful_stream_ordering,
+            event_2.internal_metadata.stream_ordering,
+        )

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -598,8 +598,8 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
         #   - e1: message from u1
         #   - e2: remote user u2:host2 joins
         #   - e3: message from u1
-        #   - e4: u1 accidentally kicks user u2:host2
-        #   - e5: u1 invites user u2:host2
+        #   - e4: message from u1
+        #   - e5: u1 kicks user u2:host2
         # - catchup to begin for host2, after having last successfully sent them e3
         per_dest_queue, sent_pdus = self.make_fake_destination_queue()
 
@@ -622,19 +622,13 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
             event_injection.inject_member_event(self.hs, room, "@u2:host2", "join")
         ).event_id
         event_id_3 = self.helper.send(room, "Nicholas,", tok=u1_token)["event_id"]
-        event_id_4 = self.helper.change_membership(
-            room,
-            src="@u1:test",
-            targ="@u2:host2",
-            membership="leave",
-            tok=u1_token,
-        )["event_id"]
+        event_id_4 = self.helper.send(room, "how's the hand?", tok=u1_token)["event_id"]
         event_id_5 = self.get_success(
             event_injection.inject_member_event(
                 self.hs,
                 room,
                 sender="@u1:test",
-                target="@u2:host2",
+                target="@u3:host2",
                 membership="invite",
             )
         ).event_id

--- a/tests/rest/client/utils.py
+++ b/tests/rest/client/utils.py
@@ -279,7 +279,7 @@ class RestHelper:
         expect_code: int = HTTPStatus.OK,
         expect_errcode: Optional[str] = None,
         expect_additional_fields: Optional[dict] = None,
-    ) -> None:
+    ) -> JsonDict:
         """
         Send a membership state event into a room.
 
@@ -353,6 +353,7 @@ class RestHelper:
                 )
 
         self.auth_user_id = temp_id
+        return channel.json_body
 
     def send(
         self,

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -69,6 +69,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 events_to_filter,
                 redact=True,
                 filter_out_erased_senders=True,
+                filter_out_partial_state_rooms=True,
             )
         )
 
@@ -96,6 +97,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                     [outlier],
                     redact=True,
                     filter_out_erased_senders=True,
+                    filter_out_partial_state_rooms=True,
                 )
             ),
             [outlier],
@@ -112,6 +114,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 [outlier, evt],
                 redact=True,
                 filter_out_erased_senders=True,
+                filter_out_partial_state_rooms=True,
             )
         )
         self.assertEqual(len(filtered), 2, f"expected 2 results, got: {filtered}")
@@ -129,6 +132,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 [outlier, evt],
                 redact=True,
                 filter_out_erased_senders=True,
+                filter_out_partial_state_rooms=True,
             )
         )
         self.assertEqual(filtered[0], outlier)
@@ -169,6 +173,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 events_to_filter,
                 redact=True,
                 filter_out_erased_senders=True,
+                filter_out_partial_state_rooms=True,
             )
         )
 

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -69,7 +69,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 events_to_filter,
                 redact=True,
                 filter_out_erased_senders=True,
-                filter_out_partial_state_rooms=True,
+                filter_out_remote_partial_state_events=True,
             )
         )
 
@@ -97,7 +97,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                     [outlier],
                     redact=True,
                     filter_out_erased_senders=True,
-                    filter_out_partial_state_rooms=True,
+                    filter_out_remote_partial_state_events=True,
                 )
             ),
             [outlier],
@@ -114,7 +114,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 [outlier, evt],
                 redact=True,
                 filter_out_erased_senders=True,
-                filter_out_partial_state_rooms=True,
+                filter_out_remote_partial_state_events=True,
             )
         )
         self.assertEqual(len(filtered), 2, f"expected 2 results, got: {filtered}")
@@ -132,7 +132,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 [outlier, evt],
                 redact=True,
                 filter_out_erased_senders=True,
-                filter_out_partial_state_rooms=True,
+                filter_out_remote_partial_state_events=True,
             )
         )
         self.assertEqual(filtered[0], outlier)
@@ -173,7 +173,7 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
                 events_to_filter,
                 redact=True,
                 filter_out_erased_senders=True,
-                filter_out_partial_state_rooms=True,
+                filter_out_remote_partial_state_events=True,
             )
         )
 

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -63,7 +63,12 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
 
         filtered = self.get_success(
             filter_events_for_server(
-                self._storage_controllers, "test_server", "hs", events_to_filter
+                self._storage_controllers,
+                "test_server",
+                "hs",
+                events_to_filter,
+                redact=True,
+                filter_out_erased_senders=True,
             )
         )
 
@@ -85,7 +90,12 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
         self.assertEqual(
             self.get_success(
                 filter_events_for_server(
-                    self._storage_controllers, "remote_hs", "hs", [outlier]
+                    self._storage_controllers,
+                    "remote_hs",
+                    "hs",
+                    [outlier],
+                    redact=True,
+                    filter_out_erased_senders=True,
                 )
             ),
             [outlier],
@@ -96,7 +106,12 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
 
         filtered = self.get_success(
             filter_events_for_server(
-                self._storage_controllers, "remote_hs", "local_hs", [outlier, evt]
+                self._storage_controllers,
+                "remote_hs",
+                "local_hs",
+                [outlier, evt],
+                redact=True,
+                filter_out_erased_senders=True,
             )
         )
         self.assertEqual(len(filtered), 2, f"expected 2 results, got: {filtered}")
@@ -108,7 +123,12 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
         # be redacted)
         filtered = self.get_success(
             filter_events_for_server(
-                self._storage_controllers, "other_server", "local_hs", [outlier, evt]
+                self._storage_controllers,
+                "other_server",
+                "local_hs",
+                [outlier, evt],
+                redact=True,
+                filter_out_erased_senders=True,
             )
         )
         self.assertEqual(filtered[0], outlier)
@@ -143,7 +163,12 @@ class FilterEventsForServerTestCase(unittest.HomeserverTestCase):
         # ... and the filtering happens.
         filtered = self.get_success(
             filter_events_for_server(
-                self._storage_controllers, "test_server", "local_hs", events_to_filter
+                self._storage_controllers,
+                "test_server",
+                "local_hs",
+                events_to_filter,
+                redact=True,
+                filter_out_erased_senders=True,
             )
         )
 


### PR DESCRIPTION
Intended to fix #15220.
Follows from #14404.

Builds on https://github.com/matrix-org/synapse/pull/15240.