### PR TITLE
Add a primitive helper script for listing worker endpoints.

### DIFF
--- a/changelog.d/15243.feature
+++ b/changelog.d/15243.feature
@@ -1,0 +1,1 @@
+Add a primitive helper script for listing worker endpoints.

--- a/synapse/_scripts/generate_workers_map.py
+++ b/synapse/_scripts/generate_workers_map.py
@@ -74,7 +74,13 @@ def main():
 
     client_resource = ClientRestResource(hs)
 
+    # Avoid re-processing servlets (as they might have multiple paths registered separately).
+    servlet_names = set()
     for path_entry in itertools.chain(*client_resource.path_regexs.values()):
+        if path_entry.servlet_classname in servlet_names:
+            continue
+        servlet_names.add(path_entry.servlet_classname)
+
         # This assumes the servlet is attached to a class.
         if getattr(path_entry.callback.__self__, "WORKERS", False):
             print(path_entry.pattern.pattern)

--- a/synapse/_scripts/generate_workers_map.py
+++ b/synapse/_scripts/generate_workers_map.py
@@ -56,7 +56,7 @@ def main():
         "format": "%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(message)s",
     }
     # TODO
-    #logging.basicConfig(**logging_config)
+    # logging.basicConfig(**logging_config)
 
     # Load, process and sanity-check the config.
     hs_config = yaml.safe_load(args.config_path)
@@ -82,8 +82,11 @@ def main():
         servlet_names.add(path_entry.servlet_classname)
 
         # This assumes the servlet is attached to a class.
-        if getattr(path_entry.callback.__self__, "WORKERS", False):
-            print(path_entry.pattern.pattern)
+        worker_paths = getattr(path_entry.callback.__self__, "WORKER_PATTERNS", [])
+        for worker_path in worker_paths:
+            print(worker_path.pattern)
+
+    # TODO Federation servlets.
 
 
 if __name__ == "__main__":

--- a/synapse/_scripts/generate_workers_map.py
+++ b/synapse/_scripts/generate_workers_map.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import itertools
+import logging
+
+import yaml
+
+from synapse.config.homeserver import HomeServerConfig
+from synapse.rest import ClientRestResource
+from synapse.server import HomeServer
+from synapse.storage import DataStore
+
+logger = logging.getLogger("generate_workers_map")
+
+
+class MockHomeserver(HomeServer):
+    DATASTORE_CLASS = DataStore
+
+    def __init__(self, config):
+        super().__init__(config.server.server_name, config=config)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Updates a synapse database to the latest schema and optionally runs background updates"
+            " on it."
+        )
+    )
+    parser.add_argument("-v", action="store_true")
+    parser.add_argument(
+        "--config-path",
+        type=argparse.FileType("r"),
+        required=True,
+        help="Synapse configuration file",
+    )
+
+    args = parser.parse_args()
+
+    logging_config = {
+        "level": logging.DEBUG if args.v else logging.INFO,
+        "format": "%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(message)s",
+    }
+    # TODO
+    #logging.basicConfig(**logging_config)
+
+    # Load, process and sanity-check the config.
+    hs_config = yaml.safe_load(args.config_path)
+
+    config = HomeServerConfig()
+    config.parse_config_dict(hs_config, "", "")
+
+    hs = MockHomeserver(config)
+
+    # Setup instantiates the store within the homeserver object and updates the
+    # DB.
+    #
+    # TODO This doesn't really need to access the database.
+    hs.setup()
+
+    client_resource = ClientRestResource(hs)
+
+    for path_entry in itertools.chain(*client_resource.path_regexs.values()):
+        # This assumes the servlet is attached to a class.
+        if getattr(path_entry.callback.__self__, "WORKERS", False):
+            print(path_entry.pattern.pattern)
+
+
+if __name__ == "__main__":
+    main()

--- a/synapse/_scripts/generate_workers_map.py
+++ b/synapse/_scripts/generate_workers_map.py
@@ -79,6 +79,9 @@ def main():
 
     client_resource = ClientRestResource(hs)
 
+    # The resulting paths that workers can handle.
+    results = []
+
     # Avoid re-processing servlets (as they might have multiple paths registered separately).
     servlet_names = set()
     for path_entry in itertools.chain(*client_resource.path_regexs.values()):
@@ -91,7 +94,11 @@ def main():
         for worker_path in worker_paths:
             # Remove any capturing groups and replace with wildcards.
             pattern = GROUP_PATTERN.sub(".*", worker_path.pattern)
-            print(pattern)
+            results.append(pattern)
+
+    # Print the results after sorting (to give a stable output).
+    for result in sorted(results):
+        print(result)
 
     # TODO Federation servlets.
 

--- a/synapse/_scripts/generate_workers_map.py
+++ b/synapse/_scripts/generate_workers_map.py
@@ -16,6 +16,8 @@
 import argparse
 import itertools
 import logging
+import re
+from typing import Pattern
 
 import yaml
 
@@ -32,6 +34,9 @@ class MockHomeserver(HomeServer):
 
     def __init__(self, config):
         super().__init__(config.server.server_name, config=config)
+
+
+GROUP_PATTERN = re.compile(r"\(\?P<[^>]+?>(.+?)\)")
 
 
 def main():
@@ -84,7 +89,9 @@ def main():
         # This assumes the servlet is attached to a class.
         worker_paths = getattr(path_entry.callback.__self__, "WORKER_PATTERNS", [])
         for worker_path in worker_paths:
-            print(worker_path.pattern)
+            # Remove any capturing groups and replace with wildcards.
+            pattern = GROUP_PATTERN.sub(".*", worker_path.pattern)
+            print(pattern)
 
     # TODO Federation servlets.
 

--- a/synapse/_scripts/generate_workers_map.py
+++ b/synapse/_scripts/generate_workers_map.py
@@ -112,6 +112,10 @@ def main():
             pattern = "^" + servlet.PREFIX + worker_path
             results.append(pattern)
 
+    # Add the /key resources manually since those are directly registered (not
+    # via servlets).
+    results.append("^/_matrix/key/v2/query")
+
     # Print the results after sorting (to give a stable output).
     for result in sorted(results):
         print(result)

--- a/synapse/_scripts/generate_workers_map.py
+++ b/synapse/_scripts/generate_workers_map.py
@@ -167,6 +167,17 @@ def elide_http_methods_if_unconflicting(
     return output
 
 
+def simplify_path_regexes(
+    registrations: Dict[Tuple[str, str], EndpointDescription]
+) -> Dict[Tuple[str, str], EndpointDescription]:
+    def simplify_path_regex(path: str) -> str:
+        # TODO it's hard to choose between these two
+        # return GROUP_PATTERN.sub(r"\1", path)
+        return GROUP_PATTERN.sub(r".*", path)
+
+    return {(m, simplify_path_regex(p)): v for (m, p), v in registrations.items()}
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
@@ -205,10 +216,14 @@ def main() -> None:
 
     # TODO SSO endpoints (pick_idp etc) NOT REGISTERED BY THIS SCRIPT
 
-    for ln in sorted(p for m, p in elided_worker_paths if m == "*"):
+    for ln in sorted(
+        p for m, p in simplify_path_regexes(elided_worker_paths) if m == "*"
+    ):
         print(ln)
     print()
-    for ln in sorted(f"{m:6} {p}" for m, p in elided_worker_paths if m != "*"):
+    for ln in sorted(
+        f"{m:6} {p}" for m, p in simplify_path_regexes(elided_worker_paths) if m != "*"
+    ):
         print(ln)
 
 

--- a/synapse/federation/transport/server/__init__.py
+++ b/synapse/federation/transport/server/__init__.py
@@ -214,6 +214,7 @@ class OpenIdUserInfo(BaseFederationServlet):
     """
 
     PATH = "/openid/userinfo"
+    CATEGORY = "Federation requests"
 
     REQUIRE_AUTH = False
 

--- a/synapse/federation/transport/server/__init__.py
+++ b/synapse/federation/transport/server/__init__.py
@@ -108,6 +108,7 @@ class PublicRoomList(BaseFederationServlet):
     """
 
     PATH = "/publicRooms"
+    WORKER_PATH = PATH
 
     def __init__(
         self,

--- a/synapse/federation/transport/server/__init__.py
+++ b/synapse/federation/transport/server/__init__.py
@@ -108,7 +108,6 @@ class PublicRoomList(BaseFederationServlet):
     """
 
     PATH = "/publicRooms"
-    WORKER_PATH = PATH
     CATEGORY = "Federation requests"
 
     def __init__(

--- a/synapse/federation/transport/server/__init__.py
+++ b/synapse/federation/transport/server/__init__.py
@@ -109,6 +109,7 @@ class PublicRoomList(BaseFederationServlet):
 
     PATH = "/publicRooms"
     WORKER_PATH = PATH
+    CATEGORY = "Federation requests"
 
     def __init__(
         self,

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -70,6 +70,7 @@ class BaseFederationServerServlet(BaseFederationServlet):
 
 class FederationSendServlet(BaseFederationServerServlet):
     PATH = "/send/(?P<transaction_id>[^/]*)/?"
+    CATEGORY = "Inbound federation transaction request"
 
     # We ratelimit manually in the handler as we queue up the requests and we
     # don't want to fill up the ratelimiter with blocked requests.
@@ -139,6 +140,7 @@ class FederationSendServlet(BaseFederationServerServlet):
 class FederationEventServlet(BaseFederationServerServlet):
     PATH = "/event/(?P<event_id>[^/]*)/?"
     WORKER_PATH = "/event/"
+    CATEGORY = "Federation requests"
 
     # This is when someone asks for a data item for a given server data_id pair.
     async def on_GET(
@@ -154,6 +156,7 @@ class FederationEventServlet(BaseFederationServerServlet):
 class FederationStateV1Servlet(BaseFederationServerServlet):
     PATH = "/state/(?P<room_id>[^/]*)/?"
     WORKER_PATH = "/state/"
+    CATEGORY = "Federation requests"
 
     # This is when someone asks for all data for a given room.
     async def on_GET(
@@ -173,6 +176,7 @@ class FederationStateV1Servlet(BaseFederationServerServlet):
 class FederationStateIdsServlet(BaseFederationServerServlet):
     PATH = "/state_ids/(?P<room_id>[^/]*)/?"
     WORKER_PATH = "/state_ids/"
+    CATEGORY = "Federation requests"
 
     async def on_GET(
         self,
@@ -191,6 +195,7 @@ class FederationStateIdsServlet(BaseFederationServerServlet):
 class FederationBackfillServlet(BaseFederationServerServlet):
     PATH = "/backfill/(?P<room_id>[^/]*)/?"
     WORKER_PATH = "/backfill/"
+    CATEGORY = "Federation requests"
 
     async def on_GET(
         self,
@@ -229,6 +234,7 @@ class FederationTimestampLookupServlet(BaseFederationServerServlet):
     """
 
     PATH = "/timestamp_to_event/(?P<room_id>[^/]*)/?"
+    CATEGORY = "Federation requests"
 
     async def on_GET(
         self,
@@ -251,6 +257,7 @@ class FederationTimestampLookupServlet(BaseFederationServerServlet):
 class FederationQueryServlet(BaseFederationServerServlet):
     PATH = "/query/(?P<query_type>[^/]*)"
     WORKER_PATH = "/query/"
+    CATEGORY = "Federation requests"
 
     # This is when we receive a server-server Query
     async def on_GET(
@@ -268,6 +275,7 @@ class FederationQueryServlet(BaseFederationServerServlet):
 class FederationMakeJoinServlet(BaseFederationServerServlet):
     PATH = "/make_join/(?P<room_id>[^/]*)/(?P<user_id>[^/]*)"
     WORKER_PATH = "/make_join/"
+    CATEGORY = "Federation requests"
 
     async def on_GET(
         self,
@@ -304,6 +312,7 @@ class FederationMakeJoinServlet(BaseFederationServerServlet):
 class FederationMakeLeaveServlet(BaseFederationServerServlet):
     PATH = "/make_leave/(?P<room_id>[^/]*)/(?P<user_id>[^/]*)"
     WORKER_PATH = "/make_leave/"
+    CATEGORY = "Federation requests"
 
     async def on_GET(
         self,
@@ -320,6 +329,7 @@ class FederationMakeLeaveServlet(BaseFederationServerServlet):
 class FederationV1SendLeaveServlet(BaseFederationServerServlet):
     PATH = "/send_leave/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
     WORKER_PATH = "/send_leave/"
+    CATEGORY = "Federation requests"
 
     async def on_PUT(
         self,
@@ -336,6 +346,7 @@ class FederationV1SendLeaveServlet(BaseFederationServerServlet):
 class FederationV2SendLeaveServlet(BaseFederationServerServlet):
     PATH = "/send_leave/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
     WORKER_PATH = "/send_leave/"
+    CATEGORY = "Federation requests"
 
     PREFIX = FEDERATION_V2_PREFIX
 
@@ -353,6 +364,7 @@ class FederationV2SendLeaveServlet(BaseFederationServerServlet):
 
 class FederationMakeKnockServlet(BaseFederationServerServlet):
     PATH = "/make_knock/(?P<room_id>[^/]*)/(?P<user_id>[^/]*)"
+    CATEGORY = "Federation requests"
 
     async def on_GET(
         self,
@@ -375,6 +387,7 @@ class FederationMakeKnockServlet(BaseFederationServerServlet):
 
 class FederationV1SendKnockServlet(BaseFederationServerServlet):
     PATH = "/send_knock/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
+    CATEGORY = "Federation requests"
 
     async def on_PUT(
         self,
@@ -391,6 +404,7 @@ class FederationV1SendKnockServlet(BaseFederationServerServlet):
 class FederationEventAuthServlet(BaseFederationServerServlet):
     PATH = "/event_auth/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
     WORKER_PATH = "/event_auth/"
+    CATEGORY = "Federation requests"
 
     async def on_GET(
         self,
@@ -406,6 +420,7 @@ class FederationEventAuthServlet(BaseFederationServerServlet):
 class FederationV1SendJoinServlet(BaseFederationServerServlet):
     PATH = "/send_join/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
     WORKER_PATH = "/send_join/"
+    CATEGORY = "Federation requests"
 
     async def on_PUT(
         self,
@@ -424,6 +439,7 @@ class FederationV1SendJoinServlet(BaseFederationServerServlet):
 class FederationV2SendJoinServlet(BaseFederationServerServlet):
     PATH = "/send_join/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
     WORKER_PATH = "/send_join/"
+    CATEGORY = "Federation requests"
 
     PREFIX = FEDERATION_V2_PREFIX
 
@@ -468,6 +484,7 @@ class FederationV2SendJoinServlet(BaseFederationServerServlet):
 class FederationV1InviteServlet(BaseFederationServerServlet):
     PATH = "/invite/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
     WORKER_PATH = "/invite/"
+    CATEGORY = "Federation requests"
 
     async def on_PUT(
         self,
@@ -493,6 +510,7 @@ class FederationV1InviteServlet(BaseFederationServerServlet):
 class FederationV2InviteServlet(BaseFederationServerServlet):
     PATH = "/invite/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
     WORKER_PATH = "/invite/"
+    CATEGORY = "Federation requests"
 
     PREFIX = FEDERATION_V2_PREFIX
 
@@ -530,6 +548,7 @@ class FederationV2InviteServlet(BaseFederationServerServlet):
 class FederationThirdPartyInviteExchangeServlet(BaseFederationServerServlet):
     PATH = "/exchange_third_party_invite/(?P<room_id>[^/]*)"
     WORKER_PATH = "/exchange_third_party_invite/"
+    CATEGORY = "Federation requests"
 
     async def on_PUT(
         self,
@@ -554,6 +573,7 @@ class FederationClientKeysQueryServlet(BaseFederationServerServlet):
 class FederationUserDevicesQueryServlet(BaseFederationServerServlet):
     PATH = "/user/devices/(?P<user_id>[^/]*)"
     WORKER_PATH = "/user/devices/"
+    CATEGORY = "Federation requests"
 
     async def on_GET(
         self,
@@ -578,6 +598,7 @@ class FederationClientKeysClaimServlet(BaseFederationServerServlet):
 class FederationGetMissingEventsServlet(BaseFederationServerServlet):
     PATH = "/get_missing_events/(?P<room_id>[^/]*)"
     WORKER_PATH = "/get_missing_events/"
+    CATEGORY = "Federation requests"
 
     async def on_POST(
         self,
@@ -635,6 +656,7 @@ class On3pidBindServlet(BaseFederationServerServlet):
 
 class FederationVersionServlet(BaseFederationServlet):
     PATH = "/version"
+    CATEGORY = "Federation requests"
 
     REQUIRE_AUTH = False
 
@@ -658,6 +680,7 @@ class FederationVersionServlet(BaseFederationServlet):
 class FederationRoomHierarchyServlet(BaseFederationServlet):
     PATH = "/hierarchy/(?P<room_id>[^/]*)"
     WORKER_PATH = "/hierarchy/"
+    CATEGORY = "Federation requests"
 
     def __init__(
         self,

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -563,6 +563,7 @@ class FederationThirdPartyInviteExchangeServlet(BaseFederationServerServlet):
 
 class FederationClientKeysQueryServlet(BaseFederationServerServlet):
     PATH = "/user/keys/query"
+    CATEGORY = "Federation requests"
 
     async def on_POST(
         self, origin: str, content: JsonDict, query: Dict[bytes, List[bytes]]
@@ -587,6 +588,7 @@ class FederationUserDevicesQueryServlet(BaseFederationServerServlet):
 
 class FederationClientKeysClaimServlet(BaseFederationServerServlet):
     PATH = "/user/keys/claim"
+    CATEGORY = "Federation requests"
 
     async def on_POST(
         self, origin: str, content: JsonDict, query: Dict[bytes, List[bytes]]
@@ -624,6 +626,7 @@ class FederationGetMissingEventsServlet(BaseFederationServerServlet):
 
 class On3pidBindServlet(BaseFederationServerServlet):
     PATH = "/3pid/onbind"
+    CATEGORY = "Federation requests"
 
     REQUIRE_AUTH = False
 
@@ -713,6 +716,7 @@ class RoomComplexityServlet(BaseFederationServlet):
 
     PATH = "/rooms/(?P<room_id>[^/]*)/complexity"
     PREFIX = FEDERATION_UNSTABLE_PREFIX
+    CATEGORY = "Federation requests (unstable)"
 
     def __init__(
         self,

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -138,6 +138,7 @@ class FederationSendServlet(BaseFederationServerServlet):
 
 class FederationEventServlet(BaseFederationServerServlet):
     PATH = "/event/(?P<event_id>[^/]*)/?"
+    WORKER_PATH = "/event/"
 
     # This is when someone asks for a data item for a given server data_id pair.
     async def on_GET(
@@ -152,6 +153,7 @@ class FederationEventServlet(BaseFederationServerServlet):
 
 class FederationStateV1Servlet(BaseFederationServerServlet):
     PATH = "/state/(?P<room_id>[^/]*)/?"
+    WORKER_PATH = "/state/"
 
     # This is when someone asks for all data for a given room.
     async def on_GET(
@@ -170,6 +172,7 @@ class FederationStateV1Servlet(BaseFederationServerServlet):
 
 class FederationStateIdsServlet(BaseFederationServerServlet):
     PATH = "/state_ids/(?P<room_id>[^/]*)/?"
+    WORKER_PATH = "/state_ids/"
 
     async def on_GET(
         self,
@@ -187,6 +190,7 @@ class FederationStateIdsServlet(BaseFederationServerServlet):
 
 class FederationBackfillServlet(BaseFederationServerServlet):
     PATH = "/backfill/(?P<room_id>[^/]*)/?"
+    WORKER_PATH = "/backfill/"
 
     async def on_GET(
         self,
@@ -246,6 +250,7 @@ class FederationTimestampLookupServlet(BaseFederationServerServlet):
 
 class FederationQueryServlet(BaseFederationServerServlet):
     PATH = "/query/(?P<query_type>[^/]*)"
+    WORKER_PATH = "/query/"
 
     # This is when we receive a server-server Query
     async def on_GET(
@@ -262,6 +267,7 @@ class FederationQueryServlet(BaseFederationServerServlet):
 
 class FederationMakeJoinServlet(BaseFederationServerServlet):
     PATH = "/make_join/(?P<room_id>[^/]*)/(?P<user_id>[^/]*)"
+    WORKER_PATH = "/make_join/"
 
     async def on_GET(
         self,
@@ -297,6 +303,7 @@ class FederationMakeJoinServlet(BaseFederationServerServlet):
 
 class FederationMakeLeaveServlet(BaseFederationServerServlet):
     PATH = "/make_leave/(?P<room_id>[^/]*)/(?P<user_id>[^/]*)"
+    WORKER_PATH = "/make_leave/"
 
     async def on_GET(
         self,
@@ -312,6 +319,7 @@ class FederationMakeLeaveServlet(BaseFederationServerServlet):
 
 class FederationV1SendLeaveServlet(BaseFederationServerServlet):
     PATH = "/send_leave/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
+    WORKER_PATH = "/send_leave/"
 
     async def on_PUT(
         self,
@@ -327,6 +335,7 @@ class FederationV1SendLeaveServlet(BaseFederationServerServlet):
 
 class FederationV2SendLeaveServlet(BaseFederationServerServlet):
     PATH = "/send_leave/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
+    WORKER_PATH = "/send_leave/"
 
     PREFIX = FEDERATION_V2_PREFIX
 
@@ -381,6 +390,7 @@ class FederationV1SendKnockServlet(BaseFederationServerServlet):
 
 class FederationEventAuthServlet(BaseFederationServerServlet):
     PATH = "/event_auth/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
+    WORKER_PATH = "/event_auth/"
 
     async def on_GET(
         self,
@@ -395,6 +405,7 @@ class FederationEventAuthServlet(BaseFederationServerServlet):
 
 class FederationV1SendJoinServlet(BaseFederationServerServlet):
     PATH = "/send_join/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
+    WORKER_PATH = "/send_join/"
 
     async def on_PUT(
         self,
@@ -412,6 +423,7 @@ class FederationV1SendJoinServlet(BaseFederationServerServlet):
 
 class FederationV2SendJoinServlet(BaseFederationServerServlet):
     PATH = "/send_join/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
+    WORKER_PATH = "/send_join/"
 
     PREFIX = FEDERATION_V2_PREFIX
 
@@ -455,6 +467,7 @@ class FederationV2SendJoinServlet(BaseFederationServerServlet):
 
 class FederationV1InviteServlet(BaseFederationServerServlet):
     PATH = "/invite/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
+    WORKER_PATH = "/invite/"
 
     async def on_PUT(
         self,
@@ -479,6 +492,7 @@ class FederationV1InviteServlet(BaseFederationServerServlet):
 
 class FederationV2InviteServlet(BaseFederationServerServlet):
     PATH = "/invite/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
+    WORKER_PATH = "/invite/"
 
     PREFIX = FEDERATION_V2_PREFIX
 
@@ -515,6 +529,7 @@ class FederationV2InviteServlet(BaseFederationServerServlet):
 
 class FederationThirdPartyInviteExchangeServlet(BaseFederationServerServlet):
     PATH = "/exchange_third_party_invite/(?P<room_id>[^/]*)"
+    WORKER_PATH = "/exchange_third_party_invite/"
 
     async def on_PUT(
         self,
@@ -538,6 +553,7 @@ class FederationClientKeysQueryServlet(BaseFederationServerServlet):
 
 class FederationUserDevicesQueryServlet(BaseFederationServerServlet):
     PATH = "/user/devices/(?P<user_id>[^/]*)"
+    WORKER_PATH = "/user/devices/"
 
     async def on_GET(
         self,
@@ -561,6 +577,7 @@ class FederationClientKeysClaimServlet(BaseFederationServerServlet):
 
 class FederationGetMissingEventsServlet(BaseFederationServerServlet):
     PATH = "/get_missing_events/(?P<room_id>[^/]*)"
+    WORKER_PATH = "/get_missing_events/"
 
     async def on_POST(
         self,
@@ -640,6 +657,7 @@ class FederationVersionServlet(BaseFederationServlet):
 
 class FederationRoomHierarchyServlet(BaseFederationServlet):
     PATH = "/hierarchy/(?P<room_id>[^/]*)"
+    WORKER_PATH = "/hierarchy/"
 
     def __init__(
         self,

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -139,7 +139,6 @@ class FederationSendServlet(BaseFederationServerServlet):
 
 class FederationEventServlet(BaseFederationServerServlet):
     PATH = "/event/(?P<event_id>[^/]*)/?"
-    WORKER_PATH = "/event/"
     CATEGORY = "Federation requests"
 
     # This is when someone asks for a data item for a given server data_id pair.
@@ -155,7 +154,6 @@ class FederationEventServlet(BaseFederationServerServlet):
 
 class FederationStateV1Servlet(BaseFederationServerServlet):
     PATH = "/state/(?P<room_id>[^/]*)/?"
-    WORKER_PATH = "/state/"
     CATEGORY = "Federation requests"
 
     # This is when someone asks for all data for a given room.
@@ -175,7 +173,6 @@ class FederationStateV1Servlet(BaseFederationServerServlet):
 
 class FederationStateIdsServlet(BaseFederationServerServlet):
     PATH = "/state_ids/(?P<room_id>[^/]*)/?"
-    WORKER_PATH = "/state_ids/"
     CATEGORY = "Federation requests"
 
     async def on_GET(
@@ -194,7 +191,6 @@ class FederationStateIdsServlet(BaseFederationServerServlet):
 
 class FederationBackfillServlet(BaseFederationServerServlet):
     PATH = "/backfill/(?P<room_id>[^/]*)/?"
-    WORKER_PATH = "/backfill/"
     CATEGORY = "Federation requests"
 
     async def on_GET(
@@ -256,7 +252,6 @@ class FederationTimestampLookupServlet(BaseFederationServerServlet):
 
 class FederationQueryServlet(BaseFederationServerServlet):
     PATH = "/query/(?P<query_type>[^/]*)"
-    WORKER_PATH = "/query/"
     CATEGORY = "Federation requests"
 
     # This is when we receive a server-server Query
@@ -274,7 +269,6 @@ class FederationQueryServlet(BaseFederationServerServlet):
 
 class FederationMakeJoinServlet(BaseFederationServerServlet):
     PATH = "/make_join/(?P<room_id>[^/]*)/(?P<user_id>[^/]*)"
-    WORKER_PATH = "/make_join/"
     CATEGORY = "Federation requests"
 
     async def on_GET(
@@ -311,7 +305,6 @@ class FederationMakeJoinServlet(BaseFederationServerServlet):
 
 class FederationMakeLeaveServlet(BaseFederationServerServlet):
     PATH = "/make_leave/(?P<room_id>[^/]*)/(?P<user_id>[^/]*)"
-    WORKER_PATH = "/make_leave/"
     CATEGORY = "Federation requests"
 
     async def on_GET(
@@ -328,7 +321,6 @@ class FederationMakeLeaveServlet(BaseFederationServerServlet):
 
 class FederationV1SendLeaveServlet(BaseFederationServerServlet):
     PATH = "/send_leave/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
-    WORKER_PATH = "/send_leave/"
     CATEGORY = "Federation requests"
 
     async def on_PUT(
@@ -345,7 +337,6 @@ class FederationV1SendLeaveServlet(BaseFederationServerServlet):
 
 class FederationV2SendLeaveServlet(BaseFederationServerServlet):
     PATH = "/send_leave/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
-    WORKER_PATH = "/send_leave/"
     CATEGORY = "Federation requests"
 
     PREFIX = FEDERATION_V2_PREFIX
@@ -403,7 +394,6 @@ class FederationV1SendKnockServlet(BaseFederationServerServlet):
 
 class FederationEventAuthServlet(BaseFederationServerServlet):
     PATH = "/event_auth/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
-    WORKER_PATH = "/event_auth/"
     CATEGORY = "Federation requests"
 
     async def on_GET(
@@ -419,7 +409,6 @@ class FederationEventAuthServlet(BaseFederationServerServlet):
 
 class FederationV1SendJoinServlet(BaseFederationServerServlet):
     PATH = "/send_join/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
-    WORKER_PATH = "/send_join/"
     CATEGORY = "Federation requests"
 
     async def on_PUT(
@@ -438,7 +427,6 @@ class FederationV1SendJoinServlet(BaseFederationServerServlet):
 
 class FederationV2SendJoinServlet(BaseFederationServerServlet):
     PATH = "/send_join/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
-    WORKER_PATH = "/send_join/"
     CATEGORY = "Federation requests"
 
     PREFIX = FEDERATION_V2_PREFIX
@@ -483,7 +471,6 @@ class FederationV2SendJoinServlet(BaseFederationServerServlet):
 
 class FederationV1InviteServlet(BaseFederationServerServlet):
     PATH = "/invite/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
-    WORKER_PATH = "/invite/"
     CATEGORY = "Federation requests"
 
     async def on_PUT(
@@ -509,7 +496,6 @@ class FederationV1InviteServlet(BaseFederationServerServlet):
 
 class FederationV2InviteServlet(BaseFederationServerServlet):
     PATH = "/invite/(?P<room_id>[^/]*)/(?P<event_id>[^/]*)"
-    WORKER_PATH = "/invite/"
     CATEGORY = "Federation requests"
 
     PREFIX = FEDERATION_V2_PREFIX
@@ -547,7 +533,6 @@ class FederationV2InviteServlet(BaseFederationServerServlet):
 
 class FederationThirdPartyInviteExchangeServlet(BaseFederationServerServlet):
     PATH = "/exchange_third_party_invite/(?P<room_id>[^/]*)"
-    WORKER_PATH = "/exchange_third_party_invite/"
     CATEGORY = "Federation requests"
 
     async def on_PUT(
@@ -573,7 +558,6 @@ class FederationClientKeysQueryServlet(BaseFederationServerServlet):
 
 class FederationUserDevicesQueryServlet(BaseFederationServerServlet):
     PATH = "/user/devices/(?P<user_id>[^/]*)"
-    WORKER_PATH = "/user/devices/"
     CATEGORY = "Federation requests"
 
     async def on_GET(
@@ -599,7 +583,6 @@ class FederationClientKeysClaimServlet(BaseFederationServerServlet):
 
 class FederationGetMissingEventsServlet(BaseFederationServerServlet):
     PATH = "/get_missing_events/(?P<room_id>[^/]*)"
-    WORKER_PATH = "/get_missing_events/"
     CATEGORY = "Federation requests"
 
     async def on_POST(
@@ -682,7 +665,6 @@ class FederationVersionServlet(BaseFederationServlet):
 
 class FederationRoomHierarchyServlet(BaseFederationServlet):
     PATH = "/hierarchy/(?P<room_id>[^/]*)"
-    WORKER_PATH = "/hierarchy/"
     CATEGORY = "Federation requests"
 
     def __init__(

--- a/synapse/rest/client/_base.py
+++ b/synapse/rest/client/_base.py
@@ -45,11 +45,11 @@ def client_patterns(
     """
     versions = []
 
-    if unstable:
-        versions.append("unstable")
     if v1:
         versions.append("api/v1")
     versions.extend(releases)
+    if unstable:
+        versions.append("unstable")
 
     if len(versions) == 1:
         versions_str = versions[0]

--- a/synapse/rest/client/_base.py
+++ b/synapse/rest/client/_base.py
@@ -43,19 +43,22 @@ def client_patterns(
     Returns:
         An iterable of patterns.
     """
-    patterns = []
+    versions = []
 
     if unstable:
-        unstable_prefix = CLIENT_API_PREFIX + "/unstable"
-        patterns.append(re.compile("^" + unstable_prefix + path_regex))
+        versions.append("unstable")
     if v1:
-        v1_prefix = CLIENT_API_PREFIX + "/api/v1"
-        patterns.append(re.compile("^" + v1_prefix + path_regex))
-    for release in releases:
-        new_prefix = CLIENT_API_PREFIX + f"/{release}"
-        patterns.append(re.compile("^" + new_prefix + path_regex))
+        versions.append("api/v1")
+    versions.extend(releases)
 
-    return patterns
+    if len(versions) == 1:
+        versions_str = versions[0]
+    elif len(versions) > 1:
+        versions_str = "(" + "|".join(versions) + ")"
+    else:
+        raise RuntimeError("Must have at least one version for a URL")
+
+    return [re.compile("^" + CLIENT_API_PREFIX + "/" + versions_str + path_regex)]
 
 
 def set_timeline_upper_limit(filter_json: JsonDict, filter_timeline_limit: int) -> None:

--- a/synapse/rest/client/account.py
+++ b/synapse/rest/client/account.py
@@ -577,7 +577,6 @@ class AddThreepidMsisdnSubmitTokenServlet(RestServlet):
 class ThreepidRestServlet(RestServlet):
     PATTERNS = client_patterns("/account/3pid$")
     # This is used as a proxy for all the 3pid endpoints.
-    WORKER_PATTERNS = client_patterns("/account/3pid")
 
     CATEGORY = "Client API requests"
 

--- a/synapse/rest/client/account.py
+++ b/synapse/rest/client/account.py
@@ -579,6 +579,8 @@ class ThreepidRestServlet(RestServlet):
     # This is used as a proxy for all the 3pid endpoints.
     WORKER_PATTERNS = client_patterns("/account/3pid")
 
+    CATEGORY = "Client API requests"
+
     def __init__(self, hs: "HomeServer"):
         super().__init__()
         self.hs = hs
@@ -836,6 +838,7 @@ def assert_valid_next_link(hs: "HomeServer", next_link: str) -> None:
 
 class WhoamiRestServlet(RestServlet):
     PATTERNS = client_patterns("/account/whoami$")
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/account.py
+++ b/synapse/rest/client/account.py
@@ -576,6 +576,8 @@ class AddThreepidMsisdnSubmitTokenServlet(RestServlet):
 
 class ThreepidRestServlet(RestServlet):
     PATTERNS = client_patterns("/account/3pid$")
+    # This is used as a proxy for all the 3pid endpoints.
+    WORKER_PATTERNS = client_patterns("/account/3pid")
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/account_data.py
+++ b/synapse/rest/client/account_data.py
@@ -38,7 +38,6 @@ class AccountDataServlet(RestServlet):
     PATTERNS = client_patterns(
         "/user/(?P<user_id>[^/]*)/account_data/(?P<account_data_type>[^/]*)"
     )
-    WORKER_PATTERNS = client_patterns("/(?P<user_id_and_room_id>[^/]*)/account_data")
     CATEGORY = "Account data requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/account_data.py
+++ b/synapse/rest/client/account_data.py
@@ -138,6 +138,7 @@ class RoomAccountDataServlet(RestServlet):
         "/rooms/(?P<room_id>[^/]*)"
         "/account_data/(?P<account_data_type>[^/]*)"
     )
+    CATEGORY = "Account data requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/account_data.py
+++ b/synapse/rest/client/account_data.py
@@ -38,6 +38,7 @@ class AccountDataServlet(RestServlet):
     PATTERNS = client_patterns(
         "/user/(?P<user_id>[^/]*)/account_data/(?P<account_data_type>[^/]*)"
     )
+    WORKER_PATTERNS = client_patterns("/(?P<user_id_and_room_id>[^/]*)/account_data")
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/account_data.py
+++ b/synapse/rest/client/account_data.py
@@ -39,6 +39,7 @@ class AccountDataServlet(RestServlet):
         "/user/(?P<user_id>[^/]*)/account_data/(?P<account_data_type>[^/]*)"
     )
     WORKER_PATTERNS = client_patterns("/(?P<user_id_and_room_id>[^/]*)/account_data")
+    CATEGORY = "Account data requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 class DevicesRestServlet(RestServlet):
     PATTERNS = client_patterns("/devices$")
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -124,6 +124,7 @@ class DeleteDevicesRestServlet(RestServlet):
 
 class DeviceRestServlet(RestServlet):
     PATTERNS = client_patterns("/devices/(?P<device_id>[^/]*)$")
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -40,7 +40,6 @@ logger = logging.getLogger(__name__)
 
 class DevicesRestServlet(RestServlet):
     PATTERNS = client_patterns("/devices$")
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/devices.py
+++ b/synapse/rest/client/devices.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 class DevicesRestServlet(RestServlet):
     PATTERNS = client_patterns("/devices$")
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/events.py
+++ b/synapse/rest/client/events.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 class EventStreamRestServlet(RestServlet):
     PATTERNS = client_patterns("/events$", v1=True)
+    CATEGORY = "Sync requests"
 
     DEFAULT_LONGPOLL_TIME_MS = 30000
 

--- a/synapse/rest/client/events.py
+++ b/synapse/rest/client/events.py
@@ -77,6 +77,7 @@ class EventStreamRestServlet(RestServlet):
 
 class EventRestServlet(RestServlet):
     PATTERNS = client_patterns("/events/(?P<event_id>[^/]*)$", v1=True)
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/filter.py
+++ b/synapse/rest/client/filter.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 class GetFilterRestServlet(RestServlet):
     PATTERNS = client_patterns("/user/(?P<user_id>[^/]*)/filter/(?P<filter_id>[^/]*)")
+    CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -69,6 +70,7 @@ class GetFilterRestServlet(RestServlet):
 
 class CreateFilterRestServlet(RestServlet):
     PATTERNS = client_patterns("/user/(?P<user_id>[^/]*)/filter")
+    CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/initial_sync.py
+++ b/synapse/rest/client/initial_sync.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 # TODO: Needs unit testing
 class InitialSyncRestServlet(RestServlet):
     PATTERNS = client_patterns("/initialSync$", v1=True)
+    CATEGORY = "Sync requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/keys.py
+++ b/synapse/rest/client/keys.py
@@ -89,6 +89,7 @@ class KeyUploadServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/keys/upload(/(?P<device_id>[^/]+))?$")
+    CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -183,6 +184,7 @@ class KeyQueryServlet(RestServlet):
 
     PATTERNS = client_patterns("/keys/query$")
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -227,6 +229,7 @@ class KeyChangesServlet(RestServlet):
 
     PATTERNS = client_patterns("/keys/changes$")
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -277,6 +280,7 @@ class OneTimeKeyServlet(RestServlet):
 
     PATTERNS = client_patterns("/keys/claim$")
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/keys.py
+++ b/synapse/rest/client/keys.py
@@ -183,7 +183,6 @@ class KeyQueryServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/keys/query$")
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -228,7 +227,6 @@ class KeyChangesServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/keys/changes$")
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -279,7 +277,6 @@ class OneTimeKeyServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/keys/claim$")
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/keys.py
+++ b/synapse/rest/client/keys.py
@@ -182,6 +182,7 @@ class KeyQueryServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/keys/query$")
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -225,6 +226,7 @@ class KeyChangesServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/keys/changes$")
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -274,6 +276,7 @@ class OneTimeKeyServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/keys/claim$")
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/knock.py
+++ b/synapse/rest/client/knock.py
@@ -40,6 +40,7 @@ class KnockRoomAliasServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/knock/(?P<room_identifier>[^/]*)")
+    CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -72,6 +72,8 @@ class LoginResponse(TypedDict, total=False):
 
 class LoginRestServlet(RestServlet):
     PATTERNS = client_patterns("/login$", v1=True)
+    WORKER_PATTERNS = PATTERNS
+
     CAS_TYPE = "m.login.cas"
     SSO_TYPE = "m.login.sso"
     TOKEN_TYPE = "m.login.token"

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -73,6 +73,7 @@ class LoginResponse(TypedDict, total=False):
 class LoginRestServlet(RestServlet):
     PATTERNS = client_patterns("/login$", v1=True)
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Registration/login requests"
 
     CAS_TYPE = "m.login.cas"
     SSO_TYPE = "m.login.sso"

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -540,6 +540,7 @@ def _get_auth_flow_dict_for_idp(idp: SsoIdentityProvider) -> JsonDict:
 
 class RefreshTokenServlet(RestServlet):
     PATTERNS = client_patterns("/refresh$")
+    CATEGORY = "Registration/login requests"
 
     def __init__(self, hs: "HomeServer"):
         self._auth_handler = hs.get_auth_handler()

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -72,7 +72,6 @@ class LoginResponse(TypedDict, total=False):
 
 class LoginRestServlet(RestServlet):
     PATTERNS = client_patterns("/login$", v1=True)
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Registration/login requests"
 
     CAS_TYPE = "m.login.cas"

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -593,6 +593,7 @@ class SsoRedirectServlet(RestServlet):
             + "/(r0|v3)/login/sso/redirect/(?P<idp_id>[A-Za-z0-9_.~-]+)$"
         )
     ]
+    CATEGORY = "SSO requests needed for all SSO providers"
 
     def __init__(self, hs: "HomeServer"):
         # make sure that the relevant handlers are instantiated, so that they

--- a/synapse/rest/client/presence.py
+++ b/synapse/rest/client/presence.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 class PresenceStatusRestServlet(RestServlet):
     PATTERNS = client_patterns("/presence/(?P<user_id>[^/]*)/status", v1=True)
+    WORKER_PATTERNS = client_patterns("/presence/", v1=True)
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/presence.py
+++ b/synapse/rest/client/presence.py
@@ -33,7 +33,6 @@ logger = logging.getLogger(__name__)
 
 class PresenceStatusRestServlet(RestServlet):
     PATTERNS = client_patterns("/presence/(?P<user_id>[^/]*)/status", v1=True)
-    WORKER_PATTERNS = client_patterns("/presence/", v1=True)
     CATEGORY = "Presence requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/presence.py
+++ b/synapse/rest/client/presence.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 class PresenceStatusRestServlet(RestServlet):
     PATTERNS = client_patterns("/presence/(?P<user_id>[^/]*)/status", v1=True)
     WORKER_PATTERNS = client_patterns("/presence/", v1=True)
+    CATEGORY = "Presence requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/profile.py
+++ b/synapse/rest/client/profile.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
 
 class ProfileDisplaynameRestServlet(RestServlet):
     PATTERNS = client_patterns("/profile/(?P<user_id>[^/]*)/displayname", v1=True)
-    WORKER_PATTERNS = client_patterns("/profile/", v1=True)
     CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/profile.py
+++ b/synapse/rest/client/profile.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 class ProfileDisplaynameRestServlet(RestServlet):
     PATTERNS = client_patterns("/profile/(?P<user_id>[^/]*)/displayname", v1=True)
     WORKER_PATTERNS = client_patterns("/profile/", v1=True)
+    CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -87,6 +88,7 @@ class ProfileDisplaynameRestServlet(RestServlet):
 
 class ProfileAvatarURLRestServlet(RestServlet):
     PATTERNS = client_patterns("/profile/(?P<user_id>[^/]*)/avatar_url", v1=True)
+    CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/profile.py
+++ b/synapse/rest/client/profile.py
@@ -143,6 +143,7 @@ class ProfileAvatarURLRestServlet(RestServlet):
 
 class ProfileRestServlet(RestServlet):
     PATTERNS = client_patterns("/profile/(?P<user_id>[^/]*)", v1=True)
+    CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/profile.py
+++ b/synapse/rest/client/profile.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 class ProfileDisplaynameRestServlet(RestServlet):
     PATTERNS = client_patterns("/profile/(?P<user_id>[^/]*)/displayname", v1=True)
+    WORKER_PATTERNS = client_patterns("/profile/", v1=True)
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/push_rule.py
+++ b/synapse/rest/client/push_rule.py
@@ -45,6 +45,7 @@ class PushRuleRestServlet(RestServlet):
     )
 
     WORKERS_DENIED_METHODS = ["PUT", "DELETE"]
+    CATEGORY = "Push rule requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/push_rule.py
+++ b/synapse/rest/client/push_rule.py
@@ -44,6 +44,8 @@ class PushRuleRestServlet(RestServlet):
         "Unrecognised request: You probably wanted a trailing slash"
     )
 
+    WORKERS_DENIED_METHODS = ["PUT", "DELETE"]
+
     def __init__(self, hs: "HomeServer"):
         super().__init__()
         self.auth = hs.get_auth()

--- a/synapse/rest/client/read_marker.py
+++ b/synapse/rest/client/read_marker.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 class ReadMarkerRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/read_markers$")
+    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/read_markers")
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/read_marker.py
+++ b/synapse/rest/client/read_marker.py
@@ -31,7 +31,6 @@ logger = logging.getLogger(__name__)
 
 class ReadMarkerRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/read_markers$")
-    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/read_markers")
     CATEGORY = "Receipts requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/read_marker.py
+++ b/synapse/rest/client/read_marker.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 class ReadMarkerRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/read_markers$")
     WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/read_markers")
+    CATEGORY = "Receipts requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/receipts.py
+++ b/synapse/rest/client/receipts.py
@@ -37,6 +37,7 @@ class ReceiptRestServlet(RestServlet):
         "/(?P<event_id>[^/]*)$"
     )
     WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/receipt")
+    CATEGORY = "Receipts requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/receipts.py
+++ b/synapse/rest/client/receipts.py
@@ -36,7 +36,6 @@ class ReceiptRestServlet(RestServlet):
         "/receipt/(?P<receipt_type>[^/]*)"
         "/(?P<event_id>[^/]*)$"
     )
-    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/receipt")
     CATEGORY = "Receipts requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/receipts.py
+++ b/synapse/rest/client/receipts.py
@@ -36,6 +36,7 @@ class ReceiptRestServlet(RestServlet):
         "/receipt/(?P<receipt_type>[^/]*)"
         "/(?P<event_id>[^/]*)$"
     )
+    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/receipt")
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -367,6 +367,7 @@ class RegistrationTokenValidityRestServlet(RestServlet):
         f"/register/{LoginType.REGISTRATION_TOKEN}/validity",
         releases=("v1",),
     )
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -395,6 +396,7 @@ class RegistrationTokenValidityRestServlet(RestServlet):
 
 class RegisterRestServlet(RestServlet):
     PATTERNS = client_patterns("/register$")
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -368,6 +368,7 @@ class RegistrationTokenValidityRestServlet(RestServlet):
         releases=("v1",),
     )
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Registration/login requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -397,6 +398,7 @@ class RegistrationTokenValidityRestServlet(RestServlet):
 class RegisterRestServlet(RestServlet):
     PATTERNS = client_patterns("/register$")
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Registration/login requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -367,7 +367,6 @@ class RegistrationTokenValidityRestServlet(RestServlet):
         f"/register/{LoginType.REGISTRATION_TOKEN}/validity",
         releases=("v1",),
     )
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Registration/login requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -397,7 +396,6 @@ class RegistrationTokenValidityRestServlet(RestServlet):
 
 class RegisterRestServlet(RestServlet):
     PATTERNS = client_patterns("/register$")
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Registration/login requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/relations.py
+++ b/synapse/rest/client/relations.py
@@ -42,6 +42,7 @@ class RelationPaginationServlet(RestServlet):
         "(/(?P<relation_type>[^/]*)(/(?P<event_type>[^/]*))?)?$",
         releases=("v1",),
     )
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -84,6 +85,7 @@ class RelationPaginationServlet(RestServlet):
 
 class ThreadsServlet(RestServlet):
     PATTERNS = (re.compile("^/_matrix/client/v1/rooms/(?P<room_id>[^/]*)/threads"),)
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -142,6 +142,7 @@ class TransactionRestServlet(RestServlet):
 class RoomCreateRestServlet(TransactionRestServlet):
     # No PATTERN; we have custom dispatch rules here
     WORKER_PATTERNS = client_patterns("/createRoom$", v1=True)
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
@@ -182,6 +183,7 @@ class RoomCreateRestServlet(TransactionRestServlet):
 # TODO: Needs unit testing for generic events
 class RoomStateEventRestServlet(RestServlet):
     WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/state/")
+    CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -327,6 +329,7 @@ class RoomStateEventRestServlet(RestServlet):
 # TODO: Needs unit testing for generic events + feedback
 class RoomSendEventRestServlet(TransactionRestServlet):
     WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/send", v1=True)
+    CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
@@ -404,6 +407,7 @@ class RoomSendEventRestServlet(TransactionRestServlet):
 # TODO: Needs unit testing for room ID + alias joins
 class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
     WORKER_PATTERNS = client_patterns("/join/", v1=True)
+    CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
@@ -468,6 +472,7 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
 class PublicRoomListRestServlet(RestServlet):
     PATTERNS = client_patterns("/publicRooms$", v1=True)
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -587,6 +592,7 @@ class PublicRoomListRestServlet(RestServlet):
 class RoomMemberListRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/members$", v1=True)
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -643,6 +649,7 @@ class RoomMemberListRestServlet(RestServlet):
 class JoinedRoomMemberListRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/joined_members$", v1=True)
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -731,6 +738,7 @@ class RoomMessageListRestServlet(RestServlet):
 class RoomStateRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/state$", v1=True)
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -872,6 +880,7 @@ class RoomEventContextServlet(RestServlet):
         "/rooms/(?P<room_id>[^/]*)/context/(?P<event_id>[^/]*)$", v1=True
     )
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -975,6 +984,7 @@ class RoomMembershipRestServlet(TransactionRestServlet):
     WORKER_PATTERNS = client_patterns(
         "/rooms/(?P<room_id>[^/]*)/(join|invite|leave|ban|unban|kick)$", v1=True
     )
+    CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
@@ -1090,6 +1100,7 @@ class RoomMembershipRestServlet(TransactionRestServlet):
 
 class RoomRedactEventRestServlet(TransactionRestServlet):
     WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/redact", v1=True)
+    CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
@@ -1265,6 +1276,7 @@ class RoomAliasListServlet(RestServlet):
 class SearchRestServlet(RestServlet):
     PATTERNS = client_patterns("/search$", v1=True)
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -1285,6 +1297,7 @@ class SearchRestServlet(RestServlet):
 class JoinedRoomsRestServlet(RestServlet):
     PATTERNS = client_patterns("/joined_rooms$", v1=True)
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -1356,6 +1369,7 @@ class TimestampLookupRestServlet(RestServlet):
     PATTERNS = (
         re.compile("^/_matrix/client/v1/rooms/(?P<room_id>[^/]*)/timestamp_to_event$"),
     )
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -1388,6 +1402,7 @@ class TimestampLookupRestServlet(RestServlet):
 class RoomHierarchyRestServlet(RestServlet):
     PATTERNS = (re.compile("^/_matrix/client/v1/rooms/(?P<room_id>[^/]*)/hierarchy$"),)
     WORKERS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -1429,6 +1444,7 @@ class RoomSummaryRestServlet(ResolveRoomIdMixin, RestServlet):
         ),
     )
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -582,6 +582,7 @@ class PublicRoomListRestServlet(RestServlet):
 # TODO: Needs unit testing
 class RoomMemberListRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/members$", v1=True)
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -637,6 +638,7 @@ class RoomMemberListRestServlet(RestServlet):
 # except it does custom AS logic and has a simpler return format
 class JoinedRoomMemberListRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/joined_members$", v1=True)
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -724,6 +726,7 @@ class RoomMessageListRestServlet(RestServlet):
 # TODO: Needs unit testing
 class RoomStateRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/state$", v1=True)
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -862,6 +865,7 @@ class RoomEventContextServlet(RestServlet):
     PATTERNS = client_patterns(
         "/rooms/(?P<room_id>[^/]*)/context/(?P<event_id>[^/]*)$", v1=True
     )
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -141,9 +141,7 @@ class TransactionRestServlet(RestServlet):
 
 class RoomCreateRestServlet(TransactionRestServlet):
     # No PATTERN; we have custom dispatch rules here
-    WORKER_PATTERNS = [
-        re.compile("^/_matrix/client/(api/v1|r0|v3|unstable)/createRoom$")
-    ]
+    WORKER_PATTERNS = client_patterns("/createRoom$", v1=True)
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
@@ -183,6 +181,7 @@ class RoomCreateRestServlet(TransactionRestServlet):
 
 # TODO: Needs unit testing for generic events
 class RoomStateEventRestServlet(RestServlet):
+    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/state/")
     def __init__(self, hs: "HomeServer"):
         super().__init__()
         self.event_creation_handler = hs.get_event_creation_handler()
@@ -326,6 +325,8 @@ class RoomStateEventRestServlet(RestServlet):
 
 # TODO: Needs unit testing for generic events + feedback
 class RoomSendEventRestServlet(TransactionRestServlet):
+    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/send", v1=True)
+
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
         self.event_creation_handler = hs.get_event_creation_handler()
@@ -401,6 +402,8 @@ class RoomSendEventRestServlet(TransactionRestServlet):
 
 # TODO: Needs unit testing for room ID + alias joins
 class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
+    WORKER_PATTERNS = client_patterns("/join/", v1=True)
+
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
         super(ResolveRoomIdMixin, self).__init__(hs)  # ensure the Mixin is set up
@@ -773,6 +776,7 @@ class RoomEventServlet(RestServlet):
     PATTERNS = client_patterns(
         "/rooms/(?P<room_id>[^/]*)/event/(?P<event_id>[^/]*)$", v1=True
     )
+    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/event/")
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -966,6 +970,10 @@ class RoomForgetRestServlet(TransactionRestServlet):
 
 # TODO: Needs unit testing
 class RoomMembershipRestServlet(TransactionRestServlet):
+    WORKER_PATTERNS = client_patterns(
+        "/rooms/(?P<room_id>[^/]*)/(join|invite|leave|ban|unban|kick)$", v1=True
+    )
+
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
         self.room_member_handler = hs.get_room_member_handler()
@@ -1079,6 +1087,8 @@ class RoomMembershipRestServlet(TransactionRestServlet):
 
 
 class RoomRedactEventRestServlet(TransactionRestServlet):
+    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/redact", v1=True)
+
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
         self.event_creation_handler = hs.get_event_creation_handler()
@@ -1252,6 +1262,7 @@ class RoomAliasListServlet(RestServlet):
 
 class SearchRestServlet(RestServlet):
     PATTERNS = client_patterns("/search$", v1=True)
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -1271,6 +1282,7 @@ class SearchRestServlet(RestServlet):
 
 class JoinedRoomsRestServlet(RestServlet):
     PATTERNS = client_patterns("/joined_rooms$", v1=True)
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -1373,6 +1385,7 @@ class TimestampLookupRestServlet(RestServlet):
 
 class RoomHierarchyRestServlet(RestServlet):
     PATTERNS = (re.compile("^/_matrix/client/v1/rooms/(?P<room_id>[^/]*)/hierarchy$"),)
+    WORKERS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -1413,6 +1426,7 @@ class RoomSummaryRestServlet(ResolveRoomIdMixin, RestServlet):
             "/rooms/(?P<room_identifier>[^/]*)/summary$"
         ),
     )
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -787,6 +787,7 @@ class RoomEventServlet(RestServlet):
         "/rooms/(?P<room_id>[^/]*)/event/(?P<event_id>[^/]*)$", v1=True
     )
     WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/event/")
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -1195,6 +1196,7 @@ class RoomTypingRestServlet(RestServlet):
     PATTERNS = client_patterns(
         "/rooms/(?P<room_id>[^/]*)/typing/(?P<user_id>[^/]*)$", v1=True
     )
+    CATEGORY = "The typing stream"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -140,8 +140,6 @@ class TransactionRestServlet(RestServlet):
 
 
 class RoomCreateRestServlet(TransactionRestServlet):
-    # No PATTERN; we have custom dispatch rules here
-    WORKER_PATTERNS = client_patterns("/createRoom$", v1=True)
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -182,7 +180,6 @@ class RoomCreateRestServlet(TransactionRestServlet):
 
 # TODO: Needs unit testing for generic events
 class RoomStateEventRestServlet(RestServlet):
-    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/state/")
     CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -328,7 +325,6 @@ class RoomStateEventRestServlet(RestServlet):
 
 # TODO: Needs unit testing for generic events + feedback
 class RoomSendEventRestServlet(TransactionRestServlet):
-    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/send", v1=True)
     CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -406,7 +402,6 @@ class RoomSendEventRestServlet(TransactionRestServlet):
 
 # TODO: Needs unit testing for room ID + alias joins
 class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
-    WORKER_PATTERNS = client_patterns("/join/", v1=True)
     CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -471,7 +466,6 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
 # TODO: Needs unit testing
 class PublicRoomListRestServlet(RestServlet):
     PATTERNS = client_patterns("/publicRooms$", v1=True)
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -591,7 +585,6 @@ class PublicRoomListRestServlet(RestServlet):
 # TODO: Needs unit testing
 class RoomMemberListRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/members$", v1=True)
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -648,7 +641,6 @@ class RoomMemberListRestServlet(RestServlet):
 # except it does custom AS logic and has a simpler return format
 class JoinedRoomMemberListRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/joined_members$", v1=True)
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -741,7 +733,6 @@ class RoomMessageListRestServlet(RestServlet):
 # TODO: Needs unit testing
 class RoomStateRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/state$", v1=True)
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -790,7 +781,6 @@ class RoomEventServlet(RestServlet):
     PATTERNS = client_patterns(
         "/rooms/(?P<room_id>[^/]*)/event/(?P<event_id>[^/]*)$", v1=True
     )
-    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/event/")
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -884,7 +874,6 @@ class RoomEventContextServlet(RestServlet):
     PATTERNS = client_patterns(
         "/rooms/(?P<room_id>[^/]*)/context/(?P<event_id>[^/]*)$", v1=True
     )
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -986,9 +975,6 @@ class RoomForgetRestServlet(TransactionRestServlet):
 
 # TODO: Needs unit testing
 class RoomMembershipRestServlet(TransactionRestServlet):
-    WORKER_PATTERNS = client_patterns(
-        "/rooms/(?P<room_id>[^/]*)/(join|invite|leave|ban|unban|kick)$", v1=True
-    )
     CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -1104,7 +1090,6 @@ class RoomMembershipRestServlet(TransactionRestServlet):
 
 
 class RoomRedactEventRestServlet(TransactionRestServlet):
-    WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/redact", v1=True)
     CATEGORY = "Event sending requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -1282,7 +1267,6 @@ class RoomAliasListServlet(RestServlet):
 
 class SearchRestServlet(RestServlet):
     PATTERNS = client_patterns("/search$", v1=True)
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -1303,7 +1287,6 @@ class SearchRestServlet(RestServlet):
 
 class JoinedRoomsRestServlet(RestServlet):
     PATTERNS = client_patterns("/joined_rooms$", v1=True)
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
@@ -1450,7 +1433,6 @@ class RoomSummaryRestServlet(ResolveRoomIdMixin, RestServlet):
             "/rooms/(?P<room_identifier>[^/]*)/summary$"
         ),
     )
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -182,6 +182,7 @@ class RoomCreateRestServlet(TransactionRestServlet):
 # TODO: Needs unit testing for generic events
 class RoomStateEventRestServlet(RestServlet):
     WORKER_PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/state/")
+
     def __init__(self, hs: "HomeServer"):
         super().__init__()
         self.event_creation_handler = hs.get_event_creation_handler()
@@ -752,6 +753,7 @@ class RoomStateRestServlet(RestServlet):
 # TODO: Needs unit testing
 class RoomInitialSyncRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/initialSync$", v1=True)
+    CATEGORY = "Sync requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -671,6 +671,10 @@ class JoinedRoomMemberListRestServlet(RestServlet):
 # TODO: Needs better unit testing
 class RoomMessageListRestServlet(RestServlet):
     PATTERNS = client_patterns("/rooms/(?P<room_id>[^/]*)/messages$", v1=True)
+    # TODO The routing information should be exposed programatically.
+    #      I want to do this but for now I felt bad about leaving this without
+    #      at least a visible warning on it.
+    CATEGORY = "Client API requests (ALL FOR SAME ROOM MUST GO TO SAME WORKER)"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -1257,6 +1261,7 @@ class RoomAliasListServlet(RestServlet):
             r"/rooms/(?P<room_id>[^/]*)/aliases"
         ),
     ] + list(client_patterns("/rooms/(?P<room_id>[^/]*)/aliases$", unstable=False))
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -141,6 +141,9 @@ class TransactionRestServlet(RestServlet):
 
 class RoomCreateRestServlet(TransactionRestServlet):
     # No PATTERN; we have custom dispatch rules here
+    WORKER_PATTERNS = [
+        re.compile("^/_matrix/client/(api/v1|r0|v3|unstable)/createRoom$")
+    ]
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
@@ -460,6 +463,7 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, TransactionRestServlet):
 # TODO: Needs unit testing
 class PublicRoomListRestServlet(RestServlet):
     PATTERNS = client_patterns("/publicRooms$", v1=True)
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -1195,7 +1199,7 @@ class RoomTypingRestServlet(RestServlet):
         # Limit timeout to stop people from setting silly typing timeouts.
         timeout = min(content.get("timeout", 30000), 120000)
 
-        # Defer getting the typing handler since it will raise on workers.
+        # Defer getting the typing handler since it will raise on WORKER_PATTERNS.
         typing_handler = self.hs.get_typing_writer_handler()
 
         try:

--- a/synapse/rest/client/room_batch.py
+++ b/synapse/rest/client/room_batch.py
@@ -69,6 +69,7 @@ class RoomBatchSendEventRestServlet(RestServlet):
             "/rooms/(?P<room_id>[^/]*)/batch_send$"
         ),
     )
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/room_keys.py
+++ b/synapse/rest/client/room_keys.py
@@ -37,7 +37,6 @@ class RoomKeysServlet(RestServlet):
     PATTERNS = client_patterns(
         "/room_keys/keys(/(?P<room_id>[^/]+))?(/(?P<session_id>[^/]+))?$"
     )
-    WORKER_PATTERNS = client_patterns("/room_keys/")
     CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/room_keys.py
+++ b/synapse/rest/client/room_keys.py
@@ -255,6 +255,7 @@ class RoomKeysServlet(RestServlet):
 
 class RoomKeysNewVersionServlet(RestServlet):
     PATTERNS = client_patterns("/room_keys/version$")
+    CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -330,6 +331,7 @@ class RoomKeysNewVersionServlet(RestServlet):
 
 class RoomKeysVersionServlet(RestServlet):
     PATTERNS = client_patterns("/room_keys/version/(?P<version>[^/]+)$")
+    CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/room_keys.py
+++ b/synapse/rest/client/room_keys.py
@@ -37,6 +37,7 @@ class RoomKeysServlet(RestServlet):
     PATTERNS = client_patterns(
         "/room_keys/keys(/(?P<room_id>[^/]+))?(/(?P<session_id>[^/]+))?$"
     )
+    WORKER_PATTERNS = client_patterns("/room_keys/")
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/room_keys.py
+++ b/synapse/rest/client/room_keys.py
@@ -38,6 +38,7 @@ class RoomKeysServlet(RestServlet):
         "/room_keys/keys(/(?P<room_id>[^/]+))?(/(?P<session_id>[^/]+))?$"
     )
     WORKER_PATTERNS = client_patterns("/room_keys/")
+    CATEGORY = "Encryption requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/sendtodevice.py
+++ b/synapse/rest/client/sendtodevice.py
@@ -36,6 +36,7 @@ class SendToDeviceRestServlet(servlet.RestServlet):
         "/sendToDevice/(?P<message_type>[^/]*)/(?P<txn_id>[^/]*)$"
     )
     WORKER_PATTERNS = client_patterns("/sendToDevice/")
+    CATEGORY = "The to_device stream"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/sendtodevice.py
+++ b/synapse/rest/client/sendtodevice.py
@@ -35,7 +35,6 @@ class SendToDeviceRestServlet(servlet.RestServlet):
     PATTERNS = client_patterns(
         "/sendToDevice/(?P<message_type>[^/]*)/(?P<txn_id>[^/]*)$"
     )
-    WORKER_PATTERNS = client_patterns("/sendToDevice/")
     CATEGORY = "The to_device stream"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/sendtodevice.py
+++ b/synapse/rest/client/sendtodevice.py
@@ -35,6 +35,7 @@ class SendToDeviceRestServlet(servlet.RestServlet):
     PATTERNS = client_patterns(
         "/sendToDevice/(?P<message_type>[^/]*)/(?P<txn_id>[^/]*)$"
     )
+    WORKER_PATTERNS = client_patterns("/sendToDevice/")
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -86,6 +86,7 @@ class SyncRestServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/sync$")
+    WORKERS = True
     ALLOWED_PRESENCE = {"online", "offline", "unavailable"}
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -86,7 +86,6 @@ class SyncRestServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/sync$")
-    WORKERS = PATTERNS
     ALLOWED_PRESENCE = {"online", "offline", "unavailable"}
     CATEGORY = "Sync requests"
 

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -88,6 +88,7 @@ class SyncRestServlet(RestServlet):
     PATTERNS = client_patterns("/sync$")
     WORKERS = PATTERNS
     ALLOWED_PRESENCE = {"online", "offline", "unavailable"}
+    CATEGORY = "Sync requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -86,7 +86,7 @@ class SyncRestServlet(RestServlet):
     """
 
     PATTERNS = client_patterns("/sync$")
-    WORKERS = True
+    WORKERS = PATTERNS
     ALLOWED_PRESENCE = {"online", "offline", "unavailable"}
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/tags.py
+++ b/synapse/rest/client/tags.py
@@ -38,6 +38,7 @@ class TagListServlet(RestServlet):
         "/user/(?P<user_id>[^/]*)/rooms/(?P<room_id>[^/]*)/tags$"
     )
     WORKER_PATTERNS = client_patterns("/(?P<user_id_and_room_id>[^/]*)/tags")
+    CATEGORY = "Account data requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()
@@ -65,6 +66,7 @@ class TagServlet(RestServlet):
     PATTERNS = client_patterns(
         "/user/(?P<user_id>[^/]*)/rooms/(?P<room_id>[^/]*)/tags/(?P<tag>[^/]*)"
     )
+    CATEGORY = "Account data requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/tags.py
+++ b/synapse/rest/client/tags.py
@@ -37,6 +37,7 @@ class TagListServlet(RestServlet):
     PATTERNS = client_patterns(
         "/user/(?P<user_id>[^/]*)/rooms/(?P<room_id>[^/]*)/tags$"
     )
+    WORKER_PATTERNS = client_patterns("/(?P<user_id_and_room_id>[^/]*)/tags")
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/tags.py
+++ b/synapse/rest/client/tags.py
@@ -37,7 +37,6 @@ class TagListServlet(RestServlet):
     PATTERNS = client_patterns(
         "/user/(?P<user_id>[^/]*)/rooms/(?P<room_id>[^/]*)/tags$"
     )
-    WORKER_PATTERNS = client_patterns("/(?P<user_id_and_room_id>[^/]*)/tags")
     CATEGORY = "Account data requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/user_directory.py
+++ b/synapse/rest/client/user_directory.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 class UserDirectorySearchRestServlet(RestServlet):
     PATTERNS = client_patterns("/user_directory/search$")
+    CATEGORY = "User directory search requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -34,7 +34,6 @@ logger = logging.getLogger(__name__)
 
 class VersionsRestServlet(RestServlet):
     PATTERNS = [re.compile("^/_matrix/client/versions$")]
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 class VersionsRestServlet(RestServlet):
     PATTERNS = [re.compile("^/_matrix/client/versions$")]
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 class VersionsRestServlet(RestServlet):
     PATTERNS = [re.compile("^/_matrix/client/versions$")]
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/voip.py
+++ b/synapse/rest/client/voip.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
 
 class VoipRestServlet(RestServlet):
     PATTERNS = client_patterns("/voip/turnServer$", v1=True)
-    WORKER_PATTERNS = PATTERNS
     CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):

--- a/synapse/rest/client/voip.py
+++ b/synapse/rest/client/voip.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 class VoipRestServlet(RestServlet):
     PATTERNS = client_patterns("/voip/turnServer$", v1=True)
+    WORKER_PATTERNS = PATTERNS
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/client/voip.py
+++ b/synapse/rest/client/voip.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 class VoipRestServlet(RestServlet):
     PATTERNS = client_patterns("/voip/turnServer$", v1=True)
     WORKER_PATTERNS = PATTERNS
+    CATEGORY = "Client API requests"
 
     def __init__(self, hs: "HomeServer"):
         super().__init__()

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -93,6 +93,8 @@ class RemoteKey(RestServlet):
     }
     """
 
+    CATEGORY = "Federation requests"
+
     def __init__(self, hs: "HomeServer"):
         self.fetcher = ServerKeyFetcher(hs)
         self.store = hs.get_datastores().main


### PR DESCRIPTION
This is an extension of Patrick's branch.

Currently this only lists endpoints handleable by `synapse.app.generic_worker` and doesn't include any of the information needed for routing decisions,
but I think that can be added in time.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
Part of: #12139 <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

I recommend reviewing this as a whole, because the commit history is likely too messy to be useful.

---

# Example output

```
# Client API requests
^/_matrix/client/(api/v1|r0|v3|unstable)/createRoom$
^/_matrix/client/(api/v1|r0|v3|unstable)/createRoom/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/events/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/joined_rooms$
^/_matrix/client/(api/v1|r0|v3|unstable)/publicRooms$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/context/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/event/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/joined_members$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/members$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/state$
^/_matrix/client/(api/v1|r0|v3|unstable)/search$
^/_matrix/client/(api/v1|r0|v3|unstable)/voip/turnServer$
^/_matrix/client/(r0|v3)/rooms/.*/aliases$
^/_matrix/client/(r0|v3|unstable)/account/3pid$
^/_matrix/client/(r0|v3|unstable)/account/whoami$
^/_matrix/client/(r0|v3|unstable)/devices$
^/_matrix/client/(v1|unstable)/rooms/.*/relations/.*(/.*(/.*)?)?$
^/_matrix/client/unstable/org\.matrix\.msc2432/rooms/.*/aliases
^/_matrix/client/v1/rooms/.*/hierarchy$
^/_matrix/client/v1/rooms/.*/threads
^/_matrix/client/v1/rooms/.*/timestamp_to_event$
^/_matrix/client/versions$


# Sync requests
^/_matrix/client/(api/v1|r0|v3|unstable)/events$
^/_matrix/client/(api/v1|r0|v3|unstable)/initialSync$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/initialSync$
^/_matrix/client/(r0|v3|unstable)/sync$


# Event sending requests
^/_matrix/client/(api/v1|r0|v3|unstable)/join/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/join/.*/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/profile/.*
^/_matrix/client/(api/v1|r0|v3|unstable)/profile/.*/avatar_url
^/_matrix/client/(api/v1|r0|v3|unstable)/profile/.*/displayname
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/.*/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/redact/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/redact/.*/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/send/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/send/.*/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/state/.*$
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/state/.*/.*$
^/_matrix/client/(r0|v3|unstable)/knock/.*


# Client API requests (ALL FOR SAME ROOM MUST GO TO SAME WORKER)
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/messages$


# The typing stream
^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/typing/.*$


# Registration/login requests
^/_matrix/client/(api/v1|r0|v3|unstable)/login$
^/_matrix/client/(r0|v3|unstable)/refresh$
^/_matrix/client/(r0|v3|unstable)/register$
^/_matrix/client/(v1|unstable)/register/m.login.registration_token/validity


# SSO requests needed for all SSO providers
^/_matrix/client/(api/v1|r0|v3|unstable)/login/(cas|sso)/redirect$
^/_matrix/client/(r0|v3)/login/sso/redirect/.*$


# Presence requests
^/_matrix/client/(api/v1|r0|v3|unstable)/presence/.*/status


# Push rule requests

GET    ^/_matrix/client/(api/v1|r0|v3|unstable)/.*$

# Encryption requests
^/_matrix/client/(r0|v3|unstable)/keys/changes$
^/_matrix/client/(r0|v3|unstable)/keys/claim$
^/_matrix/client/(r0|v3|unstable)/keys/query$
^/_matrix/client/(r0|v3|unstable)/keys/upload(/.*)?$
^/_matrix/client/(r0|v3|unstable)/room_keys/keys(/.*)?(/.*)?$
^/_matrix/client/(r0|v3|unstable)/room_keys/version$
^/_matrix/client/(r0|v3|unstable)/room_keys/version/.*$
^/_matrix/client/(r0|v3|unstable)/user/.*/filter
^/_matrix/client/(r0|v3|unstable)/user/.*/filter/.*


# Receipts requests
^/_matrix/client/(r0|v3|unstable)/rooms/.*/read_markers$
^/_matrix/client/(r0|v3|unstable)/rooms/.*/receipt/.*/.*$


# Account data requests
^/_matrix/client/(r0|v3|unstable)/user/.*/account_data/.*
^/_matrix/client/(r0|v3|unstable)/user/.*/rooms/.*/account_data/.*
^/_matrix/client/(r0|v3|unstable)/user/.*/rooms/.*/tags$
^/_matrix/client/(r0|v3|unstable)/user/.*/rooms/.*/tags/.*


# The to_device stream
^/_matrix/client/(r0|v3|unstable)/sendToDevice/.*/.*$


# User directory search requests
^/_matrix/client/(r0|v3|unstable)/user_directory/search$


# Inbound federation transaction request
^/_matrix/federation/v1/send/.*/?$


# Federation requests
^/_matrix/federation/v1/3pid/onbind$
^/_matrix/federation/v1/backfill/.*/?$
^/_matrix/federation/v1/event/.*/?$
^/_matrix/federation/v1/event_auth/.*/.*$
^/_matrix/federation/v1/exchange_third_party_invite/.*$
^/_matrix/federation/v1/get_missing_events/.*$
^/_matrix/federation/v1/hierarchy/.*$
^/_matrix/federation/v1/invite/.*/.*$
^/_matrix/federation/v1/make_join/.*/.*$
^/_matrix/federation/v1/make_knock/.*/.*$
^/_matrix/federation/v1/make_leave/.*/.*$
^/_matrix/federation/v1/openid/userinfo$
^/_matrix/federation/v1/publicRooms$
^/_matrix/federation/v1/query/.*$
^/_matrix/federation/v1/send_join/.*/.*$
^/_matrix/federation/v1/send_knock/.*/.*$
^/_matrix/federation/v1/send_leave/.*/.*$
^/_matrix/federation/v1/state/.*/?$
^/_matrix/federation/v1/state_ids/.*/?$
^/_matrix/federation/v1/timestamp_to_event/.*/?$
^/_matrix/federation/v1/user/devices/.*$
^/_matrix/federation/v1/user/keys/claim$
^/_matrix/federation/v1/user/keys/query$
^/_matrix/federation/v1/version$
^/_matrix/federation/v2/invite/.*/.*$
^/_matrix/federation/v2/send_join/.*/.*$
^/_matrix/federation/v2/send_leave/.*/.*$
^/_matrix/key/v2/query$
^/_matrix/key/v2/query/.*(/.*)?$


# Federation requests (unstable)
^/_matrix/federation/unstable/rooms/.*/complexity$
```

(I'm hoping it will eventually auto-generate the docs page — hence the categorisation — but it's not quite there yet.)

---

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

POC 

</li>
<li>

Reduce patterns per servlet. 

</li>
<li>

Move unstable to last entry. 

</li>
<li>

Avoid duplicate entries. 

</li>
<li>

More explicit paths for workers. 

</li>
<li>

Handle capturing groups. 

</li>
<li>

Sort results. 

</li>
<li>

Add other client endpoints. 

</li>
<li>

Add federation endpoints. 

</li>
<li>

Add key resource. 

</li>
<li>

Let the script be an HttpServer and just have paths registered onto it 

</li>
<li>

Simplify path regexes, as before 

</li>
<li>

Read categories from servlets and group the endpoints together by those 

</li>
<li>

Category: Sync requests 

</li>
<li>

Category: Federation requests 

</li>
<li>

Categories: client API requests &c 

</li>
<li>

Less obvious stragglers... 

</li>
<li>

Add more stragglers 

</li>
</ol>
