### PR TITLE
Enable running tests & release artifacts on merge queue.

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -4,13 +4,15 @@ name: Build release artifacts
 
 on:
   # we build on PRs and develop to (hopefully) get early warning
-  # of things breaking (but only build one set of debs)
+  # of things breaking (but only build one set of debs). PRs skip
+  # building wheels on macOS & ARM.
   pull_request:
   push:
     branches: ["develop", "release-*"]
 
     # we do the full build on tags.
     tags: ["v*"]
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["develop", "release-*"]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/changelog.d/15244.misc
+++ b/changelog.d/15244.misc
@@ -1,0 +1,1 @@
+Configure GitHub Actions for merge queues.


### PR DESCRIPTION
This is a step to enabling merge queues on Synapse. We might be able to slim down on PRs a little bit, maybe:

* Run portdb on once?
* Do not run sytest with and without asyncio?
* Do not build wheels / debs on PRs?

This only adds the merge queue for `tests.yml` & `release-artifacts.yml`; the other things which run for PRs are:

* `docs-pr.yml`: We build a preview of docs for PRs and then build them when we push to `develop`, I don't think we need to do it here too. (This check isn't part of our CI checks just a convenience.)
* `dependabot_changelog.yml`: These run when dependabot pushes PRs?
* `poetry_lockfile.yaml`: If two PRs modify the lockfile I don't see how this check could fail (it checks to ensure all deps have sdists -- if this is true for each PR individually it must be true for the combined?)

Not sure about others. My hope is to [enable the merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#managing-a-merge-queue) on `develop` with the defaults (except where noted)

* Merge method: squash
* Build concurrency: 5
* Merge limits: Min of 1 after 5 minutes, max of 5
* Only merge non-failing pull requests: OFF (**THIS IS NOT THE DEFAULT**)
* Status check timeout: 60 minutes