### PR TITLE
Do not calculate whether to create auto-rooms if there aren't any configured

### DIFF
--- a/changelog.d/15262.misc
+++ b/changelog.d/15262.misc
@@ -1,0 +1,1 @@
+Skip processing of auto-join room behaviour if there are not auto-join rooms configured.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -596,14 +596,20 @@ class RegistrationHandler:
         Args:
             user_id: The user to join
         """
+        # If there are no rooms to auto-join, just bail.
+        if not self.hs.config.registration.auto_join_rooms:
+            return
+
         # auto-join the user to any rooms we're supposed to dump them into
 
         # try to create the room if we're the first real user on the server. Note
         # that an auto-generated support or bot user is not a real user and will never be
         # the user to create the room
         should_auto_create_rooms = False
-        is_real_user = await self.store.is_real_user(user_id)
-        if self.hs.config.registration.autocreate_auto_join_rooms and is_real_user:
+        if (
+            self.hs.config.registration.autocreate_auto_join_rooms
+            and await self.store.is_real_user(user_id)
+        ):
             count = await self.store.count_real_users()
             should_auto_create_rooms = count == 1
 


### PR DESCRIPTION
This hot-paths out of the auto-join room functionality if there are no auto-join rooms configured.