### PR TITLE
Remove unused class: DirectTcpReplicationClientFactory.

### DIFF
--- a/changelog.d/15272.misc
+++ b/changelog.d/15272.misc
@@ -1,0 +1,1 @@
+Remove unused class `DirectTcpReplicationClientFactory`.


### PR DESCRIPTION
Part of #11728 -- this is simply an unused class, but some more code we can drop.