### PR TITLE
Make `configure_workers_and_start` script used in Complement tests compatible with older versions of Python.

### DIFF
--- a/changelog.d/15275.misc
+++ b/changelog.d/15275.misc
@@ -1,0 +1,1 @@
+Make `configure_workers_and_start` script used in Complement tests compatible with older versions of Python.

--- a/docker/configure_workers_and_start.py
+++ b/docker/configure_workers_and_start.py
@@ -422,7 +422,7 @@ def add_worker_roles_to_shared_config(
 
 
 def merge_worker_template_configs(
-    existing_dict: Dict[str, Any] | None,
+    existing_dict: Optional[Dict[str, Any]],
     to_be_merged_dict: Dict[str, Any],
 ) -> Dict[str, Any]:
     """When given an existing dict of worker template configuration consisting with both


### PR DESCRIPTION
This `| None` syntax seems to not be supported on older versions, which tripped up some testing.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Make configure_workers_and_start more backwards compatible 

</li>
</ol>
