### PR TITLE
Mirror images to the GitHub Container Registry (`ghcr.io/matrix-org/synapse`).

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/metadata-action@master
         with:
           images: |
-            matrixdotorg/synapse
+            docker.io/matrixdotorg/synapse
             ghcr.io/matrix-org/synapse
           flavor: |
             latest=false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,11 +34,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Calculate docker image tag
         id: set-tag
         uses: docker/metadata-action@master
         with:
-          images: matrixdotorg/synapse
+          images: |
+            matrixdotorg/synapse
+            ghcr.io/matrix-org/synapse
           flavor: |
             latest=false
           tags: |

--- a/changelog.d/15281.docker
+++ b/changelog.d/15281.docker
@@ -1,0 +1,1 @@
+Mirror images to the GitHub Container Registry (`ghcr.io/matrix-org/synapse`).


### PR DESCRIPTION
Will document this when we check it is working...

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
Part of: #10977 <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Push images to both GHCR and Docker Hub 

</li>
</ol>
