### PR TITLE
Document that our Docker images are mirrored to GHCR.

### DIFF
--- a/changelog.d/15282.docker
+++ b/changelog.d/15282.docker
@@ -1,0 +1,1 @@
+Mirror images to the GitHub Container Registry (`ghcr.io/matrix-org/synapse`).

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -26,8 +26,8 @@ for most users.
 #### Docker images and Ansible playbooks
 
 There is an official synapse image available at
-<https://hub.docker.com/r/matrixdotorg/synapse> which can be used with
-the docker-compose file available at
+<https://hub.docker.com/r/matrixdotorg/synapse> or at [`ghcr.io/matrix-org/synapse`](https://ghcr.io/matrix-org/synapse)
+which can be used with the docker-compose file available at
 [contrib/docker](https://github.com/matrix-org/synapse/tree/develop/contrib/docker).
 Further information on this including configuration options is available in the README
 on hub.docker.com.


### PR DESCRIPTION
Fixes: #10977 <!-- -->
<!--
Supersedes: # <!-- -->
Follows: #15281 <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Document that our docker image can now additionally be acquired from GHCR 

</li>
</ol>


Blocked:

- [ ] confirm the image gets to GHCR and works