### PR TITLE
Add stable unstable feature for jump to date before `v1.6` is fully supported on Synapse

### DIFF
--- a/changelog.d/15283.feature
+++ b/changelog.d/15283.feature
@@ -1,0 +1,1 @@
+Add stable unstable feature (`org.matrix.msc3030.stable`) for [MSC3030](https://github.com/matrix-org/matrix-spec-proposals/pull/3030) jump to date [before Matrix `v1.6` is fully supported on Synapse](https://github.com/matrix-org/synapse/issues/15089).

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -111,6 +111,10 @@ class VersionsRestServlet(RestServlet):
                     "fi.mau.msc2815": self.config.experimental.msc2815_enabled,
                     # Adds a ping endpoint for appservices to check HS->AS connection
                     "fi.mau.msc2659": self.config.experimental.msc2659_enabled,
+                    # Adds support for jump to date endpoints (/timestamp_to_event) as per MSC3030.
+                    # TODO: Remove when Synapse advertises support for `v1.6` which includes MSC3030
+                    # (https://github.com/matrix-org/synapse/issues/15089)
+                    "org.matrix.msc3030.stable": True,
                     # Adds support for login token requests as per MSC3882
                     "org.matrix.msc3882": self.config.experimental.msc3882_enabled,
                     # Adds support for remotely enabling/disabling pushers, as per MSC3881


### PR DESCRIPTION
Add stable unstable feature (`org.matrix.msc3030.stable`) for jump to date [before `v1.6` is fully supported on a homeserver](https://github.com/matrix-org/synapse/issues/15089). Discussion for whether we are okay with moving forward with this -> https://github.com/matrix-org/synapse/pull/15283#discussion_r1140669410

Related to https://github.com/matrix-org/synapse/issues/15089

Fix https://github.com/vector-im/element-web/issues/24362

Element Web PR to honor `org.matrix.msc3030.stable`: https://github.com/matrix-org/matrix-react-sdk/pull/10398

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
