### PR TITLE
Apply & bundle edits for non-message events.

### DIFF
--- a/changelog.d/15295.bugfix
+++ b/changelog.d/15295.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where edits of non-`m.room.message` events would not be correctly bundled or have their new content applied.

--- a/synapse/storage/databases/main/relations.py
+++ b/synapse/storage/databases/main/relations.py
@@ -472,12 +472,11 @@ class RelationsWorkerStore(SQLBaseStore):
             the event will map to None.
         """
 
-        # We only allow edits for `m.room.message` events that have the same sender
-        # and event type. We can't assert these things during regular event auth so
-        # we have to do the checks post hoc.
+        # We only allow edits for events that have the same sender and event type.
+        # We can't assert these things during regular event auth so we have to do
+        # the checks post hoc.
 
-        # Fetches latest edit that has the same type and sender as the
-        # original, and is an `m.room.message`.
+        # Fetches latest edit that has the same type and sender as the original.
         if isinstance(self.database_engine, PostgresEngine):
             # The `DISTINCT ON` clause will pick the *first* row it encounters,
             # so ordering by origin server ts + event ID desc will ensure we get
@@ -493,7 +492,6 @@ class RelationsWorkerStore(SQLBaseStore):
                 WHERE
                     %s
                     AND relation_type = ?
-                    AND edit.type = 'm.room.message'
                 ORDER by original.event_id DESC, edit.origin_server_ts DESC, edit.event_id DESC
             """
         else:
@@ -512,7 +510,6 @@ class RelationsWorkerStore(SQLBaseStore):
                 WHERE
                     %s
                     AND relation_type = ?
-                    AND edit.type = 'm.room.message'
                 ORDER by edit.origin_server_ts, edit.event_id
             """
 


### PR DESCRIPTION
Currently Synapse only fetches edits for `m.room.message` events, this is not correct according to the specification. It should [apply for all types of events](https://spec.matrix.org/v1.4/client-server-api/#validity-of-replacement-events).

This manifest in two related bugs (see below):

* No edit information is bundled for events which aren't `m.room.message`.
* `m.new_content` is not applied where available.

Due to the structure of our code both of these have the same room cause, which is simply that we enforce that the event type must be `m.room.message` when fetching edits from the database. We relax that in this PR.

Note that I didn't modify any tests since the current tests send `m.room.message` events, which is still valid.

Fixes #12793, fixes #12503

----

This reapplies #14034, which was reverted in #14283 due to #14252.

I'm fairly certain that the Element Web bug that links to is now fixed, but I'm less confident on whether the Element Android bugs will re-occur. This will probably need a bit of testing.