### PR TITLE
Make `EventHandler.get_event` return `None` when the requested event is not found

### DIFF
--- a/synapse/handlers/events.py
+++ b/synapse/handlers/events.py
@@ -159,15 +159,16 @@ class EventHandler:
         Returns:
             An event, or None if there is no event matching this ID.
         Raises:
-            SynapseError if there was a problem retrieving this event, or
-            AuthError if the user does not have the rights to inspect this
-            event.
+            AuthError: if the user does not have the rights to inspect this event.
         """
         redact_behaviour = (
             EventRedactBehaviour.as_is if show_redacted else EventRedactBehaviour.redact
         )
         event = await self.store.get_event(
-            event_id, check_room_id=room_id, redact_behaviour=redact_behaviour
+            event_id,
+            check_room_id=room_id,
+            redact_behaviour=redact_behaviour,
+            allow_none=True,
         )
 
         if not event:

--- a/tests/rest/client/test_report_event.py
+++ b/tests/rest/client/test_report_event.py
@@ -84,6 +84,11 @@ class ReportEventTestCase(unittest.HomeserverTestCase):
             access_token=self.other_user_tok,
         )
         self.assertEqual(404, channel.code, msg=channel.result["body"])
+        self.assertEqual(
+            "Unable to report event: it does not exist or you aren't able to see it.",
+            channel.json_body["error"],
+            msg=channel.result["body"],
+        )
 
     def _assert_status(self, response_status: int, data: JsonDict) -> None:
         channel = self.make_request(


### PR DESCRIPTION
`EventHandler.get_event`s docstring says:

> Returns:
>            An event, or None if there is no event matching this ID.

But this is not currently true. If the event does not exist, this method will currently raise a `NotFoundError`. All callers of this method seem to follow the docstring, leading to incorrect behaviour.

I found this while investigating `ReportEventRestServlet`, which would end up returning:

```json5
{
    "errcode": 404,
    "error": "Could not find event $abcde:example.com"
}
```

instead of the intended:

```json5
{
    "errcode": 404,
    "error": "Unable to report event: it does not exist or you aren't able to see it."
}
```