### PR TITLE
Revert  "check sqlite database file exists before porting/#14692" 

### DIFF
--- a/changelog.d/15297.misc
+++ b/changelog.d/15297.misc
@@ -1,0 +1,1 @@
+Revert "check sqlite database file exists before porting" PR #14692.

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -1329,7 +1329,7 @@ def main() -> None:
     sqlite_config = {
         "name": "sqlite3",
         "args": {
-            "database": "file:{}?mode=rw".format(args.sqlite_database),
+            "database": args.sqlite_database,
             "cp_min": 1,
             "cp_max": 1,
             "check_same_thread": False,


### PR DESCRIPTION
Revert changes in #14692 as they appear to have caused a regression in the `port_db` script, see https://github.com/matrix-org/synapse/issues/15219#issuecomment-1460163469.