### PR TITLE
Make event objects unhashable

### DIFF
--- a/changelog.d/15305.misc
+++ b/changelog.d/15305.misc
@@ -1,0 +1,1 @@
+Make EventBase unhashable.

--- a/synapse/events/__init__.py
+++ b/synapse/events/__init__.py
@@ -24,6 +24,7 @@ from typing import (
     Generic,
     Iterable,
     List,
+    NoReturn,
     Optional,
     Sequence,
     Tuple,
@@ -337,6 +338,9 @@ class EventBase(metaclass=abc.ABCMeta):
     state_key: DictProperty[str] = DictProperty("state_key")
     type: DictProperty[str] = DictProperty("type")
     user_id: DictProperty[str] = DictProperty("sender")
+
+    def __hash__(self) -> NoReturn:
+        raise NotImplementedError()
 
     @property
     def event_id(self) -> str:


### PR DESCRIPTION
Generally speaking one should look up an event by its id. Otherwise we'll fall back to `object.__hash__` (the instance's address, under CPython) which is probably not what you want.

Noticed in #15240.
