### PR TITLE
Add a check to SQLite port DB script to ensure that the sqlite database passed to the script exists before trying to port from it

### DIFF
--- a/changelog.d/15306.bugfix
+++ b/changelog.d/15306.bugfix
@@ -1,0 +1,2 @@
+Add a check to [SQLite port_db script](https://matrix-org.github.io/synapse/latest/postgres.html#porting-from-sqlite)
+to ensure that the sqlite database passed to the script exists before trying to port from it.

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -18,6 +18,7 @@
 import argparse
 import curses
 import logging
+import os
 import sys
 import time
 import traceback
@@ -1325,6 +1326,11 @@ def main() -> None:
         format="%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(message)s",
         filename="port-synapse.log" if args.curses else None,
     )
+
+    if not os.path.isfile(args.sqlite_database):
+        sys.stderr.write("The sqlite database you specified does not exist, please check that you have the" \
+        "correct path.")
+        sys.exit(1)
 
     sqlite_config = {
         "name": "sqlite3",

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -1328,8 +1328,10 @@ def main() -> None:
     )
 
     if not os.path.isfile(args.sqlite_database):
-        sys.stderr.write("The sqlite database you specified does not exist, please check that you have the" \
-        "correct path.")
+        sys.stderr.write(
+            "The sqlite database you specified does not exist, please check that you have the"
+            "correct path."
+        )
         sys.exit(1)
 
     sqlite_config = {


### PR DESCRIPTION
Fixes #3982. Adds a check to see if the SQLite DB passed as an argument to the script is a file, and if it's not, exits the script. 

Note that #14692 originally fixed #3982, but the fix was backed out in #15301 as it was determined to have caused #15219. Per the discussion on #15219, there was a suggestion to re-try the fix in #14692 while passing `uri=True`, however, I could not reproduce the failure in #15219 so I decided to just fix the original issue with the file check rather than going any deeper down the rabbit hole. 