### PR TITLE
As an optimisation, use `TRUNCATE` on Postgres when clearing the user directory tables.

### DIFF
--- a/changelog.d/15316.misc
+++ b/changelog.d/15316.misc
@@ -1,0 +1,1 @@
+As an optimisation, use `TRUNCATE` on Postgres when clearing the user directory tables.


### PR DESCRIPTION
<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
Part of: #15264 <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Use TRUNCATE on Postgres for the user directory tables 

</li>
</ol>
