### PR TITLE
Fix `.gitignore` rule for the Complement source tarball downloaded automatically by `complement.sh`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ book/
 
 # complement
 /complement-*
-/master.tar.gz
+/main.tar.gz
 
 # rust
 /target/

--- a/changelog.d/15319.misc
+++ b/changelog.d/15319.misc
@@ -1,0 +1,1 @@
+Fix `.gitignore` rule for the Complement source tarball downloaded automatically by `complement.sh`.


### PR DESCRIPTION
<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Fix Complement gitignore rule 

</li>
</ol>
