### PR TITLE
Allow OIDC token response `id_token` to be an empty string

### DIFF
--- a/changelog.d/15322.bugfix
+++ b/changelog.d/15322.bugfix
@@ -1,0 +1,1 @@
+Fix OAuth2 compatibility with Mattermost as an OIDC provider and add example configuration for it.

--- a/docs/openid.md
+++ b/docs/openid.md
@@ -590,6 +590,37 @@ oidc_providers:
 
 Note that the fields `client_id` and `client_secret` are taken from the CURL response above.
 
+### Mattermost
+
+[Mattermost](https://mattermost.com) is not an OpenID provider but works with Synapse as an Oauth2 provider.
+
+Follow [the documentation](https://developers.mattermost.com/integrate/apps/authentication/oauth2/)
+to create a new application. Your callback URL should be `[synapse public baseurl]/_synapse/client/oidc/callback`.
+
+Synapse config:
+
+```yaml
+oidc_providers:
+  - idp_id: my_mattermost
+    idp_name: "Mattermost example"
+    discover: false
+    issuer: "https://your.mattermost.domain"
+    client_id: "someclientid_123"
+    client_secret: "someclientsecret_123"
+    client_auth_method: "client_secret_post"
+    scopes: []  # Scopes not supported
+    authorization_endpoint: "https://your.mattermost.domain/oauth/authorize"
+    token_endpoint: "https://your.mattermost.domain/oauth/access_token"
+    userinfo_endpoint: "https://your.mattermost.domain/api/v4/users/me"
+    user_mapping_provider:
+      config:
+        subject_template: "{{ user.id }}"
+        localpart_template: "{{ user.username }}"
+        # Optionally display name and email
+        display_name_template: "{{ user.first_name + ' ' + user.last_name }}"
+        email_template: "{{ user.email }}"
+```
+
 ### Shibboleth with OIDC Plugin
 
 [Shibboleth](https://www.shibboleth.net/) is an open Standard IdP solution widely used by Universities.

--- a/synapse/handlers/oidc.py
+++ b/synapse/handlers/oidc.py
@@ -1053,7 +1053,7 @@ class OidcProvider:
 
         # If there is an id_token, it should be validated, regardless of the
         # userinfo endpoint is used or not.
-        if token.get("id_token") is not None:
+        if token.get("id_token"):
             try:
                 id_token = await self._parse_id_token(token, nonce=session_data.nonce)
                 sid = id_token.get("sid")


### PR DESCRIPTION
Mattermost seems to respond with an empty `id_token` string as it has that in the shared data model with its consumer OpenID implementation. This causes Synapse to think it needs to validate it even though Mattermost doesn't support it.

Allow an empty string, not just not being defined.

Add also example documentation to using Mattermost as an OAuth2 provider.

Refs: https://github.com/matrix-org/synapse/issues/12980#issuecomment-1483286992

Signed-off-by: `Jason Robinson <mail@jasonrobinson.me>`

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
