### PR TITLE
Prune old typing notifications

### DIFF
--- a/changelog.d/15332.bugfix
+++ b/changelog.d/15332.bugfix
@@ -1,0 +1,1 @@
+Fix bug in worker mode where on a rolling restart of workers the "typing" worker would consume 100% CPU until it got restarted.


### PR DESCRIPTION
Rather than keeping them around forever in memory, slowing things down.

Fixes #11750.