### PR TITLE
debian package: don't make homeserver config file and data directory world-readable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
 matrix-synapse-py3 (1.80.0+nmu1) UNRELEASED; urgency=medium
 
   [ nodiscc ]
-  * Don't make homeserver config file and data directory world-readable
+  * Don't make matrix-synapse configuration directory, homeserver config file and data directory world-readable
 
  -- Synapse Packaging team <packages@matrix.org>  Tue, 28 Mar 2023 15:03:17 +0200
 

--- a/debian/matrix-synapse-py3.postinst
+++ b/debian/matrix-synapse-py3.postinst
@@ -44,13 +44,13 @@ EOF
       adduser --quiet --system --group --no-create-home --home /var/lib/matrix-synapse $USER
     fi
 
-    for DIR in /var/log/matrix-synapse /etc/matrix-synapse; do
+    for DIR in /var/log/matrix-synapse; do
       if ! dpkg-statoverride --list --quiet $DIR >/dev/null; then
         dpkg-statoverride --force-statoverride-add --quiet --update --add $USER "$(id -gn $USER)" 0755 $DIR
       fi
     done
 
-    if ! dpkg-statoverride --list --quiet /var/lib/matrix-synapse >/dev/null; then
+    if ! dpkg-statoverride --list --quiet /var/lib/matrix-synapse /etc/matrix-synapse >/dev/null; then
       dpkg-statoverride --force-statoverride-add --quiet --update --add $USER "$(id -gn $USER)" 0770 /var/lib/matrix-synapse
     fi
 


### PR DESCRIPTION
- fixes https://github.com/matrix-org/synapse/issues/2955
- ref. https://github.com/matrix-org/synapse/issues/6364
- these files/directories contain sensitive information and should only be readable by the synapse user

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
