### PR TITLE
Speed up pydantic CI lint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install Rust
+        # There don't seem to be versioned releases of this action per se: for each rust
+        # version there is a branch which gets constantly rebased on top of master.
+        # We pin to a specific commit for paranoia's sake.
+        uses: dtolnay/rust-toolchain@fc3253060d0c959bea12a59f10f8391454a0b02d
+        with:
+            toolchain: 1.58.1
+      - uses: Swatinem/rust-cache@v2
       - uses: matrix-org/setup-python-poetry@v1
         with:
           poetry-version: "1.3.2"

--- a/changelog.d/15339.misc
+++ b/changelog.d/15339.misc
@@ -1,0 +1,1 @@
+Speed up pydantic CI job.


### PR DESCRIPTION
Most of the time taken currently is building the rust bit, which we can cache.