### PR TITLE
Move experimental features MSC3026, MSC2654, MSC3881, and MSC3967 to per-user flags

### DIFF
--- a/changelog.d/15345.feature
+++ b/changelog.d/15345.feature
@@ -1,0 +1,3 @@
+Follow-up to adding experimental feature flags per-user (#15344) which moves experimental features MSC3026 (busy presence),
+MSC2654 (unread counts), MSC3881 (remotely toggle push notifications for another client), and
+MSC3967 (Do not require UIA when first uploading cross signing keys) from the experimental config to per-user flags.

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -43,9 +43,6 @@ class ExperimentalConfig(Config):
     def read_config(self, config: JsonDict, **kwargs: Any) -> None:
         experimental = config.get("experimental_features") or {}
 
-        # MSC3026 (busy presence state)
-        self.msc3026_enabled: bool = experimental.get("msc3026_enabled", False)
-
         # MSC2716 (importing historical messages)
         self.msc2716_enabled: bool = experimental.get("msc2716_enabled", False)
 

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -119,9 +119,6 @@ class ExperimentalConfig(Config):
         raw_msc3866_config = experimental.get("msc3866", {})
         self.msc3866 = MSC3866Config(**raw_msc3866_config)
 
-        # MSC3881: Remotely toggle push notifications for another client
-        self.msc3881_enabled: bool = experimental.get("msc3881_enabled", False)
-
         # MSC3882: Allow an existing session to sign in a new session
         self.msc3882_enabled: bool = experimental.get("msc3882_enabled", False)
         self.msc3882_ui_auth: bool = experimental.get("msc3882_ui_auth", True)

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -178,8 +178,5 @@ class ExperimentalConfig(Config):
             "msc3958_supress_edit_notifs", False
         )
 
-        # MSC3967: Do not require UIA when first uploading cross signing keys
-        self.msc3967_enabled = experimental.get("msc3967_enabled", False)
-
         # MSC2659: Application service ping endpoint
         self.msc2659_enabled = experimental.get("msc2659_enabled", False)

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -91,12 +91,6 @@ class ExperimentalConfig(Config):
         # MSC3720 (Account status endpoint)
         self.msc3720_enabled: bool = experimental.get("msc3720_enabled", False)
 
-        # MSC2654: Unread counts
-        #
-        # Note that enabling this will result in an incorrect unread count for
-        # previously calculated push actions.
-        self.msc2654_enabled: bool = experimental.get("msc2654_enabled", False)
-
         # MSC2815 (allow room moderators to view redacted event content)
         self.msc2815_enabled: bool = experimental.get("msc2815_enabled", False)
 

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -148,8 +148,6 @@ class BasePresenceHandler(abc.ABC):
 
         self._federation_queue = PresenceFederationQueue(hs, self)
 
-        self._busy_presence_enabled = hs.config.experimental.msc3026_enabled
-
         active_presence = self.store.take_presence_startup_info()
         self.user_to_current_state = {state.user_id: state for state in active_presence}
 
@@ -422,8 +420,6 @@ class WorkerPresenceHandler(BasePresenceHandler):
             self.send_stop_syncing, UPDATE_SYNCING_USERS_MS
         )
 
-        self._busy_presence_enabled = hs.config.experimental.msc3026_enabled
-
         hs.get_reactor().addSystemEventTrigger(
             "before",
             "shutdown",
@@ -609,8 +605,12 @@ class WorkerPresenceHandler(BasePresenceHandler):
             PresenceState.BUSY,
         )
 
+        busy_presence_enabled = await self.hs.get_datastores().main.get_feature_enabled(
+            target_user.to_string(), "msc3026"
+        )
+
         if presence not in valid_presence or (
-            presence == PresenceState.BUSY and not self._busy_presence_enabled
+            presence == PresenceState.BUSY and not busy_presence_enabled
         ):
             raise SynapseError(400, "Invalid presence state")
 
@@ -1238,8 +1238,12 @@ class PresenceHandler(BasePresenceHandler):
             PresenceState.BUSY,
         )
 
+        busy_presence_enabled = await self.hs.get_datastores().main.get_feature_enabled(
+            target_user.to_string(), "msc3026"
+        )
+
         if presence not in valid_presence or (
-            presence == PresenceState.BUSY and not self._busy_presence_enabled
+            presence == PresenceState.BUSY and not busy_presence_enabled
         ):
             raise SynapseError(400, "Invalid presence state")
 
@@ -1257,7 +1261,7 @@ class PresenceHandler(BasePresenceHandler):
             new_fields["status_msg"] = status_msg
 
         if presence == PresenceState.ONLINE or (
-            presence == PresenceState.BUSY and self._busy_presence_enabled
+            presence == PresenceState.BUSY and busy_presence_enabled
         ):
             new_fields["last_active_ts"] = self.clock.time_msec()
 

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -27,6 +27,7 @@ from typing import (
     Union,
 )
 
+import attr
 from prometheus_client import Counter
 
 from synapse.api.constants import (
@@ -105,6 +106,17 @@ def _should_count_as_unread(event: EventBase, context: EventContext) -> bool:
         return True
 
     return False
+
+
+@attr.s(slots=True, auto_attribs=True)
+class ActionsForUser:
+    """
+    A class to hold the actions for a given event and whether the event should
+    increment the unread count.
+    """
+
+    actions: Collection[Union[Mapping, str]]
+    count_as_unread: bool
 
 
 class BulkPushRuleEvaluator:
@@ -335,15 +347,8 @@ class BulkPushRuleEvaluator:
             # (historical messages persisted in reverse-chronological order).
             return
 
-        # Disable counting as unread unless the experimental configuration is
-        # enabled, as it can cause additional (unwanted) rows to be added to the
-        # event_push_actions table.
-        count_as_unread = False
-        if self.hs.config.experimental.msc2654_enabled:
-            count_as_unread = _should_count_as_unread(event, context)
-
         rules_by_user = await self._get_rules_for_event(event)
-        actions_by_user: Dict[str, Collection[Union[Mapping, str]]] = {}
+        actions_by_user: Dict[str, ActionsForUser] = {}
 
         room_member_count = await self.store.get_number_joined_users_in_room(
             event.room_id
@@ -428,17 +433,19 @@ class BulkPushRuleEvaluator:
                     if not isinstance(display_name, str):
                         display_name = None
 
-            if count_as_unread:
-                # Add an element for the current user if the event needs to be marked as
-                # unread, so that add_push_actions_to_staging iterates over it.
-                # If the event shouldn't be marked as unread but should notify the
-                # current user, it'll be added to the dict later.
-                actions_by_user[uid] = []
-
             actions = evaluator.run(rules, uid, display_name)
-            if "notify" in actions:
-                # Push rules say we should notify the user of this event
-                actions_by_user[uid] = actions
+
+            # check whether unread counts are enabled for this user
+            unread_enabled = await self.store.get_feature_enabled(uid, "msc2654")
+            if unread_enabled:
+                count_as_unread = _should_count_as_unread(event, context)
+            else:
+                count_as_unread = False
+
+            if "notify" in actions or count_as_unread:
+                # Push rules say we should notify the user of this event or the event should
+                # increment the unread count
+                actions_by_user[uid] = ActionsForUser(actions, count_as_unread)
 
         # If there aren't any actions then we can skip the rest of the
         # processing.
@@ -466,7 +473,6 @@ class BulkPushRuleEvaluator:
         await self.store.add_push_actions_to_staging(
             event.event_id,
             actions_by_user,
-            count_as_unread,
             thread_id,
         )
 

--- a/synapse/rest/client/keys.py
+++ b/synapse/rest/client/keys.py
@@ -316,7 +316,7 @@ class SigningKeyUploadServlet(RestServlet):
         user_id = requester.user.to_string()
         body = parse_json_object_from_request(request)
 
-        if self.hs.config.experimental.msc3967_enabled:
+        if await self.hs.get_datastores().main.get_feature_enabled(user_id, "msc3967"):
             if await self.e2e_keys_handler.is_cross_signing_set_up_for_user(user_id):
                 # If we already have a master key then cross signing is set up and we require UIA to reset
                 await self.auth_handler.validate_user_via_ui_auth(

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -96,7 +96,7 @@ class VersionsRestServlet(RestServlet):
                     "io.element.e2ee_forced.private": self.e2ee_forced_private,
                     "io.element.e2ee_forced.trusted_private": self.e2ee_forced_trusted_private,
                     # Supports the busy presence state described in MSC3026.
-                    "org.matrix.msc3026.busy_presence": self.config.experimental.msc3026_enabled,
+                    "org.matrix.msc3026.busy_presence": True,
                     # Supports receiving private read receipts as per MSC2285
                     "org.matrix.msc2285.stable": True,  # TODO: Remove when MSC2285 becomes a part of the spec
                     # Supports filtering of /publicRooms by room type as per MSC3827

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -115,7 +115,7 @@ class VersionsRestServlet(RestServlet):
                     # Adds support for login token requests as per MSC3882
                     "org.matrix.msc3882": self.config.experimental.msc3882_enabled,
                     # Adds support for remotely enabling/disabling pushers, as per MSC3881
-                    "org.matrix.msc3881": self.config.experimental.msc3881_enabled,
+                    "org.matrix.msc3881": True,
                     # Adds support for filtering /messages by event relation.
                     "org.matrix.msc3874": self.config.experimental.msc3874_enabled,
                     # Adds support for simple HTTP rendezvous as per MSC3886

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -15,7 +15,6 @@
 from typing import Optional, cast
 from unittest.mock import Mock, call
 
-from parameterized import parameterized
 from signedjson.key import generate_signing_key
 
 from twisted.test.proto_helpers import MemoryReactor
@@ -724,14 +723,6 @@ class PresenceHandlerTestCase(BaseMultiWorkerStreamTestCase):
         # our status message should be the same as it was before
         self.assertEqual(state.status_msg, status_msg)
 
-    @parameterized.expand([(False,), (True,)])
-    @unittest.override_config(
-        {
-            "experimental_features": {
-                "msc3026_enabled": True,
-            },
-        }
-    )
     def test_set_presence_from_syncing_keeps_busy(
         self, test_with_workers: bool
     ) -> None:
@@ -743,6 +734,13 @@ class PresenceHandlerTestCase(BaseMultiWorkerStreamTestCase):
         """
         user_id = "@test:server"
         status_msg = "I'm busy!"
+
+        # set busy state in db
+        self.get_success(
+            self.hs.get_datastores().main.set_feature_for_user(
+                user_id, "msc_3026", True
+            )
+        )
 
         # By default, we call /sync against the main process.
         worker_to_sync_against = self.hs

--- a/tests/replication/slave/storage/test_events.py
+++ b/tests/replication/slave/storage/test_events.py
@@ -24,6 +24,7 @@ from synapse.api.room_versions import RoomVersions
 from synapse.events import EventBase, _EventInternalMetadata, make_event_from_dict
 from synapse.events.snapshot import EventContext
 from synapse.handlers.room import RoomEventSource
+from synapse.push.bulk_push_rule_evaluator import ActionsForUser
 from synapse.server import HomeServer
 from synapse.storage.databases.main.event_push_actions import (
     NotifCounts,
@@ -412,8 +413,10 @@ class EventsWorkerStoreTestCase(BaseSlavedStoreTestCase):
         self.get_success(
             self.master_store.add_push_actions_to_staging(
                 event.event_id,
-                dict(push_actions),
-                False,
+                {
+                    user_id: ActionsForUser(actions, False)
+                    for user_id, actions in push_actions
+                },
                 "main",
             )
         )

--- a/tests/rest/client/test_keys.py
+++ b/tests/rest/client/test_keys.py
@@ -205,7 +205,6 @@ class KeyQueryTestCase(unittest.HomeserverTestCase):
 
     @override_config(
         {
-            "experimental_features": {"msc3967_enabled": True},
             "ui_auth": {"session_timeout": "15s"},
         }
     )
@@ -215,6 +214,13 @@ class KeyQueryTestCase(unittest.HomeserverTestCase):
         device_id = "ABCDEFGHI"
         alice_id = self.register_user("alice", password)
         alice_token = self.login("alice", password, device_id=device_id)
+
+        # enable msc3967 in db
+        self.get_success(
+            self.hs.get_datastores().main.set_feature_for_user(
+                alice_id, "msc3967", True
+            )
+        )
 
         keys1 = self.make_device_keys(alice_id, device_id)
 

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -538,9 +538,6 @@ class UnreadMessagesTestCase(unittest.HomeserverTestCase):
 
     def default_config(self) -> JsonDict:
         config = super().default_config()
-        config["experimental_features"] = {
-            "msc2654_enabled": True,
-        }
         return config
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
@@ -588,6 +585,9 @@ class UnreadMessagesTestCase(unittest.HomeserverTestCase):
 
     def test_unread_counts(self) -> None:
         """Tests that /sync returns the right value for the unread count (MSC2654)."""
+        # add per-user flag to the DB
+        ex_handler = self.hs.get_experimental_features_manager()
+        self.get_success(ex_handler.set_feature_for_user(self.user_id, "msc2654", True))
 
         # Check that our own messages don't increase the unread count.
         self.helper.send(self.room_id, "hello", tok=self.tok)


### PR DESCRIPTION
This is a follow up to #15344 which actually implements moving the features from the experimental config to per-user flags. 

Best reviewable commit-by-commit. 