### PR TITLE
Fix missing app variable in mail subject, again

### DIFF
--- a/synapse/push/mailer.py
+++ b/synapse/push/mailer.py
@@ -149,7 +149,7 @@ class Mailer:
         await self.send_email(
             email_address,
             self.email_subjects.password_reset
-            % {"server_name": self.hs.config.server.server_name},
+            % {"server_name": self.hs.config.server.server_name, "app": self.app_name},
             template_vars,
         )
 


### PR DESCRIPTION
One of my users was unable to reset his password due to this error:
```
2023-03-29 13:34:58,973 - synapse.handlers.identity - 394 - ERROR - POST-58 - Error sending threepid validation email to bob@example.com
Traceback (most recent call last):
  File "/opt/matrix-synapse/lib/python3.10/site-packages/synapse/handlers/identity.py", line 392, in send_threepid_validation
    await send_email_func(email_address, token, client_secret, session_id)
  File "/opt/matrix-synapse/lib/python3.10/site-packages/synapse/push/mailer.py", line 151, in send_password_reset_mail
    self.email_subjects.password_reset
KeyError: 'app'
```

A little investigation lead me to this PR https://github.com/matrix-org/synapse/pull/11745. I copied the little snippet ant that seems to have fixed everything.

Relevant email config from `homeserver.yaml`:
```yaml
email:
  app_name:                                       "Evulid.cc Matrix Server"
  subjects:
    password_reset:                               "[%(app)s] Password Reset"
```

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
