### PR TITLE
Drop `IS NULL` indices *after* the `ALTER TABLE` statement.

### DIFF
--- a/changelog.d/15357.misc
+++ b/changelog.d/15357.misc
@@ -1,0 +1,1 @@
+Make the `thread_id` column on `event_push_actions`, `event_push_actions_staging`, and `event_push_summary` non-null.

--- a/synapse/storage/schema/main/delta/74/03thread_notifications_not_null.sql.postgres
+++ b/synapse/storage/schema/main/delta/74/03thread_notifications_not_null.sql.postgres
@@ -13,11 +13,13 @@
  * limitations under the License.
  */
 
--- Drop the indexes used to find null thread_ids.
-DROP INDEX IF EXISTS event_push_actions_thread_id_null;
-DROP INDEX IF EXISTS event_push_summary_thread_id_null;
-
 -- The thread_id columns can now be made non-nullable.
 ALTER TABLE event_push_actions_staging ALTER COLUMN thread_id SET NOT NULL;
 ALTER TABLE event_push_actions ALTER COLUMN thread_id SET NOT NULL;
 ALTER TABLE event_push_summary ALTER COLUMN thread_id SET NOT NULL;
+
+-- Drop the indexes used to find null thread_ids.
+-- Only do this *after* the ALTER because the indices may be useful for validating
+-- the NOT NULL constraint.
+DROP INDEX IF EXISTS event_push_actions_thread_id_null;
+DROP INDEX IF EXISTS event_push_summary_thread_id_null;


### PR DESCRIPTION
We made the assumption that the `IS NULL` index would help validate the addition `NOT NULL` constraint, but we didn't even give ourselves a chance because we dropped it before adding the `NOT NULL` constraint.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
Follows: #15350 <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Move DROP INDEX to after ALTER .. SET NOT NULL 

</li>
</ol>
