### PR TITLE
Speed up membership queries for users with forgotten rooms

### DIFF
--- a/changelog.d/15385.misc
+++ b/changelog.d/15385.misc
@@ -1,0 +1,1 @@
+Speed up membership queries for users with forgotten rooms.

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -1391,6 +1391,12 @@ class RoomMemberBackgroundUpdateStore(SQLBaseStore):
             columns=["user_id", "room_id"],
             where_clause="forgotten = 1",
         )
+        self.db_pool.updates.register_background_index_update(
+            "room_membership_user_room_index",
+            index_name="room_membership_user_room_idx",
+            table="room_memberships",
+            columns=["user_id", "room_id"],
+        )
 
     async def _background_add_membership_profile(
         self, progress: JsonDict, batch_size: int

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -419,7 +419,11 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         )
 
         # Now we filter out forgotten and excluded rooms
-        rooms_to_exclude = await self.get_forgotten_rooms_for_user(user_id)
+        rooms_to_exclude = set()
+
+        # Users can't forget joined/invited rooms, so we skip the check for such look ups.
+        if not all(m in (Membership.JOIN, Membership.INVITE) for m in membership_list):
+            rooms_to_exclude = await self.get_forgotten_rooms_for_user(user_id)
 
         if excluded_rooms is not None:
             # Take a copy to avoid mutating the in-cache set

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -419,7 +419,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         )
 
         # Now we filter out forgotten and excluded rooms
-        rooms_to_exclude = set()
+        rooms_to_exclude: AbstractSet[str] = set()
 
         # Users can't forget joined/invited rooms, so we skip the check for such look ups.
         if not all(m in (Membership.JOIN, Membership.INVITE) for m in membership_list):

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -422,7 +422,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
         rooms_to_exclude: AbstractSet[str] = set()
 
         # Users can't forget joined/invited rooms, so we skip the check for such look ups.
-        if not all(m in (Membership.JOIN, Membership.INVITE) for m in membership_list):
+        if any(m not in (Membership.JOIN, Membership.INVITE) for m in membership_list):
             rooms_to_exclude = await self.get_forgotten_rooms_for_user(user_id)
 
         if excluded_rooms is not None:

--- a/synapse/storage/schema/main/delta/74/03_room_membership_index.sql
+++ b/synapse/storage/schema/main/delta/74/03_room_membership_index.sql
@@ -1,0 +1,19 @@
+/* Copyright 2023 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Add an index to `room_membership(user_id, room_id)` to make querying for
+-- forgotten rooms faster.
+INSERT INTO background_updates (ordering, update_name, progress_json) VALUES
+    (7403, 'room_membership_user_room_index', '{}');


### PR DESCRIPTION
The queries were written on the assumption that users would only have a small number of forgotten rooms, this turns out not to be the case for some users. This causes *very* slow query times for `get_forgotten_rooms_for_user`, an example plan currently:

```
 Group  (cost=0.56..9917.58 rows=19 width=68)
   Group Key: m.room_id, m.user_id
   ->  Index Only Scan using room_memberships_user_room_forgotten on room_memberships m  (cost=0.56..4.89 rows=19 width=60)
         Index Cond: (user_id = '?'::text)
   SubPlan 1
     ->  Aggregate  (cost=521.71..521.72 rows=1 width=8)
           ->  Bitmap Heap Scan on room_memberships  (cost=519.69..521.70 rows=1 width=0)
                 Recheck Cond: ((user_id = m.user_id) AND (room_id = m.room_id))
                 Filter: (forgotten = 0)
                 ->  BitmapAnd  (cost=519.69..519.69 rows=1 width=0)
                       ->  Bitmap Index Scan on room_memberships_user_id  (cost=0.00..49.14 rows=1926 width=0)
                             Index Cond: (user_id = m.user_id)
                       ->  Bitmap Index Scan on room_memberships_room_id  (cost=0.00..470.29 rows=19946 width=0)
                             Index Cond: (room_id = m.room_id)
(14 rows)
```

We fix this in two ways:
1. add an index to avoid the `Bitmap Heap Scan`; and
2. skip fetching forgotten users unless we're querying left/banned rooms