### PR TITLE
Fix the 'set_device_id_for_pushers_txn' background update.

### DIFF
--- a/changelog.d/15391.bugfix
+++ b/changelog.d/15391.bugfix
@@ -1,0 +1,1 @@
+Fix the `set_device_id_for_pushers_txn` background update crash.

--- a/synapse/storage/databases/main/pusher.py
+++ b/synapse/storage/databases/main/pusher.py
@@ -562,7 +562,7 @@ class PusherBackgroundUpdatesStore(SQLBaseStore):
             )
 
             self.db_pool.updates._background_update_progress_txn(
-                txn, "set_device_id_for_pushers", {"pusher_id": rows[-1]["id"]}
+                txn, "set_device_id_for_pushers", {"pusher_id": rows[-1]["pusher_id"]}
             )
 
             return len(rows)


### PR DESCRIPTION
Fixes #15389

This should be included for v1.81.0rc2

One thing I don't know, is if the background update will properly continue/restart for people who have upgraded to v1.81.0rc1. Am I right to assume that no progress on the update should have been recorded, so it should just restart from the beginning?