### PR TITLE
Delete pushers after calling on_logged_out module hook on device delete

### DIFF
--- a/changelog.d/15410.bugfix
+++ b/changelog.d/15410.bugfix
@@ -1,0 +1,1 @@
+Fix and document untold assumption that `on_logged_out` module hooks will be called before pushers deletion.

--- a/docs/modules/password_auth_provider_callbacks.md
+++ b/docs/modules/password_auth_provider_callbacks.md
@@ -103,6 +103,9 @@ Called during a logout request for a user. It is passed the qualified user ID, t
 deactivated device (if any: access tokens are occasionally created without an associated
 device ID), and the (now deactivated) access token.
 
+Deleting the related pushers is done after calling `on_logged_out`, so you can rely on them
+to still be present.
+
 If multiple modules implement this callback, Synapse runs them all in order.
 
 ### `get_username_for_registration`

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -513,8 +513,6 @@ class DeviceHandler(DeviceWorkerHandler):
             else:
                 raise
 
-        await self.hs.get_pusherpool().remove_pushers_by_devices(user_id, device_ids)
-
         # Delete data specific to each device. Not optimised as it is not
         # considered as part of a critical path.
         for device_id in device_ids:
@@ -532,6 +530,10 @@ class DeviceHandler(DeviceWorkerHandler):
                     user_id,
                     f"org.matrix.msc3890.local_notification_settings.{device_id}",
                 )
+
+        # Pushers are deleted after `delete_access_tokens_for_user` is called so that
+        # modules using `on_logged_out` hook can use them if needed.
+        await self.hs.get_pusherpool().remove_pushers_by_devices(user_id, device_ids)
 
         await self.notify_device_update(user_id, device_ids)
 

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -535,7 +535,7 @@ class HomeServer(metaclass=abc.ABCMeta):
 
     @cache_in_self
     def get_device_handler(self) -> DeviceWorkerHandler:
-        if not self.config.worker.worker_app:
+        if self.config.worker.worker_app:
             return DeviceWorkerHandler(self)
         else:
             return DeviceHandler(self)

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -535,7 +535,7 @@ class HomeServer(metaclass=abc.ABCMeta):
 
     @cache_in_self
     def get_device_handler(self) -> DeviceWorkerHandler:
-        if self.config.worker.worker_app:
+        if not self.config.worker.worker_app:
             return DeviceWorkerHandler(self)
         else:
             return DeviceHandler(self)

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -779,7 +779,7 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
         """
         device_id = "AAAAAAA"
         user_id = self.register_user("test_on_logged_out", "secret")
-        token = self.login("test_on_logged_out", "secret", device_id)
+        self.login("test_on_logged_out", "secret", device_id)
 
         self.get_success(
             self.hs.get_pusherpool().add_or_update_pusher(

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -796,7 +796,7 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
             )
         )
 
-        self.nb_of_pushers: Optional[int] = None
+        self.nb_of_pushers_in_callback: Optional[int] = None
 
         self.module_api.register_password_auth_provider_callbacks(
             on_logged_out=self._on_logged_out_mock
@@ -806,12 +806,16 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
         assert isinstance(device_handler, DeviceHandler)
         self.get_success(device_handler.delete_devices(user_id, [device_id]))
 
-        self.assertEqual(self.nb_of_pushers, 1)
+        self.assertEqual(self.nb_of_pushers_in_callback, 1)
+
+        self.assertEqual(len(self.hs.get_pusherpool().pushers[user_id].values()), 0)
 
     async def _on_logged_out_mock(
         self, user_id: str, device_id: Optional[str], access_token: str
     ) -> None:
-        self.nb_of_pushers = len(self.hs.get_pusherpool().pushers[user_id].values())
+        self.nb_of_pushers_in_callback = len(
+            self.hs.get_pusherpool().pushers[user_id].values()
+        )
 
 
 class ModuleApiWorkerTestCase(BaseModuleApiTestCase, BaseMultiWorkerStreamTestCase):


### PR DESCRIPTION
The assumption that `on_logged_out` module hooks will be called before deleting the pushers has been "broken" by #15280.

This behavior was not really specified, hence my quoted `broken`, so this PR also add it to the doc of the module API.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
