### PR TITLE
Refactor `SimpleHttpClient` to pull out reusable methods

### DIFF
--- a/changelog.d/15427.misc
+++ b/changelog.d/15427.misc
@@ -1,0 +1,1 @@
+Refactor `SimpleHttpClient` to pull out a base class.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -312,7 +312,7 @@ class BlacklistingAgentWrapper(Agent):
         )
 
 
-class BaseSynapseClient:
+class BaseHttpClient:
     """
     A simple, no-frills HTTP client with methods that wrap up common ways of
     using HTTP in Matrix
@@ -757,9 +757,9 @@ class BaseSynapseClient:
 
 class SimpleHttpClient(BaseSynapseClient):
     """
-    An HTTP client capable of crossing a proxy and respecting a block/allow list. This
-    does set up a HTTPConnectionPool based on a multiplier of 100 times
-    hs.config.caches.global_factor, as it is responsible for pushing to Sygnal.
+    An HTTP client capable of crossing a proxy and respecting a block/allow list.
+
+    This also configures a larger / longer lasting HTTP connection pool.
 
     Args:
         hs: The HomeServer instance to pass in
@@ -788,11 +788,8 @@ class SimpleHttpClient(BaseSynapseClient):
             # If we have an IP blacklist, we need to use a DNS resolver which
             # filters out blacklisted IP addresses, to prevent DNS rebinding.
             self.reactor: ISynapseReactor = BlacklistingReactorWrapper(
-                hs.get_reactor(), self._ip_whitelist, self._ip_blacklist
+                self.reactor, self._ip_whitelist, self._ip_blacklist
             )
-        else:
-            # This should have already been set up in the call to super(). Make sure.
-            self.reactor = hs.get_reactor()
 
         # the pusher makes lots of concurrent SSL connections to Sygnal, and tends to
         # do so in batches, so we need to allow the pool to keep lots of idle

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -315,12 +315,15 @@ class BlacklistingAgentWrapper(Agent):
 class BaseHttpClient:
     """
     A simple, no-frills HTTP client with methods that wrap up common ways of
-    using HTTP in Matrix
+    using HTTP in Matrix. Does not come with a default Agent, subclasses will need to
+    define their own.
 
     Args:
         hs: The HomeServer instance to pass in
         treq_args: Extra keyword arguments to be given to treq.request.
     """
+
+    agent: IAgent
 
     def __init__(
         self,
@@ -344,11 +347,6 @@ class BaseHttpClient:
         # We use this for our body producers to ensure that they use the correct
         # reactor.
         self._cooperator = Cooperator(scheduler=_make_scheduler(hs.get_reactor()))
-
-        self.agent: IAgent = Agent(
-            self.reactor,
-            contextFactory=hs.get_http_client_context_factory(),
-        )
 
     async def request(
         self,

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -755,7 +755,7 @@ class BaseHttpClient:
         )
 
 
-class SimpleHttpClient(BaseSynapseClient):
+class SimpleHttpClient(BaseHttpClient):
     """
     An HTTP client capable of crossing a proxy and respecting a block/allow list.
 


### PR DESCRIPTION
Simple refactor job. The main use of `SimpleHttpClient` is to allow crossing a proxy and to respect a block/allow list. Most of the other methods are unrelated to that and are reusable. Factor those out so creating/deduplicating other `Client`'s is less work.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>