### PR TITLE
More precise type for LoggingTransaction.execute

### DIFF
--- a/changelog.d/15429.misc
+++ b/changelog.d/15429.misc
@@ -1,1 +1,0 @@
-Improve DB performance of clearing out old data from `stream_ordering_to_exterm`.

--- a/changelog.d/15429.misc
+++ b/changelog.d/15429.misc
@@ -1,0 +1,1 @@
+Improve DB performance of clearing out old data from `stream_ordering_to_exterm`.

--- a/changelog.d/15432.misc
+++ b/changelog.d/15432.misc
@@ -1,0 +1,1 @@
+Improve type hints.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -370,6 +370,7 @@ class LoggingTransaction:
 
         if isinstance(self.database_engine, PostgresEngine):
             from psycopg2.extras import execute_batch
+
             # TODO: is it safe for values to be Iterable[Iterable[Any]] here?
             # https://www.psycopg.org/docs/extras.html?highlight=execute_batch#psycopg2.extras.execute_batch
             # suggests each arg in args should be a sequence or mapping

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -58,7 +58,7 @@ from synapse.metrics import register_threadpool
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.storage.background_updates import BackgroundUpdater
 from synapse.storage.engines import BaseDatabaseEngine, PostgresEngine, Sqlite3Engine
-from synapse.storage.types import Connection, Cursor, _Parameters
+from synapse.storage.types import Connection, Cursor, SQLQueryParameters
 from synapse.util.async_helpers import delay_cancellation
 from synapse.util.iterutils import batch_iter
 
@@ -404,7 +404,7 @@ class LoggingTransaction:
             sql,
         )
 
-    def execute(self, sql: str, parameters: _Parameters = ()) -> None:
+    def execute(self, sql: str, parameters: SQLQueryParameters = ()) -> None:
         self._do_execute(self.txn.execute, sql, parameters)
 
     def executemany(self, sql: str, *args: Any) -> None:

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -58,7 +58,7 @@ from synapse.metrics import register_threadpool
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.storage.background_updates import BackgroundUpdater
 from synapse.storage.engines import BaseDatabaseEngine, PostgresEngine, Sqlite3Engine
-from synapse.storage.types import Connection, Cursor
+from synapse.storage.types import Connection, Cursor, _Parameters
 from synapse.util.async_helpers import delay_cancellation
 from synapse.util.iterutils import batch_iter
 
@@ -394,8 +394,8 @@ class LoggingTransaction:
             sql,
         )
 
-    def execute(self, sql: str, *args: Any) -> None:
-        self._do_execute(self.txn.execute, sql, *args)
+    def execute(self, sql: str, parameters: _Parameters = ()) -> None:
+        self._do_execute(self.txn.execute, sql, parameters)
 
     def executemany(self, sql: str, *args: Any) -> None:
         self._do_execute(self.txn.executemany, sql, *args)

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1712,7 +1712,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
                 DELETE FROM stream_ordering_to_exterm
                 WHERE stream_ordering < ?
             """
-            txn.execute(sql, self.stream_ordering_month_ago)
+            txn.execute(sql, (self.stream_ordering_month_ago,))
 
         await self.db_pool.runInteraction(
             "_delete_old_forward_extrem_cache",

--- a/synapse/storage/databases/main/event_federation.py
+++ b/synapse/storage/databases/main/event_federation.py
@@ -1712,7 +1712,7 @@ class EventFederationWorkerStore(SignatureWorkerStore, EventsWorkerStore, SQLBas
                 DELETE FROM stream_ordering_to_exterm
                 WHERE stream_ordering < ?
             """
-            txn.execute(sql, (self.stream_ordering_month_ago,))
+            txn.execute(sql, self.stream_ordering_month_ago)
 
         await self.db_pool.runInteraction(
             "_delete_old_forward_extrem_cache",

--- a/synapse/storage/types.py
+++ b/synapse/storage/types.py
@@ -31,14 +31,14 @@ from typing_extensions import Protocol
 Some very basic protocol definitions for the DB-API2 classes specified in PEP-249
 """
 
-_Parameters = Union[Sequence[Any], Mapping[str, Any]]
+SQLQueryParameters = Union[Sequence[Any], Mapping[str, Any]]
 
 
 class Cursor(Protocol):
-    def execute(self, sql: str, parameters: _Parameters = ...) -> Any:
+    def execute(self, sql: str, parameters: SQLQueryParameters = ...) -> Any:
         ...
 
-    def executemany(self, sql: str, parameters: Sequence[_Parameters]) -> Any:
+    def executemany(self, sql: str, parameters: Sequence[SQLQueryParameters]) -> Any:
         ...
 
     def fetchone(self) -> Optional[Tuple]:


### PR DESCRIPTION
More precise type for `LoggingTransaction.execute` to catch expression misuse where a tuple should go.

ex. (via https://stackoverflow.com/a/7992642/796832)
```
(1)  # the number 1 (the parentheses are wrapping the expression `1`)
(1,) # a 1-tuple holding a number 1
() # confusingly, a 0-tuple
```

---

If you revert https://github.com/matrix-org/synapse/pull/15429 atop this PR and run mypy, it spots the error. See [here](https://github.com/matrix-org/synapse/actions/runs/4694603815/jobs/8322922294#step:7:16) on https://github.com/matrix-org/synapse/pull/15432/commits/f0863f735947d157e3a8083ff1449d9c4e69b304:


```
Run poetry run mypy
synapse/storage/databases/main/event_federation.py:1715: error: Argument 2 to "execute" of "LoggingTransaction" has incompatible type "Optional[int]"; expected "Union[Sequence[Any], Mapping[str, Any]]"  [arg-type]
Found 1 error in 1 file (checked 795 source files)
Error: Process completed with exit code 1.
```