### PR TITLE
Disable directory listing for `StaticResource`

### DIFF
--- a/changelog.d/15438.misc
+++ b/changelog.d/15438.misc
@@ -1,0 +1,1 @@
+Disable directory listing for static resources in `/_matrix/static/`.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -46,7 +46,10 @@ from twisted.internet import defer, interfaces
 from twisted.internet.defer import CancelledError
 from twisted.python import failure
 from twisted.web import resource
-from twisted.web.pages import notFound
+try:
+    from twisted.web.pages import notFound
+except ImportError:
+    from twisted.web.resource import NoResource as notFound
 from twisted.web.resource import IResource
 from twisted.web.server import NOT_DONE_YET, Request
 from twisted.web.static import File

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -46,6 +46,8 @@ from twisted.internet import defer, interfaces
 from twisted.internet.defer import CancelledError
 from twisted.python import failure
 from twisted.web import resource
+from twisted.web.pages import notFound
+from twisted.web.resource import IResource
 from twisted.web.server import NOT_DONE_YET, Request
 from twisted.web.static import File
 from twisted.web.util import redirectTo
@@ -569,8 +571,8 @@ class StaticResource(File):
         set_clickjacking_protection_headers(request)
         return super().render_GET(request)
 
-    def directoryListing(self) -> resource.NoResource:
-        return self.childNotFound
+    def directoryListing(self) -> IResource:
+        return notFound()
 
 
 class UnrecognizedRequestResource(resource.Resource):

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -569,6 +569,9 @@ class StaticResource(File):
         set_clickjacking_protection_headers(request)
         return super().render_GET(request)
 
+    def directoryListing(self) -> resource.NoResource:
+        return self.childNotFound
+
 
 class UnrecognizedRequestResource(resource.Resource):
     """

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -46,10 +46,12 @@ from twisted.internet import defer, interfaces
 from twisted.internet.defer import CancelledError
 from twisted.python import failure
 from twisted.web import resource
+
 try:
     from twisted.web.pages import notFound
 except ImportError:
     from twisted.web.resource import NoResource as notFound
+
 from twisted.web.resource import IResource
 from twisted.web.server import NOT_DONE_YET, Request
 from twisted.web.static import File

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -50,7 +50,7 @@ from twisted.web import resource
 try:
     from twisted.web.pages import notFound
 except ImportError:
-    from twisted.web.resource import NoResource as notFound
+    from twisted.web.resource import NoResource as notFound  # type: ignore[assignment]
 
 from twisted.web.resource import IResource
 from twisted.web.server import NOT_DONE_YET, Request


### PR DESCRIPTION
Disable directory listing for `/_matrix/static/`.

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Dirk Klimpel [5740567+dklimpel@users.noreply.github.com](mailto:5740567+dklimpel@users.noreply.github.com)