### PR TITLE
Add a note to the config documentation that the 'delete_stale_devices_after' job always runs on the main process

### DIFF
--- a/changelog.d/15452.doc
+++ b/changelog.d/15452.doc
@@ -1,0 +1,1 @@
+Note that the `delete_stale_devices_after` background job always runs on the main process.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -577,6 +577,10 @@ delete any device that hasn't been accessed for more than the specified amount o
 
 Defaults to no duration, which means devices are never pruned.
 
+**Note:** This task will always run on the main process, regardless of the value of
+`run_background_tasks_on`. This is due to workers currently not having the ability to
+delete devices.
+
 Example configuration:
 ```yaml
 delete_stale_devices_after: 1y


### PR DESCRIPTION
I was prompted to add this little tidbit of information after receiving a question about it from an Element customer.