### PR TITLE
Finish up type hints for federation client code

### DIFF
--- a/changelog.d/15465.misc
+++ b/changelog.d/15465.misc
@@ -1,0 +1,1 @@
+Improve type hints.

--- a/mypy.ini
+++ b/mypy.ini
@@ -33,9 +33,6 @@ exclude = (?x)
    |synapse/storage/schema/
    )$
 
-[mypy-synapse.federation.transport.client]
-disallow_untyped_defs = False
-
 [mypy-synapse.metrics._reactor_metrics]
 disallow_untyped_defs = False
 # This module imports select.epoll. That exists on Linux, but doesn't on macOS.

--- a/mypy.ini
+++ b/mypy.ini
@@ -36,9 +36,6 @@ exclude = (?x)
 [mypy-synapse.federation.transport.client]
 disallow_untyped_defs = False
 
-[mypy-synapse.http.matrixfederationclient]
-disallow_untyped_defs = False
-
 [mypy-synapse.metrics._reactor_metrics]
 disallow_untyped_defs = False
 # This module imports select.epoll. That exists on Linux, but doesn't on macOS.

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -280,15 +280,11 @@ class FederationClient(FederationBase):
         logger.debug("backfill transaction_data=%r", transaction_data)
 
         if not isinstance(transaction_data, dict):
-            # TODO we probably want an exception type specific to federation
-            # client validation.
-            raise TypeError("Backfill transaction_data is not a dict.")
+            raise InvalidResponseError("Backfill transaction_data is not a dict.")
 
         transaction_data_pdus = transaction_data.get("pdus")
         if not isinstance(transaction_data_pdus, list):
-            # TODO we probably want an exception type specific to federation
-            # client validation.
-            raise TypeError("transaction_data.pdus is not a list.")
+            raise InvalidResponseError("transaction_data.pdus is not a list.")
 
         room_version = await self.store.get_room_version(room_id)
 

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -88,7 +88,6 @@ class TransportLayerClient:
             path=path,
             args={"event_id": event_id},
             try_trailing_slash_on_400=True,
-            parser=JsonDictParser(),
         )
 
     async def get_room_state(
@@ -141,7 +140,6 @@ class TransportLayerClient:
             path=path,
             timeout=timeout,
             try_trailing_slash_on_400=True,
-            parser=JsonDictParser(),
         )
 
     async def backfill(
@@ -261,7 +259,6 @@ class TransportLayerClient:
             long_retries=True,
             backoff_on_404=True,  # If we get a 404 the other side has gone
             try_trailing_slash_on_400=True,
-            parser=JsonDictParser(),
         )
 
     async def make_query(
@@ -282,7 +279,6 @@ class TransportLayerClient:
             retry_on_dns_fail=retry_on_dns_fail,
             timeout=10000,
             ignore_backoff=ignore_backoff,
-            parser=JsonDictParser(),
         )
 
     async def make_membership_event(
@@ -344,7 +340,6 @@ class TransportLayerClient:
             retry_on_dns_fail=retry_on_dns_fail,
             timeout=20000,
             ignore_backoff=ignore_backoff,
-            parser=JsonDictParser(),
         )
 
     async def send_join_v1(
@@ -421,7 +416,6 @@ class TransportLayerClient:
             # server was just having a momentary blip, the room will be out of
             # sync.
             ignore_backoff=True,
-            parser=JsonDictParser(),
         )
 
     async def send_knock_v1(
@@ -457,7 +451,6 @@ class TransportLayerClient:
             destination=destination,
             path=path,
             data=content,
-            parser=JsonDictParser(),
         )
 
     async def send_invite_v1(
@@ -483,7 +476,6 @@ class TransportLayerClient:
             path=path,
             data=content,
             ignore_backoff=True,
-            parser=JsonDictParser(),
         )
 
     async def get_public_rooms(
@@ -548,7 +540,6 @@ class TransportLayerClient:
                     path=path,
                     args=args,
                     ignore_backoff=True,
-                    parser=JsonDictParser(),
                 )
             except HttpResponseException as e:
                 if e.code == 403:
@@ -749,7 +740,6 @@ class TransportLayerClient:
             destination=destination,
             path=path,
             args={"suggested_only": "true" if suggested_only else "false"},
-            parser=JsonDictParser(),
         )
 
     async def get_room_hierarchy_unstable(
@@ -769,7 +759,6 @@ class TransportLayerClient:
             destination=destination,
             path=path,
             args={"suggested_only": "true" if suggested_only else "false"},
-            parser=JsonDictParser(),
         )
 
     async def get_account_status(

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -43,11 +43,7 @@ from synapse.api.urls import (
 )
 from synapse.events import EventBase, make_event_from_dict
 from synapse.federation.units import Transaction
-from synapse.http.matrixfederationclient import (
-    ByteParser,
-    JsonDictParser,
-    LegacyJsonDictParser,
-)
+from synapse.http.matrixfederationclient import ByteParser, LegacyJsonSendParser
 from synapse.http.types import QueryParams
 from synapse.types import JsonDict
 from synapse.util import ExceptionBundle
@@ -136,10 +132,7 @@ class TransportLayerClient:
 
         path = _create_v1_path("/event/%s", event_id)
         return await self.client.get_json(
-            destination,
-            path=path,
-            timeout=timeout,
-            try_trailing_slash_on_400=True,
+            destination, path=path, timeout=timeout, try_trailing_slash_on_400=True
         )
 
     async def backfill(
@@ -399,7 +392,7 @@ class TransportLayerClient:
             # server was just having a momentary blip, the room will be out of
             # sync.
             ignore_backoff=True,
-            parser=LegacyJsonDictParser(),
+            parser=LegacyJsonSendParser(),
         )
 
     async def send_leave_v2(
@@ -448,9 +441,7 @@ class TransportLayerClient:
         path = _create_v1_path("/send_knock/%s/%s", room_id, event_id)
 
         return await self.client.put_json(
-            destination=destination,
-            path=path,
-            data=content,
+            destination=destination, path=path, data=content
         )
 
     async def send_invite_v1(
@@ -463,7 +454,7 @@ class TransportLayerClient:
             path=path,
             data=content,
             ignore_backoff=True,
-            parser=LegacyJsonDictParser(),
+            parser=LegacyJsonSendParser(),
         )
 
     async def send_invite_v2(
@@ -472,10 +463,7 @@ class TransportLayerClient:
         path = _create_v2_path("/invite/%s/%s", room_id, event_id)
 
         return await self.client.put_json(
-            destination=destination,
-            path=path,
-            data=content,
-            ignore_backoff=True,
+            destination=destination, path=path, data=content, ignore_backoff=True
         )
 
     async def get_public_rooms(
@@ -536,10 +524,7 @@ class TransportLayerClient:
 
             try:
                 response = await self.client.get_json(
-                    destination=remote_server,
-                    path=path,
-                    args=args,
-                    ignore_backoff=True,
+                    destination=remote_server, path=path, args=args, ignore_backoff=True
                 )
             except HttpResponseException as e:
                 if e.code == 403:
@@ -559,7 +544,7 @@ class TransportLayerClient:
         path = _create_v1_path("/exchange_third_party_invite/%s", room_id)
 
         return await self.client.put_json(
-            destination=destination, path=path, data=event_dict, parser=JsonDictParser()
+            destination=destination, path=path, data=event_dict
         )
 
     async def get_event_auth(
@@ -567,9 +552,7 @@ class TransportLayerClient:
     ) -> JsonDict:
         path = _create_v1_path("/event_auth/%s/%s", room_id, event_id)
 
-        return await self.client.get_json(
-            destination=destination, path=path, parser=JsonDictParser()
-        )
+        return await self.client.get_json(destination=destination, path=path)
 
     async def query_client_keys(
         self, destination: str, query_content: JsonDict, timeout: int
@@ -648,7 +631,7 @@ class TransportLayerClient:
         path = _create_v1_path("/user/devices/%s", user_id)
 
         return await self.client.get_json(
-            destination=destination, path=path, timeout=timeout, parser=JsonDictParser()
+            destination=destination, path=path, timeout=timeout
         )
 
     async def claim_client_keys(
@@ -721,9 +704,7 @@ class TransportLayerClient:
         """
         path = _create_path(FEDERATION_UNSTABLE_PREFIX, "/rooms/%s/complexity", room_id)
 
-        return await self.client.get_json(
-            destination=destination, path=path, parser=JsonDictParser()
-        )
+        return await self.client.get_json(destination=destination, path=path)
 
     async def get_room_hierarchy(
         self, destination: str, room_id: str, suggested_only: bool

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -17,7 +17,6 @@ import codecs
 import logging
 import random
 import sys
-import typing
 import urllib.parse
 from http import HTTPStatus
 from io import BytesIO, StringIO
@@ -30,9 +29,11 @@ from typing import (
     Generic,
     List,
     Optional,
+    TextIO,
     Tuple,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
@@ -313,9 +314,7 @@ async def _handle_response(
 class BinaryIOWrapper:
     """A wrapper for a TextIO which converts from bytes on the fly."""
 
-    def __init__(
-        self, file: typing.TextIO, encoding: str = "utf-8", errors: str = "strict"
-    ):
+    def __init__(self, file: TextIO, encoding: str = "utf-8", errors: str = "strict"):
         self.decoder = codecs.getincrementaldecoder(encoding)(errors)
         self.file = file
 
@@ -825,8 +824,8 @@ class MatrixFederationHttpClient:
         ignore_backoff: bool = False,
         backoff_on_404: bool = False,
         try_trailing_slash_on_400: bool = False,
-        parser: Optional[ByteParser] = None,
-    ):
+        parser: Optional[ByteParser[T]] = None,
+    ) -> Union[JsonDict, list, T]:
         """Sends the specified json data using PUT
 
         Args:
@@ -902,7 +901,7 @@ class MatrixFederationHttpClient:
             _sec_timeout = self.default_timeout
 
         if parser is None:
-            parser = JsonParser()
+            parser = cast(ByteParser[T], JsonParser())
 
         body = await _handle_response(
             self.reactor,
@@ -1024,8 +1023,8 @@ class MatrixFederationHttpClient:
         timeout: Optional[int] = None,
         ignore_backoff: bool = False,
         try_trailing_slash_on_400: bool = False,
-        parser: Optional[ByteParser] = None,
-    ):
+        parser: Optional[ByteParser[T]] = None,
+    ) -> Union[JsonDict, list, T]:
         """GETs some json from the given host homeserver and path
 
         Args:
@@ -1091,7 +1090,7 @@ class MatrixFederationHttpClient:
             _sec_timeout = self.default_timeout
 
         if parser is None:
-            parser = JsonParser()
+            parser = cast(ByteParser[T], JsonParser())
 
         body = await _handle_response(
             self.reactor,

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -210,6 +210,7 @@ class JsonParser(_BaseJsonParser[Union[JsonDict, list]]):
 
 class JsonDictParser(_BaseJsonParser[JsonDict]):
     """Ensure the response is a JSON object."""
+
     def __init__(self) -> None:
         super().__init__(self._validate)
 
@@ -220,6 +221,7 @@ class JsonDictParser(_BaseJsonParser[JsonDict]):
 
 class LegacyJsonDictParser(_BaseJsonParser[Tuple[int, JsonDict]]):
     """Ensure the legacy responses of /send_join & /send_leave are correct."""
+
     def __init__(self) -> None:
         super().__init__(self._validate)
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -200,7 +200,7 @@ class _BaseJsonParser(ByteParser[T]):
     def finish(self) -> T:
         result = json_decoder.decode(self._buffer.getvalue())
         if self._validator is not None and not self._validator(result):
-            raise ValueError("Unexpected JSON object")
+            raise ValueError(f"Received incorrect JSON value: {result.__class__.__name__}")
         return result
 
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -837,7 +837,7 @@ class MatrixFederationHttpClient:
         backoff_on_404: bool = False,
         try_trailing_slash_on_400: bool = False,
         parser: Literal[None] = None,
-    ) -> Union[JsonDict, list]:
+    ) -> JsonDict:
         ...
 
     @overload
@@ -870,7 +870,7 @@ class MatrixFederationHttpClient:
         backoff_on_404: bool = False,
         try_trailing_slash_on_400: bool = False,
         parser: Optional[ByteParser[T]] = None,
-    ) -> Union[JsonDict, list, T]:
+    ) -> Union[JsonDict, T]:
         """Sends the specified json data using PUT
 
         Args:
@@ -946,7 +946,7 @@ class MatrixFederationHttpClient:
             _sec_timeout = self.default_timeout
 
         if parser is None:
-            parser = cast(ByteParser[T], JsonParser())
+            parser = cast(ByteParser[T], JsonDictParser())
 
         body = await _handle_response(
             self.reactor,
@@ -1047,7 +1047,7 @@ class MatrixFederationHttpClient:
         ignore_backoff: bool = False,
         try_trailing_slash_on_400: bool = False,
         parser: Literal[None] = None,
-    ) -> Union[JsonDict, list]:
+    ) -> JsonDict:
         ...
 
     @overload
@@ -1074,7 +1074,7 @@ class MatrixFederationHttpClient:
         ignore_backoff: bool = False,
         try_trailing_slash_on_400: bool = False,
         parser: Optional[ByteParser[T]] = None,
-    ) -> Union[JsonDict, list, T]:
+    ) -> Union[JsonDict, T]:
         """GETs some json from the given host homeserver and path
 
         Args:
@@ -1140,7 +1140,7 @@ class MatrixFederationHttpClient:
             _sec_timeout = self.default_timeout
 
         if parser is None:
-            parser = cast(ByteParser[T], JsonParser())
+            parser = cast(ByteParser[T], JsonDictParser())
 
         body = await _handle_response(
             self.reactor,

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -189,7 +189,14 @@ class _BaseJsonParser(ByteParser[T]):
 
     CONTENT_TYPE = "application/json"
 
-    def __init__(self, validator: Optional[Callable[[Any], bool]] = None) -> None:
+    def __init__(
+        self, validator: Optional[Callable[[Optional[object]], bool]] = None
+    ) -> None:
+        """
+        Args:
+            validator: A callable which takes the parsed JSON value and returns
+                true if the value is valid.
+        """
         self._buffer = StringIO()
         self._binary_wrapper = BinaryIOWrapper(self._buffer)
         self._validator = validator
@@ -200,7 +207,9 @@ class _BaseJsonParser(ByteParser[T]):
     def finish(self) -> T:
         result = json_decoder.decode(self._buffer.getvalue())
         if self._validator is not None and not self._validator(result):
-            raise ValueError(f"Received incorrect JSON value: {result.__class__.__name__}")
+            raise ValueError(
+                f"Received incorrect JSON value: {result.__class__.__name__}"
+            )
         return result
 
 

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -213,12 +213,8 @@ class _BaseJsonParser(ByteParser[T]):
         return result
 
 
-class JsonParser(_BaseJsonParser[Union[JsonDict, list]]):
-    """A parser that buffers the response and tries to parse it as JSON."""
-
-
-class JsonDictParser(_BaseJsonParser[JsonDict]):
-    """Ensure the response is a JSON object."""
+class JsonParser(_BaseJsonParser[JsonDict]):
+    """A parser that buffers the response and tries to parse it as a JSON object."""
 
     def __init__(self) -> None:
         super().__init__(self._validate)
@@ -228,7 +224,7 @@ class JsonDictParser(_BaseJsonParser[JsonDict]):
         return isinstance(v, dict)
 
 
-class LegacyJsonDictParser(_BaseJsonParser[Tuple[int, JsonDict]]):
+class LegacyJsonSendParser(_BaseJsonParser[Tuple[int, JsonDict]]):
     """Ensure the legacy responses of /send_join & /send_leave are correct."""
 
     def __init__(self) -> None:
@@ -946,7 +942,7 @@ class MatrixFederationHttpClient:
             _sec_timeout = self.default_timeout
 
         if parser is None:
-            parser = cast(ByteParser[T], JsonDictParser())
+            parser = cast(ByteParser[T], JsonParser())
 
         body = await _handle_response(
             self.reactor,
@@ -1027,12 +1023,7 @@ class MatrixFederationHttpClient:
             _sec_timeout = self.default_timeout
 
         body = await _handle_response(
-            self.reactor,
-            _sec_timeout,
-            request,
-            response,
-            start_ms,
-            parser=JsonDictParser(),
+            self.reactor, _sec_timeout, request, response, start_ms, parser=JsonParser()
         )
         return body
 
@@ -1140,7 +1131,7 @@ class MatrixFederationHttpClient:
             _sec_timeout = self.default_timeout
 
         if parser is None:
-            parser = cast(ByteParser[T], JsonDictParser())
+            parser = cast(ByteParser[T], JsonParser())
 
         body = await _handle_response(
             self.reactor,
@@ -1161,7 +1152,7 @@ class MatrixFederationHttpClient:
         timeout: Optional[int] = None,
         ignore_backoff: bool = False,
         args: Optional[QueryParams] = None,
-    ) -> Union[JsonDict, list]:
+    ) -> JsonDict:
         """Send a DELETE request to the remote expecting some json response
 
         Args:

--- a/tests/federation/test_complexity.py
+++ b/tests/federation/test_complexity.py
@@ -75,7 +75,7 @@ class RoomComplexityTests(unittest.FederatingHomeserverTestCase):
         fed_transport = self.hs.get_federation_transport_client()
 
         # Mock out some things, because we don't want to test the whole join
-        fed_transport.client.get_json = Mock(return_value=make_awaitable({"v1": 9999}))
+        fed_transport.client.get_json = Mock(return_value=make_awaitable({"v1": 9999}))  # type: ignore[assignment]
         handler.federation_handler.do_invite_join = Mock(  # type: ignore[assignment]
             return_value=make_awaitable(("", 1))
         )
@@ -106,7 +106,7 @@ class RoomComplexityTests(unittest.FederatingHomeserverTestCase):
         fed_transport = self.hs.get_federation_transport_client()
 
         # Mock out some things, because we don't want to test the whole join
-        fed_transport.client.get_json = Mock(return_value=make_awaitable({"v1": 9999}))
+        fed_transport.client.get_json = Mock(return_value=make_awaitable({"v1": 9999}))  # type: ignore[assignment]
         handler.federation_handler.do_invite_join = Mock(  # type: ignore[assignment]
             return_value=make_awaitable(("", 1))
         )
@@ -143,7 +143,7 @@ class RoomComplexityTests(unittest.FederatingHomeserverTestCase):
         fed_transport = self.hs.get_federation_transport_client()
 
         # Mock out some things, because we don't want to test the whole join
-        fed_transport.client.get_json = Mock(return_value=make_awaitable(None))
+        fed_transport.client.get_json = Mock(return_value=make_awaitable(None))  # type: ignore[assignment]
         handler.federation_handler.do_invite_join = Mock(  # type: ignore[assignment]
             return_value=make_awaitable(("", 1))
         )
@@ -200,7 +200,7 @@ class RoomComplexityAdminTests(unittest.FederatingHomeserverTestCase):
         fed_transport = self.hs.get_federation_transport_client()
 
         # Mock out some things, because we don't want to test the whole join
-        fed_transport.client.get_json = Mock(return_value=make_awaitable({"v1": 9999}))
+        fed_transport.client.get_json = Mock(return_value=make_awaitable({"v1": 9999}))  # type: ignore[assignment]
         handler.federation_handler.do_invite_join = Mock(  # type: ignore[assignment]
             return_value=make_awaitable(("", 1))
         )
@@ -230,7 +230,7 @@ class RoomComplexityAdminTests(unittest.FederatingHomeserverTestCase):
         fed_transport = self.hs.get_federation_transport_client()
 
         # Mock out some things, because we don't want to test the whole join
-        fed_transport.client.get_json = Mock(return_value=make_awaitable({"v1": 9999}))
+        fed_transport.client.get_json = Mock(return_value=make_awaitable({"v1": 9999}))  # type: ignore[assignment]
         handler.federation_handler.do_invite_join = Mock(  # type: ignore[assignment]
             return_value=make_awaitable(("", 1))
         )

--- a/tests/http/test_matrixfederationclient.py
+++ b/tests/http/test_matrixfederationclient.py
@@ -26,7 +26,7 @@ from twisted.web.http import HTTPChannel
 
 from synapse.api.errors import RequestSendFailed
 from synapse.http.matrixfederationclient import (
-    JsonParser,
+    ByteParser,
     MatrixFederationHttpClient,
     MatrixFederationRequest,
 )
@@ -618,9 +618,9 @@ class FederationClientTests(HomeserverTestCase):
         while not test_d.called:
             protocol.dataReceived(b"a" * chunk_size)
             sent += chunk_size
-            self.assertLessEqual(sent, JsonParser.MAX_RESPONSE_SIZE)
+            self.assertLessEqual(sent, ByteParser.MAX_RESPONSE_SIZE)
 
-        self.assertEqual(sent, JsonParser.MAX_RESPONSE_SIZE)
+        self.assertEqual(sent, ByteParser.MAX_RESPONSE_SIZE)
 
         f = self.failureResultOf(test_d)
         self.assertIsInstance(f.value, RequestSendFailed)


### PR DESCRIPTION
Requires type hints for `synapse/federation/transport/client.py` and `synapse/http/matrixfederationclient.py`. The commits are fairly separate.

