### PR TITLE
HTTP Replication Client

### DIFF
--- a/changelog.d/15470.misc
+++ b/changelog.d/15470.misc
@@ -1,0 +1,1 @@
+Create new `Client` for use with HTTP Replication between workers. Contributed by Jason Little.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -826,7 +826,6 @@ class SimpleReplicationClient(BaseHttpClient):
     Uses existing BaseHttpClient methods but replaces the 'agent' used to make the
     request with one that supports HTTP and HTTPS.
     Attributes:
-            endpoints.
         agent: The custom Twisted Agent used for constructing the connection.
     """
 

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -821,10 +821,8 @@ class SimpleHttpClient(BaseHttpClient):
 
 
 class SimpleReplicationClient(BaseHttpClient):
-    """No frills client for connecting to Replication endpoints.
+    """Client for connecting to replication endpoints via HTTP and HTTPS.
 
-    Uses existing BaseHttpClient methods but replaces the 'agent' used to make the
-    request with one that supports HTTP and HTTPS.
     Attributes:
         agent: The custom Twisted Agent used for constructing the connection.
     """

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -873,8 +873,7 @@ class SimpleReplicationClient(BaseHttpClient):
         """
         outgoing_requests_counter.labels(method).inc()
 
-        # log request but strip `access_token` (AS requests for example include this)
-        logger.debug("Sending request %s %s", method, redact_uri(uri))
+        logger.debug("Sending request %s %s", method, uri)
 
         with start_active_span(
             "outgoing-replication-request",
@@ -922,7 +921,7 @@ class SimpleReplicationClient(BaseHttpClient):
                 logger.info(
                     "Received response to %s %s: %s",
                     method,
-                    redact_uri(uri),
+                    uri,
                     response.code,
                 )
                 return response
@@ -931,7 +930,7 @@ class SimpleReplicationClient(BaseHttpClient):
                 logger.info(
                     "Error sending request to  %s %s: %s %s",
                     method,
-                    redact_uri(uri),
+                    uri,
                     type(e).__name__,
                     e.args[0],
                 )

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -835,7 +835,7 @@ class SimpleReplicationClient(BaseHttpClient):
     ):
         """
         Args:
-            hs
+            hs: The HomeServer instance to pass in
         """
         super().__init__(hs)
 

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -820,7 +820,7 @@ class SimpleHttpClient(BaseHttpClient):
             )
 
 
-class SimpleReplicationClient(BaseHttpClient):
+class ReplicationClient(BaseHttpClient):
     """Client for connecting to replication endpoints via HTTP and HTTPS.
 
     Attributes:

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -856,6 +856,8 @@ class ReplicationClient(BaseHttpClient):
         headers: Optional[Headers] = None,
     ) -> IResponse:
         """
+        Make a request, differs from BaseHttpClient.request in that it does not use treq.
+
         Args:
             method: HTTP method to use.
             uri: URI to query.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -847,7 +847,6 @@ class SimpleReplicationClient(BaseHttpClient):
 
         self.agent: IAgent = ReplicationAgent(
             hs.get_reactor(),
-            hs,
             contextFactory=hs.get_http_client_context_factory(),
             pool=pool,
         )

--- a/synapse/http/replicationagent.py
+++ b/synapse/http/replicationagent.py
@@ -77,9 +77,9 @@ class ReplicationEndpointFactory:
 @implementer(IAgent)
 class ReplicationAgent(_AgentBase):
     """
-    This Agent is solely for the purposes of connecting to Synapse replication
-    endpoints, and can handle https and http connections. Appropriate comments are
-    copied from Twisted's Agent Class.
+    Client for connecting to replication endpoints via HTTP and HTTPS.
+    
+    Much of this code is copied from Twisted's twisted.web.client.Agent.
 
     Attributes:
         _endpointFactory: The IAgentEndpointFactory which will
@@ -139,15 +139,20 @@ class ReplicationAgent(_AgentBase):
     ) -> "defer.Deferred[IResponse]":
         """
         Issue a request to the server indicated by the given uri.
+
         An existing connection from the connection pool may be used or a new
         one may be created.
+
         Currently, HTTP and HTTPS schemes are supported in uri.
+
+        This is copied from twisted.web.client.Agent, except:
+        
+        * It uses a different pool key (combining the host & port).
+        * It does not call _ensureValidURI(...) since it breaks on some
+          UNIX paths.
 
         See: twisted.web.iweb.IAgent.request
         """
-        # This function is overridden in preparation of future work:
-        # * So as to properly set a key for the pool and
-        # * to remove an _ensureValidURI() that will be in the way.
         parsedURI = URI.fromBytes(uri)
         try:
             endpoint = self._getEndpoint(parsedURI)

--- a/synapse/http/replicationagent.py
+++ b/synapse/http/replicationagent.py
@@ -1,0 +1,175 @@
+# Copyright 2023 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from zope.interface import implementer
+
+from twisted.internet import defer
+from twisted.internet.endpoints import HostnameEndpoint, wrapClientTLS
+from twisted.internet.interfaces import IStreamClientEndpoint
+from twisted.python.failure import Failure
+from twisted.web.client import (
+    URI,
+    HTTPConnectionPool,
+    _AgentBase,
+    _DeprecatedToCurrentPolicyForHTTPS,
+)
+from twisted.web.error import SchemeNotSupported
+from twisted.web.http_headers import Headers
+from twisted.web.iweb import (
+    IAgent,
+    IAgentEndpointFactory,
+    IBodyProducer,
+    IPolicyForHTTPS,
+    IResponse,
+)
+
+from synapse.types import ISynapseReactor
+
+if TYPE_CHECKING:
+    from synapse.server import HomeServer
+
+logger = logging.getLogger(__name__)
+
+
+@implementer(IAgentEndpointFactory)
+class ReplicationEndpointFactory:
+    """Connect to a given TCP socket"""
+
+    def __init__(
+        self,
+        reactor: ISynapseReactor,
+        hs: "HomeServer",
+        context_factory: Optional[IPolicyForHTTPS],
+    ) -> None:
+        self.reactor = reactor
+        self.hs = hs
+        self.context_factory = context_factory
+
+    def endpointForURI(self, uri: URI) -> IStreamClientEndpoint:
+        """
+        This part of the factory decides what kind of endpoint is being connected to.
+
+        Args:
+            uri: The pre-parsed URI object containing all the uri data
+
+        Returns: The correct client endpoint object
+        """
+        if b"http" in uri.scheme:
+            endpoint = HostnameEndpoint(self.reactor, uri.host, int(uri.port))
+            if uri.scheme == b"https":
+                endpoint = wrapClientTLS(self.context_factory, endpoint)
+            return endpoint
+        else:
+            raise SchemeNotSupported()
+
+
+@implementer(IAgent)
+class ReplicationAgent(_AgentBase):
+    """
+    This Agent is solely for the purposes of connecting to Synapse replication
+    endpoints, and can handle https and http connections. Appropriate comments are
+    copied from Twisted's Agent Class.
+
+    Attributes:
+        _endpointFactory: The IAgentEndpointFactory which will
+            be used to create endpoints for outgoing TCP connections.
+    """
+
+    def __init__(
+        self,
+        reactor: ISynapseReactor,
+        hs: "HomeServer",
+        contextFactory: Optional[IPolicyForHTTPS] = None,
+        connectTimeout: Optional[float] = None,
+        bindAddress: Optional[bytes] = None,
+        pool: Optional[HTTPConnectionPool] = None,
+    ):
+        """
+        Create a ReplicationAgent.
+
+        Args:
+            reactor: A reactor for this Agent to place outgoing connections.
+            hs: The HomeServer instance
+            contextFactory: A factory for TLS contexts, to control the
+                verification parameters of OpenSSL.  The default is to use a
+                BrowserLikePolicyForHTTPS, so unless you have special
+                requirements you can leave this as-is.
+            connectTimeout: The amount of time that this Agent will wait
+                for the peer to accept a connection.
+            bindAddress: The local address for client sockets to bind to.
+            pool: An HTTPConnectionPool instance, or None, in which
+                case a non-persistent HTTPConnectionPool instance will be
+                created.
+        """
+        if not IPolicyForHTTPS.providedBy(contextFactory):
+            logger.warning(
+                f"{contextFactory} was passed as the HTTPS policy for an "
+                "Agent, but it does not provide IPolicyForHTTPS.  Since Twisted 14.0, "
+                "you must pass a provider of IPolicyForHTTPS.",
+            )
+            contextFactory = _DeprecatedToCurrentPolicyForHTTPS(contextFactory)
+
+        _AgentBase.__init__(self, reactor, pool)
+        endpoint_factory = ReplicationEndpointFactory(reactor, hs, contextFactory)
+        self._endpointFactory = endpoint_factory
+
+    def _getEndpoint(self, uri: URI) -> IStreamClientEndpoint:
+        """
+        Get an endpoint for the given URI, using self._endpointFactory.
+            uri: The URI of the request.
+        Returns: An endpoint which can be used to connect to given address.
+        """
+        return self._endpointFactory.endpointForURI(uri)
+
+    def request(
+        self,
+        method: bytes,
+        uri: bytes,
+        headers: Optional[Headers] = None,
+        bodyProducer: Optional[IBodyProducer] = None,
+    ) -> "defer.Deferred[IResponse]":
+        """
+        Issue a request to the server indicated by the given uri.
+        An existing connection from the connection pool may be used or a new
+        one may be created.
+        Currently, HTTP and HTTPS schemes are supported in uri.
+
+        See: twisted.web.iweb.IAgent.request
+        """
+        # This function is overridden in preparation of future work:
+        # * So as to properly set a key for the pool and
+        # * to remove an _ensureValidURI() that will be in the way.
+        parsedURI = URI.fromBytes(uri)
+        try:
+            endpoint = self._getEndpoint(parsedURI)
+        except SchemeNotSupported:
+            return defer.fail(Failure())
+
+        # This sets the Pool key to be:
+        #  (http(s), <host:ip>)
+        key = (parsedURI.scheme, parsedURI.netloc)
+
+        # _requestWithEndpoint comes from _AgentBase class
+        return self._requestWithEndpoint(
+            key,
+            endpoint,
+            method,
+            parsedURI,
+            headers,
+            bodyProducer,
+            parsedURI.originForm,
+        )

--- a/synapse/http/replicationagent.py
+++ b/synapse/http/replicationagent.py
@@ -64,7 +64,7 @@ class ReplicationEndpointFactory:
         Returns: The correct client endpoint object
         """
         if b"http" in uri.scheme:
-            endpoint = HostnameEndpoint(self.reactor, uri.host, int(uri.port))
+            endpoint = HostnameEndpoint(self.reactor, uri.host, uri.port)
             if uri.scheme == b"https":
                 endpoint = wrapClientTLS(self.context_factory, endpoint)
             return endpoint

--- a/synapse/http/replicationagent.py
+++ b/synapse/http/replicationagent.py
@@ -21,11 +21,7 @@ from twisted.internet import defer
 from twisted.internet.endpoints import HostnameEndpoint, wrapClientTLS
 from twisted.internet.interfaces import IStreamClientEndpoint
 from twisted.python.failure import Failure
-from twisted.web.client import (
-    URI,
-    HTTPConnectionPool,
-    _AgentBase,
-)
+from twisted.web.client import URI, HTTPConnectionPool, _AgentBase
 from twisted.web.error import SchemeNotSupported
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import (

--- a/synapse/http/replicationagent.py
+++ b/synapse/http/replicationagent.py
@@ -49,7 +49,7 @@ class ReplicationEndpointFactory:
     def __init__(
         self,
         reactor: ISynapseReactor,
-        context_factory: Optional[IPolicyForHTTPS],
+        context_factory: IPolicyForHTTPS,
     ) -> None:
         self.reactor = reactor
         self.context_factory = context_factory
@@ -66,7 +66,9 @@ class ReplicationEndpointFactory:
         if b"http" in uri.scheme:
             endpoint = HostnameEndpoint(self.reactor, uri.host, uri.port)
             if uri.scheme == b"https":
-                endpoint = wrapClientTLS(self.context_factory, endpoint)
+                endpoint = wrapClientTLS(
+                    self.context_factory.creatorForNetloc(uri.host, uri.port), endpoint
+                )
             return endpoint
         else:
             raise SchemeNotSupported()

--- a/synapse/http/replicationagent.py
+++ b/synapse/http/replicationagent.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from zope.interface import implementer
 
@@ -39,9 +39,6 @@ from twisted.web.iweb import (
 
 from synapse.types import ISynapseReactor
 
-if TYPE_CHECKING:
-    from synapse.server import HomeServer
-
 logger = logging.getLogger(__name__)
 
 
@@ -52,11 +49,9 @@ class ReplicationEndpointFactory:
     def __init__(
         self,
         reactor: ISynapseReactor,
-        hs: "HomeServer",
         context_factory: Optional[IPolicyForHTTPS],
     ) -> None:
         self.reactor = reactor
-        self.hs = hs
         self.context_factory = context_factory
 
     def endpointForURI(self, uri: URI) -> IStreamClientEndpoint:
@@ -92,7 +87,6 @@ class ReplicationAgent(_AgentBase):
     def __init__(
         self,
         reactor: ISynapseReactor,
-        hs: "HomeServer",
         contextFactory: Optional[IPolicyForHTTPS] = None,
         connectTimeout: Optional[float] = None,
         bindAddress: Optional[bytes] = None,
@@ -124,7 +118,7 @@ class ReplicationAgent(_AgentBase):
             contextFactory = _DeprecatedToCurrentPolicyForHTTPS(contextFactory)
 
         _AgentBase.__init__(self, reactor, pool)
-        endpoint_factory = ReplicationEndpointFactory(reactor, hs, contextFactory)
+        endpoint_factory = ReplicationEndpointFactory(reactor, contextFactory)
         self._endpointFactory = endpoint_factory
 
     def _getEndpoint(self, uri: URI) -> IStreamClientEndpoint:

--- a/synapse/http/replicationagent.py
+++ b/synapse/http/replicationagent.py
@@ -63,7 +63,7 @@ class ReplicationEndpointFactory:
 
         Returns: The correct client endpoint object
         """
-        if b"http" in uri.scheme:
+        if uri.scheme in (b"http", b"https"):
             endpoint = HostnameEndpoint(self.reactor, uri.host, uri.port)
             if uri.scheme == b"https":
                 endpoint = wrapClientTLS(
@@ -71,7 +71,7 @@ class ReplicationEndpointFactory:
                 )
             return endpoint
         else:
-            raise SchemeNotSupported()
+            raise SchemeNotSupported(f"Unsupported scheme: {uri.scheme!r}")
 
 
 @implementer(IAgent)

--- a/synapse/http/replicationagent.py
+++ b/synapse/http/replicationagent.py
@@ -99,7 +99,6 @@ class ReplicationAgent(_AgentBase):
 
         Args:
             reactor: A reactor for this Agent to place outgoing connections.
-            hs: The HomeServer instance
             contextFactory: A factory for TLS contexts, to control the
                 verification parameters of OpenSSL.  The default is to use a
                 BrowserLikePolicyForHTTPS, so unless you have special

--- a/synapse/replication/http/_base.py
+++ b/synapse/replication/http/_base.py
@@ -194,7 +194,7 @@ class ReplicationEndpoint(metaclass=abc.ABCMeta):
         the `instance_map` config).
         """
         clock = hs.get_clock()
-        client = hs.get_simple_http_client()
+        client = hs.get_replication_client()
         local_instance_name = hs.get_instance_name()
 
         # The value of these option should match the replication listener settings

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -459,13 +459,6 @@ class HomeServer(metaclass=abc.ABCMeta):
         )
 
     @cache_in_self
-    def get_replication_client(self) -> ReplicationClient:
-        """
-        An HTTP client for HTTP replication.
-        """
-        return ReplicationClient(self)
-
-    @cache_in_self
     def get_federation_http_client(self) -> MatrixFederationHttpClient:
         """
         An HTTP client for federation.
@@ -474,6 +467,13 @@ class HomeServer(metaclass=abc.ABCMeta):
             self.config
         )
         return MatrixFederationHttpClient(self, tls_client_options_factory)
+
+    @cache_in_self
+    def get_replication_client(self) -> ReplicationClient:
+        """
+        An HTTP client for HTTP replication.
+        """
+        return ReplicationClient(self)
 
     @cache_in_self
     def get_room_creation_handler(self) -> RoomCreationHandler:

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -107,8 +107,8 @@ from synapse.handlers.typing import FollowerTypingHandler, TypingWriterHandler
 from synapse.handlers.user_directory import UserDirectoryHandler
 from synapse.http.client import (
     InsecureInterceptableContextFactory,
+    ReplicationClient,
     SimpleHttpClient,
-    SimpleReplicationClient,
 )
 from synapse.http.matrixfederationclient import MatrixFederationHttpClient
 from synapse.media.media_repository import MediaRepository
@@ -459,11 +459,11 @@ class HomeServer(metaclass=abc.ABCMeta):
         )
 
     @cache_in_self
-    def get_replication_client(self) -> SimpleReplicationClient:
+    def get_replication_client(self) -> ReplicationClient:
         """
         An HTTP client for HTTP replication.
         """
-        return SimpleReplicationClient(self)
+        return ReplicationClient(self)
 
     @cache_in_self
     def get_federation_http_client(self) -> MatrixFederationHttpClient:

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -105,7 +105,11 @@ from synapse.handlers.stats import StatsHandler
 from synapse.handlers.sync import SyncHandler
 from synapse.handlers.typing import FollowerTypingHandler, TypingWriterHandler
 from synapse.handlers.user_directory import UserDirectoryHandler
-from synapse.http.client import InsecureInterceptableContextFactory, SimpleHttpClient
+from synapse.http.client import (
+    InsecureInterceptableContextFactory,
+    SimpleHttpClient,
+    SimpleReplicationClient,
+)
 from synapse.http.matrixfederationclient import MatrixFederationHttpClient
 from synapse.media.media_repository import MediaRepository
 from synapse.metrics.common_usage_metrics import CommonUsageMetricsManager
@@ -453,6 +457,13 @@ class HomeServer(metaclass=abc.ABCMeta):
             ip_blacklist=self.config.server.ip_range_blacklist,
             use_proxy=True,
         )
+
+    @cache_in_self
+    def get_replication_client(self) -> SimpleReplicationClient:
+        """
+        An HTTP client for HTTP replication.
+        """
+        return SimpleReplicationClient(self)
 
     @cache_in_self
     def get_federation_http_client(self) -> MatrixFederationHttpClient:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -228,6 +228,7 @@ class StateTestCase(unittest.TestCase):
                 "get_macaroon_generator",
                 "get_instance_name",
                 "get_simple_http_client",
+                "get_replication_client",
                 "hostname",
             ]
         )


### PR DESCRIPTION
Part 3 of 5(ish) to wire up HTTP replication Unix socket support.

Create a new Client that doesn't have support for Forward Proxies, Browser-like redirects, Cookie Handling, IP Block/Allow listing, Buffered Response Bodies and has a smaller `HttpConnectionPool` than `SimpleHttpClient`. This should be a drop-in replacement. Only set up to handle HTTP and HTTPS at this time.

Additional notes: 
* Unlike `SimpleHttpClient` and it's base class(`BaseHttpClient`), this removes `treq` as the request library as it was an extra layer that seemed to bring some of the functionality we no longer need and was getting in the way of future work in this area by enforcing IDNA2008 standards which won't be used or needed as well.
* Opentracing span was named `outgoing-replication-request`

Inspiration for how to use the `Agent` directly was found in MatrixFederationHttpClient

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>