### PR TITLE
Do not return extensible events experimental push rules by default.

### DIFF
--- a/changelog.d/15494.bugfix
+++ b/changelog.d/15494.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.73.0 where some experimental push rules were returned by default.

--- a/rust/src/push/mod.rs
+++ b/rust/src/push/mod.rs
@@ -568,7 +568,10 @@ impl FilteredPushRules {
             .filter(|rule| {
                 // Ignore disabled experimental push rules
 
-                if !self.msc1767_enabled && rule.rule_id.contains("org.matrix.msc1767") {
+                if !self.msc1767_enabled
+                    && (rule.rule_id.contains("org.matrix.msc1767")
+                        || rule.rule_id.contains("org.matrix.msc3933"))
+                {
                     return false;
                 }
 


### PR DESCRIPTION
This fixes a regression from #14524 where some of the experimental push rules were being leaked even if the feature was not enabled.

I tested this with:

```bash
curl --header "Authorization: Bearer $TOK" http://localhost:8080/_matrix/client/v3/pushrules/  |
    jq '.global[][] | select(.rule_id | startswith(".org"))'
```