### PR TITLE
Reduce the size of the HTTP connection pool for non-pushers.

### DIFF
--- a/changelog.d/15514.misc
+++ b/changelog.d/15514.misc
@@ -1,0 +1,1 @@
+Reduce the size of the HTTP connection pool for non-pushers.

--- a/synapse/http/client.py
+++ b/synapse/http/client.py
@@ -768,6 +768,7 @@ class SimpleHttpClient(BaseHttpClient):
            request if it were otherwise caught in a blacklist.
         use_proxy: Whether proxy settings should be discovered and used
             from conventional environment variables.
+        connection_pool: The connection pool to use for this client's agent.
     """
 
     def __init__(
@@ -777,6 +778,7 @@ class SimpleHttpClient(BaseHttpClient):
         ip_whitelist: Optional[IPSet] = None,
         ip_blacklist: Optional[IPSet] = None,
         use_proxy: bool = False,
+        connection_pool: Optional[HTTPConnectionPool] = None,
     ):
         super().__init__(hs, treq_args=treq_args)
         self._ip_whitelist = ip_whitelist
@@ -789,22 +791,12 @@ class SimpleHttpClient(BaseHttpClient):
                 self.reactor, self._ip_whitelist, self._ip_blacklist
             )
 
-        # the pusher makes lots of concurrent SSL connections to Sygnal, and tends to
-        # do so in batches, so we need to allow the pool to keep lots of idle
-        # connections around.
-        pool = HTTPConnectionPool(self.reactor)
-        # XXX: The justification for using the cache factor here is that larger
-        # instances will need both more cache and more connections.
-        # Still, this should probably be a separate dial
-        pool.maxPersistentPerHost = max(int(100 * hs.config.caches.global_factor), 5)
-        pool.cachedConnectionTimeout = 2 * 60
-
         self.agent: IAgent = ProxyAgent(
             self.reactor,
             hs.get_reactor(),
             connectTimeout=15,
             contextFactory=self.hs.get_http_client_context_factory(),
-            pool=pool,
+            pool=connection_pool,
             use_proxy=use_proxy,
         )
 

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -24,13 +24,13 @@ from twisted.web.client import HTTPConnectionPool
 
 from synapse.api.constants import EventTypes
 from synapse.events import EventBase
+from synapse.http.client import SimpleHttpClient
 from synapse.logging import opentracing
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.push import Pusher, PusherConfig, PusherConfigException
 from synapse.storage.databases.main.event_push_actions import HttpPushAction
 from synapse.types import JsonDict, JsonMapping
 
-from ..http.client import SimpleHttpClient
 from . import push_tools
 
 if TYPE_CHECKING:

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -20,11 +20,9 @@ from prometheus_client import Counter
 
 from twisted.internet.error import AlreadyCalled, AlreadyCancelled
 from twisted.internet.interfaces import IDelayedCall
-from twisted.web.client import HTTPConnectionPool
 
 from synapse.api.constants import EventTypes
 from synapse.events import EventBase
-from synapse.http.client import SimpleHttpClient
 from synapse.logging import opentracing
 from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.push import Pusher, PusherConfig, PusherConfigException
@@ -142,24 +140,7 @@ class HttpPusher(Pusher):
             )
 
         self.url = url
-
-        # the pusher makes lots of concurrent SSL connections to Sygnal, and tends to
-        # do so in batches, so we need to allow the pool to keep lots of idle
-        # connections around.
-        pool = HTTPConnectionPool(hs.get_reactor())
-        # XXX: The justification for using the cache factor here is that larger
-        # instances will need both more cache and more connections.
-        # Still, this should probably be a separate dial
-        pool.maxPersistentPerHost = max(int(100 * hs.config.caches.global_factor), 5)
-        pool.cachedConnectionTimeout = 2 * 60
-
-        self.http_client = SimpleHttpClient(
-            hs,
-            ip_whitelist=hs.config.server.ip_range_whitelist,
-            ip_blacklist=hs.config.server.ip_range_blacklist,
-            use_proxy=True,
-            connection_pool=pool,
-        )
+        self.http_client = hs.get_pusher_http_client()
 
         self.data_minus_url = {}
         self.data_minus_url.update(self.data)

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -27,6 +27,7 @@ from typing_extensions import TypeAlias
 
 from twisted.internet.interfaces import IOpenSSLContextFactory
 from twisted.internet.tcp import Port
+from twisted.web.client import HTTPConnectionPool
 from twisted.web.iweb import IPolicyForHTTPS
 from twisted.web.resource import Resource
 
@@ -451,6 +452,26 @@ class HomeServer(metaclass=abc.ABCMeta):
             ip_whitelist=self.config.server.ip_range_whitelist,
             ip_blacklist=self.config.server.ip_range_blacklist,
             use_proxy=True,
+        )
+
+    @cache_in_self
+    def get_pusher_http_client(self) -> SimpleHttpClient:
+        # the pusher makes lots of concurrent SSL connections to Sygnal, and tends to
+        # do so in batches, so we need to allow the pool to keep lots of idle
+        # connections around.
+        pool = HTTPConnectionPool(self.get_reactor())
+        # XXX: The justification for using the cache factor here is that larger
+        # instances will need both more cache and more connections.
+        # Still, this should probably be a separate dial
+        pool.maxPersistentPerHost = max(int(100 * self.config.caches.global_factor), 5)
+        pool.cachedConnectionTimeout = 2 * 60
+
+        return SimpleHttpClient(
+            self,
+            ip_whitelist=self.config.server.ip_range_whitelist,
+            ip_blacklist=self.config.server.ip_range_blacklist,
+            use_proxy=True,
+            connection_pool=pool,
         )
 
     @cache_in_self

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -52,7 +52,7 @@ class HTTPPusherTests(HomeserverTestCase):
 
         m.post_json_get_json = post_json_get_json
 
-        hs = self.setup_test_homeserver(proxied_blacklisted_http_client=m)
+        hs = self.setup_test_homeserver(pusher_http_client=m)
 
         return hs
 

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -93,7 +93,7 @@ class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
         self.make_worker_hs(
             "synapse.app.generic_worker",
             {"worker_name": "pusher1", "pusher_instances": ["pusher1"]},
-            proxied_blacklisted_http_client=http_client_mock,
+            pusher_http_client=http_client_mock,
         )
 
         event_id = self._create_pusher_and_send_msg("user")
@@ -126,7 +126,7 @@ class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
                 "worker_name": "pusher1",
                 "pusher_instances": ["pusher1", "pusher2"],
             },
-            proxied_blacklisted_http_client=http_client_mock1,
+            pusher_http_client=http_client_mock1,
         )
 
         http_client_mock2 = Mock(spec_set=["post_json_get_json"])
@@ -140,7 +140,7 @@ class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
                 "worker_name": "pusher2",
                 "pusher_instances": ["pusher1", "pusher2"],
             },
-            proxied_blacklisted_http_client=http_client_mock2,
+            pusher_http_client=http_client_mock2,
         )
 
         # We choose a user name that we know should go to pusher1.


### PR DESCRIPTION
#2817 increased the size of the HTTP connection pool for all `SimpleHttpClient` due to the HTTP pushers being killed by TLS negotiation.

In #15440 I noted that for URL previews this means we might keep lots of connections hanging around which might never be re-used.

To solve this we allow overriding the pool and then *only* override it for the pusher pool.