### PR TITLE
Fix deleting of old highlight notifications

### DIFF
--- a/changelog.d/15519.bugfix
+++ b/changelog.d/15519.bugfix
@@ -1,0 +1,1 @@
+Fix bug where we didn't clean out old highlight push notifications from the database. Introduced in v1.62.0.

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -1836,6 +1836,15 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
             # deletes.
             batch_size = self._rotate_count
 
+            if isinstance(self.database_engine, PostgresEngine):
+                # Temporarily disable sequential scans in this transaction. We
+                # need to do this as the postgres statistics don't take into
+                # account the `highlight = 0` part when estimating the
+                # distribution of `stream_ordering`. I.e. since we keep old
+                # highlight rows the query planner thinks there are way more old
+                # rows to delete than there actually are.
+                txn.execute("SET LOCAL enable_seqscan=off")
+
             txn.execute(
                 """
                 SELECT stream_ordering FROM event_push_actions


### PR DESCRIPTION
In #13118 we accidentally stopped deleting old highlight notifications, and instead only deleted non-highlight notifications.

While we're here we also enforce that we use index scans (rather than seq scans), which we also do for state queries. The reason to enforce this is that we can't correctly get PostgreSQL to understand the distribution of `stream_ordering` depends on `highlight`, and so it always defaults (on matrix.org) to sequential scans. This was especially exacerbated by us keeping old highlight notifications around.