### PR TITLE
Suppress the trusted key server warning for matrix.org in the demo scripts

### DIFF
--- a/changelog.d/15527.misc
+++ b/changelog.d/15527.misc
@@ -1,0 +1,1 @@
+Suppress the trusted key server warning when running the demo scripts.

--- a/changelog.d/15527.misc
+++ b/changelog.d/15527.misc
@@ -1,1 +1,1 @@
-Suppress the trusted key server warning when running the demo scripts.
+Don't use a trusted key server when running the demo scripts.

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -46,7 +46,7 @@ for port in 8080 8081 8082; do
             echo ''
 
 			# Warning, this heredoc depends on the interaction of tabs and spaces.
-			# Please don't accidentaly bork me with your fancy settings.
+			# Please don't accidentally bork me with your fancy settings.
 			listeners=$(cat <<-PORTLISTENERS
 			# Configure server to listen on both $https_port and $port
 			# This overides some of the default settings above
@@ -85,6 +85,7 @@ for port in 8080 8081 8082; do
             echo 'trusted_key_servers:'
             echo '  - server_name: "matrix.org"'
             echo '    accept_keys_insecurely: true'
+            echo 'suppress_key_server_warning: true'
             echo ''
 
 			# Allow the servers to communicate over localhost.

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -81,7 +81,9 @@ for port in 8080 8081 8082; do
             echo "tls_private_key_path: \"$DIR/$port/localhost:$port.tls.key\""
 
             # Ignore keys from the trusted keys server
-            echo '# Ignore keys from the trusted keys server'
+            echo '# Ignore keys from the trusted keys server.'
+            echo '# Specifically, we do this by omitting the "verify_keys" option'
+            echo '# and enabling "accept_keys_insecurely"'
             echo 'trusted_key_servers:'
             echo '  - server_name: "matrix.org"'
             echo '    accept_keys_insecurely: true'

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -80,15 +80,8 @@ for port in 8080 8081 8082; do
             echo "tls_certificate_path: \"$DIR/$port/localhost:$port.tls.crt\""
             echo "tls_private_key_path: \"$DIR/$port/localhost:$port.tls.key\""
 
-            # Ignore keys from the trusted keys server
-            echo '# Ignore keys from the trusted keys server.'
-            echo '# Specifically, we do this by omitting the "verify_keys" option'
-            echo '# and enabling "accept_keys_insecurely"'
-            echo 'trusted_key_servers:'
-            echo '  - server_name: "matrix.org"'
-            echo '    accept_keys_insecurely: true'
-            echo 'suppress_key_server_warning: true'
-            echo ''
+            # Request keys directly from servers contacted over federation
+            echo 'trusted_key_servers: []'
 
 			# Allow the servers to communicate over localhost.
 			allow_list=$(cat <<-ALLOW_LIST


### PR DESCRIPTION
Before this change, contributors would see the following when running `demo/start.sh`:

```
❯ ./demo/start.sh 
Starting server on port 8080... 
~/code/test-checkout/demo/8080 ~/code/test-checkout
Generating config file 8080.config
Generating log config file /home/work/code/test-checkout/demo/8080/localhost:8480.log.config which will log to /home/work/code/test-checkout/demo/8080/homeserver.log
Generating signing key file /home/work/code/test-checkout/demo/8080/localhost:8480.signing.key
A config file has been generated in '8080.config' for server name 'localhost:8480'. Please review this file and customise it to your needs.
..+...+............+...+.......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*........+.....+..........+...+..+.......+...+..+.+..+......+......+...+...+....+........................+..+...+....+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.+...+..+...............+......+....+..+......+...+...............+....+............+...+.....................+......+...+...+...+......+.....+...+......+............+...+............+...+.......+..+...+....+...............+.........+.........+.................+.+.........+...+.....+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
...+......+.+......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.............+.....+......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*....+..........+..................+..+.............+...+............+..+...+...+.+...........+..................+.........+.+......+.....+......+....+........+...+...+....+.....+.+...........+.........+.+...+.................+....+.........+............+.....+...+...+..........+...+.........+...+..+.+......+.....+....+.........+........+...+......+.........+.....................+................+.....+............+.+.....................+......+........+............+..........+...+.........+........+.......+.....+.+...........+...................+.........+..+.............+......+..+.........+.+.....+............+.+......+.........+......+....................+.+...+......+..............+......+....+.........+..+.+.................+...+...+....+...........+.+.........+.....+.+.....+...+............+.............+..+.+...+.....+.......+...+..+....+........+.......+...............+.........+............+....................+.......+...+..............+.+.......................+....+...+.........+.....+....+.....+.......+.............................+......+...+....+...+..+..........+...........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
This server is configured to use 'matrix.org' as its trusted key server via the
'trusted_key_servers' config option. 'matrix.org' is a good choice for a key
server since it is long-lived, stable and trusted. However, some admins may
wish to use another server for this purpose.

To suppress this warning and continue using 'matrix.org', admins should set
'suppress_key_server_warning' to 'true' in homeserver.yaml.
--------------------------------------------------------------------------------
<...printout from two other synapse instances omitted...>
```

The blurb at the end about trusted key servers takes up a significant portion of the output, and is not relevant to people running a local Synapse federation for development.

Motivated by a contributor coming into our internal channel and calling it out :)