### PR TITLE
Speed up rebuilding of the user directory for local users

### DIFF
--- a/changelog.d/15529.misc
+++ b/changelog.d/15529.misc
@@ -1,0 +1,1 @@
+Speed up rebuilding of the user directory for local users.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -386,13 +386,20 @@ class LoggingTransaction:
             self.executemany(sql, args)
 
     def execute_values(
-        self, sql: str, values: Iterable[Iterable[Any]], fetch: bool = True
+        self,
+        sql: str,
+        values: Iterable[Iterable[Any]],
+        template: Optional[str] = None,
+        fetch: bool = True,
     ) -> List[Tuple]:
         """Corresponds to psycopg2.extras.execute_values. Only available when
         using postgres.
 
         The `fetch` parameter must be set to False if the query does not return
         rows (e.g. INSERTs).
+
+        The `template` is the snippet to merge to every item in argslist to
+        compose the query.
         """
         assert isinstance(self.database_engine, PostgresEngine)
         from psycopg2.extras import execute_values
@@ -400,7 +407,9 @@ class LoggingTransaction:
         return self._do_execute(
             # TODO: is it safe for values to be Iterable[Iterable[Any]] here?
             # https://www.psycopg.org/docs/extras.html?highlight=execute_batch#psycopg2.extras.execute_values says values should be Sequence[Sequence]
-            lambda the_sql: execute_values(self.txn, the_sql, values, fetch=fetch),
+            lambda the_sql: execute_values(
+                self.txn, the_sql, values, template=template, fetch=fetch
+            ),
             sql,
         )
 

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -434,7 +434,7 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         # Actually insert the users with their profiles into the directory.
         await self.db_pool.runInteraction(
             "populate_user_directory_process_users_insertion",
-            self._update_profile_in_user_dir_txn,
+            self._update_profiles_in_user_dir_txn,
             profiles_to_insert,
         )
 
@@ -640,12 +640,12 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         If the user is remote, the profile will be marked as not stale.
         """
         await self.db_pool.runInteraction(
-            "update_profile_in_user_dir",
-            self._update_profile_in_user_dir_txn,
+            "update_profiles_in_user_dir",
+            self._update_profiles_in_user_dir_txn,
             [_UserDirProfile(user_id, display_name, avatar_url)],
         )
 
-    def _update_profile_in_user_dir_txn(
+    def _update_profiles_in_user_dir_txn(
         self,
         txn: LoggingTransaction,
         profiles: Sequence[_UserDirProfile],

--- a/synapse/storage/databases/main/user_directory.py
+++ b/synapse/storage/databases/main/user_directory.py
@@ -75,8 +75,10 @@ class _UserDirProfile:
     """
 
     user_id: str
-    display_name: Optional[str] = None
-    avatar_url: Optional[str] = None
+
+    # If the display name or avatar URL are unexpected types, replace with None
+    display_name: Optional[str] = attr.ib(default=None, converter=non_null_str_or_none)
+    avatar_url: Optional[str] = attr.ib(default=None, converter=non_null_str_or_none)
 
 
 class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
@@ -637,10 +639,6 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
         Update or add a user's profile in the user directory.
         If the user is remote, the profile will be marked as not stale.
         """
-        # If the display name or avatar URL are unexpected types, replace with None.
-        display_name = non_null_str_or_none(display_name)
-        avatar_url = non_null_str_or_none(avatar_url)
-
         await self.db_pool.runInteraction(
             "update_profile_in_user_dir",
             self._update_profile_in_user_dir_txn,
@@ -660,8 +658,8 @@ class UserDirectoryBackgroundUpdateStore(StateDeltasStore):
             value_names=("display_name", "avatar_url"),
             value_values=[
                 (
-                    non_null_str_or_none(p.display_name),
-                    non_null_str_or_none(p.avatar_url),
+                    p.display_name,
+                    p.avatar_url,
                 )
                 for p in profiles
             ],


### PR DESCRIPTION
The idea here is to batch up the work.

Reviewable commit-by-commit.

Note the second commit is simply moving a function out, and so reviewing with whitespace changes disabled is recommended.