### PR TITLE
Speed up deleting of old rows in `event_push_actions`

### DIFF
--- a/changelog.d/15531.misc
+++ b/changelog.d/15531.misc
@@ -1,0 +1,1 @@
+Speed up deleting of old rows in `event_push_actions`.

--- a/synapse/storage/databases/main/event_push_actions.py
+++ b/synapse/storage/databases/main/event_push_actions.py
@@ -1836,6 +1836,15 @@ class EventPushActionsWorkerStore(ReceiptsWorkerStore, StreamWorkerStore, SQLBas
             # deletes.
             batch_size = self._rotate_count
 
+            if isinstance(self.database_engine, PostgresEngine):
+                # Temporarily disable sequential scans in this transaction. We
+                # need to do this as the postgres statistics don't take into
+                # account the `highlight = 0` part when estimating the
+                # distribution of `stream_ordering`. I.e. since we keep old
+                # highlight rows the query planner thinks there are way more old
+                # rows to delete than there actually are.
+                txn.execute("SET LOCAL enable_seqscan=off")
+
             txn.execute(
                 """
                 SELECT stream_ordering FROM event_push_actions


### PR DESCRIPTION
Enforce that we use index scans (rather than seq scans), which we also do for state queries. The reason to enforce this is that we can't correctly get PostgreSQL to understand the distribution of `stream_ordering` depends on `highlight`, and so it always defaults (on matrix.org) to sequential scans. 

In #13118 we accidentally stopped deleting old highlight notifications, and instead only deleted non-highlight notifications. This is especially exacerbated the above problem.

We can't just delete old highlight notifications from the `event_push_actions` table, as they don't get summarised in the same normal notifications do. We could fix that, but that is a much bigger job.

(This PR supersedes #15519).

