### PR TITLE
Add `xmlsec` package to flake.nix

### DIFF
--- a/changelog.d/15532.misc
+++ b/changelog.d/15532.misc
@@ -1,1 +1,1 @@
-Install the `xmlsec` package in the nix development environment.
+Install the `xmlsec` package and switch back to the upstream [cachix/devenv](https://github.com/cachix/devenv) repo in the nix development environment.

--- a/changelog.d/15532.misc
+++ b/changelog.d/15532.misc
@@ -1,0 +1,1 @@
+Install the `xmlsec` package in the nix development environment.

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,7 @@
 
                   # Native dependencies for unit tests (SyTest also requires OpenSSL).
                   openssl
+                  xmlsec
 
                   # Native dependencies for running Complement.
                   olm


### PR DESCRIPTION
The [`xmlsec` library](https://search.nixos.org/packages?channel=unstable&show=xmlsec&from=0&size=50&sort=relevance&type=packages&query=xmlsec) is required to run the `tests.handlers.test_saml.SamlHandlerTestCase` unit tests:

https://github.com/matrix-org/synapse/blob/42aea0d8af1556473b4f31f78d9facb448230a1f/tests/handlers/test_saml.py#L129-L130

This PR will install the `xmlsec` library into developer environments generated by `flake.nix`. Said environments will update and install the library automatically upon re-entry.

Missed in #15495.