### PR TITLE
Switch back to upstream devenv flake

### DIFF
--- a/changelog.d/15533.misc
+++ b/changelog.d/15533.misc
@@ -1,0 +1,1 @@
+Install the `xmlsec` package and switch back to the upstream [cachix/devenv](https://github.com/cachix/devenv) repo in the nix development environment.

--- a/flake.lock
+++ b/flake.lock
@@ -8,16 +8,16 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1682534083,
-        "narHash": "sha256-lBgFaLNHRQtD3InZbBXzIS8HgZUgcPJ6jiqGa4FJPrk=",
-        "owner": "anoadragon453",
+        "lastModified": 1683102061,
+        "narHash": "sha256-kOphT6V0uQUlFNBP3GBjs7DAU7fyZGGqCs9ue1gNY6E=",
+        "owner": "cachix",
         "repo": "devenv",
-        "rev": "9694bd0a845dd184d4468cc3d3461089aace787a",
+        "rev": "ff1f29e41756553174d596cafe3a9fa77595100b",
         "type": "github"
       },
       "original": {
-        "owner": "anoadragon453",
-        "ref": "anoa/fix_languages_python",
+        "owner": "cachix",
+        "ref": "main",
         "repo": "devenv",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -50,11 +50,7 @@
     # Output a development shell for x86_64/aarch64 Linux/Darwin (MacOS).
     systems.url = "github:nix-systems/default";
     # A development environment manager built on Nix. See https://devenv.sh.
-    # This is temporarily overridden to a fork that fixes a quirk between
-    # devenv's service and python language features. This can be removed
-    # when https://github.com/cachix/devenv/pull/559 is merged upstream.
-    devenv.url = "github:anoadragon453/devenv/anoa/fix_languages_python";
-    #devenv.url = "github:cachix/devenv/main";
+    devenv.url = "github:cachix/devenv/main";
     # Rust toolchains and rust-analyzer nightly.
     fenix = {
       url = "github:nix-community/fenix";


### PR DESCRIPTION
In the PR that introduced `flake.nix` (#15495), I had to point towards a fork of https://github.com/cachix/devenv which included [a fix](https://github.com/cachix/devenv/pull/559) for a bad interaction between [devenv services (processes)](https://devenv.sh/processes/); the feature that allows devs to start up postgres and redis via `devenv up`.

We can now switch back to upstream devenv, as the fix was merged :tada: This will cause an update to `flake.lock`, which is a file that tracks "flake inputs" - the repos we pull packages from. https://github.com/cachix/devenv being one of them.

Local developer environments will rebuild automatically to point to the new upstream upon re-entry.

The changelog entry for this change is combined with: https://github.com/matrix-org/synapse/pull/15532.