### PR TITLE
Add `mdbook` to flake.nix

### DIFF
--- a/changelog.d/15532.misc
+++ b/changelog.d/15532.misc
@@ -1,1 +1,1 @@
-Install the `xmlsec` package and switch back to the upstream [cachix/devenv](https://github.com/cachix/devenv) repo in the nix development environment.
+Install the `xmlsec` and `mdbook` packages and switch back to the upstream [cachix/devenv](https://github.com/cachix/devenv) repo in the nix development environment.

--- a/changelog.d/15533.misc
+++ b/changelog.d/15533.misc
@@ -1,1 +1,1 @@
-Install the `xmlsec` package and switch back to the upstream [cachix/devenv](https://github.com/cachix/devenv) repo in the nix development environment.
+Install the `xmlsec` and `mdbook` packages and switch back to the upstream [cachix/devenv](https://github.com/cachix/devenv) repo in the nix development environment.

--- a/changelog.d/15545.misc
+++ b/changelog.d/15545.misc
@@ -1,0 +1,1 @@
+ Install the `xmlsec` and `mdbook` packages and switch back to the upstream [cachix/devenv](https://github.com/cachix/devenv) repo in the nix development environment.

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,9 @@
 
                   # Native dependencies for running Complement.
                   olm
+
+                  # For building the Synapse documentation website.
+                  mdbook
                 ];
 
                 # Install Python and manage a virtualenv with Poetry.


### PR DESCRIPTION
Such that it is available in the nix developer environment. [mdbook](https://rust-lang.github.io/mdBook/) is used to build the [Synapse documentation website](https://matrix-org.github.io/synapse).

The changelogs of #15532 and #15533 have been updated to match this PR's changelog, as they all touch the same area. This saves the maintainer from needing to do the same during the next Synapse release :)