### PR TITLE
Error if attempting to set m.push_rules account data, per MSC4010.

### DIFF
--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -202,3 +202,8 @@ class ExperimentalConfig(Config):
 
         # MSC4009: E.164 Matrix IDs
         self.msc4009_e164_mxids = experimental.get("msc4009_e164_mxids", False)
+
+        # MSC4010: Do not allow setting m.push_rules account data.
+        self.msc4010_push_rules_account_data = experimental.get(
+            "msc4010_push_rules_account_data", False
+        )

--- a/synapse/handlers/account_data.py
+++ b/synapse/handlers/account_data.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 import logging
 import random
-from typing import TYPE_CHECKING, Awaitable, Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from synapse.api.constants import AccountDataTypes
+from synapse.push.clientformat import format_push_rules_for_user
 from synapse.replication.http.account_data import (
     ReplicationAddRoomAccountDataRestServlet,
     ReplicationAddTagRestServlet,
@@ -301,6 +302,15 @@ class AccountDataHandler:
                 tag=tag,
             )
             return response["max_stream_id"]
+
+    async def push_rules_for_user(self, user: UserID) -> Dict[str, Dict[str, list]]:
+        """
+        Push rules aren't really account data, but get formatted as such for /sync.
+        """
+        user_id = user.to_string()
+        rules_raw = await self._store.get_push_rules_for_user(user_id)
+        rules = format_push_rules_for_user(user, rules_raw)
+        return rules
 
 
 class AccountDataEventSource(EventSource[int, JsonDict]):

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -50,7 +50,6 @@ from synapse.logging.opentracing import (
     start_active_span,
     trace,
 )
-from synapse.push.clientformat import format_push_rules_for_user
 from synapse.storage.databases.main.event_push_actions import RoomNotifCounts
 from synapse.storage.databases.main.roommember import extract_heroes_from_room_summary
 from synapse.storage.roommember import MemberSummary
@@ -261,6 +260,7 @@ class SyncHandler:
         self.notifier = hs.get_notifier()
         self.presence_handler = hs.get_presence_handler()
         self._relations_handler = hs.get_relations_handler()
+        self._account_data_handler = hs.get_account_data_handler()
         self.event_sources = hs.get_event_sources()
         self.clock = hs.get_clock()
         self.state = hs.get_state_handler()
@@ -427,12 +427,6 @@ class SyncHandler:
 
             set_tag(SynapseTags.SYNC_RESULT, bool(sync_result))
             return sync_result
-
-    async def push_rules_for_user(self, user: UserID) -> Dict[str, Dict[str, list]]:
-        user_id = user.to_string()
-        rules_raw = await self.store.get_push_rules_for_user(user_id)
-        rules = format_push_rules_for_user(user, rules_raw)
-        return rules
 
     async def ephemeral_by_room(
         self,
@@ -1779,7 +1773,9 @@ class SyncHandler:
                 global_account_data = dict(global_account_data)
                 global_account_data[
                     AccountDataTypes.PUSH_RULES
-                ] = await self.push_rules_for_user(sync_config.user)
+                ] = await self._account_data_handler.push_rules_for_user(
+                    sync_config.user
+                )
         else:
             all_global_account_data = await self.store.get_global_account_data_for_user(
                 user_id
@@ -1788,7 +1784,7 @@ class SyncHandler:
             global_account_data = dict(all_global_account_data)
             global_account_data[
                 AccountDataTypes.PUSH_RULES
-            ] = await self.push_rules_for_user(sync_config.user)
+            ] = await self._account_data_handler.push_rules_for_user(sync_config.user)
 
         account_data_for_user = (
             await sync_config.filter_collection.filter_global_account_data(


### PR DESCRIPTION
[MSC4010](https://github.com/matrix-org/matrix-spec-proposals/pull/4010) requests the following changes:

* Both `m.fully_read` and `m.push_rules` cannot be set (or deleted) from `/account_data` APIs, either the global or room-specific ones.
* Both `m.fully_read` and `m.push_rules` can be *read* from the `/account_data` APIs. (Note that global `m.fully_read` or room-specific push rules shouldn't exist.)