### PR TITLE
Declare support for Matrix 1.6

### DIFF
--- a/changelog.d/15559.feature
+++ b/changelog.d/15559.feature
@@ -1,0 +1,1 @@
+Advertise support for Matrix 1.6 on `/_matrix/client/versions`.

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -79,6 +79,7 @@ class VersionsRestServlet(RestServlet):
                     "v1.3",
                     "v1.4",
                     "v1.5",
+                    "v1.6",
                 ],
                 # as per MSC1497:
                 "unstable_features": {

--- a/synapse/rest/key/v2/local_key_resource.py
+++ b/synapse/rest/key/v2/local_key_resource.py
@@ -34,6 +34,8 @@ class LocalKey(RestServlet):
     """HTTP resource containing encoding the TLS X.509 certificate and NACL
     signature verification keys for this server::
 
+        GET /_matrix/key/v2/server HTTP/1.1
+
         GET /_matrix/key/v2/server/a.key.id HTTP/1.1
 
         HTTP/1.1 200 OK
@@ -100,6 +102,12 @@ class LocalKey(RestServlet):
     def on_GET(
         self, request: Request, key_id: Optional[str] = None
     ) -> Tuple[int, JsonDict]:
+        # Matrix 1.6 drops support for passing the key_id, this is incompatible
+        # with earlier versions and is allowed in order to support both.
+        # A warning is issued to help determine when it is safe to drop this.
+        if key_id:
+            logger.warning("Request received for local key with key ID: %s", key_id)
+
         time_now = self.clock.time_msec()
         # Update the expiry time if less than half the interval remains.
         if time_now + self.config.key.key_refresh_interval / 2 > self.valid_until_ts:

--- a/synapse/rest/key/v2/local_key_resource.py
+++ b/synapse/rest/key/v2/local_key_resource.py
@@ -106,7 +106,10 @@ class LocalKey(RestServlet):
         # with earlier versions and is allowed in order to support both.
         # A warning is issued to help determine when it is safe to drop this.
         if key_id:
-            logger.warning("Request received for local key with key ID: %s", key_id)
+            logger.warning(
+                "Request for local server key with deprecated key ID (logging to determine usage level for future removal): %s",
+                key_id,
+            )
 
         time_now = self.clock.time_msec()
         # Update the expiry time if less than half the interval remains.

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -130,7 +130,7 @@ class RemoteKey(RestServlet):
             # with earlier versions and is allowed in order to support both.
             # A warning is issued to help determine when it is safe to drop this.
             logger.warning(
-                "Request received for remote key for server: %s with key ID: %s",
+                "Request for remote server key with deprecated key ID (logging to determine usage level for future removal): %s / %s",
                 server,
                 key_id,
             )

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -126,6 +126,15 @@ class RemoteKey(RestServlet):
         self, request: Request, server: str, key_id: Optional[str] = None
     ) -> Tuple[int, JsonDict]:
         if server and key_id:
+            # Matrix 1.6 drops support for passing the key_id, this is incompatible
+            # with earlier versions and is allowed in order to support both.
+            # A warning is issued to help determine when it is safe to drop this.
+            logger.warning(
+                "Request received for remote key for server: %s with key ID: %s",
+                server,
+                key_id,
+            )
+
             minimum_valid_until_ts = parse_integer(request, "minimum_valid_until_ts")
             arguments = {}
             if minimum_valid_until_ts is not None:
@@ -161,7 +170,7 @@ class RemoteKey(RestServlet):
 
         time_now_ms = self.clock.time_msec()
 
-        # Map server_name->key_id->int. Note that the value of the init is unused.
+        # Map server_name->key_id->int. Note that the value of the int is unused.
         # XXX: why don't we just use a set?
         cache_misses: Dict[str, Dict[str, int]] = {}
         for (server_name, key_id, _), key_results in cached.items():


### PR DESCRIPTION
The only remaining bit is dealing with the removal of the key ID, as @richvdh [stated](https://github.com/matrix-org/synapse/issues/15089#issuecomment-1523204339) his thought for supporting 1.6 was to be technically non-compliant and just log when that happens. We can't fully drop support for it or we'd be non-compliant for Matrix <1.6.

#15089 has a list of needed features and some cross-links back out to other pieces.

Fixes #15089