### PR TITLE
Add an unstable feature flag for MSC3391 to the /versions endpoint

### DIFF
--- a/changelog.d/15562.misc
+++ b/changelog.d/15562.misc
@@ -1,0 +1,1 @@
+Declare unstable support for [MSC3391](https://github.com/matrix-org/matrix-spec-proposals/pull/3391) under `/_matrix/client/versions` if the experimental implementation is enabled.

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -125,6 +125,8 @@ class VersionsRestServlet(RestServlet):
                     "org.matrix.msc3912": self.config.experimental.msc3912_enabled,
                     # Adds support for unstable "intentional mentions" behaviour.
                     "org.matrix.msc3952_intentional_mentions": self.config.experimental.msc3952_intentional_mentions,
+                    # Adds support for deleting account data.
+                    "org.matrix.msc3391": self.config.experimental.msc3391_enabled,
                 },
             },
         )


### PR DESCRIPTION
Missed in https://github.com/matrix-org/synapse/pull/14714.

This PR adds `org.matrix.msc3391` to the unstable feature flags advertised by Synapse on `/versions`, [as specified in MSC3391](https://github.com/ShadowJonathan/matrix-doc/blob/account-data-delete/proposals/3391-account-data-delete.md#unstable-prefix). The value of the flag matches the value of the `experimental_features.msc3391_enabled` config option.