### PR TITLE
Add pkg-config package to Stage 0

### DIFF
--- a/changelog.d/15567.docker
+++ b/changelog.d/15567.docker
@@ -1,0 +1,1 @@
+Add pkg-config package to Stage 0 to be able to build Dockerfile on ppc64le architecture.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt-get update -qq && apt-get install -yqq \
-  build-essential curl git libffi-dev libssl-dev \
+  build-essential curl git libffi-dev libssl-dev pkg-config \
   && rm -rf /var/lib/apt/lists/*
 
 # Install rust and ensure its in the PATH.


### PR DESCRIPTION
Add pkg-config package to Stage 0 to be able to build Dockerfile on ppc64le architecture.

Signed-off-by: Fabian Ruf <dev@fru-its.com>