### PR TITLE
Print full startup/initialization error

### DIFF
--- a/changelog.d/15569.feature
+++ b/changelog.d/15569.feature
@@ -1,0 +1,1 @@
+Print full error and stack-trace of any exception that occurs during startup/initialization.

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -210,7 +210,7 @@ def quit_with_error(error_string: str) -> NoReturn:
 
 
 # via https://peps.python.org/pep-3134/#enhanced-reporting
-def format_exception_chain(exc: Exception) -> str:
+def format_exception_chain(exc: BaseException) -> str:
     if exc.__cause__:
         result = format_exception_chain(exc.__cause__)
         result += "\nThe above exception was the direct cause..."

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -19,9 +19,9 @@ import os
 import signal
 import socket
 import sys
-from textwrap import indent
 import traceback
 import warnings
+from textwrap import indent
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -208,12 +208,22 @@ def quit_with_error(error_string: str) -> NoReturn:
     sys.exit(1)
 
 
+# Get the full class name like `psycopg2.OperationalError` instead of just
+# `OperationalError` which a naive `type(e).__name__` would give.
+# via https://stackoverflow.com/a/58045927/796832
+def get_full_class_name(obj) -> str:
+    module = obj.__class__.__module__
+    if module is None or module == str.__class__.__module__:
+        return obj.__class__.__name__
+    return module + "." + obj.__class__.__name__
+
+
 def handle_startup_exception(e: Exception) -> NoReturn:
     # Exceptions that occur between setting up the logging and forking or starting
     # the reactor are written to the logs, followed by a summary to stderr.
     logger.exception("Exception during startup")
     quit_with_error(
-        f"Error during initialisation:\n   {e}\nThere may be more information in the logs."
+        f"Error during initialisation:\n   {get_full_class_name(e)}: {e}\nThere may be more information in the logs."
     )
 
 

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -215,10 +215,10 @@ def handle_startup_exception(e: Exception) -> NoReturn:
     logger.exception("Exception during startup")
 
     error_string = "".join(traceback.format_exception(e))
-    indendeted_error_string = indent(error_string, "    ")
+    indented_error_string = indent(error_string, "    ")
 
     quit_with_error(
-        f"Error during initialisation:\n{indendeted_error_string}\nThere may be more information in the logs."
+        f"Error during initialisation:\n{indented_error_string}\nThere may be more information in the logs."
     )
 
 

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -209,24 +209,12 @@ def quit_with_error(error_string: str) -> NoReturn:
     sys.exit(1)
 
 
-# via https://peps.python.org/pep-3134/#enhanced-reporting
-def format_exception_chain(exc: BaseException) -> str:
-    if exc.__cause__:
-        result = format_exception_chain(exc.__cause__)
-        result += "\nThe above exception was the direct cause..."
-    elif exc.__context__:
-        result = format_exception_chain(exc.__context__)
-        result += "\nDuring handling of the above exception, ..."
-
-    return "".join(traceback.format_exception(exc))
-
-
 def handle_startup_exception(e: Exception) -> NoReturn:
     # Exceptions that occur between setting up the logging and forking or starting
     # the reactor are written to the logs, followed by a summary to stderr.
     logger.exception("Exception during startup")
 
-    error_string = format_exception_chain(e)
+    error_string = "".join(traceback.format_exception(e))
     indendeted_error_string = indent(error_string, "    ")
 
     quit_with_error(


### PR DESCRIPTION
I found the error in the **Before** really vague and obtuse and didn't realize port `5432` corresponded to the Postgres port until searching the codebase. It says to check the logs but that wasn't my first instinct. It's just more obvious if we just print the full thing which gives context of the error type and the traceback to the relevant area of code.

#### Before

```
$ poetry run python -m synapse.app.homeserver -c homeserver.yaml
**********************************************************************************
 Error during initialisation:
    connection to server at "localhost" (::1), port 5432 failed: Connection refused
 	Is the server running on that host and accepting TCP/IP connections?
 connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused
 	Is the server running on that host and accepting TCP/IP connections?
 
 There may be more information in the logs.
**********************************************************************************
```

#### After

```sh
$ poetry run python -m synapse.app.homeserver -c homeserver.yaml
**********************************************************************************
 Error during initialisation:
     Traceback (most recent call last):
       File "/home/eric/Documents/github/element/synapse/synapse/app/homeserver.py", line 352, in setup
         hs.setup()
       File "/home/eric/Documents/github/element/synapse/synapse/server.py", line 337, in setup
         self.datastores = Databases(self.DATASTORE_CLASS, self)
       File "/home/eric/Documents/github/element/synapse/synapse/storage/databases/__init__.py", line 65, in __init__
         with make_conn(database_config, engine, "startup") as db_conn:
       File "/home/eric/Documents/github/element/synapse/synapse/storage/database.py", line 161, in make_conn
         native_db_conn = engine.module.connect(**db_params)
       File "/home/eric/.cache/pypoetry/virtualenvs/matrix-synapse-xCtC9ulO-py3.10/lib/python3.10/site-packages/psycopg2/__init__.py", line 122, in connect
         conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
     psycopg2.OperationalError: connection to server at "localhost" (::1), port 5432 failed: Connection refused
     	Is the server running on that host and accepting TCP/IP connections?
     connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused
     	Is the server running on that host and accepting TCP/IP connections?
 
 
 There may be more information in the logs.
**********************************************************************************
```


#### Full error from the logs for reference

```
2023-05-10 23:38:49,492 - synapse.app._base - 237 - ERROR - main - Exception during startup
Traceback (most recent call last):
  File "/home/eric/Documents/github/element/synapse/synapse/app/homeserver.py", line 352, in setup
    hs.setup()
  File "/home/eric/Documents/github/element/synapse/synapse/server.py", line 337, in setup
    self.datastores = Databases(self.DATASTORE_CLASS, self)
  File "/home/eric/Documents/github/element/synapse/synapse/storage/databases/__init__.py", line 65, in __init__
    with make_conn(database_config, engine, "startup") as db_conn:
  File "/home/eric/Documents/github/element/synapse/synapse/storage/database.py", line 161, in make_conn
    native_db_conn = engine.module.connect(**db_params)
  File "/home/eric/.cache/pypoetry/virtualenvs/matrix-synapse-xCtC9ulO-py3.10/lib/python3.10/site-packages/psycopg2/__init__.py", line 122, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
psycopg2.OperationalError: connection to server at "localhost" (::1), port 5432 failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?
connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?
```



### Dev notes


 - https://docs.python.org/3/library/traceback.html
 - https://peps.python.org/pep-3134/#enhanced-reporting


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
