### PR TITLE
Allow `pip install` to use setuptools_rust 1.6.0

### DIFF
--- a/changelog.d/15570.misc
+++ b/changelog.d/15570.misc
@@ -1,0 +1,1 @@
+Allow `pip install` to use setuptools_rust 1.6.0 when building Synapse.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,7 +368,7 @@ furo = ">=2022.12.7,<2024.0.0"
 # system changes.
 # We are happy to raise these upper bounds upon request,
 # provided we check that it's safe to do so (i.e. that CI passes).
-requires = ["poetry-core>=1.0.0,<=1.5.0", "setuptools_rust>=1.3,<=1.5.2"]
+requires = ["poetry-core>=1.0.0,<=1.5.0", "setuptools_rust>=1.3,<=1.6.0"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
This was bumped by dependabot in #15512, but we didn't bump also raise the version guard here. I don't know how we can avoid this happening in the future.

Closes #15461.

Spotted in https://github.com/matrix-org/synapse/issues/15461#issuecomment-1543513934 by @landryb.