### PR TITLE
`traceback.format_exception(...)` usage that is compatible with Python 3.7 and 3.11

### DIFF
--- a/changelog.d/15599.bugfix
+++ b/changelog.d/15599.bugfix
@@ -1,0 +1,1 @@
+Print full error and stack-trace of any exception that occurs during startup/initialization.

--- a/synapse/app/_base.py
+++ b/synapse/app/_base.py
@@ -214,7 +214,7 @@ def handle_startup_exception(e: Exception) -> NoReturn:
     # the reactor are written to the logs, followed by a summary to stderr.
     logger.exception("Exception during startup")
 
-    error_string = "".join(traceback.format_exception(e))
+    error_string = "".join(traceback.format_exception(type(e), e, e.__traceback__))
     indented_error_string = indent(error_string, "    ")
 
     quit_with_error(


### PR DESCRIPTION
`traceback.format_exception(...)` usage that is compatible with Python 3.7 ([our current minimum supported version](https://matrix-org.github.io/synapse/latest/deprecation_policy.html)) and 3.11

> Since Python 3.10, instead of passing `value` and `tb`, an exception object can
  be passed as the first argument. If `value` and `tb` are provided, the first
  argument is ignored in order to provide backwards compatibility.
>
> -- https://docs.python.org/3/library/traceback.html

As encountered by @clokep and findings from @DMRobertson, https://matrix.to/#/!vcyiEtMVHIhWXcJAfl:sw1v.org/$GIF9SEOUOkz06kGTQzRn2alUFpiLzDruOunSC3kRAbo?via=matrix.org&via=element.io&via=pixie.town

Follow-up to https://github.com/matrix-org/synapse/pull/15569

### Dev notes

 - Types: https://github.com/python/typeshed/blob/2d5dafadb75f122e0c2aeced09a5b72232373f40/stdlib/traceback.pyi#L34-L74
 - Python source:
    - https://github.com/python/cpython/blob/a712c5f42d5904e1a1cdaf11bd1f05852cfdd830/Lib/traceback.py#L139
    - https://github.com/python/cpython/blob/a712c5f42d5904e1a1cdaf11bd1f05852cfdd830/Lib/traceback.py#L101-L102



### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
