### PR TITLE
Run mypy type checking with the minimum supported Python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,10 +95,6 @@ jobs:
       - name: Setup Poetry
         uses: matrix-org/setup-python-poetry@v1
         with:
-          # We set this as our minimum supported Python version. We use the oldest
-          # Python version because later Python versions can include some overloads
-          # which don't work in the older versions.
-          python-version: '3.8'
           # We want to make use of type hints in optional dependencies too.
           extras: all
           # We have seen odd mypy failures that were resolved when we started

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,10 @@ jobs:
       - name: Setup Poetry
         uses: matrix-org/setup-python-poetry@v1
         with:
+          # We set this as our minimum supported Python version. We use the oldest
+          # Python version because later Python versions can include some overloads
+          # which don't work in the older versions.
+          python-version: '3.7'
           # We want to make use of type hints in optional dependencies too.
           extras: all
           # We have seen odd mypy failures that were resolved when we started

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
           # We set this as our minimum supported Python version. We use the oldest
           # Python version because later Python versions can include some overloads
           # which don't work in the older versions.
-          python-version: '3.7'
+          python-version: '3.8'
           # We want to make use of type hints in optional dependencies too.
           extras: all
           # We have seen odd mypy failures that were resolved when we started

--- a/changelog.d/15602.misc
+++ b/changelog.d/15602.misc
@@ -1,0 +1,1 @@
+Run mypy type checking with the minimum supported Python version to catch new usage that isn't backwards-compatible.

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,10 @@ no_implicit_optional = True
 disallow_untyped_defs = True
 strict_equality = True
 warn_redundant_casts = True
+# We set this as our minimum supported Python version. We use the oldest Python version
+# because later Python versions can include some types, overloads, etc which don't work
+# in the older versions.
+python_version = 3.8
 
 files =
   docker/,

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,9 +13,8 @@ no_implicit_optional = True
 disallow_untyped_defs = True
 strict_equality = True
 warn_redundant_casts = True
-# We set this as our minimum supported Python version. We use the oldest Python version
-# because later Python versions can include some types, overloads, etc which don't work
-# in the older versions.
+# Run mypy type checking with the minimum supported Python version to catch new usage
+# that isn't backwards-compatible (types, overloads, etc).
 python_version = 3.8
 
 files =


### PR DESCRIPTION
Run mypy type checking with the minimum supported Python version. We use the oldest Python version because later Python versions can include some overloads which don't work in the older versions which we still support.

We're using Python 3.8 instead of 3.7 which is our actual minimum support version because it's EOL is in a matter of weeks so can avoid the extra effort. And in any case, minimum Python 3.8 support is better than winging it on Python 3.11.

Example of something that changed Python 3.10 which isn't compatible with older versions: https://github.com/matrix-org/synapse/pull/15599

### Todo

 - [x] Only merge this after we fix the existing lints/failures in CI -> https://github.com/matrix-org/synapse/issues/15603




### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
