### PR TITLE
Use `Literal` from `typing_extensions` (compatible with Python 3.7)

### DIFF
--- a/changelog.d/15605.misc
+++ b/changelog.d/15605.misc
@@ -1,0 +1,1 @@
+Fix `Literal` being imported from `typing.Literal` which is only compatible with Python 3.8+.

--- a/synapse/config/_base.pyi
+++ b/synapse/config/_base.pyi
@@ -6,7 +6,6 @@ from typing import (
     Iterable,
     Iterator,
     List,
-    Literal,
     MutableMapping,
     Optional,
     Tuple,
@@ -17,6 +16,7 @@ from typing import (
 )
 
 import jinja2
+from typing_extensions import Literal
 
 from synapse.config import (  # noqa: F401
     account_validity,


### PR DESCRIPTION
Use `Literal` from `typing_extensions` (compatible with Python 3.7)

Fix the following `mypy` errors when running `mypy` with Python 3.7:
```
synapse/config/_base.pyi:2: error: Module "typing" has no attribute "Literal"  [attr-defined]
```

Part of https://github.com/matrix-org/synapse/issues/15603

`typing.Literal` is only available in Python 3.8 or later, https://docs.python.org/3/library/typing.html#typing.Literal

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
