### PR TITLE
Fix-up event_fields in filters

### DIFF
--- a/synapse/api/filtering.py
+++ b/synapse/api/filtering.py
@@ -130,17 +130,7 @@ USER_FILTER_SCHEMA = {
         "event_format": {"type": "string", "enum": ["client", "federation"]},
         "event_fields": {
             "type": "array",
-            "items": {
-                "type": "string",
-                # Don't allow '\\' in event field filters. This makes matching
-                # events a lot easier as we can then use a negative lookbehind
-                # assertion to split '\.' If we allowed \\ then it would
-                # incorrectly split '\\.' See synapse.events.utils.serialize_event
-                #
-                # Note that because this is a regular expression, we have to escape
-                # each backslash in the pattern.
-                "pattern": r"^((?!\\\\).)*$",
-            },
+            "items": {"type": "string"},
         },
     },
     "additionalProperties": True,  # Allow new fields for forward compatibility

--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -253,6 +253,15 @@ def _copy_field(src: JsonDict, dst: JsonDict, field: List[str]) -> None:
     sub_out_dict[key_to_move] = sub_dict[key_to_move]
 
 
+def _split_field(field: str) -> List[str]:
+    # Convert the field and remove escaping:
+    #
+    # 1. "content.body.thing\.with\.dots"
+    # 2. ["content", "body", "thing\.with\.dots"]
+    # 3. ["content", "body", "thing.with.dots"]
+    return [part.replace(r"\.", r".") for part in SPLIT_FIELD_REGEX.split(field)]
+
+
 def only_fields(dictionary: JsonDict, fields: List[str]) -> JsonDict:
     """Return a new dict with only the fields in 'dictionary' which are present
     in 'fields'.
@@ -275,13 +284,7 @@ def only_fields(dictionary: JsonDict, fields: List[str]) -> JsonDict:
 
     # for each field, convert it:
     # ["content.body.thing\.with\.dots"] => [["content", "body", "thing\.with\.dots"]]
-    split_fields = [SPLIT_FIELD_REGEX.split(f) for f in fields]
-
-    # for each element of the output array of arrays:
-    # remove escaping so we can use the right key names.
-    split_fields[:] = [
-        [f.replace(r"\.", r".") for f in field_array] for field_array in split_fields
-    ]
+    split_fields = [_split_field(f) for f in fields]
 
     output: JsonDict = {}
     for field_array in split_fields:

--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -248,12 +248,21 @@ def _copy_field(src: JsonDict, dst: JsonDict, field: List[str]) -> None:
 
 
 def _split_field(field: str) -> List[str]:
-    # Convert the field and remove escaping:
-    #
-    # 1. "content.body.thing\.with\.dots"
-    # 2. ["content", "body", "thing\.with\.dots"]
-    # 3. ["content", "body", "thing.with.dots"]
+    """
+    Split strings on "." but not "\." and escape backslash escaped characters.
 
+    Convert the field and remove escaping:
+
+    1. "content.body.thing\.with\.dots"
+    2. ["content", "body", "thing\.with\.dots"]
+    3. ["content", "body", "thing.with.dots"]
+
+    Args:
+        field: A string representing a path to a field.
+
+    Returns:
+        A list of nested fields to traverse.
+    """
     result = []
 
     # The current field and whether the previous character was the escape

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -48,8 +48,6 @@ class FilteringTestCase(unittest.HomeserverTestCase):
         invalid_filters: List[JsonDict] = [
             # `account_data` must be a dictionary
             {"account_data": "Hello World"},
-            # `event_fields` entries must not contain backslashes
-            {"event_fields": [r"\\foo"]},
             # `event_format` must be "client" or "federation"
             {"event_format": "other"},
             # `not_rooms` must contain valid room IDs
@@ -114,10 +112,6 @@ class FilteringTestCase(unittest.HomeserverTestCase):
                 "event_format": "client",
                 "event_fields": ["type", "content", "sender"],
             },
-            # a single backslash should be permitted (though it is debatable whether
-            # it should be permitted before anything other than `.`, and what that
-            # actually means)
-            #
             # (note that event_fields is implemented in
             # synapse.events.utils.serialize_event, and so whether this actually works
             # is tested elsewhere. We just want to check that it is allowed through the

--- a/tests/events/test_utils.py
+++ b/tests/events/test_utils.py
@@ -825,6 +825,8 @@ class SplitFieldTestCase(stdlib_unittest.TestCase):
         ["m.", ["m", ""]],
         ["m..", ["m", "", ""]],
         ["m..foo", ["m", "", "foo"]],
+        # Invalid escape sequences.
+        ["\\m", ["\\m"]],
     ])
     def test_split_field(self, input: str, expected: str) -> None:
         self.assertEqual(_split_field(input), expected)


### PR DESCRIPTION
The Synapse filtering implementation does a few off-spec things:

* Rejects any backslashes except for `\.`.
* Does not properly unescape multiple backslashes.

This was clarified in MSC3980, but from the comments in Synapse it seems this was always supposed to be supported. You can also see the [next spec release[(https://spec.matrix.org/unstable/appendices/#dot-separated-property-paths).

This essentially ports the implementation from matrix-org/matrix-js-sdk#3134. We could have used a regular expression (probably?), but it just becomes hard to follow and I'm very unconvinced that it is faster.