### PR TITLE
WIP clear event caches when we purge history

### DIFF
--- a/synapse/state/__init__.py
+++ b/synapse/state/__init__.py
@@ -595,6 +595,7 @@ class StateResolutionHandler:
         self.resolve_linearizer = Linearizer(name="state_resolve_lock")
 
         # dict of set of event_ids -> _StateCacheEntry.
+        # TODO: Clear this when we purge history?
         self._state_cache: ExpiringCache[
             FrozenSet[int], _StateCacheEntry
         ] = ExpiringCache(

--- a/synapse/storage/databases/main/events_worker.py
+++ b/synapse/storage/databases/main/events_worker.py
@@ -903,6 +903,15 @@ class EventsWorkerStore(SQLBaseStore):
         self._event_ref.pop(event_id, None)
         self._current_event_fetches.pop(event_id, None)
 
+    def _invalidate_local_get_event_cache_all(self) -> None:
+        """Clears the in-memory get event caches.
+
+        Used when we purge room history.
+        """
+        self._get_event_cache.clear()
+        self._event_ref.clear()
+        self._current_event_fetches.clear()
+
     async def _get_events_from_cache(
         self, events: Iterable[str], update_metrics: bool = True
     ) -> Dict[str, EventCacheEntry]:

--- a/synapse/storage/databases/main/purge_events.py
+++ b/synapse/storage/databases/main/purge_events.py
@@ -64,6 +64,9 @@ class PurgeEventsStore(StateGroupWorkerStore, CacheInvalidationWorkerStore):
         token: RoomStreamToken,
         delete_local_events: bool,
     ) -> Set[int]:
+        # TODO: Also stream this
+        txn.call_after(self._invalidate_caches_for_room, room_id)
+
         # Tables that should be pruned:
         #     event_auth
         #     event_backward_extremities
@@ -346,6 +349,11 @@ class PurgeEventsStore(StateGroupWorkerStore, CacheInvalidationWorkerStore):
         return state_groups_to_delete
 
     def _purge_room_txn(self, txn: LoggingTransaction, room_id: str) -> List[int]:
+        # TODO: Also stream this
+        txn.call_after(self._invalidate_caches_for_room, room_id)
+
+        # TODO: Also clear all state caches?
+
         # This collides with event persistence so we cannot write new events and metadata into
         # a room while deleting it or this transaction will fail.
         if isinstance(self.database_engine, PostgresEngine):


### PR DESCRIPTION
This needs to be finished up by:
- [ ] Actually invalidating the commented caches
- [ ] Also invalidating state caches when we delete the room
- [ ] Streaming the invalidation to other workers. Easiest is probably to do this via a special "meta" cache name, like we do for current state (c.f. `cs_cache_fake` in the code).

This should help a little with #13476