### PR TITLE
Fix olddeps build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -314,8 +314,9 @@ jobs:
       # There aren't wheels for some of the older deps, so we need to install
       # their build dependencies
       - run: |
+          sudo apt update
           sudo apt-get -qq install build-essential libffi-dev python-dev \
-          libxml2-dev libxslt-dev xmlsec1 zlib1g-dev libjpeg-dev libwebp-dev
+            libxml2-dev libxslt-dev xmlsec1 zlib1g-dev libjpeg-dev libwebp-dev
 
       - uses: actions/setup-python@v4
         with:

--- a/changelog.d/15626.misc
+++ b/changelog.d/15626.misc
@@ -1,0 +1,1 @@
+Fix the olddeps CI.


### PR DESCRIPTION
Fixes #15608  by doing an `apt update` before attempting to install packages.