### PR TITLE
Trace how many new events from the backfill response we need to process

### DIFF
--- a/changelog.d/15633.misc
+++ b/changelog.d/15633.misc
@@ -1,0 +1,1 @@
+Trace how many new events from the backfill response we need to process.

--- a/synapse/handlers/federation_event.py
+++ b/synapse/handlers/federation_event.py
@@ -890,6 +890,11 @@ class FederationEventHandler:
             # Continue on with the events that are new to us.
             new_events.append(event)
 
+        set_tag(
+            SynapseTags.RESULT_PREFIX + "new_events.length",
+            str(len(new_events)),
+        )
+
         # We want to sort these by depth so we process them and
         # tell clients about them in order.
         sorted_events = sorted(new_events, key=lambda x: x.depth)


### PR DESCRIPTION
Trace how many new events from the backfill response we need to process.

You can kinda derive this information from how many `_process_pulled_event` spans there are but it would be nice to quickly glance.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
