### PR TITLE
Fix `@trace` not wrapping some state methods that return coroutines correctly

### DIFF
--- a/changelog.d/15647.bugfix
+++ b/changelog.d/15647.bugfix
@@ -1,1 +1,1 @@
-Fix `@trace` not wrapping some state related operations that return coroutines correctly.
+Instrument `state` and `state_group` storage-related operations to better picture what's happening when tracing.

--- a/changelog.d/15647.bugfix
+++ b/changelog.d/15647.bugfix
@@ -1,0 +1,1 @@
+Fix `@trace` not wrapping some state related operations that return coroutines correctly.

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -16,7 +16,6 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
-    Awaitable,
     Callable,
     Collection,
     Dict,

--- a/synapse/storage/controllers/state.py
+++ b/synapse/storage/controllers/state.py
@@ -175,9 +175,9 @@ class StateStorageController:
 
     @trace
     @tag_args
-    def _get_state_groups_from_groups(
+    async def _get_state_groups_from_groups(
         self, groups: List[int], state_filter: StateFilter
-    ) -> Awaitable[Dict[int, StateMap[str]]]:
+    ) -> Dict[int, StateMap[str]]:
         """Returns the state groups for a given set of groups, filtering on
         types of state events.
 
@@ -190,7 +190,9 @@ class StateStorageController:
             Dict of state group to state map.
         """
 
-        return self.stores.state._get_state_groups_from_groups(groups, state_filter)
+        return await self.stores.state._get_state_groups_from_groups(
+            groups, state_filter
+        )
 
     @trace
     @tag_args
@@ -349,9 +351,9 @@ class StateStorageController:
 
     @trace
     @tag_args
-    def get_state_for_groups(
+    async def get_state_for_groups(
         self, groups: Iterable[int], state_filter: Optional[StateFilter] = None
-    ) -> Awaitable[Dict[int, MutableStateMap[str]]]:
+    ) -> Dict[int, MutableStateMap[str]]:
         """Gets the state at each of a list of state groups, optionally
         filtering by type/state_key
 
@@ -363,7 +365,7 @@ class StateStorageController:
         Returns:
             Dict of state group to state map.
         """
-        return self.stores.state._get_state_for_groups(
+        return await self.stores.state._get_state_for_groups(
             groups, state_filter or StateFilter.all()
         )
 


### PR DESCRIPTION
*As discovered by @realtyem,*

Fix `@trace` not wrapping some state methods that return coroutines correctly

```
master | 2023-05-21 09:30:09,288 - synapse.logging.opentracing - 940 - ERROR - POST-1 - @trace may not have wrapped StateStorageController.get_state_for_groups correctly! The function is not async but returned a coroutine
```

Tracing instrumentation for these functions originally introduced in https://github.com/matrix-org/synapse/pull/15610


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
