### PR TITLE
Remove outdated comment in log config

### DIFF
--- a/changelog.d/15648.doc
+++ b/changelog.d/15648.doc
@@ -1,0 +1,1 @@
+Remove outdated comment from the generated and sample homeserver log configs.

--- a/docs/sample_log_config.yaml
+++ b/docs/sample_log_config.yaml
@@ -68,9 +68,7 @@ root:
     # Write logs to the `buffer` handler, which will buffer them together in memory,
     # then write them to a file.
     #
-    # Replace "buffer" with "console" to log to stderr instead. (Note that you'll
-    # also need to update the configuration for the `twisted` logger above, in
-    # this case.)
+    # Replace "buffer" with "console" to log to stderr instead.
     #
     handlers: [buffer]
 

--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -117,9 +117,7 @@ root:
     # Write logs to the `buffer` handler, which will buffer them together in memory,
     # then write them to a file.
     #
-    # Replace "buffer" with "console" to log to stderr instead. (Note that you'll
-    # also need to update the configuration for the `twisted` logger above, in
-    # this case.)
+    # Replace "buffer" with "console" to log to stderr instead.
     #
     handlers: [buffer]
 


### PR DESCRIPTION
The now-removed comment was introduced in https://github.com/matrix-org/synapse/pull/8040, and referenced a "twisted" logging handler. That handler has since been removed from the file, so the associated comment is no longer necessary.