### PR TITLE
Add MSC3820 (room version 11) option 2 unstable room version

### DIFF
--- a/changelog.d/15666.misc
+++ b/changelog.d/15666.misc
@@ -1,0 +1,1 @@
+Implement "option 2" for [MSC3820](https://github.com/matrix-org/matrix-spec-proposals/pull/3820): Room version 11.

--- a/synapse/api/room_versions.py
+++ b/synapse/api/room_versions.py
@@ -485,6 +485,30 @@ class RoomVersions:
         msc3931_push_features=(),
         msc3989_redaction_rules=True,
     )
+    MSC3820opt2 = RoomVersion(
+        # Based upon v10
+        "org.matrix.msc3820.opt2",
+        RoomDisposition.UNSTABLE,
+        EventFormatVersions.ROOM_V4_PLUS,
+        StateResolutionVersions.V2,
+        enforce_key_validity=True,
+        special_case_aliases_auth=False,
+        strict_canonicaljson=True,
+        limit_notifications_power_levels=True,
+        msc2175_implicit_room_creator=True,  # Used by MSC3820
+        msc2176_redaction_rules=True,  # Used by MSC3820
+        msc3083_join_rules=True,
+        msc3375_redaction_rules=True,
+        msc2403_knocking=True,
+        msc2716_historical=False,
+        msc2716_redactions=False,
+        msc3389_relation_redactions=False,
+        msc3787_knock_restricted_join_rule=True,
+        msc3667_int_only_power_levels=True,
+        msc3821_redaction_rules=True,  # Used by MSC3820
+        msc3931_push_features=(),
+        msc3989_redaction_rules=True,  # Used by MSC3820
+    )
 
 
 KNOWN_ROOM_VERSIONS: Dict[str, RoomVersion] = {


### PR DESCRIPTION
MSC: https://github.com/matrix-org/matrix-spec-proposals/pull/3820

There are no tests for this because the MSCs involved should already be tested, and when v11 is accepted there might be different test cases. Instead, it's suggested that tests get moved/created when v11 becomes stable.
