### PR TITLE
Add `dch` and `notify-send` to the development Nix flake so that the release script can be used.

### DIFF
--- a/changelog.d/15673.misc
+++ b/changelog.d/15673.misc
@@ -1,0 +1,1 @@
+Add `dch` and `notify-send` to the development Nix flake so that the release script can be used.

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,10 @@
 
                   # For building the Synapse documentation website.
                   mdbook
+
+                  # For releasing Synapse
+                  debian-devscripts # (`dch` for manipulating the Debian changelog)
+                  libnotify # (the release script uses `notify-send` to tell you when CI jobs are done)
                 ];
 
                 # Install Python and manage a virtualenv with Poetry.


### PR DESCRIPTION
Fixes: #15654 <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `release-v1.84` <!-- git-stack-base-branch:release-v1.84 -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Add dch and notify-send to the Nix dev flake 

</li>
</ol>
