### PR TITLE
Remove unused `FederationServer.__str__` override

### DIFF
--- a/changelog.d/15690.misc
+++ b/changelog.d/15690.misc
@@ -1,0 +1,1 @@
+Remove some unused code.

--- a/synapse/federation/federation_server.py
+++ b/synapse/federation/federation_server.py
@@ -1291,9 +1291,6 @@ class FederationServer(FederationBase):
                 return
             lock = new_lock
 
-    def __str__(self) -> str:
-        return "<ReplicationLayer(%s)>" % self.server_name
-
     async def exchange_third_party_invite(
         self, sender_user_id: str, target_user_id: str, room_id: str, signed: Dict
     ) -> None:


### PR DESCRIPTION
Signed-off-by: Sean Quah <seanq@matrix.org>