### PR TITLE
Speed up background jobs populate_full_user_id_user_filters and populate_full_user_id_profiles

### DIFF
--- a/changelog.d/15700.misc
+++ b/changelog.d/15700.misc
@@ -1,0 +1,1 @@
+Speed up background jobs `populate_full_user_id_user_filters` and `populate_full_user_id_profiles`.

--- a/synapse/storage/databases/main/filtering.py
+++ b/synapse/storage/databases/main/filtering.py
@@ -71,7 +71,7 @@ class FilteringWorkerStore(SQLBaseStore):
                     SELECT user_id FROM user_filters
                     WHERE user_id > ?
                     ORDER BY user_id
-                    LIMIT 1 OFFSET 50
+                    LIMIT 1 OFFSET 1000
                   """
             txn.execute(sql, (lower_bound_id,))
             res = txn.fetchone()

--- a/synapse/storage/databases/main/profile.py
+++ b/synapse/storage/databases/main/profile.py
@@ -65,7 +65,7 @@ class ProfileWorkerStore(SQLBaseStore):
                     SELECT user_id FROM profiles
                     WHERE user_id > ?
                     ORDER BY user_id
-                    LIMIT 1 OFFSET 50
+                    LIMIT 1 OFFSET 1000
                   """
             txn.execute(sql, (lower_bound_id,))
             res = txn.fetchone()


### PR DESCRIPTION
This PR increases the number of entries processed per batch for each of the jobs from 50 to 1000, as it was discovered that `populate_full_user_id_profiles` was going to take ~12 days to complete at the current speed (~50 - 60hz). I bumped up the batch size in `populate_full_user_id_profiles` preemptively as it also was only processing 50 entries per batch.

Speed determined by this query that @clokep whipped up:
```
SELECT progress_json::json->'lower_bound_id' FROM background_updates WHERE update_name = 'populate_full_user_id_profiles'; SELECT pg_sleep(60); SELECT progress_json::json->'lower_bound_id' FROM background_updates WHERE update_name = 'populate_full_user_id_profiles'; SELECT pg_sleep(60); SELECT progress_json::json->'lower_bound_id' FROM background_updates WHERE update_name = 'populate_full_user_id_profiles';
```