### PR TITLE
Add a note about deprecating /register with a user property.

### DIFF
--- a/changelog.d/15703.removal
+++ b/changelog.d/15703.removal
@@ -1,0 +1,1 @@
+Deprecate calling the `/register` endpoint with a `user` property for application services.

--- a/changelog.d/15703.removal
+++ b/changelog.d/15703.removal
@@ -1,1 +1,1 @@
-Deprecate calling the `/register` endpoint with a `user` property for application services.
+Deprecate calling the `/register` endpoint with an unspecced `user` property for application services.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -88,6 +88,17 @@ process, for example:
     dpkg -i matrix-synapse-py3_1.3.0+stretch1_amd64.deb
     ```
 
+# Upgrading to v1.85.0
+
+## Application service registration with "user" property deprecation
+
+Application services should ensure they call the `/register` endpoint with a
+`username` property. The legacy `user` property is considered deprecated and
+should no longer be included.
+
+A future version of Synapse (v1.88.0 or later) will remove support for legacy
+application service login.
+
 # Upgrading to v1.84.0
 
 ## Deprecation of `worker_replication_*` configuration settings


### PR DESCRIPTION
Part of #9547.

I chose v1.88.0+ for removal to match the deprecation given in #15317.

Targeting the release branch just to get this out a bit earlier since it is docs-only.