### PR TITLE
Add context for when/why to use the `long_retries` option when sending Federation requests

### DIFF
--- a/changelog.d/15721.misc
+++ b/changelog.d/15721.misc
@@ -1,0 +1,1 @@
+Add context for when/why to use the `long_retries` option when sending Federation requests.

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -499,8 +499,11 @@ class MatrixFederationHttpClient:
                 Note that the above intervals are *in addition* to the time spent
                 waiting for the request to complete (up to `timeout` ms).
 
-                NB: the long retry algorithm takes over 20 minutes to complete, with
-                a default timeout of 60s!
+                NB: the long retry algorithm takes over 20 minutes to complete, with a
+                default timeout of 60s! It's best not to use the `long_retries` option
+                for something that is blocking a client so we don't make them wait for
+                aaaaages, whereas some things like sending transactions (server to
+                server) you can be a lot more lenient but its very fuzzy / hand-wavey.
 
             ignore_backoff: true to ignore the historical backoff data
                 and try the request anyway.

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -503,7 +503,11 @@ class MatrixFederationHttpClient:
                 default timeout of 60s! It's best not to use the `long_retries` option
                 for something that is blocking a client so we don't make them wait for
                 aaaaages, whereas some things like sending transactions (server to
-                server) you can be a lot more lenient but its very fuzzy / hand-wavey.
+                server) we can be a lot more lenient but its very fuzzy / hand-wavey.
+
+                In the future, we could be more intelligent about doing this sort of
+                thing looking at things with the bigger picture in mind,
+                https://github.com/matrix-org/synapse/issues/8917
 
             ignore_backoff: true to ignore the historical backoff data
                 and try the request anyway.

--- a/synapse/http/matrixfederationclient.py
+++ b/synapse/http/matrixfederationclient.py
@@ -506,7 +506,7 @@ class MatrixFederationHttpClient:
                 server) we can be a lot more lenient but its very fuzzy / hand-wavey.
 
                 In the future, we could be more intelligent about doing this sort of
-                thing looking at things with the bigger picture in mind,
+                thing by looking at things with the bigger picture in mind,
                 https://github.com/matrix-org/synapse/issues/8917
 
             ignore_backoff: true to ignore the historical backoff data


### PR DESCRIPTION
Add context for when/why to use the `long_retries` option when sending Federation requests

As explained by @erikjohnston, https://matrix.to/#/!vcyiEtMVHIhWXcJAfl:sw1v.org/$b56U7pYpjMqVMUU5ZU7yYLxohdTnjSOKOtrrZi8HVVs?via=matrix.org&via=element.io&via=pixie.town

Also link future ideas around more intelligent retries that @richvdh pointed out (https://github.com/matrix-org/synapse/issues/8917).

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
