### PR TITLE
Prevent "twisted trunk" and "latest deps" workflows from running on forks

### DIFF
--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -22,7 +22,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_repo:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run_workflow: ${{ steps.check_condition.outputs.should_run_workflow }}
+    steps:
+      - id: check_condition
+        run: echo "::set-output name=should_run_workflow::${{ github.repository == 'matrix-org/synapse' }}"
+
   mypy:
+    needs: check_repo
+    if: needs.check_repo.outputs.should_run_workflow == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -47,6 +57,8 @@ jobs:
         run: sed '/warn_unused_ignores = True/d' -i mypy.ini
       - run: poetry run mypy
   trial:
+    needs: check_repo
+    if: needs.check_repo.outputs.should_run_workflow == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -105,6 +117,8 @@ jobs:
 
 
   sytest:
+    needs: check_repo
+    if: needs.check_repo.outputs.should_run_workflow == 'true'
     runs-on: ubuntu-latest
     container:
       image: matrixdotorg/sytest-synapse:testing
@@ -156,7 +170,8 @@ jobs:
 
 
   complement:
-    if: "${{ !failure() && !cancelled() }}"
+    needs: check_repo
+    if: "!failure() && !cancelled() && needs.check_repo.outputs.should_run_workflow == 'true'"
     runs-on: ubuntu-latest
 
     strategy:
@@ -192,7 +207,7 @@ jobs:
   # Open an issue if the build fails, so we know about it.
   # Only do this if we're not experimenting with this action in a PR.
   open-issue:
-    if: "failure() && github.event_name != 'push' && github.event_name != 'pull_request'"
+    if: "failure() && github.event_name != 'push' && github.event_name != 'pull_request' && needs.check_repo.outputs.should_run_workflow == 'true'"
     needs:
       # TODO: should mypy be included here? It feels more brittle than the others.
       - mypy

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -23,6 +23,10 @@ concurrency:
 
 jobs:
   check_repo:
+    # Prevent this workflow from running on any fork of Synapse other than matrix-org/synapse, as it is
+    # only useful to the Synapse core team.
+    # All other workflow steps depend on this one, thus if 'should_run_workflow' is not 'true', the rest
+    # of the workflow will be skipped as well.
     runs-on: ubuntu-latest
     outputs:
       should_run_workflow: ${{ steps.check_condition.outputs.should_run_workflow }}

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -28,7 +28,7 @@ jobs:
       should_run_workflow: ${{ steps.check_condition.outputs.should_run_workflow }}
     steps:
       - id: check_condition
-        run: echo "::set-output name=should_run_workflow::${{ github.repository == 'matrix-org/synapse' }}"
+        run: echo "should_run_workflow=${{ github.repository == 'matrix-org/synapse' }}" >> "$GITHUB_OUTPUT"
 
   mypy:
     needs: check_repo

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -25,7 +25,7 @@ jobs:
       should_run_workflow: ${{ steps.check_condition.outputs.should_run_workflow }}
     steps:
       - id: check_condition
-        run: echo "::set-output name=should_run_workflow::${{ github.repository == 'matrix-org/synapse' }}"
+        run: echo "should_run_workflow=${{ github.repository == 'matrix-org/synapse' }}" >> "$GITHUB_OUTPUT"
 
   mypy:
     needs: check_repo

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -18,7 +18,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_repo:
+    if: github.repository == 'matrix-org/synapse'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run_workflow: ${{ steps.check_condition.outputs.should_run_workflow }}
+    steps:
+      - id: check_condition
+        run: echo "::set-output name=should_run_workflow::${{ github.repository == 'matrix-org/synapse' }}"
+
   mypy:
+    needs: check_repo
+    if: needs.check_repo.outputs.should_run_workflow == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -41,6 +52,8 @@ jobs:
       - run: poetry run mypy
 
   trial:
+    needs: check_repo
+    if: needs.check_repo.outputs.should_run_workflow == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -75,6 +88,8 @@ jobs:
           || true
 
   sytest:
+    needs: check_repo
+    if: needs.check_repo.outputs.should_run_workflow == 'true'
     runs-on: ubuntu-latest
     container:
       image: matrixdotorg/sytest-synapse:buster
@@ -119,7 +134,8 @@ jobs:
             /logs/**/*.log*
 
   complement:
-    if: "${{ !failure() && !cancelled() }}"
+    needs: check_repo
+    if: "!failure() && !cancelled() && needs.check_repo.outputs.should_run_workflow == 'true'"
     runs-on: ubuntu-latest
 
     strategy:
@@ -166,7 +182,7 @@ jobs:
 
   # open an issue if the build fails, so we know about it.
   open-issue:
-    if: failure()
+    if: failure() && needs.check_repo.outputs.should_run_workflow == 'true'
     needs:
       - mypy
       - trial

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -19,6 +19,10 @@ concurrency:
 
 jobs:
   check_repo:
+    # Prevent this workflow from running on any fork of Synapse other than matrix-org/synapse, as it is
+    # only useful to the Synapse core team.
+    # All other workflow steps depend on this one, thus if 'should_run_workflow' is not 'true', the rest
+    # of the workflow will be skipped as well.
     if: github.repository == 'matrix-org/synapse'
     runs-on: ubuntu-latest
     outputs:

--- a/changelog.d/15726.misc
+++ b/changelog.d/15726.misc
@@ -1,0 +1,1 @@
+Prevent the `latest_deps` and `twisted_trunk` daily GitHub Actions workflows from running on forks of the codebase.


### PR DESCRIPTION
This PR modifies the [latest_deps.yml](https://github.com/matrix-org/synapse/blob/develop/.github/workflows/latest_deps.yml) and [twisted_trunk.yml](https://github.com/matrix-org/synapse/blob/develop/.github/workflows/twisted_trunk.yml) GitHub Actions workflows - which typically run at 7 and 8am UTC respectively - such that they now only run if they are attached to the `matrix-org/synapse` repo. As a result, anyone with a fork of matrix-org/synapse will no longer have these jobs run on their fork.

Together, these two jobs check the default branch of the repository (`develop`) will not become incompatible with recently-released versions of our dependencies. This information is not very useful to people outside of our team.

As well as [preventing daily email spam](https://matrix.to/#/!vcyiEtMVHIhWXcJAfl:sw1v.org/$71UwqtDNNtx1bOdULYT4gok518yKGGGB1zQ9qIRmI58?via=matrix.org&via=element.io&via=envs.net), turning these off for contributors also reduces a significant amount of GitHub Actions jobs that are running daily across all of our forks. :evergreen_tree: 