### PR TITLE
pyproject.toml: Respect semantic versioning for requires

### DIFF
--- a/changelog.d/15727.misc
+++ b/changelog.d/15727.misc
@@ -1,0 +1,1 @@
+Allow building with poetry-core<1.7 and setuptools_rust<1.7 instead of <=1.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -369,7 +369,7 @@ furo = ">=2022.12.7,<2024.0.0"
 # system changes.
 # We are happy to raise these upper bounds upon request,
 # provided we check that it's safe to do so (i.e. that CI passes).
-requires = ["poetry-core>=1.1.0,<=1.6.0", "setuptools_rust>=1.3,<=1.6.0"]
+requires = ["poetry-core>=1.1.0,<1.7", "setuptools_rust>=1.3,<1.7"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
If poetry-core 1.6.0 and setuptools_rust 1.6.0 are good enough, there's no reason to prevent using version 1.6.1 of the same packages. Hence, change "<=1.6.0" into "<1.7".