### PR TITLE
No need for the extra join since `membership` is built-in to `current_state_events`

### DIFF
--- a/changelog.d/15731.misc
+++ b/changelog.d/15731.misc
@@ -1,0 +1,1 @@
+Remove redundant table join with `room_memberships` when doing a `is_host_joined()`/`is_host_invited()` call (`membership` is already part of the `current_state_events`).

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -927,11 +927,10 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
             raise Exception("Invalid host name")
 
         sql = """
-            SELECT state_key FROM current_state_events AS c
-            INNER JOIN room_memberships AS m USING (event_id)
-            WHERE m.membership = ?
+            SELECT state_key FROM current_state_events
+            WHERE membership = ?
                 AND type = 'm.room.member'
-                AND c.room_id = ?
+                AND room_id = ?
                 AND state_key LIKE ?
             LIMIT 1
         """


### PR DESCRIPTION
No need for the extra join since `membership` is built-in to the `current_state_events` table. This helps with the upstream `is_host_joined()` and `is_host_invited()` functions.

`membership` was added to `current_state_events` in https://github.com/matrix-org/synapse/pull/5706 and forced in https://github.com/matrix-org/synapse/pull/13745

Follow-up PRs:

 - https://github.com/matrix-org/synapse/pull/15733
 - https://github.com/matrix-org/synapse/pull/15732
 - https://github.com/matrix-org/synapse/pull/15734
 - https://github.com/matrix-org/synapse/pull/15735


### Dev notes


```sh
$ psql --user postgres synapse
synapse=# \d+ current_state_events
                                          Table "public.current_state_events"
        Column         |  Type  | Collation | Nullable | Default | Storage  | Compression | Stats target | Description
-----------------------+--------+-----------+----------+---------+----------+-------------+--------------+-------------
 event_id              | text   |           | not null |         | extended |             |              |
 room_id               | text   |           | not null |         | extended |             |              |
 type                  | text   |           | not null |         | extended |             |              |
 state_key             | text   |           | not null |         | extended |             |              |
 membership            | text   |           |          |         | extended |             |              |
 event_stream_ordering | bigint |           |          |         | plain    |             |              |
Indexes:
    "current_state_events_event_id_key" UNIQUE CONSTRAINT, btree (event_id)
    "current_state_events_member_index" btree (state_key) WHERE type = 'm.room.member'::text
    "current_state_events_room_id_type_state_key_key" UNIQUE CONSTRAINT, btree (room_id, type, state_key)
Foreign-key constraints:
    "event_stream_ordering_fkey" FOREIGN KEY (event_stream_ordering) REFERENCES events(stream_ordering) NOT VALID
Triggers:
    check_event_stream_ordering BEFORE INSERT OR UPDATE ON current_state_events FOR EACH ROW EXECUTE FUNCTION check_event_stream_ordering()
Access method: heap

synapse=# \q
```


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
