### PR TITLE
Remove extra `current_state_events` join from queries to grab profile info

### DIFF
--- a/changelog.d/15734.misc
+++ b/changelog.d/15734.misc
@@ -1,0 +1,1 @@
+Remove redundant table join with `current_state_events` when doing a `get_users_in_room_with_profiles()`/`get_subset_users_in_room_with_profiles()` call.

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -220,16 +220,12 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
             txn: LoggingTransaction,
         ) -> Dict[str, ProfileInfo]:
             clause, ids = make_in_list_sql_clause(
-                self.database_engine, "c.state_key", user_ids
+                self.database_engine, "user_id", user_ids
             )
 
             sql = """
-                SELECT state_key, display_name, avatar_url FROM room_memberships as m
-                INNER JOIN current_state_events as c
-                ON m.event_id = c.event_id
-                AND m.room_id = c.room_id
-                AND m.user_id = c.state_key
-                WHERE c.type = 'm.room.member' AND c.room_id = ? AND m.membership = ? AND %s
+                SELECT state_key, display_name, avatar_url FROM room_memberships
+                WHERE room_id = ? AND membership = ? AND %s
             """ % (
                 clause,
             )
@@ -267,12 +263,8 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
             txn: LoggingTransaction,
         ) -> Dict[str, ProfileInfo]:
             sql = """
-                SELECT state_key, display_name, avatar_url FROM room_memberships as m
-                INNER JOIN current_state_events as c
-                ON m.event_id = c.event_id
-                AND m.room_id = c.room_id
-                AND m.user_id = c.state_key
-                WHERE c.type = 'm.room.member' AND c.room_id = ? AND m.membership = ?
+                SELECT state_key, display_name, avatar_url FROM room_memberships
+                WHERE room_id = ? AND membership = ?
             """
             txn.execute(sql, (room_id, Membership.JOIN))
 

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -224,7 +224,7 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
             )
 
             sql = """
-                SELECT state_key, display_name, avatar_url FROM room_memberships
+                SELECT user_id, display_name, avatar_url FROM room_memberships
                 WHERE room_id = ? AND membership = ? AND %s
             """ % (
                 clause,
@@ -263,7 +263,7 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
             txn: LoggingTransaction,
         ) -> Dict[str, ProfileInfo]:
             sql = """
-                SELECT state_key, display_name, avatar_url FROM room_memberships
+                SELECT user_id, display_name, avatar_url FROM room_memberships
                 WHERE room_id = ? AND membership = ?
             """
             txn.execute(sql, (room_id, Membership.JOIN))


### PR DESCRIPTION
Remove extra `current_state_events` join from queries to grab profile info

Spawning from https://github.com/matrix-org/synapse/pull/15731

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
