### PR TITLE
Simplify query to `_count_known_servers()` for the `synapse_federation_known_servers` metric

### DIFF
--- a/changelog.d/15735.misc
+++ b/changelog.d/15735.misc
@@ -1,0 +1,1 @@
+Simplify query to `_count_known_servers()` for the `synapse_federation_known_servers` metric.

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -132,11 +132,9 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
                     SELECT COUNT(DISTINCT substr(out.user_id, pos+1))
                     FROM (
                         SELECT
-                            rm.user_id AS user_id,
-                            instr(rm.user_id, ':') AS pos
-                        FROM room_memberships as rm
-                        INNER JOIN current_state_events as c ON rm.event_id = c.event_id
-                        WHERE c.type = 'm.room.member'
+                            user_id AS user_id,
+                            instr(user_id, ':') AS pos
+                        FROM room_memberships
                     ) as out
                 """
             else:

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -131,8 +131,10 @@ class RoomMemberWorkerStore(EventsWorkerStore, CacheInvalidationWorkerStore):
                 query = """
                     SELECT COUNT(DISTINCT substr(out.user_id, pos+1))
                     FROM (
-                        SELECT rm.user_id as user_id, instr(rm.user_id, ':')
-                            AS pos FROM room_memberships as rm
+                        SELECT
+                            rm.user_id AS user_id,
+                            instr(rm.user_id, ':') AS pos
+                        FROM room_memberships as rm
                         INNER JOIN current_state_events as c ON rm.event_id = c.event_id
                         WHERE c.type = 'm.room.member'
                     ) as out


### PR DESCRIPTION
Simplify query to `_count_known_servers()` for the `synapse_federation_known_servers` metric

Spawning from https://github.com/matrix-org/synapse/pull/15731

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
