### PR TITLE
Avoid backfill when we already have messages to return

### DIFF
--- a/changelog.d/15737.feature
+++ b/changelog.d/15737.feature
@@ -1,0 +1,1 @@
+Improve `/messages` response time by avoiding backfill when we already have messages to return.

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -41,8 +41,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # How many single event gaps we tolerate returning in a `/messages` response before we
-# backfill and try to fill in the history. This is an arbitrarily picked number and may
-# need to be tuned in the future.
+# backfill and try to fill in the history. This is an arbitrarily picked number so feel
+# free to tune it in the future.
 BACKFILL_BECAUSE_TOO_MANY_GAPS_THRESHOLD = 3
 
 

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -41,7 +41,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # How many single events we tolerate returning in a `/messages` response before we
-# backfill and try to fill in the history
+# backfill and try to fill in the history. This is an arbitrarily picked number and may
+# need to be tuned in the future.
 BACKFILL_BECAUSE_TOO_MANY_GAPS_THRESHOLD = 3
 
 

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# How many single events we tolerate returning in a `/messages` response before we
+# How many single event gaps we tolerate returning in a `/messages` response before we
 # backfill and try to fill in the history. This is an arbitrarily picked number and may
 # need to be tuned in the future.
 BACKFILL_BECAUSE_TOO_MANY_GAPS_THRESHOLD = 3

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -564,6 +564,10 @@ class PaginationHandler:
                     # attempts and we could just treat it like a dead branch of history
                     # for now or at least something that we don't need the block the
                     # client on to try pulling.
+                    #
+                    # XXX: If we had something like MSC3871 to indicate gaps in the
+                    # timeline to the client, we could also get away with any sized gap
+                    # and just have the client refetch the holes as they see fit.
                     if depth_gap > 2:
                         found_big_gap = True
                         break

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -537,7 +537,9 @@ class PaginationHandler:
 
                 found_big_gap = False
                 number_of_gaps = 0
-                previous_event_depth = sorted_event_depths[0]
+                previous_event_depth = (
+                    sorted_event_depths[0] if len(sorted_event_depths) > 0 else 0
+                )
                 for event_depth in sorted_event_depths:
                     # We don't expect a negative depth but we'll just deal with it in
                     # any case by taking the absolute value to get the true gap between

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -536,6 +536,7 @@ class PaginationHandler:
                 event_depths: Set[int] = {event.depth for event in events}
                 sorted_event_depths = sorted(event_depths)
 
+                # Inspect the depths of the returned events to see if there are any gaps
                 found_big_gap = False
                 number_of_gaps = 0
                 previous_event_depth = (

--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -522,7 +522,11 @@ class PaginationHandler:
                 number_of_gaps = 0
                 previous_event_depth = None
                 for event_depth in sorted_event_depths:
-                    depth_gap = event_depth - previous_event_depth
+                    depth_gap = (
+                        event_depth - previous_event_depth
+                        if previous_event_depth is not None
+                        else 0
+                    )
                     if depth_gap > 0:
                         number_of_gaps += 1
 
@@ -535,7 +539,7 @@ class PaginationHandler:
                     # given events `prev_events` is one that has failed pull attempts and we
                     # could just treat it like a dead branch of history for now or at least
                     # something that we don't need the block the client on to try pulling.
-                    if event_depth - previous_event_depth > 1:
+                    if depth_gap > 1:
                         found_big_gap = True
                         break
                     previous_event_depth = event_depth


### PR DESCRIPTION
Avoid backfill when we already have messages to return.

We now only block the client to backfill when we see a large gap in the events (more than 2 events missing in a row according to `depth`), more than 3 single-event holes, or not enough messages to fill the response. Otherwise, we return the messages directly to the client and backfill in the background for eventual consistency sake. 

Fix https://github.com/matrix-org/synapse/issues/15696


#### Figure out if this change would skip backfill in a real-world scenario

For a real-world example with the [trace linked from the issue](https://github.com/matrix-org/synapse/issues/15696) (from viewing the Matrix Public Archive), it makes the following `/messages` request. If we run the JS snippet over the response, we can see that there are no gaps in response and we didn't really need to backfill at all. Which means this PR is a good change and would allow us not to block the client waiting for backfill which equates to 14s savings out of that 16s request!

`GET https://matrix-client.matrix.org/_matrix/client/r0/rooms/!OGEhHVWSdvArJzumhm%3Amatrix.org/messages?dir=b&from=t535491-3610842373_0_0_0_0_0_0_0_0_0&limit=101&filter=%7B%22lazy_load_members%22%3Atrue%2C%22event_format%22%3A%22federation%22%7D`

```js
(() => {
    const rawEventDepthList = messagesResponse1.chunk.map((event) => {
        return event.depth;
    });
    // Unique sorted event depths
    const sortedEventDepths = Array.from(new Set(rawEventDepthList.sort()).values());

    let foundBigGap = false;
    let numberOfGaps = 0;
    let previousEventDepth = sortedEventDepths[0];
    for (const eventDepth of sortedEventDepths) {
        const depthGap = eventDepth - previousEventDepth;
        console.log('depthGap', depthGap);
        if (depthGap > 1) {
            numberOfGaps += 1;
        }

        if (depthGap > 2) {
            foundBigGap = true;
        }

        previousEventDepth = eventDepth;
    }

    console.log('numberOfGaps', numberOfGaps);
    console.log('foundBigGap', foundBigGap);
})();
```


### Dev notes

Other PR where we did some backfill/processing in the background, https://github.com/matrix-org/synapse/pull/15585

[MSC3871](https://github.com/matrix-org/matrix-spec-proposals/pull/3871): Gappy timelines




### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
