### PR TITLE
Fix schema delta error in 1.85

### DIFF
--- a/changelog.d/15738.bugfix
+++ b/changelog.d/15738.bugfix
@@ -1,0 +1,1 @@
+Fix bug in schema delta that broke upgrades for some deployments. Introduced in v1.85.0.

--- a/synapse/storage/schema/main/delta/77/05thread_notifications_backfill.sql
+++ b/synapse/storage/schema/main/delta/77/05thread_notifications_backfill.sql
@@ -22,11 +22,13 @@ DELETE FROM background_updates WHERE update_name = 'event_push_backfill_thread_i
 UPDATE event_push_actions_staging SET thread_id = 'main' WHERE thread_id IS NULL;
 UPDATE event_push_actions SET thread_id = 'main' WHERE thread_id IS NULL;
 
+-- Empirically we can end up with entries in the push summary table with both a
+-- `NULL` and `main` thread ID, which causes the update below to fail. We fudge
+-- this by deleting any `NULL` rows that have a corresponding `main`.
 DELETE FROM event_push_summary AS a WHERE thread_id IS NULL AND EXISTS (
     SELECT 1 FROM event_push_summary AS b
     WHERE b.thread_id = 'main' AND a.user_id = b.user_id AND a.room_id = b.room_id
 );
-
 UPDATE event_push_summary SET thread_id = 'main' WHERE thread_id IS NULL;
 
 -- Drop the background updates to calculate the indexes used to find null thread_ids.

--- a/synapse/storage/schema/main/delta/77/05thread_notifications_backfill.sql
+++ b/synapse/storage/schema/main/delta/77/05thread_notifications_backfill.sql
@@ -21,6 +21,12 @@ DELETE FROM background_updates WHERE update_name = 'event_push_backfill_thread_i
 -- Overwrite any null thread_id values.
 UPDATE event_push_actions_staging SET thread_id = 'main' WHERE thread_id IS NULL;
 UPDATE event_push_actions SET thread_id = 'main' WHERE thread_id IS NULL;
+
+DELETE FROM event_push_summary AS a WHERE thread_id IS NULL AND EXISTS (
+    SELECT 1 FROM event_push_summary AS b
+    WHERE b.thread_id = 'main' AND a.user_id = b.user_id AND a.room_id = b.room_id
+);
+
 UPDATE event_push_summary SET thread_id = 'main' WHERE thread_id IS NULL;
 
 -- Drop the background updates to calculate the indexes used to find null thread_ids.


### PR DESCRIPTION
There appears to be a race where you can end up with entries in `event_push_summary` with both a `NULL` and `main` thread ID.

Fixes #15736

Introduced in https://github.com/matrix-org/synapse/pull/15597