### PR TITLE
Fix MSC3983 support: Use the unstable /keys/claim federation endpoint if multiple keys are requested

### DIFF
--- a/changelog.d/15755.misc
+++ b/changelog.d/15755.misc
@@ -1,1 +1,1 @@
-Fix requesting multiple keys at once over federation, related to [MSC3984](https://github.com/matrix-org/matrix-spec-proposals/pull/3984).
+Fix requesting multiple keys at once over federation, related to [MSC3983](https://github.com/matrix-org/matrix-spec-proposals/pull/3983).

--- a/changelog.d/15755.misc
+++ b/changelog.d/15755.misc
@@ -1,0 +1,1 @@
+Fix requesting multiple keys at once over federation, related to [MSC3984](https://github.com/matrix-org/matrix-spec-proposals/pull/3984).

--- a/synapse/federation/federation_client.py
+++ b/synapse/federation/federation_client.py
@@ -260,7 +260,9 @@ class FederationClient(FederationBase):
         use_unstable = False
         for user_id, one_time_keys in query.items():
             for device_id, algorithms in one_time_keys.items():
-                if any(count > 1 for count in algorithms.values()):
+                # If more than one algorithm is requested, attempt to use the unstable
+                # endpoint.
+                if sum(algorithms.values()) > 1:
                     use_unstable = True
                 if algorithms:
                     # For the stable query, choose only the first algorithm.
@@ -296,6 +298,7 @@ class FederationClient(FederationBase):
         else:
             logger.debug("Skipping unstable claim client keys API")
 
+        # TODO Potentially attempt multiple queries and combine the results?
         return await self.transport_layer.claim_client_keys(
             user, destination, content, timeout
         )


### PR DESCRIPTION
Not just if one key is requested multiple times, e.g. `{"algo1": 2}` and {`"algo1": 1, "algo2": 1}` should both use unstable.