### PR TITLE
Fix joining rooms through aliases where the alias server isn't a real homeserver

### DIFF
--- a/changelog.d/15776.bugfix
+++ b/changelog.d/15776.bugfix
@@ -1,0 +1,1 @@
+Fix joining rooms through aliases where the alias server isn't a real homeserver. Contributed by @tulir @ Beeper

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -1498,7 +1498,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         # put the server which owns the alias at the front of the server list.
         if room_alias.domain in servers:
             servers.remove(room_alias.domain)
-        servers.insert(0, room_alias.domain)
+            servers.insert(0, room_alias.domain)
 
         return RoomID.from_string(room_id), servers
 


### PR DESCRIPTION
Like https://github.com/tulir/mauliasproxy

I think it'd also work if the server returned a properly formatted `M_NOT_FOUND` code, so I'll probably make mauliasproxy do that too, but I don't think synapse should insert the room alias server to the list if it's not already there.