### PR TITLE
push rules: fix internal conversion from _type to value

### DIFF
--- a/changelog.d/15781.bugfix
+++ b/changelog.d/15781.bugfix
@@ -1,0 +1,1 @@
+Fix a bug in push rules handling leading to an invalid (per spec) `is_user_mention` rule sent to clients.

--- a/changelog.d/15781.bugfix
+++ b/changelog.d/15781.bugfix
@@ -1,1 +1,1 @@
-Fix a bug in push rules handling leading to an invalid (per spec) `is_user_mention` rule sent to clients.
+Fix a bug in push rules handling leading to an invalid (per spec) `is_user_mention` rule sent to clients. Also fix wrong rule names for `is_user_mention` and `is_room_mention`.

--- a/rust/src/push/base_rules.rs
+++ b/rust/src/push/base_rules.rs
@@ -142,7 +142,7 @@ pub const BASE_APPEND_OVERRIDE_RULES: &[PushRule] = &[
         default_enabled: true,
     },
     PushRule {
-        rule_id: Cow::Borrowed("global/override/.m.is_user_mention"),
+        rule_id: Cow::Borrowed("global/override/.m.rule.is_user_mention"),
         priority_class: 5,
         conditions: Cow::Borrowed(&[Condition::Known(
             KnownCondition::ExactEventPropertyContainsType(EventPropertyIsTypeCondition {
@@ -163,7 +163,7 @@ pub const BASE_APPEND_OVERRIDE_RULES: &[PushRule] = &[
         default_enabled: true,
     },
     PushRule {
-        rule_id: Cow::Borrowed("global/override/.m.is_room_mention"),
+        rule_id: Cow::Borrowed("global/override/.m.rule.is_room_mention"),
         priority_class: 5,
         conditions: Cow::Borrowed(&[
             Condition::Known(KnownCondition::EventPropertyIs(EventPropertyIsCondition {

--- a/synapse/push/clientformat.py
+++ b/synapse/push/clientformat.py
@@ -41,13 +41,6 @@ def format_push_rules_for_user(
 
         rulearray.append(template_rule)
 
-        for type_key in ("pattern", "value"):
-            type_value = template_rule.pop(f"{type_key}_type", None)
-            if type_value == "user_id":
-                template_rule[type_key] = user.to_string()
-            elif type_value == "user_localpart":
-                template_rule[type_key] = user.localpart
-
         template_rule["enabled"] = enabled
 
         if "conditions" not in template_rule:
@@ -63,15 +56,12 @@ def format_push_rules_for_user(
         for c in template_rule["conditions"]:
             c.pop("_cache_key", None)
 
-            pattern_type = c.pop("pattern_type", None)
-            if pattern_type == "user_id":
-                c["pattern"] = user.to_string()
-            elif pattern_type == "user_localpart":
-                c["pattern"] = user.localpart
-
-            sender_type = c.pop("sender_type", None)
-            if sender_type == "user_id":
-                c["sender"] = user.to_string()
+            for type_key in ("pattern", "sender", "value"):
+                type_value = c.pop(f"{type_key}_type", None)
+                if type_value == "user_id":
+                    c[type_key] = user.to_string()
+                elif type_value == "user_localpart":
+                    c[type_key] = user.localpart
 
     return rules
 

--- a/synapse/push/clientformat.py
+++ b/synapse/push/clientformat.py
@@ -41,6 +41,8 @@ def format_push_rules_for_user(
 
         rulearray.append(template_rule)
 
+        _convert_type_to_value(template_rule, user)
+
         template_rule["enabled"] = enabled
 
         if "conditions" not in template_rule:
@@ -56,14 +58,18 @@ def format_push_rules_for_user(
         for c in template_rule["conditions"]:
             c.pop("_cache_key", None)
 
-            for type_key in ("pattern", "sender", "value"):
-                type_value = c.pop(f"{type_key}_type", None)
-                if type_value == "user_id":
-                    c[type_key] = user.to_string()
-                elif type_value == "user_localpart":
-                    c[type_key] = user.localpart
+            _convert_type_to_value(c, user)
 
     return rules
+
+
+def _convert_type_to_value(rule_or_cond: Dict[str, Any], user: UserID) -> None:
+    for type_key in ("pattern", "value"):
+        type_value = rule_or_cond.pop(f"{type_key}_type", None)
+        if type_value == "user_id":
+            rule_or_cond[type_key] = user.to_string()
+        elif type_value == "user_localpart":
+            rule_or_cond[type_key] = user.localpart
 
 
 def _add_empty_priority_class_arrays(d: Dict[str, list]) -> Dict[str, list]:

--- a/tests/rest/client/test_push_rule_attrs.py
+++ b/tests/rest/client/test_push_rule_attrs.py
@@ -428,14 +428,27 @@ class PushRuleAttributesTestCase(HomeserverTestCase):
         )
 
         self.assertEqual(channel.code, 200)
-        self.assertIn("pattern", channel.json_body)
-        self.assertEqual(channel.json_body["pattern"], username)
+
+        self.assertEqual(
+            {
+                "rule_id": ".m.rule.contains_user_name",
+                "default": True,
+                "enabled": True,
+                "pattern": "bob",
+                "actions": [
+                    "notify",
+                    {"set_tweak": "highlight"},
+                    {"set_tweak": "sound", "value": "default"},
+                ],
+            },
+            channel.json_body,
+        )
 
     def test_is_user_mention(self) -> None:
         """
         Tests that `is_user_mention` rule is present and have proper value in `value`.
         """
-        user = self.register_user("bob", "pass")
+        self.register_user("bob", "pass")
         token = self.login("bob", "pass")
 
         channel = self.make_request(
@@ -445,7 +458,24 @@ class PushRuleAttributesTestCase(HomeserverTestCase):
         )
 
         self.assertEqual(channel.code, 200)
-        self.assertIn("conditions", channel.json_body)
-        self.assertEqual(len(channel.json_body["conditions"]), 1)
-        self.assertIn("value", channel.json_body["conditions"][0])
-        self.assertEqual(channel.json_body["conditions"][0]["value"], user)
+
+        self.assertEqual(
+            {
+                "rule_id": ".m.rule.is_user_mention",
+                "default": True,
+                "enabled": True,
+                "conditions": [
+                    {
+                        "kind": "event_property_contains",
+                        "key": "content.m\\.mentions.user_ids",
+                        "value": "@bob:test",
+                    }
+                ],
+                "actions": [
+                    "notify",
+                    {"set_tweak": "highlight"},
+                    {"set_tweak": "sound", "value": "default"},
+                ],
+            },
+            channel.json_body,
+        )

--- a/tests/rest/client/test_push_rule_attrs.py
+++ b/tests/rest/client/test_push_rule_attrs.py
@@ -434,7 +434,7 @@ class PushRuleAttributesTestCase(HomeserverTestCase):
                 "rule_id": ".m.rule.contains_user_name",
                 "default": True,
                 "enabled": True,
-                "pattern": "bob",
+                "pattern": username,
                 "actions": [
                     "notify",
                     {"set_tweak": "highlight"},
@@ -448,7 +448,7 @@ class PushRuleAttributesTestCase(HomeserverTestCase):
         """
         Tests that `is_user_mention` rule is present and have proper value in `value`.
         """
-        self.register_user("bob", "pass")
+        user = self.register_user("bob", "pass")
         token = self.login("bob", "pass")
 
         channel = self.make_request(
@@ -468,7 +468,7 @@ class PushRuleAttributesTestCase(HomeserverTestCase):
                     {
                         "kind": "event_property_contains",
                         "key": "content.m\\.mentions.user_ids",
-                        "value": "@bob:test",
+                        "value": user,
                     }
                 ],
                 "actions": [

--- a/tests/rest/client/test_push_rule_attrs.py
+++ b/tests/rest/client/test_push_rule_attrs.py
@@ -412,3 +412,41 @@ class PushRuleAttributesTestCase(HomeserverTestCase):
         )
         self.assertEqual(channel.code, 404)
         self.assertEqual(channel.json_body["errcode"], Codes.NOT_FOUND)
+
+
+    def test_contains_user_name(self) -> None:
+        """
+        Tests that `contains_user_name` rule is present and have proper value in `pattern`.
+        """
+        username = "bob"
+        self.register_user(username, "pass")
+        token = self.login(username, "pass")
+
+        channel = self.make_request(
+            "GET",
+            "/pushrules/global/content/.m.rule.contains_user_name",
+            access_token=token,
+        )
+
+        self.assertEqual(channel.code, 200)
+        self.assertIn("pattern", channel.json_body)
+        self.assertEqual(channel.json_body["pattern"], username)
+
+    def test_is_user_mention(self) -> None:
+        """
+        Tests that `is_user_mention` rule is present and have proper value in `value`.
+        """
+        user = self.register_user("bob", "pass")
+        token = self.login("bob", "pass")
+
+        channel = self.make_request(
+            "GET",
+            "/pushrules/global/override/.m.rule.is_user_mention",
+            access_token=token,
+        )
+
+        self.assertEqual(channel.code, 200)
+        self.assertIn("conditions", channel.json_body)
+        self.assertEqual(len(channel.json_body["conditions"]), 1)
+        self.assertIn("value", channel.json_body["conditions"][0])
+        self.assertEqual(channel.json_body["conditions"][0]["value"], user)

--- a/tests/rest/client/test_push_rule_attrs.py
+++ b/tests/rest/client/test_push_rule_attrs.py
@@ -413,7 +413,6 @@ class PushRuleAttributesTestCase(HomeserverTestCase):
         self.assertEqual(channel.code, 404)
         self.assertEqual(channel.json_body["errcode"], Codes.NOT_FOUND)
 
-
     def test_contains_user_name(self) -> None:
         """
         Tests that `contains_user_name` rule is present and have proper value in `pattern`.


### PR DESCRIPTION
Also fix wrong rule names for `is_user_mention` and `is_room_mention`.

So we don't store a specific push rule per user, Synapse uses an internal generic representation for `is_user_mention`, and convert it to a spec compliant push rule on the fly.

This conversion is currently happening at the root of the push rule object while it should also be done for each of its `condition`.

Fix #15780.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
