### PR TITLE
Don't always lock "user_ips" table when performing non-native upsert

### DIFF
--- a/changelog.d/15788.bugfix
+++ b/changelog.d/15788.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in 1.57.0 where the wrong table would be locked on updating database rows when using SQLite as the database backend.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1529,7 +1529,7 @@ class DatabasePool:
         # Lock the table just once, to prevent it being done once per row.
         # Note that, according to Postgres' documentation, once obtained,
         # the lock is held for the remainder of the current transaction.
-        self.engine.lock_table(txn, "user_ips")
+        self.engine.lock_table(txn, table)
 
         for keyv, valv in zip(key_values, value_values):
             _keys = dict(zip(key_names, keyv))


### PR DESCRIPTION
This seems to have been a typo in https://github.com/matrix-org/synapse/pull/12252