### PR TITLE
Fix Sytest environmental variable evaluation in CI 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -399,8 +399,8 @@ jobs:
       env:
         SYTEST_BRANCH: ${{ github.head_ref }}
         POSTGRES: ${{ matrix.job.postgres && 1}}
-        MULTI_POSTGRES: ${{ (matrix.job.postgres == 'multi-postgres') && 1}}
-        ASYNCIO_REACTOR: ${{ (matrix.job.reactor == 'asyncio') && 1 }}
+        MULTI_POSTGRES: ${{ (matrix.job.postgres == 'multi-postgres') || '' }}
+        ASYNCIO_REACTOR: ${{ (matrix.job.reactor == 'asyncio') || '' }}
         WORKERS: ${{ matrix.job.workers && 1 }}
         BLACKLIST: ${{ matrix.job.workers && 'synapse-blacklist-with-workers' }}
         TOP: ${{ github.workspace }}

--- a/changelog.d/15804.bugfix
+++ b/changelog.d/15804.bugfix
@@ -1,0 +1,1 @@
+Fix Sytest environmental variable evaluation in CI.


### PR DESCRIPTION
This was subtle: the code as it was before this change assigned the Sytest environment variables with an expression that evaluated to either true or false. However, since the Sytest script only checks that the environment variable is non-empty, the environment variables that were assigned false were still counted and the part of the script run gated by that variable still ran. In practice this means that Sytest has been running on mulitpostgres for all of it's runs. 
This PR fixes this by replacing the expression that evaluated to true or false with one that evaluates to either true or an empty string. You can verify that this change is correct by checking the output of the Sytest runs below against the expected output from https://github.com/matrix-org/sytest/blob/develop/scripts/synapse_sytest.sh.