### PR TITLE
Ignore key request if the device inbox is already big

### DIFF
--- a/changelog.d/15808.misc
+++ b/changelog.d/15808.misc
@@ -1,0 +1,1 @@
+Ignore key request if the device inbox is already big.


### PR DESCRIPTION
I noticed that my Android device wasn't catching up even with Element Web open. (it) was stuck with hundreds `/keys/query` requests.

This PR is trying to avoid the backlog to get the new `/keys/query` through

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
