### PR TITLE
Fix could not serialize access due to concurrent `DELETE` from presence_stream

### DIFF
--- a/changelog.d/15826.misc
+++ b/changelog.d/15826.misc
@@ -1,0 +1,1 @@
+Use lower isolation level when cleaning old presence stream data to avoid serialization errors.


### PR DESCRIPTION
* Fixes #15827
 
I considered(and tested) using a Linearizer for this, I liked it's queueing behavior. However on further investigation, I found out that this type of situation has occurred before in Synapse history and was simply changing the isolation level to be slightly less strict than the default of `REPEATABLE_READ`. Using `READ_COMMITTED` allows the `DELETE` transaction to continue, even if it means the `DELETE` not seeing the concurrent transaction taking place to add a lower Stream ID(that this `DELETE` would otherwise have removed). Since either function will run again shortly, it will then subsequently remove the lower Stream ID entry and all will be well. The Postgres docs suggest that depending on the order of the transaction, it may still go ahead and `DELETE` the row anyways instead of ignoring it, which seems to have been the intended behavior.

> ... DELETE,... commands behave the same as SELECT in terms of searching for target rows: they will only find target rows that were committed as of the command start time. However, such a target row might have already been updated (or deleted or locked) by another concurrent transaction by the time it is found. In this case, the would-be updater will wait for the first updating transaction to commit or roll back (if it is still in progress). If the first updater rolls back, then its effects are negated and the second updater can proceed with updating the originally found row. If the first updater commits, the second updater will ignore the row if the first updater deleted it, otherwise it will attempt to apply its operation to the updated version of the row. The search condition of the command (the WHERE clause) is re-evaluated to see if the updated version of the row still matches the search condition. If so, the second updater proceeds with its operation using the updated version of the row.

Related docs and PRs/Issues:
* #12957
* #12942
* #10294
* #11567
* [Postgres docs on isolation level](https://www.postgresql.org/docs/current/transaction-iso.html)

Note: This has no effect for SQLite usage, as `attempt_to_set_isolation_level()`[SQLite version](https://github.com/matrix-org/synapse/blob/d53547352063c3e66302f7bdc40d7ac7270e605c/synapse/storage/engines/sqlite.py#L136-L141) says everything is set to `SERIALIZABLE` regardless.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>

EDIT: Added some pretty pictures
![Example 1](https://github.com/matrix-org/synapse/assets/1582365/5f9158cd-4c53-42d1-87be-d90342f47757)
![Example 2](https://github.com/matrix-org/synapse/assets/1582365/688818a3-187b-4ac7-b952-5d40be1da904)
