### PR TITLE
Add a timeout that aborts any Postgres statement taking more than 1 hour.

### DIFF
--- a/changelog.d/15853.misc
+++ b/changelog.d/15853.misc
@@ -1,0 +1,1 @@
+Add a timeout that aborts any Postgres statement taking more than 1 hour.

--- a/synapse/storage/engines/postgres.py
+++ b/synapse/storage/engines/postgres.py
@@ -45,6 +45,15 @@ class PostgresEngine(
 
         psycopg2.extensions.register_adapter(bytes, _disable_bytes_adapter)
         self.synchronous_commit: bool = database_config.get("synchronous_commit", True)
+        # Set the statement timeout to 1 hour by default.
+        # Any query taking more than 1 hour should probably be considered a bug;
+        # most of the time this is a sign that work needs to be split up or that
+        # some degenerate query plan has been created and the client has probably
+        # timed out/walked off anyway.
+        # This is in milliseconds.
+        self.statement_timeout: Optional[int] = database_config.get(
+            "statement_timeout", 60 * 60 * 1000
+        )
         self._version: Optional[int] = None  # unknown as yet
 
         self.isolation_level_map: Mapping[int, int] = {
@@ -156,6 +165,10 @@ class PostgresEngine(
         # https://www.postgresql.org/docs/current/static/wal-async-commit.html
         if not self.synchronous_commit:
             cursor.execute("SET synchronous_commit TO OFF")
+
+        # Abort really long-running statements and turn them into errors.
+        if self.statement_timeout is not None:
+            cursor.execute("SET statement_timeout TO ?", (self.statement_timeout,))
 
         cursor.close()
         db_conn.commit()


### PR DESCRIPTION
We hit a problem where an 8-hour event search query (which the client had already walked away from) caused Postgres to not be able to vacuum, which in turn causes general DB slowness and notably
updating stream positions was slow, so event persistence was slow and an apdex page was raised.

I propose that we limit statements to 1 hour by default. I propose that we consider anything taking more than 1 hour to be a bug as it blocks Postgres from vacuuming, which is more or less essential housekeeping.

I considered going tighter but I am not sure if some of our background or admin operations might rely on longer-running queries and I think I would rather start at 1 hour and tighten later if we think that is sensible.

This limit is technically configurable but we also don't document `synchronous_commit` so I have chosen not to document this for now.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Add a timeout to Postgres statements 

</li>
</ol>
