### PR TITLE
Fix the `devenv up` configuration which was ignoring the config overrides.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ __pycache__/
 /logs
 /media_store/
 /uploads
+/homeserver-config-overrides.d
 
 # For direnv users
 /.envrc

--- a/changelog.d/15854.misc
+++ b/changelog.d/15854.misc
@@ -1,0 +1,1 @@
+Fix the `devenv up` configuration which was ignoring the config overrides.

--- a/flake.nix
+++ b/flake.nix
@@ -178,7 +178,7 @@
                   EOF
                 '';
                 # Start synapse when `devenv up` is run.
-                processes.synapse.exec = "poetry run python -m synapse.app.homeserver -c homeserver.yaml --config-directory homeserver-config-overrides.d";
+                processes.synapse.exec = "poetry run python -m synapse.app.homeserver -c homeserver.yaml -c homeserver-config-overrides.d";
 
                 # Define the perl modules we require to run SyTest.
                 #


### PR DESCRIPTION
I was confused when this wasn't hitting any of the logging I set for Postgres, then noticed that the database was empty. Oh.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
Follows: #15613 <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Fix use of config override directory in `devenv up` \
`--config-directory` is for the generate config script; `-c` is for usage


</li>
<li>

Add homeserver config override directory to gitignore 

</li>
</ol>
