### PR TITLE
Remove `worker_replication_*` deprecated settings, with helpful errors on startup

### DIFF
--- a/changelog.d/15860.removal
+++ b/changelog.d/15860.removal
@@ -1,1 +1,1 @@
-Remove deprecated `worker_replication_host`, `worker_replication_http_port` and `worker_replication_http_tls`.
+Remove deprecated `worker_replication_host`, `worker_replication_http_port` and `worker_replication_http_tls` configuration options.

--- a/changelog.d/15860.removal
+++ b/changelog.d/15860.removal
@@ -1,0 +1,1 @@
+Remove deprecated `worker_replication_host`, `worker_replication_http_port` and `worker_replication_http_tls`.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -87,6 +87,14 @@ process, for example:
     wget https://packages.matrix.org/debian/pool/main/m/matrix-synapse-py3/matrix-synapse-py3_1.3.0+stretch1_amd64.deb
     dpkg -i matrix-synapse-py3_1.3.0+stretch1_amd64.deb
     ```
+# Upgrading to v1.88.0
+
+## Removal of `worker_replication_*` settings
+As mentioned in v1.84.0, these settings are deprecated and are being removed. Ensure you
+have migrated to using `main` on your shared configuration `instance_map`(or create one
+if necessary) if you have ***any*** workers at all.
+
+
 # Upgrading to v1.86.0
 
 ## Minimum supported Rust version

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -90,14 +90,19 @@ process, for example:
 # Upgrading to v1.88.0
 
 ## Removal of `worker_replication_*` settings
-As mentioned below in [Upgrading to v1.84.0](#upgrading-to-v1840), these settings are deprecated and are being removed. Ensure you
-have migrated to using `main` on your shared configuration `instance_map`(or create one
-if necessary) if you have ***any*** workers at all.
 
-Specifically, to be removed(links for relevant docs attached):
-* [`worker_replication_host`](usage/configuration/config_documentation.md#worker_replication_host)
-* [`worker_replication_http_port`](usage/configuration/config_documentation.md#worker_replication_http_port)
-* [`worker_replication_http_tls`](usage/configuration/config_documentation.md#worker_replication_http_tls)
+As mentioned previously in [Upgrading to v1.84.0](#upgrading-to-v1840), the following deprecated settings
+are being removed in this release of Synapse:
+
+* [`worker_replication_host`](https://matrix-org.github.io/synapse/v1.86/usage/configuration/config_documentation.html#worker_replication_host)
+* [`worker_replication_http_port`](https://matrix-org.github.io/synapse/v1.86/usage/configuration/config_documentation.html#worker_replication_http_port)
+* [`worker_replication_http_tls`](https://matrix-org.github.io/synapse/v1.86/usage/configuration/config_documentation.html#worker_replication_http_tls)
+
+Please ensure that you have migrated to using `main` on your shared configuration's `instance_map`
+(or create one if necessary). This is required if you have ***any*** workers at all;
+administrators of single-process (monolith) installations don't need to do anything.
+
+For an illustrative example, please see [Upgrading to v1.84.0](#upgrading-to-v1840) below.
 
 
 # Upgrading to v1.86.0

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -90,9 +90,14 @@ process, for example:
 # Upgrading to v1.88.0
 
 ## Removal of `worker_replication_*` settings
-As mentioned in v1.84.0, these settings are deprecated and are being removed. Ensure you
+As mentioned below in [Upgrading to v1.84.0](#upgrading-to-v1840), these settings are deprecated and are being removed. Ensure you
 have migrated to using `main` on your shared configuration `instance_map`(or create one
 if necessary) if you have ***any*** workers at all.
+
+Specifically, to be removed(links for relevant docs attached):
+* [`worker_replication_host`](usage/configuration/config_documentation.md#worker_replication_host)
+* [`worker_replication_http_port`](usage/configuration/config_documentation.md#worker_replication_http_port)
+* [`worker_replication_http_tls`](usage/configuration/config_documentation.md#worker_replication_http_tls)
 
 
 # Upgrading to v1.86.0

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -4107,51 +4107,6 @@ Example configuration:
 worker_name: generic_worker1
 ```
 ---
-### `worker_replication_host`
-*Deprecated as of version 1.84.0. Place `host` under `main` entry on the [`instance_map`](#instance_map) in your shared yaml configuration instead.*
-
-The HTTP replication endpoint that it should talk to on the main Synapse process.
-The main Synapse process defines this with a `replication` resource in
-[`listeners` option](#listeners).
-
-Example configuration:
-```yaml
-worker_replication_host: 127.0.0.1
-```
----
-### `worker_replication_http_port`
-*Deprecated as of version 1.84.0. Place `port` under `main` entry on the [`instance_map`](#instance_map) in your shared yaml configuration instead.*
-
-The HTTP replication port that it should talk to on the main Synapse process.
-The main Synapse process defines this with a `replication` resource in
-[`listeners` option](#listeners).
-
-Example configuration:
-```yaml
-worker_replication_http_port: 9093
-```
----
-### `worker_replication_http_tls`
-*Deprecated as of version 1.84.0. Place `tls` under `main` entry on the [`instance_map`](#instance_map) in your shared yaml configuration instead.*
-
-Whether TLS should be used for talking to the HTTP replication port on the main
-Synapse process.
-The main Synapse process defines this with the `tls` option on its [listener](#listeners) that
-has the `replication` resource enabled.
-
-**Please note:** by default, it is not safe to expose replication ports to the
-public Internet, even with TLS enabled.
-See [`worker_replication_secret`](#worker_replication_secret).
-
-Defaults to `false`.
-
-*Added in Synapse 1.72.0.*
-
-Example configuration:
-```yaml
-worker_replication_http_tls: true
-```
----
 ### `worker_listeners`
 
 A worker can handle HTTP requests. To do so, a `worker_listeners` option

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -145,11 +145,6 @@ In the config file for each worker, you must specify:
    with an `http` listener.
  * **Synapse 1.72 and older:** if handling the `^/_matrix/client/v3/keys/upload` endpoint, the HTTP URI for
    the main process (`worker_main_http_uri`). This config option is no longer required and is ignored when running Synapse 1.73 and newer.
- * **Synapse 1.83 and older:** The HTTP replication endpoint that the worker should talk to on the main synapse process
-   ([`worker_replication_host`](usage/configuration/config_documentation.md#worker_replication_host) and
-   [`worker_replication_http_port`](usage/configuration/config_documentation.md#worker_replication_http_port)). If
-   using Synapse 1.84 and newer, these are not needed if `main` is defined on the
-   [shared configuration](#shared-configuration) `instance_map`. **Backwards compatibility fully removed as of Synapse 1.88.0.**
 
 For example:
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -147,7 +147,9 @@ In the config file for each worker, you must specify:
    the main process (`worker_main_http_uri`). This config option is no longer required and is ignored when running Synapse 1.73 and newer.
  * **Synapse 1.83 and older:** The HTTP replication endpoint that the worker should talk to on the main synapse process
    ([`worker_replication_host`](usage/configuration/config_documentation.md#worker_replication_host) and
-   [`worker_replication_http_port`](usage/configuration/config_documentation.md#worker_replication_http_port)). If using Synapse 1.84 and newer, these are not needed if `main` is defined on the [shared configuration](#shared-configuration) `instance_map`
+   [`worker_replication_http_port`](usage/configuration/config_documentation.md#worker_replication_http_port)). If
+   using Synapse 1.84 and newer, these are not needed if `main` is defined on the
+   [shared configuration](#shared-configuration) `instance_map`. **Backwards compatibility fully removed as of Synapse 1.88.0.**
 
 For example:
 

--- a/synapse/config/workers.py
+++ b/synapse/config/workers.py
@@ -41,11 +41,17 @@ Synapse version. Please use ``%s: name_of_worker`` instead.
 
 _MISSING_MAIN_PROCESS_INSTANCE_MAP_DATA = """
 Missing data for a worker to connect to main process. Please include '%s' in the
-`instance_map` declared in your shared yaml configuration, or optionally(as a deprecated
-solution) in every worker's yaml as various `worker_replication_*` settings as defined
-in workers documentation here:
+`instance_map` declared in your shared yaml configuration as defined in configuration
+documentation here:
+`https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#instance_map`
+"""
+
+WORKER_REPLICATION_SETTING_DEPRECATED_MESSAGE = """
+'%s' is no longer a supported worker setting, please place '%s' onto your shared
+configuration under `main` inside the `instance_map`. See workers documentation here:
 `https://matrix-org.github.io/synapse/latest/workers.html#worker-configuration`
 """
+
 # This allows for a handy knob when it's time to change from 'master' to
 # something with less 'history'
 MAIN_PROCESS_INSTANCE_NAME = "master"
@@ -216,22 +222,37 @@ class WorkerConfig(Config):
         )
 
         # A map from instance name to host/port of their HTTP replication endpoint.
-        # Check if the main process is declared. Inject it into the map if it's not,
-        # based first on if a 'main' block is declared then on 'worker_replication_*'
-        # data. If both are available, default to instance_map. The main process
-        # itself doesn't need this data as it would never have to talk to itself.
+        # Check if the main process is declared. The main process itself doesn't need
+        # this data as it would never have to talk to itself.
         instance_map: Dict[str, Any] = config.get("instance_map", {})
 
         if self.instance_name is not MAIN_PROCESS_INSTANCE_NAME:
+            # TODO: The next 3 condition blocks can be deleted after some time has
+            #  passed and we're ready to stop checking for these settings.
             # The host used to connect to the main synapse
             main_host = config.get("worker_replication_host", None)
+            if main_host:
+                raise ConfigError(
+                    WORKER_REPLICATION_SETTING_DEPRECATED_MESSAGE
+                    % ("worker_replication_host", main_host)
+                )
 
             # The port on the main synapse for HTTP replication endpoint
             main_port = config.get("worker_replication_http_port")
+            if main_port:
+                raise ConfigError(
+                    WORKER_REPLICATION_SETTING_DEPRECATED_MESSAGE
+                    % ("worker_replication_http_port", main_port)
+                )
 
             # The tls mode on the main synapse for HTTP replication endpoint.
             # For backward compatibility this defaults to False.
             main_tls = config.get("worker_replication_http_tls", False)
+            if main_tls:
+                raise ConfigError(
+                    WORKER_REPLICATION_SETTING_DEPRECATED_MESSAGE
+                    % ("worker_replication_http_tls", main_tls)
+                )
 
             # For now, accept 'main' in the instance_map, but the replication system
             # expects 'master', force that into being until it's changed later.
@@ -241,22 +262,9 @@ class WorkerConfig(Config):
                 ]
                 del instance_map[MAIN_PROCESS_INSTANCE_MAP_NAME]
 
-            # This is the backwards compatibility bit that handles the
-            # worker_replication_* bits using setdefault() to not overwrite anything.
-            elif main_host is not None and main_port is not None:
-                instance_map.setdefault(
-                    MAIN_PROCESS_INSTANCE_NAME,
-                    {
-                        "host": main_host,
-                        "port": main_port,
-                        "tls": main_tls,
-                    },
-                )
-
             else:
                 # If we've gotten here, it means that the main process is not on the
-                # instance_map and that not enough worker_replication_* variables
-                # were declared in the worker's yaml.
+                # instance_map.
                 raise ConfigError(
                     _MISSING_MAIN_PROCESS_INSTANCE_MAP_DATA
                     % MAIN_PROCESS_INSTANCE_MAP_NAME

--- a/tests/app/test_homeserver_start.py
+++ b/tests/app/test_homeserver_start.py
@@ -25,9 +25,9 @@ class HomeserverAppStartTestCase(ConfigFileTestCase):
         # Add a blank line as otherwise the next addition ends up on a line with a comment
         self.add_lines_to_config(["  "])
         self.add_lines_to_config(["worker_app: test_worker_app"])
-        self.add_lines_to_config(["worker_replication_host: 127.0.0.1"])
-        self.add_lines_to_config(["worker_replication_http_port: 0"])
-
+        self.add_lines_to_config(["worker_log_config: /data/logconfig.config"])
+        self.add_lines_to_config(["instance_map:"])
+        self.add_lines_to_config(["  main:", "    host: 127.0.0.1", "    port: 1234"])
         # Ensure that starting master process with worker config raises an exception
         with self.assertRaises(ConfigError):
             synapse.app.homeserver.setup(["-c", self.config_file])

--- a/tests/config/test_workers.py
+++ b/tests/config/test_workers.py
@@ -17,7 +17,7 @@ from unittest.mock import Mock
 from immutabledict import immutabledict
 
 from synapse.config import ConfigError
-from synapse.config.workers import InstanceLocationConfig, WorkerConfig
+from synapse.config.workers import WorkerConfig
 
 from tests.unittest import TestCase
 
@@ -323,28 +323,3 @@ class WorkerDutyConfigTestCase(TestCase):
         )
         self.assertTrue(worker2_config.should_notify_appservices)
         self.assertFalse(worker2_config.should_update_user_directory)
-
-    def test_worker_instance_map_compat(self) -> None:
-        """
-        Test that `worker_replication_*` settings are compatibly handled by
-        adding them to the instance map as a `main` entry.
-        """
-
-        worker1_config = self._make_worker_config(
-            worker_app="synapse.app.generic_worker",
-            worker_name="worker1",
-            extras={
-                "notify_appservices_from_worker": "worker2",
-                "update_user_directory_from_worker": "worker1",
-                "worker_replication_host": "127.0.0.42",
-                "worker_replication_http_port": 1979,
-            },
-        )
-        self.assertEqual(
-            worker1_config.instance_map,
-            {
-                "master": InstanceLocationConfig(
-                    host="127.0.0.42", port=1979, tls=False
-                ),
-            },
-        )


### PR DESCRIPTION
What it says on the tin. <del>Needs Sytest modifications.</del> Needs [#sytest/1357](https://github.com/matrix-org/sytest/pull/1357)

I'm not going to mark this as fixing the [issue](https://github.com/matrix-org/synapse/issues/15655) that's related, but if we could update that and pin it for another month, I'll finish the removal then.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>