### PR TITLE
Remove old rows from the `cache_invalidation_stream_by_instance` table automatically. (This table is not used when Synapse is configured to use SQLite.)

### DIFF
--- a/changelog.d/15868.feature
+++ b/changelog.d/15868.feature
@@ -1,0 +1,1 @@
+Remove old rows from the `cache_invalidation_stream_by_instance` table automatically (this table is unused in SQLite).

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -618,7 +618,7 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
         self, delete_up_to_millisec: int
     ) -> bool:
         """
-        Cleans up a batch of old cache invalidations.
+        Remove old rows from the `cache_invalidation_stream_by_instance` table automatically (this table is unused in SQLite).
 
         Up to `CLEAN_UP_BATCH_SIZE` rows will be deleted at once.
 

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -632,7 +632,8 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
             txn.execute(
                 """
                 SELECT stream_id FROM cache_invalidation_stream_by_instance
-                ORDER BY stream_id LIMIT 1
+                ORDER BY stream_id ASC
+                LIMIT 1
                 """
             )
             row = txn.fetchone()

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -623,7 +623,8 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
 
         Up to `CLEAN_UP_BATCH_SIZE` rows will be deleted at once.
 
-        Returns true iff we were limited by batch size (i.e. we are in backlog).
+        Returns true if and only if we were limited by batch size (i.e. we are in backlog:
+        there are more things to clean up).
         """
 
         def _clean_up_batch_of_old_cache_invalidations_txn(

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -115,12 +115,13 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
         else:
             self._cache_id_gen = None
 
+        # Occasionally clean up the cache invalidations stream table by deleting
+        # old rows.
+        # This is only applicable when Postgres is in use; this table is unused
+        # and not populated at all when SQLite is the active database engine.
         if hs.config.worker.run_background_tasks and isinstance(
             self.database_engine, PostgresEngine
         ):
-            # Occasionally clean up the cache invalidations stream table.
-            # This is only applicable if we are on Postgres and therefore populate
-            # those tables.
             self.hs.get_clock().call_later(
                 CATCH_UP_CLEANUP_INTERVAL_MS / 1000,
                 self._clean_up_cache_invalidation_wrapper,

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -114,8 +114,12 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
         else:
             self._cache_id_gen = None
 
-        # TODO should run background jobs?
-        if False and isinstance(self.database_engine, PostgresEngine):
+        if hs.config.worker.run_background_tasks and isinstance(
+            self.database_engine, PostgresEngine
+        ):
+            # Occasionally clean up the cache invalidations stream table.
+            # This is only applicable if we are on Postgres and therefore populate
+            # those tables.
             self.hs.get_clock().call_later(
                 CATCH_UP_CLEANUP_INTERVAL_MILLISEC,
                 self._clean_up_cache_invalidation_wrapper,

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -583,7 +583,7 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
             return 0
 
     def _clean_up_cache_invalidation_wrapper(self) -> None:
-        async def _clean_up_cache_invalidation_background():
+        async def _clean_up_cache_invalidation_background() -> None:
             """
             Clean up cache invalidation stream table entries occasionally.
             If we are behind (i.e. there are entries old enough to

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -121,7 +121,7 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
             # This is only applicable if we are on Postgres and therefore populate
             # those tables.
             self.hs.get_clock().call_later(
-                CATCH_UP_CLEANUP_INTERVAL_MILLISEC,
+                CATCH_UP_CLEANUP_INTERVAL_MILLISEC / 1000,
                 self._clean_up_cache_invalidation_wrapper,
             )
 
@@ -607,7 +607,7 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
                 next_interval = REGULAR_CLEANUP_INTERVAL_MILLISEC
 
             self.hs.get_clock().call_later(
-                next_interval, self._clean_up_cache_invalidation_wrapper
+                next_interval / 1000, self._clean_up_cache_invalidation_wrapper
             )
 
         run_as_background_process(


### PR DESCRIPTION
I propose a mechanism to clean up old (> 7d old, to be very generous) rows from the `cache_invalidation_stream_by_instance` table.

On LPnet, this table is 700 MB (4e6 rows) and has never been cleaned before. On Morg, this table is 191 GB (8e8 rows) but seems to have been manually cleaned in 2020.

These rows are only needed for mere instants whilst other workers catch up with the stream, so there is no utility in keeping them around for longer than a few instants.
However, to allow for clock drift, debugging and just generally out of caution, I set the cut-off to 7 days.


Fixes: #3665 <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Add a cache invalidation clean-up task 

</li>
<li>

Run the cache invalidation stream clean-up on the background worker 

</li>
<li>

Tune down 

</li>
<li>

call_later is in millis! 

</li>
</ol>
