### PR TITLE
Fix TLS in the federation outbound proxy

### DIFF
--- a/changelog.d/15886.feature
+++ b/changelog.d/15886.feature
@@ -1,0 +1,1 @@
+Allow configuring the set of workers to proxy outbound federation traffic through via `outbound_federation_restricted_to`.

--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -152,7 +152,7 @@ class ProxyAgent(_AgentBase):
 
                 if federation_proxy.tls:
                     tls_connection_creator = self._policy_for_https.creatorForNetloc(
-                        federation_proxy.host,
+                        federation_proxy.host.encode("utf-8"),
                         federation_proxy.port,
                     )
                     endpoint = wrapClientTLS(tls_connection_creator, endpoint)


### PR DESCRIPTION
Fix TLS in the federation outbound proxy

Same fix as https://github.com/matrix-org/synapse/pull/15746

Thanks to @realtyem for pointing it out!

`creatorForNetloc(...)` doesn't come with typing and expects `host` to be `bytes` instead of a `str`. It would be nice to add typing somehow so we don't keep running into this foot-gun

`ProxyAgent` was introduced with the federation outbound proxy: https://github.com/matrix-org/synapse/pull/15773

(this is wholly untested)

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [ ] ~~Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)~~
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
