### PR TITLE
Stop running sytest on buster/python3.7

### DIFF
--- a/.ci/scripts/calculate_jobs.py
+++ b/.ci/scripts/calculate_jobs.py
@@ -134,11 +134,6 @@ if not IS_PR:
                 "sytest-tag": "testing",
                 "postgres": "postgres",
             },
-            {
-                "sytest-tag": "buster",
-                "postgres": "multi-postgres",
-                "workers": "workers",
-            },
         ]
     )
 

--- a/changelog.d/15892.misc
+++ b/changelog.d/15892.misc
@@ -1,0 +1,1 @@
+Stop running sytest on buster/python3.7.


### PR DESCRIPTION
After noticing that tests were failing on merge, I found that we are still running Sytest on buster/python3.7, which now results in failure as we have [dropped support for Python 3.7](https://github.com/matrix-org/synapse/pull/15851). This PR drops this run from ci. Note that this was only being run against merges, not PRs. 