### PR TITLE
Drop debian buster

### DIFF
--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -96,6 +96,7 @@ jobs:
     if: needs.check_repo.outputs.should_run_workflow == 'true'
     runs-on: ubuntu-latest
     container:
+      # We're using ubuntu:focal because it uses Python 3.8 which is our minimum supported Python version
       image: matrixdotorg/sytest-synapse:focal
       volumes:
         - ${{ github.workspace }}:/src

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -96,7 +96,7 @@ jobs:
     if: needs.check_repo.outputs.should_run_workflow == 'true'
     runs-on: ubuntu-latest
     container:
-      image: matrixdotorg/sytest-synapse:buster
+      image: matrixdotorg/sytest-synapse:focal
       volumes:
         - ${{ github.workspace }}:/src
 

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -96,7 +96,10 @@ jobs:
     if: needs.check_repo.outputs.should_run_workflow == 'true'
     runs-on: ubuntu-latest
     container:
-      # We're using ubuntu:focal because it uses Python 3.8 which is our minimum supported Python version
+      # We're using ubuntu:focal because it uses Python 3.8 which is our minimum supported Python version.
+      # This job is a canary to warn us about unreleased twisted changes that would cause problems for us if
+      # they were to be released immediately. For simplicity's sake (and to save CI runners) we use the oldest
+      # version, assuming that any incompatibilities on newer versions would also be present on the oldest.
       image: matrixdotorg/sytest-synapse:focal
       volumes:
         - ${{ github.workspace }}:/src

--- a/changelog.d/15893.misc
+++ b/changelog.d/15893.misc
@@ -1,0 +1,1 @@
+Drop debian buster.

--- a/changelog.d/15893.misc
+++ b/changelog.d/15893.misc
@@ -1,1 +1,1 @@
-Drop debian buster.
+Drop Debian Buster since we no longer support Python 3.7.

--- a/docs/deprecation_policy.md
+++ b/docs/deprecation_policy.md
@@ -23,7 +23,7 @@ people building from source should ensure they can fetch recent versions of Rust
 (e.g. by using [rustup](https://rustup.rs/)).
 
 The oldest supported version of SQLite is the version
-[provided](https://packages.debian.org/buster/libsqlite3-0) by
+[provided](https://packages.debian.org/bullseye/libsqlite3-0) by
 [Debian oldstable](https://wiki.debian.org/DebianOldStable).
 
 Context

--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -322,7 +322,7 @@ The following command will let you run the integration test with the most common
 configuration:
 
 ```sh
-$ docker run --rm -it -v /path/where/you/have/cloned/the/repository\:/src:ro -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:buster
+$ docker run --rm -it -v /path/where/you/have/cloned/the/repository\:/src:ro -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:focal
 ```
 (Note that the paths must be full paths! You could also write `$(realpath relative/path)` if needed.)
 

--- a/scripts-dev/build_debian_packages.py
+++ b/scripts-dev/build_debian_packages.py
@@ -23,7 +23,6 @@ from typing import Collection, Optional, Sequence, Set
 # These are expanded inside the dockerfile to be a fully qualified image name.
 # e.g. docker.io/library/debian:bullseye
 DISTS = (
-    "debian:buster",  # oldstable: EOL 2022-08
     "debian:bullseye",
     "debian:bookworm",
     "debian:sid",


### PR DESCRIPTION
As part of the work around dropping python 3.7 drop any old references to buster/update any places we were still using it. 

Follow-up to:

 - https://github.com/matrix-org/synapse/pull/15892
 - https://github.com/matrix-org/synapse/pull/15851