### PR TITLE
Clarify some loggers context behaviours

### DIFF
--- a/changelog.d/15905.doc
+++ b/changelog.d/15905.doc
@@ -1,0 +1,1 @@
+Clarified some of the behaviour of the `synapse` vs `root` logger contexts. Contributed by @semiviral.

--- a/docs/structured_logging.md
+++ b/docs/structured_logging.md
@@ -67,14 +67,31 @@ handlers:
         host: 10.1.2.3
         port: 9999
 
+## If using no workers, this configuration will suffice:
 loggers:
     synapse:
         level: INFO
         handlers: [remote]
     synapse.storage.SQL:
         level: WARNING
+
+## However, if utilizing workers, the following configuration
+## will provide much more consistent logging reception:
+# loggers:
+#     synapse.storage.SQL:
+#         level: WARNING
+#
+# root:
+#     level: INFO
+#     handlers: [remote]
 ```
 
 The above logging config will set Synapse as 'INFO' logging level by default,
 with the SQL layer at 'WARNING', and will log JSON formatted messages to a
 remote endpoint at 10.1.2.3:9999.
+
+While a fully-remote logging configuration is possible, it can be prudent to
+also configure a short-term file-based handler as well. For example, one could
+set up a buffered rotating file handler, as well as a remote endpoint handler.
+This ensures that if your remote endpoint ever goes down, you retain the ability
+to easily examine logs.


### PR DESCRIPTION
Simply utilizing the `synapse` logger as a remote handled context does not result in the (ostensibly) expected behavior when configuring logging with workers involved.

To remedy this somewhat, further clarification on the behavior of the `synapse` vs `root` logging context is provided, with some additional YAML source code to exemplify the distinction.

Signed-off-by: Zavier Divelbiss <zavier.a.divelbiss@proton.me>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
