### PR TITLE
Add `Server` to Access-Control-Expose-Headers header

### DIFF
--- a/changelog.d/15908.misc
+++ b/changelog.d/15908.misc
@@ -1,0 +1,1 @@
+Add `Server` to Access-Control-Expose-Headers header.

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -910,7 +910,7 @@ def set_cors_headers(request: SynapseRequest) -> None:
         )
         request.setHeader(
             b"Access-Control-Expose-Headers",
-            b"Synapse-Trace-Id",
+            b"Synapse-Trace-Id, Server",
         )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -268,7 +268,7 @@ class OptionsResourceTests(unittest.TestCase):
         )
         self.assertEqual(
             channel.headers.getRawHeaders(b"Access-Control-Expose-Headers"),
-            [b"Synapse-Trace-Id"],
+            [b"Synapse-Trace-Id, Server"],
         )
 
     def _check_cors_msc3886_headers(self, channel: FakeChannel) -> None:


### PR DESCRIPTION
Like https://github.com/matrix-org/synapse/pull/14974 but for https://github.com/vector-im/element-web/issues/11070 - without this the Server header is not accessible to Web browser clients

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
