### PR TITLE
Remove unneeded __init__.

### DIFF
--- a/changelog.d/15926.misc
+++ b/changelog.d/15926.misc
@@ -1,0 +1,1 @@
+Remove unneeded `__init__`.

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -432,15 +432,6 @@ class FederationV2SendJoinServlet(BaseFederationServerServlet):
 
     PREFIX = FEDERATION_V2_PREFIX
 
-    def __init__(
-        self,
-        hs: "HomeServer",
-        authenticator: Authenticator,
-        ratelimiter: FederationRateLimiter,
-        server_name: str,
-    ):
-        super().__init__(hs, authenticator, ratelimiter, server_name)
-
     async def on_PUT(
         self,
         origin: str,


### PR DESCRIPTION
`FederationV2SendJoinServlet__ini__` simply calls `super().__init__(...)` with all the same input arguments.