### PR TITLE
Add a way to register the lower-case version of a conflicting MXID

### DIFF
--- a/synapse/_scripts/register_new_matrix_user.py
+++ b/synapse/_scripts/register_new_matrix_user.py
@@ -44,10 +44,18 @@ def request_registration(
     shared_secret: str,
     admin: bool = False,
     user_type: Optional[str] = None,
+    inhibit_user_in_use_error: bool = False,
     _print: Callable[[str], None] = print,
     exit: Callable[[int], None] = sys.exit,
 ) -> None:
-    url = "%s/_synapse/admin/v1/register" % (server_location.rstrip("/"),)
+    qs_url_piece = ""
+    if inhibit_user_in_use_error:
+        qs_url_piece = "?inhibit_user_in_use_error=true"
+
+    url = "%s/_synapse/admin/v1/register%s" % (
+        server_location.rstrip("/"),
+        qs_url_piece,
+    )
 
     # Get the nonce
     r = requests.get(url, verify=False)
@@ -99,7 +107,8 @@ def request_registration(
                 pass
         return exit(1)
 
-    _print("Success!")
+    result = r.json()
+    _print("Success! -> %s" % result)
 
 
 def register_new_user(
@@ -109,6 +118,7 @@ def register_new_user(
     shared_secret: str,
     admin: Optional[bool],
     user_type: Optional[str],
+    inhibit_user_in_use_error: bool = False,
 ) -> None:
     if not user:
         try:
@@ -148,7 +158,13 @@ def register_new_user(
             admin = False
 
     request_registration(
-        user, password, server_location, shared_secret, bool(admin), user_type
+        user,
+        password,
+        server_location,
+        shared_secret,
+        bool(admin),
+        user_type,
+        inhibit_user_in_use_error=inhibit_user_in_use_error,
     )
 
 
@@ -178,6 +194,14 @@ def main() -> None:
         "--user_type",
         default=None,
         help="User type as specified in synapse.api.constants.UserTypes",
+    )
+    parser.add_argument(
+        "--inhibit_user_in_use_error",
+        default=False,
+        help="Whether to inhibit errors raised when registering a new account if the user ID already exists. "
+        "Useful when there is a collision with another MXID that has capital letters "
+        "but you want to register the same user with lower-case. "
+        "The registration will still fail if you try to register with the same MXID. Defaults to False",
     )
     admin_group = parser.add_mutually_exclusive_group()
     admin_group.add_argument(
@@ -264,7 +288,13 @@ def main() -> None:
         admin = args.admin
 
     register_new_user(
-        args.user, args.password, server_url, secret, admin, args.user_type
+        args.user,
+        args.password,
+        server_url,
+        secret,
+        admin,
+        args.user_type,
+        inhibit_user_in_use_error=args.inhibit_user_in_use_error,
     )
 
 

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -218,6 +218,7 @@ class RegistrationHandler:
         user_agent_ips: Optional[List[Tuple[str, str]]] = None,
         auth_provider_id: Optional[str] = None,
         approved: bool = False,
+        inhibit_user_in_use_error: bool = False,
     ) -> str:
         """Registers a new client on the server.
 
@@ -283,7 +284,11 @@ class RegistrationHandler:
             await self.auth_blocking.check_auth_blocking(threepid=threepid)
 
         if localpart is not None:
-            await self.check_username(localpart, guest_access_token=guest_access_token)
+            await self.check_username(
+                localpart,
+                guest_access_token=guest_access_token,
+                inhibit_user_in_use_error=inhibit_user_in_use_error,
+            )
 
             was_guest = guest_access_token is not None
 

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -520,6 +520,10 @@ class UserRegisterServlet(RestServlet):
                 HTTPStatus.BAD_REQUEST, "Shared secret registration is not enabled"
             )
 
+        inhibit_user_in_use_error = parse_boolean(
+            request, "inhibit_user_in_use_error", False
+        )
+
         body = parse_json_object_from_request(request)
 
         if "nonce" not in body:
@@ -615,6 +619,7 @@ class UserRegisterServlet(RestServlet):
             default_display_name=displayname,
             by_admin=True,
             approved=True,
+            inhibit_user_in_use_error=inhibit_user_in_use_error,
         )
 
         result = await register._create_registration_details(user_id, body)


### PR DESCRIPTION
Add a way to register the lower-case version of a conflicting MXID.

This isn't meant to merge to main-line and is just a one-off fix so I can register a specific user.

Basically, if you have `@Foo:matrix.org` already registered, this will allow you register `@foo:matrix.org`

```
poetry run register_new_matrix_user --inhibit_user_in_use_error 1 -c homeserver.yaml
```

---

[`inhibit_user_in_use_error`](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#inhibit_user_in_use_error) is already a homeserver configuration option but only applies to the username availability endpoint. This change makes it possible to configure the option when using the admin API to register a user.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). 
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
