### PR TITLE
Mention that you cannot login as yourself on /_synapse/admin/v1/users/<user_id>/login

### DIFF
--- a/changelog.d/15938.doc
+++ b/changelog.d/15938.doc
@@ -1,0 +1,1 @@
+Improve the documentation for the login as a user admin API.

--- a/docs/admin_api/user_admin_api.md
+++ b/docs/admin_api/user_admin_api.md
@@ -732,7 +732,8 @@ POST /_synapse/admin/v1/users/<user_id>/login
 
 An optional `valid_until_ms` field can be specified in the request body as an
 integer timestamp that specifies when the token should expire. By default tokens
-do not expire.
+do not expire. Note that this API does not allow a user to login as themselves
+(to create more tokens).
 
 A response body like the following is returned:
 


### PR DESCRIPTION
This bit me today. I suspect it's a sensible security precaution, but we should call it out.