### PR TITLE
Add CI to check the nix development environment builds successfully

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -1,0 +1,13 @@
+name: "Build the nix development environment"
+on:
+  pull_request:
+  push:
+jobs:
+  build_dev_env:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac  # v22
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix develop --impure


### PR DESCRIPTION
This PR adds a new CI job that checks that the nix-powered development environment builds correctly.

An alternative is to use the development environment to just run our tests, thus not introducing a new CI job.