### PR TITLE
Add a locality to a few presence metrics

### DIFF
--- a/changelog.d/15952.misc
+++ b/changelog.d/15952.misc
@@ -1,0 +1,1 @@
+Update presence metrics to differentiate remote vs local users.


### PR DESCRIPTION
...to easily see if a presence state being processed is for a local or remote user.

### Presence State Transitions
Turns this:
![state_transitions_before](https://github.com/matrix-org/synapse/assets/1582365/9498235e-f9b7-41f9-9ac1-93cfae20e396)

Into being able to do this:
![state_transitions_after](https://github.com/matrix-org/synapse/assets/1582365/05417aec-e189-4c06-b3a0-cb923fa0e809)

Notes:
To make this pretty, change the Legend template to include `{{locality}}`
I used `{{job}}{{index}}: {{locality}}:{{from}} -> {{to}}` for mine.

### Presence Notify Reason
Turns this:
![notify_reason_before](https://github.com/matrix-org/synapse/assets/1582365/66b54893-196c-4430-b8df-5125bb34ff9a)

Into being able to do this:
![notify_reason_after](https://github.com/matrix-org/synapse/assets/1582365/96211c70-8912-440c-9cfa-4430194a4b37)

Notes:
To make this pretty, change the Legend template to include `{{locality}}`.
I used `{{job}}{{index}}: {{locality}}:{{reason}}` for mine.
### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>