### PR TITLE
Ensure a long state res does not starve CPU

### DIFF
--- a/changelog.d/15960.misc
+++ b/changelog.d/15960.misc
@@ -1,0 +1,1 @@
+Ensure a long state res does not starve CPU by occasionally yielding to the reactor.


### PR DESCRIPTION
We do this by yielding the reactor in hot loops.

Note: we do this already in other places in state res.