### PR TITLE
Remove support for legacy application service paths

### DIFF
--- a/changelog.d/15964.removal
+++ b/changelog.d/15964.removal
@@ -1,0 +1,1 @@
+Remove support for legacy application service paths.

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -82,7 +82,6 @@ HOUR_IN_MS = 60 * 60 * 1000
 
 
 APP_SERVICE_PREFIX = "/_matrix/app/v1"
-APP_SERVICE_UNSTABLE_PREFIX = "/_matrix/app/unstable"
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -179,7 +178,7 @@ class ApplicationServiceApi(SimpleHttpClient):
         try:
             response = await self._send_with_fallbacks(
                 service,
-                [APP_SERVICE_PREFIX, ""],
+                [APP_SERVICE_PREFIX],
                 f"/users/{urllib.parse.quote(user_id)}",
                 self.get_json,
                 {"access_token": service.hs_token},
@@ -205,7 +204,7 @@ class ApplicationServiceApi(SimpleHttpClient):
         try:
             response = await self._send_with_fallbacks(
                 service,
-                [APP_SERVICE_PREFIX, ""],
+                [APP_SERVICE_PREFIX],
                 f"/rooms/{urllib.parse.quote(alias)}",
                 self.get_json,
                 {"access_token": service.hs_token},
@@ -247,7 +246,7 @@ class ApplicationServiceApi(SimpleHttpClient):
             }
             response = await self._send_with_fallbacks(
                 service,
-                [APP_SERVICE_PREFIX, APP_SERVICE_UNSTABLE_PREFIX],
+                [APP_SERVICE_PREFIX],
                 f"/thirdparty/{kind}/{urllib.parse.quote(protocol)}",
                 self.get_json,
                 args=args,
@@ -287,7 +286,7 @@ class ApplicationServiceApi(SimpleHttpClient):
             try:
                 info = await self._send_with_fallbacks(
                     service,
-                    [APP_SERVICE_PREFIX, APP_SERVICE_UNSTABLE_PREFIX],
+                    [APP_SERVICE_PREFIX],
                     f"/thirdparty/protocol/{urllib.parse.quote(protocol)}",
                     self.get_json,
                     {"access_token": service.hs_token},

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -17,8 +17,6 @@ import urllib.parse
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
-    Callable,
     Dict,
     Iterable,
     List,
@@ -30,7 +28,7 @@ from typing import (
 )
 
 from prometheus_client import Counter
-from typing_extensions import Concatenate, ParamSpec, TypeGuard
+from typing_extensions import ParamSpec, TypeGuard
 
 from synapse.api.constants import EventTypes, Membership, ThirdPartyEntityKind
 from synapse.api.errors import CodeMessageException, HttpResponseException
@@ -80,9 +78,6 @@ sent_todevice_counter = Counter(
 
 HOUR_IN_MS = 60 * 60 * 1000
 
-
-APP_SERVICE_PREFIX = "/_matrix/app/v1"
-
 P = ParamSpec("P")
 R = TypeVar("R")
 
@@ -127,47 +122,6 @@ class ApplicationServiceApi(SimpleHttpClient):
             hs.get_clock(), "as_protocol_meta", timeout_ms=HOUR_IN_MS
         )
 
-    async def _send_with_fallbacks(
-        self,
-        service: "ApplicationService",
-        prefixes: List[str],
-        path: str,
-        func: Callable[Concatenate[str, P], Awaitable[R]],
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> R:
-        """
-        Attempt to call an application service with multiple paths, falling back
-        until one succeeds.
-
-        Args:
-            service: The appliacation service, this provides the base URL.
-            prefixes: A last of paths to try in order for the requests.
-            path: A suffix to append to each prefix.
-            func: The function to call, the first argument will be the full
-                endpoint to fetch. Other arguments are provided by args/kwargs.
-
-        Returns:
-            The return value of func.
-        """
-        for i, prefix in enumerate(prefixes, start=1):
-            uri = f"{service.url}{prefix}{path}"
-            try:
-                return await func(uri, *args, **kwargs)
-            except HttpResponseException as e:
-                # If an error is received that is due to an unrecognised path,
-                # fallback to next path (if one exists). Otherwise, consider it
-                # a legitimate error and raise.
-                if i < len(prefixes) and is_unknown_endpoint(e):
-                    continue
-                raise
-            except Exception:
-                # Unexpected exceptions get sent to the caller.
-                raise
-
-        # The function should always exit via the return or raise above this.
-        raise RuntimeError("Unexpected fallback behaviour. This should never be seen.")
-
     async def query_user(self, service: "ApplicationService", user_id: str) -> bool:
         if service.url is None:
             return False
@@ -176,11 +130,8 @@ class ApplicationServiceApi(SimpleHttpClient):
         assert service.hs_token is not None
 
         try:
-            response = await self._send_with_fallbacks(
-                service,
-                [APP_SERVICE_PREFIX],
-                f"/users/{urllib.parse.quote(user_id)}",
-                self.get_json,
+            response = await self.get_json(
+                f"{service.url}/_matrix/app/v1/users/{urllib.parse.quote(user_id)}",
                 {"access_token": service.hs_token},
                 headers={"Authorization": [f"Bearer {service.hs_token}"]},
             )
@@ -202,11 +153,8 @@ class ApplicationServiceApi(SimpleHttpClient):
         assert service.hs_token is not None
 
         try:
-            response = await self._send_with_fallbacks(
-                service,
-                [APP_SERVICE_PREFIX],
-                f"/rooms/{urllib.parse.quote(alias)}",
-                self.get_json,
+            response = await self.get_json(
+                f"{service.url}/_matrix/app/v1/rooms/{urllib.parse.quote(alias)}",
                 {"access_token": service.hs_token},
                 headers={"Authorization": [f"Bearer {service.hs_token}"]},
             )
@@ -244,11 +192,8 @@ class ApplicationServiceApi(SimpleHttpClient):
                 **fields,
                 b"access_token": service.hs_token,
             }
-            response = await self._send_with_fallbacks(
-                service,
-                [APP_SERVICE_PREFIX],
-                f"/thirdparty/{kind}/{urllib.parse.quote(protocol)}",
-                self.get_json,
+            response = await self.get_json(
+                f"{service.url}/_matrix/app/v1/thirdparty/{kind}/{urllib.parse.quote(protocol)}",
                 args=args,
                 headers={"Authorization": [f"Bearer {service.hs_token}"]},
             )
@@ -284,11 +229,8 @@ class ApplicationServiceApi(SimpleHttpClient):
             # This is required by the configuration.
             assert service.hs_token is not None
             try:
-                info = await self._send_with_fallbacks(
-                    service,
-                    [APP_SERVICE_PREFIX],
-                    f"/thirdparty/protocol/{urllib.parse.quote(protocol)}",
-                    self.get_json,
+                info = await self.get_json(
+                    f"{service.url}/_matrix/app/v1/thirdparty/protocol/{urllib.parse.quote(protocol)}",
                     {"access_token": service.hs_token},
                     headers={"Authorization": [f"Bearer {service.hs_token}"]},
                 )
@@ -325,7 +267,7 @@ class ApplicationServiceApi(SimpleHttpClient):
         assert service.hs_token is not None
 
         await self.post_json_get_json(
-            uri=f"{service.url}{APP_SERVICE_PREFIX}/ping",
+            uri=f"{service.url}/_matrix/app/v1/ping",
             post_json={"transaction_id": txn_id},
             headers={"Authorization": [f"Bearer {service.hs_token}"]},
         )
@@ -400,11 +342,8 @@ class ApplicationServiceApi(SimpleHttpClient):
                 }
 
         try:
-            await self._send_with_fallbacks(
-                service,
-                [APP_SERVICE_PREFIX, ""],
-                f"/transactions/{urllib.parse.quote(str(txn_id))}",
-                self.put_json,
+            await self.put_json(
+                f"{service.url}/_matrix/app/v1/transactions/{urllib.parse.quote(str(txn_id))}",
                 json_body=body,
                 args={"access_token": service.hs_token},
                 headers={"Authorization": [f"Bearer {service.hs_token}"]},

--- a/synapse/appservice/api.py
+++ b/synapse/appservice/api.py
@@ -78,6 +78,8 @@ sent_todevice_counter = Counter(
 
 HOUR_IN_MS = 60 * 60 * 1000
 
+APP_SERVICE_PREFIX = "/_matrix/app/v1"
+
 P = ParamSpec("P")
 R = TypeVar("R")
 
@@ -131,7 +133,7 @@ class ApplicationServiceApi(SimpleHttpClient):
 
         try:
             response = await self.get_json(
-                f"{service.url}/_matrix/app/v1/users/{urllib.parse.quote(user_id)}",
+                f"{service.url}{APP_SERVICE_PREFIX}/users/{urllib.parse.quote(user_id)}",
                 {"access_token": service.hs_token},
                 headers={"Authorization": [f"Bearer {service.hs_token}"]},
             )
@@ -154,7 +156,7 @@ class ApplicationServiceApi(SimpleHttpClient):
 
         try:
             response = await self.get_json(
-                f"{service.url}/_matrix/app/v1/rooms/{urllib.parse.quote(alias)}",
+                f"{service.url}{APP_SERVICE_PREFIX}/rooms/{urllib.parse.quote(alias)}",
                 {"access_token": service.hs_token},
                 headers={"Authorization": [f"Bearer {service.hs_token}"]},
             )
@@ -193,7 +195,7 @@ class ApplicationServiceApi(SimpleHttpClient):
                 b"access_token": service.hs_token,
             }
             response = await self.get_json(
-                f"{service.url}/_matrix/app/v1/thirdparty/{kind}/{urllib.parse.quote(protocol)}",
+                f"{service.url}{APP_SERVICE_PREFIX}/thirdparty/{kind}/{urllib.parse.quote(protocol)}",
                 args=args,
                 headers={"Authorization": [f"Bearer {service.hs_token}"]},
             )
@@ -230,7 +232,7 @@ class ApplicationServiceApi(SimpleHttpClient):
             assert service.hs_token is not None
             try:
                 info = await self.get_json(
-                    f"{service.url}/_matrix/app/v1/thirdparty/protocol/{urllib.parse.quote(protocol)}",
+                    f"{service.url}{APP_SERVICE_PREFIX}/thirdparty/protocol/{urllib.parse.quote(protocol)}",
                     {"access_token": service.hs_token},
                     headers={"Authorization": [f"Bearer {service.hs_token}"]},
                 )
@@ -267,7 +269,7 @@ class ApplicationServiceApi(SimpleHttpClient):
         assert service.hs_token is not None
 
         await self.post_json_get_json(
-            uri=f"{service.url}/_matrix/app/v1/ping",
+            uri=f"{service.url}{APP_SERVICE_PREFIX}/ping",
             post_json={"transaction_id": txn_id},
             headers={"Authorization": [f"Bearer {service.hs_token}"]},
         )
@@ -343,7 +345,7 @@ class ApplicationServiceApi(SimpleHttpClient):
 
         try:
             await self.put_json(
-                f"{service.url}/_matrix/app/v1/transactions/{urllib.parse.quote(str(txn_id))}",
+                f"{service.url}{APP_SERVICE_PREFIX}/transactions/{urllib.parse.quote(str(txn_id))}",
                 json_body=body,
                 args={"access_token": service.hs_token},
                 headers={"Authorization": [f"Bearer {service.hs_token}"]},


### PR DESCRIPTION
https://github.com/matrix-org/synapse/pull/15317 added support for using `/_matrix/app/v1` prefix and falling back to legacy paths if those failed - and deprecated these legacy paths. This PR removes support for the legacy paths in accordance with the deprecation. Fixes #15380. 