### PR TITLE
Update synapse_port_db for new sequences

### DIFF
--- a/changelog.d/15965.bugfix
+++ b/changelog.d/15965.bugfix
@@ -1,0 +1,1 @@
+Fix `synapse_port_db` not configuring the `application_services_txns` and `un_partial_stated_event_stream_sequence` sequences. Contributed by @vanguacamolie.


### PR DESCRIPTION
This makes sure we that the port script sets up the `application_services_txns` sequence (#12209). and the `un_partial_stated_event_stream_sequence` sequence (#14545), which fixes errors like the one below from appearing when trying to connect to the postgresql database after running the script:

    Postgres sequence 'application_services_txn_id_seq' is inconsistent with associated
    table 'application_services_txns'. This can happen if Synapse has been downgraded and
    then upgraded again, or due to a bad migration.

    To fix this error, shut down Synapse (including any and all workers)
    and run the following SQL:

        SELECT setval('application_services_txn_id_seq', (
            SELECT GREATEST(MAX(txn_id), 0) FROM application_services_txns
        ));

    See docs/postgres.md for more information.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [X] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
