### PR TITLE
Properly handle redactions of creation events

### DIFF
--- a/changelog.d/15973.bugfix
+++ b/changelog.d/15973.bugfix
@@ -1,0 +1,1 @@
+Properly handle redactions of creation events.

--- a/synapse/events/utils.py
+++ b/synapse/events/utils.py
@@ -136,11 +136,13 @@ def prune_event_dict(room_version: RoomVersion, event_dict: JsonDict) -> JsonDic
                     ]
 
     elif event_type == EventTypes.Create:
-        # MSC2176 rules state that create events cannot be redacted.
         if room_version.updated_redaction_rules:
-            return event_dict
+            # MSC2176 rules state that create events cannot have their `content` redacted.
+            new_content = event_dict["content"]
+        elif not room_version.implicit_room_creator:
+            # Some room versions give meaning to `creator`
+            add_fields("creator")
 
-        add_fields("creator")
     elif event_type == EventTypes.JoinRules:
         add_fields("join_rule")
         if room_version.restricted_join_rule:

--- a/tests/events/test_utils.py
+++ b/tests/events/test_utils.py
@@ -225,9 +225,14 @@ class PruneEventTestCase(stdlib_unittest.TestCase):
             },
         )
 
-        # After MSC2176, create events get nothing redacted.
+        # After MSC2176, create events should preserve field `content`
         self.run_test(
-            {"type": "m.room.create", "content": {"not_a_real_key": True}},
+            {
+                "type": "m.room.create",
+                "content": {"not_a_real_key": True},
+                "origin": "some_homeserver",
+                "nonsense_field": "some_random_garbage",
+            },
             {
                 "type": "m.room.create",
                 "content": {"not_a_real_key": True},


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/15962 and https://github.com/matrix-org/synapse/issues/15963.

Ensures that 
a: the `content` field is wholly preserved when redacting an event in room v11, but other non-allowed fields are removed, and that
b: the `creator` field is only added back when redacting an event in rooms < v11, leading to a partial redaction of `content`.
Note that there is already a test for b, as the behavior here is technically not changing but is made more explicit. 