### PR TITLE
Resync stale devices in background

### DIFF
--- a/changelog.d/15975.bugfix
+++ b/changelog.d/15975.bugfix
@@ -1,0 +1,1 @@
+Fix bug where resyncing stale device lists could block responding to federation transactions, and thus delay receiving new data from the remote server.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -1124,7 +1124,14 @@ class DeviceListUpdater(DeviceListWorkerUpdater):
                 )
 
             if resync:
-                await self.multi_user_device_resync([user_id])
+                # We mark as stale up front in case we get restarted.
+                await self.store.mark_remote_users_device_caches_as_stale([user_id])
+                run_as_background_process(
+                    "_maybe_retry_device_resync",
+                    self.multi_user_device_resync,
+                    [user_id],
+                    False,
+                )
             else:
                 # Simply update the single device, since we know that is the only
                 # change (because of the single prev_id matching the current cache)


### PR DESCRIPTION
This is so we don't block responding to federation transaction while we try and fetch the device lists.

Requires: https://github.com/matrix-org/sytest/pull/1359