### PR TITLE
Presence fix for idle mode

### DIFF
--- a/changelog.d/15989.bugfix
+++ b/changelog.d/15989.bugfix
@@ -1,0 +1,1 @@
+Allow presence to achieve idle state.

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -1254,7 +1254,7 @@ class PresenceHandler(BasePresenceHandler):
             new_fields["status_msg"] = status_msg
 
         if (
-            prev_state.state == PresenceState.OFFLINE
+            prev_state.state != PresenceState.ONLINE
             and presence == PresenceState.ONLINE
         ) or (presence == PresenceState.BUSY and self._busy_presence_enabled):
             # By updating last_active_ts in this way, currently_active will be triggered
@@ -1982,14 +1982,6 @@ def handle_update(
                     obj=user_id,
                     then=new_state.last_active_ts + LAST_ACTIVE_GRANULARITY,
                 )
-            if prev_state.state == PresenceState.UNAVAILABLE:
-                # If we had idled out, but are still syncing, then new state will look
-                # like it's online. Verify with last_active_ts, as that is a sign of a
-                # pro-active event. Override that we are online when we probably aren't.
-                if now - new_state.last_active_ts > IDLE_TIMER:
-                    new_state = new_state.copy_and_replace(
-                        state=PresenceState.UNAVAILABLE
-                    )
 
         if new_state.state != PresenceState.OFFLINE:
             # User has stopped syncing

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -1254,7 +1254,7 @@ class PresenceHandler(BasePresenceHandler):
             new_fields["status_msg"] = status_msg
 
         if (
-            prev_state.state != PresenceState.ONLINE
+            prev_state.state == PresenceState.OFFLINE
             and presence == PresenceState.ONLINE
         ) or (presence == PresenceState.BUSY and self._busy_presence_enabled):
             # By updating last_active_ts in this way, currently_active will be triggered
@@ -1982,6 +1982,14 @@ def handle_update(
                     obj=user_id,
                     then=new_state.last_active_ts + LAST_ACTIVE_GRANULARITY,
                 )
+            if prev_state.state == PresenceState.UNAVAILABLE:
+                # If we had idled out, but are still syncing, then new state will look
+                # like it's online. Verify with last_active_ts, as that is a sign of a
+                # pro-active event. Override that we are online when we probably aren't.
+                if now - new_state.last_active_ts > IDLE_TIMER:
+                    new_state = new_state.copy_and_replace(
+                        state=PresenceState.UNAVAILABLE
+                    )
 
         if new_state.state != PresenceState.OFFLINE:
             # User has stopped syncing

--- a/synapse/handlers/presence.py
+++ b/synapse/handlers/presence.py
@@ -1982,6 +1982,14 @@ def handle_update(
                     obj=user_id,
                     then=new_state.last_active_ts + LAST_ACTIVE_GRANULARITY,
                 )
+            if prev_state.state == PresenceState.UNAVAILABLE:
+                # If we had idled out, but are still syncing, then new state will look
+                # like it's online. Verify with last_active_ts, as that is a sign of a
+                # pro-active event. Override that we are online when we probably aren't.
+                if now - new_state.last_active_ts > IDLE_TIMER:
+                    new_state = new_state.copy_and_replace(
+                        state=PresenceState.UNAVAILABLE
+                    )
 
         if new_state.state != PresenceState.OFFLINE:
             # User has stopped syncing


### PR DESCRIPTION
Presence has an idle mode, called 'Unavailable' which currently doesn't work right and is generating some additional traffic. Make it behave.

This is what it looks like if you zoom in to a 1 second resolution. 

![presence_flicker_1](https://github.com/matrix-org/synapse/assets/1582365/7a65e087-030f-49ad-80f2-92ba330fe7dd)

And it's repetitive. This is my client sitting open and largely untouched.

![presence_flicker_frequency](https://github.com/matrix-org/synapse/assets/1582365/41fbdde5-425e-46de-8a6d-4ac59c06c282)

But it doesn't ever actually idle. It goes back to online in nearly the same second. For testing this PR and for all the following pictures, I parked myself into an empty room so it would not be contaminated by read receipts, read markers, or typing (and of course didn't send myself any messages) as all of those will bump `last_active_ts` and not allow idling. I also ramped up the scraping interval and changed Grafana's display points to use `$__rate_interval` so I could get 1 second resolution on the timing(which makes the scale weird). The point was that I could see how often it was happening.

A client/user is considered idle after 5 minutes of no 'pro-active' events or activity. As you can see, it's not quite....right.

The fix is three-fold
1. Fix the `last_active_ts` bug, which allows a user to not update their `last_active_ts` just by syncing.
2. Stop a race between TCP replication calls to `USER_SYNC` in which one would say we are 'online' and another would say we are 'offline', creating a flicker(@nico-famedly). This appeared to only occur on a worker-mode dance between a sync worker and a presence stream_writer, but would still propagate over federation as it was a change of state. I want to thank @anoadragon453 for putting on an archeology hat and providing the fix for this. I don't think I would have looked here if it wasn't for that.
3. Add a condition that checks that a `PresenceState` was in 'unavailable'(which is what idle is called by the spec) and verifies that per the `last_active_ts` to see if the call to be 'online' is accurate. I want to thank @jevolk for letting me borrow his homeserver to see what was happening on the other side of federation.

<details><summary>One without Two resulted in this bad dream(every 35 seconds):</summary>

Just the yellow one on the left, the orange one on the right we'll deal with in Three.

![offline_flicker](https://github.com/matrix-org/synapse/assets/1582365/0d0644c7-2eca-48ab-a53f-b33180a9d690)

I called it after 30 minutes that this was enough of that.

![offline_flicker_zoomed_out](https://github.com/matrix-org/synapse/assets/1582365/55cb3274-21e7-46f3-a505-aac6205078c0)

</details>

<details><summary>One and Two without Three gave this nightmare(which didn't start for over 5 minutes, but then every 5 seconds):</summary>

Close up on these is up above.

![idle_flicker_fail](https://github.com/matrix-org/synapse/assets/1582365/e9ee6fe1-05e2-4126-9b83-3e7a534fb1a7)

</details>

And I threw in some tests to check this stuff. They pass now but on `develop` you get:

```log
===============================================================================
[FAIL]
Traceback (most recent call last):
  File "/home/jason/matrix-org/synapse/tests/handlers/test_presence.py", line 829, in test_syncing_appropriately_handles_last_active_ts
    self.assertEqual(prev_state.last_active_ts, state.last_active_ts)
  File "/home/jason/.cache/pypoetry/virtualenvs/matrix-synapse-8koxSNBY-py3.10/lib/python3.10/site-packages/twisted/trial/_synctest.py", line 441, in assertEqual
    super().assertEqual(first, second, msg)
  File "/usr/lib/python3.10/unittest/case.py", line 845, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib/python3.10/unittest/case.py", line 838, in _baseAssertEqual
    raise self.failureException(msg)
twisted.trial.unittest.FailTest: 2000 != 4000

tests.handlers.test_presence.PresenceHandlerTestCase.test_syncing_appropriately_handles_last_active_ts
===============================================================================
[FAIL]
Traceback (most recent call last):
  File "/home/jason/matrix-org/synapse/tests/handlers/test_presence.py", line 330, in test_idle_while_syncing_stays_idle
    self.assertFalse(persist_and_notify)
  File "/home/jason/.cache/pypoetry/virtualenvs/matrix-synapse-8koxSNBY-py3.10/lib/python3.10/site-packages/twisted/trial/_synctest.py", line 386, in assertFalse
    super().assertFalse(condition, msg)
  File "/usr/lib/python3.10/unittest/case.py", line 681, in assertFalse
    raise self.failureException(msg)
twisted.trial.unittest.FailTest: True is not false

tests.handlers.test_presence.PresenceUpdateTestCase.test_idle_while_syncing_stays_idle

```

(For those that were paying attention, you may have noticed that the original version of this PR had the conditional to fix `last_active_ts` check against `!= PresenceState.ONLINE`. This was affecting using idle, so was changed to exclude it.)

<details><summary>Hey look, it works now</summary>

![online](https://github.com/matrix-org/synapse/assets/1582365/d5068bd2-808f-446f-b4a4-73b14c74849a)

![online_3_min](https://github.com/matrix-org/synapse/assets/1582365/0955d953-609f-4fc2-bf47-3304efc829de)

![idle_6_min](https://github.com/matrix-org/synapse/assets/1582365/aca2834b-a743-4091-9f6a-6860806dd5bf)

![idle_33_min](https://github.com/matrix-org/synapse/assets/1582365/18b8cb2a-8b79-4b56-958f-cb1c07198591)

</details>

Correct idling federation traffic:
* Spike one is coming online
* Spike two is currently_active going false
* Spike three is going idle(unavailable)
* Spike four is the federation ping

![outgoing_edu_final](https://github.com/matrix-org/synapse/assets/1582365/67b29724-2284-4e23-871c-fa86a773ac52)


![presence_behaving](https://github.com/matrix-org/synapse/assets/1582365/c2f8f588-2299-45d7-b6ec-f7d0a4eaaee5)

<details><summary>Output provided by jevolk's server(does not match up with metrics above, but was used to verify unavailable state)</summary>

```log
Sun, 23 Jul 2023 06:30:23 +0000 {"currently_active":true,"last_active_ago":464,"presence":"online","user_id":"@<me>"} $eWtdp-Km0YduwJzMdsYcAhsOC4BteBzBpNDbWNTELQQ
Sun, 23 Jul 2023 06:22:56 +0000 {"currently_active":false,"last_active_ago":305634,"presence":"unavailable","user_id":"@<me>"} $pogN1n4O2OHAEj5LIF_BHKd435zyFZIQNWSNhg9P0Ag
Sun, 23 Jul 2023 06:18:56 +0000 {"currently_active":false,"last_active_ago":65630,"presence":"online","user_id":"@<me>"} $fqAhopBuouGn4bnl6WgCk-HzMjrBEx4j4tpNAtP_Km0
Sun, 23 Jul 2023 06:17:45 +0000 {"currently_active":true,"last_active_ago":347,"presence":"online","user_id":"@<me>"} $W4LcbnApxYcPz9KWkwoomdUZfv3USqpc6VVlgY1AOhg
Sun, 23 Jul 2023 06:16:01 +0000 {"currently_active":false,"last_active_ago":303489,"presence":"unavailable","user_id":"@<me>"} $frgWplfuLdWx8rKxPlpyQ3OXTAMVJaaELNYlYvL1-ZA
Sun, 23 Jul 2023 06:12:01 +0000 {"currently_active":false,"last_active_ago":62724,"presence":"online","user_id":"@<me>"} $A0sT_8xg-UbVUEvi8Sk0e7YnlvmWubPwsO9E9VTkRlw
Sun, 23 Jul 2023 06:10:16 +0000 {"currently_active":true,"last_active_ago":168,"presence":"online","user_id":"@<me>"} $WCTjiYvvJMUC5prdZGP01STaSAEp8qrApxGZ9Udcxso
Sun, 23 Jul 2023 06:09:56 +0000 {"currently_active":false,"last_active_ago":63547,"presence":"online","user_id":"@<me>"} $lw3ujOfLF7cZtMhqAPse1mA9uB-ffevqqcln5JJqg-M
Sun, 23 Jul 2023 06:04:16 +0000 {"currently_active":true,"last_active_ago":235,"presence":"online","user_id":"@<me>"} $sFl_bBDjpr3ZyZyEz7wrjsr7N4iAcd8iny05oEKxxJE
Sun, 23 Jul 2023 06:03:31 +0000 {"currently_active":false,"last_active_ago":62517,"presence":"online","user_id":"@<me>"} $80BGZnbXSg6Tj_d-gAMz_uHp97XUFNXpsjprnjVmV8g
Sun, 23 Jul 2023 06:01:35 +0000 {"currently_active":true,"last_active_ago":126,"presence":"online","user_id":"@<me>"} $rENTSkRYg_HYwtJI0UK1ubjf4hJ0ckvFOLQPOJrOnWU
Sun, 23 Jul 2023 06:01:28 +0000 {"currently_active":false,"last_active_ago":62886,"presence":"online","user_id":"@<me>"} $NxA6uvC6ekLR1plHtjLC3GNbF5SPZ0wyDPsPfeiCbnw
Sun, 23 Jul 2023 05:58:07 +0000 {"currently_active":true,"last_active_ago":264,"presence":"online","user_id":"@<me>"} $n4ebVHKlrlPtFoofgISFmiUQ4NAbsOHqEZYNz7rzccI
Sun, 23 Jul 2023 05:50:58 +0000 {"currently_active":true,"last_active_ago":2761,"presence":"online","user_id":"@<me>"} $jRJWtnex4F-5dkVs9YO3VG4sHK6Myi2cBcgfXoaPAYg
Sun, 23 Jul 2023 05:41:11 +0000 {"currently_active":true,"last_active_ago":3188,"presence":"online","user_id":"@<me>"} $y3p-j2XIjoAtAONLo-MDKPsGB0dJe2cmOxA0AXFn2sY
Sun, 23 Jul 2023 05:14:49 +0000 {"currently_active":false,"last_active_ago":98635,"presence":"online","user_id":"@<me>"} $GbeWx4z3FhbkKQfkNS37sIhJvRLopGUCGKllPlPTOQk
```

</details>

There is more to do in this area, but will be on a different PR as it may be somewhat contentious.


Should...
* Fixes #12424 
* maybe others

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>