### PR TITLE
Stop presence active time being updated too frequently...

### DIFF
--- a/changelog.d/15995.misc
+++ b/changelog.d/15995.misc
@@ -1,0 +1,1 @@
+Stop updating presence last active timestamp on unimportant events.

--- a/synapse/rest/client/read_marker.py
+++ b/synapse/rest/client/read_marker.py
@@ -52,8 +52,6 @@ class ReadMarkerRestServlet(RestServlet):
     ) -> Tuple[int, JsonDict]:
         requester = await self.auth.get_user_by_req(request)
 
-        await self.presence_handler.bump_presence_active_time(requester.user)
-
         body = parse_json_object_from_request(request)
 
         unrecognized_types = set(body.keys()) - self._known_receipt_types

--- a/synapse/rest/client/receipts.py
+++ b/synapse/rest/client/receipts.py
@@ -94,8 +94,6 @@ class ReceiptRestServlet(RestServlet):
                     Codes.INVALID_PARAM,
                 )
 
-        await self.presence_handler.bump_presence_active_time(requester.user)
-
         if receipt_type == ReceiptTypes.FULLY_READ:
             await self.read_marker_handler.received_client_read_marker(
                 room_id,


### PR DESCRIPTION
...Or, "stop telling everyone else I'm online and that someone else is online when they are just received a message someone else sent from a room I'm in that has nothing to do with me and I'm probably not even participating in".

The Matrix Spec for Presence says:
> The server maintains a timestamp of the last time it saw a pro-active event from the user. ***A pro-active event may be sending a message to a room or changing presence state to `online`.*** This timestamp is presented via a key called `last_active_ago` which gives the relative number of milliseconds since the pro-active event.

> The server will automatically set a user’s presence to `unavailable` if their last active time was over a threshold value (e.g. 5 minutes). Clients can manually set a user’s presence to `unavailable`. ***Any activity that bumps the last active time on any of the user’s clients will cause the server to automatically set their presence to `online`.***

<sub>reference [`1`](https://spec.matrix.org/v1.7/client-server-api/#last-active-ago) and [`2`](https://spec.matrix.org/v1.7/client-server-api/#idle-timeout) Emphasis above is mine.</sub>

I assert that my client telling my server that I've read a message that was sent isn't classified as an active event. 
* Maybe I'm sitting looking at the screen and see the new message. 
* Or maybe my client was left open and I've wandered off and I won't come back for a while. 
* Or maybe my I'm at my computer but I've minimized the window.

Any time my client sees a new message received, it is bumping my `last_active_ts` which is setting `currently_active` to `True`. Which then falls off after 60 seconds and sends presence across federation, both when `currently_active` is set to `True` and again when it's set to `False`. That's silly, I may not even actually be sitting at my computer!

Please make it stop

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>