### PR TITLE
Add `client_secret_path` as alternative for `client_secret` for OIDC config

### DIFF
--- a/changelog.d/16030.feature
+++ b/changelog.d/16030.feature
@@ -1,1 +1,1 @@
-Allow specifying `client_secret_path` as alternative to `client_secret` for OIDC providers. That way, the client secret doesn't need to be leaked into the homeserver config. Contributed by @Ma27.
+Allow specifying `client_secret_path` as alternative to `client_secret` for OIDC providers. This avoids leaking the client secret in the homeserver config. Contributed by @Ma27.

--- a/changelog.d/16030.feature
+++ b/changelog.d/16030.feature
@@ -1,0 +1,1 @@
+Allow specifying `client_secret_path` as alternative to `client_secret` for OIDC providers. That way, the client secret doesn't need to be leaked into the homeserver config. Contributed by @Ma27.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3170,6 +3170,10 @@ Options for each entry include:
 * `client_secret`: oauth2 client secret to use. May be omitted if
   `client_secret_jwt_key` is given, or if `client_auth_method` is 'none'.
 
+* `client_secret_path`: path to the oauth2 client secret to use. With that
+   it's not necessary to leak secrets into the config file itself.
+   Mutually exclusive with `client_secret`.
+
 * `client_secret_jwt_key`: Alternative to client_secret: details of a key used
    to create a JSON Web Token to be used as an OAuth2 client secret. If
    given, must be a dictionary with the following properties:

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3176,6 +3176,8 @@ Options for each entry include:
    Mutually exclusive with `client_secret`. Can be omitted if
    `client_secret_jwt_key` is specified.
 
+   *Added in Synapse 1.91.0.*
+
 * `client_secret_jwt_key`: Alternative to client_secret: details of a key used
    to create a JSON Web Token to be used as an OAuth2 client secret. If
    given, must be a dictionary with the following properties:

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3169,10 +3169,12 @@ Options for each entry include:
 
 * `client_secret`: oauth2 client secret to use. May be omitted if
   `client_secret_jwt_key` is given, or if `client_auth_method` is 'none'.
+  Must be omitted if `client_secret_path` is specified.
 
 * `client_secret_path`: path to the oauth2 client secret to use. With that
    it's not necessary to leak secrets into the config file itself.
-   Mutually exclusive with `client_secret`.
+   Mutually exclusive with `client_secret`. Can be omitted if
+   `client_secret_jwt_key` is specified.
 
 * `client_secret_jwt_key`: Alternative to client_secret: details of a key used
    to create a JSON Web Token to be used as an OAuth2 client secret. If


### PR DESCRIPTION
That way you don't have to leak your bind password into your config. Useful for e.g. NixOS where config is stored in a world-readable location.

Tested against a live synapse instance with authentik as OIDC provider.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
