### PR TITLE
Rename Rust evaluator `event_property_contains` field value_type to value too

### DIFF
--- a/rust/src/push/base_rules.rs
+++ b/rust/src/push/base_rules.rs
@@ -147,7 +147,7 @@ pub const BASE_APPEND_OVERRIDE_RULES: &[PushRule] = &[
         conditions: Cow::Borrowed(&[Condition::Known(
             KnownCondition::ExactEventPropertyContainsType(EventPropertyIsTypeCondition {
                 key: Cow::Borrowed("content.m\\.mentions.user_ids"),
-                value_type: Cow::Borrowed(&EventMatchPatternType::UserId),
+                value: Cow::Borrowed(&EventMatchPatternType::UserId),
             }),
         )]),
         actions: Cow::Borrowed(&[Action::Notify, HIGHLIGHT_ACTION, SOUND_ACTION]),

--- a/rust/src/push/evaluator.rs
+++ b/rust/src/push/evaluator.rs
@@ -312,7 +312,7 @@ impl PushRuleEvaluator {
                     return Ok(false);
                 };
 
-                let pattern = match &*exact_event_match.value_type {
+                let pattern = match &*exact_event_match.value {
                     EventMatchPatternType::UserId => user_id,
                     EventMatchPatternType::UserLocalpart => get_localpart_from_id(user_id)?,
                 };

--- a/rust/src/push/mod.rs
+++ b/rust/src/push/mod.rs
@@ -405,7 +405,7 @@ pub struct EventPropertyIsTypeCondition {
     pub key: Cow<'static, str>,
     // During serialization, the pattern_type property gets replaced with a
     // pattern property of the correct value in synapse.push.clientformat.format_push_rules_for_user.
-    pub value_type: Cow<'static, EventMatchPatternType>,
+    pub value: Cow<'static, EventMatchPatternType>,
 }
 
 /// The body of a [`Condition::RelatedEventMatch`]


### PR DESCRIPTION
Following what happened in https://github.com/matrix-org/synapse/pull/15781.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
