### PR TITLE
Fix deletion for Dehydrated Devices

### DIFF
--- a/changelog.d/16046.bugfix
+++ b/changelog.d/16046.bugfix
@@ -1,0 +1,1 @@
+Fix deletion in dehydrated devices v2.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -722,6 +722,22 @@ class DeviceHandler(DeviceWorkerHandler):
 
         return {"success": True}
 
+    async def delete_dehydrated_device(self, user_id: str, device_id: str) -> None:
+        """
+        Delete a stored dehydrated device.
+
+        Args:
+            user_id: the user_id to delete the device from
+            device_id: id of the dehydrated device to delete
+        """
+        success = await self.store.remove_dehydrated_device(user_id, device_id)
+
+        if not success:
+            raise errors.NotFoundError()
+
+        await self.delete_devices(user_id, [device_id])
+        await self.store.delete_e2e_keys_by_device(user_id=user_id, device_id=device_id)
+
     @wrap_as_background_process("_handle_new_device_update_async")
     async def _handle_new_device_update_async(self) -> None:
         """Called when we have a new local device list update that we need to


### PR DESCRIPTION
The DELETE method for the `unstable/org.matrix.msc3814.v1/dehydrated_device` endpoint was deleting the old dehydrated device rather than the current one. This PR adds a simple function to delete the dehydrated device, and employs it 
- when DELETE is called
- when a new device is PUT by the user

as well as adding a test to verify that it is working. Fixes #16022.
