### PR TITLE
Allow disabled federation presence, both receiving and sending

### DIFF
--- a/changelog.d/16058.misc
+++ b/changelog.d/16058.misc
@@ -1,0 +1,1 @@
+Add configuration option to disable sending and receiving presence over federation. Local presence is unaffected.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -372,6 +372,10 @@ class ServerConfig(Config):
         if self.use_presence is None:
             self.use_presence = config.get("use_presence", True)
 
+        self.presence_federation_disabled: bool = presence_config.get(
+            "disable_federation_presence", False
+        )
+
         # Custom presence router module
         # This is the legacy way of configuring it (the config should now be put in the modules section)
         self.presence_router_module_class = None


### PR DESCRIPTION
This should allow for not processing presence received over federation and also not sending it out over federation.

I have tests written for the room joining cases, I'm still working on the <del>regular send and </del>receive cases.

Set in your shared configuration:
```yaml
presence:
  enabled: true
  disable_federation_presence: true
```
An oddity I noticed while writing some of the tests, we are queueing up presence states to send out over federation for ourselves, but they are filtered out at the federation sender level. Since that is extra traffic that goes over replication, I'll probably rip that out later on. But in the mean time, I left a comment in the one test where it'll need to be switched over to match that behavior.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>