### PR TITLE
Make the "don't use retention" warning less subtle

### DIFF
--- a/changelog.d/16062.doc
+++ b/changelog.d/16062.doc
@@ -1,0 +1,1 @@
+Emphasise more strongly that message retention is experimental and buggy.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1084,6 +1084,7 @@ retention:
       interval: 1d
 ```
 </details>
+
 ---
 ## TLS
 

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1004,16 +1004,18 @@ templates:
 This option and the associated options determine message retention policy at the
 server level.
 
-#### ⚠️  WARNING
+> #### ⚠️  WARNING
+> 
+> The message retention policies feature is disabled by default. Please be advised
+> that enabling this feature carries some risk. **There are known bugs with the implementation
+> which [*can cause database corruption*](https://github.com/matrix-org/synapse/issues/13476)**. 
+> Setting retention to delete older history is less risky than deleting newer history,
+> but in general caution is strongly advised when enabling this
+> experimental feature. You can read more about this feature [here](../../message_retention_policies.md).
 
-The message retention policies feature is disabled by default. Please be advised
-that enabling this feature carries some risk. **There are known bugs with the implementation
-which [*can cause database corruption*](https://github.com/matrix-org/synapse/issues/13476)**. 
-Setting retention to delete older history is less risky than deleting newer history,
-but in general caution is strongly advised when enabling this
-experimental feature. You can read more about this feature [here](../../message_retention_policies.md).
+<details>
+<summary>I understand I risk corrupting my homeserver, show me the details</summary>
 
-#### Details
 
 Room admins and mods can define a retention period for their rooms using the
 `m.room.retention` state event, and server admins can cap this period by setting
@@ -1081,6 +1083,7 @@ retention:
     - shortest_max_lifetime: 3d
       interval: 1d
 ```
+</details>
 ---
 ## TLS
 

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1004,6 +1004,17 @@ templates:
 This option and the associated options determine message retention policy at the
 server level.
 
+#### ⚠️  WARNING
+
+The message retention policies feature is disabled by default. Please be advised
+that enabling this feature carries some risk. **There are known bugs with the implementation
+which [*can cause database corruption*](https://github.com/matrix-org/synapse/issues/13476)**. 
+Setting retention to delete older history is less risky than deleting newer history,
+but in general caution is strongly advised when enabling this
+experimental feature. You can read more about this feature [here](../../message_retention_policies.md).
+
+#### Details
+
 Room admins and mods can define a retention period for their rooms using the
 `m.room.retention` state event, and server admins can cap this period by setting
 the `allowed_lifetime_min` and `allowed_lifetime_max` config options.
@@ -1012,12 +1023,6 @@ If this feature is enabled, Synapse will regularly look for and purge events
 which are older than the room's maximum retention period. Synapse will also
 filter events received over federation so that events that should have been
 purged are ignored and not stored again.
-
-The message retention policies feature is disabled by default. Please be advised
-that enabling this feature carries some risk. There are known bugs with the implementation
-which can cause database corruption. Setting retention to delete older history
-is less risky than deleting newer history but in general caution is advised when enabling this
-experimental feature. You can read more about this feature [here](../../message_retention_policies.md).
 
 This setting has the following sub-options:
 * `default_policy`: Default retention policy. If set, Synapse will apply it to rooms that lack the


### PR DESCRIPTION
No, really, don't use it.

Now: 
![image](https://github.com/matrix-org/synapse/assets/8614563/5091e1d8-ec1d-4b5a-8e55-8f609157c3c0)

See #13476.

Follow up to #13475, #13497.