### PR TITLE
Switch `devenv` dependency in the nix development environment to the latest release (instead of the development branch)

### DIFF
--- a/changelog.d/16063.misc
+++ b/changelog.d/16063.misc
@@ -1,0 +1,1 @@
+Fix building the nix development environment on MacOS systems.

--- a/flake.lock
+++ b/flake.lock
@@ -8,16 +8,16 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1690534632,
-        "narHash": "sha256-kOXS9x5y17VKliC7wZxyszAYrWdRl1JzggbQl0gyo94=",
+        "lastModified": 1688058187,
+        "narHash": "sha256-ipDcc7qrucpJ0+0eYNlwnE+ISTcq4m03qW+CWUshRXI=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "6568e7e485a46bbf32051e4d6347fa1fed8b2f25",
+        "rev": "c8778e3dc30eb9043e218aaa3861d42d4992de77",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "main",
+        "ref": "v0.6.3",
         "repo": "devenv",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
     # Output a development shell for x86_64/aarch64 Linux/Darwin (MacOS).
     systems.url = "github:nix-systems/default";
     # A development environment manager built on Nix. See https://devenv.sh.
-    devenv.url = "github:cachix/devenv/main";
+    devenv.url = "github:cachix/devenv/v0.6.3";
     # Rust toolchain.
     rust-overlay.url = "github:oxalica/rust-overlay";
   };


### PR DESCRIPTION
https://github.com/cachix/devenv/issues/756 introduced a regression into the development branch of devenv which caused the `devenv up` command (which we utilise to start up a local Synapse, postgres and redis) to return an error.

We updated our pinned dependencies in https://github.com/matrix-org/synapse/pull/16019. This would have been caught if someone ran 'devenv up' during manual testing of that PR, or better yet, if we had CI for the nix developer environment.

This PR switches back to the latest release version of devenv ([v0.6.3](https://github.com/cachix/devenv/releases/tag/v0.6.3)), which doesn't have the regression. We are not relying on any features introduced since that version was tagged.

Uses the same changelog as https://github.com/matrix-org/synapse/pull/16019.