### PR TITLE
Override global statement timeout when creating indexes in Postgres

### DIFF
--- a/changelog.d/16085.misc
+++ b/changelog.d/16085.misc
@@ -1,0 +1,1 @@
+Override global statement timeout when creating indexes in Postgres.

--- a/synapse/storage/background_updates.py
+++ b/synapse/storage/background_updates.py
@@ -760,7 +760,7 @@ class BackgroundUpdater:
 
                 # override the global statement timeout to avoid accidentally squashing
                 # a long-running index creation process
-                timeout_sql = "SET LOCAL statement timeout = 0"
+                timeout_sql = "SET LOCAL statement_timeout = 0"
                 c.execute(timeout_sql)
 
                 sql = (

--- a/synapse/storage/background_updates.py
+++ b/synapse/storage/background_updates.py
@@ -758,6 +758,11 @@ class BackgroundUpdater:
                 logger.debug("[SQL] %s", sql)
                 c.execute(sql)
 
+                # override the global statement timeout to avoid accidentally squashing
+                # a long-running index creation process
+                timeout_sql = "SET LOCAL statement timeout = 0"
+                c.execute(timeout_sql)
+
                 sql = (
                     "CREATE %(unique)s INDEX CONCURRENTLY %(name)s"
                     " ON %(table)s"


### PR DESCRIPTION
 #15853 added a global timeout for long-running Postgres statements, but this may interfere with long-running index creation. This PR adds a local statement timeout to override the global timeout and disable it when creating an index in the background. Fixes #15942.