### PR TITLE
Add GCC and GNU Make to the Nix flake development environment so that `ruff` can be compiled.

### DIFF
--- a/changelog.d/16090.misc
+++ b/changelog.d/16090.misc
@@ -1,0 +1,1 @@
+Add GCC and GNU Make to the Nix flake development environment so that `ruff` can be compiled.

--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,10 @@
                   })
                   # The rust-analyzer language server implementation.
                   rust-analyzer
+                  # GCC includes a linker; needed for building `ruff`
+                  gcc
+                  # Needed for building `ruff`
+                  gnumake
 
                   # Native dependencies for running Synapse.
                   icu

--- a/flake.nix
+++ b/flake.nix
@@ -240,6 +240,19 @@
                   URI
                   YAMLLibYAML
                 ]}";
+
+                # Clear the LD_LIBRARY_PATH environment variable on shell init.
+                #
+                # By default, devenv will set LD_LIBRARY_PATH to point to .devenv/profile/lib. This causes
+                # issues when we include `gcc` as a dependency to build C libraries, as the version of glibc
+                # that the development environment's cc compiler uses may differ from that of the system.
+                #
+                # When LD_LIBRARY_PATH is set, system tools will attempt to use the development environment's
+                # libraries. Which, when built against an different glibc version lead, to "version 'GLIBC_X.YY' not
+                # found" errors.
+                enterShell = ''
+                  unset LD_LIBRARY_PATH
+                '';
               }
             ];
           };


### PR DESCRIPTION
I found that compiling/installing ruff needed `cc` as a linker and `make`.

Adding these got me away and running.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Add gcc and GNU make to the Nix flake 

</li>
</ol>
