### PR TITLE
Add cache to `get_server_keys_json_for_remote`

### DIFF
--- a/changelog.d/16123.misc
+++ b/changelog.d/16123.misc
@@ -1,0 +1,1 @@
+Add cache to `get_server_keys_json_for_remote`.

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -162,7 +162,7 @@ class RemoteKey(RestServlet):
             if not key_ids:
                 key_ids = (None,)
             for key_id in key_ids:
-                store_queries.append((server_name, key_id, None))
+                store_queries.append((server_name, key_id))
 
         cached = await self.store.get_server_keys_json_for_remote(store_queries)
 
@@ -173,7 +173,7 @@ class RemoteKey(RestServlet):
         # Map server_name->key_id->int. Note that the value of the int is unused.
         # XXX: why don't we just use a set?
         cache_misses: Dict[str, Dict[str, int]] = {}
-        for (server_name, key_id, _), key_results in cached.items():
+        for (server_name, key_id), key_results in cached.items():
             results = [(result["ts_added_ms"], result) for result in key_results]
 
             if key_id is None:

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -158,7 +158,7 @@ class RemoteKey(RestServlet):
     ) -> JsonDict:
         logger.info("Handling query for keys %r", query)
 
-        cached: Dict[Tuple[str, str], Optional[FetchKeyResultForRemote]] = {}
+        server_keys: Dict[Tuple[str, str], Optional[FetchKeyResultForRemote]] = {}
         for server_name, key_ids in query.items():
             if key_ids:
                 results: Mapping[
@@ -171,7 +171,7 @@ class RemoteKey(RestServlet):
                     server_name
                 )
 
-            cached.update(
+            server_keys.update(
                 ((server_name, key_id), res) for key_id, res in results.items()
             )
 
@@ -182,7 +182,7 @@ class RemoteKey(RestServlet):
         # Map server_name->key_id->int. Note that the value of the int is unused.
         # XXX: why don't we just use a set?
         cache_misses: Dict[str, Dict[str, int]] = {}
-        for (server_name, key_id), key_result in cached.items():
+        for (server_name, key_id), key_result in server_keys.items():
             if not query[server_name]:
                 # all keys were requested. Just return what we have without worrying
                 # about validity

--- a/synapse/rest/key/v2/remote_key_resource.py
+++ b/synapse/rest/key/v2/remote_key_resource.py
@@ -173,22 +173,20 @@ class RemoteKey(RestServlet):
         # Map server_name->key_id->int. Note that the value of the int is unused.
         # XXX: why don't we just use a set?
         cache_misses: Dict[str, Dict[str, int]] = {}
-        for (server_name, key_id), key_results in cached.items():
-            results = [(result.added_ts, result) for result in key_results]
-
-            if key_id is None:
+        for (server_name, key_id), key_result in cached.items():
+            if not query[server_name]:
                 # all keys were requested. Just return what we have without worrying
                 # about validity
-                for _, result in results:
-                    json_results.add(result.key_json)
+                if key_result:
+                    json_results.add(key_result.key_json)
                 continue
 
             miss = False
-            if not results:
+            if key_result is None:
                 miss = True
             else:
-                ts_added_ms, most_recent_result = max(results)
-                ts_valid_until_ms = most_recent_result.valid_until_ts
+                ts_added_ms = key_result.added_ts
+                ts_valid_until_ms = key_result.valid_until_ts
                 req_key = query.get(server_name, {}).get(key_id, {})
                 req_valid_until = req_key.get("minimum_valid_until_ts")
                 if req_valid_until is not None:
@@ -235,7 +233,7 @@ class RemoteKey(RestServlet):
                         time_now_ms,
                     )
 
-                json_results.add(most_recent_result.key_json)
+                json_results.add(key_result.key_json)
 
             if miss and query_remote_on_cache_miss:
                 # only bother attempting to fetch keys from servers on our whitelist

--- a/synapse/storage/databases/main/keys.py
+++ b/synapse/storage/databases/main/keys.py
@@ -295,5 +295,5 @@ class KeyStore(SQLBaseStore):
             return results
 
         return await self.db_pool.runInteraction(
-            "get_server_keys_json", _get_server_keys_json_txn
+            "get_server_keys_json_for_remote", _get_server_keys_json_txn
         )

--- a/synapse/storage/databases/main/keys.py
+++ b/synapse/storage/databases/main/keys.py
@@ -293,6 +293,7 @@ class KeyStore(CacheInvalidationWorkerStore):
         if not rows:
             return {}
 
+        # We sort the rows so that the most recently added entry is picked up.
         rows.sort(key=lambda r: r["ts_added_ms"])
 
         return {

--- a/synapse/storage/keys.py
+++ b/synapse/storage/keys.py
@@ -25,3 +25,10 @@ logger = logging.getLogger(__name__)
 class FetchKeyResult:
     verify_key: VerifyKey  # the key itself
     valid_until_ts: int  # how long we can use this key for
+
+
+@attr.s(slots=True, frozen=True, auto_attribs=True)
+class FetchKeyResultForRemote:
+    key_json: bytes  # the full key JSON
+    valid_until_ts: int  # how long we can use this key for
+    added_ts: int  # When we added this key

--- a/synapse/storage/keys.py
+++ b/synapse/storage/keys.py
@@ -30,5 +30,5 @@ class FetchKeyResult:
 @attr.s(slots=True, frozen=True, auto_attribs=True)
 class FetchKeyResultForRemote:
     key_json: bytes  # the full key JSON
-    valid_until_ts: int  # how long we can use this key for
-    added_ts: int  # When we added this key
+    valid_until_ts: int  # how long we can use this key for, in milliseconds.
+    added_ts: int  # When we added this key, in milliseconds.

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -462,9 +462,9 @@ class ServerKeyFetcherTestCase(unittest.HomeserverTestCase):
                 [lookup_tuple]
             )
         )
-        res_keys = key_json[lookup_tuple]
-        self.assertEqual(len(res_keys), 1)
-        res = res_keys[0]
+        res = key_json[lookup_tuple]
+        self.assertIsNotNone(res)
+        assert res is not None
         self.assertEqual(res.added_ts, self.reactor.seconds() * 1000)
         self.assertEqual(res.valid_until_ts, VALID_UNTIL_TS)
 
@@ -578,9 +578,9 @@ class PerspectivesKeyFetcherTestCase(unittest.HomeserverTestCase):
                 [lookup_tuple]
             )
         )
-        res_keys = key_json[lookup_tuple]
-        self.assertEqual(len(res_keys), 1)
-        res = res_keys[0]
+        res = key_json[lookup_tuple]
+        self.assertIsNotNone(res)
+        assert res is not None
         self.assertEqual(res.added_ts, self.reactor.seconds() * 1000)
         self.assertEqual(res.valid_until_ts, VALID_UNTIL_TS)
 
@@ -697,9 +697,9 @@ class PerspectivesKeyFetcherTestCase(unittest.HomeserverTestCase):
                 [lookup_tuple]
             )
         )
-        res_keys = key_json[lookup_tuple]
-        self.assertEqual(len(res_keys), 1)
-        res = res_keys[0]
+        res = key_json[lookup_tuple]
+        self.assertIsNotNone(res)
+        assert res is not None
         self.assertEqual(res.added_ts, self.reactor.seconds() * 1000)
         self.assertEqual(res.valid_until_ts, VALID_UNTIL_TS)
 

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -456,13 +456,13 @@ class ServerKeyFetcherTestCase(unittest.HomeserverTestCase):
         self.assertEqual(k.verify_key.version, "ver1")
 
         # check that the perspectives store is correctly updated
-        lookup_triplet = (SERVER_NAME, testverifykey_id, None)
+        lookup_tuple = (SERVER_NAME, testverifykey_id)
         key_json = self.get_success(
             self.hs.get_datastores().main.get_server_keys_json_for_remote(
-                [lookup_triplet]
+                [lookup_tuple]
             )
         )
-        res_keys = key_json[lookup_triplet]
+        res_keys = key_json[lookup_tuple]
         self.assertEqual(len(res_keys), 1)
         res = res_keys[0]
         self.assertEqual(res["key_id"], testverifykey_id)
@@ -576,13 +576,13 @@ class PerspectivesKeyFetcherTestCase(unittest.HomeserverTestCase):
         self.assertEqual(k.verify_key.version, "ver1")
 
         # check that the perspectives store is correctly updated
-        lookup_triplet = (SERVER_NAME, testverifykey_id, None)
+        lookup_tuple = (SERVER_NAME, testverifykey_id)
         key_json = self.get_success(
             self.hs.get_datastores().main.get_server_keys_json_for_remote(
-                [lookup_triplet]
+                [lookup_tuple]
             )
         )
-        res_keys = key_json[lookup_triplet]
+        res_keys = key_json[lookup_tuple]
         self.assertEqual(len(res_keys), 1)
         res = res_keys[0]
         self.assertEqual(res["key_id"], testverifykey_id)
@@ -699,13 +699,13 @@ class PerspectivesKeyFetcherTestCase(unittest.HomeserverTestCase):
         self.assertEqual(k.verify_key.version, "ver1")
 
         # check that the perspectives store is correctly updated
-        lookup_triplet = (SERVER_NAME, testverifykey_id, None)
+        lookup_tuple = (SERVER_NAME, testverifykey_id)
         key_json = self.get_success(
             self.hs.get_datastores().main.get_server_keys_json_for_remote(
-                [lookup_triplet]
+                [lookup_tuple]
             )
         )
-        res_keys = key_json[lookup_triplet]
+        res_keys = key_json[lookup_tuple]
         self.assertEqual(len(res_keys), 1)
         res = res_keys[0]
         self.assertEqual(res["key_id"], testverifykey_id)

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -455,14 +455,13 @@ class ServerKeyFetcherTestCase(unittest.HomeserverTestCase):
         self.assertEqual(k.verify_key.alg, "ed25519")
         self.assertEqual(k.verify_key.version, "ver1")
 
-        # check that the perspectives store is correctly updated
-        lookup_tuple = (SERVER_NAME, testverifykey_id)
+        # check that the perspectives store is correctly updated=
         key_json = self.get_success(
             self.hs.get_datastores().main.get_server_keys_json_for_remote(
-                [lookup_tuple]
+                SERVER_NAME, [testverifykey_id]
             )
         )
-        res = key_json[lookup_tuple]
+        res = key_json[testverifykey_id]
         self.assertIsNotNone(res)
         assert res is not None
         self.assertEqual(res.added_ts, self.reactor.seconds() * 1000)
@@ -572,13 +571,12 @@ class PerspectivesKeyFetcherTestCase(unittest.HomeserverTestCase):
         self.assertEqual(k.verify_key.version, "ver1")
 
         # check that the perspectives store is correctly updated
-        lookup_tuple = (SERVER_NAME, testverifykey_id)
         key_json = self.get_success(
             self.hs.get_datastores().main.get_server_keys_json_for_remote(
-                [lookup_tuple]
+                SERVER_NAME, [testverifykey_id]
             )
         )
-        res = key_json[lookup_tuple]
+        res = key_json[testverifykey_id]
         self.assertIsNotNone(res)
         assert res is not None
         self.assertEqual(res.added_ts, self.reactor.seconds() * 1000)
@@ -691,13 +689,12 @@ class PerspectivesKeyFetcherTestCase(unittest.HomeserverTestCase):
         self.assertEqual(k.verify_key.version, "ver1")
 
         # check that the perspectives store is correctly updated
-        lookup_tuple = (SERVER_NAME, testverifykey_id)
         key_json = self.get_success(
             self.hs.get_datastores().main.get_server_keys_json_for_remote(
-                [lookup_tuple]
+                SERVER_NAME, [testverifykey_id]
             )
         )
-        res = key_json[lookup_tuple]
+        res = key_json[testverifykey_id]
         self.assertIsNotNone(res)
         assert res is not None
         self.assertEqual(res.added_ts, self.reactor.seconds() * 1000)

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -455,7 +455,7 @@ class ServerKeyFetcherTestCase(unittest.HomeserverTestCase):
         self.assertEqual(k.verify_key.alg, "ed25519")
         self.assertEqual(k.verify_key.version, "ver1")
 
-        # check that the perspectives store is correctly updated=
+        # check that the perspectives store is correctly updated
         key_json = self.get_success(
             self.hs.get_datastores().main.get_server_keys_json_for_remote(
                 SERVER_NAME, [testverifykey_id]

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -465,15 +465,11 @@ class ServerKeyFetcherTestCase(unittest.HomeserverTestCase):
         res_keys = key_json[lookup_tuple]
         self.assertEqual(len(res_keys), 1)
         res = res_keys[0]
-        self.assertEqual(res["key_id"], testverifykey_id)
-        self.assertEqual(res["from_server"], SERVER_NAME)
-        self.assertEqual(res["ts_added_ms"], self.reactor.seconds() * 1000)
-        self.assertEqual(res["ts_valid_until_ms"], VALID_UNTIL_TS)
+        self.assertEqual(res.added_ts, self.reactor.seconds() * 1000)
+        self.assertEqual(res.valid_until_ts, VALID_UNTIL_TS)
 
         # we expect it to be encoded as canonical json *before* it hits the db
-        self.assertEqual(
-            bytes(res["key_json"]), canonicaljson.encode_canonical_json(response)
-        )
+        self.assertEqual(res.key_json, canonicaljson.encode_canonical_json(response))
 
         # change the server name: the result should be ignored
         response["server_name"] = "OTHER_SERVER"
@@ -585,14 +581,10 @@ class PerspectivesKeyFetcherTestCase(unittest.HomeserverTestCase):
         res_keys = key_json[lookup_tuple]
         self.assertEqual(len(res_keys), 1)
         res = res_keys[0]
-        self.assertEqual(res["key_id"], testverifykey_id)
-        self.assertEqual(res["from_server"], self.mock_perspective_server.server_name)
-        self.assertEqual(res["ts_added_ms"], self.reactor.seconds() * 1000)
-        self.assertEqual(res["ts_valid_until_ms"], VALID_UNTIL_TS)
+        self.assertEqual(res.added_ts, self.reactor.seconds() * 1000)
+        self.assertEqual(res.valid_until_ts, VALID_UNTIL_TS)
 
-        self.assertEqual(
-            bytes(res["key_json"]), canonicaljson.encode_canonical_json(response)
-        )
+        self.assertEqual(res.key_json, canonicaljson.encode_canonical_json(response))
 
     def test_get_multiple_keys_from_perspectives(self) -> None:
         """Check that we can correctly request multiple keys for the same server"""
@@ -708,14 +700,10 @@ class PerspectivesKeyFetcherTestCase(unittest.HomeserverTestCase):
         res_keys = key_json[lookup_tuple]
         self.assertEqual(len(res_keys), 1)
         res = res_keys[0]
-        self.assertEqual(res["key_id"], testverifykey_id)
-        self.assertEqual(res["from_server"], self.mock_perspective_server.server_name)
-        self.assertEqual(res["ts_added_ms"], self.reactor.seconds() * 1000)
-        self.assertEqual(res["ts_valid_until_ms"], VALID_UNTIL_TS)
+        self.assertEqual(res.added_ts, self.reactor.seconds() * 1000)
+        self.assertEqual(res.valid_until_ts, VALID_UNTIL_TS)
 
-        self.assertEqual(
-            bytes(res["key_json"]), canonicaljson.encode_canonical_json(response)
-        )
+        self.assertEqual(res.key_json, canonicaljson.encode_canonical_json(response))
 
     def test_invalid_perspectives_responses(self) -> None:
         """Check that invalid responses from the perspectives server are rejected"""


### PR DESCRIPTION
Plus a lot of refactoring. 

Note that Synapse really only generates queries to this API for a single server name and a specific set of key IDs (rather than for multiple servers, or for all keys for a given server).

Reviewable commit-by-commit.