### PR TITLE
Disallow user_consent where experimental MSC3861 is enabled

### DIFF
--- a/changelog.d/16127.bugfix
+++ b/changelog.d/16127.bugfix
@@ -1,0 +1,1 @@
+User consent on registration cannot be used when experimental MSC3861 is enabled.

--- a/changelog.d/16127.bugfix
+++ b/changelog.d/16127.bugfix
@@ -1,1 +1,1 @@
-User consent on registration cannot be used when experimental MSC3861 is enabled.
+User consent cannot be configured when experimental MSC3861 is enabled.

--- a/changelog.d/16127.bugfix
+++ b/changelog.d/16127.bugfix
@@ -1,1 +1,1 @@
-User consent cannot be configured when experimental MSC3861 is enabled.
+User consent features cannot be enabled when using experimental MSC3861.

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -173,6 +173,12 @@ class MSC3861:
                 ("enable_registration",),
             )
 
+        if root.consent.user_consent_at_registration:
+            raise ConfigError(
+                "User consent at registration cannot be enabled when OAuth delegation is enabled",
+                ("user_consent", "require_at_registration"),
+            )
+
         if (
             root.oidc.oidc_enabled
             or root.saml2.saml2_enabled

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -173,10 +173,11 @@ class MSC3861:
                 ("enable_registration",),
             )
 
-        if root.consent.user_consent_at_registration:
+        # We only need to test the user consent version, as if it must be set if the user_consent section was present in the config
+        if root.consent.user_consent_version is not None:
             raise ConfigError(
-                "User consent at registration cannot be enabled when OAuth delegation is enabled",
-                ("user_consent", "require_at_registration"),
+                "User consent cannot be enabled when OAuth delegation is enabled",
+                ("user_consent",),
             )
 
         if (

--- a/tests/config/test_oauth_delegation.py
+++ b/tests/config/test_oauth_delegation.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from unittest.mock import Mock
 
 from synapse.config import ConfigError
@@ -167,8 +168,18 @@ class MSC3861OAuthDelegation(TestCase):
         with self.assertRaises(ConfigError):
             self.parse_config()
 
-    def test_user_consent_on_registration_cannot_be_enabled(self) -> None:
-        self.config_dict["user_consent"] = {"require_at_registration": True}
+    def test_user_consent_cannot_be_enabled(self) -> None:
+        tmpdir = self.mktemp()
+        os.mkdir(tmpdir)
+        self.config_dict["user_consent"] = {
+            "require_at_registration": True,
+            "version": "1",
+            "template_dir": tmpdir,
+            "server_notice_content": {
+                "msgtype": "m.text",
+                "body": "foo",
+            },
+        }
         with self.assertRaises(ConfigError):
             self.parse_config()
 

--- a/tests/config/test_oauth_delegation.py
+++ b/tests/config/test_oauth_delegation.py
@@ -167,6 +167,11 @@ class MSC3861OAuthDelegation(TestCase):
         with self.assertRaises(ConfigError):
             self.parse_config()
 
+    def test_user_consent_on_registration_cannot_be_enabled(self) -> None:
+        self.config_dict["user_consent"]["require_at_registration"] = True
+        with self.assertRaises(ConfigError):
+            self.parse_config()
+
     def test_password_config_cannot_be_enabled(self) -> None:
         self.config_dict["password_config"] = {"enabled": True}
         with self.assertRaises(ConfigError):

--- a/tests/config/test_oauth_delegation.py
+++ b/tests/config/test_oauth_delegation.py
@@ -168,7 +168,7 @@ class MSC3861OAuthDelegation(TestCase):
             self.parse_config()
 
     def test_user_consent_on_registration_cannot_be_enabled(self) -> None:
-        self.config_dict["user_consent"]["require_at_registration"] = True
+        self.config_dict["user_consent"] = {"require_at_registration": True}
         with self.assertRaises(ConfigError):
             self.parse_config()
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/synapse/issues/16126

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
