### PR TITLE
Do not call setup_background_tasks twice in tests.

### DIFF
--- a/changelog.d/16150.misc
+++ b/changelog.d/16150.misc
@@ -1,0 +1,1 @@
+Clean-up calling `setup_background_tasks` in unit tests.

--- a/tests/server.py
+++ b/tests/server.py
@@ -1000,8 +1000,6 @@ def setup_test_homeserver(
     hs.tls_server_context_factory = Mock()
 
     hs.setup()
-    if homeserver_to_use == TestHomeServer:
-        hs.setup_background_tasks()
 
     if isinstance(db_engine, PostgresEngine):
         database_pool = hs.get_datastores().databases[0]


### PR DESCRIPTION
This gets called anyway via `hs.setup()`:

https://github.com/matrix-org/synapse/blob/358896e1b835bf693ef40d4cf9f10077432e935b/synapse/server.py#L346-L347

This is important in that `hs.setup()` has an extra if-statement which *only* runs this code if the worker is running background tasks, instead of unconditionally.

Spun out of #16066.