### PR TITLE
Always update `retry_last_ts`

### DIFF
--- a/changelog.d/16164.bugfix
+++ b/changelog.d/16164.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in 1.87 where synapse would send an excessive amount of federation requests to servers which have been offline for a long time. Contributed by Nico.


### PR DESCRIPTION
Follow on from #16156

I think by updating `retry_last_ts` we recover from the failure modes quicker (as we don't need to wait for the retry interval to ramp up?)