### PR TITLE
Time out busy presence status & test multi-device busy

### DIFF
--- a/changelog.d/16174.bugfix
+++ b/changelog.d/16174.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where multi-device accounts could cause high load due to presence.


### PR DESCRIPTION
Adds tests for the (unstable) busy presence with multiple workers (i.e. #16066, but for busy). It then also fixes those tests by adding a (long) timeout to when a "busy" device can timeout. This is kind of against what [MSC3026](https://github.com/matrix-org/matrix-spec-proposals/pull/3026) calls for, but I think implementation-wise it is the only reasonable thing to do. See https://github.com/matrix-org/matrix-spec-proposals/pull/3026#discussion_r1287453423 for MSC thread.

Spun-out of #16066. Builds on #16170, #16171, #16172, and #16066.