### PR TITLE
 Document `exclude_rooms_fom_sync` configuration option

### DIFF
--- a/changelog.d/16178.doc
+++ b/changelog.d/16178.doc
@@ -1,0 +1,2 @@
+Document exclude_rooms_fom_sync configuration option.
+

--- a/changelog.d/16178.doc
+++ b/changelog.d/16178.doc
@@ -1,2 +1,1 @@
-Document exclude_rooms_fom_sync configuration option.
-
+Document `exclude_rooms_from_sync` configuration option.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3865,6 +3865,19 @@ Example configuration:
 ```yaml
 forget_rooms_on_leave: false
 ```
+---
+### `exclude_rooms_from_sync`
+A list of rooms to exclude from sync responses. This is useful for server
+administrators wishing to group users into a room without these users being able
+to see it from their client.
+
+By default, no room is excluded.
+
+Example configuration:
+```yaml
+exclude_rooms_from_sync:
+    - !foo:example.com
+```
 
 ---
 ## Opentracing


### PR DESCRIPTION
As the title states - adds documentation about this option to the configuration docs. 
