### PR TITLE
Send proper JSON POST data to /publicRooms

### DIFF
--- a/changelog.d/16185.bugfix
+++ b/changelog.d/16185.bugfix
@@ -1,0 +1,1 @@
+Fix a spec compliance issue where requests to the `/publicRooms` federation API would specify `include_all_networks` as a string.

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -479,9 +479,7 @@ class TransportLayerClient:
 
         if search_filter:
             # this uses MSC2197 (Search Filtering over Federation)
-            data: Dict[str, Any] = {
-                "include_all_networks": include_all_networks
-            }
+            data: Dict[str, Any] = {"include_all_networks": include_all_networks}
             if third_party_instance_id:
                 data["third_party_instance_id"] = third_party_instance_id
             if limit:

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -475,10 +475,10 @@ class TransportLayerClient:
         See synapse.federation.federation_client.FederationClient.get_public_rooms for
         more information.
         """
+        path = _create_v1_path("/publicRooms")
+
         if search_filter:
             # this uses MSC2197 (Search Filtering over Federation)
-            path = _create_v1_path("/publicRooms")
-
             data: Dict[str, Any] = {
                 "include_all_networks": include_all_networks
             }
@@ -505,8 +505,6 @@ class TransportLayerClient:
                     )
                 raise
         else:
-            path = _create_v1_path("/publicRooms")
-
             args: Dict[str, Union[str, Iterable[str]]] = {
                 "include_all_networks": "true" if include_all_networks else "false"
             }

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -511,11 +511,11 @@ class TransportLayerClient:
                 "include_all_networks": "true" if include_all_networks else "false"
             }
             if third_party_instance_id:
-                args["third_party_instance_id"] = (third_party_instance_id,)
+                args["third_party_instance_id"] = third_party_instance_id
             if limit:
-                args["limit"] = [str(limit)]
+                args["limit"] = str(limit)
             if since_token:
-                args["since"] = [since_token]
+                args["since"] = since_token
 
             try:
                 response = await self.client.get_json(

--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -480,7 +480,7 @@ class TransportLayerClient:
             path = _create_v1_path("/publicRooms")
 
             data: Dict[str, Any] = {
-                "include_all_networks": "true" if include_all_networks else "false"
+                "include_all_networks": include_all_networks
             }
             if third_party_instance_id:
                 data["third_party_instance_id"] = third_party_instance_id


### PR DESCRIPTION
When using a search filter with `include_all_networks`, Synapse currently sends invalid data (strings instead of bools). It seems this was *always* this way from #5859, although a similar issue with `limit` was fixed in #12364.

Note that when *parsing* this Synapse [doesn't attempt to convert the string](https://github.com/matrix-org/synapse/blob/8e9739449dd6d3c133adf9e995d27d06518a0bcf/synapse/federation/transport/server/__init__.py#L167), so both of these would be treated as `True`.

Also has some misc. clean-up.