### PR TITLE
service-identity, incremental, and setuptools-rust now have type hints.

### DIFF
--- a/changelog.d/16186.misc
+++ b/changelog.d/16186.misc
@@ -1,0 +1,1 @@
+Improve type hints.

--- a/mypy.ini
+++ b/mypy.ini
@@ -96,6 +96,3 @@ ignore_missing_imports = True
 
 [mypy-incremental.*]
 ignore_missing_imports = True
-
-[mypy-setuptools_rust.*]
-ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -87,9 +87,6 @@ ignore_missing_imports = True
 [mypy-saml2.*]
 ignore_missing_imports = True
 
-[mypy-service_identity.*]
-ignore_missing_imports = True
-
 [mypy-srvlookup.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -93,6 +93,3 @@ ignore_missing_imports = True
 # https://github.com/twisted/treq/pull/366
 [mypy-treq.*]
 ignore_missing_imports = True
-
-[mypy-incremental.*]
-ignore_missing_imports = True


### PR DESCRIPTION
There's no reason to exclude their imports anymore. Luckily mypy didn't detect any errors when doing so! 🎉 