### PR TITLE
Fix inaccurate error message while trying to ban or unban a user with the same or higher PL

### DIFF
--- a/changelog.d/16205.bugfix
+++ b/changelog.d/16205.bugfix
@@ -1,0 +1,1 @@
+Fix inaccurate error message while attempting to ban or unban a user with the same or higher PL by spliting the conditional statements. Contributed by @leviosacz.

--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -669,10 +669,16 @@ def _is_membership_change_allowed(
                     errcode=Codes.INSUFFICIENT_POWER,
                 )
     elif Membership.BAN == membership:
-        if user_level < ban_level or user_level <= target_level:
+        if user_level < ban_level:
             raise UnstableSpecAuthError(
                 403,
                 "You don't have permission to ban",
+                errcode=Codes.INSUFFICIENT_POWER,
+            )
+        elif user_level <= target_level:
+            raise UnstableSpecAuthError(
+                403,
+                "You don't have permission to ban this user",
                 errcode=Codes.INSUFFICIENT_POWER,
             )
     elif room_version.knock_join_rule and Membership.KNOCK == membership:


### PR DESCRIPTION
Resolved issue#16202 of an inaccurate error message displaying "You don't have permission to ban" while attempting to ban or unban a user with the same or higher PL. Restructured the conditional statements to provide a more precise error message: "You don't have permission to ban this user."
Fixes matrix-org/synapse#16202