### PR TITLE
Fix rare bug that broke looping calls

### DIFF
--- a/changelog.d/16210.bugfix
+++ b/changelog.d/16210.bugfix
@@ -1,0 +1,1 @@
+Fix rare bug that broke looping calls, which could lead to e.g. linearly increasing memory usage. Introduced in v1.90.0.

--- a/synapse/storage/databases/main/lock.py
+++ b/synapse/storage/databases/main/lock.py
@@ -17,7 +17,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Collection, Optional, Set, Tuple, Type
 from weakref import WeakValueDictionary
 
-from twisted.internet.interfaces import IReactorCore
+from twisted.internet.task import LoopingCall
 
 from synapse.metrics.background_process_metrics import wrap_as_background_process
 from synapse.storage._base import SQLBaseStore
@@ -26,6 +26,7 @@ from synapse.storage.database import (
     LoggingDatabaseConnection,
     LoggingTransaction,
 )
+from synapse.types import ISynapseReactor
 from synapse.util import Clock
 from synapse.util.stringutils import random_string
 
@@ -358,7 +359,7 @@ class Lock:
 
     def __init__(
         self,
-        reactor: IReactorCore,
+        reactor: ISynapseReactor,
         clock: Clock,
         store: LockStore,
         read_write: bool,
@@ -377,18 +378,24 @@ class Lock:
 
         self._table = "worker_read_write_locks" if read_write else "worker_locks"
 
-        self._looping_call = clock.looping_call(
-            self._renew,
-            _RENEWAL_INTERVAL_MS,
-            store,
-            clock,
-            read_write,
-            lock_name,
-            lock_key,
-            token,
-        )
+        # We might be called from a non-main thread, so we defer setting up the
+        # looping call.
+        self._looping_call: Optional[LoopingCall] = None
+        reactor.callFromThread(self._setup_looping_call)
 
         self._dropped = False
+
+    def _setup_looping_call(self) -> None:
+        self._looping_call = self._clock.looping_call(
+            self._renew,
+            _RENEWAL_INTERVAL_MS,
+            self._store,
+            self._clock,
+            self._read_write,
+            self._lock_name,
+            self._lock_key,
+            self._token,
+        )
 
     @staticmethod
     @wrap_as_background_process("Lock._renew")
@@ -459,7 +466,7 @@ class Lock:
         if self._dropped:
             return
 
-        if self._looping_call.running:
+        if self._looping_call and self._looping_call.running:
             self._looping_call.stop()
 
         await self._store.db_pool.simple_delete(
@@ -486,8 +493,9 @@ class Lock:
             # We should not be dropped without the lock being released (unless
             # we're shutting down), but if we are then let's at least stop
             # renewing the lock.
-            if self._looping_call.running:
-                self._looping_call.stop()
+            if self._looping_call and self._looping_call.running:
+                # We might be called from a non-main thread.
+                self._reactor.callFromThread(self._looping_call.stop)
 
             if self._reactor.running:
                 logger.error(

--- a/tests/storage/databases/main/test_lock.py
+++ b/tests/storage/databases/main/test_lock.py
@@ -132,6 +132,7 @@ class LockTestCase(unittest.HomeserverTestCase):
 
         # We simulate the process getting stuck by cancelling the looping call
         # that keeps the lock active.
+        assert lock._looping_call
         lock._looping_call.stop()
 
         # Wait for the lock to timeout.
@@ -403,6 +404,7 @@ class ReadWriteLockTestCase(unittest.HomeserverTestCase):
 
         # We simulate the process getting stuck by cancelling the looping call
         # that keeps the lock active.
+        assert lock._looping_call
         lock._looping_call.stop()
 
         # Wait for the lock to timeout.


### PR DESCRIPTION
We can't interact with the reactor from the main thread via looping call. If you do then you can break existing looping calls (due to changing list size during iteration).

Introduced in v1.90.0 / #15791.

Example stack trace:

```
2023-08-30 07:44:09,624 - twisted - 275 - CRITICAL - sentinel - 
Traceback (most recent call last):
  File "/home/erikj/.synapse39/lib/python3.9/site-packages/twisted/internet/defer.py", line 892, in _runCallbacks
    current.result = callback(  # type: ignore[misc]
  File "/home/erikj/.synapse39/lib/python3.9/site-packages/twisted/internet/task.py", line 238, in cb
    self._scheduleFrom(self.clock.seconds())
  File "/home/erikj/.synapse39/lib/python3.9/site-packages/twisted/internet/task.py", line 291, in _scheduleFrom
    self.call = self.clock.callLater(howLong(), self)
  File "/home/erikj/.synapse39/lib/python3.9/site-packages/twisted/internet/asyncioreactor.py", line 289, in callLater
    abs_time = self._asyncioEventloop.time() + self.timeout()
  File "/home/erikj/.synapse39/lib/python3.9/site-packages/twisted/internet/base.py", line 936, in timeout
    self._insertNewDelayedCalls()
  File "/home/erikj/.synapse39/lib/python3.9/site-packages/twisted/internet/base.py", line 924, in _insertNewDelayedCalls
    heappush(self._pendingTimedCalls, call)
RuntimeError: list changed size during iteration
```