### PR TITLE
Gracefully handle failing to thumbnail images

### DIFF
--- a/changelog.d/16211.bugfix
+++ b/changelog.d/16211.bugfix
@@ -1,0 +1,1 @@
+Fix bug where uploading images would fail if we could not generate thumbanils for them.

--- a/changelog.d/16211.bugfix
+++ b/changelog.d/16211.bugfix
@@ -1,1 +1,1 @@
-Fix bug where uploading images would fail if we could not generate thumbanils for them.
+Fix a long-standing bug where uploading images would fail if we could not generate thumbnails for them.

--- a/synapse/__init__.py
+++ b/synapse/__init__.py
@@ -21,8 +21,13 @@ import os
 import sys
 from typing import Any, Dict
 
+from PIL import ImageFile
+
 from synapse.util.rust import check_rust_lib_up_to_date
 from synapse.util.stringutils import strtobool
+
+# Allow truncated JPEG images to be thumbnailed.
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 # Check that we're not running on an unsupported Python version.
 #

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -214,7 +214,10 @@ class MediaRepository:
             user_id=auth_user,
         )
 
-        await self._generate_thumbnails(None, media_id, media_id, media_type)
+        try:
+            await self._generate_thumbnails(None, media_id, media_id, media_type)
+        except Exception as e:
+            logger.info("Failed to generate thumbnails: %s", e)
 
         return MXCUri(self.server_name, media_id)
 


### PR DESCRIPTION
This is done by:

1. telling pillow that we don't mind truncated jpegs; and
2. ignoring failures to create thumbnails

I'm not 100% convinced that we should do the second one, in case there is a temporary problem generating the thumbnails.