### PR TITLE
Fix typo where we ended up with multiple `WorkerLocksHandler`

### DIFF
--- a/changelog.d/16220.misc
+++ b/changelog.d/16220.misc
@@ -1,0 +1,1 @@
+Fix typo where we ended up with multiple `WorkerLocksHandler`.

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -913,6 +913,7 @@ class HomeServer(metaclass=abc.ABCMeta):
         """Usage metrics shared between phone home stats and the prometheus exporter."""
         return CommonUsageMetricsManager(self)
 
+    @cache_in_self
     def get_worker_locks_handler(self) -> WorkerLocksHandler:
         return WorkerLocksHandler(self)
 


### PR DESCRIPTION
I don't think has caused any actual issues.

Introduced in #15891
