### PR TITLE
Cache device resync requests over replication

### DIFF
--- a/changelog.d/16241.misc
+++ b/changelog.d/16241.misc
@@ -1,0 +1,1 @@
+Cache device resync requests over replication.

--- a/synapse/replication/http/devices.py
+++ b/synapse/replication/http/devices.py
@@ -62,7 +62,7 @@ class ReplicationMultiUserDevicesResyncRestServlet(ReplicationEndpoint):
 
     NAME = "multi_user_device_resync"
     PATH_ARGS = ()
-    CACHE = False
+    CACHE = True
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)


### PR DESCRIPTION
We have tested this internally on matrix.org and it has seemed to work well in practice.