### PR TITLE
Skip IntrospectionTokenCacheInvalidationTestCase when authlib is not installed

### DIFF
--- a/changelog.d/16253.misc
+++ b/changelog.d/16253.misc
@@ -1,0 +1,1 @@
+Fix `IntrospectionTokenCacheInvalidationTestCase` when `authlib` is not available.

--- a/tests/replication/test_intro_token_invalidation.py
+++ b/tests/replication/test_intro_token_invalidation.py
@@ -17,8 +17,17 @@ from typing import Any, Dict
 import synapse.rest.admin._base
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase
+from tests.unittest import skip_unless
+
+try:
+    import authlib  # noqa: F401
+
+    HAS_AUTHLIB = True
+except ImportError:
+    HAS_AUTHLIB = False
 
 
+@skip_unless(HAS_AUTHLIB, "requires authlib")
 class IntrospectionTokenCacheInvalidationTestCase(BaseMultiWorkerStreamTestCase):
     servlets = [synapse.rest.admin.register_servlets]
 


### PR DESCRIPTION
Fixes #16244

This is broken for 1.91.x. I targeted that branch for it, but not sure if that makes sense or not?