### PR TITLE
Fix bug where we kept re-requesting a remote server's key repeatedly. 

### DIFF
--- a/changelog.d/16257.bugfix
+++ b/changelog.d/16257.bugfix
@@ -1,0 +1,1 @@
+Fix long-standing bug where we kept re-requesting a remote server's key repeatedly, potentially causing delays in receiving events over federation.


### PR DESCRIPTION
We have two tables:
1. `server_keys_json` which stores the raw JSON that we got, and is unique on `(server_name, key_json, from_server)`.
2. `server_signature_keys` which stores the JSON fields as columns, and is unique on `(server_name, key_json)`

When fetching keys from the store in `Keyring`, we used the first table. However, the fetch function didn't correctly account for multiple rows per server / key ID, and so would return whichever row happened to be returned last by Postgres. (This is often the most recent row, but also often not). 

The fix here is: a) fix the read path to return the most recently added key JSON, and b) use the `server_signature_keys` instead for `Keyring` as we don't need the full JSON anyway. 