### PR TITLE
Fix bug with new task scheduler using lots of CPU.

### DIFF
--- a/changelog.d/16278.misc
+++ b/changelog.d/16278.misc
@@ -1,0 +1,1 @@
+Fix using the new task scheduler causing lots of CPU to be used.


### PR DESCRIPTION
Using the new `TaskScheduler` meant that we'ed create lots of new metrics (due to adding task ID to the desc of background process), resulting in requests for metrics taking an increasing amount of CPU.

This doesn't affect a released version, as nothing uses the task scheduler yet.