### PR TITLE
Log values at DEBUG level with execute_values

### DIFF
--- a/changelog.d/16281.misc
+++ b/changelog.d/16281.misc
@@ -1,0 +1,1 @@
+Include values in SQL debug when using `execute_values` with Postgres.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -422,10 +422,11 @@ class LoggingTransaction:
         return self._do_execute(
             # TODO: is it safe for values to be Iterable[Iterable[Any]] here?
             # https://www.psycopg.org/docs/extras.html?highlight=execute_batch#psycopg2.extras.execute_values says values should be Sequence[Sequence]
-            lambda the_sql: execute_values(
-                self.txn, the_sql, values, template=template, fetch=fetch
+            lambda the_sql, the_values: execute_values(
+                self.txn, the_sql, the_values, template=template, fetch=fetch
             ),
             sql,
+            values,
         )
 
     def execute(self, sql: str, parameters: SQLQueryParameters = ()) -> None:


### PR DESCRIPTION
In #16271 I asked to see debug SQL logs to understand what exactly the user directory rebuild was doing. Unfortunately the logs didn't include the list of values given to the SQL statement:

```
2023-09-08 06:55:35,291 - synapse.storage.SQL - 449 - DEBUG - background_updates-1 - [SQL] {populate_user_directory_temp-1aa} INSERT INTO user_directory_search(user_id, vector) VALUES ? ON CONFLICT (user_id) DO UPDATE SET vector=EXCLUDED.vector
2023-09-08 06:55:35,292 - synapse.storage.SQL - 475 - DEBUG - background_updates-1 - [SQL time] {populate_user_directory_temp-1aa} 0.000619 sec
```

With my change, I ran the same(ish) logic using `SYNAPSE_POSTGRES=1 SYNAPSE_TEST_LOG_LEVEL=DEBUG trial tests.storage.test_user_directory` and observed e.g.

```
* 2023-09-08 13:52:47+0100 [-] synapse.storage.SQL - 465 - DEBUG - sentinel - [SQL] {update_profiles_in_user_dir-62} INSERT INTO user_directory_search(user_id, vector) VALUES ? ON CONFLICT (user_id) DO UPDATE SET vector=EXCLUDED.vector
  2023-09-08 13:52:47+0100 [-] synapse.storage.SQL - 470 - DEBUG - sentinel - [SQL values] {update_profiles_in_user_dir-62} [('@alice:a', 'alice', 'a', 'gáo')]
  2023-09-08 13:52:47+0100 [-] synapse.storage.SQL - 491 - DEBUG - sentinel - [SQL time] {update_profiles_in_user_dir-62} 0.000417 sec
```