### PR TITLE
Fix using dehydrated devices & refresh tokens

### DIFF
--- a/changelog.d/16288.bugfix
+++ b/changelog.d/16288.bugfix
@@ -1,1 +1,1 @@
-Fix bug when rehydrated devices do not have the device refresh tokens. Contributed by Hanadi.
+Fix bug introduced in Synapse 1.49.0 when using dehydrated devices ([MSC2697](https://github.com/matrix-org/matrix-spec-proposals/pull/2697)) and refresh tokens. Contributed by Hanadi.

--- a/changelog.d/16288.bugfix
+++ b/changelog.d/16288.bugfix
@@ -1,0 +1,1 @@
+Fix bug when rehydrated devices do not have the device refresh tokens. Contributed by Hanadi.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -764,7 +764,7 @@ class DeviceHandler(DeviceWorkerHandler):
         old_device_id = await self.store.set_device_for_access_token(
             access_token, device_id
         )
-        await self.store.move_device_refresh_token(old_device_id, device_id)
+        await self.store.set_device_for_refresh_token(user_id, old_device_id, device_id)
         old_device = await self.store.get_device(user_id, old_device_id)
         if old_device is None:
             raise errors.NotFoundError()

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -758,12 +758,13 @@ class DeviceHandler(DeviceWorkerHandler):
 
         # If the dehydrated device was successfully deleted (the device ID
         # matched the stored dehydrated device), then modify the access
-        # token to use the dehydrated device's ID and copy the old device
-        # display name to the dehydrated device, and destroy the old device
-        # ID
+        # token and refresh token to use the dehydrated device's ID and
+        # copy the old device display name to the dehydrated device,
+        # and destroy the old device ID
         old_device_id = await self.store.set_device_for_access_token(
             access_token, device_id
         )
+        await self.store.move_device_refresh_token(old_device_id, device_id)
         old_device = await self.store.get_device(user_id, old_device_id)
         if old_device is None:
             raise errors.NotFoundError()

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -2327,9 +2327,9 @@ class RegistrationStore(StatsStore, RegistrationBackgroundUpdateStore):
 
         await self.db_pool.simple_update(
             "refresh_tokens",
-            {"user_id": user_id, "device_id": old_device_id},
-            {"device_id": device_id},
-            "set_device_for_refresh_token",
+            keyvalues={"user_id": user_id, "device_id": old_device_id},
+            updatevalues={"device_id": device_id},
+            desc="set_device_for_refresh_token",
         )
 
     def _set_device_for_access_token_txn(

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -2312,6 +2312,37 @@ class RegistrationStore(StatsStore, RegistrationBackgroundUpdateStore):
 
         return next_id
 
+    def _move_device_refresh_token_txn(
+        self, txn: LoggingTransaction, old_device_id: str, device_id: str
+    ) -> None:
+        """Updates rows of old_device_id with current device_id"""
+
+        self.db_pool.simple_update_txn(
+            txn,
+            "refresh_tokens",
+            {"device_id": old_device_id},
+            {"device_id": device_id},
+        )
+
+    async def move_device_refresh_token(
+        self, old_device_id: str, device_id: str
+    ) -> None:
+        """Moves refresh tokens from old device to current device
+
+        Args:
+            old_device_id: The old device.
+            device_id: The new device ID.
+        Returns:
+            None
+        """
+
+        await self.db_pool.runInteraction(
+            "move_device_refresh_token",
+            self._move_device_refresh_token_txn,
+            old_device_id,
+            device_id,
+        )
+
     def _set_device_for_access_token_txn(
         self, txn: LoggingTransaction, token: str, device_id: str
     ) -> str:

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -2312,35 +2312,24 @@ class RegistrationStore(StatsStore, RegistrationBackgroundUpdateStore):
 
         return next_id
 
-    def _move_device_refresh_token_txn(
-        self, txn: LoggingTransaction, old_device_id: str, device_id: str
-    ) -> None:
-        """Updates rows of old_device_id with current device_id"""
-
-        self.db_pool.simple_update_txn(
-            txn,
-            "refresh_tokens",
-            {"device_id": old_device_id},
-            {"device_id": device_id},
-        )
-
-    async def move_device_refresh_token(
-        self, old_device_id: str, device_id: str
+    async def set_device_for_refresh_token(
+        self, user_id: str, old_device_id: str, device_id: str
     ) -> None:
         """Moves refresh tokens from old device to current device
 
         Args:
+            user_id: The user of the devices.
             old_device_id: The old device.
             device_id: The new device ID.
         Returns:
             None
         """
 
-        await self.db_pool.runInteraction(
-            "move_device_refresh_token",
-            self._move_device_refresh_token_txn,
-            old_device_id,
-            device_id,
+        await self.db_pool.simple_update(
+            "refresh_tokens",
+            {"user_id": user_id, "device_id": old_device_id},
+            {"device_id": device_id},
+            "set_device_for_refresh_token",
         )
 
     def _set_device_for_access_token_txn(

--- a/tests/handlers/test_device.py
+++ b/tests/handlers/test_device.py
@@ -461,6 +461,7 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
         self.message_handler = hs.get_device_message_handler()
         self.registration = hs.get_registration_handler()
         self.auth = hs.get_auth()
+        self.auth_handler = hs.get_auth_handler()
         self.store = hs.get_datastores().main
         return hs
 
@@ -492,6 +493,7 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
                 user_id=user_id,
                 device_id=None,
                 initial_display_name="new device",
+                should_issue_refresh_token=True,
             )
         )
 
@@ -521,6 +523,14 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
         user_info = self.get_success(self.auth.get_user_by_access_token(access_token))
 
         self.assertEqual(user_info.device_id, retrieved_device_id)
+
+        # make sure the user device has the refresh token
+        if _refresh_token:
+            self.get_success(
+                self.auth_handler.refresh_token(
+                    _refresh_token, 5 * 60 * 1000, 5 * 60 * 1000
+                )
+            )
 
         # make sure the device has the display name that was set from the login
         res = self.get_success(self.handler.get_device(user_id, retrieved_device_id))

--- a/tests/handlers/test_device.py
+++ b/tests/handlers/test_device.py
@@ -488,7 +488,7 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
         self.assertEqual(device_data, {"device_data": {"foo": "bar"}})
 
         # Create a new login for the user and dehydrated the device
-        device_id, access_token, _expiration_time, _refresh_token = self.get_success(
+        device_id, access_token, _expiration_time, refresh_token = self.get_success(
             self.registration.register_device(
                 user_id=user_id,
                 device_id=None,
@@ -525,12 +525,10 @@ class DehydrationTestCase(unittest.HomeserverTestCase):
         self.assertEqual(user_info.device_id, retrieved_device_id)
 
         # make sure the user device has the refresh token
-        if _refresh_token:
-            self.get_success(
-                self.auth_handler.refresh_token(
-                    _refresh_token, 5 * 60 * 1000, 5 * 60 * 1000
-                )
-            )
+        assert refresh_token is not None
+        self.get_success(
+            self.auth_handler.refresh_token(refresh_token, 5 * 60 * 1000, 5 * 60 * 1000)
+        )
 
         # make sure the device has the display name that was set from the login
         res = self.get_success(self.handler.get_device(user_id, retrieved_device_id))


### PR DESCRIPTION
### Short description of the fix:
During re-hydration, after setting the access tokens from the current requester device to the re-hydrated device, we move the current device refresh tokens to the re-hydrated device as well. Technically, update the fields with old device id to the re-hydrated device id.

This is regarding the dehydrated devices feature [msc2697](https://github.com/matrix-org/matrix-spec-proposals/pull/2697).
Please check [16284](https://github.com/matrix-org/synapse/issues/16284) for bug description.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: [Hanadi](https://github.com/hanadi92)

This PR is related to this issue : fixes [16284](https://github.com/matrix-org/synapse/issues/16284)
