### PR TITLE
Stop saving `thread_id` in the `data` field of `receipts_graph`

### DIFF
--- a/changelog.d/16297.misc
+++ b/changelog.d/16297.misc
@@ -1,0 +1,1 @@
+Stop saving `thread_id` in `data` for the `receipts_graph`.

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -93,7 +93,7 @@ class ReceiptsHandler:
 
                     # Check if these receipts apply to a thread.
                     data = user_values.get("data", {})
-                    thread_id = data.get("thread_id")
+                    thread_id = data.pop("thread_id")
                     # If the thread ID is invalid, consider it missing.
                     if not isinstance(thread_id, str):
                         thread_id = None


### PR DESCRIPTION
Noticed this while watching the Postgres logs, so went to look deeper and found
![weird_receipt_graph_artifact](https://github.com/matrix-org/synapse/assets/1582365/1dcac68e-ac55-42c8-b0e3-8dbfde77277a)

Which doesn't seem right. It's on a `JsonDict`, so it can be `pop()`ped instead of just being `got()`.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>