### PR TITLE
Convert `_insert_graph_receipts_txn` to `simple_upsert`

### DIFF
--- a/changelog.d/16299.misc
+++ b/changelog.d/16299.misc
@@ -1,1 +1,1 @@
-Use a stricter isolation level on `receipts_graph` Postgres transactions to stop error messages.
+Refactor `receipts_graph` Postgres transactions to stop error messages.

--- a/changelog.d/16299.misc
+++ b/changelog.d/16299.misc
@@ -1,0 +1,1 @@
+Use a stricter isolation level on `receipts_graph` Postgres transactions to stop error messages.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -1193,6 +1193,7 @@ class DatabasePool:
         keyvalues: Dict[str, Any],
         values: Dict[str, Any],
         insertion_values: Optional[Dict[str, Any]] = None,
+        where_clause: Optional[str] = None,
         desc: str = "simple_upsert",
     ) -> bool:
         """Insert a row with values + insertion_values; on conflict, update with values.
@@ -1243,6 +1244,7 @@ class DatabasePool:
             keyvalues: The unique key columns and their new values
             values: The nonunique columns and their new values
             insertion_values: additional key/values to use only when inserting
+            where_clause: An index predicate to apply to the upsert.
             desc: description of the transaction, for logging and metrics
         Returns:
             Returns True if a row was inserted or updated (i.e. if `values` is
@@ -1263,6 +1265,7 @@ class DatabasePool:
                     keyvalues,
                     values,
                     insertion_values,
+                    where_clause,
                     db_autocommit=autocommit,
                 )
             except self.engine.module.IntegrityError as e:

--- a/synapse/storage/databases/main/receipts.py
+++ b/synapse/storage/databases/main/receipts.py
@@ -804,6 +804,9 @@ class ReceiptsWorkerStore(SQLBaseStore):
             event_ids,
             thread_id,
             data,
+            # Use READ_COMMITTED to avoid 'could not serialize access due to concurrent
+            # update' Postgres errors which lead to rollbacks and re-dos.
+            isolation_level=IsolationLevel.READ_COMMITTED,
         )
 
         max_persisted_id = self._receipts_id_gen.get_current_token()


### PR DESCRIPTION
Which should cut down on Postgres log spam like:
```log
2023-09-11 05:37:47.811 CDT [13934] ERROR:  could not serialize access due to concurrent update
2023-09-11 05:37:47.811 CDT [13934] STATEMENT:  INSERT INTO receipts_graph (room_id, receipt_type, user_id, thread_id, event_ids, data) VALUES ('!room_1:computer.surgery', 'm.read', '@some_redacted_user:gnome.org', 'main', '["$hCBJpUJwHjjG6ztFwHrDPtqHFyMQ8eWMOCRUhmO3UBs"]', '{"thread_id":"main","ts":1694427550626}') ON CONFLICT (room_id, receipt_type, user_id, thread_id)  DO UPDATE SET event_ids=EXCLUDED.event_ids, data=EXCLUDED.data
2023-09-11 05:52:03.258 CDT [13934] ERROR:  could not serialize access due to concurrent update
2023-09-11 05:52:03.258 CDT [13934] STATEMENT:  INSERT INTO receipts_graph (room_id, receipt_type, user_id, thread_id, event_ids, data) VALUES ('!alCakyySsFIAVfZLDL:matrix.org', 'm.read', '@some_other_redacted_user:personal_homeserver.uk', 'main', '["$ekmtqEQ5PFNHFg49-zZamgw6LDNcwqYMh0dyGSQ3A2E"]', '{"thread_id":"main","ts":1694429513585}') ON CONFLICT (room_id, receipt_type, user_id, thread_id)  DO UPDATE SET event_ids=EXCLUDED.event_ids, data=EXCLUDED.data
2023-09-11 05:57:43.559 CDT [14238] ERROR:  could not serialize access due to concurrent update
2023-09-11 05:57:43.559 CDT [14238] STATEMENT:  INSERT INTO receipts_graph (room_id, receipt_type, user_id, thread_id, event_ids, data) VALUES ('!no_idea_room_id:matrix.org', 'm.read', '@another_random_user_id:other_homeserver.pt', 'main', '["$nBSxdTs9h73YOLm40A-ggrfSOvv7KL-iJHOaRzOjMnY"]', '{"thread_id":"main","ts":1694429518348}') ON CONFLICT (room_id, receipt_type, user_id, thread_id)  DO UPDATE SET event_ids=EXCLUDED.event_ids, data=EXCLUDED.data
```

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Jason Little <realtyem@gmail.com>