### PR TITLE
Improve logging of replication

### DIFF
--- a/changelog.d/16309.misc
+++ b/changelog.d/16309.misc
@@ -1,0 +1,1 @@
+Small improvements to logging in replication code.

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -644,7 +644,7 @@ class ReplicationCommandHandler:
                     [stream.parse_row(row) for row in rows],
                 )
 
-            logger.info("Caught up with stream '%s' to %i", stream_name, cmd.new_token)
+        logger.info("Caught up with stream '%s' to %i", stream_name, cmd.new_token)
 
         # We've now caught up to position sent to us, notify handler.
         await self._replication_data_handler.on_position(

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -191,7 +191,12 @@ class ReplicationStreamer:
 
                         if updates:
                             logger.info(
-                                "Streaming: %s -> %s", stream.NAME, updates[-1][0]
+                                "Streaming: %s -> %s (limited: %s, updates: %s, max token: %s)",
+                                stream.NAME,
+                                updates[-1][0],
+                                limited,
+                                len(updates),
+                                current_token,
                             )
                             stream_updates_counter.labels(stream.NAME).inc(len(updates))
 


### PR DESCRIPTION
Two changes:

1. "Caught up with stream" was logged *within* the loop fetching updates, so was inaccurate. Move it till *after* the loop.
2. When sending replication include how many updates we're sending, whether there's more to send, and the current token of the stream. (This makes it obvious when we fall behind sending replication).