### PR TITLE
Fix deleting device inbox when using background worker

### DIFF
--- a/changelog.d/16311.misc
+++ b/changelog.d/16311.misc
@@ -1,0 +1,1 @@
+Delete device messages asynchronously and in staged batches using the task scheduler.


### PR DESCRIPTION
Introduced in https://github.com/matrix-org/synapse/pull/16240

The action for the task was only defined on the "master" handler, rather than the base worker one.