### PR TITLE
Only use literal strings for process names

### DIFF
--- a/changelog.d/16315.misc
+++ b/changelog.d/16315.misc
@@ -1,0 +1,1 @@
+Only use literal strings for background process names.

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -33,7 +33,7 @@ from typing import (
 
 from prometheus_client import Metric
 from prometheus_client.core import REGISTRY, Counter, Gauge
-from typing_extensions import LiteralString, ParamSpec
+from typing_extensions import ParamSpec
 
 from twisted.internet import defer
 
@@ -47,6 +47,9 @@ from synapse.metrics._types import Collector
 
 if TYPE_CHECKING:
     import resource
+
+    # Old versions don't have `LiteralString`
+    from typing_extensions import LiteralString
 
 
 logger = logging.getLogger(__name__)
@@ -191,7 +194,7 @@ R = TypeVar("R")
 
 
 def run_as_background_process(
-    desc: LiteralString,
+    desc: "LiteralString",
     func: Callable[..., Awaitable[Optional[R]]],
     *args: Any,
     bg_start_span: bool = True,
@@ -259,7 +262,7 @@ P = ParamSpec("P")
 
 
 def wrap_as_background_process(
-    desc: LiteralString,
+    desc: "LiteralString",
 ) -> Callable[
     [Callable[P, Awaitable[Optional[R]]]],
     Callable[P, "defer.Deferred[Optional[R]]"],

--- a/synapse/metrics/background_process_metrics.py
+++ b/synapse/metrics/background_process_metrics.py
@@ -33,7 +33,7 @@ from typing import (
 
 from prometheus_client import Metric
 from prometheus_client.core import REGISTRY, Counter, Gauge
-from typing_extensions import ParamSpec
+from typing_extensions import LiteralString, ParamSpec
 
 from twisted.internet import defer
 
@@ -191,7 +191,7 @@ R = TypeVar("R")
 
 
 def run_as_background_process(
-    desc: str,
+    desc: LiteralString,
     func: Callable[..., Awaitable[Optional[R]]],
     *args: Any,
     bg_start_span: bool = True,
@@ -259,7 +259,7 @@ P = ParamSpec("P")
 
 
 def wrap_as_background_process(
-    desc: str,
+    desc: LiteralString,
 ) -> Callable[
     [Callable[P, Awaitable[Optional[R]]]],
     Callable[P, "defer.Deferred[Optional[R]]"],

--- a/synapse/util/caches/expiringcache.py
+++ b/synapse/util/caches/expiringcache.py
@@ -84,9 +84,7 @@ class ExpiringCache(Generic[KT, VT]):
             return
 
         def f() -> "defer.Deferred[None]":
-            return run_as_background_process(
-                "prune_cache_%s" % self._cache_name, self._prune_cache
-            )
+            return run_as_background_process("prune_cache", self._prune_cache)
 
         self._clock.looping_call(f, self._expiry_ms / 2)
 


### PR DESCRIPTION
`LiteralString` doesn't do anything yet until https://github.com/python/mypy/issues/12554 lands.

Using unique names blows up our prometheus metrics and causes lots of CPU on `/metrics` requests.