### PR TITLE
Speed up deleting to-device messages task

### DIFF
--- a/changelog.d/16318.misc
+++ b/changelog.d/16318.misc
@@ -1,0 +1,1 @@
+Speed up task to delete to-device messages.


### PR DESCRIPTION
Currently if we need to delete a large number of rows we'll delete 100 each time the task is rerun, which is once a minute.

Instead of that, let's just do the batched deletions in a loop.