### PR TITLE
Ensure emails get mapped to SSO users when the user does not pick a username.

### DIFF
--- a/synapse/handlers/sso.py
+++ b/synapse/handlers/sso.py
@@ -653,6 +653,8 @@ class SsoHandler:
             remote_user_id=remote_user_id,
             display_name=attributes.display_name,
             emails=attributes.emails,
+            # Default to using all mapped emails. Will be overwritten in handle_submit_username_request.
+            emails_to_use=attributes.emails,
             client_redirect_url=client_redirect_url,
             expiry_time_ms=now + self._MAPPING_SESSION_VALIDITY_PERIOD_MS,
             extra_login_attributes=extra_login_attributes,


### PR DESCRIPTION
Followup from #16317.

I think the sensible solution here is to default the `emails_to_use` parameter to the full set returned by the IDP, which will be overwritten if the user goes through the pick flow. This aligns up with the expected flow, as this is already the case if the user doesn't go through the consent flow.

