### PR TITLE
Set email charset as utf-8 rather than utf8

### DIFF
--- a/changelog.d/16329.bugfix
+++ b/changelog.d/16329.bugfix
@@ -1,0 +1,1 @@
+Use standard name for UTF-8 charset in emails.

--- a/synapse/handlers/send_email.py
+++ b/synapse/handlers/send_email.py
@@ -174,8 +174,8 @@ class SendEmailHandler:
         if raw_to == "":
             raise RuntimeError("Invalid 'to' address")
 
-        html_part = MIMEText(html, "html", "utf8")
-        text_part = MIMEText(text, "plain", "utf8")
+        html_part = MIMEText(html, "html", "utf-8")
+        text_part = MIMEText(text, "plain", "utf-8")
 
         multipart_msg = MIMEMultipart("alternative")
         multipart_msg["Subject"] = subject


### PR DESCRIPTION
As stated by the [W3C], the charset parameter can be set to "any character encoding that has been registered with IANA". A full list of these is available [on their website][IANA].

Notably missing from that list is the `utf8` value that was being used for email charsets. The strictly more correct name is `utf-8` (or `UTF-8`, since these names are case-insensitive).

The popularity of UTF-8 has meant that aliases like `utf8` are supported by a number of email servers. Unfortunately, not all are as accommodating (see for example https://github.com/emersion/hydroxide/issues/165), so a more standard name means Synapse can be used even with the more opinionated servers.

[W3C]: https://www.w3.org/International/articles/http-charset/index
[IANA]: http://www.iana.org/assignments/character-sets/character-sets.xhtml
[3]: https://github.com/emersion/hydroxide/issues/165

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
