### PR TITLE
Skip export-data on non-code (e.g. docs) PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -702,6 +702,7 @@ jobs:
             trial-olddeps
             sytest
             portdb
+            export-data
             complement
             check-signoff
             lint-newsfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -499,8 +499,8 @@ jobs:
             /logs/**/*.log*
 
   export-data:
-    if: ${{ !failure() && !cancelled() }} # Allow previous steps to be skipped, but not fail
-    needs: [linting-done, portdb]
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.integration == 'true'}} # Allow previous steps to be skipped, but not fail
+    needs: [linting-done, portdb, changes]
     runs-on: ubuntu-latest
     env:
       TOP: ${{ github.workspace }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -535,7 +535,7 @@ jobs:
 
 
   portdb:
-    if: ${{ !failure() && !cancelled() && needs.changes.outputs.linting == 'true' }} # Allow previous steps to be skipped, but not fail
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.integration == 'true'}} # Allow previous steps to be skipped, but not fail
     needs:
       - linting-done
       - changes

--- a/changelog.d/16387.misc
+++ b/changelog.d/16387.misc
@@ -1,0 +1,1 @@
+Avoid running CI steps when the files they check have not been changed.


### PR DESCRIPTION
Also sneak in a fix to #14745: consider portdb an integration test, not a linter.