### PR TITLE
Downgrade repl stream time out error to warning

### DIFF
--- a/changelog.d/16401.misc
+++ b/changelog.d/16401.misc
@@ -1,0 +1,1 @@
+Downgrade replication stream time out error log lines to warning.

--- a/synapse/replication/tcp/client.py
+++ b/synapse/replication/tcp/client.py
@@ -339,7 +339,7 @@ class ReplicationDataHandler:
             try:
                 await make_deferred_yieldable(deferred)
             except defer.TimeoutError:
-                logger.error(
+                logger.warning(
                     "Timed out waiting for repl stream %r to reach %s (%s)"
                     "; currently at: %s",
                     stream_name,


### PR DESCRIPTION
This is because if a worker reaches ~100% CPU then everything starts lagging and we hit the log line a lot. When at error we invoke sentry and that has a lot of overhead, which then puts even more pressure on the worker.