### PR TITLE
Add __slots__ to replication commands.

### DIFF
--- a/changelog.d/16429.misc
+++ b/changelog.d/16429.misc
@@ -1,0 +1,1 @@
+Reduce the size of each replication command instance.

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -18,7 +18,7 @@ allowed to be sent by which side.
 """
 import abc
 import logging
-from typing import Optional, Tuple, Type, TypeVar
+from typing import List, Optional, Tuple, Type, TypeVar
 
 from synapse.replication.tcp.streams._base import StreamRow
 from synapse.util import json_decoder, json_encoder
@@ -241,7 +241,7 @@ class ReplicateCommand(Command):
         REPLICATE
     """
 
-    __slots__ = []
+    __slots__: List[str] = []
 
     NAME = "REPLICATE"
 

--- a/synapse/replication/tcp/commands.py
+++ b/synapse/replication/tcp/commands.py
@@ -74,6 +74,8 @@ SC = TypeVar("SC", bound="_SimpleCommand")
 class _SimpleCommand(Command):
     """An implementation of Command whose argument is just a 'data' string."""
 
+    __slots__ = ["data"]
+
     def __init__(self, data: str):
         self.data = data
 
@@ -121,6 +123,8 @@ class RdataCommand(Command):
         RDATA presence master batch ["@bar:example.com", "online", ...]
         RDATA presence master 59 ["@baz:example.com", "online", ...]
     """
+
+    __slots__ = ["stream_name", "instance_name", "token", "row"]
 
     NAME = "RDATA"
 
@@ -179,6 +183,8 @@ class PositionCommand(Command):
     of the stream.
     """
 
+    __slots__ = ["stream_name", "instance_name", "prev_token", "new_token"]
+
     NAME = "POSITION"
 
     def __init__(
@@ -235,6 +241,8 @@ class ReplicateCommand(Command):
         REPLICATE
     """
 
+    __slots__ = []
+
     NAME = "REPLICATE"
 
     def __init__(self) -> None:
@@ -263,6 +271,8 @@ class UserSyncCommand(Command):
 
     Where <state> is either "start" or "end"
     """
+
+    __slots__ = ["instance_id", "user_id", "device_id", "is_syncing", "last_sync_ms"]
 
     NAME = "USER_SYNC"
 
@@ -316,6 +326,8 @@ class ClearUserSyncsCommand(Command):
         CLEAR_USER_SYNC <instance_id>
     """
 
+    __slots__ = ["instance_id"]
+
     NAME = "CLEAR_USER_SYNC"
 
     def __init__(self, instance_id: str):
@@ -343,6 +355,8 @@ class FederationAckCommand(Command):
         FEDERATION_ACK <instance_name> <token>
     """
 
+    __slots__ = ["instance_name", "token"]
+
     NAME = "FEDERATION_ACK"
 
     def __init__(self, instance_name: str, token: int):
@@ -367,6 +381,15 @@ class UserIpCommand(Command):
 
         USER_IP <user_id>, <access_token>, <ip>, <device_id>, <last_seen>, <user_agent>
     """
+
+    __slots__ = [
+        "user_id",
+        "access_token",
+        "ip",
+        "user_agent",
+        "device_id",
+        "last_seen",
+    ]
 
     NAME = "USER_IP"
 
@@ -440,6 +463,8 @@ class LockReleasedCommand(Command):
 
         LOCK_RELEASED ["<instance_name>", "<lock_name>", "<lock_key>"]
     """
+
+    __slots__ = ["instance_name", "lock_name", "lock_key"]
 
     NAME = "LOCK_RELEASED"
 


### PR DESCRIPTION
I'm hoping this will slim down our replication needs very very slightly, but it is also minimal effort.

WIth this change we have the following, sizes are done using [`_get_size_of`](https://github.com/matrix-org/synapse/blob/21fea6b7493533985f7fa14924949514b5a356e2/synapse/util/caches/lrucache.py#L64-L78).

| Class | Original size (bytes) | Final size (bytes) | Savings (bytes) |
|---|---|---|---|
| Any `_SimpleCommand` subclass | 408 | 360 | 48 |
| `RdataCommand` | 592 | 384 | 208 |
| `PositionCommand` | 672 | 448 | 224 |
| `UserSyncCommand` | 728 | 456 | 272 |
| `ClearUserSyncsCommand` | 416 | 360 | 56 |
| `FederationAckCommand` | 504 | 400 | 104 |
| `UserIpCommand` | 752 | 432 | 320 |
| `LockReleasedCommand` | 544 | 376 | 168 |

<details>
<summary>Code to produce the above</summary>

```python
from synapse.util.caches.lrucache import _get_size_of
from synapse.replication.tcp.commands import *

def do(inst):
    print(f"{inst.__class__.__name__}: {_get_size_of(inst)}")


do(ServerCommand(""))
do(RdataCommand("", "", None, ()))
do(PositionCommand("", "", 0, 1))
do(UserSyncCommand("", "", None, True, 1))
do(ClearUserSyncsCommand(""))
do(FederationAckCommand("", 1))
do(UserIpCommand("", "", 1, "", None, 1))
do(LockReleasedCommand("", "", ""))

```

</details>