### PR TITLE
Convert simple_search_list/simple_search_list_txn to return tuples.

### DIFF
--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -842,19 +842,16 @@ class SearchUsersRestServlet(RestServlet):
         logger.info("term: %s ", term)
 
         ret = await self.store.search_users(term)
-        if ret is not None:
-            results = [
-                {
-                    "name": name,
-                    "password_hash": password_hash,
-                    "is_guest": is_guest,
-                    "admin": admin,
-                    "user_type": user_type,
-                }
-                for name, password_hash, is_guest, admin, user_type in ret
-            ]
-        else:
-            results = None
+        results = [
+            {
+                "name": name,
+                "password_hash": password_hash,
+                "is_guest": is_guest,
+                "admin": admin,
+                "user_type": user_type,
+            }
+            for name, password_hash, is_guest, admin, user_type in ret
+        ]
 
         return HTTPStatus.OK, results
 

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -842,7 +842,21 @@ class SearchUsersRestServlet(RestServlet):
         logger.info("term: %s ", term)
 
         ret = await self.store.search_users(term)
-        return HTTPStatus.OK, ret
+        if ret is not None:
+            results = [
+                {
+                    "name": name,
+                    "password_hash": password_hash,
+                    "is_guest": is_guest,
+                    "admin": admin,
+                    "user_type": user_type,
+                }
+                for name, password_hash, is_guest, admin, user_type in ret
+            ]
+        else:
+            results = None
+
+        return HTTPStatus.OK, results
 
 
 class UserAdminServlet(RestServlet):

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -2479,11 +2479,11 @@ class DatabasePool:
     async def simple_search_list(
         self,
         table: str,
-        term: Optional[str],
+        term: str,
         col: str,
         retcols: Collection[str],
         desc: str = "simple_search_list",
-    ) -> Optional[List[Tuple[Any, ...]]]:
+    ) -> List[Tuple[Any, ...]]:
         """Executes a SELECT query on the named table, which may return zero or
         more rows, returning the result as a list of dicts.
 
@@ -2494,7 +2494,7 @@ class DatabasePool:
             retcols: the names of the columns to return
 
         Returns:
-            A list of tuples or None.
+            A list of tuples.
         """
 
         return await self.runInteraction(
@@ -2512,10 +2512,10 @@ class DatabasePool:
         cls,
         txn: LoggingTransaction,
         table: str,
-        term: Optional[str],
+        term: str,
         col: str,
         retcols: Iterable[str],
-    ) -> Optional[List[Tuple[Any, ...]]]:
+    ) -> List[Tuple[Any, ...]]:
         """Executes a SELECT query on the named table, which may return zero or
         more rows, returning the result as a list of dicts.
 
@@ -2527,14 +2527,14 @@ class DatabasePool:
             retcols: the names of the columns to return
 
         Returns:
-            A list of tuples or None.
+            A list of tuples.
         """
         if term:
             sql = "SELECT %s FROM %s WHERE %s LIKE ?" % (", ".join(retcols), table, col)
             termvalues = ["%%" + term + "%%"]
             txn.execute(sql, termvalues)
         else:
-            return None
+            return []
 
         return txn.fetchall()
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -2483,7 +2483,7 @@ class DatabasePool:
         col: str,
         retcols: Collection[str],
         desc: str = "simple_search_list",
-    ) -> Optional[List[Dict[str, Any]]]:
+    ) -> Optional[List[Tuple[Any, ...]]]:
         """Executes a SELECT query on the named table, which may return zero or
         more rows, returning the result as a list of dicts.
 
@@ -2494,7 +2494,7 @@ class DatabasePool:
             retcols: the names of the columns to return
 
         Returns:
-            A list of dictionaries or None.
+            A list of tuples or None.
         """
 
         return await self.runInteraction(
@@ -2515,7 +2515,7 @@ class DatabasePool:
         term: Optional[str],
         col: str,
         retcols: Iterable[str],
-    ) -> Optional[List[Dict[str, Any]]]:
+    ) -> Optional[List[Tuple[Any, ...]]]:
         """Executes a SELECT query on the named table, which may return zero or
         more rows, returning the result as a list of dicts.
 
@@ -2527,7 +2527,7 @@ class DatabasePool:
             retcols: the names of the columns to return
 
         Returns:
-            None if no term is given, otherwise a list of dictionaries.
+            A list of tuples or None.
         """
         if term:
             sql = "SELECT %s FROM %s WHERE %s LIKE ?" % (", ".join(retcols), table, col)
@@ -2536,7 +2536,7 @@ class DatabasePool:
         else:
             return None
 
-        return cls.cursor_to_dict(txn)
+        return txn.fetchall()
 
 
 def make_in_list_sql_clause(

--- a/synapse/storage/databases/main/__init__.py
+++ b/synapse/storage/databases/main/__init__.py
@@ -316,7 +316,9 @@ class DataStore(
             "get_users_paginate_txn", get_users_paginate_txn
         )
 
-    async def search_users(self, term: str) -> Optional[List[JsonDict]]:
+    async def search_users(
+        self, term: str
+    ) -> Optional[List[Tuple[str, str, bool, bool, str]]]:
         """Function to search users list for one or more users with
         the matched term.
 
@@ -324,14 +326,17 @@ class DataStore(
             term: search term
 
         Returns:
-            A list of dictionaries or None.
+            A list of tuples of name, password_hash, is_guest, admin, user_type or None.
         """
-        return await self.db_pool.simple_search_list(
-            table="users",
-            term=term,
-            col="name",
-            retcols=["name", "password_hash", "is_guest", "admin", "user_type"],
-            desc="search_users",
+        return cast(
+            List[Tuple[str, str, bool, bool, str]],
+            await self.db_pool.simple_search_list(
+                table="users",
+                term=term,
+                col="name",
+                retcols=["name", "password_hash", "is_guest", "admin", "user_type"],
+                desc="search_users",
+            ),
         )
 
 

--- a/synapse/storage/databases/main/__init__.py
+++ b/synapse/storage/databases/main/__init__.py
@@ -316,9 +316,7 @@ class DataStore(
             "get_users_paginate_txn", get_users_paginate_txn
         )
 
-    async def search_users(
-        self, term: str
-    ) -> Optional[List[Tuple[str, str, bool, bool, str]]]:
+    async def search_users(self, term: str) -> List[Tuple[str, str, bool, bool, str]]:
         """Function to search users list for one or more users with
         the matched term.
 


### PR DESCRIPTION
More removals of `cursor_to_dict`. This one might be controversial since it just manually creates the dict at the REST layer.

I assert that this is better because it is *explicit about the information we return to clients*, as opposed to choosing from the database layer.

It also does a couple of other simplifications while I was there.