### PR TITLE
Handle content types with parameters.

### DIFF
--- a/changelog.d/16440.bugfix
+++ b/changelog.d/16440.bugfix
@@ -1,0 +1,1 @@
+Properly return inline media when content types have parameters.

--- a/synapse/media/_base.py
+++ b/synapse/media/_base.py
@@ -148,7 +148,9 @@ def add_file_headers(
 
     # A strict subset of content types is allowed to be inlined  so that they may
     # be viewed directly in a browser. Other file types are forced to be downloads.
-    if media_type.lower() in INLINE_CONTENT_TYPES:
+    #
+    # Only the type & subtype are important, parameters can be ignored.
+    if media_type.lower().split(";", 1)[0] in INLINE_CONTENT_TYPES:
         disposition = "inline"
     else:
         disposition = "attachment"

--- a/tests/media/test_base.py
+++ b/tests/media/test_base.py
@@ -42,18 +42,38 @@ class GetFileNameFromHeadersTests(unittest.TestCase):
 
 class AddFileHeadersTests(unittest.TestCase):
     TEST_CASES = {
+        # Safe values use inline.
         "text/plain": b"inline; filename=file.name",
         "text/csv": b"inline; filename=file.name",
         "image/png": b"inline; filename=file.name",
+
+        # Unlisted values are set to attachment.
         "text/html": b"attachment; filename=file.name",
         "any/thing": b"attachment; filename=file.name",
+
+        # Parameters get ignored.
+        "text/plain; charset=utf-8": b"inline; filename=file.name",
+        "text/markdown; charset=utf-8; variant=CommonMark": b"attachment; filename=file.name",
+        # Parsed as lowercase.
+        "Text/Plain": b"inline; filename=file.name",
+
+        # Bad values don't choke.
+        "": b"attachment; filename=file.name",
+        ";": b"attachment; filename=file.name",
     }
 
     def test_content_disposition(self) -> None:
         for media_type, expected in self.TEST_CASES.items():
             request = Mock()
             add_file_headers(request, media_type, 0, "file.name")
-            request.setHeader.assert_any_call(b"Content-Disposition", expected)
+            # There should be a single call to set Content-Disposition.
+            for call in request.setHeader.call_args_list:
+                args, _ = call
+                if args[0] == b"Content-Disposition":
+                    break
+            else:
+                self.fail(f"No Content-Disposition header found for {media_type}")
+            self.assertEqual(args[1], expected, media_type)
 
     def test_no_filename(self) -> None:
         request = Mock()

--- a/tests/media/test_base.py
+++ b/tests/media/test_base.py
@@ -46,17 +46,14 @@ class AddFileHeadersTests(unittest.TestCase):
         "text/plain": b"inline; filename=file.name",
         "text/csv": b"inline; filename=file.name",
         "image/png": b"inline; filename=file.name",
-
         # Unlisted values are set to attachment.
         "text/html": b"attachment; filename=file.name",
         "any/thing": b"attachment; filename=file.name",
-
         # Parameters get ignored.
         "text/plain; charset=utf-8": b"inline; filename=file.name",
         "text/markdown; charset=utf-8; variant=CommonMark": b"attachment; filename=file.name",
         # Parsed as lowercase.
         "Text/Plain": b"inline; filename=file.name",
-
         # Bad values don't choke.
         "": b"attachment; filename=file.name",
         ";": b"attachment; filename=file.name",


### PR DESCRIPTION
See https://github.com/matrix-org/synapse/issues/15885#issuecomment-1749200283

Complement tests: https://github.com/matrix-org/complement/pull/664