### PR TITLE
Apply join rate limiter outside the lineariser

### DIFF
--- a/changelog.d/16441.misc
+++ b/changelog.d/16441.misc
@@ -1,0 +1,1 @@
+Improve rate limiting logic.

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -620,6 +620,8 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                     await self._join_rate_per_room_limiter.ratelimit(
                         requester, key=room_id, update=False
                     )
+            elif action == Membership.INVITE:
+                await self.ratelimit_invite(requester, room_id, target.to_string())
 
         if action == Membership.INVITE and requester.shadow_banned:
             # We randomly sleep a bit just to annoy the requester.
@@ -797,8 +799,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
 
         if effective_membership_state == Membership.INVITE:
             target_id = target.to_string()
-            if ratelimit:
-                await self.ratelimit_invite(requester, room_id, target_id)
 
             # block any attempts to invite the server notices mxid
             if target_id == self._server_notices_mxid:

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -382,8 +382,10 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         and persist a new event for the new membership change.
 
         Args:
-            requester:
-            target:
+            requester: User requesting the membership change, i.e. the sender of the
+                desired membership event.
+            target: Use whose membership should change, i.e. the state_key of the
+                desired membership event.
             room_id:
             membership:
 


### PR DESCRIPTION
I came across this logic; got confused, then tried to tidy it up. I found this much easier to reason about---doing the rate limit check up front.

At some point, someone should draw out a flowchart of the various membership-updating functions here. It's very confusing.

Commitwise reviewable.