### PR TITLE
Don't block CI on sign-off

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -280,7 +280,6 @@ jobs:
       - check-lockfile
       - lint-clippy
       - lint-rustfmt
-      - check-signoff
     runs-on: ubuntu-latest
     steps:
       - run: "true"

--- a/changelog.d/16454.misc
+++ b/changelog.d/16454.misc
@@ -1,0 +1,1 @@
+Do not block running of CI behind the check for sign-off on PRs.


### PR DESCRIPTION
As this doesn't work with the private sign off flow.

c.f. https://github.com/matrix-org/synapse/pull/16404 for an example