### PR TITLE
Drop unused tables & unneeded access token ID for events.

### DIFF
--- a/changelog.d/16522.misc
+++ b/changelog.d/16522.misc
@@ -1,0 +1,1 @@
+Clean-up unused tables.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -693,13 +693,9 @@ class EventCreationHandler:
         if require_consent and not is_exempt:
             await self.assert_accepted_privacy_policy(requester)
 
-        # Save the access token ID, the device ID and the transaction ID in the event
-        # internal metadata. This is useful to determine if we should echo the
-        # transaction_id in events.
+        # Save the the device ID and the transaction ID in the event internal metadata.
+        # This is useful to determine if we should echo the transaction_id in events.
         # See `synapse.events.utils.EventClientSerializer.serialize_event`
-        if requester.access_token_id is not None:
-            builder.internal_metadata.token_id = requester.access_token_id
-
         if requester.device_id is not None:
             builder.internal_metadata.device_id = requester.device_id
 

--- a/synapse/storage/schema/__init__.py
+++ b/synapse/storage/schema/__init__.py
@@ -129,8 +129,8 @@ Changes in SCHEMA_VERSION = 83
 
 
 SCHEMA_COMPAT_VERSION = (
-    # The `event_txn_id_device_id` must be written to for new events.
-    80
+    # The event_txn_id table and tables from MSC2716 no longer exist.
+    83
 )
 """Limit on how far the synapse codebase can be rolled back without breaking db compat
 

--- a/synapse/storage/schema/main/delta/83/01_drop_old_tables.sql
+++ b/synapse/storage/schema/main/delta/83/01_drop_old_tables.sql
@@ -1,0 +1,24 @@
+/* Copyright 2023 The Matrix.org Foundation C.I.C
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Drop the old event transaction ID table, the event_txn_id_device_id table
+-- should be used instead.
+DROP TABLE IF EXISTS event_txn_id;
+
+-- Drop tables related to MSC2716 since the implementation is being removed
+DROP TABLE IF EXISTS insertion_events;
+DROP TABLE IF EXISTS insertion_event_edges;
+DROP TABLE IF EXISTS insertion_event_extremities;
+DROP TABLE IF EXISTS batch_events;


### PR DESCRIPTION
This relands #16268 which was backed out in #16465.

This depends on #16521, which will hopefully land in Synapse 1.96.0. Meaning this PR can land in 1.98.0.

Fixes #16042 and fixes #15786.