### PR TITLE
Build Debian packages for Ubuntu 23.10 Mantic Minotaur

### DIFF
--- a/changelog.d/16524.misc
+++ b/changelog.d/16524.misc
@@ -1,0 +1,1 @@
+Build Debian packages for [Ubuntu 23.10 Mantic Minotaur](https://canonical.com/blog/canonical-releases-ubuntu-23-10-mantic-minotaur).

--- a/scripts-dev/build_debian_packages.py
+++ b/scripts-dev/build_debian_packages.py
@@ -33,6 +33,7 @@ DISTS = (
     "ubuntu:focal",  # 20.04 LTS (EOL 2025-04) (our EOL forced by Python 3.8 is 2024-10-14)
     "ubuntu:jammy",  # 22.04 LTS (EOL 2027-04) (our EOL forced by Python 3.10 is 2026-10-04)
     "ubuntu:lunar",  # 23.04 (EOL 2024-01) (our EOL forced by Python 3.11 is 2027-10-24)
+    "ubuntu:mantic",  # 23.10 (EOL 2024-07) (our EOL forced by Python 3.11 is 2027-10-24)
     "debian:trixie",  # (EOL not specified yet)
 )
 


### PR DESCRIPTION
which was released a week ago: https://canonical.com/blog/canonical-releases-ubuntu-23-10-mantic-minotaur

Previously: #15381
Xref https://github.com/matrix-org/pkg-repo-configs/pull/21