### PR TITLE
Mention how to redirect the Jaeger traces to a specific Jaeger instance

### DIFF
--- a/changelog.d/16531.doc
+++ b/changelog.d/16531.doc
@@ -1,0 +1,1 @@
+Add a sentence to the opentracing docs on how you can have jaeger in a different place than synapse.

--- a/docs/opentracing.md
+++ b/docs/opentracing.md
@@ -53,7 +53,7 @@ docker run -d --name jaeger \
 
 By default, Synapse will publish traces to Jaeger on localhost.
 If Jaeger is hosted elsewhere, point Synapse to the correct host by setting
-`opentracing.jaeger_config.local_agent.reporting_host` in the synapse configuration
+`opentracing.jaeger_config.local_agent.reporting_host` [in the Synapse configuration](usage/configuration/config_documentation.md#opentracing-1)
 or by setting the `JAEGER_AGENT_HOST` environment variable to the desired address.
 
 Latest documentation is probably at

--- a/docs/opentracing.md
+++ b/docs/opentracing.md
@@ -51,8 +51,10 @@ docker run -d --name jaeger \
   jaegertracing/all-in-one:1
 ```
 
-Additionally to point synapse to a specific IP you can use the
-`JAEGER_AGENT_HOST` environment variable.
+By default, Synapse will publish traces to Jaeger on localhost.
+If Jaeger is hosted elsewhere, point Synapse to the correct host by setting
+`opentracing.jaeger_config.local_agent.reporting_host` in the synapse configuration
+or by setting the `JAEGER_AGENT_HOST` environment variable to the desired address.
 
 Latest documentation is probably at
 https://www.jaegertracing.io/docs/latest/getting-started.

--- a/docs/opentracing.md
+++ b/docs/opentracing.md
@@ -51,6 +51,9 @@ docker run -d --name jaeger \
   jaegertracing/all-in-one:1
 ```
 
+Additionally to point synapse to a specific IP you can use the
+`JAEGER_AGENT_HOST` environment variable.
+
 Latest documentation is probably at
 https://www.jaegertracing.io/docs/latest/getting-started.
 


### PR DESCRIPTION
This adds a small note to the opentracing docs when your jaeger is not on localhost next to synapse. For example in a Kubernetes env.

Signed-Off-By: Marcel Radzio <support@nordgedanken.dev>

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
