### PR TITLE
Support reactor timing on more reactors.

### DIFF
--- a/changelog.d/16532.misc
+++ b/changelog.d/16532.misc
@@ -1,0 +1,1 @@
+Support reactor tick timings on more types of event loops.

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,8 +37,8 @@ files =
   build_rust.py
 
 [mypy-synapse.metrics._reactor_metrics]
-# This module imports select.epoll. That exists on Linux, but doesn't on macOS.
-# See https://github.com/matrix-org/synapse/pull/11771.
+# This module  pokes at the internals of OS-specific classes, to appease mypy
+# on different systems we add additional ignores.
 warn_unused_ignores = False
 
 [mypy-synapse.util.caches.treecache]

--- a/synapse/metrics/_reactor_metrics.py
+++ b/synapse/metrics/_reactor_metrics.py
@@ -119,7 +119,8 @@ class ReactorLastSeenMetric(Collector):
 # made about the shape.
 wrapper = None
 if isinstance(reactor, (PollReactor, EPollReactor)):
-    wrapper = reactor._poller.poll = CallWrapper(reactor._poller.poll)
+    reactor._poller = ObjWrapper(reactor._poller, "poll")  # type: ignore[attr-defined]
+    wrapper = reactor._poller._wrapped_method  # type: ignore[attr-defined]
 
 elif isinstance(reactor, selectreactor.SelectReactor):
     # Twisted uses a module-level _select function.

--- a/synapse/metrics/_reactor_metrics.py
+++ b/synapse/metrics/_reactor_metrics.py
@@ -133,6 +133,7 @@ elif isinstance(reactor, AsyncioSelectorReactor):
         if isinstance(selector, SelectSelector):
             wrapper = selector._select = CallWrapper(selector._select)  # type: ignore[attr-defined]
 
+        # poll, epoll, and /dev/poll.
         elif isinstance(selector, _PollLikeSelector):
             selector._selector = ObjWrapper(selector._selector, "poll")  # type: ignore[attr-defined]
             wrapper = selector._selector._wrapped_method  # type: ignore[attr-defined]


### PR DESCRIPTION
Supports timing reactor ticks on `select` and `poll` reactors, as well as `epoll` (which we previously supported). Also supports reactor timings when using the `asyncio` reactor (when used with an underlying `select`, `poll`, `epoll`, `/dev/poll`, or `kqueue` event loop).