### PR TITLE
Fix bug that could cause a `/sync` to tightloop with sqlite after restart

### DIFF
--- a/changelog.d/16540.bugfix
+++ b/changelog.d/16540.bugfix
@@ -1,0 +1,1 @@
+Fix long-standing bug where `/sync` could tightloop after restart when using SQLite.

--- a/synapse/storage/databases/main/account_data.py
+++ b/synapse/storage/databases/main/account_data.py
@@ -94,7 +94,10 @@ class AccountDataWorkerStore(PushRulesWorkerStore, CacheInvalidationWorkerStore)
                 hs.get_replication_notifier(),
                 "room_account_data",
                 "stream_id",
-                extra_tables=[("room_tags_revisions", "stream_id")],
+                extra_tables=[
+                    ("account_data", "stream_id"),
+                    ("room_tags_revisions", "stream_id"),
+                ],
                 is_writer=self._instance_name in hs.config.worker.writers.account_data,
             )
 


### PR DESCRIPTION
This could happen if the last rows in the account data stream were inserted into `account_data`. After a restart the max account ID would be calculated without looking at the `account_data` table, and so have an old ID.