### PR TITLE
Reduce spurious replication catchup

### DIFF
--- a/changelog.d/16555.misc
+++ b/changelog.d/16555.misc
@@ -1,0 +1,1 @@
+Reduce some spurious logging in worker mode.

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -615,7 +615,7 @@ class ReplicationCommandHandler:
 	    # then we're up to date and there's nothing to do. Otherwise, fetch
 	    # all updates between then and now.
         #
-        # Note: We also have to check that `current_token` is at least the
+        # Note: We also have to check that `current_token` is at most the
         # new position, to handle the case where the stream gets "reset" 
         # (e.g. for `caches` and `typing` after the writer's restart).
         missing_updates = not (cmd.prev_token <= current_token <= cmd.new_token)

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -611,10 +611,14 @@ class ReplicationCommandHandler:
         # Find where we previously streamed up to.
         current_token = stream.current_token(cmd.instance_name)
 
-        # If the position token matches our current token then we're up to
-        # date and there's nothing to do. Otherwise, fetch all updates
-        # between then and now.
-        missing_updates = cmd.prev_token != current_token
+        # If the position token matches our current token then we're up to date
+        # and there's nothing to do. Otherwise, fetch all updates between then
+        # and now.
+        #
+        # Note: We have to check that `current_token` is within the range, to
+        # handle the case where the stream gets "reset" (e.g. for `caches` and
+        # `typing` after the writer's restart).
+        missing_updates = not (cmd.prev_token <= current_token <= cmd.new_token)
         while missing_updates:
             # Note: There may very well not be any new updates, but we check to
             # make sure. This can particularly happen for the event stream where
@@ -644,7 +648,7 @@ class ReplicationCommandHandler:
                     [stream.parse_row(row) for row in rows],
                 )
 
-        logger.info("Caught up with stream '%s' to %i", stream_name, cmd.new_token)
+            logger.info("Caught up with stream '%s' to %i", stream_name, current_token)
 
         # We've now caught up to position sent to us, notify handler.
         await self._replication_data_handler.on_position(

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -611,13 +611,13 @@ class ReplicationCommandHandler:
         # Find where we previously streamed up to.
         current_token = stream.current_token(cmd.instance_name)
 
-        # If the position token matches our current token then we're up to date
-        # and there's nothing to do. Otherwise, fetch all updates between then
-        # and now.
+        # If the incoming previous position is less than our current position
+	    # then we're up to date and there's nothing to do. Otherwise, fetch
+	    # all updates between then and now.
         #
-        # Note: We have to check that `current_token` is within the range, to
-        # handle the case where the stream gets "reset" (e.g. for `caches` and
-        # `typing` after the writer's restart).
+        # Note: We also have to check that `current_token` is at least the
+        # new position, to handle the case where the stream gets "reset" 
+        # (e.g. for `caches` and `typing` after the writer's restart).
         missing_updates = not (cmd.prev_token <= current_token <= cmd.new_token)
         while missing_updates:
             # Note: There may very well not be any new updates, but we check to

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -612,11 +612,11 @@ class ReplicationCommandHandler:
         current_token = stream.current_token(cmd.instance_name)
 
         # If the incoming previous position is less than our current position
-	    # then we're up to date and there's nothing to do. Otherwise, fetch
-	    # all updates between then and now.
+        # then we're up to date and there's nothing to do. Otherwise, fetch
+        # all updates between then and now.
         #
         # Note: We also have to check that `current_token` is at most the
-        # new position, to handle the case where the stream gets "reset" 
+        # new position, to handle the case where the stream gets "reset"
         # (e.g. for `caches` and `typing` after the writer's restart).
         missing_updates = not (cmd.prev_token <= current_token <= cmd.new_token)
         while missing_updates:


### PR DESCRIPTION
The `POSITION` command includes two tokens, the "prev" and "new" tokens. The "new" token is what we should set the current token for the instance to be, and the "prev" token was where it was previously (i.e. the instance produced no rows between the "prev" and "new" tokens).

This means that we can safely relax the condition to only check for missing updates if the current token for the writer is strictly less than the "prev" token.

A common case is receiving something like `POSITIONS event_persister1 events 15 16`, which indicates the writer advanced their events stream token from 15 to 16 (usually as a response to another instance persisting an event with stream ID 16). Usually, the other instances would already have inferred that `event_persister1` must have advanced their token, so the `current_token` would already be set to 16, thus triggering a lookup for missing updates between tokens 16 (`cmd.new_token`) and 16 (`current_token`), which is silly.

We also move the logging back into the loop so that we don't log in the common case.