### PR TITLE
Portdb: don't copy a table that gets rebuilt

### DIFF
--- a/changelog.d/16563.misc
+++ b/changelog.d/16563.misc
@@ -1,0 +1,1 @@
+Stop porting a table in port db that we're going to nuke and rebuild anyway.

--- a/synapse/_scripts/synapse_port_db.py
+++ b/synapse/_scripts/synapse_port_db.py
@@ -191,7 +191,7 @@ IGNORED_TABLES = {
     "user_directory_search_stat",
     "user_directory_search_pos",
     "users_who_share_private_rooms",
-    "users_in_public_room",
+    "users_in_public_rooms",
     # UI auth sessions have foreign keys so additional care needs to be taken,
     # the sessions are transient anyway, so ignore them.
     "ui_auth_sessions",


### PR DESCRIPTION
The table itself is fine to port over AFAICS:

```sql
CREATE TABLE IF NOT EXISTS users_in_public_rooms (
    user_id TEXT NOT NULL,
    room_id TEXT NOT NULL
);
```

But I think the user directory is deliberately rebuilt after porting (the FTS tables aren't portable).

Typo 1 introduced in #2375, moved in #7711, then changed to typo 2 in #7717.