### PR TITLE
Run actions/setup-go after checking out complement

### DIFF
--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -203,6 +203,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           cache-dependency-path: complement/go.sum
+          go-version-file: complement/go.mod
 
       - run: |
           set -o pipefail

--- a/.github/workflows/latest_deps.yml
+++ b/.github/workflows/latest_deps.yml
@@ -197,10 +197,12 @@ jobs:
         with:
           path: synapse
 
-      - uses: actions/setup-go@v4
-
       - name: Prepare Complement's Prerequisites
         run: synapse/.ci/scripts/setup_complement_prerequisites.sh
+
+      - uses: actions/setup-go@v4
+        with:
+          cache-dependency-path: complement/go.sum
 
       - run: |
           set -o pipefail

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -639,6 +639,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           cache-dependency-path: complement/go.sum
+          go-version-file: complement/go.mod
 
         # use p=1 concurrency as GHA boxes are underpowered and don't like running tons of synapses at once.
       - run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -633,10 +633,12 @@ jobs:
         uses: dtolnay/rust-toolchain@1.61.0
       - uses: Swatinem/rust-cache@v2
 
-      - uses: actions/setup-go@v4
-
       - name: Prepare Complement's Prerequisites
         run: synapse/.ci/scripts/setup_complement_prerequisites.sh
+
+      - uses: actions/setup-go@v4
+        with:
+          cache-dependency-path: complement/go.sum
 
         # use p=1 concurrency as GHA boxes are underpowered and don't like running tons of synapses at once.
       - run: |

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -168,10 +168,12 @@ jobs:
         with:
           path: synapse
 
-      - uses: actions/setup-go@v4
-
       - name: Prepare Complement's Prerequisites
         run: synapse/.ci/scripts/setup_complement_prerequisites.sh
+
+      - uses: actions/setup-go@v4
+        with:
+          cache-dependency-path: complement/go.sum
 
       # This step is specific to the 'Twisted trunk' test run:
       - name: Patch dependencies

--- a/.github/workflows/twisted_trunk.yml
+++ b/.github/workflows/twisted_trunk.yml
@@ -174,6 +174,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           cache-dependency-path: complement/go.sum
+          go-version-file: complement/go.mod
 
       # This step is specific to the 'Twisted trunk' test run:
       - name: Patch dependencies

--- a/changelog.d/16567.misc
+++ b/changelog.d/16567.misc
@@ -1,1 +1,1 @@
-Run actions/setup-go after checking out complement.
+Deal with warnings from running complement in CI.

--- a/changelog.d/16567.misc
+++ b/changelog.d/16567.misc
@@ -1,0 +1,1 @@
+Run actions/setup-go after checking out complement.


### PR DESCRIPTION
This should suppress the warnings in test runs, e.g. from https://github.com/matrix-org/synapse/actions/runs/6673818366?pr=16565
![image](https://github.com/matrix-org/synapse/assets/8614563/cd04c8d7-38fa-48f7-8d3a-6b2cd367f5b2)

and presumably make it mildly quicker to prepare the complement test binary.