### PR TITLE
Clients link fixed in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ You will need to change the server you are logging into from ``matrix.org``
 and instead specify a Homeserver URL of ``https://<server_name>:8448``
 (or just ``https://<server_name>`` if you are using a reverse proxy).
 If you prefer to use another client, refer to our
-`client breakdown <https://matrix.org/docs/projects/clients-matrix>`_.
+`client breakdown <https://matrix.org/ecosystem/clients/>`_.
 
 If all goes well you should at least be able to log in, create a room, and
 start sending messages.

--- a/changelog.d/16569.bugfix
+++ b/changelog.d/16569.bugfix
@@ -1,1 +1,0 @@
-Clients Broken link fixed in README.

--- a/changelog.d/16569.bugfix
+++ b/changelog.d/16569.bugfix
@@ -1,0 +1,1 @@
+Clients Broken link fixed in README.

--- a/changelog.d/16569.doc
+++ b/changelog.d/16569.doc
@@ -1,0 +1,1 @@
+Fix a broken link to the [client breakdown](https://matrix.org/ecosystem/clients/) in the README.


### PR DESCRIPTION
In this PR, I have fixed the broken link of clients in the README file. Now it redirects to the correct link.
### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
