### PR TITLE
Claim fallback keys in bulk

### DIFF
--- a/changelog.d/16570.feature
+++ b/changelog.d/16570.feature
@@ -1,0 +1,1 @@
+Improve the performance of claiming encryption keys.

--- a/synapse/handlers/e2e_keys.py
+++ b/synapse/handlers/e2e_keys.py
@@ -659,6 +659,20 @@ class E2eKeysHandler:
         timeout: Optional[int],
         always_include_fallback_keys: bool,
     ) -> JsonDict:
+        """
+        Args:
+            query: A chain of maps from (user_id, device_id, algorithm) to the requested
+                number of keys to claim.
+            user: The user who is claiming these keys.
+            timeout: How long to wait for any federation key claim requests before
+                giving up.
+            always_include_fallback_keys: always include a fallback key for local users'
+                devices, even if we managed to claim a one-time-key.
+
+        Returns: a heterogeneous dict with two keys:
+            one_time_keys: chain of maps user ID -> device ID -> key ID -> key.
+            failures: map from remote destination to a JsonDict describing the error.
+        """
         local_query: List[Tuple[str, str, str, int]] = []
         remote_queries: Dict[str, Dict[str, Dict[str, Dict[str, int]]]] = {}
 

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -420,6 +420,16 @@ class LoggingTransaction:
         self._do_execute(self.txn.execute, sql, parameters)
 
     def executemany(self, sql: str, *args: Any) -> None:
+        """Repeatedly execute the same piece of SQL with different parameters.
+
+        See https://peps.python.org/pep-0249/#executemany. Note in particular that
+
+        > Use of this method for an operation which produces one or more result sets
+        > constitutes undefined behavior
+
+        so you can't use this for e.g. a SELECT, an UPDATE ... RETURNING, or a
+        DELETE FROM... RETURNING.
+        """
         # TODO: we should add a type for *args here. Looking at Cursor.executemany
         # and DBAPI2 it ought to be Sequence[_Parameter], but we pass in
         # Iterable[Iterable[Any]] in execute_batch and execute_values above, which mypy

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -1298,7 +1298,7 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
         """
         claimed_keys = cast(
             List[Tuple[str, str, str, str, str]],
-            list(txn.execute_values(sql, query_list)),
+            txn.execute_values(sql, query_list),
         )
 
         seen_user_device: Set[Tuple[str, str]] = set()

--- a/synapse/storage/databases/main/end_to_end_keys.py
+++ b/synapse/storage/databases/main/end_to_end_keys.py
@@ -1260,6 +1260,16 @@ class EndToEndKeyWorkerStore(EndToEndKeyBackgroundStore, CacheInvalidationWorker
         Returns:
             A map of user ID -> a map device ID -> a map of key ID -> JSON.
         """
+        if isinstance(self.database_engine, PostgresEngine):
+            raise NotImplementedError()
+        else:
+            return await self._claim_e2e_fallback_keys_simple(query_list)
+
+    async def _claim_e2e_fallback_keys_simple(
+        self,
+        query_list: Iterable[Tuple[str, str, str, bool]],
+    ) -> Dict[str, Dict[str, Dict[str, JsonDict]]]:
+        """Naive, inefficient implementation of claim_e2e_fallback_keys for SQLite."""
         results: Dict[str, Dict[str, Dict[str, JsonDict]]] = {}
         for user_id, device_id, algorithm, mark_as_used in query_list:
             row = await self.db_pool.simple_select_one(

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -386,7 +386,7 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
             {"failures": {}, "one_time_keys": {expected_claims}},
         )
 
-        for user_id, device in fallback_keys.items():
+        for user_id, devices in fallback_keys.items():
             for device_id in devices:
                 fallback_res = self.get_success(
                     self.store.get_e2e_unused_fallback_key_types(user_id, device_id)

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -383,7 +383,7 @@ class E2eKeysHandlerTestCase(unittest.HomeserverTestCase):
         }
         self.assertEqual(
             claim_res,
-            {"failures": {}, "one_time_keys": {expected_claims}},
+            {"failures": {}, "one_time_keys": expected_claims},
         )
 
         for user_id, devices in fallback_keys.items():


### PR DESCRIPTION
This is the second performance change as suggested by from Rich in #16554. The first was #16565.

<details><summary>Testing that the query is legit</summary>

```sql
\echo nuke table\\
DROP TABLE IF EXISTS e2e_fallback_keys_json;

\echo Make table\\
CREATE TABLE e2e_fallback_keys_json (
    user_id   text    NOT NULL,
    device_id text    NOT NULL,
    algorithm text    NOT NULL,
    key_id    text    NOT NULL,
    key_json  text    NOT NULL,
    used      boolean NOT NULL,
    UNIQUE (user_id, device_id, algorithm)
);

\echo Dummy data. 10 users, with 10 devices, with 10 algorithms. One key per alg. Keys alternate used and unused. \\
INSERT INTO e2e_fallback_keys_json (user_id, device_id, algorithm, key_id, key_json, used)
SELECT concat('@user_', id / 100, ':test'),
       concat('user_', id / 100, '_dev_', (id / 10) % 10),
       concat('alg_', id % 10),
       concat('key', id.id),
       concat('json', id.id),
       id % 2 = 0
FROM generate_series(1, 1000) as id(id);

\echo Select the rows we want to update. \\

SELECT *
FROM e2e_fallback_keys_json
WHERE (user_id, device_id, algorithm) = ('@user_0:test', 'user_0_dev_0', 'alg_1')
   OR (user_id, device_id, algorithm) = ('@user_0:test', 'user_0_dev_1', 'alg_2')
   OR (user_id, device_id, algorithm) = ('@user_1:test', 'user_1_dev_2', 'alg_4')
   OR (user_id, device_id, algorithm) = ('@user_1:test', 'user_1_dev_2', 'alg_9')
;

\echo The query of doom. \\

WITH
    claims(user_id, device_id, algorithm, mark_as_used) AS (
        VALUES ('@user_0:test', 'user_0_dev_0', 'alg_1', FALSE),
               ('@user_0:test', 'user_0_dev_1', 'alg_2', FALSE),
               ('@user_1:test', 'user_1_dev_2', 'alg_4', TRUE),
               ('@user_1:test', 'user_1_dev_2', 'alg_9', TRUE)
    )
UPDATE e2e_fallback_keys_json k
SET used = used OR mark_as_used
FROM claims
WHERE (k.user_id, k.device_id, k.algorithm) = (claims.user_id, claims.device_id, claims.algorithm)
RETURNING k.user_id, k.device_id, k.algorithm, k.key_id, k.key_json, k.used;

\echo Reselect the rows that should have been updated. \\
SELECT *
FROM e2e_fallback_keys_json
WHERE (user_id, device_id, algorithm) = ('@user_0:test', 'user_0_dev_0', 'alg_1')  -- used false, mark false
   OR (user_id, device_id, algorithm) = ('@user_0:test', 'user_0_dev_1', 'alg_2')  -- used true, mark true
   OR (user_id, device_id, algorithm) = ('@user_1:test', 'user_1_dev_2', 'alg_4')  -- used true, mark false
   OR (user_id, device_id, algorithm) = ('@user_1:test', 'user_1_dev_2', 'alg_9')  -- used false, mark true
;
```
</details>

Commitwise reviewable. Completely untested outside of the practice query and CI.