### PR TITLE
Fix HTTP repl response to use minimum token

### DIFF
--- a/changelog.d/16578.bugfix
+++ b/changelog.d/16578.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing, exceedingly rare edge case where the first event persisted by a new event persister worker might not be sent down `/sync`.

--- a/synapse/replication/http/_base.py
+++ b/synapse/replication/http/_base.py
@@ -433,7 +433,7 @@ class ReplicationEndpoint(metaclass=abc.ABCMeta):
 
         if self.WAIT_FOR_STREAMS:
             response[_STREAM_POSITION_KEY] = {
-                stream.NAME: stream.current_token(self._instance_name)
+                stream.NAME: stream.minimal_local_current_token()
                 for stream in self._streams
             }
 


### PR DESCRIPTION
Follow on from #16473, where we tried to change the HTTP replication to return the *minimum* current token for a stream (as this is used to wait for a position in the stream). However, turns out we need to change this in *two* places, both the request and response.