### PR TITLE
Add fast path for replication events stream fetch

### DIFF
--- a/changelog.d/16580.bugfix
+++ b/changelog.d/16580.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing, exceedingly rare edge case where the first event persisted by a new event persister worker might not be sent down `/sync`.

--- a/synapse/replication/tcp/streams/events.py
+++ b/synapse/replication/tcp/streams/events.py
@@ -157,6 +157,12 @@ class EventsStream(_StreamFromIdGen):
         current_token: Token,
         target_row_count: int,
     ) -> StreamUpdateResult:
+        # The events stream cannot be "reset", so its safe to return early if
+        # the from token is larger than the current token (the DB query will
+        # trivially return 0 rows anyway).
+        if from_token >= current_token:
+            return [], current_token, False
+
         # the events stream merges together three separate sources:
         #  * new events
         #  * current_state changes


### PR DESCRIPTION
We can bail early if the from token is greater than or equal to the current token.

This can happen when the ID gen advances the current token for a remote writer past its last write.

Side note: I want to change how we do all this streaming stuff to put the ID generators in charge, which might be easier to grok rather than having abstract "streams" :shrug: 

Kinda follows on from #16473