### PR TITLE
Use simple_select_many_txn in event persistance code.

### DIFF
--- a/changelog.d/16585.misc
+++ b/changelog.d/16585.misc
@@ -1,1 +1,1 @@
-Use `make_in_list_sql_clause` in persistance path.
+Use standard SQL helpers in persistence code.

--- a/changelog.d/16585.misc
+++ b/changelog.d/16585.misc
@@ -1,0 +1,1 @@
+Use `make_in_list_sql_clause` in persistance path.

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1359,7 +1359,7 @@ class PersistEventsStore:
                 [event.event_id for event, _ in events_and_contexts],
                 keyvalues={},
                 retcols=("event_id", "outlier"),
-            )
+            ),
         )
 
         have_persisted = dict(rows)

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1350,14 +1350,19 @@ class PersistEventsStore:
             PartialStateConflictError: if attempting to persist a partial state event in
                 a room that has been un-partial stated.
         """
-        clause, args = make_in_list_sql_clause(
-            self.db_pool.engine,
-            "event_id",
-            [event.event_id for event, _ in events_and_contexts],
+        rows = cast(
+            List[Tuple[str, bool]],
+            self.db_pool.simple_select_many_txn(
+                txn,
+                "events",
+                "event_id",
+                [event.event_id for event, _ in events_and_contexts],
+                keyvalues={},
+                retcols=("event_id", "outlier"),
+            )
         )
-        txn.execute(f"SELECT event_id, outlier FROM events WHERE {clause}", args)
 
-        have_persisted = dict(cast(Iterable[Tuple[str, bool]], txn))
+        have_persisted = dict(rows)
 
         logger.debug(
             "_update_outliers_txn: events=%s have_persisted=%s",

--- a/synapse/storage/databases/main/events.py
+++ b/synapse/storage/databases/main/events.py
@@ -1350,11 +1350,12 @@ class PersistEventsStore:
             PartialStateConflictError: if attempting to persist a partial state event in
                 a room that has been un-partial stated.
         """
-        txn.execute(
-            "SELECT event_id, outlier FROM events WHERE event_id in (%s)"
-            % (",".join(["?"] * len(events_and_contexts)),),
+        clause, args = make_in_list_sql_clause(
+            self.db_pool.engine,
+            "event_id",
             [event.event_id for event, _ in events_and_contexts],
         )
+        txn.execute(f"SELECT event_id, outlier FROM events WHERE {clause}", args)
 
         have_persisted = dict(cast(Iterable[Tuple[str, bool]], txn))
 


### PR DESCRIPTION
Theoretically the `ANY(?)` query is more efficient in PostgreSQL?