### PR TITLE
Update the stream_cache less often.

### DIFF
--- a/changelog.d/16586.misc
+++ b/changelog.d/16586.misc
@@ -1,0 +1,1 @@
+Avoid updating the stream cache unnecessarily.


### PR DESCRIPTION
I think this is safe to do -- instead of updating the stream cache (which is somewhat expensive) for each persisted event, only do it for the maximum stream ordering being persisted.

Based on #16584.