### PR TITLE
Collect information for PushRuleEvaluator in parallel.

### DIFF
--- a/changelog.d/16590.misc
+++ b/changelog.d/16590.misc
@@ -1,0 +1,1 @@
+Run push rule evaluator setup in parallel.

--- a/synapse/push/bulk_push_rule_evaluator.py
+++ b/synapse/push/bulk_push_rule_evaluator.py
@@ -30,7 +30,6 @@ from typing import (
 
 from prometheus_client import Counter
 
-from twisted.internet import defer
 from twisted.internet.defer import Deferred
 
 from synapse.api.constants import (
@@ -47,9 +46,8 @@ from synapse.events.snapshot import EventContext
 from synapse.logging.context import make_deferred_yieldable, run_in_background
 from synapse.state import POWER_KEY
 from synapse.storage.databases.main.roommember import EventIdMembership
-from synapse.synapse_rust.push import FilteredPushRules, PushRuleEvaluator
-
 from synapse.storage.roommember import ProfileInfo
+from synapse.synapse_rust.push import FilteredPushRules, PushRuleEvaluator
 from synapse.types import JsonValue
 from synapse.types.state import StateFilter
 from synapse.util import unwrapFirstError
@@ -384,7 +382,7 @@ class BulkPushRuleEvaluator:
                         ),
                     ),
                     consumeErrors=True,
-                ),  # .addErrback(unwrapFirstError)
+                ).addErrback(unwrapFirstError),
             )
         )
 

--- a/synapse/util/async_helpers.py
+++ b/synapse/util/async_helpers.py
@@ -345,6 +345,7 @@ async def yieldable_gather_results_delaying_cancellation(
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
+T4 = TypeVar("T4")
 
 
 @overload
@@ -377,6 +378,19 @@ def gather_results(
     ],
     consumeErrors: bool = ...,
 ) -> "defer.Deferred[Tuple[T1, T2, T3]]":
+    ...
+
+
+@overload
+def gather_results(
+    deferredList: Tuple[
+        "defer.Deferred[T1]",
+        "defer.Deferred[T2]",
+        "defer.Deferred[T3]",
+        "defer.Deferred[T4]",
+    ],
+    consumeErrors: bool = ...,
+) -> "defer.Deferred[Tuple[T1, T2, T3, T4]]":
     ...
 
 


### PR DESCRIPTION
The `PushRuleEvaluator` requires a bunch of information about the room / sender, etc. based on the new event, most of this information does not depend on each other and can be calculated in parallel.

Additionally `bulk_get_push_rules` has two separate queries which can be done in parallel.

Ideally we would use PostgreSQL pipeling here instead, but that's not available to use in psycopg2 (or PostgreSQL < 14).

Note that these queries running in parallel will still be subject to thread pool contention, but worse case they get serialized, as they are today.