### PR TITLE
Bump setuptools_rust to match pinned version.

### DIFF
--- a/changelog.d/16605.misc
+++ b/changelog.d/16605.misc
@@ -1,0 +1,1 @@
+Bump setuptools-rust from 1.8.0 to 1.8.1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -381,7 +381,7 @@ furo = ">=2022.12.7,<2024.0.0"
 # system changes.
 # We are happy to raise these upper bounds upon request,
 # provided we check that it's safe to do so (i.e. that CI passes).
-requires = ["poetry-core>=1.1.0,<=1.7.0", "setuptools_rust>=1.3,<=1.8.0"]
+requires = ["poetry-core>=1.1.0,<=1.7.0", "setuptools_rust>=1.3,<=1.8.1"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
Missed in #16601.