### PR TITLE
Avoid updating the same rows multiple times with simple_update_many_txn.

### DIFF
--- a/changelog.d/16609.bugfix
+++ b/changelog.d/16609.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where some queries updated the same row twice. Introduced in Synapse 1.57.0.

--- a/synapse/storage/database.py
+++ b/synapse/storage/database.py
@@ -2047,10 +2047,7 @@ class DatabasePool:
 
         # List of tuples of (value values, then key values)
         # (This matches the order needed for the query)
-        args = [tuple(x) + tuple(y) for x, y in zip(value_values, key_values)]
-
-        for ks, vs in zip(key_values, value_values):
-            args.append(tuple(vs) + tuple(ks))
+        args = [tuple(vv) + tuple(kv) for vv, kv in zip(value_values, key_values)]
 
         # 'col1 = ?, col2 = ?, ...'
         set_clause = ", ".join(f"{n} = ?" for n in value_names)

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -371,12 +371,12 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             self.mock_execute_batch.assert_called_once_with(
                 self.mock_txn,
                 "UPDATE tablename SET col3 = ? WHERE col1 = ? AND col2 = ?",
-                [("val3", "val1", "val2"), ("val3", "val1", "val2")],
+                [("val3", "val1", "val2")],
             )
         else:
             self.mock_txn.executemany.assert_called_once_with(
                 "UPDATE tablename SET col3 = ? WHERE col1 = ? AND col2 = ?",
-                [("val3", "val1", "val2"), ("val3", "val1", "val2")],
+                [("val3", "val1", "val2")],
             )
 
         # key_values and value_values must be the same length.


### PR DESCRIPTION
Right now when we use `simple_update_many_txn` (or `simple_update_many`) it appends the arguments twice meaning each row is found and updated twice.

I noticed this while writing the tests in #16596.

Logic has existed since it was added in #12252.

This is used when:

* Adding client IPs to the database.
* Updating unread counts based on processing of receipts.
* The `set_device_id_for_pushers` background update.