### PR TITLE
Use dbname instead of database for Postgres config.

### DIFF
--- a/changelog.d/16618.misc
+++ b/changelog.d/16618.misc
@@ -1,0 +1,1 @@
+Use `dbname` instead of the deprecated `database` connection parameter for psycopg2.

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -66,7 +66,7 @@ database:
   args:
     user: <user>
     password: <pass>
-    database: <db>
+    dbname: <db>
     host: <host>
     cp_min: 5
     cp_max: 10

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -1447,7 +1447,7 @@ database:
   args:
     user: synapse_user
     password: secretpassword
-    database: synapse
+    dbname: synapse
     host: localhost
     port: 5432
     cp_min: 5
@@ -1526,7 +1526,7 @@ databases:
     args:
       user: synapse_user
       password: secretpassword
-      database: synapse_main
+      dbname: synapse_main
       host: localhost
       port: 5432
       cp_min: 5
@@ -1539,7 +1539,7 @@ databases:
     args:
       user: synapse_user
       password: secretpassword
-      database: synapse_state
+      dbname: synapse_state
       host: localhost
       port: 5432
       cp_min: 5

--- a/tests/server.py
+++ b/tests/server.py
@@ -974,7 +974,7 @@ def setup_test_homeserver(
         database_config = {
             "name": "psycopg2",
             "args": {
-                "database": test_db,
+                "dbname": test_db,
                 "host": POSTGRES_HOST,
                 "password": POSTGRES_PASSWORD,
                 "user": POSTGRES_USER,
@@ -1033,7 +1033,7 @@ def setup_test_homeserver(
         import psycopg2.extensions
 
         db_conn = db_engine.module.connect(
-            database=POSTGRES_BASE_DB,
+            dbname=POSTGRES_BASE_DB,
             user=POSTGRES_USER,
             host=POSTGRES_HOST,
             port=POSTGRES_PORT,
@@ -1080,7 +1080,7 @@ def setup_test_homeserver(
 
             # Drop the test database
             db_conn = db_engine.module.connect(
-                database=POSTGRES_BASE_DB,
+                dbname=POSTGRES_BASE_DB,
                 user=POSTGRES_USER,
                 host=POSTGRES_HOST,
                 port=POSTGRES_PORT,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -80,7 +80,7 @@ def setupdb() -> None:
 
         # Set up in the db
         db_conn = db_engine.module.connect(
-            database=POSTGRES_BASE_DB,
+            dbname=POSTGRES_BASE_DB,
             user=POSTGRES_USER,
             host=POSTGRES_HOST,
             port=POSTGRES_PORT,


### PR DESCRIPTION
According to the [psycopg2 docs](https://www.psycopg.org/docs/module.html#psycopg2.connect) the connection should use `dbname`:

> `dbname` – the database name (`database` is a deprecated alias)

I don't think we need to do mapping or anything in the config since we document this as drive-specific configuration.

This was taken from my psycopg3 branch, which requires using `dbname`.