### PR TITLE
Improve the performance of fetching event reports over the admin API when there are many of them and the requester has paginated far down the list.

### DIFF
--- a/changelog.d/16620.misc
+++ b/changelog.d/16620.misc
@@ -1,0 +1,1 @@
+Improve the performance of fetching event reports over the admin API when there are many of them and the requester has paginated far down the list.


### PR DESCRIPTION
Partial fix to #16619

General idea: defer the join to `events` until after the limit has applied. It's hard to get an unbiased measurement for this, but the old query took ~3s and the new query took ~500ms for a given query (identical results).

It'd be nicer to add proper indices and defer the other join too (and even change the pagination scheme to not use OFFSET), but this is all I had for a drive-by improvement.

<!--
Fixes: # <!-- -->
<!--
Supersedes: # <!-- -->
<!--
Follows: # <!-- -->
<!--
Part of: # <!-- -->
Base: `develop` <!-- git-stack-base-branch:develop -->

<!--
This pull request is commit-by-commit review friendly. <!-- -->
<!--
This pull request is intended for commit-by-commit review. <!-- -->

Original commit schedule, with full messages:

<ol>
<li>

Improve performance of fetching event reports when there are many of them 

</li>
</ol>
