### PR TITLE
Fix outbound_federation_restricted_to docs & note when added

### DIFF
--- a/changelog.d/16628.doc
+++ b/changelog.d/16628.doc
@@ -1,0 +1,1 @@
+Note that the option [`outbound_federation_restricted_to`](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#outbound_federation_restricted_to) was added in Synapse 1.89.0, and fix a nearby formatting error.

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -4219,6 +4219,9 @@ outbound_federation_restricted_to:
 Also see the [worker
 documentation](../../workers.md#restrict-outbound-federation-traffic-to-a-specific-set-of-workers)
 for more info.
+
+_Added in Synapse 1.89.0._
+
 ---
 ### `run_background_tasks_on`
 


### PR DESCRIPTION
Missed in https://github.com/matrix-org/synapse/pull/15773 and https://github.com/matrix-org/synapse/pull/15913.