### PR TITLE
Improve documentation for `/_synapse/admin/v1/rooms/<room_id>/timestamp_to_event`

### DIFF
--- a/changelog.d/16631.doc
+++ b/changelog.d/16631.doc
@@ -1,0 +1,1 @@
+Update parameter information for /timestamp_to_event admin API.

--- a/changelog.d/16631.doc
+++ b/changelog.d/16631.doc
@@ -1,1 +1,1 @@
-Update parameter information for /timestamp_to_event admin API.
+Update parameter information for the `/timestamp_to_event` admin API.

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -537,7 +537,7 @@ The following query parameters are available:
 **Response**
 
 * `event_id` - The event ID closest to the given timestamp.
-* `origin_server_ts` - The timestamp of the event.
+* `origin_server_ts` - The timestamp of the event in milliseconds since the Unix epoch.
 
 # Block Room API
 The Block Room admin API allows server admins to block and unblock rooms,

--- a/docs/admin_api/rooms.md
+++ b/docs/admin_api/rooms.md
@@ -536,7 +536,8 @@ The following query parameters are available:
 
 **Response**
 
-* `event_id` - converted from timestamp
+* `event_id` - The event ID closest to the given timestamp.
+* `origin_server_ts` - The timestamp of the event.
 
 # Block Room API
 The Block Room admin API allows server admins to block and unblock rooms,


### PR DESCRIPTION
It returns an extra timestamp parameter, and also the event_id description was a little confused.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
