### PR TITLE
Add links to pre-1.0 changelog issue/PR references.

### DIFF
--- a/changelog.d/16638.misc
+++ b/changelog.d/16638.misc
@@ -1,0 +1,1 @@
+Improve references to GitHub issues.

--- a/docs/changelogs/CHANGES-pre-1.0.md
+++ b/docs/changelogs/CHANGES-pre-1.0.md
@@ -1272,7 +1272,7 @@ Misc
 Changes in synapse v0.31.2 (2018-06-14)
 =======================================
 
-SECURITY UPDATE: Prevent unauthorised users from setting state events in a room when there is no `m.room.power_levels` event in force in the room.. ([\#3397](https://github.com/matrix-org/synapse/issues/3397))
+SECURITY UPDATE: Prevent unauthorised users from setting state events in a room when there is no `m.room.power_levels` event in force in the room. ([\#3397](https://github.com/matrix-org/synapse/issues/3397))
 
 Discussion around the Matrix Spec change proposal for this change can be followed at <https://github.com/matrix-org/matrix-doc/issues/1304>.
 
@@ -1642,7 +1642,7 @@ Features:
 -   Add ability for ASes to override message send time. ([\#2754](https://github.com/matrix-org/synapse/issues/2754))
 -   Add support for custom storage providers for media repository. ([\#2867](https://github.com/matrix-org/synapse/issues/2867), [\#2777](https://github.com/matrix-org/synapse/issues/2777), [\#2783](https://github.com/matrix-org/synapse/issues/2783), [\#2789](https://github.com/matrix-org/synapse/issues/2789), [\#2791](https://github.com/matrix-org/synapse/issues/2791), [\#2804](https://github.com/matrix-org/synapse/issues/2804), [\#2812](https://github.com/matrix-org/synapse/issues/2812), [\#2814](https://github.com/matrix-org/synapse/issues/2814), [\#2857](https://github.com/matrix-org/synapse/issues/2857), [\#2868](https://github.com/matrix-org/synapse/issues/2868), [\#2767](https://github.com/matrix-org/synapse/issues/2767))
 -   Add purge API features, see [docs/admin_api/purge_history_api.rst](docs/admin_api/purge_history_api.rst) for full details. ([\#2858](https://github.com/matrix-org/synapse/issues/2858), [\#2867](https://github.com/matrix-org/synapse/issues/2867), [\#2882](https://github.com/matrix-org/synapse/issues/2882), [\#2946](https://github.com/matrix-org/synapse/issues/2946), [\#2962](https://github.com/matrix-org/synapse/issues/2962), [\#2943](https://github.com/matrix-org/synapse/issues/2943))
--   Add support for whitelisting 3PIDs that users can register.. ([\#2813](https://github.com/matrix-org/synapse/issues/2813))
+-   Add support for whitelisting 3PIDs that users can register. ([\#2813](https://github.com/matrix-org/synapse/issues/2813))
 -   Add `/room/{id}/event/{id}` API. ([\#2766](https://github.com/matrix-org/synapse/issues/2766))
 -   Add an admin API to get all the media in a room. Thanks to @turt2live! ([\#2818](https://github.com/matrix-org/synapse/issues/2818))
 -   Add `federation_domain_whitelist` option. ([\#2820](https://github.com/matrix-org/synapse/issues/2820), [\#2821](https://github.com/matrix-org/synapse/issues/2821))
@@ -1748,7 +1748,7 @@ Changes:
 -   Log login requests. ([\#2618](https://github.com/matrix-org/synapse/issues/2618))
 -   Always return `is_public` in the `/groups/:group_id/rooms` API. ([\#2630](https://github.com/matrix-org/synapse/issues/2630))
 -   Avoid no-op media deletes. Thanks to @spantaleev! ([\#2637](https://github.com/matrix-org/synapse/issues/2637))
--   Fix various embarrassing typos around `user_directory` and add some doc.. ([\#2643](https://github.com/matrix-org/synapse/issues/2643))
+-   Fix various embarrassing typos around `user_directory` and add some doc. ([\#2643](https://github.com/matrix-org/synapse/issues/2643))
 -   Return whether a user is an admin within a group. ([\#2647](https://github.com/matrix-org/synapse/issues/2647))
 -   Namespace visibility options for groups. ([\#2657](https://github.com/matrix-org/synapse/issues/2657))
 -   Downcase UserIDs on registration. ([\#2662](https://github.com/matrix-org/synapse/issues/2662))
@@ -2010,11 +2010,11 @@ Features:
 
 Changes:
 
--   Use JSONSchema for validation of filters. Thanks @pik!. ([\#1783](https://github.com/matrix-org/synapse/issues/1783))
+-   Use JSONSchema for validation of filters. Thanks @pik! ([\#1783](https://github.com/matrix-org/synapse/issues/1783))
 -   Reread log config on SIGHUP. ([\#1982](https://github.com/matrix-org/synapse/issues/1982))
 -   Speed up public room list. ([\#1989](https://github.com/matrix-org/synapse/issues/1989))
 -   Add helpful texts to logger config options. ([\#1990](https://github.com/matrix-org/synapse/issues/1990))
--   Minor `/sync` performance improvements.. ([\#2002](https://github.com/matrix-org/synapse/issues/2002), [\#2013](https://github.com/matrix-org/synapse/issues/2013), [\#2022](https://github.com/matrix-org/synapse/issues/2022))
+-   Minor `/sync` performance improvements. ([\#2002](https://github.com/matrix-org/synapse/issues/2002), [\#2013](https://github.com/matrix-org/synapse/issues/2013), [\#2022](https://github.com/matrix-org/synapse/issues/2022))
 -   Add some debug to help diagnose weird federation issue. ([\#2035](https://github.com/matrix-org/synapse/issues/2035))
 -   Correctly limit retries for all federation requests. ([\#2050](https://github.com/matrix-org/synapse/issues/2050), [\#2061](https://github.com/matrix-org/synapse/issues/2061))
 -   Don't lock table when persisting new one time keys. ([\#2053](https://github.com/matrix-org/synapse/issues/2053))
@@ -2030,7 +2030,7 @@ Bug fixes:
 -   Fix `current_state_events` table to not lie. ([\#1996](https://github.com/matrix-org/synapse/issues/1996))
 -   Fix CAS login to handle PartialDownloadError. ([\#1997](https://github.com/matrix-org/synapse/issues/1997))
 -   Fix assertion to stop transaction queue getting wedged. ([\#2010](https://github.com/matrix-org/synapse/issues/2010))
--   Fix presence to fallback to `last_active_ts` if it beats the last sync time. Thanks @Half-Shot!. ([\#2014](https://github.com/matrix-org/synapse/issues/2014))
+-   Fix presence to fallback to `last_active_ts` if it beats the last sync time. Thanks @Half-Shot! ([\#2014](https://github.com/matrix-org/synapse/issues/2014))
 -   Fix bug when federation received a PDU while a room join is in progress. ([\#2016](https://github.com/matrix-org/synapse/issues/2016))
 -   Fix resetting state on rejected events. ([\#2025](https://github.com/matrix-org/synapse/issues/2025))
 -   Fix installation issues in readme. Thanks @ricco386. ([\#2037](https://github.com/matrix-org/synapse/issues/2037))
@@ -2055,31 +2055,31 @@ Changes in synapse v0.19.3-rc1 (2017-03-08)
 
 Features:
 
--   Add some administration functionalities. Thanks to morteza-araby!. ([\#1784](https://github.com/matrix-org/synapse/issues/1784))
+-   Add some administration functionalities. Thanks to morteza-araby! ([\#1784](https://github.com/matrix-org/synapse/issues/1784))
 
 Changes:
 
 -   Reduce database table sizes. ([\#1873](https://github.com/matrix-org/synapse/issues/1873), [\#1916](https://github.com/matrix-org/synapse/issues/1916), [\#1923](https://github.com/matrix-org/synapse/issues/1923), [\#1963](https://github.com/matrix-org/synapse/issues/1963))
--   Update contrib/ to not use syutil. Thanks to andrewshadura!. ([\#1907](https://github.com/matrix-org/synapse/issues/1907))
+-   Update contrib/ to not use syutil. Thanks to andrewshadura! ([\#1907](https://github.com/matrix-org/synapse/issues/1907))
 -   Don't fetch current state when sending an event in common case. ([\#1955](https://github.com/matrix-org/synapse/issues/1955))
 
 Bug fixes:
 
--   Fix synapse_port_db failure. Thanks to Pneumaticat!. ([\#1904](https://github.com/matrix-org/synapse/issues/1904))
+-   Fix synapse_port_db failure. Thanks to Pneumaticat! ([\#1904](https://github.com/matrix-org/synapse/issues/1904))
 -   Fix caching to not cache error responses. ([\#1913](https://github.com/matrix-org/synapse/issues/1913))
 -   Fix APIs to make kick & ban reasons work. ([\#1917](https://github.com/matrix-org/synapse/issues/1917))
 -   Fix bugs in the /keys/changes api. ([\#1921](https://github.com/matrix-org/synapse/issues/1921))
 -   Fix bug where users couldn't forget rooms they were banned from. ([\#1922](https://github.com/matrix-org/synapse/issues/1922))
 -   Fix issue with long language values in pushers API. ([\#1925](https://github.com/matrix-org/synapse/issues/1925))
 -   Fix a race in transaction queue. ([\#1930](https://github.com/matrix-org/synapse/issues/1930))
--   Fix dynamic thumbnailing to preserve aspect ratio. Thanks to jkolo!. ([\#1945](https://github.com/matrix-org/synapse/issues/1945))
+-   Fix dynamic thumbnailing to preserve aspect ratio. Thanks to jkolo! ([\#1945](https://github.com/matrix-org/synapse/issues/1945))
 -   Fix device list update to not constantly resync. ([\#1964](https://github.com/matrix-org/synapse/issues/1964))
 -   Fix potential for huge memory usage when getting device that have changed. ([\#1969](https://github.com/matrix-org/synapse/issues/1969))
 
 Changes in synapse v0.19.2 (2017-02-20)
 =======================================
 
--   Fix bug with event visibility check in /context/ API. Thanks to Tokodomo for pointing it out!. ([\#1929](https://github.com/matrix-org/synapse/issues/1929))
+-   Fix bug with event visibility check in /context/ API. Thanks to Tokodomo for pointing it out! ([\#1929](https://github.com/matrix-org/synapse/issues/1929))
 
 Changes in synapse v0.19.1 (2017-02-09)
 =======================================
@@ -2417,7 +2417,7 @@ Changes:
 Bug fixes:
 
 -   Fix /notifications API when used with `from` param. ([\#1080](https://github.com/matrix-org/synapse/issues/1080))
--   Fix backfill when cannot find an event.. ([\#1107](https://github.com/matrix-org/synapse/issues/1107))
+-   Fix backfill when cannot find an event. ([\#1107](https://github.com/matrix-org/synapse/issues/1107))
 
 Changes in synapse v0.17.3 (2016-09-09)
 =======================================
@@ -2441,7 +2441,7 @@ Features:
 Changes:
 
 -   Avoid pulling the full state of a room out so often. ([\#1047](https://github.com/matrix-org/synapse/issues/1047), [\#1049](https://github.com/matrix-org/synapse/issues/1049), [\#1063](https://github.com/matrix-org/synapse/issues/1063), [\#1068](https://github.com/matrix-org/synapse/issues/1068))
--   Don't notify for online to online presence transitions.. ([\#1054](https://github.com/matrix-org/synapse/issues/1054))
+-   Don't notify for online to online presence transitions. ([\#1054](https://github.com/matrix-org/synapse/issues/1054))
 -   Occasionally persist unpersisted presence updates. ([\#1055](https://github.com/matrix-org/synapse/issues/1055))
 -   Allow application services to have an optional `url`. ([\#1056](https://github.com/matrix-org/synapse/issues/1056))
 -   Clean up old sent transactions from DB. ([\#1059](https://github.com/matrix-org/synapse/issues/1059))
@@ -2477,7 +2477,7 @@ Changes:
 -   Various federation /event/ perf improvements. ([\#998](https://github.com/matrix-org/synapse/issues/998))
 -   Only process one local membership event per room at a time. ([\#1005](https://github.com/matrix-org/synapse/issues/1005))
 -   Move default display name push rule. ([\#1011](https://github.com/matrix-org/synapse/issues/1011), [\#1023](https://github.com/matrix-org/synapse/issues/1023))
--   Fix up preview URL API. Add tests.. ([\#1015](https://github.com/matrix-org/synapse/issues/1015))
+-   Fix up preview URL API. Add tests. ([\#1015](https://github.com/matrix-org/synapse/issues/1015))
 -   Set `Content-Security-Policy` on media repo. ([\#1021](https://github.com/matrix-org/synapse/issues/1021))
 -   Make `notify_interested_services` faster. ([\#1022](https://github.com/matrix-org/synapse/issues/1022))
 -   Add usage stats to prometheus monitoring. ([\#1037](https://github.com/matrix-org/synapse/issues/1037))
@@ -2557,9 +2557,9 @@ Features:
 -   Add purge local room history API. ([\#911](https://github.com/matrix-org/synapse/issues/911), [\#923](https://github.com/matrix-org/synapse/issues/923), [\#924](https://github.com/matrix-org/synapse/issues/924))
 -   Add requestToken endpoints. ([\#915](https://github.com/matrix-org/synapse/issues/915))
 -   Add an /account/deactivate endpoint. ([\#921](https://github.com/matrix-org/synapse/issues/921))
--   Add filter param to /messages. Add `contains_url` to filter.. ([\#922](https://github.com/matrix-org/synapse/issues/922))
+-   Add filter param to /messages. Add `contains_url` to filter. ([\#922](https://github.com/matrix-org/synapse/issues/922))
 -   Add `device_id` support to /login. ([\#929](https://github.com/matrix-org/synapse/issues/929))
--   Add `device_id` support to /v2/register flow.. ([\#937](https://github.com/matrix-org/synapse/issues/937), [\#942](https://github.com/matrix-org/synapse/issues/942))
+-   Add `device_id` support to /v2/register flow. ([\#937](https://github.com/matrix-org/synapse/issues/937), [\#942](https://github.com/matrix-org/synapse/issues/942))
 -   Add GET /devices endpoint. ([\#939](https://github.com/matrix-org/synapse/issues/939), [\#944](https://github.com/matrix-org/synapse/issues/944))
 -   Add GET /device/{deviceId}. ([\#943](https://github.com/matrix-org/synapse/issues/943))
 -   Add update and delete APIs for devices. ([\#949](https://github.com/matrix-org/synapse/issues/949))
@@ -2568,7 +2568,7 @@ Changes:
 
 -   Rewrite LDAP Authentication against ldap3. Contributed by mweinelt. ([\#843](https://github.com/matrix-org/synapse/issues/843))
 -   Linearize some federation endpoints based on `(origin, room_id)`. ([\#879](https://github.com/matrix-org/synapse/issues/879))
--   Remove the legacy v0 content upload API.. ([\#888](https://github.com/matrix-org/synapse/issues/888))
+-   Remove the legacy v0 content upload API. ([\#888](https://github.com/matrix-org/synapse/issues/888))
 -   Use similar naming we use in email notifs for push. ([\#894](https://github.com/matrix-org/synapse/issues/894))
 -   Optionally include password hash in createUser endpoint. Contributed by KentShikama. ([\#905](https://github.com/matrix-org/synapse/issues/905))
 -   Use a query that postgresql optimises better for `get_events_around`. ([\#906](https://github.com/matrix-org/synapse/issues/906))
@@ -2887,7 +2887,7 @@ Changes in synapse v0.12.0-rc3 (2015-12-23)
 ===========================================
 
 -   Allow guest accounts access to `/sync`. ([\#455](https://github.com/matrix-org/synapse/issues/455))
--   Allow filters to include/exclude rooms at the room level rather than just from the components of the sync for each room.. ([\#454](https://github.com/matrix-org/synapse/issues/454))
+-   Allow filters to include/exclude rooms at the room level rather than just from the components of the sync for each room. ([\#454](https://github.com/matrix-org/synapse/issues/454))
 -   Include urls for room avatars in the response to `/publicRooms`. ([\#453](https://github.com/matrix-org/synapse/issues/453))
 -   Don't set a identicon as the avatar for a user when they register. ([\#450](https://github.com/matrix-org/synapse/issues/450))
 -   Add a `display_name` to third-party invites. ([\#449](https://github.com/matrix-org/synapse/issues/449))
@@ -2912,7 +2912,7 @@ Changes in synapse v0.12.0-rc1 (2015-12-10)
 
 -   Host the client APIs released as r0 by <https://matrix.org/docs/spec/r0.0.0/client_server.html> on paths prefixed by `/_matrix/client/r0`. ([\#430](https://github.com/matrix-org/synapse/issues/430), [\#415](https://github.com/matrix-org/synapse/issues/415), [\#400](https://github.com/matrix-org/synapse/issues/400))
 -   Updates the client APIs to match r0 of the matrix specification.
-    -   All APIs return events in the new event format, old APIs also include the fields needed to parse the event using the old format for compatibility.. ([\#402](https://github.com/matrix-org/synapse/issues/402))
+    -   All APIs return events in the new event format, old APIs also include the fields needed to parse the event using the old format for compatibility. ([\#402](https://github.com/matrix-org/synapse/issues/402))
     -   Search results are now given as a JSON array rather than a JSON object. ([\#405](https://github.com/matrix-org/synapse/issues/405))
     -   Miscellaneous changes to search. ([\#403](https://github.com/matrix-org/synapse/issues/403), [\#406](https://github.com/matrix-org/synapse/issues/406), [\#412](https://github.com/matrix-org/synapse/issues/412))
     -   Filter JSON objects may now be passed as query parameters to `/sync`. ([\#431](https://github.com/matrix-org/synapse/issues/431))
@@ -2925,7 +2925,7 @@ Changes in synapse v0.12.0-rc1 (2015-12-10)
     -   Add per-request counters for CPU time spent on the main python thread. ([\#421](https://github.com/matrix-org/synapse/issues/421), [\#420](https://github.com/matrix-org/synapse/issues/420))
     -   Add per-request counters for time spent in the database. ([\#429](https://github.com/matrix-org/synapse/issues/429))
     -   Make state updates in the C+S API idempotent. ([\#416](https://github.com/matrix-org/synapse/issues/416))
-    -   Only fire `user_joined_room` if the user has actually joined.. ([\#410](https://github.com/matrix-org/synapse/issues/410))
+    -   Only fire `user_joined_room` if the user has actually joined. ([\#410](https://github.com/matrix-org/synapse/issues/410))
     -   Reuse a single http client, rather than creating new ones. ([\#413](https://github.com/matrix-org/synapse/issues/413))
 -   Fixed a bug upgrading from older versions of synapse on postgresql. ([\#417](https://github.com/matrix-org/synapse/issues/417))
 
@@ -2982,10 +2982,10 @@ Changes in synapse v0.10.1-rc1 (2015-10-15)
 -   Add support for CAS, thanks to Steven Hammerton. ([\#295](https://github.com/matrix-org/synapse/issues/295), [\#296](https://github.com/matrix-org/synapse/issues/296))
 -   Add support for using macaroons for `access_token`. ([\#256](https://github.com/matrix-org/synapse/issues/256), [\#229](https://github.com/matrix-org/synapse/issues/229))
 -   Add support for `m.room.canonical_alias`. ([\#287](https://github.com/matrix-org/synapse/issues/287))
--   Add support for viewing the history of rooms that they have left.. ([\#276](https://github.com/matrix-org/synapse/issues/276), [\#294](https://github.com/matrix-org/synapse/issues/294))
+-   Add support for viewing the history of rooms that they have left. ([\#276](https://github.com/matrix-org/synapse/issues/276), [\#294](https://github.com/matrix-org/synapse/issues/294))
 -   Add support for refresh tokens. ([\#240](https://github.com/matrix-org/synapse/issues/240))
 -   Add flag on creation which disables federation of the room. ([\#279](https://github.com/matrix-org/synapse/issues/279))
--   Add some room state to invites.. ([\#275](https://github.com/matrix-org/synapse/issues/275))
+-   Add some room state to invites. ([\#275](https://github.com/matrix-org/synapse/issues/275))
 -   Atomically persist events when joining a room over federation. ([\#283](https://github.com/matrix-org/synapse/issues/283))
 -   Change default history visibility for private rooms. ([\#271](https://github.com/matrix-org/synapse/issues/271))
 -   Allow users to redact their own sent events. ([\#262](https://github.com/matrix-org/synapse/issues/262))
@@ -3023,14 +3023,14 @@ Changes in synapse v0.10.0-rc5 (2015-08-27)
 Changes in synapse v0.10.0-rc4 (2015-08-27)
 ===========================================
 
--   Allow UTF-8 filenames for upload.. ([\#259](https://github.com/matrix-org/synapse/issues/259))
+-   Allow UTF-8 filenames for upload. ([\#259](https://github.com/matrix-org/synapse/issues/259))
 
 Changes in synapse v0.10.0-rc3 (2015-08-25)
 ===========================================
 
--   Add `--keys-directory` config option to specify where files such as certs and signing keys should be stored in, when using `--generate-config` or `--generate-keys`.. ([\#250](https://github.com/matrix-org/synapse/issues/250))
--   Allow `--config-path` to specify a directory, causing synapse to use all `*.yaml` files in the directory as config files.. ([\#249](https://github.com/matrix-org/synapse/issues/249))
--   Add `web_client_location` config option to specify static files to be hosted by synapse under `/_matrix/client`.. ([\#245](https://github.com/matrix-org/synapse/issues/245))
+-   Add `--keys-directory` config option to specify where files such as certs and signing keys should be stored in, when using `--generate-config` or `--generate-keys`. ([\#250](https://github.com/matrix-org/synapse/issues/250))
+-   Allow `--config-path` to specify a directory, causing synapse to use all `*.yaml` files in the directory as config files. ([\#249](https://github.com/matrix-org/synapse/issues/249))
+-   Add `web_client_location` config option to specify static files to be hosted by synapse under `/_matrix/client`. ([\#245](https://github.com/matrix-org/synapse/issues/245))
 -   Add helper utility to synapse to read and parse the config files and extract the value of a given key. For example:
 
         $ python -m synapse.config read server_name -c homeserver.yaml
@@ -3052,35 +3052,35 @@ Also see v0.9.4-rc1 changelog, which has been amalgamated into this release.
 General:
 
 -   Upgrade to Twisted 15. ([\#173](https://github.com/matrix-org/synapse/issues/173))
--   Add support for serving and fetching encryption keys over federation.. ([\#208](https://github.com/matrix-org/synapse/issues/208))
+-   Add support for serving and fetching encryption keys over federation. ([\#208](https://github.com/matrix-org/synapse/issues/208))
 -   Add support for logging in with email address. ([\#234](https://github.com/matrix-org/synapse/issues/234))
--   Add support for new `m.room.canonical_alias` event.. ([\#233](https://github.com/matrix-org/synapse/issues/233))
+-   Add support for new `m.room.canonical_alias` event. ([\#233](https://github.com/matrix-org/synapse/issues/233))
 -   Change synapse to treat user IDs case insensitively during registration and login. (If two users already exist with case insensitive matching user ids, synapse will continue to require them to specify their user ids exactly.)
--   Error if a user tries to register with an email already in use.. ([\#211](https://github.com/matrix-org/synapse/issues/211))
+-   Error if a user tries to register with an email already in use. ([\#211](https://github.com/matrix-org/synapse/issues/211))
 -   Add extra and improve existing caches. ([\#212](https://github.com/matrix-org/synapse/issues/212), [\#219](https://github.com/matrix-org/synapse/issues/219), [\#226](https://github.com/matrix-org/synapse/issues/226), [\#228](https://github.com/matrix-org/synapse/issues/228))
 -   Batch various storage request. ([\#226](https://github.com/matrix-org/synapse/issues/226), [\#228](https://github.com/matrix-org/synapse/issues/228))
 -   Fix bug where we didn't correctly log the entity that triggered the request if the request came in via an application service. ([\#230](https://github.com/matrix-org/synapse/issues/230))
--   Fix bug where we needlessly regenerated the full list of rooms an AS is interested in.. ([\#232](https://github.com/matrix-org/synapse/issues/232))
+-   Fix bug where we needlessly regenerated the full list of rooms an AS is interested in. ([\#232](https://github.com/matrix-org/synapse/issues/232))
 -   Add support for AS's to use `v2_alpha` registration API. ([\#210](https://github.com/matrix-org/synapse/issues/210))
 
 Configuration:
 
--   Add `--generate-keys` that will generate any missing cert and key files in the configuration files. This is equivalent to running `--generate-config` on an existing configuration file.. ([\#220](https://github.com/matrix-org/synapse/issues/220))
--   `--generate-config` now no longer requires a `--server-name` parameter when used on existing configuration files.. ([\#220](https://github.com/matrix-org/synapse/issues/220))
--   Add `--print-pidfile` flag that controls the printing of the pid to stdout of the demonised process.. ([\#213](https://github.com/matrix-org/synapse/issues/213))
+-   Add `--generate-keys` that will generate any missing cert and key files in the configuration files. This is equivalent to running `--generate-config` on an existing configuration file. ([\#220](https://github.com/matrix-org/synapse/issues/220))
+-   `--generate-config` now no longer requires a `--server-name` parameter when used on existing configuration files. ([\#220](https://github.com/matrix-org/synapse/issues/220))
+-   Add `--print-pidfile` flag that controls the printing of the pid to stdout of the demonised process. ([\#213](https://github.com/matrix-org/synapse/issues/213))
 
 Media Repository:
 
--   Fix bug where we picked a lower resolution image than requested.. ([\#205](https://github.com/matrix-org/synapse/issues/205))
--   Add support for specifying if a the media repository should dynamically thumbnail images or not.. ([\#206](https://github.com/matrix-org/synapse/issues/206))
+-   Fix bug where we picked a lower resolution image than requested. ([\#205](https://github.com/matrix-org/synapse/issues/205))
+-   Add support for specifying if a the media repository should dynamically thumbnail images or not. ([\#206](https://github.com/matrix-org/synapse/issues/206))
 
 Metrics:
 
--   Add statistics from the reactor to the metrics API.. ([\#224](https://github.com/matrix-org/synapse/issues/224), [\#225](https://github.com/matrix-org/synapse/issues/225))
+-   Add statistics from the reactor to the metrics API. ([\#224](https://github.com/matrix-org/synapse/issues/224), [\#225](https://github.com/matrix-org/synapse/issues/225))
 
 Demo Homeservers:
 
--   Fix starting the demo homeservers without rate-limiting enabled.. ([\#182](https://github.com/matrix-org/synapse/issues/182))
+-   Fix starting the demo homeservers without rate-limiting enabled. ([\#182](https://github.com/matrix-org/synapse/issues/182))
 -   Fix enabling registration on demo homeservers. ([\#223](https://github.com/matrix-org/synapse/issues/223))
 
 Changes in synapse v0.9.4-rc1 (2015-07-21)
@@ -3089,13 +3089,13 @@ Changes in synapse v0.9.4-rc1 (2015-07-21)
 General:
 
 -   Add basic implementation of receipts. (SPEC-99)
--   Add support for configuration presets in room creation API.. ([\#203](https://github.com/matrix-org/synapse/issues/203))
+-   Add support for configuration presets in room creation API. ([\#203](https://github.com/matrix-org/synapse/issues/203))
 -   Add auth event that limits the visibility of history for new users. (SPEC-134)
 -   Add SAML2 login/registration support. Thanks Muthu Subramanian! ([\#201](https://github.com/matrix-org/synapse/issues/201))
--   Add client side key management APIs for end to end encryption.. ([\#198](https://github.com/matrix-org/synapse/issues/198))
+-   Add client side key management APIs for end to end encryption. ([\#198](https://github.com/matrix-org/synapse/issues/198))
 -   Change power level semantics so that you cannot kick, ban or change power levels of users that have equal or greater power level than you. (SYN-192)
--   Improve performance by bulk inserting events where possible.. ([\#193](https://github.com/matrix-org/synapse/issues/193))
--   Improve performance by bulk verifying signatures where possible.. ([\#194](https://github.com/matrix-org/synapse/issues/194))
+-   Improve performance by bulk inserting events where possible. ([\#193](https://github.com/matrix-org/synapse/issues/193))
+-   Improve performance by bulk verifying signatures where possible. ([\#194](https://github.com/matrix-org/synapse/issues/194))
 
 Configuration:
 

--- a/docs/changelogs/CHANGES-pre-1.0.md
+++ b/docs/changelogs/CHANGES-pre-1.0.md
@@ -1315,29 +1315,29 @@ Changes:
 -   Avoid sending consent notice to guest users (PR #3288)
 -   disable CPUMetrics if no /proc/self/stat (PR #3299)
 -   Consistently use six's iteritems and wrap lazy keys/values in list() if they're not meant to be lazy (PR #3307)
--   Add private IPv6 addresses to example config for url preview blacklist (PR #3317) Thanks to @thegcat!
+-   Add private IPv6 addresses to example config for url preview blacklist. Thanks to @thegcat! ([\#3317](https://github.com/matrix-org/synapse/issues/3317))
 -   Reduce stuck read-receipts: ignore depth when updating (PR #3318)
 -   Put python's logs into Trial when running unit tests (PR #3319)
 
 Changes, python 3 migration:
 
--   Replace some more comparisons with six (PR #3243) Thanks to @NotAFile!
--   replace some iteritems with six (PR #3244) Thanks to @NotAFile!
--   Add `batch_iter` to utils (PR #3245) Thanks to @NotAFile!
--   use repr, not str (PR #3246) Thanks to @NotAFile!
--   Misc Python3 fixes (PR #3247) Thanks to @NotAFile!
--   Py3 `storage/_base.py` (PR #3278) Thanks to @NotAFile!
--   more six iteritems (PR #3279) Thanks to @NotAFile!
--   More Misc. py3 fixes (PR #3280) Thanks to @NotAFile!
--   remaining isintance fixes (PR #3281) Thanks to @NotAFile!
--   py3-ize state.py (PR #3283) Thanks to @NotAFile!
--   extend tox testing for py3 to avoid regressions (PR #3302) Thanks to @krombel!
--   use memoryview in py3 (PR #3303) Thanks to @NotAFile!
+-   Replace some more comparisons with six. Thanks to @NotAFile! ([\#3243](https://github.com/matrix-org/synapse/issues/3243))
+-   replace some iteritems with six. Thanks to @NotAFile! ([\#3244](https://github.com/matrix-org/synapse/issues/3244))
+-   Add `batch_iter` to utils. Thanks to @NotAFile! ([\#3245](https://github.com/matrix-org/synapse/issues/3245))
+-   use repr, not str. Thanks to @NotAFile! ([\#3246](https://github.com/matrix-org/synapse/issues/3246))
+-   Misc Python3 fixes. Thanks to @NotAFile! ([\#3247](https://github.com/matrix-org/synapse/issues/3247))
+-   Py3 `storage/_base.py`. Thanks to @NotAFile! ([\#3278](https://github.com/matrix-org/synapse/issues/3278))
+-   more six iteritems. Thanks to @NotAFile! ([\#3279](https://github.com/matrix-org/synapse/issues/3279))
+-   More Misc. py3 fixes. Thanks to @NotAFile! ([\#3280](https://github.com/matrix-org/synapse/issues/3280))
+-   remaining isintance fixes. Thanks to @NotAFile! ([\#3281](https://github.com/matrix-org/synapse/issues/3281))
+-   py3-ize state.py. Thanks to @NotAFile! ([\#3283](https://github.com/matrix-org/synapse/issues/3283))
+-   extend tox testing for py3 to avoid regressions. Thanks to @krombel! ([\#3302](https://github.com/matrix-org/synapse/issues/3302))
+-   use memoryview in py3. Thanks to @NotAFile! ([\#3303](https://github.com/matrix-org/synapse/issues/3303))
 
 Bugs:
 
 -   Fix federation backfill bugs (PR #3261)
--   federation: fix LaterGauge usage (PR #3328) Thanks to @intelfx!
+-   federation: fix LaterGauge usage. Thanks to @intelfx! ([\#3328](https://github.com/matrix-org/synapse/issues/3328))
 
 Changes in synapse v0.30.0 (2018-05-24)
 =======================================
@@ -1372,7 +1372,7 @@ Server Notices/Consent Tracking Support:
 Features:
 
 -   Cohort analytics (PR #3163, #3241, #3251)
--   Add lxml to docker image for web previews (PR #3239) Thanks to @ptman!
+-   Add lxml to docker image for web previews. Thanks to @ptman! ([\#3239](https://github.com/matrix-org/synapse/issues/3239))
 -   Add in flight request metrics (PR #3252)
 
 Changes:
@@ -1415,11 +1415,11 @@ Potentially breaking change:
 
 Features:
 
--   Add a Dockerfile for synapse (PR #2846) Thanks to @kaiyou!
+-   Add a Dockerfile for synapse. Thanks to @kaiyou! ([\#2846](https://github.com/matrix-org/synapse/issues/2846))
 
 Changes - General:
 
--   nuke-room-from-db.sh: added postgresql option and help (PR #2337) Thanks to @rubo77!
+-   nuke-room-from-db.sh: added postgresql option and help. Thanks to @rubo77! ([\#2337](https://github.com/matrix-org/synapse/issues/2337))
 -   Part user from rooms on account deactivate (PR #3201)
 -   Make "unexpected logging context" into warnings (PR #3007)
 -   Set Server header in SynapseRequest (PR #3208)
@@ -1439,7 +1439,7 @@ Changes - Refactors:
 -   Refactor sync APIs to reuse pagination API (PR #3199)
 -   Remove unused code path from member change DB func (PR #3200)
 -   Refactor request handling wrappers (PR #3203)
--   `transaction_id`, destination defined twice (PR #3209) Thanks to @damir-manapov!
+-   `transaction_id`, destination defined twice. Thanks to @damir-manapov! ([\#3209](https://github.com/matrix-org/synapse/issues/3209))
 -   Refactor event storage to prepare for changes in state calculations (PR #3141)
 -   Set Server header in SynapseRequest (PR #3208)
 -   Use deferred.addTimeout instead of `time_bound_deferred` (PR #3127, #3178)
@@ -1447,19 +1447,19 @@ Changes - Refactors:
 
 Changes - Python 3 migration:
 
--   Construct HMAC as bytes on py3 (PR #3156) Thanks to @NotAFile!
--   run config tests on py3 (PR #3159) Thanks to @NotAFile!
--   Open certificate files as bytes (PR #3084) Thanks to @NotAFile!
--   Open config file in non-bytes mode (PR #3085) Thanks to @NotAFile!
--   Make event properties raise AttributeError instead (PR #3102) Thanks to @NotAFile!
--   Use six.moves.urlparse (PR #3108) Thanks to @NotAFile!
--   Add py3 tests to tox with folders that work (PR #3145) Thanks to @NotAFile!
--   Don't yield in list comprehensions (PR #3150) Thanks to @NotAFile!
--   Move more xrange to six (PR #3151) Thanks to @NotAFile!
--   make imports local (PR #3152) Thanks to @NotAFile!
--   move httplib import to six (PR #3153) Thanks to @NotAFile!
+-   Construct HMAC as bytes on py3. Thanks to @NotAFile! ([\#3156](https://github.com/matrix-org/synapse/issues/3156))
+-   run config tests on py3. Thanks to @NotAFile! ([\#3159](https://github.com/matrix-org/synapse/issues/3159))
+-   Open certificate files as bytes. Thanks to @NotAFile! ([\#3084](https://github.com/matrix-org/synapse/issues/3084))
+-   Open config file in non-bytes mode. Thanks to @NotAFile! ([\#3085](https://github.com/matrix-org/synapse/issues/3085))
+-   Make event properties raise AttributeError instead. Thanks to @NotAFile! ([\#3102](https://github.com/matrix-org/synapse/issues/3102))
+-   Use six.moves.urlparse. Thanks to @NotAFile! ([\#3108](https://github.com/matrix-org/synapse/issues/3108))
+-   Add py3 tests to tox with folders that work. Thanks to @NotAFile! ([\#3145](https://github.com/matrix-org/synapse/issues/3145))
+-   Don't yield in list comprehensions. Thanks to @NotAFile! ([\#3150](https://github.com/matrix-org/synapse/issues/3150))
+-   Move more xrange to six. Thanks to @NotAFile! ([\#3151](https://github.com/matrix-org/synapse/issues/3151))
+-   make imports local. Thanks to @NotAFile! ([\#3152](https://github.com/matrix-org/synapse/issues/3152))
+-   move httplib import to six. Thanks to @NotAFile! ([\#3153](https://github.com/matrix-org/synapse/issues/3153))
 -   Replace stringIO imports with six (PR #3154, #3168) Thanks to @NotAFile!
--   more bytes strings (PR #3155) Thanks to @NotAFile!
+-   more bytes strings. Thanks to @NotAFile! ([\#3155](https://github.com/matrix-org/synapse/issues/3155))
 
 Bug Fixes:
 
@@ -1468,11 +1468,11 @@ Bug Fixes:
 -   Fix a couple of logcontext leaks in unit tests (PR #3172)
 -   Fix logcontext leak in media repo (PR #3174)
 -   Escape label values in prometheus metrics (PR #3175, #3186)
--   Fix "Unhandled Error" logs with Twisted 18.4 (PR #3182) Thanks to @Half-Shot!
+-   Fix "Unhandled Error" logs with Twisted 18.4. Thanks to @Half-Shot! ([\#3182](https://github.com/matrix-org/synapse/issues/3182))
 -   Fix logcontext leaks in rate limiter (PR #3183)
--   notifications: Convert `next_token` to string according to the spec (PR #3190) Thanks to @mujx!
--   nuke-room-from-db.sh: fix deletion from search table (PR #3194) Thanks to @rubo77!
--   add guard for None on `purge_history` api (PR #3160) Thanks to @krombel!
+-   notifications: Convert `next_token` to string according to the spec. Thanks to @mujx! ([\#3190](https://github.com/matrix-org/synapse/issues/3190))
+-   nuke-room-from-db.sh: fix deletion from search table. Thanks to @rubo77! ([\#3194](https://github.com/matrix-org/synapse/issues/3194))
+-   add guard for None on `purge_history` api. Thanks to @krombel! ([\#3160](https://github.com/matrix-org/synapse/issues/3160))
 
 Changes in synapse v0.28.1 (2018-05-01)
 =======================================
@@ -1509,26 +1509,26 @@ Features:
 
 Changes:
 
--   Synapse on PyPy (PR #2760) Thanks to @Valodim!
--   move handling of `auto_join_rooms` to RegisterHandler (PR #2996) Thanks to @krombel!
--   Improve handling of SRV records for federation connections (PR #3016) Thanks to @silkeh!
+-   Synapse on PyPy. Thanks to @Valodim! ([\#2760](https://github.com/matrix-org/synapse/issues/2760))
+-   move handling of `auto_join_rooms` to RegisterHandler. Thanks to @krombel! ([\#2996](https://github.com/matrix-org/synapse/issues/2996))
+-   Improve handling of SRV records for federation connections. Thanks to @silkeh! ([\#3016](https://github.com/matrix-org/synapse/issues/3016))
 -   Document the behaviour of ResponseCache (PR #3059)
 -   Preparation for py3 (PR #3061, #3073, #3074, #3075, #3103, #3104, #3106, #3107, #3109, #3110) Thanks to @NotAFile!
--   update prometheus dashboard to use new metric names (PR #3069) Thanks to @krombel!
--   use python3-compatible prints (PR #3074) Thanks to @NotAFile!
+-   update prometheus dashboard to use new metric names. Thanks to @krombel! ([\#3069](https://github.com/matrix-org/synapse/issues/3069))
+-   use python3-compatible prints. Thanks to @NotAFile! ([\#3074](https://github.com/matrix-org/synapse/issues/3074))
 -   Send federation events concurrently (PR #3078)
 -   Limit concurrent event sends for a room (PR #3079)
 -   Improve R30 stat definition (PR #3086)
 -   Send events to ASes concurrently (PR #3088)
 -   Refactor ResponseCache usage (PR #3093)
--   Clarify that SRV may not point to a CNAME (PR #3100) Thanks to @silkeh!
--   Use str(e) instead of e.message (PR #3103) Thanks to @NotAFile!
--   Use six.itervalues in some places (PR #3106) Thanks to @NotAFile!
+-   Clarify that SRV may not point to a CNAME. Thanks to @silkeh! ([\#3100](https://github.com/matrix-org/synapse/issues/3100))
+-   Use str(e) instead of e.message. Thanks to @NotAFile! ([\#3103](https://github.com/matrix-org/synapse/issues/3103))
+-   Use six.itervalues in some places. Thanks to @NotAFile! ([\#3106](https://github.com/matrix-org/synapse/issues/3106))
 -   Refactor `store.have_events` (PR #3117)
 
 Bug Fixes:
 
--   Return 401 for invalid `access_token` on logout (PR #2938) Thanks to @dklug!
+-   Return 401 for invalid `access_token` on logout. Thanks to @dklug! ([\#2938](https://github.com/matrix-org/synapse/issues/2938))
 -   Return a 404 rather than a 500 on rejoining empty rooms (PR #3080)
 -   fix `federation_domain_whitelist` (PR #3099)
 -   Avoid creating events with huge numbers of `prev_events` (PR #3113)
@@ -1577,8 +1577,8 @@ Features:
 
 Changes:
 
--   Add a blurb explaining the main synapse worker (PR #2886) Thanks to @turt2live!
--   Replace old style error catching with `as` keyword (PR #3000) Thanks to @NotAFile!
+-   Add a blurb explaining the main synapse worker. Thanks to @turt2live! ([\#2886](https://github.com/matrix-org/synapse/issues/2886))
+-   Replace old style error catching with `as` keyword. Thanks to @NotAFile! ([\#3000](https://github.com/matrix-org/synapse/issues/3000))
 -   Use `.iter*` to avoid copies in StateHandler (PR #3006)
 -   Linearize calls to `_generate_user_id` (PR #3029)
 -   Remove last usage of ujson (PR #3030)
@@ -1589,12 +1589,12 @@ Changes:
 
 Bug fixes:
 
--   Add `room_id` to the response of rooms/{roomId}/join (PR #2986) Thanks to @jplatte!
+-   Add `room_id` to the response of rooms/{roomId}/join. Thanks to @jplatte! ([\#2986](https://github.com/matrix-org/synapse/issues/2986))
 -   Fix replication after switch to simplejson (PR #3015)
 -   404 correctly on missing paths via NoResource (PR #3022)
 -   Fix error when claiming e2e keys from offline servers (PR #3034)
 -   fix `tests/storage/test_user_directory.py` (PR #3042)
--   use `PUT` instead of `POST` for federating `groups`/`m.join_policy` (PR #3070) Thanks to @krombel!
+-   use `PUT` instead of `POST` for federating `groups`/`m.join_policy`. Thanks to @krombel! ([\#3070](https://github.com/matrix-org/synapse/issues/3070))
 -   postgres port script: fix `state_groups_pkey` error (PR #3072)
 
 Changes in synapse v0.27.2 (2018-03-26)
@@ -1644,29 +1644,29 @@ Features:
 -   Add purge API features, see [docs/admin_api/purge_history_api.rst](docs/admin_api/purge_history_api.rst) for full details (PR #2858, #2867, #2882, #2946, #2962, #2943)
 -   Add support for whitelisting 3PIDs that users can register. (PR #2813)
 -   Add `/room/{id}/event/{id}` API (PR #2766)
--   Add an admin API to get all the media in a room (PR #2818) Thanks to @turt2live!
+-   Add an admin API to get all the media in a room. Thanks to @turt2live! ([\#2818](https://github.com/matrix-org/synapse/issues/2818))
 -   Add `federation_domain_whitelist` option (PR #2820, #2821)
 
 Changes:
 
 -   Continue to factor out processing from main process and into worker processes. See updated [docs/workers.rst](docs/workers.rst) (PR #2892 - \#2904, #2913, #2920 - \#2926, #2947, #2847, #2854, #2872, #2873, #2874, #2928, #2929, #2934, #2856, #2976 - \#2984, #2987 - \#2989, #2991 - \#2993, #2995, #2784)
 -   Ensure state cache is used when persisting events (PR #2864, #2871, #2802, #2835, #2836, #2841, #2842, #2849)
--   Change the default config to bind on both IPv4 and IPv6 on all platforms (PR #2435) Thanks to @silkeh!
--   No longer require a specific version of saml2 (PR #2695) Thanks to @okurz!
+-   Change the default config to bind on both IPv4 and IPv6 on all platforms. Thanks to @silkeh! ([\#2435](https://github.com/matrix-org/synapse/issues/2435))
+-   No longer require a specific version of saml2. Thanks to @okurz! ([\#2695](https://github.com/matrix-org/synapse/issues/2695))
 -   Remove `verbosity`/`log_file` from generated config (PR #2755)
 -   Add and improve metrics and logging (PR #2770, #2778, #2785, #2786, #2787, #2793, #2794, #2795, #2809, #2810, #2833, #2834, #2844, #2965, #2927, #2975, #2790, #2796, #2838)
 -   When using synctl with workers, Don't start the main synapse automatically (PR #2774)
 -   Minor performance improvements (PR #2773, #2792)
 -   Use a connection pool for non-federation outbound connections (PR #2817)
 -   Make it possible to run unit tests against postgres (PR #2829)
--   Update pynacl dependency to 1.2.1 or higher (PR #2888) Thanks to @bachp!
+-   Update pynacl dependency to 1.2.1 or higher. Thanks to @bachp! ([\#2888](https://github.com/matrix-org/synapse/issues/2888))
 -   Remove ability for AS users to call /events and /sync (PR #2948)
--   Use bcrypt.checkpw (PR #2949) Thanks to @krombel!
+-   Use bcrypt.checkpw. Thanks to @krombel! ([\#2949](https://github.com/matrix-org/synapse/issues/2949))
 
 Bug fixes:
 
--   Fix broken `ldap_config` config option (PR #2683) Thanks to @seckrv!
--   Fix error message when user is not allowed to unban (PR #2761) Thanks to @turt2live!
+-   Fix broken `ldap_config` config option. Thanks to @seckrv! ([\#2683](https://github.com/matrix-org/synapse/issues/2683))
+-   Fix error message when user is not allowed to unban. Thanks to @turt2live! ([\#2761](https://github.com/matrix-org/synapse/issues/2761))
 -   Fix publicised groups GET API (singular) over federation (PR #2772)
 -   Fix user directory when using `user_directory_search_all_users` config option (PR #2803, #2831)
 -   Fix error on `/publicRooms` when no rooms exist (PR #2827)
@@ -1691,7 +1691,7 @@ Features:
 
 Changes:
 
--   Update example Prometheus config to new format (PR #2648) Thanks to @krombel!
+-   Update example Prometheus config to new format. Thanks to @krombel! ([\#2648](https://github.com/matrix-org/synapse/issues/2648))
 -   Rename `redact_content` option to `include_content` in Push API (PR #2650)
 -   Declare support for r0.3.0 (PR #2677)
 -   Improve upserts (PR #2684, #2688, #2689, #2713)
@@ -1704,7 +1704,7 @@ Changes:
 Bug fixes:
 
 -   Fix database port script (PR #2673)
--   Fix internal server error on login with `ldap_auth_provider` (PR #2678) Thanks to @jkolo!
+-   Fix internal server error on login with `ldap_auth_provider`. Thanks to @jkolo! ([\#2678](https://github.com/matrix-org/synapse/issues/2678))
 -   Fix error on sqlite 3.7 (PR #2697)
 -   Fix `OPTIONS` on `preview_url` (PR #2707)
 -   Fix error handling on dns lookup (PR #2711)
@@ -1731,15 +1731,15 @@ Changes in synapse v0.25.0-rc1 (2017-11-14)
 Features:
 
 -   Add `is_public` to groups table to allow for private groups (PR #2582)
--   Add a route for determining who you are (PR #2668) Thanks to @turt2live!
+-   Add a route for determining who you are. Thanks to @turt2live! ([\#2668](https://github.com/matrix-org/synapse/issues/2668))
 -   Add more features to the password providers (PR #2608, #2610, #2620, #2622, #2623, #2624, #2626, #2628, #2629)
 -   Add a hook for custom rest endpoints (PR #2627)
 -   Add API to update group room visibility (PR #2651)
 
 Changes:
 
--   Ignore `<noscript\>` tags when generating URL preview descriptions (PR #2576) Thanks to @maximevaillancourt!
--   Register some /unstable endpoints in /r0 as well (PR #2579) Thanks to @krombel!
+-   Ignore `<noscript\>` tags when generating URL preview descriptions. Thanks to @maximevaillancourt! ([\#2576](https://github.com/matrix-org/synapse/issues/2576))
+-   Register some /unstable endpoints in /r0 as well. Thanks to @krombel! ([\#2579](https://github.com/matrix-org/synapse/issues/2579))
 -   Support /keys/upload on /r0 as well as /unstable (PR #2585)
 -   Front-end proxy: pass through auth header (PR #2586)
 -   Allow ASes to deactivate their own users (PR #2589)
@@ -1747,7 +1747,7 @@ Changes:
 -   Automatically set default displayname on register (PR #2617)
 -   Log login requests (PR #2618)
 -   Always return `is_public` in the `/groups/:group_id/rooms` API (PR #2630)
--   Avoid no-op media deletes (PR #2637) Thanks to @spantaleev!
+-   Avoid no-op media deletes. Thanks to @spantaleev! ([\#2637](https://github.com/matrix-org/synapse/issues/2637))
 -   Fix various embarrassing typos around `user_directory` and add some doc. (PR #2643)
 -   Return whether a user is an admin within a group (PR #2647)
 -   Namespace visibility options for groups (PR #2657)
@@ -1761,8 +1761,8 @@ Bug fixes:
 -   Fix UI auth when deleting devices (PR #2591)
 -   Fix typo when checking if user is invited to group (PR #2599)
 -   Fix the port script to drop NUL values in all tables (PR #2611)
--   Fix appservices being backlogged and not receiving new events due to a bug in `notify_interested_services` (PR #2631) Thanks to @xyzz!
--   Fix updating rooms avatar/display name when modified by admin (PR #2636) Thanks to @farialima!
+-   Fix appservices being backlogged and not receiving new events due to a bug in `notify_interested_services`. Thanks to @xyzz! ([\#2631](https://github.com/matrix-org/synapse/issues/2631))
+-   Fix updating rooms avatar/display name when modified by admin. Thanks to @farialima! ([\#2636](https://github.com/matrix-org/synapse/issues/2636))
 -   Fix bug in state group storage (PR #2649)
 -   Fix 500 on invalid utf-8 in request (PR #2663)
 
@@ -1803,7 +1803,7 @@ Changes:
 Bug fixes:
 
 -   Fix handling SERVFAILs when doing AAAA lookups for federation (PR #2477)
--   Fix incompatibility with newer versions of ujson (PR #2483) Thanks to @jeremycline!
+-   Fix incompatibility with newer versions of ujson. Thanks to @jeremycline! ([\#2483](https://github.com/matrix-org/synapse/issues/2483))
 -   Fix notification keywords that start/end with non-word chars (PR #2500)
 -   Fix stack overflow and logcontexts from linearizer (PR #2532)
 -   Fix 500 error when fields missing from `power_levels` event (PR #2552)
@@ -1840,11 +1840,11 @@ Features:
 
 Changes:
 
--   Use bcrypt module instead of py-bcrypt (PR #2288) Thanks to @kyrias!
+-   Use bcrypt module instead of py-bcrypt. Thanks to @kyrias! ([\#2288](https://github.com/matrix-org/synapse/issues/2288))
 -   Improve performance of generating push notifications (PR #2343, #2357, #2365, #2366, #2371)
 -   Improve DB performance for device list handling in sync (PR #2362)
 -   Include a sample prometheus config (PR #2416)
--   Document known to work postgres version (PR #2433) Thanks to @ptman!
+-   Document known to work postgres version. Thanks to @ptman! ([\#2433](https://github.com/matrix-org/synapse/issues/2433))
 
 Bug fixes:
 
@@ -1890,25 +1890,25 @@ Features:
 -   Add a user directory API (PR #2252, and many more)
 -   Add shutdown room API to remove room from local server (PR #2291)
 -   Add API to quarantine media (PR #2292)
--   Add new config option to not send event contents to push servers (PR #2301) Thanks to @cjdelisle!
+-   Add new config option to not send event contents to push servers. Thanks to @cjdelisle! ([\#2301](https://github.com/matrix-org/synapse/issues/2301))
 
 Changes:
 
 -   Various performance fixes (PR #2177, #2233, #2230, #2238, #2248, #2256, #2274)
--   Deduplicate sync filters (PR #2219) Thanks to @krombel!
--   Correct a typo in UPGRADE.rst (PR #2231) Thanks to @aaronraimist!
+-   Deduplicate sync filters. Thanks to @krombel! ([\#2219](https://github.com/matrix-org/synapse/issues/2219))
+-   Correct a typo in UPGRADE.rst. Thanks to @aaronraimist! ([\#2231](https://github.com/matrix-org/synapse/issues/2231))
 -   Add count of one time keys to sync stream (PR #2237)
 -   Only store `event_auth` for state events (PR #2247)
 -   Store URL cache preview downloads separately (PR #2299)
 
 Bug fixes:
 
--   Fix users not getting notifications when AS listened to that `user_id` (PR #2216) Thanks to @slipeer!
+-   Fix users not getting notifications when AS listened to that `user_id`. Thanks to @slipeer! ([\#2216](https://github.com/matrix-org/synapse/issues/2216))
 -   Fix users without push set up not getting notifications after joining rooms (PR #2236)
 -   Fix preview url API to trim long descriptions (PR #2243)
 -   Fix bug where we used cached but unpersisted state group as prev group, resulting in broken state of restart (PR #2263)
 -   Fix removing of pushers when using workers (PR #2267)
--   Fix CORS headers to allow Authorization header (PR #2285) Thanks to @krombel!
+-   Fix CORS headers to allow Authorization header. Thanks to @krombel! ([\#2285](https://github.com/matrix-org/synapse/issues/2285))
 
 Changes in synapse v0.21.1 (2017-06-15)
 =======================================
@@ -1928,14 +1928,14 @@ Changes in synapse v0.21.0-rc3 (2017-05-17)
 Features:
 
 -   Add per user rate-limiting overrides (PR #2208)
--   Add config option to limit maximum number of events requested by `/sync` and `/messages` (PR #2221) Thanks to @psaavedra!
+-   Add config option to limit maximum number of events requested by `/sync` and `/messages`. Thanks to @psaavedra! ([\#2221](https://github.com/matrix-org/synapse/issues/2221))
 
 Changes:
 
 -   Various small performance fixes (PR #2201, #2202, #2224, #2226, #2227, #2228, #2229)
 -   Update username availability checker API (PR #2209, #2213)
 -   When purging, Don't de-delta state groups we're about to delete (PR #2214)
--   Documentation to check synapse version (PR #2215) Thanks to @hamber-dick!
+-   Documentation to check synapse version. Thanks to @hamber-dick! ([\#2215](https://github.com/matrix-org/synapse/issues/2215))
 -   Add an index to `event_search` to speed up purge history API (PR #2218)
 
 Bug fixes:
@@ -2174,7 +2174,7 @@ Changes in synapse v0.18.6 (2017-01-06)
 
 Bug fixes:
 
--   Fix bug when checking if a guest user is allowed to join a room (PR #1772) Thanks to Patrik Oldsberg for diagnosing and the fix!
+-   Fix bug when checking if a guest user is allowed to join a room. Thanks to Patrik Oldsberg for diagnosing and the fix! ([\#1772](https://github.com/matrix-org/synapse/issues/1772))
 
 Changes in synapse v0.18.6-rc3 (2017-01-05)
 ===========================================

--- a/docs/changelogs/CHANGES-pre-1.0.md
+++ b/docs/changelogs/CHANGES-pre-1.0.md
@@ -1407,7 +1407,7 @@ Notable changes, a docker file for running Synapse (Thanks to @kaiyou!) and a cl
 
 Potentially breaking change:
 
--   Make Client-Server API return 401 for invalid token (PR #3161).
+-   Make Client-Server API return 401 for invalid token. ([\#3161](https://github.com/matrix-org/synapse/issues/3161))
 
     This changes the Client-server spec to return a 401 error code instead of 403 when the access token is unrecognised. This is the behaviour required by the specification, but some clients may be relying on the old, incorrect behaviour.
 
@@ -1732,7 +1732,7 @@ Features:
 
 -   Add `is_public` to groups table to allow for private groups. ([\#2582](https://github.com/matrix-org/synapse/issues/2582))
 -   Add a route for determining who you are. Thanks to @turt2live! ([\#2668](https://github.com/matrix-org/synapse/issues/2668))
--   Add more features to the password providers (PR #2608, #2610, #2620, #2622, #2623, #2624, #2626, #2628, #2629)
+-   Add more features to the password providers ([\#2608](https://github.com/matrix-org/synapse/issues/2608), [\#2610](https://github.com/matrix-org/synapse/issues/2610), [\#2620](https://github.com/matrix-org/synapse/issues/2620), [\#2622](https://github.com/matrix-org/synapse/issues/2622), [\#2623](https://github.com/matrix-org/synapse/issues/2623), [\#2624](https://github.com/matrix-org/synapse/issues/2624), [\#2626](https://github.com/matrix-org/synapse/issues/2626), [\#2628](https://github.com/matrix-org/synapse/issues/2628), [\#2629](https://github.com/matrix-org/synapse/issues/2629))
 -   Add a hook for custom rest endpoints. ([\#2627](https://github.com/matrix-org/synapse/issues/2627))
 -   Add API to update group room visibility. ([\#2651](https://github.com/matrix-org/synapse/issues/2651))
 
@@ -1783,7 +1783,7 @@ Changes in synapse v0.24.0-rc1 (2017-10-19)
 
 Features:
 
--   Add Group Server (PR #2352, #2363, #2374, #2377, #2378, #2382, #2410, #2426, #2430, #2454, #2471, #2472, #2544)
+-   Add Group Server ([\#2352](https://github.com/matrix-org/synapse/issues/2352), [\#2363](https://github.com/matrix-org/synapse/issues/2363), [\#2374](https://github.com/matrix-org/synapse/issues/2374), [\#2377](https://github.com/matrix-org/synapse/issues/2377), [\#2378](https://github.com/matrix-org/synapse/issues/2378), [\#2382](https://github.com/matrix-org/synapse/issues/2382), [\#2410](https://github.com/matrix-org/synapse/issues/2410), [\#2426](https://github.com/matrix-org/synapse/issues/2426), [\#2430](https://github.com/matrix-org/synapse/issues/2430), [\#2454](https://github.com/matrix-org/synapse/issues/2454), [\#2471](https://github.com/matrix-org/synapse/issues/2471), [\#2472](https://github.com/matrix-org/synapse/issues/2472), [\#2544](https://github.com/matrix-org/synapse/issues/2544))
 -   Add support for channel notifications. ([\#2501](https://github.com/matrix-org/synapse/issues/2501))
 -   Add basic implementation of backup media store. ([\#2538](https://github.com/matrix-org/synapse/issues/2538))
 -   Add config option to auto-join new users to rooms. ([\#2545](https://github.com/matrix-org/synapse/issues/2545))
@@ -1894,7 +1894,7 @@ Features:
 
 Changes:
 
--   Various performance fixes (PR #2177, #2233, #2230, #2238, #2248, #2256, #2274)
+-   Various performance fixes. ([\#2177](https://github.com/matrix-org/synapse/issues/2177), [\#2233](https://github.com/matrix-org/synapse/issues/2233), [\#2230](https://github.com/matrix-org/synapse/issues/2230), [\#2238](https://github.com/matrix-org/synapse/issues/2238), [\#2248](https://github.com/matrix-org/synapse/issues/2248), [\#2256](https://github.com/matrix-org/synapse/issues/2256), [\#2274](https://github.com/matrix-org/synapse/issues/2274))
 -   Deduplicate sync filters. Thanks to @krombel! ([\#2219](https://github.com/matrix-org/synapse/issues/2219))
 -   Correct a typo in UPGRADE.rst. Thanks to @aaronraimist! ([\#2231](https://github.com/matrix-org/synapse/issues/2231))
 -   Add count of one time keys to sync stream. ([\#2237](https://github.com/matrix-org/synapse/issues/2237))
@@ -1932,7 +1932,7 @@ Features:
 
 Changes:
 
--   Various small performance fixes (PR #2201, #2202, #2224, #2226, #2227, #2228, #2229)
+-   Various small performance fixes. ([\#2201](https://github.com/matrix-org/synapse/issues/2201), [\#2202](https://github.com/matrix-org/synapse/issues/2202), [\#2224](https://github.com/matrix-org/synapse/issues/2224), [\#2226](https://github.com/matrix-org/synapse/issues/2226), [\#2227](https://github.com/matrix-org/synapse/issues/2227), [\#2228](https://github.com/matrix-org/synapse/issues/2228), [\#2229](https://github.com/matrix-org/synapse/issues/2229))
 -   Update username availability checker API. ([\#2209](https://github.com/matrix-org/synapse/issues/2209), [\#2213](https://github.com/matrix-org/synapse/issues/2213))
 -   When purging, Don't de-delta state groups we're about to delete. ([\#2214](https://github.com/matrix-org/synapse/issues/2214))
 -   Documentation to check synapse version. Thanks to @hamber-dick! ([\#2215](https://github.com/matrix-org/synapse/issues/2215))
@@ -1965,18 +1965,18 @@ Changes:
 
 -   Enable guest access for the 3pl/3pid APIs. ([\#1986](https://github.com/matrix-org/synapse/issues/1986))
 -   Add setting to support TURN for guests. ([\#2011](https://github.com/matrix-org/synapse/issues/2011))
--   Various performance improvements (PR #2075, #2076, #2080, #2083, #2108, #2158, #2176, #2185)
+-   Various performance improvements. ([\#2075](https://github.com/matrix-org/synapse/issues/2075), [\#2076](https://github.com/matrix-org/synapse/issues/2076), [\#2080](https://github.com/matrix-org/synapse/issues/2080), [\#2083](https://github.com/matrix-org/synapse/issues/2083), [\#2108](https://github.com/matrix-org/synapse/issues/2108), [\#2158](https://github.com/matrix-org/synapse/issues/2158), [\#2176](https://github.com/matrix-org/synapse/issues/2176), [\#2185](https://github.com/matrix-org/synapse/issues/2185))
 -   Make synctl a bit more user friendly. ([\#2078](https://github.com/matrix-org/synapse/issues/2078), [\#2127](https://github.com/matrix-org/synapse/issues/2127)) Thanks @APwhitehat!
--   Replace HTTP replication with TCP replication (PR #2082, #2097, #2098, #2099, #2103, #2014, #2016, #2115, #2116, #2117)
--   Support authenticated SMTP (PR #2102) Thanks @DanielDent!
+-   Replace HTTP replication with TCP replication. ([\#2082](https://github.com/matrix-org/synapse/issues/2082), [\#2097](https://github.com/matrix-org/synapse/issues/2097), [\#2098](https://github.com/matrix-org/synapse/issues/2098), [\#2099](https://github.com/matrix-org/synapse/issues/2099), [\#2103](https://github.com/matrix-org/synapse/issues/2103), [\#2014](https://github.com/matrix-org/synapse/issues/2014), [\#2016](https://github.com/matrix-org/synapse/issues/2016), [\#2115](https://github.com/matrix-org/synapse/issues/2115), [\#2116](https://github.com/matrix-org/synapse/issues/2116), [\#2117](https://github.com/matrix-org/synapse/issues/2117))
+-   Support authenticated SMTP. Thanks @DanielDent! ([\#2102](https://github.com/matrix-org/synapse/issues/2102))
 -   Add a counter metric for successfully-sent transactions. ([\#2121](https://github.com/matrix-org/synapse/issues/2121))
 -   Propagate errors sensibly from proxied IS requests. ([\#2147](https://github.com/matrix-org/synapse/issues/2147))
 -   Add more granular event send metrics. ([\#2178](https://github.com/matrix-org/synapse/issues/2178))
 
 Bug fixes:
 
--   Fix nuke-room script to work with current schema (PR #1927) Thanks @zuckschwerdt!
--   Fix db port script to not assume postgres tables are in the public schema (PR #2024) Thanks @jerrykan!
+-   Fix nuke-room script to work with current schema. Thanks @zuckschwerdt! ([\#1927](https://github.com/matrix-org/synapse/issues/1927))
+-   Fix db port script to not assume postgres tables are in the public schema. Thanks @jerrykan! ([\#2024](https://github.com/matrix-org/synapse/issues/2024))
 -   Fix getting latest device IP for user with no devices. ([\#2118](https://github.com/matrix-org/synapse/issues/2118))
 -   Fix rejection of invites to unreachable servers. ([\#2145](https://github.com/matrix-org/synapse/issues/2145))
 -   Fix code for reporting old verify keys in synapse. ([\#2156](https://github.com/matrix-org/synapse/issues/2156))
@@ -1987,11 +1987,11 @@ Bug fixes:
 
 Docs:
 
--   Clarify doc for SQLite to PostgreSQL port (PR #1961) Thanks @benhylau!
--   Fix typo in synctl help (PR #2107) Thanks @HarHarLinks!
--   `web_client_location` documentation fix (PR #2131) Thanks @matthewjwolff!
--   Update README.rst with FreeBSD changes (PR #2132) Thanks @feld!
--   Clarify setting up metrics (PR #2149) Thanks @encks!
+-   Clarify doc for SQLite to PostgreSQL port. Thanks @benhylau! ([\#1961](https://github.com/matrix-org/synapse/issues/1961))
+-   Fix typo in synctl help. Thanks @HarHarLinks! ([\#2107](https://github.com/matrix-org/synapse/issues/2107))
+-   `web_client_location` documentation fix. Thanks @matthewjwolff! ([\#2131](https://github.com/matrix-org/synapse/issues/2131))
+-   Update README.rst with FreeBSD changes. Thanks @feld! ([\#2132](https://github.com/matrix-org/synapse/issues/2132))
+-   Clarify setting up metrics. Thanks @encks! ([\#2149](https://github.com/matrix-org/synapse/issues/2149))
 
 Changes in synapse v0.20.0 (2017-04-11)
 =======================================
@@ -2122,7 +2122,7 @@ Features:
 
 Changes:
 
--   Improve IPv6 support (PR #1696). Thanks to @kyrias and @glyph!
+-   Improve IPv6 support. Thanks to @kyrias and @glyph! ([\#1696](https://github.com/matrix-org/synapse/issues/#1696)) 
 -   Log which files we saved attachments to in the `media_repository`. ([\#1791](https://github.com/matrix-org/synapse/issues/1791))
 -   Linearize updates to membership via PUT /state/ to better handle multiple joins. ([\#1787](https://github.com/matrix-org/synapse/issues/1787))
 -   Limit number of entries to prefill from cache on startup. ([\#1792](https://github.com/matrix-org/synapse/issues/1792))
@@ -2566,13 +2566,13 @@ Features:
 
 Changes:
 
--   Rewrite LDAP Authentication against ldap3 (PR #843 by mweinelt)
+-   Rewrite LDAP Authentication against ldap3. Contributed by mweinelt. ([\#843](https://github.com/matrix-org/synapse/issues/843))
 -   Linearize some federation endpoints based on `(origin, room_id)`. ([\#879](https://github.com/matrix-org/synapse/issues/879))
 -   Remove the legacy v0 content upload API.. ([\#888](https://github.com/matrix-org/synapse/issues/888))
 -   Use similar naming we use in email notifs for push. ([\#894](https://github.com/matrix-org/synapse/issues/894))
--   Optionally include password hash in createUser endpoint (PR #905 by KentShikama)
+-   Optionally include password hash in createUser endpoint. Contributed by KentShikama. ([\#905](https://github.com/matrix-org/synapse/issues/905))
 -   Use a query that postgresql optimises better for `get_events_around`. ([\#906](https://github.com/matrix-org/synapse/issues/906))
--   Fall back to '`username` if `user` is not given for appservice registration. (PR #927 by Half-Shot)
+-   Fall back to '`username` if `user` is not given for appservice registration. Contributed by Half-Shot. ([\#927](https://github.com/matrix-org/synapse/issues/927))
 -   Add metrics for psutil derived memory usage. ([\#936](https://github.com/matrix-org/synapse/issues/936))
 -   Record `device_id` in `client_ips`. ([\#938](https://github.com/matrix-org/synapse/issues/938))
 -   Send the correct host header when fetching keys. ([\#941](https://github.com/matrix-org/synapse/issues/941))

--- a/docs/changelogs/CHANGES-pre-1.0.md
+++ b/docs/changelogs/CHANGES-pre-1.0.md
@@ -97,7 +97,7 @@ Bugfixes
 - start.sh: Fix the --no-rate-limit option for messages and make it bypass rate limit on registration and login too. ([\#4981](https://github.com/matrix-org/synapse/issues/4981))
 - Transfer related groups on room upgrade. ([\#4990](https://github.com/matrix-org/synapse/issues/4990))
 - Prevent the ability to kick users from a room they aren't in. ([\#4999](https://github.com/matrix-org/synapse/issues/4999))
-- Fix issue #4596 so synapse_port_db script works with --curses option on Python 3. Contributed by Anders Jensen-Waud <anders@jensenwaud.com>. ([\#5003](https://github.com/matrix-org/synapse/issues/5003))
+- Fix issue [\#4596](https://github.com/matrix-org/synapse/issues/4596) so synapse_port_db script works with --curses option on Python 3. Contributed by Anders Jensen-Waud <anders@jensenwaud.com>. ([\#5003](https://github.com/matrix-org/synapse/issues/5003))
 - Clients timing out/disappearing while downloading from the media repository will now no longer log a spurious "Producer was not unregistered" message. ([\#5009](https://github.com/matrix-org/synapse/issues/5009))
 - Fix "cannot import name execute_batch" error with postgres. ([\#5032](https://github.com/matrix-org/synapse/issues/5032))
 - Fix disappearing exceptions in manhole. ([\#5035](https://github.com/matrix-org/synapse/issues/5035))
@@ -111,7 +111,7 @@ Bugfixes
 Internal Changes
 ----------------
 
-- Add test to verify threepid auth check added in #4435. ([\#4474](https://github.com/matrix-org/synapse/issues/4474))
+- Add test to verify threepid auth check added in [\#4435](https://github.com/matrix-org/synapse/issues/4435). ([\#4474](https://github.com/matrix-org/synapse/issues/4474))
 - Fix/improve some docstrings in the replication code. ([\#4949](https://github.com/matrix-org/synapse/issues/4949))
 - Split synapse.replication.tcp.streams into smaller files. ([\#4953](https://github.com/matrix-org/synapse/issues/4953))
 - Refactor replication row generation/parsing. ([\#4954](https://github.com/matrix-org/synapse/issues/4954))
@@ -186,7 +186,7 @@ Features
 - Add support for /keys/query and /keys/changes REST endpoints to client_reader worker. ([\#4796](https://github.com/matrix-org/synapse/issues/4796))
 - Add checks to incoming events over federation for events evading auth (aka "soft fail"). ([\#4814](https://github.com/matrix-org/synapse/issues/4814))
 - Add configurable rate limiting to the /login endpoint. ([\#4821](https://github.com/matrix-org/synapse/issues/4821), [\#4865](https://github.com/matrix-org/synapse/issues/4865))
-- Remove trailing slashes from certain outbound federation requests. Retry if receiving a 404. Context: #3622. ([\#4840](https://github.com/matrix-org/synapse/issues/4840))
+- Remove trailing slashes from certain outbound federation requests. Retry if receiving a 404. Context: [\#3622](https://github.com/matrix-org/synapse/issues/3622). ([\#4840](https://github.com/matrix-org/synapse/issues/4840))
 - Allow passing --daemonize flags to workers in the same way as with master. ([\#4853](https://github.com/matrix-org/synapse/issues/4853))
 - Batch up outgoing read-receipts to reduce federation traffic. ([\#4890](https://github.com/matrix-org/synapse/issues/4890), [\#4927](https://github.com/matrix-org/synapse/issues/4927))
 - Add option to disable searching the user directory. ([\#4895](https://github.com/matrix-org/synapse/issues/4895))
@@ -231,12 +231,12 @@ Internal Changes
 - Add some debug about processing read receipts. ([\#4798](https://github.com/matrix-org/synapse/issues/4798))
 - Clean up some replication code. ([\#4799](https://github.com/matrix-org/synapse/issues/4799))
 - Add some docstrings. ([\#4815](https://github.com/matrix-org/synapse/issues/4815))
-- Add debug logger to try and track down #4422. ([\#4816](https://github.com/matrix-org/synapse/issues/4816))
+- Add debug logger to try and track down [\#4422](https://github.com/matrix-org/synapse/issues/4422). ([\#4816](https://github.com/matrix-org/synapse/issues/4816))
 - Make shutdown API send explanation message to room after users have been forced joined. ([\#4817](https://github.com/matrix-org/synapse/issues/4817))
 - Update example_log_config.yaml. ([\#4820](https://github.com/matrix-org/synapse/issues/4820))
 - Document the `generate` option for the docker image. ([\#4824](https://github.com/matrix-org/synapse/issues/4824))
 - Fix check-newsfragment for debian-only changes. ([\#4825](https://github.com/matrix-org/synapse/issues/4825))
-- Add some debug logging for device list updates to help with #4828. ([\#4828](https://github.com/matrix-org/synapse/issues/4828))
+- Add some debug logging for device list updates to help with [\#4828](https://github.com/matrix-org/synapse/issues/4828). ([\#4828](https://github.com/matrix-org/synapse/issues/4828))
 - Improve federation documentation, specifically .well-known support. Many thanks to @vaab. ([\#4832](https://github.com/matrix-org/synapse/issues/4832))
 - Disable captcha registration by default in unit tests. ([\#4839](https://github.com/matrix-org/synapse/issues/4839))
 - Add stuff back to the .gitignore. ([\#4843](https://github.com/matrix-org/synapse/issues/4843))
@@ -895,7 +895,7 @@ Bugfixes
 - Bump dependency on pyopenssl 16.x, to avoid incompatibility with recent Twisted. ([\#3804](https://github.com/matrix-org/synapse/issues/3804))
 - Fix existing room tags not coming down sync when joining a room ([\#3810](https://github.com/matrix-org/synapse/issues/3810))
 - Fix jwt import check ([\#3824](https://github.com/matrix-org/synapse/issues/3824))
-- fix VOIP crashes under Python 3 (#3821) ([\#3835](https://github.com/matrix-org/synapse/issues/3835))
+- fix VOIP crashes under Python 3 (issue [\#3821](https://github.com/matrix-org/synapse/issues/3821)). ([\#3835](https://github.com/matrix-org/synapse/issues/3835))
 - Fix manhole so that it works with latest openssh clients ([\#3841](https://github.com/matrix-org/synapse/issues/3841))
 - Fix outbound requests occasionally wedging, which can result in federation breaking between servers. ([\#3845](https://github.com/matrix-org/synapse/issues/3845))
 - Show heroes if room name/canonical alias has been deleted ([\#3851](https://github.com/matrix-org/synapse/issues/3851))
@@ -1123,7 +1123,7 @@ Bugfixes
 - Catch failures saving metrics captured by Measure, and instead log the faulty metrics information for further analysis. ([\#3548](https://github.com/matrix-org/synapse/issues/3548))
 - Unicode passwords are now normalised before hashing, preventing the instance where two different devices or browsers might send a different UTF-8 sequence for the password. ([\#3569](https://github.com/matrix-org/synapse/issues/3569))
 - Fix potential stack overflow and deadlock under heavy load ([\#3570](https://github.com/matrix-org/synapse/issues/3570))
-- Respond with M_NOT_FOUND when profiles are not found locally or over federation. Fixes #3585 ([\#3585](https://github.com/matrix-org/synapse/issues/3585))
+- Respond with M_NOT_FOUND when profiles are not found locally or over federation. Fixes [\#3585](https://github.com/matrix-org/synapse/issues/3585). ([\#3585](https://github.com/matrix-org/synapse/issues/3585))
 - Fix failure to persist events over federation under load ([\#3601](https://github.com/matrix-org/synapse/issues/3601))
 - Fix updating of cached remote profiles ([\#3605](https://github.com/matrix-org/synapse/issues/3605))
 - Fix 'tuple index out of range' error ([\#3607](https://github.com/matrix-org/synapse/issues/3607))
@@ -1513,7 +1513,7 @@ Changes:
 -   move handling of `auto_join_rooms` to RegisterHandler. Thanks to @krombel! ([\#2996](https://github.com/matrix-org/synapse/issues/2996))
 -   Improve handling of SRV records for federation connections. Thanks to @silkeh! ([\#3016](https://github.com/matrix-org/synapse/issues/3016))
 -   Document the behaviour of ResponseCache. ([\#3059](https://github.com/matrix-org/synapse/issues/3059))
--   Preparation for py3. Thanks to @NotAFile! (PR #3061, #3073, #3074, #3075, #3103, #3104, #3106, #3107, #3109, #3110)
+-   Preparation for py3. Thanks to @NotAFile! ([\#3061](https://github.com/matrix-org/synapse/issues/3061), [\#3073](https://github.com/matrix-org/synapse/issues/3073), [\#3074](https://github.com/matrix-org/synapse/issues/3074), [\#3075](https://github.com/matrix-org/synapse/issues/3075), [\#3103](https://github.com/matrix-org/synapse/issues/3103), [\#3104](https://github.com/matrix-org/synapse/issues/3104), [\#3106](https://github.com/matrix-org/synapse/issues/3106), [\#3107](https://github.com/matrix-org/synapse/issues/3107), [\#3109](https://github.com/matrix-org/synapse/issues/3109), [\#3110](https://github.com/matrix-org/synapse/issues/3110))
 -   update prometheus dashboard to use new metric names. Thanks to @krombel! ([\#3069](https://github.com/matrix-org/synapse/issues/3069))
 -   use python3-compatible prints. Thanks to @NotAFile! ([\#3074](https://github.com/matrix-org/synapse/issues/3074))
 -   Send federation events concurrently. ([\#3078](https://github.com/matrix-org/synapse/issues/3078))
@@ -1539,14 +1539,14 @@ Changes in synapse v0.27.4 (2018-04-13)
 
 Changes:
 
--   Update canonicaljson dependency (\#3095)
+-   Update canonicaljson dependency. ([\#3095](https://github.com/matrix-org/synapse/issues/3095))
 
 Changes in synapse v0.27.3 (2018-04-11)
 ======================================
 
 Bug fixes:
 
--   URL quote path segments over federation (\#3082)
+-   URL quote path segments over federation. ([\#3082](https://github.com/matrix-org/synapse/issues/3082))
 
 Changes in synapse v0.27.3-rc2 (2018-04-09)
 ===========================================
@@ -1640,8 +1640,8 @@ This release also begins the process of renaming a number of the metrics reporte
 Features:
 
 -   Add ability for ASes to override message send time. ([\#2754](https://github.com/matrix-org/synapse/issues/2754))
--   Add support for custom storage providers for media repository (PR #2867, #2777, #2783, #2789, #2791, #2804, #2812, #2814, #2857, #2868, #2767)
--   Add purge API features, see [docs/admin_api/purge_history_api.rst](docs/admin_api/purge_history_api.rst) for full details (PR #2858, #2867, #2882, #2946, #2962, #2943)
+-   Add support for custom storage providers for media repository. ([\#2867](https://github.com/matrix-org/synapse/issues/2867), [\#2777](https://github.com/matrix-org/synapse/issues/2777), [\#2783](https://github.com/matrix-org/synapse/issues/2783), [\#2789](https://github.com/matrix-org/synapse/issues/2789), [\#2791](https://github.com/matrix-org/synapse/issues/2791), [\#2804](https://github.com/matrix-org/synapse/issues/2804), [\#2812](https://github.com/matrix-org/synapse/issues/2812), [\#2814](https://github.com/matrix-org/synapse/issues/2814), [\#2857](https://github.com/matrix-org/synapse/issues/2857), [\#2868](https://github.com/matrix-org/synapse/issues/2868), [\#2767](https://github.com/matrix-org/synapse/issues/2767))
+-   Add purge API features, see [docs/admin_api/purge_history_api.rst](docs/admin_api/purge_history_api.rst) for full details. ([\#2858](https://github.com/matrix-org/synapse/issues/2858), [\#2867](https://github.com/matrix-org/synapse/issues/2867), [\#2882](https://github.com/matrix-org/synapse/issues/2882), [\#2946](https://github.com/matrix-org/synapse/issues/2946), [\#2962](https://github.com/matrix-org/synapse/issues/2962), [\#2943](https://github.com/matrix-org/synapse/issues/2943))
 -   Add support for whitelisting 3PIDs that users can register.. ([\#2813](https://github.com/matrix-org/synapse/issues/2813))
 -   Add `/room/{id}/event/{id}` API. ([\#2766](https://github.com/matrix-org/synapse/issues/2766))
 -   Add an admin API to get all the media in a room. Thanks to @turt2live! ([\#2818](https://github.com/matrix-org/synapse/issues/2818))
@@ -1649,12 +1649,12 @@ Features:
 
 Changes:
 
--   Continue to factor out processing from main process and into worker processes. See updated [docs/workers.rst](docs/workers.rst) (PR #2892 - \#2904, #2913, #2920 - \#2926, #2947, #2847, #2854, #2872, #2873, #2874, #2928, #2929, #2934, #2856, #2976 - \#2984, #2987 - \#2989, #2991 - \#2993, #2995, #2784)
--   Ensure state cache is used when persisting events (PR #2864, #2871, #2802, #2835, #2836, #2841, #2842, #2849)
+-   Continue to factor out processing from main process and into worker processes. See updated [docs/workers.rst](docs/workers.rst) ([\#2892](https://github.com/matrix-org/synapse/issues/2892), [\#2893](https://github.com/matrix-org/synapse/issues/2893), [\#2894](https://github.com/matrix-org/synapse/issues/2894), [\#2896](https://github.com/matrix-org/synapse/issues/2896), [\#2897](https://github.com/matrix-org/synapse/issues/2897), [\#2898](https://github.com/matrix-org/synapse/issues/2898), [\#2899](https://github.com/matrix-org/synapse/issues/2899), [\#2900](https://github.com/matrix-org/synapse/issues/2900), [\#2901](https://github.com/matrix-org/synapse/issues/2901), [\#2902](https://github.com/matrix-org/synapse/issues/2902), [\#2903](https://github.com/matrix-org/synapse/issues/2903), [\#2904](https://github.com/matrix-org/synapse/issues/2904), [\#2913](https://github.com/matrix-org/synapse/issues/2913), [\#2920](https://github.com/matrix-org/synapse/issues/2920), [\#2921](https://github.com/matrix-org/synapse/issues/2921), [\#2922](https://github.com/matrix-org/synapse/issues/2922), [\#2923](https://github.com/matrix-org/synapse/issues/2923), [\#2924](https://github.com/matrix-org/synapse/issues/2924), [\#2925](https://github.com/matrix-org/synapse/issues/2925), [\#2926](https://github.com/matrix-org/synapse/issues/2926), [\#2947](https://github.com/matrix-org/synapse/issues/2947), [\#2847](https://github.com/matrix-org/synapse/issues/2847), [\#2854](https://github.com/matrix-org/synapse/issues/2854), [\#2872](https://github.com/matrix-org/synapse/issues/2872), [\#2873](https://github.com/matrix-org/synapse/issues/2873), [\#2874](https://github.com/matrix-org/synapse/issues/2874), [\#2928](https://github.com/matrix-org/synapse/issues/2928), [\#2929](https://github.com/matrix-org/synapse/issues/2929), [\#2934](https://github.com/matrix-org/synapse/issues/2934), [\#2856](https://github.com/matrix-org/synapse/issues/2856), [\#2976](https://github.com/matrix-org/synapse/issues/2976), [\#2977](https://github.com/matrix-org/synapse/issues/2977), [\#2978](https://github.com/matrix-org/synapse/issues/2978), [\#2979](https://github.com/matrix-org/synapse/issues/2979), [\#2980](https://github.com/matrix-org/synapse/issues/2980), [\#2981](https://github.com/matrix-org/synapse/issues/2981), [\#2982](https://github.com/matrix-org/synapse/issues/2982), [\#2983](https://github.com/matrix-org/synapse/issues/2983), [\#2984](https://github.com/matrix-org/synapse/issues/2984), [\#2987](https://github.com/matrix-org/synapse/issues/2987), [\#2988](https://github.com/matrix-org/synapse/issues/2988), [\#2989](https://github.com/matrix-org/synapse/issues/2989), [\#2991](https://github.com/matrix-org/synapse/issues/2991), [\#2992](https://github.com/matrix-org/synapse/issues/2992), [\#2993](https://github.com/matrix-org/synapse/issues/2993), [\#2995](https://github.com/matrix-org/synapse/issues/2995), [\#2784](https://github.com/matrix-org/synapse/issues/2784))
+-   Ensure state cache is used when persisting events. ([\#2864](https://github.com/matrix-org/synapse/issues/2864), [\#2871](https://github.com/matrix-org/synapse/issues/2871), [\#2802](https://github.com/matrix-org/synapse/issues/2802), [\#2835](https://github.com/matrix-org/synapse/issues/2835), [\#2836](https://github.com/matrix-org/synapse/issues/2836), [\#2841](https://github.com/matrix-org/synapse/issues/2841), [\#2842](https://github.com/matrix-org/synapse/issues/2842), [\#2849](https://github.com/matrix-org/synapse/issues/2849))
 -   Change the default config to bind on both IPv4 and IPv6 on all platforms. Thanks to @silkeh! ([\#2435](https://github.com/matrix-org/synapse/issues/2435))
 -   No longer require a specific version of saml2. Thanks to @okurz! ([\#2695](https://github.com/matrix-org/synapse/issues/2695))
 -   Remove `verbosity`/`log_file` from generated config. ([\#2755](https://github.com/matrix-org/synapse/issues/2755))
--   Add and improve metrics and logging (PR #2770, #2778, #2785, #2786, #2787, #2793, #2794, #2795, #2809, #2810, #2833, #2834, #2844, #2965, #2927, #2975, #2790, #2796, #2838)
+-   Add and improve metrics and logging. ([\#2770](https://github.com/matrix-org/synapse/issues/2770), [\#2778](https://github.com/matrix-org/synapse/issues/2778), [\#2785](https://github.com/matrix-org/synapse/issues/2785), [\#2786](https://github.com/matrix-org/synapse/issues/2786), [\#2787](https://github.com/matrix-org/synapse/issues/2787), [\#2793](https://github.com/matrix-org/synapse/issues/2793), [\#2794](https://github.com/matrix-org/synapse/issues/2794), [\#2795](https://github.com/matrix-org/synapse/issues/2795), [\#2809](https://github.com/matrix-org/synapse/issues/2809), [\#2810](https://github.com/matrix-org/synapse/issues/2810), [\#2833](https://github.com/matrix-org/synapse/issues/2833), [\#2834](https://github.com/matrix-org/synapse/issues/2834), [\#2844](https://github.com/matrix-org/synapse/issues/2844), [\#2965](https://github.com/matrix-org/synapse/issues/2965), [\#2927](https://github.com/matrix-org/synapse/issues/2927), [\#2975](https://github.com/matrix-org/synapse/issues/2975), [\#2790](https://github.com/matrix-org/synapse/issues/2790), [\#2796](https://github.com/matrix-org/synapse/issues/2796), [\#2838](https://github.com/matrix-org/synapse/issues/2838))
 -   When using synctl with workers, Don't start the main synapse automatically. ([\#2774](https://github.com/matrix-org/synapse/issues/2774))
 -   Minor performance improvements. ([\#2773](https://github.com/matrix-org/synapse/issues/2773), [\#2792](https://github.com/matrix-org/synapse/issues/2792))
 -   Use a connection pool for non-federation outbound connections. ([\#2817](https://github.com/matrix-org/synapse/issues/2817))
@@ -1841,7 +1841,7 @@ Features:
 Changes:
 
 -   Use bcrypt module instead of py-bcrypt. Thanks to @kyrias! ([\#2288](https://github.com/matrix-org/synapse/issues/2288))
--   Improve performance of generating push notifications (PR #2343, #2357, #2365, #2366, #2371)
+-   Improve performance of generating push notifications. ([\#2343](https://github.com/matrix-org/synapse/issues/2343), [\#2357](https://github.com/matrix-org/synapse/issues/2357), [\#2365](https://github.com/matrix-org/synapse/issues/2365), [\#2366](https://github.com/matrix-org/synapse/issues/2366), [\#2371](https://github.com/matrix-org/synapse/issues/2371))
 -   Improve DB performance for device list handling in sync. ([\#2362](https://github.com/matrix-org/synapse/issues/2362))
 -   Include a sample prometheus config. ([\#2416](https://github.com/matrix-org/synapse/issues/2416))
 -   Document known to work postgres version. Thanks to @ptman! ([\#2433](https://github.com/matrix-org/synapse/issues/2433))
@@ -1887,7 +1887,7 @@ Changes in synapse v0.22.0-rc1 (2017-06-26)
 
 Features:
 
--   Add a user directory API (PR #2252, and many more)
+-   Add a user directory API ([\#2252](https://github.com/matrix-org/synapse/issues/2252), and many more)
 -   Add shutdown room API to remove room from local server. ([\#2291](https://github.com/matrix-org/synapse/issues/2291))
 -   Add API to quarantine media. ([\#2292](https://github.com/matrix-org/synapse/issues/2292))
 -   Add new config option to not send event contents to push servers. Thanks to @cjdelisle! ([\#2301](https://github.com/matrix-org/synapse/issues/2301))
@@ -2122,7 +2122,7 @@ Features:
 
 Changes:
 
--   Improve IPv6 support. Thanks to @kyrias and @glyph! ([\#1696](https://github.com/matrix-org/synapse/issues/#1696)) 
+-   Improve IPv6 support. Thanks to @kyrias and @glyph! ([\#1696](https://github.com/matrix-org/synapse/issues/1696))
 -   Log which files we saved attachments to in the `media_repository`. ([\#1791](https://github.com/matrix-org/synapse/issues/1791))
 -   Linearize updates to membership via PUT /state/ to better handle multiple joins. ([\#1787](https://github.com/matrix-org/synapse/issues/1787))
 -   Limit number of entries to prefill from cache on startup. ([\#1792](https://github.com/matrix-org/synapse/issues/1792))
@@ -2165,9 +2165,9 @@ Changes in synapse v0.18.7-rc1 (2017-01-06)
 
 Bug fixes:
 
--   Fix error in \#PR 1764 to actually fix the nightmare \#1753 bug.
+-   Fix error in [\#1764](https://github.com/matrix-org/synapse/issues/1764) to actually fix the nightmare [\#1753](https://github.com/matrix-org/synapse/issues/1753) bug.
 -   Improve deadlock logging further
--   Discard inbound federation traffic from invalid domains, to immunise against \#1753
+-   Discard inbound federation traffic from invalid domains, to immunise against [\#1753](https://github.com/matrix-org/synapse/issues/1753).
 
 Changes in synapse v0.18.6 (2017-01-06)
 =======================================
@@ -2497,7 +2497,7 @@ Changes in synapse v0.17.0 (2016-08-08)
 
 This release contains significant security bug fixes regarding authenticating events received over federation. PLEASE UPGRADE.
 
-This release changes the LDAP configuration format in a backwards incompatible way, see PR #843 for details.
+This release changes the LDAP configuration format in a backwards incompatible way, see [\#843](https://github.com/matrix-org/synapse/issues/843) for details.
 
 Changes:
 
@@ -2546,13 +2546,13 @@ Changes in synapse v0.17.0-rc2 (2016-08-02)
 Changes in synapse v0.17.0-rc1 (2016-07-28)
 ===========================================
 
-This release changes the LDAP configuration format in a backwards incompatible way, see PR #843 for details.
+This release changes the LDAP configuration format in a backwards incompatible way, see [\#843](https://github.com/matrix-org/synapse/issues/843) for details.
 
 Features:
 
 -   Add `purge_media_cache` admin API. ([\#902](https://github.com/matrix-org/synapse/issues/902))
 -   Add deactivate account admin API. ([\#903](https://github.com/matrix-org/synapse/issues/903))
--   Add optional pepper to password hashing (PR #907, #910 by KentShikama)
+-   Add optional pepper to password hashing by KentShikama. ([\#907](https://github.com/matrix-org/synapse/issues/907), [\#910](https://github.com/matrix-org/synapse/issues/910))
 -   Add an admin option to shared secret registration (breaks backwards compat). ([\#909](https://github.com/matrix-org/synapse/issues/909))
 -   Add purge local room history API. ([\#911](https://github.com/matrix-org/synapse/issues/911), [\#923](https://github.com/matrix-org/synapse/issues/923), [\#924](https://github.com/matrix-org/synapse/issues/924))
 -   Add requestToken endpoints. ([\#915](https://github.com/matrix-org/synapse/issues/915))
@@ -2674,7 +2674,7 @@ Version 0.15 was not released. See v0.15.0-rc1 below for additional changes.
 
 Features:
 
--   Add email notifications for missed messages (PR #759, #786, #799, #810, #815, #821)
+-   Add email notifications for missed messages. ([\#759](https://github.com/matrix-org/synapse/issues/759), [\#786](https://github.com/matrix-org/synapse/issues/786), [\#799](https://github.com/matrix-org/synapse/issues/799), [\#810](https://github.com/matrix-org/synapse/issues/810), [\#815](https://github.com/matrix-org/synapse/issues/815), [\#821](https://github.com/matrix-org/synapse/issues/821))
 -   Add a `url_preview_ip_range_whitelist` config param. ([\#760](https://github.com/matrix-org/synapse/issues/760))
 -   Add /report endpoint. ([\#762](https://github.com/matrix-org/synapse/issues/762))
 -   Add basic ignore user API. ([\#763](https://github.com/matrix-org/synapse/issues/763))
@@ -2718,7 +2718,7 @@ Changes in synapse v0.15.0-rc1 (2016-04-26)
 
 Features:
 
--   Add login support for Javascript Web Tokens, thanks to Niklas Riekenbrauck (PR #671,\#687)
+-   Add login support for Javascript Web Tokens, thanks to Niklas Riekenbrauck. ([\#671](https://github.com/matrix-org/synapse/issues/671), [\#687](https://github.com/matrix-org/synapse/issues/687))
 -   Add URL previewing support. ([\#688](https://github.com/matrix-org/synapse/issues/688))
 -   Add login support for LDAP, thanks to Christoph Witzany. ([\#701](https://github.com/matrix-org/synapse/issues/701))
 -   Add GET endpoint for pushers. ([\#716](https://github.com/matrix-org/synapse/issues/716))
@@ -2757,9 +2757,9 @@ Features:
 
 Changes:
 
--   Change various caches to consume less memory (PR #656, #658, #660, #662, #663, #665)
+-   Change various caches to consume less memory. ([\#656](https://github.com/matrix-org/synapse/issues/656), [\#658](https://github.com/matrix-org/synapse/issues/658), [\#660](https://github.com/matrix-org/synapse/issues/660), [\#662](https://github.com/matrix-org/synapse/issues/662), [\#663](https://github.com/matrix-org/synapse/issues/663), [\#665](https://github.com/matrix-org/synapse/issues/665))
 -   Allow rooms to be published without requiring an alias. ([\#664](https://github.com/matrix-org/synapse/issues/664))
--   Intern common strings in caches to reduce memory footprint (\#666)
+-   Intern common strings in caches to reduce memory footprint. ([\#666](https://github.com/matrix-org/synapse/issues/666))
 
 Bug fixes:
 
@@ -2828,7 +2828,7 @@ This version includes an upgrade of the schema, specifically adding an index to 
 
 Changes:
 
--   Improve general performance (PR #540, #543. \#544, #54, #549, #567)
+-   Improve general performance. ([\#540](https://github.com/matrix-org/synapse/issues/540), [\#543](https://github.com/matrix-org/synapse/issues/543). [\#544](https://github.com/matrix-org/synapse/issues/544), [\#54](https://github.com/matrix-org/synapse/issues/54), [\#549](https://github.com/matrix-org/synapse/issues/549), [\#567](https://github.com/matrix-org/synapse/issues/567))
 -   Change guest user ids to be incrementing integers. ([\#550](https://github.com/matrix-org/synapse/issues/550))
 -   Improve performance of public room list API. ([\#552](https://github.com/matrix-org/synapse/issues/552))
 -   Change profile API to omit keys rather than return null. ([\#557](https://github.com/matrix-org/synapse/issues/557))
@@ -2963,14 +2963,14 @@ Changes in synapse v0.11.0-rc2 (2015-11-13)
 Changes in synapse v0.11.0-rc1 (2015-11-11)
 ===========================================
 
--   Add Search API (PR #307, #324, #327, #336, #350, #359)
+-   Add Search API. ([\#307](https://github.com/matrix-org/synapse/issues/307), [\#324](https://github.com/matrix-org/synapse/issues/324), [\#327](https://github.com/matrix-org/synapse/issues/327), [\#336](https://github.com/matrix-org/synapse/issues/336), [\#350](https://github.com/matrix-org/synapse/issues/350), [\#359](https://github.com/matrix-org/synapse/issues/359))
 -   Add `archived` state to v2 /sync API. ([\#316](https://github.com/matrix-org/synapse/issues/316))
 -   Add ability to reject invites. ([\#317](https://github.com/matrix-org/synapse/issues/317))
 -   Add config option to disable password login. ([\#322](https://github.com/matrix-org/synapse/issues/322))
 -   Add the login fallback API. ([\#330](https://github.com/matrix-org/synapse/issues/330))
 -   Add room context API. ([\#334](https://github.com/matrix-org/synapse/issues/334))
 -   Add room tagging support. ([\#335](https://github.com/matrix-org/synapse/issues/335))
--   Update v2 /sync API to match spec (PR #305, #316, #321, #332, #337, #341)
+-   Update v2 /sync API to match spec. ([\#305](https://github.com/matrix-org/synapse/issues/305), [\#316](https://github.com/matrix-org/synapse/issues/316), [\#321](https://github.com/matrix-org/synapse/issues/321), [\#332](https://github.com/matrix-org/synapse/issues/332), [\#337](https://github.com/matrix-org/synapse/issues/337), [\#341](https://github.com/matrix-org/synapse/issues/341))
 -   Change retry schedule for application services. ([\#320](https://github.com/matrix-org/synapse/issues/320))
 -   Change retry schedule for remote servers. ([\#340](https://github.com/matrix-org/synapse/issues/340))
 -   Fix bug where we hosted static content in the incorrect place. ([\#329](https://github.com/matrix-org/synapse/issues/329))
@@ -2997,7 +2997,7 @@ Changes in synapse v0.10.0-r2 (2015-09-16)
 
 -   Fix bug where we always fetched remote server signing keys instead of using ones in our cache.
 -   Fix adding threepids to an existing account.
--   Fix bug with invinting over federation where remote server was already in the room. (PR #281, SYN-392)
+-   Fix bug with invinting over federation where remote server was already in the room. ([\#281](https://github.com/matrix-org/synapse/issues/281), SYN-392)
 
 Changes in synapse v0.10.0-r1 (2015-09-08)
 ==========================================
@@ -3091,7 +3091,7 @@ General:
 -   Add basic implementation of receipts. (SPEC-99)
 -   Add support for configuration presets in room creation API.. ([\#203](https://github.com/matrix-org/synapse/issues/203))
 -   Add auth event that limits the visibility of history for new users. (SPEC-134)
--   Add SAML2 login/registration support. (PR #201. Thanks Muthu Subramanian!)
+-   Add SAML2 login/registration support. Thanks Muthu Subramanian! ([\#201](https://github.com/matrix-org/synapse/issues/201))
 -   Add client side key management APIs for end to end encryption.. ([\#198](https://github.com/matrix-org/synapse/issues/198))
 -   Change power level semantics so that you cannot kick, ban or change power levels of users that have equal or greater power level than you. (SYN-192)
 -   Improve performance by bulk inserting events where possible.. ([\#193](https://github.com/matrix-org/synapse/issues/193))

--- a/docs/changelogs/CHANGES-pre-1.0.md
+++ b/docs/changelogs/CHANGES-pre-1.0.md
@@ -1272,7 +1272,7 @@ Misc
 Changes in synapse v0.31.2 (2018-06-14)
 =======================================
 
-SECURITY UPDATE: Prevent unauthorised users from setting state events in a room when there is no `m.room.power_levels` event in force in the room. (PR #3397)
+SECURITY UPDATE: Prevent unauthorised users from setting state events in a room when there is no `m.room.power_levels` event in force in the room.. ([\#3397](https://github.com/matrix-org/synapse/issues/3397))
 
 Discussion around the Matrix Spec change proposal for this change can be followed at <https://github.com/matrix-org/matrix-doc/issues/1304>.
 
@@ -1285,7 +1285,7 @@ We are not aware of it being actively exploited but please upgrade asap.
 
 Bug Fixes:
 
--   Fix event filtering in `get_missing_events` handler (PR #3371)
+-   Fix event filtering in `get_missing_events` handler. ([\#3371](https://github.com/matrix-org/synapse/issues/3371))
 
 Changes in synapse v0.31.0 (2018-06-06)
 =======================================
@@ -1294,7 +1294,7 @@ Most notable change from v0.30.0 is to switch to the python prometheus library t
 
 Bug Fixes:
 
--   Fix metric documentation tables (PR #3341)
+-   Fix metric documentation tables. ([\#3341](https://github.com/matrix-org/synapse/issues/3341))
 -   Fix LaterGauge error handling (694968f)
 -   Fix replication metrics (b7e7fd2)
 
@@ -1303,21 +1303,21 @@ Changes in synapse v0.31.0-rc1 (2018-06-04)
 
 Features:
 
--   Switch to the Python Prometheus library (PR #3256, #3274)
--   Let users leave the server notice room after joining (PR #3287)
+-   Switch to the Python Prometheus library. ([\#3256](https://github.com/matrix-org/synapse/issues/3256), [\#3274](https://github.com/matrix-org/synapse/issues/3274))
+-   Let users leave the server notice room after joining. ([\#3287](https://github.com/matrix-org/synapse/issues/3287))
 
 Changes:
 
--   daily user type phone home stats (PR #3264)
--   Use `iter*` methods for `_filter_events_for_server` (PR #3267)
--   Docs on consent bits (PR #3268)
--   Remove users from user directory on deactivate (PR #3277)
--   Avoid sending consent notice to guest users (PR #3288)
--   disable CPUMetrics if no /proc/self/stat (PR #3299)
--   Consistently use six's iteritems and wrap lazy keys/values in list() if they're not meant to be lazy (PR #3307)
+-   daily user type phone home stats. ([\#3264](https://github.com/matrix-org/synapse/issues/3264))
+-   Use `iter*` methods for `_filter_events_for_server`. ([\#3267](https://github.com/matrix-org/synapse/issues/3267))
+-   Docs on consent bits. ([\#3268](https://github.com/matrix-org/synapse/issues/3268))
+-   Remove users from user directory on deactivate. ([\#3277](https://github.com/matrix-org/synapse/issues/3277))
+-   Avoid sending consent notice to guest users. ([\#3288](https://github.com/matrix-org/synapse/issues/3288))
+-   disable CPUMetrics if no /proc/self/stat. ([\#3299](https://github.com/matrix-org/synapse/issues/3299))
+-   Consistently use six's iteritems and wrap lazy keys/values in list() if they're not meant to be lazy. ([\#3307](https://github.com/matrix-org/synapse/issues/3307))
 -   Add private IPv6 addresses to example config for url preview blacklist. Thanks to @thegcat! ([\#3317](https://github.com/matrix-org/synapse/issues/3317))
--   Reduce stuck read-receipts: ignore depth when updating (PR #3318)
--   Put python's logs into Trial when running unit tests (PR #3319)
+-   Reduce stuck read-receipts: ignore depth when updating. ([\#3318](https://github.com/matrix-org/synapse/issues/3318))
+-   Put python's logs into Trial when running unit tests. ([\#3319](https://github.com/matrix-org/synapse/issues/3319))
 
 Changes, python 3 migration:
 
@@ -1336,7 +1336,7 @@ Changes, python 3 migration:
 
 Bugs:
 
--   Fix federation backfill bugs (PR #3261)
+-   Fix federation backfill bugs. ([\#3261](https://github.com/matrix-org/synapse/issues/3261))
 -   federation: fix LaterGauge usage. Thanks to @intelfx! ([\#3328](https://github.com/matrix-org/synapse/issues/3328))
 
 Changes in synapse v0.30.0 (2018-05-24)
@@ -1350,50 +1350,50 @@ This feature is specific to Synapse, but uses standard Matrix communication mech
 
 Further Server Notices/Consent Tracking Support:
 
--   Allow overriding the `server_notices` user's avatar (PR #3273)
--   Use the localpart in the consent uri (PR #3272)
--   Support for putting `%(consent_uri)s` in messages (PR #3271)
--   Block attempts to send server notices to remote users (PR #3270)
--   Docs on consent bits (PR #3268)
+-   Allow overriding the `server_notices` user's avatar. ([\#3273](https://github.com/matrix-org/synapse/issues/3273))
+-   Use the localpart in the consent uri. ([\#3272](https://github.com/matrix-org/synapse/issues/3272))
+-   Support for putting `%(consent_uri)s` in messages. ([\#3271](https://github.com/matrix-org/synapse/issues/3271))
+-   Block attempts to send server notices to remote users. ([\#3270](https://github.com/matrix-org/synapse/issues/3270))
+-   Docs on consent bits. ([\#3268](https://github.com/matrix-org/synapse/issues/3268))
 
 Changes in synapse v0.30.0-rc1 (2018-05-23)
 ===========================================
 
 Server Notices/Consent Tracking Support:
 
--   ConsentResource to gather policy consent from users (PR #3213)
--   Move RoomCreationHandler out of synapse.handlers.Handlers (PR #3225)
--   Infrastructure for a server notices room (PR #3232)
--   Send users a server notice about consent (PR #3236)
--   Reject attempts to send event before privacy consent is given (PR #3257)
--   Add a `has_consented` template var to consent forms (PR #3262)
--   Fix dependency on jinja2 (PR #3263)
+-   ConsentResource to gather policy consent from users. ([\#3213](https://github.com/matrix-org/synapse/issues/3213))
+-   Move RoomCreationHandler out of synapse.handlers.Handlers. ([\#3225](https://github.com/matrix-org/synapse/issues/3225))
+-   Infrastructure for a server notices room. ([\#3232](https://github.com/matrix-org/synapse/issues/3232))
+-   Send users a server notice about consent. ([\#3236](https://github.com/matrix-org/synapse/issues/3236))
+-   Reject attempts to send event before privacy consent is given. ([\#3257](https://github.com/matrix-org/synapse/issues/3257))
+-   Add a `has_consented` template var to consent forms. ([\#3262](https://github.com/matrix-org/synapse/issues/3262))
+-   Fix dependency on jinja2. ([\#3263](https://github.com/matrix-org/synapse/issues/3263))
 
 Features:
 
--   Cohort analytics (PR #3163, #3241, #3251)
+-   Cohort analytics. ([\#3163](https://github.com/matrix-org/synapse/issues/3163), [\#3241](https://github.com/matrix-org/synapse/issues/3241), [\#3251](https://github.com/matrix-org/synapse/issues/3251))
 -   Add lxml to docker image for web previews. Thanks to @ptman! ([\#3239](https://github.com/matrix-org/synapse/issues/3239))
--   Add in flight request metrics (PR #3252)
+-   Add in flight request metrics. ([\#3252](https://github.com/matrix-org/synapse/issues/3252))
 
 Changes:
 
--   Remove unused `update_external_syncs` (PR #3233)
--   Use stream rather depth ordering for push actions (PR #3212)
--   Make `purge_history` operate on tokens (PR #3221)
--   Don't support limitless pagination (PR #3265)
+-   Remove unused `update_external_syncs`. ([\#3233](https://github.com/matrix-org/synapse/issues/3233))
+-   Use stream rather depth ordering for push actions. ([\#3212](https://github.com/matrix-org/synapse/issues/3212))
+-   Make `purge_history` operate on tokens. ([\#3221](https://github.com/matrix-org/synapse/issues/3221))
+-   Don't support limitless pagination. ([\#3265](https://github.com/matrix-org/synapse/issues/3265))
 
 Bug Fixes:
 
--   Fix logcontext resource usage tracking (PR #3258)
--   Fix error in handling receipts (PR #3235)
--   Stop the transaction cache caching failures (PR #3255)
+-   Fix logcontext resource usage tracking. ([\#3258](https://github.com/matrix-org/synapse/issues/3258))
+-   Fix error in handling receipts. ([\#3235](https://github.com/matrix-org/synapse/issues/3235))
+-   Stop the transaction cache caching failures. ([\#3255](https://github.com/matrix-org/synapse/issues/3255))
 
 Changes in synapse v0.29.1 (2018-05-17)
 =======================================
 
 Changes:
 
--   Update docker documentation (PR #3222)
+-   Update docker documentation. ([\#3222](https://github.com/matrix-org/synapse/issues/3222))
 
 Changes in synapse v0.29.0 (2018-05-16)
 =======================================
@@ -1420,30 +1420,30 @@ Features:
 Changes - General:
 
 -   nuke-room-from-db.sh: added postgresql option and help. Thanks to @rubo77! ([\#2337](https://github.com/matrix-org/synapse/issues/2337))
--   Part user from rooms on account deactivate (PR #3201)
--   Make "unexpected logging context" into warnings (PR #3007)
--   Set Server header in SynapseRequest (PR #3208)
--   remove duplicates from groups tables (PR #3129)
--   Improve exception handling for background processes (PR #3138)
--   Add missing consumeErrors to improve exception handling (PR #3139)
--   reraise exceptions more carefully (PR #3142)
--   Remove redundant call to `preserve_fn` (PR #3143)
--   Trap exceptions thrown within `run_in_background` (PR #3144)
+-   Part user from rooms on account deactivate. ([\#3201](https://github.com/matrix-org/synapse/issues/3201))
+-   Make "unexpected logging context" into warnings. ([\#3007](https://github.com/matrix-org/synapse/issues/3007))
+-   Set Server header in SynapseRequest. ([\#3208](https://github.com/matrix-org/synapse/issues/3208))
+-   remove duplicates from groups tables. ([\#3129](https://github.com/matrix-org/synapse/issues/3129))
+-   Improve exception handling for background processes. ([\#3138](https://github.com/matrix-org/synapse/issues/3138))
+-   Add missing consumeErrors to improve exception handling. ([\#3139](https://github.com/matrix-org/synapse/issues/3139))
+-   reraise exceptions more carefully. ([\#3142](https://github.com/matrix-org/synapse/issues/3142))
+-   Remove redundant call to `preserve_fn`. ([\#3143](https://github.com/matrix-org/synapse/issues/3143))
+-   Trap exceptions thrown within `run_in_background`. ([\#3144](https://github.com/matrix-org/synapse/issues/3144))
 
 Changes - Refactors:
 
--   Refactor /context to reuse pagination storage functions (PR #3193)
--   Refactor recent events func to use pagination func (PR #3195)
--   Refactor pagination DB API to return concrete type (PR #3196)
--   Refactor `get_recent_events_for_room` return type (PR #3198)
--   Refactor sync APIs to reuse pagination API (PR #3199)
--   Remove unused code path from member change DB func (PR #3200)
--   Refactor request handling wrappers (PR #3203)
+-   Refactor /context to reuse pagination storage functions. ([\#3193](https://github.com/matrix-org/synapse/issues/3193))
+-   Refactor recent events func to use pagination func. ([\#3195](https://github.com/matrix-org/synapse/issues/3195))
+-   Refactor pagination DB API to return concrete type. ([\#3196](https://github.com/matrix-org/synapse/issues/3196))
+-   Refactor `get_recent_events_for_room` return type. ([\#3198](https://github.com/matrix-org/synapse/issues/3198))
+-   Refactor sync APIs to reuse pagination API. ([\#3199](https://github.com/matrix-org/synapse/issues/3199))
+-   Remove unused code path from member change DB func. ([\#3200](https://github.com/matrix-org/synapse/issues/3200))
+-   Refactor request handling wrappers. ([\#3203](https://github.com/matrix-org/synapse/issues/3203))
 -   `transaction_id`, destination defined twice. Thanks to @damir-manapov! ([\#3209](https://github.com/matrix-org/synapse/issues/3209))
--   Refactor event storage to prepare for changes in state calculations (PR #3141)
--   Set Server header in SynapseRequest (PR #3208)
--   Use deferred.addTimeout instead of `time_bound_deferred` (PR #3127, #3178)
--   Use `run_in_background` in preference to `preserve_fn` (PR #3140)
+-   Refactor event storage to prepare for changes in state calculations. ([\#3141](https://github.com/matrix-org/synapse/issues/3141))
+-   Set Server header in SynapseRequest. ([\#3208](https://github.com/matrix-org/synapse/issues/3208))
+-   Use deferred.addTimeout instead of `time_bound_deferred`. ([\#3127](https://github.com/matrix-org/synapse/issues/3127), [\#3178](https://github.com/matrix-org/synapse/issues/3178))
+-   Use `run_in_background` in preference to `preserve_fn`. ([\#3140](https://github.com/matrix-org/synapse/issues/3140))
 
 Changes - Python 3 migration:
 
@@ -1458,18 +1458,18 @@ Changes - Python 3 migration:
 -   Move more xrange to six. Thanks to @NotAFile! ([\#3151](https://github.com/matrix-org/synapse/issues/3151))
 -   make imports local. Thanks to @NotAFile! ([\#3152](https://github.com/matrix-org/synapse/issues/3152))
 -   move httplib import to six. Thanks to @NotAFile! ([\#3153](https://github.com/matrix-org/synapse/issues/3153))
--   Replace stringIO imports with six (PR #3154, #3168) Thanks to @NotAFile!
+-   Replace stringIO imports with six. Thanks to @NotAFile! ([\#3154](https://github.com/matrix-org/synapse/issues/3154), [\#3168](https://github.com/matrix-org/synapse/issues/3168))
 -   more bytes strings. Thanks to @NotAFile! ([\#3155](https://github.com/matrix-org/synapse/issues/3155))
 
 Bug Fixes:
 
--   synapse fails to start under Twisted >= 18.4 (PR #3157)
--   Fix a class of logcontext leaks (PR #3170)
--   Fix a couple of logcontext leaks in unit tests (PR #3172)
--   Fix logcontext leak in media repo (PR #3174)
--   Escape label values in prometheus metrics (PR #3175, #3186)
+-   synapse fails to start under Twisted >= 18.4. ([\#3157](https://github.com/matrix-org/synapse/issues/3157))
+-   Fix a class of logcontext leaks. ([\#3170](https://github.com/matrix-org/synapse/issues/3170))
+-   Fix a couple of logcontext leaks in unit tests. ([\#3172](https://github.com/matrix-org/synapse/issues/3172))
+-   Fix logcontext leak in media repo. ([\#3174](https://github.com/matrix-org/synapse/issues/3174))
+-   Escape label values in prometheus metrics. ([\#3175](https://github.com/matrix-org/synapse/issues/3175), [\#3186](https://github.com/matrix-org/synapse/issues/3186))
 -   Fix "Unhandled Error" logs with Twisted 18.4. Thanks to @Half-Shot! ([\#3182](https://github.com/matrix-org/synapse/issues/3182))
--   Fix logcontext leaks in rate limiter (PR #3183)
+-   Fix logcontext leaks in rate limiter. ([\#3183](https://github.com/matrix-org/synapse/issues/3183))
 -   notifications: Convert `next_token` to string according to the spec. Thanks to @mujx! ([\#3190](https://github.com/matrix-org/synapse/issues/3190))
 -   nuke-room-from-db.sh: fix deletion from search table. Thanks to @rubo77! ([\#3194](https://github.com/matrix-org/synapse/issues/3194))
 -   add guard for None on `purge_history` api. Thanks to @krombel! ([\#3160](https://github.com/matrix-org/synapse/issues/3160))
@@ -1492,8 +1492,8 @@ Changes in synapse v0.28.0 (2018-04-26)
 
 Bug Fixes:
 
--   Fix quarantine media admin API and search reindex (PR #3130)
--   Fix media admin APIs (PR #3134)
+-   Fix quarantine media admin API and search reindex. ([\#3130](https://github.com/matrix-org/synapse/issues/3130))
+-   Fix media admin APIs. ([\#3134](https://github.com/matrix-org/synapse/issues/3134))
 
 Changes in synapse v0.28.0-rc1 (2018-04-24)
 ===========================================
@@ -1504,35 +1504,35 @@ Minor performance improvement to federation sending and bug fixes.
 
 Features:
 
--   Add metrics for event processing lag (PR #3090)
--   Add metrics for ResponseCache (PR #3092)
+-   Add metrics for event processing lag. ([\#3090](https://github.com/matrix-org/synapse/issues/3090))
+-   Add metrics for ResponseCache. ([\#3092](https://github.com/matrix-org/synapse/issues/3092))
 
 Changes:
 
 -   Synapse on PyPy. Thanks to @Valodim! ([\#2760](https://github.com/matrix-org/synapse/issues/2760))
 -   move handling of `auto_join_rooms` to RegisterHandler. Thanks to @krombel! ([\#2996](https://github.com/matrix-org/synapse/issues/2996))
 -   Improve handling of SRV records for federation connections. Thanks to @silkeh! ([\#3016](https://github.com/matrix-org/synapse/issues/3016))
--   Document the behaviour of ResponseCache (PR #3059)
--   Preparation for py3 (PR #3061, #3073, #3074, #3075, #3103, #3104, #3106, #3107, #3109, #3110) Thanks to @NotAFile!
+-   Document the behaviour of ResponseCache. ([\#3059](https://github.com/matrix-org/synapse/issues/3059))
+-   Preparation for py3. Thanks to @NotAFile! (PR #3061, #3073, #3074, #3075, #3103, #3104, #3106, #3107, #3109, #3110)
 -   update prometheus dashboard to use new metric names. Thanks to @krombel! ([\#3069](https://github.com/matrix-org/synapse/issues/3069))
 -   use python3-compatible prints. Thanks to @NotAFile! ([\#3074](https://github.com/matrix-org/synapse/issues/3074))
--   Send federation events concurrently (PR #3078)
--   Limit concurrent event sends for a room (PR #3079)
--   Improve R30 stat definition (PR #3086)
--   Send events to ASes concurrently (PR #3088)
--   Refactor ResponseCache usage (PR #3093)
+-   Send federation events concurrently. ([\#3078](https://github.com/matrix-org/synapse/issues/3078))
+-   Limit concurrent event sends for a room. ([\#3079](https://github.com/matrix-org/synapse/issues/3079))
+-   Improve R30 stat definition. ([\#3086](https://github.com/matrix-org/synapse/issues/3086))
+-   Send events to ASes concurrently. ([\#3088](https://github.com/matrix-org/synapse/issues/3088))
+-   Refactor ResponseCache usage. ([\#3093](https://github.com/matrix-org/synapse/issues/3093))
 -   Clarify that SRV may not point to a CNAME. Thanks to @silkeh! ([\#3100](https://github.com/matrix-org/synapse/issues/3100))
 -   Use str(e) instead of e.message. Thanks to @NotAFile! ([\#3103](https://github.com/matrix-org/synapse/issues/3103))
 -   Use six.itervalues in some places. Thanks to @NotAFile! ([\#3106](https://github.com/matrix-org/synapse/issues/3106))
--   Refactor `store.have_events` (PR #3117)
+-   Refactor `store.have_events`. ([\#3117](https://github.com/matrix-org/synapse/issues/3117))
 
 Bug Fixes:
 
 -   Return 401 for invalid `access_token` on logout. Thanks to @dklug! ([\#2938](https://github.com/matrix-org/synapse/issues/2938))
--   Return a 404 rather than a 500 on rejoining empty rooms (PR #3080)
--   fix `federation_domain_whitelist` (PR #3099)
--   Avoid creating events with huge numbers of `prev_events` (PR #3113)
--   Reject events which have lots of `prev_events` (PR #3118)
+-   Return a 404 rather than a 500 on rejoining empty rooms. ([\#3080](https://github.com/matrix-org/synapse/issues/3080))
+-   fix `federation_domain_whitelist`. ([\#3099](https://github.com/matrix-org/synapse/issues/3099))
+-   Avoid creating events with huge numbers of `prev_events`. ([\#3113](https://github.com/matrix-org/synapse/issues/3113))
+-   Reject events which have lots of `prev_events`. ([\#3118](https://github.com/matrix-org/synapse/issues/3118))
 
 Changes in synapse v0.27.4 (2018-04-13)
 =======================================
@@ -1566,43 +1566,43 @@ Counts the number of native 30 day retained users, defined as:
 
 Features:
 
--   Add joinability for groups (PR #3045)
--   Implement group join API (PR #3046)
--   Add counter metrics for calculating state delta (PR #3033)
--   R30 stats (PR #3041)
--   Measure time it takes to calculate state group ID (PR #3043)
--   Add basic performance statistics to phone home (PR #3044)
--   Add response size metrics (PR #3071)
--   phone home cache size configurations (PR #3063)
+-   Add joinability for groups. ([\#3045](https://github.com/matrix-org/synapse/issues/3045))
+-   Implement group join API. ([\#3046](https://github.com/matrix-org/synapse/issues/3046))
+-   Add counter metrics for calculating state delta. ([\#3033](https://github.com/matrix-org/synapse/issues/3033))
+-   R30 stats. ([\#3041](https://github.com/matrix-org/synapse/issues/3041))
+-   Measure time it takes to calculate state group ID. ([\#3043](https://github.com/matrix-org/synapse/issues/3043))
+-   Add basic performance statistics to phone home. ([\#3044](https://github.com/matrix-org/synapse/issues/3044))
+-   Add response size metrics. ([\#3071](https://github.com/matrix-org/synapse/issues/3071))
+-   phone home cache size configurations. ([\#3063](https://github.com/matrix-org/synapse/issues/3063))
 
 Changes:
 
 -   Add a blurb explaining the main synapse worker. Thanks to @turt2live! ([\#2886](https://github.com/matrix-org/synapse/issues/2886))
 -   Replace old style error catching with `as` keyword. Thanks to @NotAFile! ([\#3000](https://github.com/matrix-org/synapse/issues/3000))
--   Use `.iter*` to avoid copies in StateHandler (PR #3006)
--   Linearize calls to `_generate_user_id` (PR #3029)
--   Remove last usage of ujson (PR #3030)
--   Use simplejson throughout (PR #3048)
--   Use static JSONEncoders (PR #3049)
--   Remove uses of events.content (PR #3060)
--   Improve database cache performance (PR #3068)
+-   Use `.iter*` to avoid copies in StateHandler. ([\#3006](https://github.com/matrix-org/synapse/issues/3006))
+-   Linearize calls to `_generate_user_id`. ([\#3029](https://github.com/matrix-org/synapse/issues/3029))
+-   Remove last usage of ujson. ([\#3030](https://github.com/matrix-org/synapse/issues/3030))
+-   Use simplejson throughout. ([\#3048](https://github.com/matrix-org/synapse/issues/3048))
+-   Use static JSONEncoders. ([\#3049](https://github.com/matrix-org/synapse/issues/3049))
+-   Remove uses of events.content. ([\#3060](https://github.com/matrix-org/synapse/issues/3060))
+-   Improve database cache performance. ([\#3068](https://github.com/matrix-org/synapse/issues/3068))
 
 Bug fixes:
 
 -   Add `room_id` to the response of rooms/{roomId}/join. Thanks to @jplatte! ([\#2986](https://github.com/matrix-org/synapse/issues/2986))
--   Fix replication after switch to simplejson (PR #3015)
--   404 correctly on missing paths via NoResource (PR #3022)
--   Fix error when claiming e2e keys from offline servers (PR #3034)
--   fix `tests/storage/test_user_directory.py` (PR #3042)
+-   Fix replication after switch to simplejson. ([\#3015](https://github.com/matrix-org/synapse/issues/3015))
+-   404 correctly on missing paths via NoResource. ([\#3022](https://github.com/matrix-org/synapse/issues/3022))
+-   Fix error when claiming e2e keys from offline servers. ([\#3034](https://github.com/matrix-org/synapse/issues/3034))
+-   fix `tests/storage/test_user_directory.py`. ([\#3042](https://github.com/matrix-org/synapse/issues/3042))
 -   use `PUT` instead of `POST` for federating `groups`/`m.join_policy`. Thanks to @krombel! ([\#3070](https://github.com/matrix-org/synapse/issues/3070))
--   postgres port script: fix `state_groups_pkey` error (PR #3072)
+-   postgres port script: fix `state_groups_pkey` error. ([\#3072](https://github.com/matrix-org/synapse/issues/3072))
 
 Changes in synapse v0.27.2 (2018-03-26)
 =======================================
 
 Bug fixes:
 
--   Fix bug which broke TCP replication between workers (PR #3015)
+-   Fix bug which broke TCP replication between workers. ([\#3015](https://github.com/matrix-org/synapse/issues/3015))
 
 Changes in synapse v0.27.1 (2018-03-26)
 =======================================
@@ -1621,14 +1621,14 @@ Pulls in v0.26.1
 
 Bug fixes:
 
--   Fix bug introduced in v0.27.0-rc1 that causes much increased memory usage in state cache (PR #3005)
+-   Fix bug introduced in v0.27.0-rc1 that causes much increased memory usage in state cache. ([\#3005](https://github.com/matrix-org/synapse/issues/3005))
 
 Changes in synapse v0.26.1 (2018-03-15)
 =======================================
 
 Bug fixes:
 
--   Fix bug where an invalid event caused server to stop functioning correctly, due to parsing and serializing bugs in ujson library (PR #3008)
+-   Fix bug where an invalid event caused server to stop functioning correctly, due to parsing and serializing bugs in ujson library. ([\#3008](https://github.com/matrix-org/synapse/issues/3008))
 
 Changes in synapse v0.27.0-rc1 (2018-03-14)
 ===========================================
@@ -1639,13 +1639,13 @@ This release also begins the process of renaming a number of the metrics reporte
 
 Features:
 
--   Add ability for ASes to override message send time (PR #2754)
+-   Add ability for ASes to override message send time. ([\#2754](https://github.com/matrix-org/synapse/issues/2754))
 -   Add support for custom storage providers for media repository (PR #2867, #2777, #2783, #2789, #2791, #2804, #2812, #2814, #2857, #2868, #2767)
 -   Add purge API features, see [docs/admin_api/purge_history_api.rst](docs/admin_api/purge_history_api.rst) for full details (PR #2858, #2867, #2882, #2946, #2962, #2943)
--   Add support for whitelisting 3PIDs that users can register. (PR #2813)
--   Add `/room/{id}/event/{id}` API (PR #2766)
+-   Add support for whitelisting 3PIDs that users can register.. ([\#2813](https://github.com/matrix-org/synapse/issues/2813))
+-   Add `/room/{id}/event/{id}` API. ([\#2766](https://github.com/matrix-org/synapse/issues/2766))
 -   Add an admin API to get all the media in a room. Thanks to @turt2live! ([\#2818](https://github.com/matrix-org/synapse/issues/2818))
--   Add `federation_domain_whitelist` option (PR #2820, #2821)
+-   Add `federation_domain_whitelist` option. ([\#2820](https://github.com/matrix-org/synapse/issues/2820), [\#2821](https://github.com/matrix-org/synapse/issues/2821))
 
 Changes:
 
@@ -1653,27 +1653,27 @@ Changes:
 -   Ensure state cache is used when persisting events (PR #2864, #2871, #2802, #2835, #2836, #2841, #2842, #2849)
 -   Change the default config to bind on both IPv4 and IPv6 on all platforms. Thanks to @silkeh! ([\#2435](https://github.com/matrix-org/synapse/issues/2435))
 -   No longer require a specific version of saml2. Thanks to @okurz! ([\#2695](https://github.com/matrix-org/synapse/issues/2695))
--   Remove `verbosity`/`log_file` from generated config (PR #2755)
+-   Remove `verbosity`/`log_file` from generated config. ([\#2755](https://github.com/matrix-org/synapse/issues/2755))
 -   Add and improve metrics and logging (PR #2770, #2778, #2785, #2786, #2787, #2793, #2794, #2795, #2809, #2810, #2833, #2834, #2844, #2965, #2927, #2975, #2790, #2796, #2838)
--   When using synctl with workers, Don't start the main synapse automatically (PR #2774)
--   Minor performance improvements (PR #2773, #2792)
--   Use a connection pool for non-federation outbound connections (PR #2817)
--   Make it possible to run unit tests against postgres (PR #2829)
+-   When using synctl with workers, Don't start the main synapse automatically. ([\#2774](https://github.com/matrix-org/synapse/issues/2774))
+-   Minor performance improvements. ([\#2773](https://github.com/matrix-org/synapse/issues/2773), [\#2792](https://github.com/matrix-org/synapse/issues/2792))
+-   Use a connection pool for non-federation outbound connections. ([\#2817](https://github.com/matrix-org/synapse/issues/2817))
+-   Make it possible to run unit tests against postgres. ([\#2829](https://github.com/matrix-org/synapse/issues/2829))
 -   Update pynacl dependency to 1.2.1 or higher. Thanks to @bachp! ([\#2888](https://github.com/matrix-org/synapse/issues/2888))
--   Remove ability for AS users to call /events and /sync (PR #2948)
+-   Remove ability for AS users to call /events and /sync. ([\#2948](https://github.com/matrix-org/synapse/issues/2948))
 -   Use bcrypt.checkpw. Thanks to @krombel! ([\#2949](https://github.com/matrix-org/synapse/issues/2949))
 
 Bug fixes:
 
 -   Fix broken `ldap_config` config option. Thanks to @seckrv! ([\#2683](https://github.com/matrix-org/synapse/issues/2683))
 -   Fix error message when user is not allowed to unban. Thanks to @turt2live! ([\#2761](https://github.com/matrix-org/synapse/issues/2761))
--   Fix publicised groups GET API (singular) over federation (PR #2772)
--   Fix user directory when using `user_directory_search_all_users` config option (PR #2803, #2831)
--   Fix error on `/publicRooms` when no rooms exist (PR #2827)
--   Fix bug in `quarantine_media` (PR #2837)
--   Fix `url_previews` when no `Content-Type` is returned from URL (PR #2845)
--   Fix rare race in sync API when joining room (PR #2944)
--   Fix slow event search, switch back from GIST to GIN indexes (PR #2769, #2848)
+-   Fix publicised groups GET API (singular) over federation. ([\#2772](https://github.com/matrix-org/synapse/issues/2772))
+-   Fix user directory when using `user_directory_search_all_users` config option. ([\#2803](https://github.com/matrix-org/synapse/issues/2803), [\#2831](https://github.com/matrix-org/synapse/issues/2831))
+-   Fix error on `/publicRooms` when no rooms exist. ([\#2827](https://github.com/matrix-org/synapse/issues/2827))
+-   Fix bug in `quarantine_media`. ([\#2837](https://github.com/matrix-org/synapse/issues/2837))
+-   Fix `url_previews` when no `Content-Type` is returned from URL. ([\#2845](https://github.com/matrix-org/synapse/issues/2845))
+-   Fix rare race in sync API when joining room. ([\#2944](https://github.com/matrix-org/synapse/issues/2944))
+-   Fix slow event search, switch back from GIST to GIN indexes. ([\#2769](https://github.com/matrix-org/synapse/issues/2769), [\#2848](https://github.com/matrix-org/synapse/issues/2848))
 
 Changes in synapse v0.26.0 (2018-01-05)
 =======================================
@@ -1685,93 +1685,93 @@ Changes in synapse v0.26.0-rc1 (2017-12-13)
 
 Features:
 
--   Add ability for ASes to publicise groups for their users (PR #2686)
--   Add all local users to the `user_directory` and optionally search them (PR #2723)
--   Add support for custom login types for validating users (PR #2729)
+-   Add ability for ASes to publicise groups for their users. ([\#2686](https://github.com/matrix-org/synapse/issues/2686))
+-   Add all local users to the `user_directory` and optionally search them. ([\#2723](https://github.com/matrix-org/synapse/issues/2723))
+-   Add support for custom login types for validating users. ([\#2729](https://github.com/matrix-org/synapse/issues/2729))
 
 Changes:
 
 -   Update example Prometheus config to new format. Thanks to @krombel! ([\#2648](https://github.com/matrix-org/synapse/issues/2648))
--   Rename `redact_content` option to `include_content` in Push API (PR #2650)
--   Declare support for r0.3.0 (PR #2677)
--   Improve upserts (PR #2684, #2688, #2689, #2713)
--   Improve documentation of workers (PR #2700)
--   Improve tracebacks on exceptions (PR #2705)
--   Allow guest access to group APIs for reading (PR #2715)
--   Support for posting content in `federation_client` script (PR #2716)
--   Delete devices and pushers on logouts etc (PR #2722)
+-   Rename `redact_content` option to `include_content` in Push API. ([\#2650](https://github.com/matrix-org/synapse/issues/2650))
+-   Declare support for r0.3.0. ([\#2677](https://github.com/matrix-org/synapse/issues/2677))
+-   Improve upserts. ([\#2684](https://github.com/matrix-org/synapse/issues/2684), [\#2688](https://github.com/matrix-org/synapse/issues/2688), [\#2689](https://github.com/matrix-org/synapse/issues/2689), [\#2713](https://github.com/matrix-org/synapse/issues/2713))
+-   Improve documentation of workers. ([\#2700](https://github.com/matrix-org/synapse/issues/2700))
+-   Improve tracebacks on exceptions. ([\#2705](https://github.com/matrix-org/synapse/issues/2705))
+-   Allow guest access to group APIs for reading. ([\#2715](https://github.com/matrix-org/synapse/issues/2715))
+-   Support for posting content in `federation_client` script. ([\#2716](https://github.com/matrix-org/synapse/issues/2716))
+-   Delete devices and pushers on logouts etc. ([\#2722](https://github.com/matrix-org/synapse/issues/2722))
 
 Bug fixes:
 
--   Fix database port script (PR #2673)
+-   Fix database port script. ([\#2673](https://github.com/matrix-org/synapse/issues/2673))
 -   Fix internal server error on login with `ldap_auth_provider`. Thanks to @jkolo! ([\#2678](https://github.com/matrix-org/synapse/issues/2678))
--   Fix error on sqlite 3.7 (PR #2697)
--   Fix `OPTIONS` on `preview_url` (PR #2707)
--   Fix error handling on dns lookup (PR #2711)
--   Fix wrong avatars when inviting multiple users when creating room (PR #2717)
--   Fix 500 when joining matrix-dev (PR #2719)
+-   Fix error on sqlite 3.7. ([\#2697](https://github.com/matrix-org/synapse/issues/2697))
+-   Fix `OPTIONS` on `preview_url`. ([\#2707](https://github.com/matrix-org/synapse/issues/2707))
+-   Fix error handling on dns lookup. ([\#2711](https://github.com/matrix-org/synapse/issues/2711))
+-   Fix wrong avatars when inviting multiple users when creating room. ([\#2717](https://github.com/matrix-org/synapse/issues/2717))
+-   Fix 500 when joining matrix-dev. ([\#2719](https://github.com/matrix-org/synapse/issues/2719))
 
 Changes in synapse v0.25.1 (2017-11-17)
 =======================================
 
 Bug fixes:
 
--   Fix login with LDAP and other password provider modules (PR #2678). Thanks to @jkolo!
+-   Fix login with LDAP and other password provider modules. Thanks to @jkolo! ([\#2678](https://github.com/matrix-org/synapse/issues/2678))
 
 Changes in synapse v0.25.0 (2017-11-15)
 =======================================
 
 Bug fixes:
 
--   Fix port script (PR #2673)
+-   Fix port script. ([\#2673](https://github.com/matrix-org/synapse/issues/2673))
 
 Changes in synapse v0.25.0-rc1 (2017-11-14)
 ===========================================
 
 Features:
 
--   Add `is_public` to groups table to allow for private groups (PR #2582)
+-   Add `is_public` to groups table to allow for private groups. ([\#2582](https://github.com/matrix-org/synapse/issues/2582))
 -   Add a route for determining who you are. Thanks to @turt2live! ([\#2668](https://github.com/matrix-org/synapse/issues/2668))
 -   Add more features to the password providers (PR #2608, #2610, #2620, #2622, #2623, #2624, #2626, #2628, #2629)
--   Add a hook for custom rest endpoints (PR #2627)
--   Add API to update group room visibility (PR #2651)
+-   Add a hook for custom rest endpoints. ([\#2627](https://github.com/matrix-org/synapse/issues/2627))
+-   Add API to update group room visibility. ([\#2651](https://github.com/matrix-org/synapse/issues/2651))
 
 Changes:
 
 -   Ignore `<noscript\>` tags when generating URL preview descriptions. Thanks to @maximevaillancourt! ([\#2576](https://github.com/matrix-org/synapse/issues/2576))
 -   Register some /unstable endpoints in /r0 as well. Thanks to @krombel! ([\#2579](https://github.com/matrix-org/synapse/issues/2579))
--   Support /keys/upload on /r0 as well as /unstable (PR #2585)
--   Front-end proxy: pass through auth header (PR #2586)
--   Allow ASes to deactivate their own users (PR #2589)
--   Remove refresh tokens (PR #2613)
--   Automatically set default displayname on register (PR #2617)
--   Log login requests (PR #2618)
--   Always return `is_public` in the `/groups/:group_id/rooms` API (PR #2630)
+-   Support /keys/upload on /r0 as well as /unstable. ([\#2585](https://github.com/matrix-org/synapse/issues/2585))
+-   Front-end proxy: pass through auth header. ([\#2586](https://github.com/matrix-org/synapse/issues/2586))
+-   Allow ASes to deactivate their own users. ([\#2589](https://github.com/matrix-org/synapse/issues/2589))
+-   Remove refresh tokens. ([\#2613](https://github.com/matrix-org/synapse/issues/2613))
+-   Automatically set default displayname on register. ([\#2617](https://github.com/matrix-org/synapse/issues/2617))
+-   Log login requests. ([\#2618](https://github.com/matrix-org/synapse/issues/2618))
+-   Always return `is_public` in the `/groups/:group_id/rooms` API. ([\#2630](https://github.com/matrix-org/synapse/issues/2630))
 -   Avoid no-op media deletes. Thanks to @spantaleev! ([\#2637](https://github.com/matrix-org/synapse/issues/2637))
--   Fix various embarrassing typos around `user_directory` and add some doc. (PR #2643)
--   Return whether a user is an admin within a group (PR #2647)
--   Namespace visibility options for groups (PR #2657)
--   Downcase UserIDs on registration (PR #2662)
--   Cache failures when fetching URL previews (PR #2669)
+-   Fix various embarrassing typos around `user_directory` and add some doc.. ([\#2643](https://github.com/matrix-org/synapse/issues/2643))
+-   Return whether a user is an admin within a group. ([\#2647](https://github.com/matrix-org/synapse/issues/2647))
+-   Namespace visibility options for groups. ([\#2657](https://github.com/matrix-org/synapse/issues/2657))
+-   Downcase UserIDs on registration. ([\#2662](https://github.com/matrix-org/synapse/issues/2662))
+-   Cache failures when fetching URL previews. ([\#2669](https://github.com/matrix-org/synapse/issues/2669))
 
 Bug fixes:
 
--   Fix port script (PR #2577)
--   Fix error when running synapse with no logfile (PR #2581)
--   Fix UI auth when deleting devices (PR #2591)
--   Fix typo when checking if user is invited to group (PR #2599)
--   Fix the port script to drop NUL values in all tables (PR #2611)
+-   Fix port script. ([\#2577](https://github.com/matrix-org/synapse/issues/2577))
+-   Fix error when running synapse with no logfile. ([\#2581](https://github.com/matrix-org/synapse/issues/2581))
+-   Fix UI auth when deleting devices. ([\#2591](https://github.com/matrix-org/synapse/issues/2591))
+-   Fix typo when checking if user is invited to group. ([\#2599](https://github.com/matrix-org/synapse/issues/2599))
+-   Fix the port script to drop NUL values in all tables. ([\#2611](https://github.com/matrix-org/synapse/issues/2611))
 -   Fix appservices being backlogged and not receiving new events due to a bug in `notify_interested_services`. Thanks to @xyzz! ([\#2631](https://github.com/matrix-org/synapse/issues/2631))
 -   Fix updating rooms avatar/display name when modified by admin. Thanks to @farialima! ([\#2636](https://github.com/matrix-org/synapse/issues/2636))
--   Fix bug in state group storage (PR #2649)
--   Fix 500 on invalid utf-8 in request (PR #2663)
+-   Fix bug in state group storage. ([\#2649](https://github.com/matrix-org/synapse/issues/2649))
+-   Fix 500 on invalid utf-8 in request. ([\#2663](https://github.com/matrix-org/synapse/issues/2663))
 
 Changes in synapse v0.24.1 (2017-10-24)
 =======================================
 
 Bug fixes:
 
--   Fix updating group profiles over federation (PR #2567)
+-   Fix updating group profiles over federation. ([\#2567](https://github.com/matrix-org/synapse/issues/2567))
 
 Changes in synapse v0.24.0 (2017-10-23)
 =======================================
@@ -1784,30 +1784,30 @@ Changes in synapse v0.24.0-rc1 (2017-10-19)
 Features:
 
 -   Add Group Server (PR #2352, #2363, #2374, #2377, #2378, #2382, #2410, #2426, #2430, #2454, #2471, #2472, #2544)
--   Add support for channel notifications (PR #2501)
--   Add basic implementation of backup media store (PR #2538)
--   Add config option to auto-join new users to rooms (PR #2545)
+-   Add support for channel notifications. ([\#2501](https://github.com/matrix-org/synapse/issues/2501))
+-   Add basic implementation of backup media store. ([\#2538](https://github.com/matrix-org/synapse/issues/2538))
+-   Add config option to auto-join new users to rooms. ([\#2545](https://github.com/matrix-org/synapse/issues/2545))
 
 Changes:
 
--   Make the spam checker a module (PR #2474)
--   Delete expired url cache data (PR #2478)
--   Ignore incoming events for rooms that we have left (PR #2490)
--   Allow spam checker to reject invites too (PR #2492)
--   Add room creation checks to spam checker (PR #2495)
--   Spam checking: add the invitee to `user_may_invite` (PR #2502)
--   Process events from federation for different rooms in parallel (PR #2520)
--   Allow error strings from spam checker (PR #2531)
--   Improve error handling for missing files in config (PR #2551)
+-   Make the spam checker a module. ([\#2474](https://github.com/matrix-org/synapse/issues/2474))
+-   Delete expired url cache data. ([\#2478](https://github.com/matrix-org/synapse/issues/2478))
+-   Ignore incoming events for rooms that we have left. ([\#2490](https://github.com/matrix-org/synapse/issues/2490))
+-   Allow spam checker to reject invites too. ([\#2492](https://github.com/matrix-org/synapse/issues/2492))
+-   Add room creation checks to spam checker. ([\#2495](https://github.com/matrix-org/synapse/issues/2495))
+-   Spam checking: add the invitee to `user_may_invite`. ([\#2502](https://github.com/matrix-org/synapse/issues/2502))
+-   Process events from federation for different rooms in parallel. ([\#2520](https://github.com/matrix-org/synapse/issues/2520))
+-   Allow error strings from spam checker. ([\#2531](https://github.com/matrix-org/synapse/issues/2531))
+-   Improve error handling for missing files in config. ([\#2551](https://github.com/matrix-org/synapse/issues/2551))
 
 Bug fixes:
 
--   Fix handling SERVFAILs when doing AAAA lookups for federation (PR #2477)
+-   Fix handling SERVFAILs when doing AAAA lookups for federation. ([\#2477](https://github.com/matrix-org/synapse/issues/2477))
 -   Fix incompatibility with newer versions of ujson. Thanks to @jeremycline! ([\#2483](https://github.com/matrix-org/synapse/issues/2483))
--   Fix notification keywords that start/end with non-word chars (PR #2500)
--   Fix stack overflow and logcontexts from linearizer (PR #2532)
--   Fix 500 error when fields missing from `power_levels` event (PR #2552)
--   Fix 500 error when we get an error handling a PDU (PR #2553)
+-   Fix notification keywords that start/end with non-word chars. ([\#2500](https://github.com/matrix-org/synapse/issues/2500))
+-   Fix stack overflow and logcontexts from linearizer. ([\#2532](https://github.com/matrix-org/synapse/issues/2532))
+-   Fix 500 error when fields missing from `power_levels` event. ([\#2552](https://github.com/matrix-org/synapse/issues/2552))
+-   Fix 500 error when we get an error handling a PDU. ([\#2553](https://github.com/matrix-org/synapse/issues/2553))
 
 Changes in synapse v0.23.1 (2017-10-02)
 =======================================
@@ -1826,42 +1826,42 @@ Changes in synapse v0.23.0-rc2 (2017-09-26)
 
 Bug fixes:
 
--   Fix regression in performance of syncs (PR #2470)
+-   Fix regression in performance of syncs. ([\#2470](https://github.com/matrix-org/synapse/issues/2470))
 
 Changes in synapse v0.23.0-rc1 (2017-09-25)
 ===========================================
 
 Features:
 
--   Add a frontend proxy worker (PR #2344)
--   Add support for `event_id_only` push format (PR #2450)
--   Add a PoC for filtering spammy events (PR #2456)
--   Add a config option to block all room invites (PR #2457)
+-   Add a frontend proxy worker. ([\#2344](https://github.com/matrix-org/synapse/issues/2344))
+-   Add support for `event_id_only` push format. ([\#2450](https://github.com/matrix-org/synapse/issues/2450))
+-   Add a PoC for filtering spammy events. ([\#2456](https://github.com/matrix-org/synapse/issues/2456))
+-   Add a config option to block all room invites. ([\#2457](https://github.com/matrix-org/synapse/issues/2457))
 
 Changes:
 
 -   Use bcrypt module instead of py-bcrypt. Thanks to @kyrias! ([\#2288](https://github.com/matrix-org/synapse/issues/2288))
 -   Improve performance of generating push notifications (PR #2343, #2357, #2365, #2366, #2371)
--   Improve DB performance for device list handling in sync (PR #2362)
--   Include a sample prometheus config (PR #2416)
+-   Improve DB performance for device list handling in sync. ([\#2362](https://github.com/matrix-org/synapse/issues/2362))
+-   Include a sample prometheus config. ([\#2416](https://github.com/matrix-org/synapse/issues/2416))
 -   Document known to work postgres version. Thanks to @ptman! ([\#2433](https://github.com/matrix-org/synapse/issues/2433))
 
 Bug fixes:
 
--   Fix caching error in the push evaluator (PR #2332)
--   Fix bug where pusherpool didn't start and broke some rooms (PR #2342)
--   Fix port script for user directory tables (PR #2375)
--   Fix device lists notifications when user rejoins a room (PR #2443, #2449)
--   Fix sync to always send down current state events in timeline (PR #2451)
--   Fix bug where guest users were incorrectly kicked (PR #2453)
--   Fix bug talking to IPv6 only servers using SRV records (PR #2462)
+-   Fix caching error in the push evaluator. ([\#2332](https://github.com/matrix-org/synapse/issues/2332))
+-   Fix bug where pusherpool didn't start and broke some rooms. ([\#2342](https://github.com/matrix-org/synapse/issues/2342))
+-   Fix port script for user directory tables. ([\#2375](https://github.com/matrix-org/synapse/issues/2375))
+-   Fix device lists notifications when user rejoins a room. ([\#2443](https://github.com/matrix-org/synapse/issues/2443), [\#2449](https://github.com/matrix-org/synapse/issues/2449))
+-   Fix sync to always send down current state events in timeline. ([\#2451](https://github.com/matrix-org/synapse/issues/2451))
+-   Fix bug where guest users were incorrectly kicked. ([\#2453](https://github.com/matrix-org/synapse/issues/2453))
+-   Fix bug talking to IPv6 only servers using SRV records. ([\#2462](https://github.com/matrix-org/synapse/issues/2462))
 
 Changes in synapse v0.22.1 (2017-07-06)
 =======================================
 
 Bug fixes:
 
--   Fix bug where pusher pool didn't start and caused issues when interacting with some rooms (PR #2342)
+-   Fix bug where pusher pool didn't start and caused issues when interacting with some rooms. ([\#2342](https://github.com/matrix-org/synapse/issues/2342))
 
 Changes in synapse v0.22.0 (2017-07-06)
 =======================================
@@ -1873,14 +1873,14 @@ Changes in synapse v0.22.0-rc2 (2017-07-04)
 
 Changes:
 
--   Improve performance of storing user IPs (PR #2307, #2308)
--   Slightly improve performance of verifying access tokens (PR #2320)
--   Slightly improve performance of event persistence (PR #2321)
--   Increase default cache factor size from 0.1 to 0.5 (PR #2330)
+-   Improve performance of storing user IPs. ([\#2307](https://github.com/matrix-org/synapse/issues/2307), [\#2308](https://github.com/matrix-org/synapse/issues/2308))
+-   Slightly improve performance of verifying access tokens. ([\#2320](https://github.com/matrix-org/synapse/issues/2320))
+-   Slightly improve performance of event persistence. ([\#2321](https://github.com/matrix-org/synapse/issues/2321))
+-   Increase default cache factor size from 0.1 to 0.5. ([\#2330](https://github.com/matrix-org/synapse/issues/2330))
 
 Bug fixes:
 
--   Fix bug with storing registration sessions that caused frequent CPU churn (PR #2319)
+-   Fix bug with storing registration sessions that caused frequent CPU churn. ([\#2319](https://github.com/matrix-org/synapse/issues/2319))
 
 Changes in synapse v0.22.0-rc1 (2017-06-26)
 ===========================================
@@ -1888,8 +1888,8 @@ Changes in synapse v0.22.0-rc1 (2017-06-26)
 Features:
 
 -   Add a user directory API (PR #2252, and many more)
--   Add shutdown room API to remove room from local server (PR #2291)
--   Add API to quarantine media (PR #2292)
+-   Add shutdown room API to remove room from local server. ([\#2291](https://github.com/matrix-org/synapse/issues/2291))
+-   Add API to quarantine media. ([\#2292](https://github.com/matrix-org/synapse/issues/2292))
 -   Add new config option to not send event contents to push servers. Thanks to @cjdelisle! ([\#2301](https://github.com/matrix-org/synapse/issues/2301))
 
 Changes:
@@ -1897,17 +1897,17 @@ Changes:
 -   Various performance fixes (PR #2177, #2233, #2230, #2238, #2248, #2256, #2274)
 -   Deduplicate sync filters. Thanks to @krombel! ([\#2219](https://github.com/matrix-org/synapse/issues/2219))
 -   Correct a typo in UPGRADE.rst. Thanks to @aaronraimist! ([\#2231](https://github.com/matrix-org/synapse/issues/2231))
--   Add count of one time keys to sync stream (PR #2237)
--   Only store `event_auth` for state events (PR #2247)
--   Store URL cache preview downloads separately (PR #2299)
+-   Add count of one time keys to sync stream. ([\#2237](https://github.com/matrix-org/synapse/issues/2237))
+-   Only store `event_auth` for state events. ([\#2247](https://github.com/matrix-org/synapse/issues/2247))
+-   Store URL cache preview downloads separately. ([\#2299](https://github.com/matrix-org/synapse/issues/2299))
 
 Bug fixes:
 
 -   Fix users not getting notifications when AS listened to that `user_id`. Thanks to @slipeer! ([\#2216](https://github.com/matrix-org/synapse/issues/2216))
--   Fix users without push set up not getting notifications after joining rooms (PR #2236)
--   Fix preview url API to trim long descriptions (PR #2243)
--   Fix bug where we used cached but unpersisted state group as prev group, resulting in broken state of restart (PR #2263)
--   Fix removing of pushers when using workers (PR #2267)
+-   Fix users without push set up not getting notifications after joining rooms. ([\#2236](https://github.com/matrix-org/synapse/issues/2236))
+-   Fix preview url API to trim long descriptions. ([\#2243](https://github.com/matrix-org/synapse/issues/2243))
+-   Fix bug where we used cached but unpersisted state group as prev group, resulting in broken state of restart. ([\#2263](https://github.com/matrix-org/synapse/issues/2263))
+-   Fix removing of pushers when using workers. ([\#2267](https://github.com/matrix-org/synapse/issues/2267))
 -   Fix CORS headers to allow Authorization header. Thanks to @krombel! ([\#2285](https://github.com/matrix-org/synapse/issues/2285))
 
 Changes in synapse v0.21.1 (2017-06-15)
@@ -1915,7 +1915,7 @@ Changes in synapse v0.21.1 (2017-06-15)
 
 Bug fixes:
 
--   Fix bug in anonymous usage statistic reporting (PR #2281)
+-   Fix bug in anonymous usage statistic reporting. ([\#2281](https://github.com/matrix-org/synapse/issues/2281))
 
 Changes in synapse v0.21.0 (2017-05-18)
 =======================================
@@ -1927,63 +1927,63 @@ Changes in synapse v0.21.0-rc3 (2017-05-17)
 
 Features:
 
--   Add per user rate-limiting overrides (PR #2208)
+-   Add per user rate-limiting overrides. ([\#2208](https://github.com/matrix-org/synapse/issues/2208))
 -   Add config option to limit maximum number of events requested by `/sync` and `/messages`. Thanks to @psaavedra! ([\#2221](https://github.com/matrix-org/synapse/issues/2221))
 
 Changes:
 
 -   Various small performance fixes (PR #2201, #2202, #2224, #2226, #2227, #2228, #2229)
--   Update username availability checker API (PR #2209, #2213)
--   When purging, Don't de-delta state groups we're about to delete (PR #2214)
+-   Update username availability checker API. ([\#2209](https://github.com/matrix-org/synapse/issues/2209), [\#2213](https://github.com/matrix-org/synapse/issues/2213))
+-   When purging, Don't de-delta state groups we're about to delete. ([\#2214](https://github.com/matrix-org/synapse/issues/2214))
 -   Documentation to check synapse version. Thanks to @hamber-dick! ([\#2215](https://github.com/matrix-org/synapse/issues/2215))
--   Add an index to `event_search` to speed up purge history API (PR #2218)
+-   Add an index to `event_search` to speed up purge history API. ([\#2218](https://github.com/matrix-org/synapse/issues/2218))
 
 Bug fixes:
 
--   Fix API to allow clients to upload one-time-keys with new sigs (PR #2206)
+-   Fix API to allow clients to upload one-time-keys with new sigs. ([\#2206](https://github.com/matrix-org/synapse/issues/2206))
 
 Changes in synapse v0.21.0-rc2 (2017-05-08)
 ===========================================
 
 Changes:
 
--   Always mark remotes as up if we receive a signed request from them (PR #2190)
+-   Always mark remotes as up if we receive a signed request from them. ([\#2190](https://github.com/matrix-org/synapse/issues/2190))
 
 Bug fixes:
 
--   Fix bug where users got pushed for rooms they had muted (PR #2200)
+-   Fix bug where users got pushed for rooms they had muted. ([\#2200](https://github.com/matrix-org/synapse/issues/2200))
 
 Changes in synapse v0.21.0-rc1 (2017-05-08)
 ===========================================
 
 Features:
 
--   Add username availability checker API (PR #2183)
--   Add read marker API (PR #2120)
+-   Add username availability checker API. ([\#2183](https://github.com/matrix-org/synapse/issues/2183))
+-   Add read marker API. ([\#2120](https://github.com/matrix-org/synapse/issues/2120))
 
 Changes:
 
--   Enable guest access for the 3pl/3pid APIs (PR #1986)
--   Add setting to support TURN for guests (PR #2011)
+-   Enable guest access for the 3pl/3pid APIs. ([\#1986](https://github.com/matrix-org/synapse/issues/1986))
+-   Add setting to support TURN for guests. ([\#2011](https://github.com/matrix-org/synapse/issues/2011))
 -   Various performance improvements (PR #2075, #2076, #2080, #2083, #2108, #2158, #2176, #2185)
--   Make synctl a bit more user friendly (PR #2078, #2127) Thanks @APwhitehat!
+-   Make synctl a bit more user friendly. ([\#2078](https://github.com/matrix-org/synapse/issues/2078), [\#2127](https://github.com/matrix-org/synapse/issues/2127)) Thanks @APwhitehat!
 -   Replace HTTP replication with TCP replication (PR #2082, #2097, #2098, #2099, #2103, #2014, #2016, #2115, #2116, #2117)
 -   Support authenticated SMTP (PR #2102) Thanks @DanielDent!
--   Add a counter metric for successfully-sent transactions (PR #2121)
--   Propagate errors sensibly from proxied IS requests (PR #2147)
--   Add more granular event send metrics (PR #2178)
+-   Add a counter metric for successfully-sent transactions. ([\#2121](https://github.com/matrix-org/synapse/issues/2121))
+-   Propagate errors sensibly from proxied IS requests. ([\#2147](https://github.com/matrix-org/synapse/issues/2147))
+-   Add more granular event send metrics. ([\#2178](https://github.com/matrix-org/synapse/issues/2178))
 
 Bug fixes:
 
 -   Fix nuke-room script to work with current schema (PR #1927) Thanks @zuckschwerdt!
 -   Fix db port script to not assume postgres tables are in the public schema (PR #2024) Thanks @jerrykan!
--   Fix getting latest device IP for user with no devices (PR #2118)
--   Fix rejection of invites to unreachable servers (PR #2145)
--   Fix code for reporting old verify keys in synapse (PR #2156)
--   Fix invite state to always include all events (PR #2163)
--   Fix bug where synapse would always fetch state for any missing event (PR #2170)
--   Fix a leak with timed out HTTP connections (PR #2180)
--   Fix bug where we didn't time out HTTP requests to ASes (PR #2192)
+-   Fix getting latest device IP for user with no devices. ([\#2118](https://github.com/matrix-org/synapse/issues/2118))
+-   Fix rejection of invites to unreachable servers. ([\#2145](https://github.com/matrix-org/synapse/issues/2145))
+-   Fix code for reporting old verify keys in synapse. ([\#2156](https://github.com/matrix-org/synapse/issues/2156))
+-   Fix invite state to always include all events. ([\#2163](https://github.com/matrix-org/synapse/issues/2163))
+-   Fix bug where synapse would always fetch state for any missing event. ([\#2170](https://github.com/matrix-org/synapse/issues/2170))
+-   Fix a leak with timed out HTTP connections. ([\#2180](https://github.com/matrix-org/synapse/issues/2180))
+-   Fix bug where we didn't time out HTTP requests to ASes. ([\#2192](https://github.com/matrix-org/synapse/issues/2192))
 
 Docs:
 
@@ -1998,45 +1998,45 @@ Changes in synapse v0.20.0 (2017-04-11)
 
 Bug fixes:
 
--   Fix joining rooms over federation where not all servers in the room saw the new server had joined (PR #2094)
+-   Fix joining rooms over federation where not all servers in the room saw the new server had joined. ([\#2094](https://github.com/matrix-org/synapse/issues/2094))
 
 Changes in synapse v0.20.0-rc1 (2017-03-30)
 ===========================================
 
 Features:
 
--   Add `delete_devices` API (PR #1993)
--   Add phone number registration/login support (PR #1994, #2055)
+-   Add `delete_devices` API. ([\#1993](https://github.com/matrix-org/synapse/issues/1993))
+-   Add phone number registration/login support. ([\#1994](https://github.com/matrix-org/synapse/issues/1994), [\#2055](https://github.com/matrix-org/synapse/issues/2055))
 
 Changes:
 
--   Use JSONSchema for validation of filters. Thanks @pik! (PR #1783)
--   Reread log config on SIGHUP (PR #1982)
--   Speed up public room list (PR #1989)
--   Add helpful texts to logger config options (PR #1990)
--   Minor `/sync` performance improvements. (PR #2002, #2013, #2022)
--   Add some debug to help diagnose weird federation issue (PR #2035)
--   Correctly limit retries for all federation requests (PR #2050, #2061)
--   Don't lock table when persisting new one time keys (PR #2053)
--   Reduce some CPU work on DB threads (PR #2054)
--   Cache hosts in room (PR #2060)
--   Batch sending of device list pokes (PR #2063)
--   Speed up persist event path in certain edge cases (PR #2070)
+-   Use JSONSchema for validation of filters. Thanks @pik!. ([\#1783](https://github.com/matrix-org/synapse/issues/1783))
+-   Reread log config on SIGHUP. ([\#1982](https://github.com/matrix-org/synapse/issues/1982))
+-   Speed up public room list. ([\#1989](https://github.com/matrix-org/synapse/issues/1989))
+-   Add helpful texts to logger config options. ([\#1990](https://github.com/matrix-org/synapse/issues/1990))
+-   Minor `/sync` performance improvements.. ([\#2002](https://github.com/matrix-org/synapse/issues/2002), [\#2013](https://github.com/matrix-org/synapse/issues/2013), [\#2022](https://github.com/matrix-org/synapse/issues/2022))
+-   Add some debug to help diagnose weird federation issue. ([\#2035](https://github.com/matrix-org/synapse/issues/2035))
+-   Correctly limit retries for all federation requests. ([\#2050](https://github.com/matrix-org/synapse/issues/2050), [\#2061](https://github.com/matrix-org/synapse/issues/2061))
+-   Don't lock table when persisting new one time keys. ([\#2053](https://github.com/matrix-org/synapse/issues/2053))
+-   Reduce some CPU work on DB threads. ([\#2054](https://github.com/matrix-org/synapse/issues/2054))
+-   Cache hosts in room. ([\#2060](https://github.com/matrix-org/synapse/issues/2060))
+-   Batch sending of device list pokes. ([\#2063](https://github.com/matrix-org/synapse/issues/2063))
+-   Speed up persist event path in certain edge cases. ([\#2070](https://github.com/matrix-org/synapse/issues/2070))
 
 Bug fixes:
 
--   Fix bug where `current_state_events` renamed to `current_state_ids` (PR #1849)
--   Fix routing loop when fetching remote media (PR #1992)
--   Fix `current_state_events` table to not lie (PR #1996)
--   Fix CAS login to handle PartialDownloadError (PR #1997)
--   Fix assertion to stop transaction queue getting wedged (PR #2010)
--   Fix presence to fallback to `last_active_ts` if it beats the last sync time. Thanks @Half-Shot! (PR #2014)
--   Fix bug when federation received a PDU while a room join is in progress (PR #2016)
--   Fix resetting state on rejected events (PR #2025)
--   Fix installation issues in readme. Thanks @ricco386 (PR #2037)
--   Fix caching of remote servers' signature keys (PR #2042)
--   Fix some leaking log context (PR #2048, #2049, #2057, #2058)
--   Fix rejection of invites not reaching sync (PR #2056)
+-   Fix bug where `current_state_events` renamed to `current_state_ids`. ([\#1849](https://github.com/matrix-org/synapse/issues/1849))
+-   Fix routing loop when fetching remote media. ([\#1992](https://github.com/matrix-org/synapse/issues/1992))
+-   Fix `current_state_events` table to not lie. ([\#1996](https://github.com/matrix-org/synapse/issues/1996))
+-   Fix CAS login to handle PartialDownloadError. ([\#1997](https://github.com/matrix-org/synapse/issues/1997))
+-   Fix assertion to stop transaction queue getting wedged. ([\#2010](https://github.com/matrix-org/synapse/issues/2010))
+-   Fix presence to fallback to `last_active_ts` if it beats the last sync time. Thanks @Half-Shot!. ([\#2014](https://github.com/matrix-org/synapse/issues/2014))
+-   Fix bug when federation received a PDU while a room join is in progress. ([\#2016](https://github.com/matrix-org/synapse/issues/2016))
+-   Fix resetting state on rejected events. ([\#2025](https://github.com/matrix-org/synapse/issues/2025))
+-   Fix installation issues in readme. Thanks @ricco386. ([\#2037](https://github.com/matrix-org/synapse/issues/2037))
+-   Fix caching of remote servers' signature keys. ([\#2042](https://github.com/matrix-org/synapse/issues/2042))
+-   Fix some leaking log context. ([\#2048](https://github.com/matrix-org/synapse/issues/2048), [\#2049](https://github.com/matrix-org/synapse/issues/2049), [\#2057](https://github.com/matrix-org/synapse/issues/2057), [\#2058](https://github.com/matrix-org/synapse/issues/2058))
+-   Fix rejection of invites not reaching sync. ([\#2056](https://github.com/matrix-org/synapse/issues/2056))
 
 Changes in synapse v0.19.3 (2017-03-20)
 =======================================
@@ -2055,36 +2055,36 @@ Changes in synapse v0.19.3-rc1 (2017-03-08)
 
 Features:
 
--   Add some administration functionalities. Thanks to morteza-araby! (PR #1784)
+-   Add some administration functionalities. Thanks to morteza-araby!. ([\#1784](https://github.com/matrix-org/synapse/issues/1784))
 
 Changes:
 
--   Reduce database table sizes (PR #1873, #1916, #1923, #1963)
--   Update contrib/ to not use syutil. Thanks to andrewshadura! (PR #1907)
--   Don't fetch current state when sending an event in common case (PR #1955)
+-   Reduce database table sizes. ([\#1873](https://github.com/matrix-org/synapse/issues/1873), [\#1916](https://github.com/matrix-org/synapse/issues/1916), [\#1923](https://github.com/matrix-org/synapse/issues/1923), [\#1963](https://github.com/matrix-org/synapse/issues/1963))
+-   Update contrib/ to not use syutil. Thanks to andrewshadura!. ([\#1907](https://github.com/matrix-org/synapse/issues/1907))
+-   Don't fetch current state when sending an event in common case. ([\#1955](https://github.com/matrix-org/synapse/issues/1955))
 
 Bug fixes:
 
--   Fix synapse_port_db failure. Thanks to Pneumaticat! (PR #1904)
--   Fix caching to not cache error responses (PR #1913)
--   Fix APIs to make kick & ban reasons work (PR #1917)
--   Fix bugs in the /keys/changes api (PR #1921)
--   Fix bug where users couldn't forget rooms they were banned from (PR #1922)
--   Fix issue with long language values in pushers API (PR #1925)
--   Fix a race in transaction queue (PR #1930)
--   Fix dynamic thumbnailing to preserve aspect ratio. Thanks to jkolo! (PR #1945)
--   Fix device list update to not constantly resync (PR #1964)
--   Fix potential for huge memory usage when getting device that have changed (PR #1969)
+-   Fix synapse_port_db failure. Thanks to Pneumaticat!. ([\#1904](https://github.com/matrix-org/synapse/issues/1904))
+-   Fix caching to not cache error responses. ([\#1913](https://github.com/matrix-org/synapse/issues/1913))
+-   Fix APIs to make kick & ban reasons work. ([\#1917](https://github.com/matrix-org/synapse/issues/1917))
+-   Fix bugs in the /keys/changes api. ([\#1921](https://github.com/matrix-org/synapse/issues/1921))
+-   Fix bug where users couldn't forget rooms they were banned from. ([\#1922](https://github.com/matrix-org/synapse/issues/1922))
+-   Fix issue with long language values in pushers API. ([\#1925](https://github.com/matrix-org/synapse/issues/1925))
+-   Fix a race in transaction queue. ([\#1930](https://github.com/matrix-org/synapse/issues/1930))
+-   Fix dynamic thumbnailing to preserve aspect ratio. Thanks to jkolo!. ([\#1945](https://github.com/matrix-org/synapse/issues/1945))
+-   Fix device list update to not constantly resync. ([\#1964](https://github.com/matrix-org/synapse/issues/1964))
+-   Fix potential for huge memory usage when getting device that have changed. ([\#1969](https://github.com/matrix-org/synapse/issues/1969))
 
 Changes in synapse v0.19.2 (2017-02-20)
 =======================================
 
--   Fix bug with event visibility check in /context/ API. Thanks to Tokodomo for pointing it out! (PR #1929)
+-   Fix bug with event visibility check in /context/ API. Thanks to Tokodomo for pointing it out!. ([\#1929](https://github.com/matrix-org/synapse/issues/1929))
 
 Changes in synapse v0.19.1 (2017-02-09)
 =======================================
 
--   Fix bug where state was incorrectly reset in a room when synapse received an event over federation that did not pass auth checks (PR #1892)
+-   Fix bug where state was incorrectly reset in a room when synapse received an event over federation that did not pass auth checks. ([\#1892](https://github.com/matrix-org/synapse/issues/1892))
 
 Changes in synapse v0.19.0 (2017-02-04)
 =======================================
@@ -2094,59 +2094,59 @@ No changes since RC 4.
 Changes in synapse v0.19.0-rc4 (2017-02-02)
 ===========================================
 
--   Bump cache sizes for common membership queries (PR #1879)
+-   Bump cache sizes for common membership queries. ([\#1879](https://github.com/matrix-org/synapse/issues/1879))
 
 Changes in synapse v0.19.0-rc3 (2017-02-02)
 ===========================================
 
--   Fix email push in pusher worker (PR #1875)
--   Make `presence.get_new_events` a bit faster (PR #1876)
--   Make /keys/changes a bit more performant (PR #1877)
+-   Fix email push in pusher worker. ([\#1875](https://github.com/matrix-org/synapse/issues/1875))
+-   Make `presence.get_new_events` a bit faster. ([\#1876](https://github.com/matrix-org/synapse/issues/1876))
+-   Make /keys/changes a bit more performant. ([\#1877](https://github.com/matrix-org/synapse/issues/1877))
 
 Changes in synapse v0.19.0-rc2 (2017-02-02)
 ===========================================
 
--   Include newly joined users in /keys/changes API (PR #1872)
+-   Include newly joined users in /keys/changes API. ([\#1872](https://github.com/matrix-org/synapse/issues/1872))
 
 Changes in synapse v0.19.0-rc1 (2017-02-02)
 ===========================================
 
 Features:
 
--   Add support for specifying multiple bind addresses (PR #1709, #1712, #1795, #1835). Thanks to @kyrias!
--   Add /account/3pid/delete endpoint (PR #1714)
--   Add config option to configure the Riot URL used in notification emails (PR #1811). Thanks to @aperezdc!
--   Add username and password config options for turn server (PR #1832). Thanks to @xsteadfastx!
--   Implement device lists updates over federation (PR #1857, #1861, #1864)
--   Implement /keys/changes (PR #1869, #1872)
+-   Add support for specifying multiple bind addresses. Thanks to @kyrias! ([\#1709](https://github.com/matrix-org/synapse/issues/1709), [\#1712](https://github.com/matrix-org/synapse/issues/1712), [\#1795](https://github.com/matrix-org/synapse/issues/1795), [\#1835](https://github.com/matrix-org/synapse/issues/1835))
+-   Add /account/3pid/delete endpoint. ([\#1714](https://github.com/matrix-org/synapse/issues/1714))
+-   Add config option to configure the Riot URL used in notification emails. Thanks to @aperezdc! ([\#1811](https://github.com/matrix-org/synapse/issues/1811))
+-   Add username and password config options for turn server. Thanks to @xsteadfastx! ([\#1832](https://github.com/matrix-org/synapse/issues/1832))
+-   Implement device lists updates over federation. ([\#1857](https://github.com/matrix-org/synapse/issues/1857), [\#1861](https://github.com/matrix-org/synapse/issues/1861), [\#1864](https://github.com/matrix-org/synapse/issues/1864))
+-   Implement /keys/changes. ([\#1869](https://github.com/matrix-org/synapse/issues/1869), [\#1872](https://github.com/matrix-org/synapse/issues/1872))
 
 Changes:
 
 -   Improve IPv6 support (PR #1696). Thanks to @kyrias and @glyph!
--   Log which files we saved attachments to in the `media_repository` (PR #1791)
--   Linearize updates to membership via PUT /state/ to better handle multiple joins (PR #1787)
--   Limit number of entries to prefill from cache on startup (PR #1792)
--   Remove `full_twisted_stacktraces` option (PR #1802)
--   Measure size of some caches by sum of the size of cached values (PR #1815)
--   Measure metrics of `string_cache` (PR #1821)
--   Reduce logging verbosity (PR #1822, #1823, #1824)
--   Don't clobber a displayname or `avatar_url` if provided by an m.room.member event (PR #1852)
--   Better handle 401/404 response for federation /send/ (PR #1866, #1871)
+-   Log which files we saved attachments to in the `media_repository`. ([\#1791](https://github.com/matrix-org/synapse/issues/1791))
+-   Linearize updates to membership via PUT /state/ to better handle multiple joins. ([\#1787](https://github.com/matrix-org/synapse/issues/1787))
+-   Limit number of entries to prefill from cache on startup. ([\#1792](https://github.com/matrix-org/synapse/issues/1792))
+-   Remove `full_twisted_stacktraces` option. ([\#1802](https://github.com/matrix-org/synapse/issues/1802))
+-   Measure size of some caches by sum of the size of cached values. ([\#1815](https://github.com/matrix-org/synapse/issues/1815))
+-   Measure metrics of `string_cache`. ([\#1821](https://github.com/matrix-org/synapse/issues/1821))
+-   Reduce logging verbosity. ([\#1822](https://github.com/matrix-org/synapse/issues/1822), [\#1823](https://github.com/matrix-org/synapse/issues/1823), [\#1824](https://github.com/matrix-org/synapse/issues/1824))
+-   Don't clobber a displayname or `avatar_url` if provided by an m.room.member event. ([\#1852](https://github.com/matrix-org/synapse/issues/1852))
+-   Better handle 401/404 response for federation /send/. ([\#1866](https://github.com/matrix-org/synapse/issues/1866), [\#1871](https://github.com/matrix-org/synapse/issues/1871))
 
 Fixes:
 
--   Fix ability to change password to a non-ascii one (PR #1711)
--   Fix push getting stuck due to looking at the wrong view of state (PR #1820)
--   Fix email address comparison to be case insensitive (PR #1827)
--   Fix occasional inconsistencies of room membership (PR #1836, #1840)
+-   Fix ability to change password to a non-ascii one. ([\#1711](https://github.com/matrix-org/synapse/issues/1711))
+-   Fix push getting stuck due to looking at the wrong view of state. ([\#1820](https://github.com/matrix-org/synapse/issues/1820))
+-   Fix email address comparison to be case insensitive. ([\#1827](https://github.com/matrix-org/synapse/issues/1827))
+-   Fix occasional inconsistencies of room membership. ([\#1836](https://github.com/matrix-org/synapse/issues/1836), [\#1840](https://github.com/matrix-org/synapse/issues/1840))
 
 Performance:
 
--   Don't block messages sending on bumping presence (PR #1789)
--   Change `device_inbox` stream index to include user (PR #1793)
--   Optimise state resolution (PR #1818)
--   Use DB cache of joined users for presence (PR #1862)
--   Add an index to make membership queries faster (PR #1867)
+-   Don't block messages sending on bumping presence. ([\#1789](https://github.com/matrix-org/synapse/issues/1789))
+-   Change `device_inbox` stream index to include user. ([\#1793](https://github.com/matrix-org/synapse/issues/1793))
+-   Optimise state resolution. ([\#1818](https://github.com/matrix-org/synapse/issues/1818))
+-   Use DB cache of joined users for presence. ([\#1862](https://github.com/matrix-org/synapse/issues/1862))
+-   Add an index to make membership queries faster. ([\#1867](https://github.com/matrix-org/synapse/issues/1867))
 
 Changes in synapse v0.18.7 (2017-01-09)
 =======================================
@@ -2181,63 +2181,63 @@ Changes in synapse v0.18.6-rc3 (2017-01-05)
 
 Bug fixes:
 
--   Fix bug where we failed to send ban events to the banned server (PR #1758)
--   Fix bug where we sent event that didn't originate on this server to other servers (PR #1764)
--   Fix bug where processing an event from a remote server took a long time because we were making long HTTP requests (PR #1765, PR #1744)
+-   Fix bug where we failed to send ban events to the banned server. ([\#1758](https://github.com/matrix-org/synapse/issues/1758))
+-   Fix bug where we sent event that didn't originate on this server to other servers. ([\#1764](https://github.com/matrix-org/synapse/issues/1764))
+-   Fix bug where processing an event from a remote server took a long time because we were making long HTTP requests. ([\#1765](https://github.com/matrix-org/synapse/issues/1765), [\#1744](https://github.com/matrix-org/synapse/issues/1744))
 
 Changes:
 
--   Improve logging for debugging deadlocks (PR #1766, PR #1767)
+-   Improve logging for debugging deadlocks. ([\#1766](https://github.com/matrix-org/synapse/issues/1766), [\#1767](https://github.com/matrix-org/synapse/issues/1767))
 
 Changes in synapse v0.18.6-rc2 (2016-12-30)
 ===========================================
 
 Bug fixes:
 
--   Fix memory leak in twisted by initialising logging correctly (PR #1731)
--   Fix bug where fetching missing events took an unacceptable amount of time in large rooms (PR #1734)
+-   Fix memory leak in twisted by initialising logging correctly. ([\#1731](https://github.com/matrix-org/synapse/issues/1731))
+-   Fix bug where fetching missing events took an unacceptable amount of time in large rooms. ([\#1734](https://github.com/matrix-org/synapse/issues/1734))
 
 Changes in synapse v0.18.6-rc1 (2016-12-29)
 ===========================================
 
 Bug fixes:
 
--   Make sure that outbound connections are closed (PR #1725)
+-   Make sure that outbound connections are closed. ([\#1725](https://github.com/matrix-org/synapse/issues/1725))
 
 Changes in synapse v0.18.5 (2016-12-16)
 =======================================
 
 Bug fixes:
 
--   Fix federation /backfill returning events it shouldn't (PR #1700)
--   Fix crash in url preview (PR #1701)
+-   Fix federation /backfill returning events it shouldn't. ([\#1700](https://github.com/matrix-org/synapse/issues/1700))
+-   Fix crash in url preview. ([\#1701](https://github.com/matrix-org/synapse/issues/1701))
 
 Changes in synapse v0.18.5-rc3 (2016-12-13)
 ===========================================
 
 Features:
 
--   Add support for E2E for guests (PR #1653)
--   Add new API appservice specific public room list (PR #1676)
--   Add new room membership APIs (PR #1680)
+-   Add support for E2E for guests. ([\#1653](https://github.com/matrix-org/synapse/issues/1653))
+-   Add new API appservice specific public room list. ([\#1676](https://github.com/matrix-org/synapse/issues/1676))
+-   Add new room membership APIs. ([\#1680](https://github.com/matrix-org/synapse/issues/1680))
 
 Changes:
 
--   Enable guest access for private rooms by default (PR #653)
--   Limit the number of events that can be created on a given room concurrently (PR #1620)
--   Log the args that we have on UI auth completion (PR #1649)
--   Stop generating `refresh_tokens` (PR #1654)
--   Stop putting a time caveat on access tokens (PR #1656)
--   Remove unspecced GET endpoints for e2e keys (PR #1694)
+-   Enable guest access for private rooms by default. ([\#653](https://github.com/matrix-org/synapse/issues/653))
+-   Limit the number of events that can be created on a given room concurrently. ([\#1620](https://github.com/matrix-org/synapse/issues/1620))
+-   Log the args that we have on UI auth completion. ([\#1649](https://github.com/matrix-org/synapse/issues/1649))
+-   Stop generating `refresh_tokens`. ([\#1654](https://github.com/matrix-org/synapse/issues/1654))
+-   Stop putting a time caveat on access tokens. ([\#1656](https://github.com/matrix-org/synapse/issues/1656))
+-   Remove unspecced GET endpoints for e2e keys. ([\#1694](https://github.com/matrix-org/synapse/issues/1694))
 
 Bug fixes:
 
--   Fix handling of 500 and 429's over federation (PR #1650)
--   Fix Content-Type header parsing (PR #1660)
--   Fix error when previewing sites that include unicode, thanks to kyrias (PR #1664)
--   Fix some cases where we drop read receipts (PR #1678)
--   Fix bug where calls to `/sync` didn't correctly timeout (PR #1683)
--   Fix bug where E2E key query would fail if a single remote host failed (PR #1686)
+-   Fix handling of 500 and 429's over federation. ([\#1650](https://github.com/matrix-org/synapse/issues/1650))
+-   Fix Content-Type header parsing. ([\#1660](https://github.com/matrix-org/synapse/issues/1660))
+-   Fix error when previewing sites that include unicode, thanks to kyrias. ([\#1664](https://github.com/matrix-org/synapse/issues/1664))
+-   Fix some cases where we drop read receipts. ([\#1678](https://github.com/matrix-org/synapse/issues/1678))
+-   Fix bug where calls to `/sync` didn't correctly timeout. ([\#1683](https://github.com/matrix-org/synapse/issues/1683))
+-   Fix bug where E2E key query would fail if a single remote host failed. ([\#1686](https://github.com/matrix-org/synapse/issues/1686))
 
 Changes in synapse v0.18.5-rc2 (2016-11-24)
 ===========================================
@@ -2251,37 +2251,37 @@ Changes in synapse v0.18.5-rc1 (2016-11-24)
 
 Features:
 
--   Implement `event_fields` in filters (PR #1638)
+-   Implement `event_fields` in filters. ([\#1638](https://github.com/matrix-org/synapse/issues/1638))
 
 Changes:
 
--   Use external ldap auth package (PR #1628)
--   Split out federation transaction sending to a worker (PR #1635)
--   Fail with a coherent error message if /sync?filter= is invalid (PR #1636)
--   More efficient notif count queries (PR #1644)
+-   Use external ldap auth package. ([\#1628](https://github.com/matrix-org/synapse/issues/1628))
+-   Split out federation transaction sending to a worker. ([\#1635](https://github.com/matrix-org/synapse/issues/1635))
+-   Fail with a coherent error message if /sync?filter= is invalid. ([\#1636](https://github.com/matrix-org/synapse/issues/1636))
+-   More efficient notif count queries. ([\#1644](https://github.com/matrix-org/synapse/issues/1644))
 
 Changes in synapse v0.18.4 (2016-11-22)
 =======================================
 
 Bug fixes:
 
--   Add workaround for buggy clients that the fail to register (PR #1632)
+-   Add workaround for buggy clients that the fail to register. ([\#1632](https://github.com/matrix-org/synapse/issues/1632))
 
 Changes in synapse v0.18.4-rc1 (2016-11-14)
 ===========================================
 
 Changes:
 
--   Various database efficiency improvements (PR #1188, #1192)
--   Update default config to blacklist more internal IPs, thanks to Euan Kemp (PR #1198)
--   Allow specifying duration in minutes in config, thanks to Daniel Dent (PR #1625)
+-   Various database efficiency improvements. ([\#1188](https://github.com/matrix-org/synapse/issues/1188), [\#1192](https://github.com/matrix-org/synapse/issues/1192))
+-   Update default config to blacklist more internal IPs, thanks to Euan Kemp. ([\#1198](https://github.com/matrix-org/synapse/issues/1198))
+-   Allow specifying duration in minutes in config, thanks to Daniel Dent. ([\#1625](https://github.com/matrix-org/synapse/issues/1625))
 
 Bug fixes:
 
--   Fix media repo to set CORs headers on responses (PR #1190)
--   Fix registration to not error on non-ascii passwords (PR #1191)
--   Fix create event code to limit the number of `prev_events` (PR #1615)
--   Fix bug in transaction ID deduplication (PR #1624)
+-   Fix media repo to set CORs headers on responses. ([\#1190](https://github.com/matrix-org/synapse/issues/1190))
+-   Fix registration to not error on non-ascii passwords. ([\#1191](https://github.com/matrix-org/synapse/issues/1191))
+-   Fix create event code to limit the number of `prev_events`. ([\#1615](https://github.com/matrix-org/synapse/issues/1615))
+-   Fix bug in transaction ID deduplication. ([\#1624](https://github.com/matrix-org/synapse/issues/1624))
 
 Changes in synapse v0.18.3 (2016-11-08)
 =======================================
@@ -2302,32 +2302,32 @@ Changes in synapse v0.18.2-rc5 (2016-10-28)
 
 Bug fixes:
 
--   Fix prometheus process metrics in worker processes (PR #1184)
+-   Fix prometheus process metrics in worker processes. ([\#1184](https://github.com/matrix-org/synapse/issues/1184))
 
 Changes in synapse v0.18.2-rc4 (2016-10-27)
 ===========================================
 
 Bug fixes:
 
--   Fix `user_threepids` schema delta, which in some instances prevented startup after upgrade (PR #1183)
+-   Fix `user_threepids` schema delta, which in some instances prevented startup after upgrade. ([\#1183](https://github.com/matrix-org/synapse/issues/1183))
 
 Changes in synapse v0.18.2-rc3 (2016-10-27)
 ===========================================
 
 Changes:
 
--   Allow clients to supply access tokens as headers (PR #1098)
--   Clarify error codes for GET /filter/, thanks to Alexander Maznev (PR #1164)
--   Make password reset email field case insensitive (PR #1170)
--   Reduce redundant database work in email pusher (PR #1174)
--   Allow configurable rate limiting per AS (PR #1175)
--   Check whether to ratelimit sooner to avoid work (PR #1176)
--   Standardise prometheus metrics (PR #1177)
+-   Allow clients to supply access tokens as headers. ([\#1098](https://github.com/matrix-org/synapse/issues/1098))
+-   Clarify error codes for GET /filter/, thanks to Alexander Maznev. ([\#1164](https://github.com/matrix-org/synapse/issues/1164))
+-   Make password reset email field case insensitive. ([\#1170](https://github.com/matrix-org/synapse/issues/1170))
+-   Reduce redundant database work in email pusher. ([\#1174](https://github.com/matrix-org/synapse/issues/1174))
+-   Allow configurable rate limiting per AS. ([\#1175](https://github.com/matrix-org/synapse/issues/1175))
+-   Check whether to ratelimit sooner to avoid work. ([\#1176](https://github.com/matrix-org/synapse/issues/1176))
+-   Standardise prometheus metrics. ([\#1177](https://github.com/matrix-org/synapse/issues/1177))
 
 Bug fixes:
 
--   Fix incredibly slow back pagination query (PR #1178)
--   Fix infinite typing bug (PR #1179)
+-   Fix incredibly slow back pagination query. ([\#1178](https://github.com/matrix-org/synapse/issues/1178))
+-   Fix infinite typing bug. ([\#1179](https://github.com/matrix-org/synapse/issues/1179))
 
 Changes in synapse v0.18.2-rc2 (2016-10-25)
 ===========================================
@@ -2339,20 +2339,20 @@ Changes in synapse v0.18.2-rc1 (2016-10-17)
 
 Changes:
 
--   Remove redundant `event_auth` index (PR #1113)
--   Reduce DB hits for replication (PR #1141)
--   Implement pluggable password auth (PR #1155)
--   Remove rate limiting from app service senders and fix `get_or_create_user` requester, thanks to Patrik Oldsberg (PR #1157)
--   window.postmessage for Interactive Auth fallback (PR #1159)
--   Use sys.executable instead of hardcoded python, thanks to Pedro Larroy (PR #1162)
--   Add config option for adding additional TLS fingerprints (PR #1167)
--   User-interactive auth on delete device (PR #1168)
+-   Remove redundant `event_auth` index. ([\#1113](https://github.com/matrix-org/synapse/issues/1113))
+-   Reduce DB hits for replication. ([\#1141](https://github.com/matrix-org/synapse/issues/1141))
+-   Implement pluggable password auth. ([\#1155](https://github.com/matrix-org/synapse/issues/1155))
+-   Remove rate limiting from app service senders and fix `get_or_create_user` requester, thanks to Patrik Oldsberg. ([\#1157](https://github.com/matrix-org/synapse/issues/1157))
+-   window.postmessage for Interactive Auth fallback. ([\#1159](https://github.com/matrix-org/synapse/issues/1159))
+-   Use sys.executable instead of hardcoded python, thanks to Pedro Larroy. ([\#1162](https://github.com/matrix-org/synapse/issues/1162))
+-   Add config option for adding additional TLS fingerprints. ([\#1167](https://github.com/matrix-org/synapse/issues/1167))
+-   User-interactive auth on delete device. ([\#1168](https://github.com/matrix-org/synapse/issues/1168))
 
 Bug fixes:
 
--   Fix not being allowed to set your own `state_key`, thanks to Patrik Oldsberg (PR #1150)
--   Fix interactive auth to return 401 from for incorrect password (PR #1160, #1166)
--   Fix email push notifs being dropped (PR #1169)
+-   Fix not being allowed to set your own `state_key`, thanks to Patrik Oldsberg. ([\#1150](https://github.com/matrix-org/synapse/issues/1150))
+-   Fix interactive auth to return 401 from for incorrect password. ([\#1160](https://github.com/matrix-org/synapse/issues/1160), [\#1166](https://github.com/matrix-org/synapse/issues/1166))
+-   Fix email push notifs being dropped. ([\#1169](https://github.com/matrix-org/synapse/issues/1169))
 
 Changes in synapse v0.18.1 (2016-10-05)
 =======================================
@@ -2364,19 +2364,19 @@ Changes in synapse v0.18.1-rc1 (2016-09-30)
 
 Features:
 
--   Add `total_room_count_estimate` to `/publicRooms` (PR #1133)
+-   Add `total_room_count_estimate` to `/publicRooms`. ([\#1133](https://github.com/matrix-org/synapse/issues/1133))
 
 Changes:
 
--   Time out typing over federation (PR #1140)
--   Restructure LDAP authentication (PR #1153)
+-   Time out typing over federation. ([\#1140](https://github.com/matrix-org/synapse/issues/1140))
+-   Restructure LDAP authentication. ([\#1153](https://github.com/matrix-org/synapse/issues/1153))
 
 Bug fixes:
 
--   Fix 3pid invites when server is already in the room (PR #1136)
--   Fix upgrading with SQLite taking lots of CPU for a few days after upgrade (PR #1144)
--   Fix upgrading from very old database versions (PR #1145)
--   Fix port script to work with recently added tables (PR #1146)
+-   Fix 3pid invites when server is already in the room. ([\#1136](https://github.com/matrix-org/synapse/issues/1136))
+-   Fix upgrading with SQLite taking lots of CPU for a few days after upgrade. ([\#1144](https://github.com/matrix-org/synapse/issues/1144))
+-   Fix upgrading from very old database versions. ([\#1145](https://github.com/matrix-org/synapse/issues/1145))
+-   Fix port script to work with recently added tables. ([\#1146](https://github.com/matrix-org/synapse/issues/1146))
 
 Changes in synapse v0.18.0 (2016-09-19)
 =======================================
@@ -2385,39 +2385,39 @@ The release includes major changes to the state storage database schemas, which 
 
 Changes:
 
--   Make public room search case insensitive (PR #1127)
+-   Make public room search case insensitive. ([\#1127](https://github.com/matrix-org/synapse/issues/1127))
 
 Bug fixes:
 
--   Fix and clean up publicRooms pagination (PR #1129)
+-   Fix and clean up publicRooms pagination. ([\#1129](https://github.com/matrix-org/synapse/issues/1129))
 
 Changes in synapse v0.18.0-rc1 (2016-09-16)
 ===========================================
 
 Features:
 
--   Add `only=highlight` on `/notifications` (PR #1081)
--   Add server param to /publicRooms (PR #1082)
--   Allow clients to ask for the whole of a single state event (PR #1094)
--   Add `is_direct` param to /createRoom (PR #1108)
--   Add pagination support to publicRooms (PR #1121)
--   Add very basic filter API to /publicRooms (PR #1126)
--   Add basic direct to device messaging support for E2E (PR #1074, #1084, #1104, #1111)
+-   Add `only=highlight` on `/notifications`. ([\#1081](https://github.com/matrix-org/synapse/issues/1081))
+-   Add server param to /publicRooms. ([\#1082](https://github.com/matrix-org/synapse/issues/1082))
+-   Allow clients to ask for the whole of a single state event. ([\#1094](https://github.com/matrix-org/synapse/issues/1094))
+-   Add `is_direct` param to /createRoom. ([\#1108](https://github.com/matrix-org/synapse/issues/1108))
+-   Add pagination support to publicRooms. ([\#1121](https://github.com/matrix-org/synapse/issues/1121))
+-   Add very basic filter API to /publicRooms. ([\#1126](https://github.com/matrix-org/synapse/issues/1126))
+-   Add basic direct to device messaging support for E2E. ([\#1074](https://github.com/matrix-org/synapse/issues/1074), [\#1084](https://github.com/matrix-org/synapse/issues/1084), [\#1104](https://github.com/matrix-org/synapse/issues/1104), [\#1111](https://github.com/matrix-org/synapse/issues/1111))
 
 Changes:
 
--   Move to storing `state_groups_state` as deltas, greatly reducing DB size (PR #1065)
--   Reduce amount of state pulled out of the DB during common requests (PR #1069)
--   Allow PDF to be rendered from media repo (PR #1071)
--   Reindex `state_groups_state` after pruning (PR #1085)
--   Clobber EDUs in send queue (PR #1095)
--   Conform better to the CAS protocol specification (PR #1100)
--   Limit how often we ask for keys from dead servers (PR #1114)
+-   Move to storing `state_groups_state` as deltas, greatly reducing DB size. ([\#1065](https://github.com/matrix-org/synapse/issues/1065))
+-   Reduce amount of state pulled out of the DB during common requests. ([\#1069](https://github.com/matrix-org/synapse/issues/1069))
+-   Allow PDF to be rendered from media repo. ([\#1071](https://github.com/matrix-org/synapse/issues/1071))
+-   Reindex `state_groups_state` after pruning. ([\#1085](https://github.com/matrix-org/synapse/issues/1085))
+-   Clobber EDUs in send queue. ([\#1095](https://github.com/matrix-org/synapse/issues/1095))
+-   Conform better to the CAS protocol specification. ([\#1100](https://github.com/matrix-org/synapse/issues/1100))
+-   Limit how often we ask for keys from dead servers. ([\#1114](https://github.com/matrix-org/synapse/issues/1114))
 
 Bug fixes:
 
--   Fix /notifications API when used with `from` param (PR #1080)
--   Fix backfill when cannot find an event. (PR #1107)
+-   Fix /notifications API when used with `from` param. ([\#1080](https://github.com/matrix-org/synapse/issues/1080))
+-   Fix backfill when cannot find an event.. ([\#1107](https://github.com/matrix-org/synapse/issues/1107))
 
 Changes in synapse v0.17.3 (2016-09-09)
 =======================================
@@ -2436,20 +2436,20 @@ Changes in synapse v0.17.2-rc1 (2016-09-05)
 
 Features:
 
--   Start adding store-and-forward direct-to-device messaging (PR #1046, #1050, #1062, #1066)
+-   Start adding store-and-forward direct-to-device messaging. ([\#1046](https://github.com/matrix-org/synapse/issues/1046), [\#1050](https://github.com/matrix-org/synapse/issues/1050), [\#1062](https://github.com/matrix-org/synapse/issues/1062), [\#1066](https://github.com/matrix-org/synapse/issues/1066))
 
 Changes:
 
--   Avoid pulling the full state of a room out so often (PR #1047, #1049, #1063, #1068)
--   Don't notify for online to online presence transitions. (PR #1054)
--   Occasionally persist unpersisted presence updates (PR #1055)
--   Allow application services to have an optional `url` (PR #1056)
--   Clean up old sent transactions from DB (PR #1059)
+-   Avoid pulling the full state of a room out so often. ([\#1047](https://github.com/matrix-org/synapse/issues/1047), [\#1049](https://github.com/matrix-org/synapse/issues/1049), [\#1063](https://github.com/matrix-org/synapse/issues/1063), [\#1068](https://github.com/matrix-org/synapse/issues/1068))
+-   Don't notify for online to online presence transitions.. ([\#1054](https://github.com/matrix-org/synapse/issues/1054))
+-   Occasionally persist unpersisted presence updates. ([\#1055](https://github.com/matrix-org/synapse/issues/1055))
+-   Allow application services to have an optional `url`. ([\#1056](https://github.com/matrix-org/synapse/issues/1056))
+-   Clean up old sent transactions from DB. ([\#1059](https://github.com/matrix-org/synapse/issues/1059))
 
 Bug fixes:
 
--   Fix None check in backfill (PR #1043)
--   Fix membership changes to be idempotent (PR #1067)
+-   Fix None check in backfill. ([\#1043](https://github.com/matrix-org/synapse/issues/1043))
+-   Fix membership changes to be idempotent. ([\#1067](https://github.com/matrix-org/synapse/issues/1067))
 -   Fix bug in `get_pdu` where it would sometimes return events with incorrect signature
 
 Changes in synapse v0.17.1 (2016-08-24)
@@ -2457,40 +2457,40 @@ Changes in synapse v0.17.1 (2016-08-24)
 
 Changes:
 
--   Delete old `received_transactions` rows (PR #1038)
--   Pass through user-supplied content in `/join/$room_id` (PR #1039)
+-   Delete old `received_transactions` rows. ([\#1038](https://github.com/matrix-org/synapse/issues/1038))
+-   Pass through user-supplied content in `/join/$room_id`. ([\#1039](https://github.com/matrix-org/synapse/issues/1039))
 
 Bug fixes:
 
--   Fix bug with backfill (PR #1040)
+-   Fix bug with backfill. ([\#1040](https://github.com/matrix-org/synapse/issues/1040))
 
 Changes in synapse v0.17.1-rc1 (2016-08-22)
 ===========================================
 
 Features:
 
--   Add notification API (PR #1028)
+-   Add notification API. ([\#1028](https://github.com/matrix-org/synapse/issues/1028))
 
 Changes:
 
--   Don't print stack traces when failing to get remote keys (PR #996)
--   Various federation /event/ perf improvements (PR #998)
--   Only process one local membership event per room at a time (PR #1005)
--   Move default display name push rule (PR #1011, #1023)
--   Fix up preview URL API. Add tests. (PR #1015)
--   Set `Content-Security-Policy` on media repo (PR #1021)
--   Make `notify_interested_services` faster (PR #1022)
--   Add usage stats to prometheus monitoring (PR #1037)
+-   Don't print stack traces when failing to get remote keys. ([\#996](https://github.com/matrix-org/synapse/issues/996))
+-   Various federation /event/ perf improvements. ([\#998](https://github.com/matrix-org/synapse/issues/998))
+-   Only process one local membership event per room at a time. ([\#1005](https://github.com/matrix-org/synapse/issues/1005))
+-   Move default display name push rule. ([\#1011](https://github.com/matrix-org/synapse/issues/1011), [\#1023](https://github.com/matrix-org/synapse/issues/1023))
+-   Fix up preview URL API. Add tests.. ([\#1015](https://github.com/matrix-org/synapse/issues/1015))
+-   Set `Content-Security-Policy` on media repo. ([\#1021](https://github.com/matrix-org/synapse/issues/1021))
+-   Make `notify_interested_services` faster. ([\#1022](https://github.com/matrix-org/synapse/issues/1022))
+-   Add usage stats to prometheus monitoring. ([\#1037](https://github.com/matrix-org/synapse/issues/1037))
 
 Bug fixes:
 
--   Fix token login (PR #993)
--   Fix CAS login (PR #994, #995)
--   Fix /sync to not clobber `status_msg` (PR #997)
--   Fix redacted state events to include `prev_content` (PR #1003)
--   Fix some bugs in the auth/ldap handler (PR #1007)
--   Fix backfill request to limit URI length, so that remotes Don't reject the requests due to path length limits (PR #1012)
--   Fix AS push code to not send duplicate events (PR #1025)
+-   Fix token login. ([\#993](https://github.com/matrix-org/synapse/issues/993))
+-   Fix CAS login. ([\#994](https://github.com/matrix-org/synapse/issues/994), [\#995](https://github.com/matrix-org/synapse/issues/995))
+-   Fix /sync to not clobber `status_msg`. ([\#997](https://github.com/matrix-org/synapse/issues/997))
+-   Fix redacted state events to include `prev_content`. ([\#1003](https://github.com/matrix-org/synapse/issues/1003))
+-   Fix some bugs in the auth/ldap handler. ([\#1007](https://github.com/matrix-org/synapse/issues/1007))
+-   Fix backfill request to limit URI length, so that remotes Don't reject the requests due to path length limits. ([\#1012](https://github.com/matrix-org/synapse/issues/1012))
+-   Fix AS push code to not send duplicate events. ([\#1025](https://github.com/matrix-org/synapse/issues/1025))
 
 Changes in synapse v0.17.0 (2016-08-08)
 =======================================
@@ -2501,42 +2501,42 @@ This release changes the LDAP configuration format in a backwards incompatible w
 
 Changes:
 
--   Add federation /version API (PR #990)
--   Make psutil dependency optional (PR #992)
+-   Add federation /version API. ([\#990](https://github.com/matrix-org/synapse/issues/990))
+-   Make psutil dependency optional. ([\#992](https://github.com/matrix-org/synapse/issues/992))
 
 Bug fixes:
 
--   Fix URL preview API to exclude HTML comments in description (PR #988)
--   Fix error handling of remote joins (PR #991)
+-   Fix URL preview API to exclude HTML comments in description. ([\#988](https://github.com/matrix-org/synapse/issues/988))
+-   Fix error handling of remote joins. ([\#991](https://github.com/matrix-org/synapse/issues/991))
 
 Changes in synapse v0.17.0-rc4 (2016-08-05)
 ===========================================
 
 Changes:
 
--   Change the way we summarize URLs when previewing (PR #973)
--   Add new `/state_ids/` federation API (PR #979)
--   Speed up processing of `/state/` response (PR #986)
+-   Change the way we summarize URLs when previewing. ([\#973](https://github.com/matrix-org/synapse/issues/973))
+-   Add new `/state_ids/` federation API. ([\#979](https://github.com/matrix-org/synapse/issues/979))
+-   Speed up processing of `/state/` response. ([\#986](https://github.com/matrix-org/synapse/issues/986))
 
 Bug fixes:
 
--   Fix event persistence when event has already been partially persisted (PR #975, #983, #985)
--   Fix port script to also copy across backfilled events (PR #982)
+-   Fix event persistence when event has already been partially persisted. ([\#975](https://github.com/matrix-org/synapse/issues/975), [\#983](https://github.com/matrix-org/synapse/issues/983), [\#985](https://github.com/matrix-org/synapse/issues/985))
+-   Fix port script to also copy across backfilled events. ([\#982](https://github.com/matrix-org/synapse/issues/982))
 
 Changes in synapse v0.17.0-rc3 (2016-08-02)
 ===========================================
 
 Changes:
 
--   Forbid non-ASes from registering users whose names begin with `_` (PR #958)
--   Add some basic admin API docs (PR #963)
+-   Forbid non-ASes from registering users whose names begin with `_`. ([\#958](https://github.com/matrix-org/synapse/issues/958))
+-   Add some basic admin API docs. ([\#963](https://github.com/matrix-org/synapse/issues/963))
 
 Bug fixes:
 
--   Send the correct host header when fetching keys (PR #941)
--   Fix joining a room that has missing auth events (PR #964)
--   Fix various push bugs (PR #966, #970)
--   Fix adding emails on registration (PR #968)
+-   Send the correct host header when fetching keys. ([\#941](https://github.com/matrix-org/synapse/issues/941))
+-   Fix joining a room that has missing auth events. ([\#964](https://github.com/matrix-org/synapse/issues/964))
+-   Fix various push bugs. ([\#966](https://github.com/matrix-org/synapse/issues/966), [\#970](https://github.com/matrix-org/synapse/issues/970))
+-   Fix adding emails on registration. ([\#968](https://github.com/matrix-org/synapse/issues/968))
 
 Changes in synapse v0.17.0-rc2 (2016-08-02)
 ===========================================
@@ -2550,47 +2550,47 @@ This release changes the LDAP configuration format in a backwards incompatible w
 
 Features:
 
--   Add `purge_media_cache` admin API (PR #902)
--   Add deactivate account admin API (PR #903)
+-   Add `purge_media_cache` admin API. ([\#902](https://github.com/matrix-org/synapse/issues/902))
+-   Add deactivate account admin API. ([\#903](https://github.com/matrix-org/synapse/issues/903))
 -   Add optional pepper to password hashing (PR #907, #910 by KentShikama)
--   Add an admin option to shared secret registration (breaks backwards compat) (PR #909)
--   Add purge local room history API (PR #911, #923, #924)
--   Add requestToken endpoints (PR #915)
--   Add an /account/deactivate endpoint (PR #921)
--   Add filter param to /messages. Add `contains_url` to filter. (PR #922)
--   Add `device_id` support to /login (PR #929)
--   Add `device_id` support to /v2/register flow. (PR #937, #942)
--   Add GET /devices endpoint (PR #939, #944)
--   Add GET /device/{deviceId} (PR #943)
--   Add update and delete APIs for devices (PR #949)
+-   Add an admin option to shared secret registration (breaks backwards compat). ([\#909](https://github.com/matrix-org/synapse/issues/909))
+-   Add purge local room history API. ([\#911](https://github.com/matrix-org/synapse/issues/911), [\#923](https://github.com/matrix-org/synapse/issues/923), [\#924](https://github.com/matrix-org/synapse/issues/924))
+-   Add requestToken endpoints. ([\#915](https://github.com/matrix-org/synapse/issues/915))
+-   Add an /account/deactivate endpoint. ([\#921](https://github.com/matrix-org/synapse/issues/921))
+-   Add filter param to /messages. Add `contains_url` to filter.. ([\#922](https://github.com/matrix-org/synapse/issues/922))
+-   Add `device_id` support to /login. ([\#929](https://github.com/matrix-org/synapse/issues/929))
+-   Add `device_id` support to /v2/register flow.. ([\#937](https://github.com/matrix-org/synapse/issues/937), [\#942](https://github.com/matrix-org/synapse/issues/942))
+-   Add GET /devices endpoint. ([\#939](https://github.com/matrix-org/synapse/issues/939), [\#944](https://github.com/matrix-org/synapse/issues/944))
+-   Add GET /device/{deviceId}. ([\#943](https://github.com/matrix-org/synapse/issues/943))
+-   Add update and delete APIs for devices. ([\#949](https://github.com/matrix-org/synapse/issues/949))
 
 Changes:
 
 -   Rewrite LDAP Authentication against ldap3 (PR #843 by mweinelt)
--   Linearize some federation endpoints based on `(origin, room_id)` (PR #879)
--   Remove the legacy v0 content upload API. (PR #888)
--   Use similar naming we use in email notifs for push (PR #894)
+-   Linearize some federation endpoints based on `(origin, room_id)`. ([\#879](https://github.com/matrix-org/synapse/issues/879))
+-   Remove the legacy v0 content upload API.. ([\#888](https://github.com/matrix-org/synapse/issues/888))
+-   Use similar naming we use in email notifs for push. ([\#894](https://github.com/matrix-org/synapse/issues/894))
 -   Optionally include password hash in createUser endpoint (PR #905 by KentShikama)
--   Use a query that postgresql optimises better for `get_events_around` (PR #906)
+-   Use a query that postgresql optimises better for `get_events_around`. ([\#906](https://github.com/matrix-org/synapse/issues/906))
 -   Fall back to '`username` if `user` is not given for appservice registration. (PR #927 by Half-Shot)
--   Add metrics for psutil derived memory usage (PR #936)
--   Record `device_id` in `client_ips` (PR #938)
--   Send the correct host header when fetching keys (PR #941)
--   Log the hostname the reCAPTCHA was completed on (PR #946)
--   Make the device id on e2e key upload optional (PR #956)
--   Add r0.2.0 to the "supported versions" list (PR #960)
--   Don't include name of room for invites in push (PR #961)
+-   Add metrics for psutil derived memory usage. ([\#936](https://github.com/matrix-org/synapse/issues/936))
+-   Record `device_id` in `client_ips`. ([\#938](https://github.com/matrix-org/synapse/issues/938))
+-   Send the correct host header when fetching keys. ([\#941](https://github.com/matrix-org/synapse/issues/941))
+-   Log the hostname the reCAPTCHA was completed on. ([\#946](https://github.com/matrix-org/synapse/issues/946))
+-   Make the device id on e2e key upload optional. ([\#956](https://github.com/matrix-org/synapse/issues/956))
+-   Add r0.2.0 to the "supported versions" list. ([\#960](https://github.com/matrix-org/synapse/issues/960))
+-   Don't include name of room for invites in push. ([\#961](https://github.com/matrix-org/synapse/issues/961))
 
 Bug fixes:
 
--   Fix substitution failure in mail template (PR #887)
--   Put most recent 20 messages in email notif (PR #892)
--   Ensure that the guest user is in the database when upgrading accounts (PR #914)
--   Fix various edge cases in auth handling (PR #919)
--   Fix 500 ISE when sending alias event without a `state_key` (PR #925)
--   Fix bug where we stored rejections in the `state_group`, persist all rejections (PR #948)
--   Fix lack of check of if the user is banned when handling 3pid invites (PR #952)
--   Fix a couple of bugs in the transaction and keyring code (PR #954, #955)
+-   Fix substitution failure in mail template. ([\#887](https://github.com/matrix-org/synapse/issues/887))
+-   Put most recent 20 messages in email notif. ([\#892](https://github.com/matrix-org/synapse/issues/892))
+-   Ensure that the guest user is in the database when upgrading accounts. ([\#914](https://github.com/matrix-org/synapse/issues/914))
+-   Fix various edge cases in auth handling. ([\#919](https://github.com/matrix-org/synapse/issues/919))
+-   Fix 500 ISE when sending alias event without a `state_key`. ([\#925](https://github.com/matrix-org/synapse/issues/925))
+-   Fix bug where we stored rejections in the `state_group`, persist all rejections. ([\#948](https://github.com/matrix-org/synapse/issues/948))
+-   Fix lack of check of if the user is banned when handling 3pid invites. ([\#952](https://github.com/matrix-org/synapse/issues/952))
+-   Fix a couple of bugs in the transaction and keyring code. ([\#954](https://github.com/matrix-org/synapse/issues/954), [\#955](https://github.com/matrix-org/synapse/issues/955))
 
 Changes in synapse v0.16.1-r1 (2016-07-08)
 ==========================================
@@ -2604,13 +2604,13 @@ Changes in synapse v0.16.1 (2016-06-20)
 
 Bug fixes:
 
--   Fix assorted bugs in `/preview_url` (PR #872)
--   Fix TypeError when setting unicode passwords (PR #873)
+-   Fix assorted bugs in `/preview_url`. ([\#872](https://github.com/matrix-org/synapse/issues/872))
+-   Fix TypeError when setting unicode passwords. ([\#873](https://github.com/matrix-org/synapse/issues/873))
 
 Performance improvements:
 
--   Turn `use_frozen_events` off by default (PR #877)
--   Disable responding with canonical json for federation (PR #878)
+-   Turn `use_frozen_events` off by default. ([\#877](https://github.com/matrix-org/synapse/issues/877))
+-   Disable responding with canonical json for federation. ([\#878](https://github.com/matrix-org/synapse/issues/878))
 
 Changes in synapse v0.16.1-rc1 (2016-06-15)
 ===========================================
@@ -2619,20 +2619,20 @@ Features: None
 
 Changes:
 
--   Log requester for `/publicRoom` endpoints when possible (PR #856)
--   502 on `/thumbnail` when can't connect to remote server (PR #862)
--   Linearize fetching of gaps on incoming events (PR #871)
+-   Log requester for `/publicRoom` endpoints when possible. ([\#856](https://github.com/matrix-org/synapse/issues/856))
+-   502 on `/thumbnail` when can't connect to remote server. ([\#862](https://github.com/matrix-org/synapse/issues/862))
+-   Linearize fetching of gaps on incoming events. ([\#871](https://github.com/matrix-org/synapse/issues/871))
 
 Bugs fixes:
 
--   Fix bug where rooms where marked as published by default (PR #857)
--   Fix bug where joining room with an event with invalid sender (PR #868)
--   Fix bug where backfilled events were sent down sync streams (PR #869)
--   Fix bug where outgoing connections could wedge indefinitely, causing push notifications to be unreliable (PR #870)
+-   Fix bug where rooms where marked as published by default. ([\#857](https://github.com/matrix-org/synapse/issues/857))
+-   Fix bug where joining room with an event with invalid sender. ([\#868](https://github.com/matrix-org/synapse/issues/868))
+-   Fix bug where backfilled events were sent down sync streams. ([\#869](https://github.com/matrix-org/synapse/issues/869))
+-   Fix bug where outgoing connections could wedge indefinitely, causing push notifications to be unreliable. ([\#870](https://github.com/matrix-org/synapse/issues/870))
 
 Performance improvements:
 
--   Improve `/publicRooms` performance(PR #859)
+-   Improve `/publicRooms` performance. ([\#859](https://github.com/matrix-org/synapse/issues/859))
 
 Changes in synapse v0.16.0 (2016-06-09)
 =======================================
@@ -2641,31 +2641,31 @@ NB: As of v0.14 all AS config files must have an ID field.
 
 Bug fixes:
 
--   Don't make rooms published by default (PR #857)
+-   Don't make rooms published by default. ([\#857](https://github.com/matrix-org/synapse/issues/857))
 
 Changes in synapse v0.16.0-rc2 (2016-06-08)
 ===========================================
 
 Features:
 
--   Add configuration option for tuning GC via `gc.set_threshold` (PR #849)
+-   Add configuration option for tuning GC via `gc.set_threshold`. ([\#849](https://github.com/matrix-org/synapse/issues/849))
 
 Changes:
 
--   Record metrics about GC (PR #771, #847, #852)
--   Add metric counter for number of persisted events (PR #841)
+-   Record metrics about GC. ([\#771](https://github.com/matrix-org/synapse/issues/771), [\#847](https://github.com/matrix-org/synapse/issues/847), [\#852](https://github.com/matrix-org/synapse/issues/852))
+-   Add metric counter for number of persisted events. ([\#841](https://github.com/matrix-org/synapse/issues/841))
 
 Bug fixes:
 
--   Fix `From` header in email notifications (PR #843)
--   Fix presence where timeouts were not being fired for the first 8h after restarts (PR #842)
+-   Fix `From` header in email notifications. ([\#843](https://github.com/matrix-org/synapse/issues/843))
+-   Fix presence where timeouts were not being fired for the first 8h after restarts. ([\#842](https://github.com/matrix-org/synapse/issues/842))
 -   Fix bug where synapse sent malformed transactions to AS's when retrying transactions (Commits 310197b, 8437906)
 
 Performance improvements:
 
--   Remove event fetching from DB threads (PR #835)
--   Change the way we cache events (PR #836)
--   Add events to cache when we persist them (PR #840)
+-   Remove event fetching from DB threads. ([\#835](https://github.com/matrix-org/synapse/issues/835))
+-   Change the way we cache events. ([\#836](https://github.com/matrix-org/synapse/issues/836))
+-   Add events to cache when we persist them. ([\#840](https://github.com/matrix-org/synapse/issues/840))
 
 Changes in synapse v0.16.0-rc1 (2016-06-03)
 ===========================================
@@ -2675,43 +2675,43 @@ Version 0.15 was not released. See v0.15.0-rc1 below for additional changes.
 Features:
 
 -   Add email notifications for missed messages (PR #759, #786, #799, #810, #815, #821)
--   Add a `url_preview_ip_range_whitelist` config param (PR #760)
--   Add /report endpoint (PR #762)
--   Add basic ignore user API (PR #763)
--   Add an openidish mechanism for proving that you own a given `user_id` (PR #765)
--   Allow clients to specify a `server_name` to avoid "No known servers" (PR #794)
--   Add `secondary_directory_servers` option to fetch room list from other servers (PR #808, #813)
+-   Add a `url_preview_ip_range_whitelist` config param. ([\#760](https://github.com/matrix-org/synapse/issues/760))
+-   Add /report endpoint. ([\#762](https://github.com/matrix-org/synapse/issues/762))
+-   Add basic ignore user API. ([\#763](https://github.com/matrix-org/synapse/issues/763))
+-   Add an openidish mechanism for proving that you own a given `user_id`. ([\#765](https://github.com/matrix-org/synapse/issues/765))
+-   Allow clients to specify a `server_name` to avoid "No known servers". ([\#794](https://github.com/matrix-org/synapse/issues/794))
+-   Add `secondary_directory_servers` option to fetch room list from other servers. ([\#808](https://github.com/matrix-org/synapse/issues/808), [\#813](https://github.com/matrix-org/synapse/issues/813))
 
 Changes:
 
--   Report per request metrics for all of the things using `request_handler` (PR #756)
--   Correctly handle `NULL` password hashes from the database (PR #775)
--   Allow receipts for events we haven't seen in the db (PR #784)
--   Make synctl read a cache factor from config file (PR #785)
--   Increment badge count per missed convo, not per msg (PR #793)
--   Special case `m.room.third_party_invite` event auth to match invites (PR #814)
+-   Report per request metrics for all of the things using `request_handler`. ([\#756](https://github.com/matrix-org/synapse/issues/756))
+-   Correctly handle `NULL` password hashes from the database. ([\#775](https://github.com/matrix-org/synapse/issues/775))
+-   Allow receipts for events we haven't seen in the db. ([\#784](https://github.com/matrix-org/synapse/issues/784))
+-   Make synctl read a cache factor from config file. ([\#785](https://github.com/matrix-org/synapse/issues/785))
+-   Increment badge count per missed convo, not per msg. ([\#793](https://github.com/matrix-org/synapse/issues/793))
+-   Special case `m.room.third_party_invite` event auth to match invites. ([\#814](https://github.com/matrix-org/synapse/issues/814))
 
 Bug fixes:
 
--   Fix typo in `event_auth` servlet path (PR #757)
--   Fix password reset (PR #758)
+-   Fix typo in `event_auth` servlet path. ([\#757](https://github.com/matrix-org/synapse/issues/757))
+-   Fix password reset. ([\#758](https://github.com/matrix-org/synapse/issues/758))
 
 Performance improvements:
 
--   Reduce database inserts when sending transactions (PR #767)
--   Queue events by room for persistence (PR #768)
--   Add cache to `get_user_by_id` (PR #772)
--   Add and use `get_domain_from_id` (PR #773)
--   Use tree cache for `get_linearized_receipts_for_room` (PR #779)
--   Remove unused indices (PR #782)
--   Add caches to `bulk_get_push_rules*` (PR #804)
--   Cache `get_event_reference_hashes` (PR #806)
--   Add `get_users_with_read_receipts_in_room` cache (PR #809)
--   Use state to calculate `get_users_in_room` (PR #811)
--   Load push rules in storage layer so that they get cached (PR #825)
--   Make `get_joined_hosts_for_room` use `get_users_in_room` (PR #828)
--   Poke notifier on next reactor tick (PR #829)
--   Change CacheMetrics to be quicker (PR #830)
+-   Reduce database inserts when sending transactions. ([\#767](https://github.com/matrix-org/synapse/issues/767))
+-   Queue events by room for persistence. ([\#768](https://github.com/matrix-org/synapse/issues/768))
+-   Add cache to `get_user_by_id`. ([\#772](https://github.com/matrix-org/synapse/issues/772))
+-   Add and use `get_domain_from_id`. ([\#773](https://github.com/matrix-org/synapse/issues/773))
+-   Use tree cache for `get_linearized_receipts_for_room`. ([\#779](https://github.com/matrix-org/synapse/issues/779))
+-   Remove unused indices. ([\#782](https://github.com/matrix-org/synapse/issues/782))
+-   Add caches to `bulk_get_push_rules*`. ([\#804](https://github.com/matrix-org/synapse/issues/804))
+-   Cache `get_event_reference_hashes`. ([\#806](https://github.com/matrix-org/synapse/issues/806))
+-   Add `get_users_with_read_receipts_in_room` cache. ([\#809](https://github.com/matrix-org/synapse/issues/809))
+-   Use state to calculate `get_users_in_room`. ([\#811](https://github.com/matrix-org/synapse/issues/811))
+-   Load push rules in storage layer so that they get cached. ([\#825](https://github.com/matrix-org/synapse/issues/825))
+-   Make `get_joined_hosts_for_room` use `get_users_in_room`. ([\#828](https://github.com/matrix-org/synapse/issues/828))
+-   Poke notifier on next reactor tick. ([\#829](https://github.com/matrix-org/synapse/issues/829))
+-   Change CacheMetrics to be quicker. ([\#830](https://github.com/matrix-org/synapse/issues/830))
 
 Changes in synapse v0.15.0-rc1 (2016-04-26)
 ===========================================
@@ -2719,29 +2719,29 @@ Changes in synapse v0.15.0-rc1 (2016-04-26)
 Features:
 
 -   Add login support for Javascript Web Tokens, thanks to Niklas Riekenbrauck (PR #671,\#687)
--   Add URL previewing support (PR #688)
--   Add login support for LDAP, thanks to Christoph Witzany (PR #701)
--   Add GET endpoint for pushers (PR #716)
+-   Add URL previewing support. ([\#688](https://github.com/matrix-org/synapse/issues/688))
+-   Add login support for LDAP, thanks to Christoph Witzany. ([\#701](https://github.com/matrix-org/synapse/issues/701))
+-   Add GET endpoint for pushers. ([\#716](https://github.com/matrix-org/synapse/issues/716))
 
 Changes:
 
--   Never notify for member events (PR #667)
--   Deduplicate identical `/sync` requests (PR #668)
--   Require user to have left room to forget room (PR #673)
--   Use DNS cache if within TTL (PR #677)
--   Let users see their own leave events (PR #699)
--   Deduplicate membership changes (PR #700)
--   Increase performance of pusher code (PR #705)
--   Respond with error status 504 if failed to talk to remote server (PR #731)
--   Increase search performance on postgres (PR #745)
+-   Never notify for member events. ([\#667](https://github.com/matrix-org/synapse/issues/667))
+-   Deduplicate identical `/sync` requests. ([\#668](https://github.com/matrix-org/synapse/issues/668))
+-   Require user to have left room to forget room. ([\#673](https://github.com/matrix-org/synapse/issues/673))
+-   Use DNS cache if within TTL. ([\#677](https://github.com/matrix-org/synapse/issues/677))
+-   Let users see their own leave events. ([\#699](https://github.com/matrix-org/synapse/issues/699))
+-   Deduplicate membership changes. ([\#700](https://github.com/matrix-org/synapse/issues/700))
+-   Increase performance of pusher code. ([\#705](https://github.com/matrix-org/synapse/issues/705))
+-   Respond with error status 504 if failed to talk to remote server. ([\#731](https://github.com/matrix-org/synapse/issues/731))
+-   Increase search performance on postgres. ([\#745](https://github.com/matrix-org/synapse/issues/745))
 
 Bug fixes:
 
--   Fix bug where disabling all notifications still resulted in push (PR #678)
--   Fix bug where users couldn't reject remote invites if remote refused (PR #691)
--   Fix bug where synapse attempted to backfill from itself (PR #693)
--   Fix bug where profile information was not correctly added when joining remote rooms (PR #703)
--   Fix bug where register API required incorrect key name for AS registration (PR #727)
+-   Fix bug where disabling all notifications still resulted in push. ([\#678](https://github.com/matrix-org/synapse/issues/678))
+-   Fix bug where users couldn't reject remote invites if remote refused. ([\#691](https://github.com/matrix-org/synapse/issues/691))
+-   Fix bug where synapse attempted to backfill from itself. ([\#693](https://github.com/matrix-org/synapse/issues/693))
+-   Fix bug where profile information was not correctly added when joining remote rooms. ([\#703](https://github.com/matrix-org/synapse/issues/703))
+-   Fix bug where register API required incorrect key name for AS registration. ([\#727](https://github.com/matrix-org/synapse/issues/727))
 
 Changes in synapse v0.14.0 (2016-03-30)
 =======================================
@@ -2753,58 +2753,58 @@ Changes in synapse v0.14.0-rc2 (2016-03-23)
 
 Features:
 
--   Add published room list API (PR #657)
+-   Add published room list API. ([\#657](https://github.com/matrix-org/synapse/issues/657))
 
 Changes:
 
 -   Change various caches to consume less memory (PR #656, #658, #660, #662, #663, #665)
--   Allow rooms to be published without requiring an alias (PR #664)
+-   Allow rooms to be published without requiring an alias. ([\#664](https://github.com/matrix-org/synapse/issues/664))
 -   Intern common strings in caches to reduce memory footprint (\#666)
 
 Bug fixes:
 
--   Fix reject invites over federation (PR #646)
--   Fix bug where registration was not idempotent (PR #649)
--   Update aliases event after deleting aliases (PR #652)
--   Fix unread notification count, which was sometimes wrong (PR #661)
+-   Fix reject invites over federation. ([\#646](https://github.com/matrix-org/synapse/issues/646))
+-   Fix bug where registration was not idempotent. ([\#649](https://github.com/matrix-org/synapse/issues/649))
+-   Update aliases event after deleting aliases. ([\#652](https://github.com/matrix-org/synapse/issues/652))
+-   Fix unread notification count, which was sometimes wrong. ([\#661](https://github.com/matrix-org/synapse/issues/661))
 
 Changes in synapse v0.14.0-rc1 (2016-03-14)
 ===========================================
 
 Features:
 
--   Add `event_id` to response to state event PUT (PR #581)
--   Allow guest users access to messages in rooms they have joined (PR #587)
--   Add config for what state is included in a room invite (PR #598)
--   Send the inviter's member event in room invite state (PR #607)
--   Add error codes for malformed/bad JSON in /login (PR #608)
--   Add support for changing the actions for default rules (PR #609)
--   Add environment variable `SYNAPSE_CACHE_FACTOR`, default it to 0.1 (PR #612)
--   Add ability for alias creators to delete aliases (PR #614)
--   Add profile information to invites (PR #624)
+-   Add `event_id` to response to state event PUT. ([\#581](https://github.com/matrix-org/synapse/issues/581))
+-   Allow guest users access to messages in rooms they have joined. ([\#587](https://github.com/matrix-org/synapse/issues/587))
+-   Add config for what state is included in a room invite. ([\#598](https://github.com/matrix-org/synapse/issues/598))
+-   Send the inviter's member event in room invite state. ([\#607](https://github.com/matrix-org/synapse/issues/607))
+-   Add error codes for malformed/bad JSON in /login. ([\#608](https://github.com/matrix-org/synapse/issues/608))
+-   Add support for changing the actions for default rules. ([\#609](https://github.com/matrix-org/synapse/issues/609))
+-   Add environment variable `SYNAPSE_CACHE_FACTOR`, default it to 0.1. ([\#612](https://github.com/matrix-org/synapse/issues/612))
+-   Add ability for alias creators to delete aliases. ([\#614](https://github.com/matrix-org/synapse/issues/614))
+-   Add profile information to invites. ([\#624](https://github.com/matrix-org/synapse/issues/624))
 
 Changes:
 
--   Enforce `user_id` exclusivity for AS registrations (PR #572)
--   Make adding push rules idempotent (PR #587)
--   Improve presence performance (PR #582, #586)
--   Change presence semantics for `last_active_ago` (PR #582, #586)
--   Don't allow `m.room.create` to be changed (PR #596)
--   Add 800x600 to default list of valid thumbnail sizes (PR #616)
--   Always include kicks and bans in full /sync (PR #625)
--   Send history visibility on boundary changes (PR #626)
--   Register endpoint now returns a `refresh_token` (PR #637)
+-   Enforce `user_id` exclusivity for AS registrations. ([\#572](https://github.com/matrix-org/synapse/issues/572))
+-   Make adding push rules idempotent. ([\#587](https://github.com/matrix-org/synapse/issues/587))
+-   Improve presence performance. ([\#582](https://github.com/matrix-org/synapse/issues/582), [\#586](https://github.com/matrix-org/synapse/issues/586))
+-   Change presence semantics for `last_active_ago`. ([\#582](https://github.com/matrix-org/synapse/issues/582), [\#586](https://github.com/matrix-org/synapse/issues/586))
+-   Don't allow `m.room.create` to be changed. ([\#596](https://github.com/matrix-org/synapse/issues/596))
+-   Add 800x600 to default list of valid thumbnail sizes. ([\#616](https://github.com/matrix-org/synapse/issues/616))
+-   Always include kicks and bans in full /sync. ([\#625](https://github.com/matrix-org/synapse/issues/625))
+-   Send history visibility on boundary changes. ([\#626](https://github.com/matrix-org/synapse/issues/626))
+-   Register endpoint now returns a `refresh_token`. ([\#637](https://github.com/matrix-org/synapse/issues/637))
 
 Bug fixes:
 
--   Fix bug where we returned incorrect state in /sync (PR #573)
--   Always return a JSON object from push rule API (PR #606)
--   Fix bug where registering without a user id sometimes failed (PR #610)
--   Report size of ExpiringCache in cache size metrics (PR #611)
--   Fix rejection of invites to empty rooms (PR #615)
--   Fix usage of `bcrypt` to not use `checkpw` (PR #619)
--   Pin `pysaml2` dependency (PR #634)
--   Fix bug in `/sync` where timeline order was incorrect for backfilled events (PR #635)
+-   Fix bug where we returned incorrect state in /sync. ([\#573](https://github.com/matrix-org/synapse/issues/573))
+-   Always return a JSON object from push rule API. ([\#606](https://github.com/matrix-org/synapse/issues/606))
+-   Fix bug where registering without a user id sometimes failed. ([\#610](https://github.com/matrix-org/synapse/issues/610))
+-   Report size of ExpiringCache in cache size metrics. ([\#611](https://github.com/matrix-org/synapse/issues/611))
+-   Fix rejection of invites to empty rooms. ([\#615](https://github.com/matrix-org/synapse/issues/615))
+-   Fix usage of `bcrypt` to not use `checkpw`. ([\#619](https://github.com/matrix-org/synapse/issues/619))
+-   Pin `pysaml2` dependency. ([\#634](https://github.com/matrix-org/synapse/issues/634))
+-   Fix bug in `/sync` where timeline order was incorrect for backfilled events. ([\#635](https://github.com/matrix-org/synapse/issues/635))
 
 Changes in synapse v0.13.3 (2016-02-11)
 =======================================
@@ -2814,7 +2814,7 @@ Changes in synapse v0.13.3 (2016-02-11)
 Changes in synapse v0.13.2 (2016-02-11)
 =======================================
 
--   Fix bug where `/events` would fail to skip some events if there had been more events than the limit specified since the last request (PR #570)
+-   Fix bug where `/events` would fail to skip some events if there had been more events than the limit specified since the last request. ([\#570](https://github.com/matrix-org/synapse/issues/570))
 
 Changes in synapse v0.13.1 (2016-02-10)
 =======================================
@@ -2829,168 +2829,168 @@ This version includes an upgrade of the schema, specifically adding an index to 
 Changes:
 
 -   Improve general performance (PR #540, #543. \#544, #54, #549, #567)
--   Change guest user ids to be incrementing integers (PR #550)
--   Improve performance of public room list API (PR #552)
--   Change profile API to omit keys rather than return null (PR #557)
--   Add `/media/r0` endpoint prefix, which is equivalent to `/media/v1/` (PR #595)
+-   Change guest user ids to be incrementing integers. ([\#550](https://github.com/matrix-org/synapse/issues/550))
+-   Improve performance of public room list API. ([\#552](https://github.com/matrix-org/synapse/issues/552))
+-   Change profile API to omit keys rather than return null. ([\#557](https://github.com/matrix-org/synapse/issues/557))
+-   Add `/media/r0` endpoint prefix, which is equivalent to `/media/v1/`. ([\#595](https://github.com/matrix-org/synapse/issues/595))
 
 Bug fixes:
 
--   Fix bug with upgrading guest accounts where it would fail if you opened the registration email on a different device (PR #547)
--   Fix bug where unread count could be wrong (PR #568)
+-   Fix bug with upgrading guest accounts where it would fail if you opened the registration email on a different device. ([\#547](https://github.com/matrix-org/synapse/issues/547))
+-   Fix bug where unread count could be wrong. ([\#568](https://github.com/matrix-org/synapse/issues/568))
 
 Changes in synapse v0.12.1-rc1 (2016-01-29)
 ===========================================
 
 Features:
 
--   Add unread notification counts in `/sync` (PR #456)
--   Add support for inviting 3pids in `/createRoom` (PR #460)
--   Add ability for guest accounts to upgrade (PR #462)
--   Add `/versions` API (PR #468)
--   Add `event` to `/context` API (PR #492)
--   Add specific error code for invalid user names in `/register` (PR #499)
--   Add support for push badge counts (PR #507)
--   Add support for non-guest users to peek in rooms using `/events` (PR #510)
+-   Add unread notification counts in `/sync`. ([\#456](https://github.com/matrix-org/synapse/issues/456))
+-   Add support for inviting 3pids in `/createRoom`. ([\#460](https://github.com/matrix-org/synapse/issues/460))
+-   Add ability for guest accounts to upgrade. ([\#462](https://github.com/matrix-org/synapse/issues/462))
+-   Add `/versions` API. ([\#468](https://github.com/matrix-org/synapse/issues/468))
+-   Add `event` to `/context` API. ([\#492](https://github.com/matrix-org/synapse/issues/492))
+-   Add specific error code for invalid user names in `/register`. ([\#499](https://github.com/matrix-org/synapse/issues/499))
+-   Add support for push badge counts. ([\#507](https://github.com/matrix-org/synapse/issues/507))
+-   Add support for non-guest users to peek in rooms using `/events`. ([\#510](https://github.com/matrix-org/synapse/issues/510))
 
 Changes:
 
--   Change `/sync` so that guest users only get rooms they've joined (PR #469)
--   Change to require unbanning before other membership changes (PR #501)
--   Change default push rules to notify for all messages (PR #486)
--   Change default push rules to not notify on membership changes (PR #514)
--   Change default push rules in one to one rooms to only notify for events that are messages (PR #529)
--   Change `/sync` to reject requests with a `from` query param (PR #512)
--   Change server manhole to use SSH rather than telnet (PR #473)
--   Change server to require AS users to be registered before use (PR #487)
--   Change server not to start when ASes are invalidly configured (PR #494)
--   Change server to require ID and `as_token` to be unique for AS's (PR #496)
--   Change maximum pagination limit to 1000 (PR #497)
+-   Change `/sync` so that guest users only get rooms they've joined. ([\#469](https://github.com/matrix-org/synapse/issues/469))
+-   Change to require unbanning before other membership changes. ([\#501](https://github.com/matrix-org/synapse/issues/501))
+-   Change default push rules to notify for all messages. ([\#486](https://github.com/matrix-org/synapse/issues/486))
+-   Change default push rules to not notify on membership changes. ([\#514](https://github.com/matrix-org/synapse/issues/514))
+-   Change default push rules in one to one rooms to only notify for events that are messages. ([\#529](https://github.com/matrix-org/synapse/issues/529))
+-   Change `/sync` to reject requests with a `from` query param. ([\#512](https://github.com/matrix-org/synapse/issues/512))
+-   Change server manhole to use SSH rather than telnet. ([\#473](https://github.com/matrix-org/synapse/issues/473))
+-   Change server to require AS users to be registered before use. ([\#487](https://github.com/matrix-org/synapse/issues/487))
+-   Change server not to start when ASes are invalidly configured. ([\#494](https://github.com/matrix-org/synapse/issues/494))
+-   Change server to require ID and `as_token` to be unique for AS's. ([\#496](https://github.com/matrix-org/synapse/issues/496))
+-   Change maximum pagination limit to 1000. ([\#497](https://github.com/matrix-org/synapse/issues/497))
 
 Bug fixes:
 
--   Fix bug where `/sync` didn't return when something under the leave key changed (PR #461)
--   Fix bug where we returned smaller rather than larger than requested thumbnails when `method=crop` (PR #464)
--   Fix thumbnails API to only return cropped thumbnails when asking for a cropped thumbnail (PR #475)
--   Fix bug where we occasionally still logged access tokens (PR #477)
--   Fix bug where `/events` would always return immediately for guest users (PR #480)
--   Fix bug where `/sync` unexpectedly returned old left rooms (PR #481)
--   Fix enabling and disabling push rules (PR #498)
--   Fix bug where `/register` returned 500 when given unicode username (PR #513)
+-   Fix bug where `/sync` didn't return when something under the leave key changed. ([\#461](https://github.com/matrix-org/synapse/issues/461))
+-   Fix bug where we returned smaller rather than larger than requested thumbnails when `method=crop`. ([\#464](https://github.com/matrix-org/synapse/issues/464))
+-   Fix thumbnails API to only return cropped thumbnails when asking for a cropped thumbnail. ([\#475](https://github.com/matrix-org/synapse/issues/475))
+-   Fix bug where we occasionally still logged access tokens. ([\#477](https://github.com/matrix-org/synapse/issues/477))
+-   Fix bug where `/events` would always return immediately for guest users. ([\#480](https://github.com/matrix-org/synapse/issues/480))
+-   Fix bug where `/sync` unexpectedly returned old left rooms. ([\#481](https://github.com/matrix-org/synapse/issues/481))
+-   Fix enabling and disabling push rules. ([\#498](https://github.com/matrix-org/synapse/issues/498))
+-   Fix bug where `/register` returned 500 when given unicode username. ([\#513](https://github.com/matrix-org/synapse/issues/513))
 
 Changes in synapse v0.12.0 (2016-01-04)
 =======================================
 
--   Expose `/login` under `r0` (PR #459)
+-   Expose `/login` under `r0`. ([\#459](https://github.com/matrix-org/synapse/issues/459))
 
 Changes in synapse v0.12.0-rc3 (2015-12-23)
 ===========================================
 
--   Allow guest accounts access to `/sync` (PR #455)
--   Allow filters to include/exclude rooms at the room level rather than just from the components of the sync for each room. (PR #454)
--   Include urls for room avatars in the response to `/publicRooms` (PR #453)
--   Don't set a identicon as the avatar for a user when they register (PR #450)
--   Add a `display_name` to third-party invites (PR #449)
--   Send more information to the identity server for third-party invites so that it can send richer messages to the invitee (PR #446)
--   Cache the responses to `/initialSync` for 5 minutes. If a client retries a request to `/initialSync` before the a response was computed to the first request then the same response is used for both requests (PR #457)
--   Fix a bug where synapse would always request the signing keys of remote servers even when the key was cached locally (PR #452)
--   Fix 500 when pagination search results (PR #447)
--   Fix a bug where synapse was leaking raw email address in third-party invites (PR #448)
+-   Allow guest accounts access to `/sync`. ([\#455](https://github.com/matrix-org/synapse/issues/455))
+-   Allow filters to include/exclude rooms at the room level rather than just from the components of the sync for each room.. ([\#454](https://github.com/matrix-org/synapse/issues/454))
+-   Include urls for room avatars in the response to `/publicRooms`. ([\#453](https://github.com/matrix-org/synapse/issues/453))
+-   Don't set a identicon as the avatar for a user when they register. ([\#450](https://github.com/matrix-org/synapse/issues/450))
+-   Add a `display_name` to third-party invites. ([\#449](https://github.com/matrix-org/synapse/issues/449))
+-   Send more information to the identity server for third-party invites so that it can send richer messages to the invitee. ([\#446](https://github.com/matrix-org/synapse/issues/446))
+-   Cache the responses to `/initialSync` for 5 minutes. If a client retries a request to `/initialSync` before the a response was computed to the first request then the same response is used for both requests. ([\#457](https://github.com/matrix-org/synapse/issues/457))
+-   Fix a bug where synapse would always request the signing keys of remote servers even when the key was cached locally. ([\#452](https://github.com/matrix-org/synapse/issues/452))
+-   Fix 500 when pagination search results. ([\#447](https://github.com/matrix-org/synapse/issues/447))
+-   Fix a bug where synapse was leaking raw email address in third-party invites. ([\#448](https://github.com/matrix-org/synapse/issues/448))
 
 Changes in synapse v0.12.0-rc2 (2015-12-14)
 ===========================================
 
--   Add caches for whether rooms have been forgotten by a user (PR #434)
--   Remove instructions to use `--process-dependency-link` since all of the dependencies of synapse are on PyPI (PR #436)
--   Parallelise the processing of `/sync` requests (PR #437)
--   Fix race updating presence in `/events` (PR #444)
--   Fix bug back-populating search results (PR #441)
--   Fix bug calculating state in `/sync` requests (PR #442)
+-   Add caches for whether rooms have been forgotten by a user. ([\#434](https://github.com/matrix-org/synapse/issues/434))
+-   Remove instructions to use `--process-dependency-link` since all of the dependencies of synapse are on PyPI. ([\#436](https://github.com/matrix-org/synapse/issues/436))
+-   Parallelise the processing of `/sync` requests. ([\#437](https://github.com/matrix-org/synapse/issues/437))
+-   Fix race updating presence in `/events`. ([\#444](https://github.com/matrix-org/synapse/issues/444))
+-   Fix bug back-populating search results. ([\#441](https://github.com/matrix-org/synapse/issues/441))
+-   Fix bug calculating state in `/sync` requests. ([\#442](https://github.com/matrix-org/synapse/issues/442))
 
 Changes in synapse v0.12.0-rc1 (2015-12-10)
 ===========================================
 
--   Host the client APIs released as r0 by <https://matrix.org/docs/spec/r0.0.0/client_server.html> on paths prefixed by `/_matrix/client/r0`. (PR #430, PR #415, PR #400)
+-   Host the client APIs released as r0 by <https://matrix.org/docs/spec/r0.0.0/client_server.html> on paths prefixed by `/_matrix/client/r0`. ([\#430](https://github.com/matrix-org/synapse/issues/430), [\#415](https://github.com/matrix-org/synapse/issues/415), [\#400](https://github.com/matrix-org/synapse/issues/400))
 -   Updates the client APIs to match r0 of the matrix specification.
-    -   All APIs return events in the new event format, old APIs also include the fields needed to parse the event using the old format for compatibility. (PR #402)
-    -   Search results are now given as a JSON array rather than a JSON object (PR #405)
-    -   Miscellaneous changes to search (PR #403, PR #406, PR #412)
-    -   Filter JSON objects may now be passed as query parameters to `/sync` (PR #431)
-    -   Fix implementation of `/admin/whois` (PR #418)
-    -   Only include the rooms that user has left in `/sync` if the client requests them in the filter (PR #423)
-    -   Don't push for `m.room.message` by default (PR #411)
-    -   Add API for setting per account user data (PR #392)
-    -   Allow users to forget rooms (PR #385)
+    -   All APIs return events in the new event format, old APIs also include the fields needed to parse the event using the old format for compatibility.. ([\#402](https://github.com/matrix-org/synapse/issues/402))
+    -   Search results are now given as a JSON array rather than a JSON object. ([\#405](https://github.com/matrix-org/synapse/issues/405))
+    -   Miscellaneous changes to search. ([\#403](https://github.com/matrix-org/synapse/issues/403), [\#406](https://github.com/matrix-org/synapse/issues/406), [\#412](https://github.com/matrix-org/synapse/issues/412))
+    -   Filter JSON objects may now be passed as query parameters to `/sync`. ([\#431](https://github.com/matrix-org/synapse/issues/431))
+    -   Fix implementation of `/admin/whois`. ([\#418](https://github.com/matrix-org/synapse/issues/418))
+    -   Only include the rooms that user has left in `/sync` if the client requests them in the filter. ([\#423](https://github.com/matrix-org/synapse/issues/423))
+    -   Don't push for `m.room.message` by default. ([\#411](https://github.com/matrix-org/synapse/issues/411))
+    -   Add API for setting per account user data. ([\#392](https://github.com/matrix-org/synapse/issues/392))
+    -   Allow users to forget rooms. ([\#385](https://github.com/matrix-org/synapse/issues/385))
 -   Performance improvements and monitoring:
-    -   Add per-request counters for CPU time spent on the main python thread. (PR #421, PR #420)
-    -   Add per-request counters for time spent in the database (PR #429)
-    -   Make state updates in the C+S API idempotent (PR #416)
-    -   Only fire `user_joined_room` if the user has actually joined. (PR #410)
-    -   Reuse a single http client, rather than creating new ones (PR #413)
--   Fixed a bug upgrading from older versions of synapse on postgresql (PR #417)
+    -   Add per-request counters for CPU time spent on the main python thread. ([\#421](https://github.com/matrix-org/synapse/issues/421), [\#420](https://github.com/matrix-org/synapse/issues/420))
+    -   Add per-request counters for time spent in the database. ([\#429](https://github.com/matrix-org/synapse/issues/429))
+    -   Make state updates in the C+S API idempotent. ([\#416](https://github.com/matrix-org/synapse/issues/416))
+    -   Only fire `user_joined_room` if the user has actually joined.. ([\#410](https://github.com/matrix-org/synapse/issues/410))
+    -   Reuse a single http client, rather than creating new ones. ([\#413](https://github.com/matrix-org/synapse/issues/413))
+-   Fixed a bug upgrading from older versions of synapse on postgresql. ([\#417](https://github.com/matrix-org/synapse/issues/417))
 
 Changes in synapse v0.11.1 (2015-11-20)
 =======================================
 
--   Add extra options to search API (PR #394)
--   Fix bug where we did not correctly cap federation retry timers. This meant it could take several hours for servers to start talking to resurrected servers, even when they were receiving traffic from them (PR #393)
--   Don't advertise login token flow unless CAS is enabled. This caused issues where some clients would always use the fallback API if they did not recognize all login flows (PR #391)
--   Change /v2 sync API to rename `private_user_data` to `account_data` (PR #386)
--   Change /v2 sync API to remove the `event_map` and rename keys in `rooms` object (PR #389)
+-   Add extra options to search API. ([\#394](https://github.com/matrix-org/synapse/issues/394))
+-   Fix bug where we did not correctly cap federation retry timers. This meant it could take several hours for servers to start talking to resurrected servers, even when they were receiving traffic from them. ([\#393](https://github.com/matrix-org/synapse/issues/393))
+-   Don't advertise login token flow unless CAS is enabled. This caused issues where some clients would always use the fallback API if they did not recognize all login flows. ([\#391](https://github.com/matrix-org/synapse/issues/391))
+-   Change /v2 sync API to rename `private_user_data` to `account_data`. ([\#386](https://github.com/matrix-org/synapse/issues/386))
+-   Change /v2 sync API to remove the `event_map` and rename keys in `rooms` object. ([\#389](https://github.com/matrix-org/synapse/issues/389))
 
 Changes in synapse v0.11.0-r2 (2015-11-19)
 ==========================================
 
--   Fix bug in database port script (PR #387)
+-   Fix bug in database port script. ([\#387](https://github.com/matrix-org/synapse/issues/387))
 
 Changes in synapse v0.11.0-r1 (2015-11-18)
 ==========================================
 
--   Retry and fail federation requests more aggressively for requests that block client side requests (PR #384)
+-   Retry and fail federation requests more aggressively for requests that block client side requests. ([\#384](https://github.com/matrix-org/synapse/issues/384))
 
 Changes in synapse v0.11.0 (2015-11-17)
 =======================================
 
--   Change CAS login API (PR #349)
+-   Change CAS login API. ([\#349](https://github.com/matrix-org/synapse/issues/349))
 
 Changes in synapse v0.11.0-rc2 (2015-11-13)
 ===========================================
 
--   Various changes to /sync API response format (PR #373)
--   Fix regression when setting display name in newly joined room over federation (PR #368)
--   Fix problem where /search was slow when using SQLite (PR #366)
+-   Various changes to /sync API response format. ([\#373](https://github.com/matrix-org/synapse/issues/373))
+-   Fix regression when setting display name in newly joined room over federation. ([\#368](https://github.com/matrix-org/synapse/issues/368))
+-   Fix problem where /search was slow when using SQLite. ([\#366](https://github.com/matrix-org/synapse/issues/366))
 
 Changes in synapse v0.11.0-rc1 (2015-11-11)
 ===========================================
 
 -   Add Search API (PR #307, #324, #327, #336, #350, #359)
--   Add `archived` state to v2 /sync API (PR #316)
--   Add ability to reject invites (PR #317)
--   Add config option to disable password login (PR #322)
--   Add the login fallback API (PR #330)
--   Add room context API (PR #334)
--   Add room tagging support (PR #335)
+-   Add `archived` state to v2 /sync API. ([\#316](https://github.com/matrix-org/synapse/issues/316))
+-   Add ability to reject invites. ([\#317](https://github.com/matrix-org/synapse/issues/317))
+-   Add config option to disable password login. ([\#322](https://github.com/matrix-org/synapse/issues/322))
+-   Add the login fallback API. ([\#330](https://github.com/matrix-org/synapse/issues/330))
+-   Add room context API. ([\#334](https://github.com/matrix-org/synapse/issues/334))
+-   Add room tagging support. ([\#335](https://github.com/matrix-org/synapse/issues/335))
 -   Update v2 /sync API to match spec (PR #305, #316, #321, #332, #337, #341)
--   Change retry schedule for application services (PR #320)
--   Change retry schedule for remote servers (PR #340)
--   Fix bug where we hosted static content in the incorrect place (PR #329)
--   Fix bug where we didn't increment retry interval for remote servers (PR #343)
+-   Change retry schedule for application services. ([\#320](https://github.com/matrix-org/synapse/issues/320))
+-   Change retry schedule for remote servers. ([\#340](https://github.com/matrix-org/synapse/issues/340))
+-   Fix bug where we hosted static content in the incorrect place. ([\#329](https://github.com/matrix-org/synapse/issues/329))
+-   Fix bug where we didn't increment retry interval for remote servers. ([\#343](https://github.com/matrix-org/synapse/issues/343))
 
 Changes in synapse v0.10.1-rc1 (2015-10-15)
 ===========================================
 
--   Add support for CAS, thanks to Steven Hammerton (PR #295, #296)
--   Add support for using macaroons for `access_token` (PR #256, #229)
--   Add support for `m.room.canonical_alias` (PR #287)
--   Add support for viewing the history of rooms that they have left. (PR #276, #294)
--   Add support for refresh tokens (PR #240)
--   Add flag on creation which disables federation of the room (PR #279)
--   Add some room state to invites. (PR #275)
--   Atomically persist events when joining a room over federation (PR #283)
--   Change default history visibility for private rooms (PR #271)
--   Allow users to redact their own sent events (PR #262)
--   Use tox for tests (PR #247)
--   Split up syutil into separate libraries (PR #243)
+-   Add support for CAS, thanks to Steven Hammerton. ([\#295](https://github.com/matrix-org/synapse/issues/295), [\#296](https://github.com/matrix-org/synapse/issues/296))
+-   Add support for using macaroons for `access_token`. ([\#256](https://github.com/matrix-org/synapse/issues/256), [\#229](https://github.com/matrix-org/synapse/issues/229))
+-   Add support for `m.room.canonical_alias`. ([\#287](https://github.com/matrix-org/synapse/issues/287))
+-   Add support for viewing the history of rooms that they have left.. ([\#276](https://github.com/matrix-org/synapse/issues/276), [\#294](https://github.com/matrix-org/synapse/issues/294))
+-   Add support for refresh tokens. ([\#240](https://github.com/matrix-org/synapse/issues/240))
+-   Add flag on creation which disables federation of the room. ([\#279](https://github.com/matrix-org/synapse/issues/279))
+-   Add some room state to invites.. ([\#275](https://github.com/matrix-org/synapse/issues/275))
+-   Atomically persist events when joining a room over federation. ([\#283](https://github.com/matrix-org/synapse/issues/283))
+-   Change default history visibility for private rooms. ([\#271](https://github.com/matrix-org/synapse/issues/271))
+-   Allow users to redact their own sent events. ([\#262](https://github.com/matrix-org/synapse/issues/262))
+-   Use tox for tests. ([\#247](https://github.com/matrix-org/synapse/issues/247))
+-   Split up syutil into separate libraries. ([\#243](https://github.com/matrix-org/synapse/issues/243))
 
 Changes in synapse v0.10.0-r2 (2015-09-16)
 ==========================================
@@ -3023,20 +3023,20 @@ Changes in synapse v0.10.0-rc5 (2015-08-27)
 Changes in synapse v0.10.0-rc4 (2015-08-27)
 ===========================================
 
--   Allow UTF-8 filenames for upload. (PR #259)
+-   Allow UTF-8 filenames for upload.. ([\#259](https://github.com/matrix-org/synapse/issues/259))
 
 Changes in synapse v0.10.0-rc3 (2015-08-25)
 ===========================================
 
--   Add `--keys-directory` config option to specify where files such as certs and signing keys should be stored in, when using `--generate-config` or `--generate-keys`. (PR #250)
--   Allow `--config-path` to specify a directory, causing synapse to use all `*.yaml` files in the directory as config files. (PR #249)
--   Add `web_client_location` config option to specify static files to be hosted by synapse under `/_matrix/client`. (PR #245)
+-   Add `--keys-directory` config option to specify where files such as certs and signing keys should be stored in, when using `--generate-config` or `--generate-keys`.. ([\#250](https://github.com/matrix-org/synapse/issues/250))
+-   Allow `--config-path` to specify a directory, causing synapse to use all `*.yaml` files in the directory as config files.. ([\#249](https://github.com/matrix-org/synapse/issues/249))
+-   Add `web_client_location` config option to specify static files to be hosted by synapse under `/_matrix/client`.. ([\#245](https://github.com/matrix-org/synapse/issues/245))
 -   Add helper utility to synapse to read and parse the config files and extract the value of a given key. For example:
 
         $ python -m synapse.config read server_name -c homeserver.yaml
         localhost
 
-    (PR #246)
+   . ([\#246](https://github.com/matrix-org/synapse/issues/246))
 
 Changes in synapse v0.10.0-rc2 (2015-08-24)
 ===========================================
@@ -3051,37 +3051,37 @@ Also see v0.9.4-rc1 changelog, which has been amalgamated into this release.
 
 General:
 
--   Upgrade to Twisted 15 (PR #173)
--   Add support for serving and fetching encryption keys over federation. (PR #208)
--   Add support for logging in with email address (PR #234)
--   Add support for new `m.room.canonical_alias` event. (PR #233)
+-   Upgrade to Twisted 15. ([\#173](https://github.com/matrix-org/synapse/issues/173))
+-   Add support for serving and fetching encryption keys over federation.. ([\#208](https://github.com/matrix-org/synapse/issues/208))
+-   Add support for logging in with email address. ([\#234](https://github.com/matrix-org/synapse/issues/234))
+-   Add support for new `m.room.canonical_alias` event.. ([\#233](https://github.com/matrix-org/synapse/issues/233))
 -   Change synapse to treat user IDs case insensitively during registration and login. (If two users already exist with case insensitive matching user ids, synapse will continue to require them to specify their user ids exactly.)
--   Error if a user tries to register with an email already in use. (PR #211)
--   Add extra and improve existing caches (PR #212, #219, #226, #228)
--   Batch various storage request (PR #226, #228)
--   Fix bug where we didn't correctly log the entity that triggered the request if the request came in via an application service (PR #230)
--   Fix bug where we needlessly regenerated the full list of rooms an AS is interested in. (PR #232)
--   Add support for AS's to use `v2_alpha` registration API (PR #210)
+-   Error if a user tries to register with an email already in use.. ([\#211](https://github.com/matrix-org/synapse/issues/211))
+-   Add extra and improve existing caches. ([\#212](https://github.com/matrix-org/synapse/issues/212), [\#219](https://github.com/matrix-org/synapse/issues/219), [\#226](https://github.com/matrix-org/synapse/issues/226), [\#228](https://github.com/matrix-org/synapse/issues/228))
+-   Batch various storage request. ([\#226](https://github.com/matrix-org/synapse/issues/226), [\#228](https://github.com/matrix-org/synapse/issues/228))
+-   Fix bug where we didn't correctly log the entity that triggered the request if the request came in via an application service. ([\#230](https://github.com/matrix-org/synapse/issues/230))
+-   Fix bug where we needlessly regenerated the full list of rooms an AS is interested in.. ([\#232](https://github.com/matrix-org/synapse/issues/232))
+-   Add support for AS's to use `v2_alpha` registration API. ([\#210](https://github.com/matrix-org/synapse/issues/210))
 
 Configuration:
 
--   Add `--generate-keys` that will generate any missing cert and key files in the configuration files. This is equivalent to running `--generate-config` on an existing configuration file. (PR #220)
--   `--generate-config` now no longer requires a `--server-name` parameter when used on existing configuration files. (PR #220)
--   Add `--print-pidfile` flag that controls the printing of the pid to stdout of the demonised process. (PR #213)
+-   Add `--generate-keys` that will generate any missing cert and key files in the configuration files. This is equivalent to running `--generate-config` on an existing configuration file.. ([\#220](https://github.com/matrix-org/synapse/issues/220))
+-   `--generate-config` now no longer requires a `--server-name` parameter when used on existing configuration files.. ([\#220](https://github.com/matrix-org/synapse/issues/220))
+-   Add `--print-pidfile` flag that controls the printing of the pid to stdout of the demonised process.. ([\#213](https://github.com/matrix-org/synapse/issues/213))
 
 Media Repository:
 
--   Fix bug where we picked a lower resolution image than requested. (PR #205)
--   Add support for specifying if a the media repository should dynamically thumbnail images or not. (PR #206)
+-   Fix bug where we picked a lower resolution image than requested.. ([\#205](https://github.com/matrix-org/synapse/issues/205))
+-   Add support for specifying if a the media repository should dynamically thumbnail images or not.. ([\#206](https://github.com/matrix-org/synapse/issues/206))
 
 Metrics:
 
--   Add statistics from the reactor to the metrics API. (PR #224, #225)
+-   Add statistics from the reactor to the metrics API.. ([\#224](https://github.com/matrix-org/synapse/issues/224), [\#225](https://github.com/matrix-org/synapse/issues/225))
 
 Demo Homeservers:
 
--   Fix starting the demo homeservers without rate-limiting enabled. (PR #182)
--   Fix enabling registration on demo homeservers (PR #223)
+-   Fix starting the demo homeservers without rate-limiting enabled.. ([\#182](https://github.com/matrix-org/synapse/issues/182))
+-   Fix enabling registration on demo homeservers. ([\#223](https://github.com/matrix-org/synapse/issues/223))
 
 Changes in synapse v0.9.4-rc1 (2015-07-21)
 ==========================================
@@ -3089,13 +3089,13 @@ Changes in synapse v0.9.4-rc1 (2015-07-21)
 General:
 
 -   Add basic implementation of receipts. (SPEC-99)
--   Add support for configuration presets in room creation API. (PR #203)
+-   Add support for configuration presets in room creation API.. ([\#203](https://github.com/matrix-org/synapse/issues/203))
 -   Add auth event that limits the visibility of history for new users. (SPEC-134)
 -   Add SAML2 login/registration support. (PR #201. Thanks Muthu Subramanian!)
--   Add client side key management APIs for end to end encryption. (PR #198)
+-   Add client side key management APIs for end to end encryption.. ([\#198](https://github.com/matrix-org/synapse/issues/198))
 -   Change power level semantics so that you cannot kick, ban or change power levels of users that have equal or greater power level than you. (SYN-192)
--   Improve performance by bulk inserting events where possible. (PR #193)
--   Improve performance by bulk verifying signatures where possible. (PR #194)
+-   Improve performance by bulk inserting events where possible.. ([\#193](https://github.com/matrix-org/synapse/issues/193))
+-   Improve performance by bulk verifying signatures where possible.. ([\#194](https://github.com/matrix-org/synapse/issues/194))
 
 Configuration:
 


### PR DESCRIPTION
This makes it more inline with our modern changelogs. It was done via a bunch of regex find & replaces.