### PR TITLE
Fix sending out of order `POSITION` over replication

### DIFF
--- a/changelog.d/16639.bugfix
+++ b/changelog.d/16639.bugfix
@@ -1,0 +1,1 @@
+Fix sending out of order `POSITION` over replication, causing additional database load.

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -416,7 +416,7 @@ class ReplicationCommandHandler:
         """Check if we should send POSITION commands for all streams ASAP."""
         return self._should_announce_positions
 
-    def will_should_announce_positions(self) -> None:
+    def will_announce_positions(self) -> None:
         """Mark that we're about to send POSITIONs out for all streams."""
         self._should_announce_positions = False
 

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -626,8 +626,9 @@ class ReplicationCommandHandler:
             # for why this can happen.
 
             logger.info(
-                "Fetching replication rows for '%s' between %i and %i",
+                "Fetching replication rows for '%s' / %s between %i and %i",
                 stream_name,
+                cmd.instance_name,
                 current_token,
                 cmd.new_token,
             )

--- a/synapse/replication/tcp/redis.py
+++ b/synapse/replication/tcp/redis.py
@@ -141,7 +141,7 @@ class RedisSubscriber(SubscriberProtocol):
         # We send out our positions when there is a new connection in case the
         # other side missed updates. We do this for Redis connections as the
         # otherside won't know we've connected and so won't issue a REPLICATE.
-        self.synapse_handler.send_positions_to_connection(self)
+        self.synapse_handler.send_positions_to_connection()
 
     def messageReceived(self, pattern: str, channel: str, message: str) -> None:
         """Received a message from redis."""

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -123,7 +123,7 @@ class ReplicationStreamer:
 
         # We check up front to see if anything has actually changed, as we get
         # poked because of changes that happened on other instances.
-        if all(
+        if not self.command_handler.should_announce_positions() and all(
             stream.last_token == stream.current_token(self._instance_name)
             for stream in self.streams
         ):
@@ -157,6 +157,21 @@ class ReplicationStreamer:
                         # so let's shuffle them around a bit when we are in torture mode.
                         all_streams = list(all_streams)
                         random.shuffle(all_streams)
+
+                    if self.command_handler.should_announce_positions():
+                        # We need to send out POSITIONs for all streams, usually
+                        # because a worker has reconnected.
+                        self.command_handler.will_should_announce_positions()
+
+                        for stream in all_streams:
+                            self.command_handler.send_command(
+                                PositionCommand(
+                                    stream.NAME,
+                                    self._instance_name,
+                                    stream.last_token,
+                                    stream.last_token,
+                                )
+                            )
 
                     for stream in all_streams:
                         if stream.last_token == stream.current_token(

--- a/synapse/replication/tcp/resource.py
+++ b/synapse/replication/tcp/resource.py
@@ -161,7 +161,7 @@ class ReplicationStreamer:
                     if self.command_handler.should_announce_positions():
                         # We need to send out POSITIONs for all streams, usually
                         # because a worker has reconnected.
-                        self.command_handler.will_should_announce_positions()
+                        self.command_handler.will_announce_positions()
 
                         for stream in all_streams:
                             self.command_handler.send_command(

--- a/tests/replication/tcp/streams/test_typing.py
+++ b/tests/replication/tcp/streams/test_typing.py
@@ -35,6 +35,10 @@ class TypingStreamTestCase(BaseStreamTestCase):
         typing = self.hs.get_typing_handler()
         assert isinstance(typing, TypingWriterHandler)
 
+        # Create a typing update before we reconnect so that there is a missing
+        # update to fetch.
+        typing._push_update(member=RoomMember(ROOM_ID, USER_ID), typing=True)
+
         self.reconnect()
 
         typing._push_update(member=RoomMember(ROOM_ID, USER_ID), typing=True)
@@ -90,6 +94,10 @@ class TypingStreamTestCase(BaseStreamTestCase):
         """
         typing = self.hs.get_typing_handler()
         assert isinstance(typing, TypingWriterHandler)
+
+        # Create a typing update before we reconnect so that there is a missing
+        # update to fetch.
+        typing._push_update(member=RoomMember(ROOM_ID, USER_ID), typing=True)
 
         self.reconnect()
 


### PR DESCRIPTION
If a worker reconnects to Redis we send out the current positions of all our streams. However, if we're also trying to send out a backlog of RDATA at the same time then we can end up sending a `POSITION` with the current token *before* we've sent all the RDATA before the current token.

This doesn't cause actual bugs as the receiving servers see the POSITION, fetch the relevant rows from the DB, and then ignore the old RDATA as they come in. However, this is inefficient so it'd be better if we didn't  send out-of-order positions