### PR TITLE
More efficiently handle no-op POSITION

### DIFF
--- a/changelog.d/16640.misc
+++ b/changelog.d/16640.misc
@@ -1,0 +1,1 @@
+More efficiently handle no-op `POSITION` over replication.

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -595,9 +595,11 @@ class ReplicationCommandHandler:
             cmd.instance_name, cmd.prev_token, cmd.new_token
         ) and self.is_stream_connected(conn, cmd.stream_name):
             logger.debug(
-                "Discarding redundant POSITION %s/%s",
+                "Discarding redundant POSITION %s/%s %s %s",
                 cmd.instance_name,
                 cmd.stream_name,
+                cmd.prev_token,
+                cmd.new_token,
             )
             return
 
@@ -616,9 +618,11 @@ class ReplicationCommandHandler:
             cmd.instance_name, cmd.prev_token, cmd.new_token
         ) and self.is_stream_connected(conn, cmd.stream_name):
             logger.debug(
-                "Discarding redundant POSITION %s/%s",
+                "Discarding redundant POSITION %s/%s %s %s",
                 cmd.instance_name,
                 cmd.stream_name,
+                cmd.prev_token,
+                cmd.new_token,
             )
             return
 

--- a/synapse/replication/tcp/handler.py
+++ b/synapse/replication/tcp/handler.py
@@ -588,6 +588,13 @@ class ReplicationCommandHandler:
 
         logger.debug("Handling '%s %s'", cmd.NAME, cmd.to_line())
 
+        # Check if we early discard this position.
+        stream = self._streams[cmd.stream_name]
+        if stream.can_discard_position(
+            cmd.instance_name, cmd.prev_token, cmd.new_token
+        ):
+            return
+
         self._add_command_to_stream_queue(conn, cmd)
 
     async def _process_position(
@@ -598,6 +605,11 @@ class ReplicationCommandHandler:
         Called after the command has been popped off the queue of inbound commands
         """
         stream = self._streams[stream_name]
+
+        if stream.can_discard_position(
+            cmd.instance_name, cmd.prev_token, cmd.new_token
+        ):
+            return
 
         # We're about to go and catch up with the stream, so remove from set
         # of connected streams.

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -236,6 +236,15 @@ class _StreamFromIdGen(Stream):
     ) -> bool:
         # These streams can't go backwards, so we know we can ignore any
         # positions where the tokens are from before the current token.
+
+        if new_token <= self.current_token(instance_name):
+            logger.info(
+                "Discarding POSITION %s/%s: %s vs %s",
+                self.NAME,
+                instance_name,
+                new_token,
+                self.current_token(instance_name),
+            )
         return new_token <= self.current_token(instance_name)
 
 

--- a/synapse/replication/tcp/streams/_base.py
+++ b/synapse/replication/tcp/streams/_base.py
@@ -237,14 +237,6 @@ class _StreamFromIdGen(Stream):
         # These streams can't go backwards, so we know we can ignore any
         # positions where the tokens are from before the current token.
 
-        if new_token <= self.current_token(instance_name):
-            logger.info(
-                "Discarding POSITION %s/%s: %s vs %s",
-                self.NAME,
-                instance_name,
-                new_token,
-                self.current_token(instance_name),
-            )
         return new_token <= self.current_token(instance_name)
 
 


### PR DESCRIPTION
We may receive `POSITION` commands where we already know that worker has advanced past that position, so there is no point in handling it.