### PR TITLE
Enable refreshable tokens on the admin registration endpoint

### DIFF
--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -630,6 +630,11 @@ class UserRegisterServlet(RestServlet):
         if not hmac.compare_digest(want_mac.encode("ascii"), got_mac.encode("ascii")):
             raise SynapseError(HTTPStatus.FORBIDDEN, "HMAC incorrect")
 
+        should_issue_refresh_token = body.get("refresh_token", False)
+        if not isinstance(should_issue_refresh_token, bool):
+            raise SynapseError(HTTPStatus.BAD_REQUEST, "refresh_token must be a boolean")
+
+
         # Reuse the parts of RegisterRestServlet to reduce code duplication
         from synapse.rest.client.register import RegisterRestServlet
 
@@ -645,7 +650,11 @@ class UserRegisterServlet(RestServlet):
             approved=True,
         )
 
-        result = await register._create_registration_details(user_id, body)
+        result = await register._create_registration_details(
+            user_id,
+            body,
+            should_issue_refresh_token=should_issue_refresh_token
+        )
         return HTTPStatus.OK, result
 
 

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -632,8 +632,9 @@ class UserRegisterServlet(RestServlet):
 
         should_issue_refresh_token = body.get("refresh_token", False)
         if not isinstance(should_issue_refresh_token, bool):
-            raise SynapseError(HTTPStatus.BAD_REQUEST, "refresh_token must be a boolean")
-
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST, "refresh_token must be a boolean"
+            )
 
         # Reuse the parts of RegisterRestServlet to reduce code duplication
         from synapse.rest.client.register import RegisterRestServlet
@@ -651,9 +652,7 @@ class UserRegisterServlet(RestServlet):
         )
 
         result = await register._create_registration_details(
-            user_id,
-            body,
-            should_issue_refresh_token=should_issue_refresh_token
+            user_id, body, should_issue_refresh_token=should_issue_refresh_token
         )
         return HTTPStatus.OK, result
 


### PR DESCRIPTION
This PR adds support for refresh tokens on the admin API registration endpoint `/_synapse/admin/v1/register`.

See #16641 for more details.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
