### PR TITLE
Speed up deleting device messages

### DIFF
--- a/changelog.d/16643.misc
+++ b/changelog.d/16643.misc
@@ -1,0 +1,1 @@
+Speed up deleting of device messages when deleting a device.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -398,7 +398,7 @@ class DeviceWorkerHandler:
         # Delete the messages in batches to avoid too much DB load.
         from_stream_id = None
         while True:
-            from_stream_id = await self.store.delete_messages_for_device_between(
+            from_stream_id, _ = await self.store.delete_messages_for_device_between(
                 user_id=user_id,
                 device_id=device_id,
                 from_stream_id=from_stream_id,

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -396,15 +396,17 @@ class DeviceWorkerHandler:
         up_to_stream_id = task.params["up_to_stream_id"]
 
         # Delete the messages in batches to avoid too much DB load.
+        from_stream_id = None
         while True:
-            res = await self.store.delete_messages_for_device(
+            from_stream_id = await self.store.delete_messages_for_device_between(
                 user_id=user_id,
                 device_id=device_id,
-                up_to_stream_id=up_to_stream_id,
+                from_stream_id=from_stream_id,
+                to_stream_id=up_to_stream_id,
                 limit=DeviceHandler.DEVICE_MSGS_DELETE_BATCH_LIMIT,
             )
 
-            if res < DeviceHandler.DEVICE_MSGS_DELETE_BATCH_LIMIT:
+            if from_stream_id is None:
                 return TaskStatus.COMPLETE, None, None
 
             await self.clock.sleep(DeviceHandler.DEVICE_MSGS_DELETE_SLEEP_MS / 1000.0)

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -524,7 +524,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
         limit: int,
     ) -> Optional[int]:
         """Delete N device messages between the stream IDs, returning the
-        highest stream ID deleted.
+        highest stream ID deleted, or None if nothing was deletable.
 
         This is more efficient than `delete_messages_for_device` when calling in
         a loop to batch delete messages.

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -450,14 +450,12 @@ class DeviceInboxWorkerStore(SQLBaseStore):
         user_id: str,
         device_id: Optional[str],
         up_to_stream_id: int,
-        limit: Optional[int] = None,
     ) -> int:
         """
         Args:
             user_id: The recipient user_id.
             device_id: The recipient device_id.
             up_to_stream_id: Where to delete messages up to.
-            limit: maximum number of messages to delete
 
         Returns:
             The number of messages deleted.
@@ -486,18 +484,13 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                 device_id,
                 from_stream_id=from_stream_id,
                 to_stream_id=up_to_stream_id,
-                limit=limit,
+                limit=1000,
             )
             count += loop_count
             if from_stream_id is None:
                 break
 
         log_kv({"message": f"deleted {count} messages for device", "count": count})
-
-        # In this case we don't know if we hit the limit or the delete is complete
-        # so let's not update the cache.
-        if count == limit:
-            return count
 
         # Update the cache, ensuring that we only ever increase the value
         updated_last_deleted_stream_id = self._last_device_delete_cache.get(

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -484,7 +484,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
             from_stream_id, loop_count = await self.delete_messages_for_device_between(
                 user_id,
                 device_id,
-                from_stream_id=None,
+                from_stream_id=from_stream_id,
                 to_stream_id=up_to_stream_id,
                 limit=limit,
             )

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -486,7 +486,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
                 device_id,
                 from_stream_id=None,
                 to_stream_id=up_to_stream_id,
-                limit=1000,
+                limit=limit,
             )
             count += loop_count
             if from_stream_id is None:

--- a/synapse/util/task_scheduler.py
+++ b/synapse/util/task_scheduler.py
@@ -193,7 +193,7 @@ class TaskScheduler:
         result: Optional[JsonMapping] = None,
         error: Optional[str] = None,
     ) -> bool:
-        """Update some task associated values. This is exposed publically so it can
+        """Update some task associated values. This is exposed publicly so it can
         be used inside task functions, mainly to update the result and be able to
         resume a task at a specific step after a restart of synapse.
 


### PR DESCRIPTION
Keeping track of a lower bound of stream ID where we've deleted everything below makes the queries much faster. Otherwise, every time we scan for rows to delete we'd re-scan across all the rows that have previously deleted (until the next table VACUUM).