### PR TITLE
Fix building wheels.

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -111,8 +111,8 @@ jobs:
 
         exclude:
           # Don't build macos wheels on PR CI.
-          #- is_pr: true
-          #  os: "macos-11"
+          - is_pr: true
+            os: "macos-11"
           # Don't build aarch64 wheels on mac.
           - os: "macos-11"
             arch: aarch64
@@ -142,9 +142,9 @@ jobs:
         if: matrix.arch == 'aarch64'
         run: echo 'CIBW_ARCHS_LINUX=aarch64' >> $GITHUB_ENV
 
-      #- name: Only build a single wheel on PR
-      #  if: startsWith(github.ref, 'refs/pull/')
-      #  run: echo "CIBW_BUILD="cp38-manylinux_${{ matrix.arch }}"" >> $GITHUB_ENV
+      - name: Only build a single wheel on PR
+        if: startsWith(github.ref, 'refs/pull/')
+        run: echo "CIBW_BUILD="cp38-manylinux_${{ matrix.arch }}"" >> $GITHUB_ENV
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -111,8 +111,8 @@ jobs:
 
         exclude:
           # Don't build macos wheels on PR CI.
-          - is_pr: true
-            os: "macos-11"
+          #- is_pr: true
+          #  os: "macos-11"
           # Don't build aarch64 wheels on mac.
           - os: "macos-11"
             arch: aarch64
@@ -130,7 +130,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.9.0
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Set up QEMU to emulate aarch64
         if: matrix.arch == 'aarch64'

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -142,9 +142,9 @@ jobs:
         if: matrix.arch == 'aarch64'
         run: echo 'CIBW_ARCHS_LINUX=aarch64' >> $GITHUB_ENV
 
-      - name: Only build a single wheel on PR
-        if: startsWith(github.ref, 'refs/pull/')
-        run: echo "CIBW_BUILD="cp38-manylinux_${{ matrix.arch }}"" >> $GITHUB_ENV
+      #- name: Only build a single wheel on PR
+      #  if: startsWith(github.ref, 'refs/pull/')
+      #  run: echo "CIBW_BUILD="cp38-manylinux_${{ matrix.arch }}"" >> $GITHUB_ENV
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/changelog.d/16653.misc
+++ b/changelog.d/16653.misc
@@ -1,0 +1,1 @@
+Fix building of wheels in CI.


### PR DESCRIPTION
See https://github.com/matrix-org/synapse/actions/runs/6894805171/job/18757418241 erroring with:

```
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```

My hope is that a newer cibuildwheel will use a newer pip which will be compatible with Python 3.12.