### PR TITLE
Reduce task concurrency

### DIFF
--- a/changelog.d/16656.misc
+++ b/changelog.d/16656.misc
@@ -1,0 +1,1 @@
+Reduce max concurrency of background tasks, reducing potential max DB load.

--- a/synapse/handlers/device.py
+++ b/synapse/handlers/device.py
@@ -383,7 +383,7 @@ class DeviceWorkerHandler:
         )
 
     DEVICE_MSGS_DELETE_BATCH_LIMIT = 1000
-    DEVICE_MSGS_DELETE_SLEEP_MS = 1000
+    DEVICE_MSGS_DELETE_SLEEP_MS = 100
 
     async def _delete_device_messages(
         self,

--- a/synapse/util/task_scheduler.py
+++ b/synapse/util/task_scheduler.py
@@ -71,7 +71,7 @@ class TaskScheduler:
     # Time before a complete or failed task is deleted from the DB
     KEEP_TASKS_FOR_MS = 7 * 24 * 60 * 60 * 1000  # 1 week
     # Maximum number of tasks that can run at the same time
-    MAX_CONCURRENT_RUNNING_TASKS = 10
+    MAX_CONCURRENT_RUNNING_TASKS = 5
     # Time from the last task update after which we will log a warning
     LAST_UPDATE_BEFORE_WARNING_MS = 24 * 60 * 60 * 1000  # 24hrs
 


### PR DESCRIPTION
Most background tasks don't have any form of limiting on resource usage, so running ten of them at a time could be problematic for DB load. The deleting device messages task does have limiting, but we can make that less aggressive now that a) the queries are more efficient, and b) we are doing fewer in parallel. 