### PR TITLE
Speed up how quickly we launch new tasks

### DIFF
--- a/changelog.d/16660.misc
+++ b/changelog.d/16660.misc
@@ -1,0 +1,1 @@
+Reduce max concurrency of background tasks, reducing potential max DB load.

--- a/synapse/util/task_scheduler.py
+++ b/synapse/util/task_scheduler.py
@@ -377,7 +377,7 @@ class TaskScheduler:
                 self._running_tasks.remove(task.id)
 
             # Try launch a new task since we've finished with this one.
-            self._clock.call_later(1, self._launch_scheduled_tasks)
+            self._clock.call_later(0.1, self._launch_scheduled_tasks)
 
         if len(self._running_tasks) >= TaskScheduler.MAX_CONCURRENT_RUNNING_TASKS:
             return


### PR DESCRIPTION
Now that we're reducing concurrency (#16656), this is more important.