### PR TITLE
Admin API for server notice: consistently bypass rate limits

### DIFF
--- a/changelog.d/16670.bugfix
+++ b/changelog.d/16670.bugfix
@@ -1,1 +1,1 @@
-Disable rate limit for all underlying calls when using the server notice admin API.
+Consistently bypass rate limits when using the server notice admin API.

--- a/changelog.d/16670.bugfix
+++ b/changelog.d/16670.bugfix
@@ -1,0 +1,1 @@
+Disable rate limit for all underlying calls when using the server notice admin API.

--- a/synapse/server_notices/server_notices_manager.py
+++ b/synapse/server_notices/server_notices_manager.py
@@ -226,6 +226,7 @@ class ServerNoticesManager:
             target=UserID.from_string(user_id),
             room_id=room_id,
             action="invite",
+            ratelimit=False,
         )
 
     async def _update_notice_user_profile_if_changed(
@@ -268,5 +269,6 @@ class ServerNoticesManager:
                 target=UserID.from_string(self.server_notices_mxid),
                 room_id=room_id,
                 action="join",
+                ratelimit=False,
                 content={"displayname": display_name, "avatar_url": avatar_url},
             )


### PR DESCRIPTION
Signed-off-by: Mathieu Velten <matmaul@gmail.com>

A lot of the underlying calls in the server notice code are already using `ratelimit=False`, but some are missing leading to still being rate limited when using the API in bulk.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
