### PR TITLE
Keep track of `user_ips` and `monthly_active_users` when delegating auth

### DIFF
--- a/changelog.d/16672.feature
+++ b/changelog.d/16672.feature
@@ -1,0 +1,1 @@
+Restore tracking of requests and monthly active users when delegating authentication to an [MSC3861](https://github.com/matrix-org/synapse/pull/16672) OIDC provider.

--- a/synapse/api/auth/internal.py
+++ b/synapse/api/auth/internal.py
@@ -22,7 +22,6 @@ from synapse.api.errors import (
     InvalidClientTokenError,
     MissingClientTokenError,
 )
-from synapse.http import get_request_user_agent
 from synapse.http.site import SynapseRequest
 from synapse.logging.opentracing import active_span, force_tracing, start_active_span
 from synapse.types import Requester, create_requester
@@ -48,8 +47,6 @@ class InternalAuth(BaseAuth):
         self._account_validity_handler = hs.get_account_validity_handler()
         self._macaroon_generator = hs.get_macaroon_generator()
 
-        self._track_appservice_user_ips = hs.config.appservice.track_appservice_user_ips
-        self._track_puppeted_user_ips = hs.config.api.track_puppeted_user_ips
         self._force_tracing_for_users = hs.config.tracing.force_tracing_for_users
 
     @cancellable
@@ -115,9 +112,6 @@ class InternalAuth(BaseAuth):
         Once get_user_by_req has set up the opentracing span, this does the actual work.
         """
         try:
-            ip_addr = request.get_client_ip_if_available()
-            user_agent = get_request_user_agent(request)
-
             access_token = self.get_access_token_from_request(request)
 
             # First check if it could be a request from an appservice
@@ -154,38 +148,7 @@ class InternalAuth(BaseAuth):
                             errcode=Codes.EXPIRED_ACCOUNT,
                         )
 
-            if ip_addr and (
-                not requester.app_service or self._track_appservice_user_ips
-            ):
-                # XXX(quenting): I'm 95% confident that we could skip setting the
-                # device_id to "dummy-device" for appservices, and that the only impact
-                # would be some rows which whould not deduplicate in the 'user_ips'
-                # table during the transition
-                recorded_device_id = (
-                    "dummy-device"
-                    if requester.device_id is None and requester.app_service is not None
-                    else requester.device_id
-                )
-                await self.store.insert_client_ip(
-                    user_id=requester.authenticated_entity,
-                    access_token=access_token,
-                    ip=ip_addr,
-                    user_agent=user_agent,
-                    device_id=recorded_device_id,
-                )
-
-                # Track also the puppeted user client IP if enabled and the user is puppeting
-                if (
-                    requester.user.to_string() != requester.authenticated_entity
-                    and self._track_puppeted_user_ips
-                ):
-                    await self.store.insert_client_ip(
-                        user_id=requester.user.to_string(),
-                        access_token=access_token,
-                        ip=ip_addr,
-                        user_agent=user_agent,
-                        device_id=requester.device_id,
-                    )
+                await self._record_request(request, requester)
 
             if requester.is_guest and not allow_guest:
                 raise AuthError(

--- a/synapse/api/auth/internal.py
+++ b/synapse/api/auth/internal.py
@@ -148,7 +148,7 @@ class InternalAuth(BaseAuth):
                             errcode=Codes.EXPIRED_ACCOUNT,
                         )
 
-                await self._record_request(request, requester)
+            await self._record_request(request, requester)
 
             if requester.is_guest and not allow_guest:
                 raise AuthError(

--- a/synapse/api/auth/msc3861_delegated.py
+++ b/synapse/api/auth/msc3861_delegated.py
@@ -226,7 +226,7 @@ class MSC3861DelegatedAuth(BaseAuth):
             # TODO: we probably want to assert the allow_guest inside this call
             # so that we don't provision the user if they don't have enough permission:
             requester = await self.get_user_by_access_token(access_token, allow_expired)
-            await self._record_request(request, requester)
+        await self._record_request(request, requester)
 
         if not allow_guest and requester.is_guest:
             raise OAuthInsufficientScopeError([SCOPE_MATRIX_API])

--- a/synapse/api/auth/msc3861_delegated.py
+++ b/synapse/api/auth/msc3861_delegated.py
@@ -226,7 +226,10 @@ class MSC3861DelegatedAuth(BaseAuth):
             # TODO: we probably want to assert the allow_guest inside this call
             # so that we don't provision the user if they don't have enough permission:
             requester = await self.get_user_by_access_token(access_token, allow_expired)
-        await self._record_request(request, requester)
+
+        # Do not record requests from MAS using the virtual `__oidc_admin` user.
+        if access_token != self._admin_token:
+            await self._record_request(request, requester)
 
         if not allow_guest and requester.is_guest:
             raise OAuthInsufficientScopeError([SCOPE_MATRIX_API])

--- a/synapse/api/auth/msc3861_delegated.py
+++ b/synapse/api/auth/msc3861_delegated.py
@@ -226,6 +226,7 @@ class MSC3861DelegatedAuth(BaseAuth):
             # TODO: we probably want to assert the allow_guest inside this call
             # so that we don't provision the user if they don't have enough permission:
             requester = await self.get_user_by_access_token(access_token, allow_expired)
+            await self._record_request(request, requester)
 
         if not allow_guest and requester.is_guest:
             raise OAuthInsufficientScopeError([SCOPE_MATRIX_API])

--- a/synapse/storage/databases/main/client_ips.py
+++ b/synapse/storage/databases/main/client_ips.py
@@ -589,6 +589,27 @@ class ClientIpWorkerStore(ClientIpBackgroundUpdateStore, MonthlyActiveUsersWorke
         device_id: Optional[str],
         now: Optional[int] = None,
     ) -> None:
+        """Record that `user_id` used `access_token` from this `ip` address.
+
+        This method does two things.
+
+        1. It queues up a row to be upserted into the `client_ips` table. These happen
+           periodically; see _update_client_ips_batch.
+        2. It immediately records this user as having taken action for the purposes of
+           MAU tracking.
+
+        Any DB writes take place on the background tasks worker, falling back to the
+        main process. If we're not that worker, this method emits a replication payload
+        to run this logic on that worker.
+
+        Two caveats to note:
+
+         - We only take action once per LAST_SEEN_GRANULARITY, to avoid spamming the
+           DB with writes.
+         - Requests using the sliding-sync proxy's user agent are excluded, as its
+           requests are not directly driven by end-users. This is a hack and we're not
+           very proud of it.
+        """
         # The sync proxy continuously triggers /sync even if the user is not
         # present so should be excluded from user_ips entries.
         if user_agent == "sync-v3-proxy-":

--- a/tests/config/test_oauth_delegation.py
+++ b/tests/config/test_oauth_delegation.py
@@ -22,15 +22,7 @@ from synapse.types import JsonDict
 
 from tests.server import get_clock, setup_test_homeserver
 from tests.unittest import TestCase, skip_unless
-from tests.utils import default_config
-
-try:
-    import authlib  # noqa: F401
-
-    HAS_AUTHLIB = True
-except ImportError:
-    HAS_AUTHLIB = False
-
+from tests.utils import HAS_AUTHLIB, default_config
 
 # These are a few constants that are used as config parameters in the tests.
 SERVER_NAME = "test"

--- a/tests/handlers/test_oauth_delegation.py
+++ b/tests/handlers/test_oauth_delegation.py
@@ -722,7 +722,8 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
 
         # First test a known access token
         channel = FakeChannel(self.site, self.reactor)
-        req = SynapseRequest(channel, self.site)
+        # type-ignore: FakeChannel is a mock of an HTTPChannel, not a proper HTTPChannel
+        req = SynapseRequest(channel, self.site)  # type: ignore[arg-type]
         req.client.host = EXAMPLE_IPV4_ADDR
         req.requestHeaders.addRawHeader("Authorization", f"Bearer {known_token}")
         req.requestHeaders.addRawHeader("User-Agent", EXAMPLE_USER_AGENT)

--- a/tests/handlers/test_oauth_delegation.py
+++ b/tests/handlers/test_oauth_delegation.py
@@ -29,7 +29,6 @@ from twisted.test.proto_helpers import MemoryReactor
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IResponse
 
-from synapse.api.auth.msc3861_delegated import MSC3861DelegatedAuth
 from synapse.api.errors import (
     AuthError,
     Codes,
@@ -132,6 +131,9 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
         self.http_client.user_agent = b"Synapse Test"
 
         hs = self.setup_test_homeserver(proxied_http_client=self.http_client)
+
+        # Import this here so that we've checked that authlib is available.
+        from synapse.api.auth.msc3861_delegated import MSC3861DelegatedAuth
 
         self.auth = checked_cast(MSC3861DelegatedAuth, hs.get_auth())
 

--- a/tests/handlers/test_oauth_delegation.py
+++ b/tests/handlers/test_oauth_delegation.py
@@ -41,15 +41,7 @@ from synapse.util import Clock
 
 from tests.test_utils import FakeResponse, get_awaitable_result
 from tests.unittest import HomeserverTestCase, skip_unless
-from tests.utils import mock_getRawHeaders
-
-try:
-    import authlib  # noqa: F401
-
-    HAS_AUTHLIB = True
-except ImportError:
-    HAS_AUTHLIB = False
-
+from tests.utils import HAS_AUTHLIB, mock_getRawHeaders
 
 # These are a few constants that are used as config parameters in the tests.
 SERVER_NAME = "test"

--- a/tests/handlers/test_oauth_delegation.py
+++ b/tests/handlers/test_oauth_delegation.py
@@ -29,6 +29,7 @@ from twisted.test.proto_helpers import MemoryReactor
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IResponse
 
+from synapse.api.auth.msc3861_delegated import MSC3861DelegatedAuth
 from synapse.api.errors import (
     AuthError,
     Codes,
@@ -46,7 +47,7 @@ from synapse.util import Clock
 from tests.server import FakeChannel
 from tests.test_utils import FakeResponse, get_awaitable_result
 from tests.unittest import HomeserverTestCase, override_config, skip_unless
-from tests.utils import HAS_AUTHLIB, mock_getRawHeaders
+from tests.utils import HAS_AUTHLIB, checked_cast, mock_getRawHeaders
 
 # These are a few constants that are used as config parameters in the tests.
 SERVER_NAME = "test"
@@ -132,7 +133,7 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
 
         hs = self.setup_test_homeserver(proxied_http_client=self.http_client)
 
-        self.auth = hs.get_auth()
+        self.auth = checked_cast(MSC3861DelegatedAuth, hs.get_auth())
 
         return hs
 
@@ -760,7 +761,7 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
         req = SynapseRequest(channel, self.site)  # type: ignore[arg-type]
         req.client.host = MAS_IPV4_ADDR
         req.requestHeaders.addRawHeader(
-            "Authorization", f"Bearer {self.hs.get_auth()._admin_token}"
+            "Authorization", f"Bearer {self.auth._admin_token}"
         )
         req.requestHeaders.addRawHeader("User-Agent", MAS_USER_AGENT)
         req.content = BytesIO(b"")

--- a/tests/rest/admin/test_jwks.py
+++ b/tests/rest/admin/test_jwks.py
@@ -19,13 +19,7 @@ from twisted.web.resource import Resource
 from synapse.rest.synapse.client import build_synapse_client_resource_tree
 
 from tests.unittest import HomeserverTestCase, override_config, skip_unless
-
-try:
-    import authlib  # noqa: F401
-
-    HAS_AUTHLIB = True
-except ImportError:
-    HAS_AUTHLIB = False
+from tests.utils import HAS_AUTHLIB
 
 
 @skip_unless(HAS_AUTHLIB, "requires authlib")

--- a/tests/rest/client/test_keys.py
+++ b/tests/rest/client/test_keys.py
@@ -30,13 +30,7 @@ from synapse.types import JsonDict, Requester, create_requester
 from tests import unittest
 from tests.http.server._base import make_request_with_cancellation_test
 from tests.unittest import override_config
-
-try:
-    import authlib  # noqa: F401
-
-    HAS_AUTHLIB = True
-except ImportError:
-    HAS_AUTHLIB = False
+from tests.utils import HAS_AUTHLIB
 
 
 class KeyQueryTestCase(unittest.HomeserverTestCase):

--- a/tests/rest/test_well_known.py
+++ b/tests/rest/test_well_known.py
@@ -16,13 +16,7 @@ from twisted.web.resource import Resource
 from synapse.rest.well_known import well_known_resource
 
 from tests import unittest
-
-try:
-    import authlib  # noqa: F401
-
-    HAS_AUTHLIB = True
-except ImportError:
-    HAS_AUTHLIB = False
+from tests.utils import HAS_AUTHLIB
 
 
 class WellKnownTests(unittest.HomeserverTestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,6 +30,13 @@ from synapse.storage.database import LoggingDatabaseConnection
 from synapse.storage.engines import create_engine
 from synapse.storage.prepare_database import prepare_database
 
+try:
+    import authlib  # noqa: F401
+
+    HAS_AUTHLIB = True
+except ImportError:
+    HAS_AUTHLIB = False
+
 # set this to True to run the tests against postgres instead of sqlite.
 #
 # When running under postgres, we first create a base database with the name


### PR DESCRIPTION
This was present in Synapse's "internal" auth, but was not available when delegating auth to an OIDC provider until now.

I haven't tested this end-to-end. But there isn't any variation in the way we write to the DB. So I'm fairly confident this should work. (Unless I'm missing something @sandhose?)