### PR TITLE
Update installation.md to fix a confusion that whether synapse can serve Client Well-Known URI

### DIFF
--- a/changelog.d/16678-doc
+++ b/changelog.d/16678-doc
@@ -1,0 +1,1 @@
+Update installation.md to fix a confusion that whether synapse can serve Client Well-Known URI.

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -496,6 +496,16 @@ Cross-Origin Resource Sharing (CORS) headers. A recommended value would be
 `Access-Control-Allow-Origin: *` which would allow all browser based clients to
 view it.
 
+Synapse will serve it once you set `public_baseurl` in your `homeserver.yaml`.
+
+Just like:
+
+```yaml
+public_baseurl: "https://<matrix.example.com>"
+```
+
+Alternatively, you can set your reverse proxy to serve it.
+
 In nginx this would be something like:
 
 ```nginx
@@ -506,14 +516,11 @@ location /.well-known/matrix/client {
 }
 ```
 
-You should also ensure the `public_baseurl` option in `homeserver.yaml` is set
+You should always ensure the `public_baseurl` option in `homeserver.yaml` is set
 correctly. `public_baseurl` should be set to the URL that clients will use to
-connect to your server. This is the same URL you put for the `m.homeserver`
-`base_url` above.
-
-```yaml
-public_baseurl: "https://<matrix.example.com>"
-```
+connect to your server. If you use reverse proxy to serve client Well-Known URI,
+you should ensure the URL you put for the `public_baseurl` in `homeserver.yaml`
+and `m.homeserver` `base_url` in your reverse proxy config must be the same.
 
 ### Email
 


### PR DESCRIPTION
Actually, by my test, Synapse can serve Client Well-Known URI once you set `public_baseurl` in `homeserver.yaml`. But current document seems unclear on this and make newbies feel "Synapse can't serve Client Well-Known URI and I must use a reverse proxy to do it".

In fact, I was stuck in it at first...

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: LiAlH4 <LiAlH4_Tr@Outlook.com>