### PR TITLE
Fix poetry version typo in contributors' guide

### DIFF
--- a/changelog.d/16695.doc
+++ b/changelog.d/16695.doc
@@ -1,0 +1,1 @@
+Fix poetry version typo in [contributors' guide](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html).

--- a/docs/development/contributing_guide.md
+++ b/docs/development/contributing_guide.md
@@ -66,7 +66,7 @@ Of their installation methods, we recommend
 
 ```shell
 pip install --user pipx
-pipx install poetry==1.5.2  # Problems with Poetry 1.6, see https://github.com/matrix-org/synapse/issues/16147
+pipx install poetry==1.5.1  # Problems with Poetry 1.6, see https://github.com/matrix-org/synapse/issues/16147
 ```
 
 but see poetry's [installation instructions](https://python-poetry.org/docs/#installation)


### PR DESCRIPTION
Typo in #16550 :(

There was never a 1.5.2 release, according to https://pypi.org/project/poetry/#history

So I assume this was just a typo on my part.