### PR TITLE
Server notices: add an autojoin setting for the notices room

### DIFF
--- a/changelog.d/16699.feature
+++ b/changelog.d/16699.feature
@@ -1,0 +1,1 @@
+Add an autojoin setting for the notices room so users get joined directly instead of receiving an invite.

--- a/docs/server_notices.md
+++ b/docs/server_notices.md
@@ -46,6 +46,7 @@ server_notices:
    system_mxid_display_name: "Server Notices"
    system_mxid_avatar_url: "mxc://server.com/oumMVlgDnLYFaPVkExemNVVZ"
    room_name: "Server Notices"
+   auto_join: true
 ```
 
 The only compulsory setting is `system_mxid_localpart`, which defines the user
@@ -54,6 +55,8 @@ room which will be created.
 
 `system_mxid_display_name` and `system_mxid_avatar_url` can be used to set the
 displayname and avatar of the Server Notices user.
+
+`auto_join` will autojoin users to the notices room instead of sending an invite.
 
 ## Sending notices
 

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3815,7 +3815,7 @@ Sub-options for this setting include:
 * `system_mxid_display_name`: set the display name of the "notices" user
 * `system_mxid_avatar_url`: set the avatar for the "notices" user
 * `room_name`: set the room name of the server notices room
-
+* `auto_join`: the user will be automatically joined to the room instead of being invited
 Example configuration:
 ```yaml
 server_notices:
@@ -3823,6 +3823,7 @@ server_notices:
   system_mxid_display_name: "Server Notices"
   system_mxid_avatar_url: "mxc://server.com/oumMVlgDnLYFaPVkExemNVVZ"
   room_name: "Server Notices"
+  auto_join: true
 ```
 ---
 ### `enable_room_list_search`

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3815,7 +3815,7 @@ Sub-options for this setting include:
 * `system_mxid_display_name`: set the display name of the "notices" user
 * `system_mxid_avatar_url`: set the avatar for the "notices" user
 * `room_name`: set the room name of the server notices room
-* `auto_join`: the user will be automatically joined to the room instead of being invited.
+* `auto_join`: boolean. If true, the user will be automatically joined to the room instead of being invited.
   Defaults to false. _Added in Synapse 1.98.0._
 Example configuration:
 ```yaml

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3815,7 +3815,8 @@ Sub-options for this setting include:
 * `system_mxid_display_name`: set the display name of the "notices" user
 * `system_mxid_avatar_url`: set the avatar for the "notices" user
 * `room_name`: set the room name of the server notices room
-* `auto_join`: the user will be automatically joined to the room instead of being invited
+* `auto_join`: the user will be automatically joined to the room instead of being invited.
+  Defaults to false. _Added in Synapse 1.98.0._
 Example configuration:
 ```yaml
 server_notices:

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -3817,6 +3817,7 @@ Sub-options for this setting include:
 * `room_name`: set the room name of the server notices room
 * `auto_join`: boolean. If true, the user will be automatically joined to the room instead of being invited.
   Defaults to false. _Added in Synapse 1.98.0._
+
 Example configuration:
 ```yaml
 server_notices:

--- a/synapse/config/server_notices.py
+++ b/synapse/config/server_notices.py
@@ -48,6 +48,7 @@ class ServerNoticesConfig(Config):
         self.server_notices_mxid_display_name: Optional[str] = None
         self.server_notices_mxid_avatar_url: Optional[str] = None
         self.server_notices_room_name: Optional[str] = None
+        self.server_notices_auto_join: bool = False
 
     def read_config(self, config: JsonDict, **kwargs: Any) -> None:
         c = config.get("server_notices")
@@ -62,3 +63,4 @@ class ServerNoticesConfig(Config):
         self.server_notices_mxid_avatar_url = c.get("system_mxid_avatar_url", None)
         # todo: i18n
         self.server_notices_room_name = c.get("room_name", "Server Notices")
+        self.server_notices_auto_join = c.get("auto_join", False)

--- a/synapse/server_notices/server_notices_manager.py
+++ b/synapse/server_notices/server_notices_manager.py
@@ -224,13 +224,26 @@ class ServerNoticesManager:
             if room.room_id == room_id:
                 return
 
+        user_id_obj = UserID.from_string(user_id)
         await self._room_member_handler.update_membership(
             requester=requester,
-            target=UserID.from_string(user_id),
+            target=user_id_obj,
             room_id=room_id,
             action="invite",
             ratelimit=False,
         )
+
+        if self._config.servernotices.server_notices_auto_join:
+            user_requester = create_requester(
+                user_id, authenticated_entity=self._server_name
+            )
+            await self._room_member_handler.update_membership(
+                requester=user_requester,
+                target=user_id_obj,
+                room_id=room_id,
+                action="join",
+                ratelimit=False,
+            )
 
     async def _update_notice_user_profile_if_changed(
         self,

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -477,6 +477,30 @@ class ServerNoticeTestCase(unittest.HomeserverTestCase):
         # second room has new ID
         self.assertNotEqual(first_room_id, second_room_id)
 
+    @override_config(
+        {"server_notices": {"system_mxid_localpart": "notices", "auto_join": True}}
+    )
+    def test_auto_join(self) -> None:
+        """
+        Tests that the user get automatically joined to the notice room
+        when `auto_join` setting is used.
+        """
+        self._check_invite_and_join_status(self.other_user, 0, 0)
+
+        server_notice_request_content = {
+            "user_id": self.other_user,
+            "content": {"msgtype": "m.text", "body": "test msg one"},
+        }
+
+        self.make_request(
+            "POST",
+            self.url,
+            access_token=self.admin_user_tok,
+            content=server_notice_request_content,
+        )
+
+        self._check_invite_and_join_status(self.other_user, 0, 1)
+
     @override_config({"server_notices": {"system_mxid_localpart": "notices"}})
     def test_update_notice_user_name_when_changed(self) -> None:
         """

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -485,8 +485,10 @@ class ServerNoticeTestCase(unittest.HomeserverTestCase):
         Tests that the user get automatically joined to the notice room
         when `auto_join` setting is used.
         """
+        # user has no room memberships
         self._check_invite_and_join_status(self.other_user, 0, 0)
 
+        # send server notice
         server_notice_request_content = {
             "user_id": self.other_user,
             "content": {"msgtype": "m.text", "body": "test msg one"},
@@ -499,6 +501,7 @@ class ServerNoticeTestCase(unittest.HomeserverTestCase):
             content=server_notice_request_content,
         )
 
+        # user has joined the room
         self._check_invite_and_join_status(self.other_user, 0, 1)
 
     @override_config({"server_notices": {"system_mxid_localpart": "notices"}})


### PR DESCRIPTION
Signed-off-by: Mathieu Velten <mathieu.velten@beta.gouv.fr>

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog).
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
