### PR TITLE
Switch UNIX socket paths to /run, and add a UNIX socket example for HAProxy

### DIFF
--- a/changelog.d/XXXXX.doc
+++ b/changelog.d/XXXXX.doc
@@ -1,0 +1,1 @@
+Switch the example UNIX socket paths to /run. Add HAProxy example configuration for UNIX sockets.

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -181,7 +181,11 @@ frontend matrix-federation
 backend matrix
   server matrix 127.0.0.1:8008
 ```
-
+Example configuration(#2, using a UNIX socket). The configuration before the `backend` part is the same.
+```
+backend matrix
+  server matrix unix@/run/synapse/main_public.sock
+```
 
 [Delegation](delegate.md) example:
 ```

--- a/docs/usage/configuration/config_documentation.md
+++ b/docs/usage/configuration/config_documentation.md
@@ -566,7 +566,7 @@ listeners:
   # Note that x_forwarded will default to true, when using a UNIX socket. Please see
   # https://matrix-org.github.io/synapse/latest/reverse_proxy.html.
   #
-  - path: /var/run/synapse/main_public.sock
+  - path: /run/synapse/main_public.sock
     type: http
     resources:
       - names: [client, federation]
@@ -4215,9 +4215,9 @@ Example configuration(#2, for UNIX sockets):
 ```yaml
 instance_map:
   main:
-    path: /var/run/synapse/main_replication.sock
+    path: /run/synapse/main_replication.sock
   worker1:
-    path: /var/run/synapse/worker1_replication.sock
+    path: /run/synapse/worker1_replication.sock
 ```
 ---
 ### `stream_writers`
@@ -4403,13 +4403,13 @@ Example configuration(#2, using UNIX sockets with a `replication` listener):
 ```yaml
 worker_listeners:
   - type: http
-    path: /var/run/synapse/worker_public.sock
-    resources:
-      - names: [client, federation]
-  - type: http
-    path: /var/run/synapse/worker_replication.sock
+    path: /run/synapse/worker_replication.sock
     resources:
       - names: [replication]
+  - type: http
+    path: /run/synapse/worker_public.sock
+    resources:
+      - names: [client, federation]
 ```
 ---
 ### `worker_manhole`


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [X] Pull request is based on the develop branch
* [X] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [X] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

### PR

Resolves #16698 

Added a HAProxy UNIX socket example as well. It was one of the reasons I wanted to check if we should swap /var/run to /run, first. I've been using Synapse's UNIX sockets with HAProxy for a while now with no issues.

For consistency, I also reversed the order of the example worker configuration replication and client/federation fields as every other example configuration lists replication stuff first, and a public listener second.

Signed-off-by: Ville Petteri Huh.