### PR TITLE
Upgrade poetry-core range to fix #16147

### DIFF
--- a/changelog.d/16702.misc
+++ b/changelog.d/16702.misc
@@ -1,0 +1,1 @@
+Raise poetry-core upper bound to <=1.8.1. This allows contributors to import Synapse after `poetry install`ing with Poetry 1.6 and above. Contributed by Mo Balaa.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,7 +382,7 @@ furo = ">=2022.12.7,<2024.0.0"
 # runtime errors caused by build system changes.
 # We are happy to raise these upper bounds upon request,
 # provided we check that it's safe to do so (i.e. that CI passes).
-requires = ["poetry-core>=1.1.0,<=1.7.0", "setuptools_rust>=1.3,<=1.8.1"]
+requires = ["poetry-core>=1.1.0,<=1.8.1", "setuptools_rust>=1.3,<=1.8.1"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
This fixes #16147 but I'm not sure this is precisely the right version bound. Looking through Poetry related issues directly or indirectly related to #16147 I tend to argue Poetry has created more problems than benefit and would prefer removing it altogether. 

For example, we are using an unsupported Poetry mechanism for building the Rust `synapse.synapse_rust` modules, see https://github.com/python-poetry/poetry/issues/2740#issuecomment-665073135

Happy to make the necessary changes in order to improve the new contributor onboarding experience, whatever they may be.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [x] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))

Signed-off-by: Mo Balaa [mo@fractalnetworks.co](mailto:mo@fractalnetworks.co)