### PR TITLE
Declare support for Matrix v1.7, v1.8, and v1.9.

### DIFF
--- a/changelog.d/16707.feature
+++ b/changelog.d/16707.feature
@@ -1,1 +1,1 @@
-Synapse now declares support for Matrix v1.7 and v1.8.
+Synapse now declares support for Matrix v1.7, v1.8, and v1.9.

--- a/changelog.d/16707.feature
+++ b/changelog.d/16707.feature
@@ -1,0 +1,1 @@
+Synapse now declares support for Matrix v1.7 and v1.8.

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -80,6 +80,8 @@ class VersionsRestServlet(RestServlet):
                     "v1.4",
                     "v1.5",
                     "v1.6",
+                    "v1.7",
+                    "v1.8",
                 ],
                 # as per MSC1497:
                 "unstable_features": {

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -82,6 +82,7 @@ class VersionsRestServlet(RestServlet):
                     "v1.6",
                     "v1.7",
                     "v1.8",
+                    "v1.9",
                 ],
                 # as per MSC1497:
                 "unstable_features": {


### PR DESCRIPTION
This depends on #16701.

This fixes #15661 and fixes #16176 and fixes #16709. I would recommend the author double check that all the bits in those are supported in Synapse.