### PR TITLE
Fix upgrading a room without `events` field in power levels

### DIFF
--- a/changelog.d/16725.bugfix
+++ b/changelog.d/16725.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Synapse 1.7.2 where rooms whose power levels lacked an `events` field could not be upgraded.

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -549,7 +549,7 @@ class RoomCreationHandler:
         except (TypeError, ValueError):
             ban = 50
         needed_power_level = max(
-            state_default_int, ban, max(event_power_levels.values())
+            state_default_int, ban, max(event_power_levels.values(), default=0)
         )
 
         # Get the user's current power level, this matches the logic in get_user_power_level,


### PR DESCRIPTION
Fixes #16715, per https://github.com/matrix-org/synapse/issues/16715#issuecomment-1838349379. Looks to have been introduced in https://github.com/matrix-org/synapse/pull/6237.

C.f. https://spec.matrix.org/v1.9/client-server-api/#mroompower_levels

Sanity checking Erik's reasoning, the point of this code is to ensure that the upgrader is able to set any state in the new room. If `event_power_levels` is empty then there are no extra requirements to impose, so I think a fallback of `0` is sensible.