### PR TITLE
Expose OIDC discovery information under the CSAPI

### DIFF
--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -423,3 +423,14 @@ class ExperimentalConfig(Config):
         self.msc4069_profile_inhibit_propagation = experimental.get(
             "msc4069_profile_inhibit_propagation", False
         )
+
+    def get_msc2965_discovery_data(self) -> Optional[JsonDict]:
+        # We use the MSC3861 values as they are used by multiple MSCs
+        if not self.msc3861.enabled:
+            return None
+
+        result = {"issuer": self.msc3861.issuer}
+        if self.msc3861.account_management_url is not None:
+            result["account"] = self.msc3861.account_management_url
+
+        return result

--- a/synapse/rest/__init__.py
+++ b/synapse/rest/__init__.py
@@ -22,6 +22,7 @@ from synapse.rest.client import (
     account_validity,
     appservice_ping,
     auth,
+    auth_issuer,
     capabilities,
     devices,
     directory,
@@ -148,3 +149,4 @@ class ClientRestResource(JsonResource):
             mutual_rooms.register_servlets(hs, client_resource)
             login_token_request.register_servlets(hs, client_resource)
             rendezvous.register_servlets(hs, client_resource)
+            auth_issuer.register_servlets(hs, client_resource)

--- a/synapse/rest/client/auth_issuer.py
+++ b/synapse/rest/client/auth_issuer.py
@@ -1,0 +1,65 @@
+# Copyright 2023 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import typing
+from typing import Tuple
+
+from synapse.api.errors import Codes, SynapseError
+from synapse.http.server import HttpServer
+from synapse.http.servlet import RestServlet
+from synapse.http.site import SynapseRequest
+from synapse.rest.client._base import client_patterns
+from synapse.types import JsonDict
+
+if typing.TYPE_CHECKING:
+    from synapse.server import HomeServer
+
+
+logger = logging.getLogger(__name__)
+
+
+class AuthIssuerServlet(RestServlet):
+    """
+    Handles Client / Server API authentication in any situations where it
+    cannot be handled in the normal flow (with requests to the same endpoint).
+    Current use is for web fallback auth.
+    """
+
+    PATTERNS = client_patterns(
+        "/org.matrix.msc2965/auth_issuer$",
+        unstable=True,
+        releases=(),
+    )
+
+    def __init__(self, hs: "HomeServer"):
+        super().__init__()
+        self._config = hs.config
+
+    async def on_GET(self, request: SynapseRequest) -> Tuple[int, JsonDict]:
+        discovery_data = self._config.experimental.get_msc2965_discovery_data()
+        if discovery_data is None:
+            # Wouldn't expect this to be reached: the servelet shouldn't have been
+            # registered. Still, fail gracefully if we are registered for some reason.
+            raise SynapseError(
+                404,
+                "OIDC discovery has not been configured on this homeserver",
+                Codes.NOT_FOUND,
+            )
+        return 200, discovery_data
+
+
+def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
+    # We use the MSC3861 values as they are used by multiple MSCs
+    if hs.config.experimental.msc3861.enabled:
+        AuthIssuerServlet(hs).register(http_server)

--- a/synapse/rest/well_known.py
+++ b/synapse/rest/well_known.py
@@ -44,15 +44,9 @@ class WellKnownBuilder:
                 "base_url": self._config.registration.default_identity_server
             }
 
-        # We use the MSC3861 values as they are used by multiple MSCs
-        if self._config.experimental.msc3861.enabled:
-            result["org.matrix.msc2965.authentication"] = {
-                "issuer": self._config.experimental.msc3861.issuer
-            }
-            if self._config.experimental.msc3861.account_management_url is not None:
-                result["org.matrix.msc2965.authentication"][
-                    "account"
-                ] = self._config.experimental.msc3861.account_management_url
+        discovery_data = self._config.experimental.get_msc2965_discovery_data()
+        if discovery_data is not None:
+            result["org.matrix.msc2965.authentication"] = discovery_data
 
         if self._config.server.extra_well_known_client_content:
             for (

--- a/tests/rest/client/test_auth_issuer.py
+++ b/tests/rest/client/test_auth_issuer.py
@@ -1,0 +1,61 @@
+# Copyright 2023 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from http import HTTPStatus
+
+from synapse.rest.client import auth_issuer
+
+from tests.unittest import HomeserverTestCase, override_config
+
+ISSUER = "https://account.example.com/"
+ACCOUNT_MANAGEMENT_URL = "https://account.example.com/myaccount/"
+
+
+class AccountDataTestCase(HomeserverTestCase):
+    servlets = [
+        auth_issuer.register_servlets,
+    ]
+
+    def test_returns_404_when_msc3861_disabled(self) -> None:
+        # Make an unauthenticated request for the discovery info.
+        channel = self.make_request(
+            "GET",
+            "/_matrix/client/unstable/org.matrix.msc2965/auth_issuer",
+        )
+        self.assertEqual(channel.code, HTTPStatus.NOT_FOUND)
+
+    @override_config(
+        {
+            "disable_registration": True,
+            "experimental_features": {
+                "msc3861": {
+                    "enabled": True,
+                    "issuer": ISSUER,
+                    "account_management_url": ACCOUNT_MANAGEMENT_URL,
+                    "client_id": "David Lister",
+                    "client_auth_method": "client_secret_post",
+                    "client_secret": "Who shot Mister Burns?",
+                }
+            },
+        }
+    )
+    def test_returns_discovery_data_when_oidc_enabled(self) -> None:
+        # Make an unauthenticated request for the discovery info.
+        channel = self.make_request(
+            "GET",
+            "/_matrix/client/unstable/org.matrix.msc2965/auth_issuer",
+        )
+        self.assertEqual(channel.code, HTTPStatus.OK)
+        self.assertEqual(
+            channel.json_body, {"issuer": ISSUER, "account": ACCOUNT_MANAGEMENT_URL}
+        )


### PR DESCRIPTION
After this change, we continue to expose discovery information in the client well-known response for backwards compatability.

The MSC [1] includes a new `actions_supported` which I don't think we currently have. I haven't done anything to add it in. LMK if you'd like me to do so.

[1]: https://github.com/matrix-org/matrix-spec-proposals/pull/2965