### PR TITLE
Set response values to zero if None for /_synapse/admin/v1/federation/destinations

### DIFF
--- a/changelog.d/16729.bugfix
+++ b/changelog.d/16729.bugfix
@@ -1,0 +1,1 @@
+Fix GET /_synapse/admin/v1/federation/destinations returning null (instead of 0) for `retry_last_ts` and `retry_interval`.

--- a/synapse/rest/admin/federation.py
+++ b/synapse/rest/admin/federation.py
@@ -89,8 +89,8 @@ class ListDestinationsRestServlet(RestServlet):
             "destinations": [
                 {
                     "destination": r[0],
-                    "retry_last_ts": r[1],
-                    "retry_interval": r[2],
+                    "retry_last_ts": r[1] or 0,
+                    "retry_interval": r[2] or 0,
                     "failure_ts": r[3],
                     "last_successful_stream_ordering": r[4],
                 }


### PR DESCRIPTION
The docs say these values should be integers (0 if no retries have been tried), but Synapse is currently returning `null` instead.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
