### PR TITLE
Fix postgres schema after batch_events dropped

### DIFF
--- a/synapse/storage/schema/main/delta/83/10_replica_identity_batch_events.sql.postgres
+++ b/synapse/storage/schema/main/delta/83/10_replica_identity_batch_events.sql.postgres
@@ -1,1 +1,0 @@
-ALTER TABLE batch_events REPLICA IDENTITY USING INDEX chunk_events_event_id;


### PR DESCRIPTION
This resolves a conflict between
https://github.com/matrix-org/synapse/pull/16658 and https://github.com/matrix-org/synapse/pull/16652
and should unsad CI.
